### PR TITLE
catalog/lease: handle errRenewLease in purgeOldVersions

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_version_state.go
+++ b/pkg/sql/catalog/lease/descriptor_version_state.go
@@ -138,6 +138,11 @@ func (s *descriptorVersionState) hasExpired(ctx context.Context, timestamp hlc.T
 	return s.getExpiration(ctx).LessEq(timestamp)
 }
 
+// hasFixedExpiration returns if the descriptor has a fixed expiration.
+func (s *descriptorVersionState) hasFixedExpiration() bool {
+	return s.expiration.Load() != nil
+}
+
 func (s *descriptorVersionState) incRefCount(ctx context.Context, expensiveLogEnabled bool) {
 	s.refcount.Add(1)
 	if expensiveLogEnabled {

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -208,8 +208,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatalf("found %d versions instead of 2", numLeases)
 	}
 	ctx := context.Background()
-	if err := purgeOldVersions(
-		ctx, kvDB, tableDesc.GetID(), false, 2 /* minVersion */, leaseManager); err != nil {
+	if err := leaseManager.purgeOldVersions(
+		ctx, kvDB, tableDesc.GetID(), false, 2 /* minVersion */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -241,8 +241,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	if numLeases := getNumVersions(ts); numLeases != 2 {
 		t.Fatalf("found %d versions instead of 2", numLeases)
 	}
-	if err := purgeOldVersions(
-		context.Background(), kvDB, tableDesc.GetID(), false, 2 /* minVersion */, leaseManager); err != nil {
+	if err := leaseManager.purgeOldVersions(
+		context.Background(), kvDB, tableDesc.GetID(), false, 2 /* minVersion */); err != nil {
 		t.Fatal(err)
 	}
 	if numLeases := getNumVersions(ts); numLeases != 1 {
@@ -347,7 +347,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	// Purge old versions and make sure that the newest lease survives the
 	// purge.
-	if err := purgeOldVersions(ctx, kvDB, tableDesc.GetID(), false, 2 /* minVersion */, leaseManager); err != nil {
+	if err := leaseManager.purgeOldVersions(ctx, kvDB, tableDesc.GetID(), false, 2 /* minVersion */); err != nil {
 		t.Fatal(err)
 	}
 	if numLeases := getNumVersions(ts); numLeases != 1 {


### PR DESCRIPTION
Previously, when purge old versions attempted to acquire a lease on the newest version of a descriptor it was possible that a errRenewLease could be hit. This would happen if we weren't able to referesh the sqlliveness sessions fast enough and descriptors never being cleaned up from the system.lease table. To address this, this patch adds defensive code to clean up all leases in storge if this happens. It also fixes incorrect handling of inative descriptors that could lead to leaked descriptors.

Fixes: #151656

Release note: None