### PR TITLE
roachprod: add roachprod as a key name

### DIFF
--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -196,7 +196,11 @@ var DefaultPubKeyNames = []string{
 	"id_ed25519",
 	"id_ed25519_sk",
 	"id_dsa",
+
+	// Cockroach additions
 	"google_compute_engine",
+	"Roachprod",
+	"roachprod",
 }
 
 // SSHPublicKeyPath returns the path to the default public key expected by


### PR DESCRIPTION
roachprod uses this list to look for a public SSH key under $HOME/.ssh.
1Password handily manages single-purpose SSH keys. This change makes
keys exported from there discoverable.

Epic: none

Release note: None
