### PR TITLE
logictest: skip distsql_stats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1,6 +1,6 @@
 # LogicTest: 5node
 
-skip under race
+skip #151839
 
 # Disable histogram collection.
 statement ok


### PR DESCRIPTION
This test is flaky.
https://github.com/cockroachdb/cockroach/issues/151839#issuecomment-3189582222

Informs: #151839
Release note: None