### PR TITLE
release-24.3: amazon: add settings to control retry behavior

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_aws_aws_sdk_go_v2//aws",
+        "@com_github_aws_aws_sdk_go_v2//aws/ratelimit",
         "@com_github_aws_aws_sdk_go_v2//aws/retry",
         "@com_github_aws_aws_sdk_go_v2//aws/transport/http",
         "@com_github_aws_aws_sdk_go_v2_config//:config",

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -489,7 +489,8 @@ func TestPutS3Endpoint(t *testing.T) {
 		testSettings := cluster.MakeTestingClusterSettings()
 		clientFactory := blobs.TestBlobServiceClient("")
 		// Force to fail quickly.
-		InjectTestingRetryMaxAttempts(1)
+
+		maxRetries.Override(ctx, &testSettings.SV, 1)
 		storage, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory,
 			nil, nil, cloud.NilMetrics)
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #151817.

/cc @cockroachdb/release

Release justification: Adds a setting `cloudstorage.s3.client_retry_token_bucket.enabled` which can be set to false to mitigate an issue impacting backups on large AWS clusters.

---

This change adds two settings to control the S3 client retry behavior:
1. `cloudstorage.s3.max_retries`: this replaces a constant that was hardcoded to 10. It controls how many times the s3 client will retry an error.
2. `cloudstorage.s3.client_retry_token_bucket.enabled`: this disables the client retry token bucket. The token bucket has no time based refill, and can only refill when new operations are started, so it can get stuck in an empty state with fixed concurrency operations like backup and restore.

There is also a minor improvement to verbose logging in the S3 client:
* --vmodule=s3_storage=1 will enable retry logging and deprecation
	warnings.
* --vmodule=s3_storage=2 logs requests and responses.
* --vmodule=s3_storage=3 logs headers+bodies of messages.

Informs: #151748
Release note: Tunes S3 client retry behavior to be more reliable in the presence of correlated errors.