### PR TITLE
build/github: fix processing of BES files

### DIFF
--- a/build/github/summarize-build.sh
+++ b/build/github/summarize-build.sh
@@ -16,6 +16,10 @@ then
     exit 0
 fi
 
+file $1
+du -sh $1
+ls -althr $1
+
 THIS_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
 if [ ! -f _bazel/bin/pkg/cmd/bazci/bazel-github-helper/bazel-github-helper_/bazel-github-helper ]

--- a/pkg/build/engflow/engflow.go
+++ b/pkg/build/engflow/engflow.go
@@ -25,6 +25,7 @@ import (
 	bazelutil "github.com/cockroachdb/cockroach/pkg/build/util"
 	"github.com/cockroachdb/cockroach/pkg/cmd/bazci/githubpost"
 	"github.com/cockroachdb/cockroach/pkg/cmd/bazci/githubpost/issues"
+
 	//lint:ignore SA1019 grandfathered
 	gproto "github.com/golang/protobuf/proto"
 	"golang.org/x/net/http2"
@@ -114,10 +115,13 @@ func getHttpClient(certFile, keyFile string) (*http.Client, error) {
 func downloadFile(client *http.Client, uri string) (string, error) {
 	url := strings.ReplaceAll(uri, "bytestream://", "https://")
 	url = strings.ReplaceAll(url, "/blobs/", "/api/v0/blob/")
+	fmt.Fprintln(os.Stderr, "downloading file:", url)
 	resp, err := client.Get(url)
 	if err != nil {
 		return "", err
 	}
+	fmt.Fprintln(os.Stderr, "file download status:", resp.StatusCode)
+
 	defer func() { _ = resp.Body.Close() }()
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
After the switch to Okta for mesolite access, processing of the bes files began failing.

Epic: none
Release note: None