### PR TITLE
optbuilder: gate crdb_internal builtins from unauthorized access

### DIFF
--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -101,6 +101,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
+        "//pkg/sql/unsafesql",
         "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/errorutil",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -465,10 +465,14 @@ func MakeTestingEvalContext(st *cluster.Settings) Context {
 // MemoryMonitor. Ownership of the memory monitor is transferred to the
 // EvalContext so do not start or close the memory monitor.
 func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonitor) Context {
+	sessionData := &sessiondata.SessionData{}
+	// Set defaults that match what the session variables system expects.
+	// allow_unsafe_internals defaults to true.
+	sessionData.AllowUnsafeInternals = true
 	ctx := Context{
 		Codec:            keys.SystemSQLCodec,
 		Txn:              &kv.Txn{},
-		SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
+		SessionDataStack: sessiondata.NewStack(sessionData),
 		Settings:         st,
 		NodeID:           base.TestingIDContainer,
 	}


### PR DESCRIPTION
The epic below outlines a set of work to prevent users from unauthorized
access to what we deem unsafe internals. These unsafe internals lie
mostly in the crdb_internal schema and the system database. This PR
makes it so crdb_internal builtins are disallowed from external use
unless the specified override is enabled.

Fixes: #151501
Epic: CRDB-24527
Release note (ops change): restricts access to all crdb_internal builtins
unless session variable `allow_unsafe_internals` is set to true, or if
the caller is internal.