### PR TITLE
backup: teach ResolveBackupManifests to use the backup index

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -458,6 +458,7 @@ func backup(
 		execCtx.User(),
 		execCtx.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
 		details,
+		backupManifest.RevisionStartTime,
 	); err != nil {
 		return roachpb.RowCount{}, 0, errors.Wrapf(err, "writing backup index metadata")
 	}

--- a/pkg/backup/backupdest/BUILD.bazel
+++ b/pkg/backup/backupdest/BUILD.bazel
@@ -31,12 +31,14 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/ioctx",
+        "//pkg/util/log",
         "//pkg/util/metamorphic",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 
@@ -73,6 +75,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/testutils",
+        "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util",

--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -32,10 +32,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -547,7 +549,62 @@ func ListFullBackupsInCollection(
 // timestamp are included in the result, otherwise they are elided. If
 // `includedCompacted` is true, then backups created from compaction will be
 // included in the result, otherwise they are filtered out.
+// TODO (kev-cao): The sheer amount of parameters is absolutely horrifying.
+// Must clean up.
 func ResolveBackupManifests(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	mem *mon.BoundAccount,
+	defaultCollectionURI string,
+	collectionURIs []string,
+	baseStores []cloud.ExternalStorage,
+	incStores []cloud.ExternalStorage,
+	mkStore cloud.ExternalStorageFromURIFactory,
+	resolvedSubdir string,
+	fullyResolvedBaseDirectory []string,
+	fullyResolvedIncrementalsDirectory []string,
+	endTime hlc.Timestamp,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+	user username.SQLUsername,
+	includeSkipped bool,
+	includeCompacted bool,
+	isCustomIncLocation bool,
+) (
+	defaultURIs []string,
+	mainBackupManifests []backuppb.BackupManifest,
+	localityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
+	reservedMemSize int64,
+	_ error,
+) {
+	rootStore, err := mkStore(ctx, defaultCollectionURI, user)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+	defer rootStore.Close()
+
+	exists, err := IndexExists(ctx, rootStore, resolvedSubdir)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	if !ReadBackupIndexEnabled.Get(&execCfg.Settings.SV) || !exists || isCustomIncLocation {
+		return legacyResolveBackupManifests(
+			ctx, execCfg, mem, defaultCollectionURI, baseStores, incStores, mkStore,
+			resolvedSubdir, fullyResolvedBaseDirectory, fullyResolvedIncrementalsDirectory,
+			endTime, encryption, kmsEnv, user, includeSkipped, includeCompacted,
+		)
+	}
+
+	return indexedResolveBackupManifests(
+		ctx, mem, collectionURIs, mkStore, resolvedSubdir, endTime, encryption, kmsEnv,
+		user, includeSkipped, includeCompacted,
+	)
+}
+
+// TODO (kev-cao): Remove in 26.2 when all restorable backups are expected to
+// have an index.
+func legacyResolveBackupManifests(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	mem *mon.BoundAccount,
@@ -566,7 +623,6 @@ func ResolveBackupManifests(
 	includeCompacted bool,
 ) (
 	defaultURIs []string,
-	// mainBackupManifests contains the manifest located at each defaultURI in the backup chain.
 	mainBackupManifests []backuppb.BackupManifest,
 	localityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
 	reservedMemSize int64,
@@ -595,18 +651,7 @@ func ResolveBackupManifests(
 			return nil, nil, nil, 0, err
 		}
 		defer rootStore.Close()
-		incrementalBackups, err = FindAllIncrementalPaths(
-			ctx,
-			execCfg,
-			incStores[0],
-			rootStore,
-			resolvedSubdir,
-			includeManifest,
-			// In the legacy path, there is no index to be used, so we may as well set
-			// customIncLocation to true rather than try to compute it from the
-			// parameters.
-			true,
-		)
+		incrementalBackups, err = LegacyFindPriorBackups(ctx, incStores[0], includeManifest)
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
@@ -702,4 +747,99 @@ func ResolveBackupManifests(
 	}
 	uris, manifests, localityInfo := backupinfo.UnzipBackupTreeEntries(validatedEntries)
 	return uris, manifests, localityInfo, totalMemSize, nil
+}
+
+func indexedResolveBackupManifests(
+	ctx context.Context,
+	mem *mon.BoundAccount,
+	collectionURIs []string,
+	mkStore cloud.ExternalStorageFromURIFactory,
+	resolvedSubdir string,
+	endTime hlc.Timestamp,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+	user username.SQLUsername,
+	includeSkipped bool,
+	includeCompacted bool,
+) (
+	defaultURIs []string,
+	mainManifests []backuppb.BackupManifest,
+	localityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
+	reservedMemSize int64,
+	_ error,
+) {
+	ctx, sp := tracing.ChildSpan(ctx, "backupdest.ResolveBackupManifestsWithIndexes")
+	defer sp.Finish()
+
+	rootStores := make([]cloud.ExternalStorage, 0, len(collectionURIs))
+	defer func() {
+		for _, store := range rootStores {
+			if store != nil {
+				if err := store.Close(); err != nil {
+					log.Dev.Errorf(ctx, "error closing store: %v", err)
+				}
+			}
+		}
+	}()
+	for _, uri := range collectionURIs {
+		store, err := mkStore(ctx, uri, user)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+		rootStores = append(rootStores, store)
+	}
+
+	indexes, err := GetBackupTreeIndexMetadata(
+		ctx, rootStores[0], resolvedSubdir,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	indexes, err = backupinfo.ValidateEndTimeAndTruncate(
+		indexes, endTime, includeSkipped, includeCompacted,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	defaultURIs = make([]string, len(indexes))
+	partitionURIs := make([][]string, len(indexes))
+	localityInfo = make([]jobspb.RestoreDetails_BackupLocalityInfo, len(indexes))
+
+	for idx, index := range indexes {
+		indexDests, err := backuputils.AppendPaths(collectionURIs, index.Path)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+		partitionURIs[idx] = indexDests
+		defaultURIs[idx] = indexDests[0]
+	}
+
+	mainManifests, manifestsMem, err := backupinfo.GetBackupManifests(
+		ctx, mem, user, mkStore, defaultURIs, encryption, kmsEnv,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	group, gCtx := errgroup.WithContext(ctx)
+	for i, indexes := range indexes {
+		group.Go(func() error {
+			locality, err := backupinfo.GetLocalityInfo(
+				gCtx, rootStores, partitionURIs[i], mainManifests[i], encryption, kmsEnv, indexes.Path,
+			)
+			if err != nil {
+				return err
+			}
+			localityInfo[i] = locality
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	return defaultURIs, mainManifests, localityInfo, manifestsMem, nil
 }

--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-package backupdest_test
+package backupdest
 
 import (
 	"bytes"
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backupbase"
-	"github.com/cockroachdb/cockroach/pkg/backup/backupdest"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
@@ -24,6 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -64,7 +65,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 		storage, err := externalStorageFromURI(ctx, collectionURI, username.RootUserName())
 		defer storage.Close()
 		require.NoError(t, err)
-		require.NoError(t, backupdest.WriteNewLatestFile(ctx, storage.Settings(), storage, latestBackupSuffix))
+		require.NoError(t, WriteNewLatestFile(ctx, storage.Settings(), storage, latestBackupSuffix))
 	}
 
 	// localizeURI returns a slice of just the base URI if localities is nil.
@@ -77,12 +78,12 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 		if localities == nil {
 			return []string{baseURI}
 		}
-		allLocalities := append([]string{backupdest.DefaultLocalityValue}, localities...)
+		allLocalities := append([]string{DefaultLocalityValue}, localities...)
 		localizedURIs := make([]string, len(allLocalities))
 		for i, locality := range allLocalities {
 			parsedURI, err := url.Parse(baseURI)
 			require.NoError(t, err)
-			if locality != backupdest.DefaultLocalityValue {
+			if locality != DefaultLocalityValue {
 				parsedURI.Path = backuputils.JoinURLPath(parsedURI.Path, locality)
 			}
 			q := parsedURI.Query()
@@ -161,11 +162,11 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 						subdir = endTime.GoTime().Format(backupbase.DateBasedIntoFolderName)
 					}
 
-					_, localityCollections, err := backupdest.GetURIsByLocalityKV(collectionTo, "")
+					_, localityCollections, err := GetURIsByLocalityKV(collectionTo, "")
 					require.NoError(t, err)
 
 					if len(incrementalTo) > 0 {
-						_, localityCollections, err = backupdest.GetURIsByLocalityKV(incrementalTo, "")
+						_, localityCollections, err = GetURIsByLocalityKV(incrementalTo, "")
 						require.NoError(t, err)
 					}
 
@@ -173,7 +174,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					kmsEnv := &cloud.TestKMSEnv{
 						ExternalIOConfig: &base.ExternalIODirConfig{},
 					}
-					backupDest, err := backupdest.ResolveDest(
+					backupDest, err := ResolveDest(
 						ctx, username.RootUserName(),
 						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir,
 							IncrementalStorage: incrementalTo, Exists: fullBackupExists},
@@ -337,4 +338,267 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 	}
 }
 
-// TODO(pbardea): Add tests for resolveBackupCollection.
+func TestResolveBackupManifests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
+		t, backuptestutils.SingleNode,
+	)
+	defer cleanupFn()
+
+	execCfg := tc.Server(0).ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
+
+	collections := []string{
+		"nodelocal://1/backup/default?COCKROACH_LOCALITY=default",
+		"nodelocal://1/backup/west?COCKROACH_LOCALITY=region%3Dwest",
+		"nodelocal://1/backup/south?COCKROACH_LOCALITY=region%3Dsouth",
+	}
+
+	var aost1 string
+	db.QueryRow(t, "SELECT now()").Scan(&aost1)
+	db.Exec(
+		t, "BACKUP INTO ($1, $2, $3) AS OF SYSTEM TIME $4::STRING",
+		collections[0], collections[1], collections[2], aost1,
+	)
+	db.Exec(
+		t, "BACKUP INTO LATEST IN ($1, $2, $3)",
+		collections[0], collections[1], collections[2],
+	)
+
+	aost1TS, err := time.Parse(time.RFC3339, aost1)
+	require.NoError(t, err)
+	aost1Hlc := hlc.Timestamp{WallTime: aost1TS.UnixNano()}
+
+	var fullSubdir string
+	db.QueryRow(
+		t, "SHOW BACKUPS IN ($1, $2, $3)",
+		collections[0], collections[1], collections[2],
+	).Scan(&fullSubdir)
+	require.NotEmpty(t, fullSubdir)
+
+	mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
+	defer mem.Close(ctx)
+
+	// TODO (kev-cao): Remove all following variables during cleanup of
+	// `ResolveBackupManifests` parameters.
+	fullyResolvedBaseDirs, err := backuputils.AppendPaths(collections, fullSubdir)
+	require.NoError(t, err)
+
+	fullyResolvedIncDirs, err := util.MapE(collections, func(uri string) (string, error) {
+		u, err := url.Parse(uri)
+		if err != nil {
+			return "", err
+		}
+		u.Path = backuputils.JoinURLPath(u.Path, "incrementals", fullSubdir)
+		return u.String(), nil
+	})
+	require.NoError(t, err)
+
+	baseStores, err := util.MapE(fullyResolvedBaseDirs, func(uri string) (cloud.ExternalStorage, error) {
+		return execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, username.RootUserName())
+	})
+	require.NoError(t, err)
+	for i := range baseStores {
+		defer baseStores[i].Close()
+	}
+
+	incStores, err := util.MapE(fullyResolvedIncDirs, func(uri string) (cloud.ExternalStorage, error) {
+		return execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, username.RootUserName())
+	})
+	require.NoError(t, err)
+	for i := range incStores {
+		defer incStores[i].Close()
+	}
+
+	t.Run("resolve backup manifests with latest AOST", func(t *testing.T) {
+		uris, manifests, locality, memSize, err := ResolveBackupManifests(
+			ctx,
+			&execCfg,
+			&mem,
+			collections[0],
+			collections,
+			baseStores,
+			incStores,
+			execCfg.DistSQLSrv.ExternalStorageFromURI,
+			fullSubdir,
+			fullyResolvedBaseDirs,
+			fullyResolvedIncDirs,
+			hlc.Timestamp{},
+			nil, /* encryption */
+			nil, /* kms */
+			username.RootUserName(),
+			false, /* includeSkipped */
+			true,  /* includeCompacted */
+			false, /* isCustomIncLocation */
+		)
+		defer mem.Shrink(ctx, memSize)
+		require.NoError(t, err)
+
+		require.Len(t, uris, 2)
+		require.Len(t, manifests, 2)
+		require.Len(t, locality, 2)
+	})
+
+	t.Run("resolve backup manifests with AOST in middle of chain", func(t *testing.T) {
+		uris, manifests, locality, memSize, err := ResolveBackupManifests(
+			ctx,
+			&execCfg,
+			&mem,
+			collections[0],
+			collections,
+			baseStores,
+			incStores,
+			execCfg.DistSQLSrv.ExternalStorageFromURI,
+			fullSubdir,
+			fullyResolvedBaseDirs,
+			fullyResolvedIncDirs,
+			aost1Hlc,
+			nil, /* encryption */
+			nil, /* kms */
+			username.RootUserName(),
+			false, /* includeSkipped */
+			true,  /* includeCompacted */
+			false, /* isCustomIncLocation */
+		)
+		defer mem.Shrink(ctx, memSize)
+		require.NoError(t, err)
+
+		require.Len(t, uris, 1)
+		require.Len(t, manifests, 1)
+		require.Len(t, locality, 1)
+	})
+}
+
+func TestIndexedResolveBackupManifestsWithCompactedBackups(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
+		t, backuptestutils.SingleNode,
+	)
+	defer cleanupFn()
+
+	const collectionURI = "nodelocal://1/backup"
+
+	execCfg := tc.Server(0).ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
+	mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
+
+	db.Exec(t, "SET CLUSTER SETTING backup.index.read.enabled = true")
+
+	var aostFull string
+	db.QueryRow(t, "SELECT now()").Scan(&aostFull)
+	aostFullTS, err := time.Parse(time.RFC3339, aostFull)
+	require.NoError(t, err)
+	aostFullHlc := hlc.Timestamp{WallTime: aostFullTS.UnixNano()}
+
+	db.Exec(
+		t, "BACKUP INTO $1 AS OF SYSTEM TIME $2::STRING",
+		collectionURI, aostFullHlc.AsOfSystemTime(),
+	)
+	db.Exec(t, "BACKUP INTO LATEST IN $1", collectionURI)
+	db.Exec(t, "BACKUP INTO LATEST IN $1", collectionURI)
+
+	var aostEnd string
+	db.QueryRow(t, "SELECT now()").Scan(&aostEnd)
+	aostEndTS, err := time.Parse(time.RFC3339, aostEnd)
+	require.NoError(t, err)
+	aostEndHlc := hlc.Timestamp{WallTime: aostEndTS.UnixNano()}
+	db.Exec(
+		t, "BACKUP INTO LATEST IN $1 AS OF SYSTEM TIME $2::STRING",
+		collectionURI, aostEndHlc.AsOfSystemTime(),
+	)
+
+	var fullSubdir string
+	db.QueryRow(
+		t, `SELECT path FROM [SHOW BACKUPS IN $1] ORDER BY path DESC`, collectionURI,
+	).Scan(&fullSubdir)
+	require.NotEmpty(t, fullSubdir)
+
+	var compactionJob jobspb.JobID
+	db.QueryRow(
+		t,
+		`SELECT crdb_internal.backup_compaction(
+				0, $1, $2, $3::DECIMAL, $4::DECIMAL
+			)`,
+		fmt.Sprintf("BACKUP INTO LATEST IN '%s'", collectionURI),
+		fullSubdir,
+		aostFullHlc.AsOfSystemTime(),
+		aostEndHlc.AsOfSystemTime(),
+	).Scan(&compactionJob)
+	jobutils.WaitForJobToSucceed(t, db, compactionJob)
+
+	// Backup chain: f@t=0, i1@t=1, i2@t=2, i3@t=4, c@t=4
+	// where c compacts i1, i2, and i3.
+	const totalBackups = 5
+	const filesPerManifest = 2 // Opening a manifest requires opening the metadata file and checksum
+	for _, tt := range []struct {
+		includeSkipped   bool
+		includeCompacted bool
+		expectedCount    int
+	}{
+		{
+			includeSkipped:   false,
+			includeCompacted: true,
+			expectedCount:    2,
+		},
+		{
+			includeSkipped:   true,
+			includeCompacted: true,
+			expectedCount:    5,
+		},
+		{
+			includeSkipped:   false,
+			includeCompacted: false,
+			expectedCount:    4,
+		},
+		{
+			includeSkipped:   true,
+			includeCompacted: false,
+			expectedCount:    4,
+		},
+	} {
+		t.Run(
+			fmt.Sprintf("includeSkipped=%t,includeCompacted=%t", tt.includeSkipped, tt.includeCompacted),
+			func(t *testing.T) {
+				baseReadersOpened := tc.Servers[0].MustGetSQLCounter("cloud.readers_opened")
+				uris, manifests, locality, memSize, err := indexedResolveBackupManifests(
+					ctx,
+					&mem,
+					[]string{collectionURI},
+					execCfg.DistSQLSrv.ExternalStorageFromURI,
+					fullSubdir,
+					hlc.Timestamp{},
+					nil, /* encryption */
+					nil, /* kms */
+					username.RootUserName(),
+					tt.includeSkipped,
+					tt.includeCompacted,
+				)
+				defer mem.Shrink(ctx, memSize)
+				require.NoError(t, err)
+				require.Len(t, uris, tt.expectedCount)
+				require.Len(t, manifests, tt.expectedCount)
+				require.Len(t, locality, tt.expectedCount)
+
+				// When using the index for ResolveBackupManifests, we use the following
+				// flow:
+				// 1. Open the index of every backup in the chain (<totalBackups> files)
+				// 2. Validate and truncate the chain to only keep relevant backups
+				// 3. Read the files required for the manifests of the relevant backups
+				//
+				// So to compute step 3, we take the total number of files opened and
+				// subtract the index files, aka readersOpened - totalBackups.
+				//
+				// And for each manifest, we open <filesPerManifest> files to read the
+				// manifest. So to compute the number of manifests opened, we take
+				// readersOpened - totalBackups and divide by filesPerManifest.
+				readersOpened := tc.Servers[0].MustGetSQLCounter("cloud.readers_opened") - baseReadersOpened
+				manifestsOpened := (readersOpened - totalBackups) / filesPerManifest
+				require.Equal(t, tt.expectedCount, int(manifestsOpened))
+			},
+		)
+	}
+}

--- a/pkg/backup/backupdest/backup_index_test.go
+++ b/pkg/backup/backupdest/backup_index_test.go
@@ -152,7 +152,7 @@ func TestWriteBackupIndexMetadata(t *testing.T) {
 	}
 
 	require.NoError(t, WriteBackupIndexMetadata(
-		ctx, execCfg, username.RootUserName(), makeExternalStorage, details,
+		ctx, execCfg, username.RootUserName(), makeExternalStorage, details, hlc.Timestamp{},
 	))
 
 	filepath, err := getBackupIndexFilePath(subdir, start, end)
@@ -217,6 +217,10 @@ func TestWriteBackupIndexMetadataWithLocalityAwareBackups(t *testing.T) {
 
 	require.True(t, fullIndex.StartTime.IsEmpty())
 	require.False(t, incrIndex.StartTime.IsEmpty())
+	require.True(t, strings.HasPrefix(
+		incrIndex.Path,
+		"/"+path.Join(backupbase.DefaultIncrementalsSubdir, fullIndex.Path),
+	))
 }
 
 func TestWriteBackupindexMetadataWithSpecifiedIncrementalLocation(t *testing.T) {
@@ -286,7 +290,7 @@ func TestDontWriteBackupIndexMetadata(t *testing.T) {
 		details.EndTime = end
 
 		require.NoError(t, WriteBackupIndexMetadata(
-			ctx, execCfg, username.RootUserName(), makeExternalStorage, details,
+			ctx, execCfg, username.RootUserName(), makeExternalStorage, details, hlc.Timestamp{},
 		))
 
 		filepath, err := getBackupIndexFilePath(subdir, start, end)
@@ -311,7 +315,7 @@ func TestDontWriteBackupIndexMetadata(t *testing.T) {
 		details.EndTime = end
 
 		require.NoError(t, WriteBackupIndexMetadata(
-			ctx, execCfg, username.RootUserName(), makeExternalStorage, details,
+			ctx, execCfg, username.RootUserName(), makeExternalStorage, details, hlc.Timestamp{},
 		))
 
 		filepath, err := getBackupIndexFilePath(subdir, start, end)
@@ -469,7 +473,7 @@ func TestIndexExists(t *testing.T) {
 						URI: collectionURI + "/" + sub.name,
 					}
 					require.NoError(t, WriteBackupIndexMetadata(
-						ctx, execCfg, username.RootUserName(), makeExternalStorage, details,
+						ctx, execCfg, username.RootUserName(), makeExternalStorage, details, hlc.Timestamp{},
 					))
 				}
 			}
@@ -540,7 +544,7 @@ func TestGetBackupTreeIndexMetadata(t *testing.T) {
 			URI: collectionURI + subdir,
 		}
 		require.NoError(t, WriteBackupIndexMetadata(
-			ctx, execCfg, username.RootUserName(), storageFactory, details,
+			ctx, execCfg, username.RootUserName(), storageFactory, details, hlc.Timestamp{},
 		))
 	}
 

--- a/pkg/backup/backupdest/incrementals_test.go
+++ b/pkg/backup/backupdest/incrementals_test.go
@@ -488,7 +488,7 @@ func writeEmptyBackupManifest(
 		t,
 		backupdest.WriteBackupIndexMetadata(
 			context.Background(), execCfg, username.RootUserName(),
-			execCfg.DistSQLSrv.ExternalStorageFromURI, backupDetails,
+			execCfg.DistSQLSrv.ExternalStorageFromURI, backupDetails, hlc.Timestamp{},
 		),
 	)
 }

--- a/pkg/backup/backuppb/backup.go
+++ b/pkg/backup/backuppb/backup.go
@@ -246,6 +246,30 @@ func (e *ExportStats) ToText() []byte {
 	return []byte(e.String())
 }
 
+// The following functions implement the ManifestLike interface in
+// manifest_handling.go. They can be removed once the interface is cleaned up.
+// TODO (kev-cao): Remove in v26.2
+
+func (b BackupIndexMetadata) Start() hlc.Timestamp {
+	return b.StartTime
+}
+
+func (b BackupIndexMetadata) End() hlc.Timestamp {
+	return b.EndTime
+}
+
+func (b BackupIndexMetadata) Compacted() bool {
+	return b.IsCompacted
+}
+
+func (b BackupIndexMetadata) MVCC() MVCCFilter {
+	return b.MVCCFilter
+}
+
+func (b BackupIndexMetadata) RevisionStart() hlc.Timestamp {
+	return b.RevisionStartTime
+}
+
 func init() {
 	protoreflect.RegisterShorthands((*BackupManifest)(nil), "backup", "backup_manifest")
 }

--- a/pkg/backup/backuppb/backup.proto
+++ b/pkg/backup/backuppb/backup.proto
@@ -162,7 +162,10 @@ message BackupIndexMetadata {
   // The path to the directory containing the backup relative to the collection
   // URI.
   string path = 3;
-  // Next ID: 4.
+  bool is_compacted = 4;
+  MVCCFilter mvcc_filter = 5 [(gogoproto.customname) = "MVCCFilter"];
+  util.hlc.Timestamp revision_start_time = 6 [(gogoproto.nullable) = false];
+  // Next ID: 7.
 }
 
 message BackupPartitionDescriptor {

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -770,9 +770,9 @@ func getBackupChain(
 	defer mem.Close(ctx)
 
 	_, manifests, localityInfo, memReserved, err := backupdest.ResolveBackupManifests(
-		ctx, execCfg, &mem, defaultCollectionURI, baseStores, incStores, mkStore, resolvedSubdir,
+		ctx, execCfg, &mem, defaultCollectionURI, dest.To, baseStores, incStores, mkStore, resolvedSubdir,
 		resolvedBaseDirs, resolvedIncDirs, endTime, baseEncryptionInfo, kmsEnv,
-		user, false /*includeSkipped */, true, /*includeCompacted */
+		user, false /*includeSkipped */, true /*includeCompacted */, len(dest.IncrementalStorage) > 0,
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -829,6 +829,7 @@ func concludeBackupCompaction(
 			execCtx.User(),
 			execCtx.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
 			details,
+			backupManifest.RevisionStartTime,
 		),
 		"writing backup index metadata",
 	)

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1805,9 +1805,9 @@ func doRestorePlan(
 	// directories, return the URIs and manifests of all backup layers in all
 	// localities. Incrementals will be searched for automatically.
 	defaultURIs, mainBackupManifests, localityInfo, memReserved, err := backupdest.ResolveBackupManifests(
-		ctx, p.ExecCfg(), &mem, defaultCollectionURI, baseStores, incStores, mkStore, fullyResolvedSubdir,
-		fullyResolvedBaseDirectory, fullyResolvedIncrementalsDirectory, endTime, encryption,
-		&kmsEnv, p.User(), false, includeCompacted,
+		ctx, p.ExecCfg(), &mem, defaultCollectionURI, from, baseStores, incStores, mkStore,
+		fullyResolvedSubdir, fullyResolvedBaseDirectory, fullyResolvedIncrementalsDirectory, endTime,
+		encryption, &kmsEnv, p.User(), false, includeCompacted, len(incFrom) > 0,
 	)
 	if err != nil {
 		return err

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -359,9 +359,10 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 
 		info.defaultURIs, info.manifests, info.localityInfo, memReserved,
 			err = backupdest.ResolveBackupManifests(
-			ctx, p.ExecCfg(), &mem, defaultCollectionURI, baseStores, incStores, mkStore, subdir,
+			ctx, p.ExecCfg(), &mem, defaultCollectionURI, dest, baseStores, incStores, mkStore, subdir,
 			fullyResolvedDest, fullyResolvedIncrementalsDirectory, hlc.Timestamp{},
 			encryption, &kmsEnv, p.User(), true /* includeSkipped */, true, /* includeCompacted */
+			len(explicitIncPaths) > 0,
 		)
 		defer func() {
 			mem.Shrink(ctx, memReserved)

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -552,23 +552,16 @@ func TestShowBackupTenantView(t *testing.T) {
 	showBackupQuery := "SELECT object_name, object_type, rows FROM [SHOW BACKUP FROM LATEST IN $1]"
 	tenant3.Exec(t, dataQuery)
 
-	// First, assert that SHOW BACKUPS on a tenant backup returns the same results if
-	// either the system tenant or tenant3 calls it.
-	tenantAddr, httpServerCleanup := makeInsecureHTTPServer(t)
-	defer httpServerCleanup()
-
-	tenant3.Exec(t, backupQuery, tenantAddr)
-	systemTenantShowRes := systemDB.QueryStr(t, showBackupQuery, tenantAddr)
-	require.Equal(t, systemTenantShowRes, tenant3.QueryStr(t, showBackupQuery, tenantAddr))
+	const collectionURI = "nodelocal://1/backup"
+	tenant3.Exec(t, backupQuery, collectionURI)
+	systemTenantShowRes := systemDB.QueryStr(t, showBackupQuery, collectionURI)
+	require.Equal(t, systemTenantShowRes, tenant3.QueryStr(t, showBackupQuery, collectionURI))
 
 	// If the system tenant created the same data, and conducted the same backup,
 	// the row counts should look the same.
-	systemAddr, httpServerCleanup2 := makeInsecureHTTPServer(t)
-	defer httpServerCleanup2()
-
 	systemDB.Exec(t, dataQuery)
-	systemDB.Exec(t, backupQuery, systemAddr)
-	require.Equal(t, systemTenantShowRes, systemDB.QueryStr(t, showBackupQuery, systemAddr))
+	systemDB.Exec(t, backupQuery, collectionURI)
+	require.Equal(t, systemTenantShowRes, systemDB.QueryStr(t, showBackupQuery, collectionURI))
 }
 
 func TestShowBackupTenants(t *testing.T) {


### PR DESCRIPTION
This commit teaches `ResolveBackupManifests` to use the backup index, which prevents unnecessarily reads of backup manifests that are elided during restore. Since backups that are not indexed are still considered restorable in this version, the legacy path of loading all manifests is still preserved and can be removed in 26.2.

Epic: CRDB-47942

Fixes: #150330, #150331, #150332

Release note: None