### PR TITLE
changefeedccl/schemafeed: add verbose logging to table event filter

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6253,6 +6253,8 @@ func TestChangefeedTruncateOrDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	require.NoError(t, log.SetVModule("table_event_filter=2"))
+
 	assertFailuresCounter := func(t *testing.T, m *Metrics, exp int64) {
 		t.Helper()
 		// If this changefeed is running as a job, we anticipate that it will move

--- a/pkg/sql/catalog/tabledesc/safe_format.go
+++ b/pkg/sql/catalog/tabledesc/safe_format.go
@@ -42,6 +42,9 @@ func formatSafeTableProperties(w *redact.StringBuilder, desc catalog.TableDescri
 	if desc.IsVirtualTable() {
 		w.Printf(", Virtual: true")
 	}
+	if desc.IsSchemaLocked() {
+		w.Printf(", SchemaLocked: true")
+	}
 	formatSafeTableColumns(w, desc)
 	formatSafeTableColumnFamilies(w, desc)
 	formatSafeTableMutationJobs(w, desc)


### PR DESCRIPTION
Informs #151523

---

**tabledesc: include SchemaLocked in safe string representation** 

Release note: None

---

**changefeedccl/schemafeed: add verbose logging to table event filter**

This patch adds some verbose logging to the schema feed table event
filter to make it easier to debug missing schema feed events.

Release note: None