### PR TITLE
server: Filter high contention insights in ListExecutionInsights

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -555,6 +555,8 @@ go_test(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/contention",
+        "//pkg/sql/contentionpb",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
         "//pkg/sql/pgwire",

--- a/pkg/sql/contention/registry.go
+++ b/pkg/sql/contention/registry.go
@@ -256,6 +256,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) {
 func (r *Registry) AddContentionEvent(event contentionpb.ExtendedContentionEvent) {
 	r.globalLock.Lock()
 	defer r.globalLock.Unlock()
+
 	if event.ContentionType == contentionpb.ContentionType_LOCK_WAIT {
 		// (xinhaoz) We will need to change the indexMap structs if we want to surface
 		// non lock wait related contention to index contention surfaces.
@@ -286,6 +287,12 @@ func (r *Registry) AddContentionEvent(event contentionpb.ExtendedContentionEvent
 	}
 
 	r.eventStore.addEvent(event)
+}
+
+// AddEventsForTest is a convenience function used by tests to directly add events to
+// the underlying eventStore.
+func (r *Registry) AddEventsForTest(events []contentionpb.ExtendedContentionEvent) {
+	r.eventStore.addEventsForTest(events)
 }
 
 // ForEachEvent implements the eventReader interface.


### PR DESCRIPTION
Previously high contention insights included in the ListExecutionInsights response often did not have their respective contention events available in the contention events registry. This led to confusion when viewing an insight execution overview page since the table displaying the contention events for the execution would often be empty.

This commit fixes this behaviour by ensuring that any high contention insights are only included in the ListExecutionInsights response if they have at least one valid contention event available in the contention event registry.

A contention event is valid if the blocking transaction fingerprint ID (i.e. the column of most interest in the UI table) is resolved.

Fixes: https://cockroachlabs.atlassian.net/browse/CRDB-53271
Release note: None