### PR TITLE
kvcoord: avoid piggybacking on any early-returning batch

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1897,8 +1897,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 		}
 	}()
 
-	canParallelize := ba.Header.MaxSpanRequestKeys == 0 && ba.Header.TargetBytes == 0 &&
-		!ba.Header.ReturnElasticCPUResumeSpans
+	canParallelize := !ba.MightStopEarly()
 	if ba.IsSingleCheckConsistencyRequest() {
 		// Don't parallelize full checksum requests as they have to touch the
 		// entirety of each replica of each range they touch.
@@ -2002,9 +2001,8 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 				ba.UpdateTxn(resp.reply.Txn)
 			}
 
-			mightStopEarly := ba.MaxSpanRequestKeys > 0 || ba.TargetBytes > 0 || ba.ReturnElasticCPUResumeSpans
 			// Check whether we've received enough responses to exit query loop.
-			if mightStopEarly {
+			if ba.MightStopEarly() {
 				var replyKeys int64
 				var replyBytes int64
 				for _, r := range resp.reply.Responses {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -1515,10 +1515,10 @@ func (rr requestRecord) toResp(
 		// a lock, we add it to the buffer since we may need to flush it as
 		// replicated lock.
 		if rr.transformed {
-
 			transformedGetResponse := br.GetInner().(*kvpb.GetResponse)
 			valueWasPresent := transformedGetResponse.Value.IsPresent()
-			lockShouldHaveBeenAcquired := valueWasPresent || req.LockNonExisting
+			lockShouldHaveBeenAcquired := (valueWasPresent || req.LockNonExisting) &&
+				transformedGetResponse.ResumeSpan == nil
 
 			if lockShouldHaveBeenAcquired {
 				dla := &bufferedDurableLockAcquisition{

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -957,6 +957,14 @@ func (ba *BatchRequest) ValidateForEvaluation() error {
 	return nil
 }
 
+// MightStopEarly returns true if any of the batch's options might result in the
+// batch response being returned before all requests have been fully processed
+// without an error.
+func (ba *BatchRequest) MightStopEarly() bool {
+	h := ba.Header
+	return h.MaxSpanRequestKeys != 0 || h.TargetBytes != 0 || h.ReturnElasticCPUResumeSpans
+}
+
 func (cb ColBatches) Size() int {
 	var size int
 	for _, b := range cb.ColBatches {


### PR DESCRIPTION
To reduce the number of batches, we'd _like_ to piggy-back our buffer
flush on the user-provided batch. But, in some cases this is problematic
as the user may have set options on the batch that can result in the
batch being incompletely processed. Here, we check for those options and
flush the buffer via a sanitized batch before processing the user's
batch.

In a follow-up, we may also _always_ use a separate batch for midTxn
flushes to avoid nearly all read-write batches.

Epic: None
Release note: None