### PR TITLE
storage, fs: move pebble cluster version compat check to InitEnv

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -247,6 +247,7 @@ func TestPebbleEncryption(t *testing.T) {
 
 	func() {
 		// Initialize the filesystem env.
+		settings := cluster.MakeTestingClusterSettings()
 		env, err := fs.InitEnvFromStoreSpec(
 			ctx,
 			base.StoreSpec{
@@ -255,12 +256,15 @@ func TestPebbleEncryption(t *testing.T) {
 				EncryptionOptions: encOptions,
 				StickyVFSID:       stickyVFSID,
 			},
-			fs.ReadWrite,
+			fs.EnvConfig{
+				RW:      fs.ReadWrite,
+				Version: settings.Version,
+			},
 			stickyRegistry, /* sticky registry */
 			nil,            /* statsCollector */
 		)
 		require.NoError(t, err)
-		db, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings())
+		db, err := storage.Open(ctx, env, settings)
 		require.NoError(t, err)
 		defer db.Close()
 
@@ -295,6 +299,7 @@ func TestPebbleEncryption(t *testing.T) {
 
 	func() {
 		// Initialize the filesystem env again, replaying the file registries.
+		settings := cluster.MakeTestingClusterSettings()
 		env, err := fs.InitEnvFromStoreSpec(
 			ctx,
 			base.StoreSpec{
@@ -303,12 +308,15 @@ func TestPebbleEncryption(t *testing.T) {
 				EncryptionOptions: encOptions,
 				StickyVFSID:       stickyVFSID,
 			},
-			fs.ReadWrite,
+			fs.EnvConfig{
+				RW:      fs.ReadWrite,
+				Version: settings.Version,
+			},
 			stickyRegistry, /* sticky registry */
 			nil,            /* statsCollector */
 		)
 		require.NoError(t, err)
-		db, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings())
+		db, err := storage.Open(ctx, env, settings)
 		require.NoError(t, err)
 		defer db.Close()
 		require.Equal(t, []byte("a"), storageutils.MVCCGetRaw(t, db, storageutils.PointKey("a", 0)))
@@ -382,6 +390,7 @@ func TestPebbleEncryption2(t *testing.T) {
 
 		// Initialize the filesystem env.
 		ctx := context.Background()
+		settings := cluster.MakeTestingClusterSettings()
 		env, err := fs.InitEnvFromStoreSpec(
 			ctx,
 			base.StoreSpec{
@@ -390,12 +399,15 @@ func TestPebbleEncryption2(t *testing.T) {
 				EncryptionOptions: encOptions,
 				StickyVFSID:       stickyVFSID,
 			},
-			fs.ReadWrite,
+			fs.EnvConfig{
+				RW:      fs.ReadWrite,
+				Version: settings.Version,
+			},
 			stickyRegistry, /* sticky registry */
 			nil,            /* statsCollector */
 		)
 		require.NoError(t, err)
-		db, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings())
+		db, err := storage.Open(ctx, env, settings)
 		require.NoError(t, err)
 		defer db.Close()
 

--- a/pkg/cli/auto_decrypt_fs_test.go
+++ b/pkg/cli/auto_decrypt_fs_test.go
@@ -72,11 +72,13 @@ func TestAutoDecryptFS(t *testing.T) {
 	expected := `
 $TMPDIR/path1: mkdir-all:  0777
 $TMPDIR/path1: lock: LOCK
+$TMPDIR/path1: open: STORAGE_MIN_VERSION
 $TMPDIR/path1: mkdir-all: $TMPDIR/path1 0755
 $TMPDIR/path1: create: $TMPDIR/path1/bar
 $TMPDIR/path1: close: $TMPDIR/path1/bar
 $TMPDIR/foo/path2: mkdir-all:  0777
 $TMPDIR/foo/path2: lock: LOCK
+$TMPDIR/foo/path2: open: STORAGE_MIN_VERSION
 $TMPDIR/foo/path2: mkdir-all: $TMPDIR/foo/path2 0755
 $TMPDIR/foo/path2: create: $TMPDIR/foo/path2/baz
 $TMPDIR/foo/path2: close: $TMPDIR/foo/path2/baz

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -163,7 +163,7 @@ func (f *keyFormat) Type() string {
 // engine, they should manually open it using storage.Open. The returned Env has
 // 1 reference and the caller must ensure it's closed.
 func OpenFilesystemEnv(dir string, rw fs.RWMode) (*fs.Env, error) {
-	envConfig := fs.EnvConfig{RW: rw}
+	envConfig := fs.EnvConfig{RW: rw, Version: serverCfg.Settings.Version}
 	if err := fillEncryptionOptionsForStore(dir, &envConfig); err != nil {
 		return nil, err
 	}
@@ -1743,7 +1743,9 @@ func pebbleCryptoInitializer(ctx context.Context) {
 		encryptedPaths = append(encryptedPaths, spec.Path)
 	}
 	resolveFn := func(dir string) (*fs.Env, error) {
-		var envConfig fs.EnvConfig
+		envConfig := fs.EnvConfig{
+			Version: serverCfg.Settings.Version,
+		}
 		if err := fillEncryptionOptionsForStore(dir, &envConfig); err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -281,6 +281,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/ttl/ttlbase",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/fingerprintutils",
         "//pkg/testutils/floatcmp",

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -280,7 +280,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/ttl/ttlbase",
-        "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/fingerprintutils",

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/storage/minversion"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -281,7 +281,7 @@ func makeVersionFixtureAndFatal(
 	// #54761.
 	c.Run(ctx, option.WithNodes(c.Node(1)), "cp", "{store-dir}/cluster-bootstrapped", "{store-dir}/"+name)
 	// Similar to the above - newer versions require the min version file to open a store.
-	c.Run(ctx, option.WithNodes(c.All()), "cp", fmt.Sprintf("{store-dir}/%s", minversion.MinVersionFilename), "{store-dir}/"+name)
+	c.Run(ctx, option.WithNodes(c.All()), "cp", fmt.Sprintf("{store-dir}/%s", fs.MinVersionFilename), "{store-dir}/"+name)
 	c.Run(ctx, option.WithNodes(c.All()), "tar", "-C", "{store-dir}/"+name, "-czf", "{log-dir}/"+name+".tgz", ".")
 	t.Fatalf(`successfully created checkpoints; failing test on purpose.
 

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/minversion"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -281,7 +281,7 @@ func makeVersionFixtureAndFatal(
 	// #54761.
 	c.Run(ctx, option.WithNodes(c.Node(1)), "cp", "{store-dir}/cluster-bootstrapped", "{store-dir}/"+name)
 	// Similar to the above - newer versions require the min version file to open a store.
-	c.Run(ctx, option.WithNodes(c.All()), "cp", fmt.Sprintf("{store-dir}/%s", storage.MinVersionFilename), "{store-dir}/"+name)
+	c.Run(ctx, option.WithNodes(c.All()), "cp", fmt.Sprintf("{store-dir}/%s", minversion.MinVersionFilename), "{store-dir}/"+name)
 	c.Run(ctx, option.WithNodes(c.All()), "tar", "-C", "{store-dir}/"+name, "-czf", "{log-dir}/"+name+".tgz", ".")
 	t.Fatalf(`successfully created checkpoints; failing test on purpose.
 

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -100,7 +100,10 @@ func verifyStatsOnServers(
 		// To recompute the metrics, we need an open engine. Open the
 		// Engine again in read-only mode (leaving the rest of the
 		// Server stopped) to compute MVCC stats.
-		env, err := fs.InitEnvFromStoreSpec(ctx, specs[storeIdx], fs.ReadOnly, stickyRegistry, nil /* statsCollector */)
+		env, err := fs.InitEnvFromStoreSpec(ctx, specs[storeIdx], fs.EnvConfig{
+			RW:      fs.ReadOnly,
+			Version: s.GetStoreConfig().Settings.Version,
+		}, stickyRegistry, nil /* statsCollector */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -407,9 +407,10 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		// VFS to verify its contents.
 		ctx := context.Background()
 		memFS := stickyVFSRegistry.Get(vfsIDs[i])
-		env, err := fs.InitEnv(ctx, memFS, cps[0], fs.EnvConfig{RW: fs.ReadOnly}, nil /* statsCollector */)
+		settings := cluster.MakeClusterSettings()
+		env, err := fs.InitEnv(ctx, memFS, cps[0], fs.EnvConfig{RW: fs.ReadOnly, Version: settings.Version}, nil /* statsCollector */)
 		require.NoError(t, err)
-		cpEng, err := storage.Open(ctx, env, cluster.MakeClusterSettings(),
+		cpEng, err := storage.Open(ctx, env, settings,
 			storage.ForTesting, storage.MustExist, storage.CacheSize(1<<20))
 		if err != nil {
 			require.NoError(t, err)

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -575,9 +575,12 @@ func TestSideloadStorageSync(t *testing.T) {
 		// able to emulate crash restart by rolling it back to last synced state.
 		ctx := context.Background()
 		memFS := vfs.NewCrashableMem()
-		env, err := fs.InitEnv(ctx, memFS, "", fs.EnvConfig{}, nil /* statsCollector */)
+		settings := cluster.MakeTestingClusterSettings()
+		env, err := fs.InitEnv(ctx, memFS, "", fs.EnvConfig{
+			Version: settings.Version,
+		}, nil /* statsCollector */)
 		require.NoError(t, err)
-		eng, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings(), storage.ForTesting)
+		eng, err := storage.Open(ctx, env, settings, storage.ForTesting)
 		require.NoError(t, err)
 		ss := newTestingSideloadStorage(eng)
 
@@ -595,9 +598,11 @@ func TestSideloadStorageSync(t *testing.T) {
 		// Reset filesystem to the last synced state.
 
 		// Emulate process restart. Load from the last synced state.
-		env, err = fs.InitEnv(ctx, crashFS, "", fs.EnvConfig{}, nil /* statsCollector */)
+		env, err = fs.InitEnv(ctx, crashFS, "", fs.EnvConfig{
+			Version: settings.Version,
+		}, nil /* statsCollector */)
 		require.NoError(t, err)
-		eng, err = storage.Open(ctx, env, cluster.MakeTestingClusterSettings(), storage.ForTesting)
+		eng, err = storage.Open(ctx, env, settings, storage.ForTesting)
 		require.NoError(t, err)
 		defer eng.Close()
 		ss = newTestingSideloadStorage(eng)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -764,7 +764,10 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 		stickyRegistry = serverKnobs.StickyVFSRegistry
 	}
 
-	storeEnvs, err := fs.InitEnvsFromStoreSpecs(ctx, cfg.Stores.Specs, fs.ReadWrite, stickyRegistry, cfg.DiskWriteStats)
+	storeEnvs, err := fs.InitEnvsFromStoreSpecs(ctx, cfg.Stores.Specs, fs.EnvConfig{
+		RW:      fs.ReadWrite,
+		Version: cfg.Settings.Version,
+	}, stickyRegistry, cfg.DiskWriteStats)
 	if err != nil {
 		return Engines{}, err
 	}

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -142,10 +142,13 @@ func buildInitialState(
 		// or not, we build the conditions using an in-memory engine for
 		// performance.
 		buildFS = vfs.NewMem()
-		env, err := fs.InitEnv(ctx, buildFS, "", fs.EnvConfig{}, nil /* statsCollector */)
+		settings := cluster.MakeClusterSettings()
+		env, err := fs.InitEnv(ctx, buildFS, "", fs.EnvConfig{
+			Version: settings.Version,
+		}, nil /* statsCollector */)
 		require.NoError(b, err)
 
-		e, err := Open(ctx, env, cluster.MakeClusterSettings(), opts...)
+		e, err := Open(ctx, env, settings, opts...)
 		require.NoError(b, err)
 		require.NoError(b, initial.Build(ctx, b, e))
 		e.Close()

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1072,7 +1072,10 @@ func TestCreateCheckpoint(t *testing.T) {
 }
 
 func mustInitTestEnv(t testing.TB, baseFS vfs.FS, dir string) *fs.Env {
-	e, err := fs.InitEnv(context.Background(), baseFS, dir, fs.EnvConfig{}, nil /* statsCollector */)
+	settings := cluster.MakeTestingClusterSettings()
+	e, err := fs.InitEnv(context.Background(), baseFS, dir, fs.EnvConfig{
+		Version: settings.Version,
+	}, nil /* statsCollector */)
 	require.NoError(t, err)
 	return e
 }

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -17,8 +17,10 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",
+        "//pkg/clusterversion",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",
         "//pkg/storage/storageconfig",

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "encryption_at_rest.go",
         "file_registry.go",
         "fs.go",
+        "min_version.go",
         "sticky_vfs.go",
         "temp_dir.go",
         "test_utils.go",
@@ -16,6 +17,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",
+        "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",

--- a/pkg/storage/fs/file_registry_test.go
+++ b/pkg/storage/fs/file_registry_test.go
@@ -752,3 +752,47 @@ func TestFileRegistryBlockedWriteAllowsRead(t *testing.T) {
 	fs.WaitForBlockAndUnblock()
 	require.NoError(t, registry.Close())
 }
+
+func TestSafeWriteToUnencryptedFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Use an in-memory FS that strictly enforces syncs.
+	mem := vfs.NewCrashableMem()
+	syncDir := func(dir string) {
+		fdir, err := mem.OpenDir(dir)
+		require.NoError(t, err)
+		require.NoError(t, fdir.Sync())
+		require.NoError(t, fdir.Close())
+	}
+	readFile := func(mem *vfs.MemFS, filename string) []byte {
+		f, err := mem.Open("foo/bar")
+		require.NoError(t, err)
+		b, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		return b
+	}
+
+	require.NoError(t, mem.MkdirAll("foo", os.ModePerm))
+	syncDir("")
+	f, err := mem.Create("foo/bar", UnspecifiedWriteCategory)
+	require.NoError(t, err)
+	_, err = io.WriteString(f, "Hello world")
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+	require.NoError(t, f.Close())
+	syncDir("foo")
+
+	// Discard any unsynced writes to make sure we set up the test
+	// preconditions correctly.
+	crashFS := mem.CrashClone(vfs.CrashCloneCfg{})
+	require.Equal(t, []byte("Hello world"), readFile(crashFS, "foo/bar"))
+
+	// Use SafeWriteToUnencryptedFile to atomically, durably change the contents of the
+	// file.
+	require.NoError(t, SafeWriteToUnencryptedFile(crashFS, "foo", "foo/bar", []byte("Hello everyone"), UnspecifiedWriteCategory))
+
+	// Discard any unsynced writes.
+	crashFS = crashFS.CrashClone(vfs.CrashCloneCfg{})
+	require.Equal(t, []byte("Hello everyone"), readFile(crashFS, "foo/bar"))
+}

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/disk"
-	"github.com/cockroachdb/cockroach/pkg/storage/minversion"
 	"github.com/cockroachdb/cockroach/pkg/storage/storageconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -204,6 +203,54 @@ func InitEnv(
 		return nil, err
 	}
 
+	// Read the current store cluster version.
+	storeClusterVersion, minVerFileExists, err := GetMinVersion(e.UnencryptedFS, e.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if minVerFileExists {
+		v := cfg.Version
+		if v == nil {
+			return nil, errors.New("version must not be nil when min-version file exists")
+		}
+		// Avoid running a binary too new for this store. This is what you'd catch
+		// if, say, you restarted directly from v21.2 into v22.2 (bumping the min
+		// version) without going through v22.1 first.
+		//
+		// Note that "going through" above means that v22.1 successfully upgrades
+		// all existing stores. If v22.1 crashes half-way through the startup
+		// sequence (so now some stores have v21.2, but others v22.1) you are
+		// expected to run v22.1 again (hopefully without the crash this time) which
+		// would then rewrite all the stores.
+		if storeClusterVersion.Less(v.MinSupportedVersion()) {
+			if storeClusterVersion.Major < clusterversion.DevOffset && v.LatestVersion().Major >= clusterversion.DevOffset {
+				return nil, errors.Errorf(
+					"store last used with cockroach non-development version v%s "+
+						"cannot be opened by development version v%s",
+					storeClusterVersion, v.LatestVersion(),
+				)
+			}
+			return nil, errors.Errorf(
+				"store last used with cockroach version v%s "+
+					"is too old for running version v%s (which requires data from v%s or later)",
+				storeClusterVersion, v.LatestVersion(), v.MinSupportedVersion(),
+			)
+		}
+
+		// Avoid running a binary too old for this store. This protects against
+		// scenarios where an older binary attempts to open a store created by
+		// a newer version that may have incompatible data structures or formats.
+		if v.LatestVersion().Less(storeClusterVersion) {
+			return nil, errors.Errorf(
+				"store last used with cockroach version v%s is too high for running "+
+					"version v%s",
+				storeClusterVersion, v.LatestVersion(),
+			)
+		}
+		e.StoreClusterVersion = storeClusterVersion
+	}
+
 	// Validate and configure encryption-at-rest. If no encryption-at-rest
 	// configuration was provided, resolveEncryptedEnvOptions will validate that
 	// there is no file registry.
@@ -240,6 +287,11 @@ type Env struct {
 	// Encryption is non-nil if encryption-at-rest has ever been enabled on
 	// the store. It provides access to encryption-at-rest stats, etc.
 	Encryption *EncryptionEnv
+
+	// StoreClusterVersion is the version of the store as read from the
+	// min-version file. This value will be empty if the min-version file
+	// does not exist (eg, the store is being created for the first time).
+	StoreClusterVersion roachpb.Version
 
 	// defaultFS is the primary VFS that most users should use. If
 	// encryption-at-rest is enabled, this VFS will handle transparently

--- a/pkg/storage/fs/min_version.go
+++ b/pkg/storage/fs/min_version.go
@@ -1,0 +1,68 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package fs
+
+import (
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// MinVersionFilename is the name of the file containing a marshaled
+// roachpb.Version that can be updated during storage-related migrations
+// and checked on startup to determine if we can safely use a
+// backwards-incompatible feature.
+const MinVersionFilename = "STORAGE_MIN_VERSION"
+
+// MinVersionIsAtLeastTargetVersion returns whether the min version recorded
+// on disk is at least the target version.
+func MinVersionIsAtLeastTargetVersion(
+	atomicRenameFS vfs.FS, dir string, target roachpb.Version,
+) (bool, error) {
+	// TODO(jackson): Assert that atomicRenameFS supports atomic renames
+	// once Pebble is bumped to the appropriate SHA.
+	if target == (roachpb.Version{}) {
+		return false, errors.New("target version should not be empty")
+	}
+	minVersion, ok, err := GetMinVersion(atomicRenameFS, dir)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	return !minVersion.Less(target), nil
+}
+
+// GetMinVersion returns the min version recorded on disk. If the min version
+// file doesn't exist, returns ok=false.
+func GetMinVersion(atomicRenameFS vfs.FS, dir string) (_ roachpb.Version, ok bool, _ error) {
+	// TODO(jackson): Assert that atomicRenameFS supports atomic renames
+	// once Pebble is bumped to the appropriate SHA.
+
+	filename := atomicRenameFS.PathJoin(dir, MinVersionFilename)
+	f, err := atomicRenameFS.Open(filename)
+	if oserror.IsNotExist(err) {
+		return roachpb.Version{}, false, nil
+	}
+	if err != nil {
+		return roachpb.Version{}, false, err
+	}
+	defer f.Close()
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return roachpb.Version{}, false, err
+	}
+	version := roachpb.Version{}
+	if err := protoutil.Unmarshal(b, &version); err != nil {
+		return roachpb.Version{}, false, err
+	}
+	return version, true, nil
+}

--- a/pkg/storage/fs/sticky_vfs_test.go
+++ b/pkg/storage/fs/sticky_vfs_test.go
@@ -36,7 +36,10 @@ func TestStickyVFS(t *testing.T) {
 		Size:        storageconfig.Size{Bytes: storeSize},
 	}
 	fs1 := registry.Get(spec1.StickyVFSID)
-	env, err := fs.InitEnvFromStoreSpec(ctx, spec1, fs.ReadWrite, registry, nil /* statsCollector */)
+	env, err := fs.InitEnvFromStoreSpec(ctx, spec1, fs.EnvConfig{
+		RW:      fs.ReadWrite,
+		Version: settings.Version,
+	}, registry, nil /* statsCollector */)
 	require.NoError(t, err)
 	engine1, err := storage.Open(ctx, env, settings)
 	require.NoError(t, err)
@@ -48,7 +51,10 @@ func TestStickyVFS(t *testing.T) {
 	// Refetching the engine should give back a different engine with the same
 	// underlying fs.
 	fs3 := registry.Get(spec1.StickyVFSID)
-	env, err = fs.InitEnvFromStoreSpec(ctx, spec1, fs.ReadWrite, registry, nil /* statsCollector */)
+	env, err = fs.InitEnvFromStoreSpec(ctx, spec1, fs.EnvConfig{
+		RW:      fs.ReadWrite,
+		Version: settings.Version,
+	}, registry, nil /* statsCollector */)
 	require.NoError(t, err)
 	engine2, err := storage.Open(ctx, env, settings)
 	require.NoError(t, err)

--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -36,7 +36,10 @@ type engineConfig struct {
 }
 
 func (e *engineConfig) create(path string, baseFS vfs.FS) (storage.Engine, error) {
-	env, err := fs.InitEnv(context.Background(), baseFS, path, fs.EnvConfig{}, nil /* diskWriteStats */)
+	settings := cluster.MakeTestingClusterSettings()
+	env, err := fs.InitEnv(context.Background(), baseFS, path, fs.EnvConfig{
+		Version: settings.Version,
+	}, nil /* diskWriteStats */)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +50,7 @@ func (e *engineConfig) create(path string, baseFS vfs.FS) (storage.Engine, error
 	if e.opts != nil {
 		configOpts = append(configOpts, storage.PebbleOptions(e.opts.String(), parseHooks))
 	}
-	eng, err := storage.Open(context.Background(), env, cluster.MakeTestingClusterSettings(), configOpts...)
+	eng, err := storage.Open(context.Background(), env, settings, configOpts...)
 	if err != nil {
 		env.Close()
 		return nil, err

--- a/pkg/storage/min_version.go
+++ b/pkg/storage/min_version.go
@@ -6,22 +6,12 @@
 package storage
 
 import (
-	"bytes"
-	"io"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/vfs"
 )
-
-// MinVersionFilename is the name of the file containing a marshaled
-// roachpb.Version that can be updated during storage-related migrations
-// and checked on startup to determine if we can safely use a
-// backwards-incompatible feature.
-const MinVersionFilename = "STORAGE_MIN_VERSION"
 
 // writeMinVersionFile writes the provided version to disk. The caller must
 // guarantee that the version will never be downgraded below the given version.
@@ -31,7 +21,7 @@ func writeMinVersionFile(atomicRenameFS vfs.FS, dir string, version roachpb.Vers
 	if version == (roachpb.Version{}) {
 		return errors.New("min version should not be empty")
 	}
-	ok, err := MinVersionIsAtLeastTargetVersion(atomicRenameFS, dir, version)
+	ok, err := fs.MinVersionIsAtLeastTargetVersion(atomicRenameFS, dir, version)
 	if err != nil {
 		return err
 	}
@@ -42,96 +32,9 @@ func writeMinVersionFile(atomicRenameFS vfs.FS, dir string, version roachpb.Vers
 	if err != nil {
 		return err
 	}
-	filename := atomicRenameFS.PathJoin(dir, MinVersionFilename)
-	if err := safeWriteToUnencryptedFile(atomicRenameFS, dir, filename, b, fs.UnspecifiedWriteCategory); err != nil {
+	filename := atomicRenameFS.PathJoin(dir, fs.MinVersionFilename)
+	if err := fs.SafeWriteToUnencryptedFile(atomicRenameFS, dir, filename, b, fs.UnspecifiedWriteCategory); err != nil {
 		return err
 	}
 	return nil
-}
-
-// MinVersionIsAtLeastTargetVersion returns whether the min version recorded
-// on disk is at least the target version.
-func MinVersionIsAtLeastTargetVersion(
-	atomicRenameFS vfs.FS, dir string, target roachpb.Version,
-) (bool, error) {
-	// TODO(jackson): Assert that atomicRenameFS supports atomic renames
-	// once Pebble is bumped to the appropriate SHA.
-	if target == (roachpb.Version{}) {
-		return false, errors.New("target version should not be empty")
-	}
-	minVersion, ok, err := getMinVersion(atomicRenameFS, dir)
-	if err != nil {
-		return false, err
-	}
-	if !ok {
-		return false, nil
-	}
-	return !minVersion.Less(target), nil
-}
-
-// getMinVersion returns the min version recorded on disk. If the min version
-// file doesn't exist, returns ok=false.
-func getMinVersion(atomicRenameFS vfs.FS, dir string) (_ roachpb.Version, ok bool, _ error) {
-	// TODO(jackson): Assert that atomicRenameFS supports atomic renames
-	// once Pebble is bumped to the appropriate SHA.
-
-	filename := atomicRenameFS.PathJoin(dir, MinVersionFilename)
-	f, err := atomicRenameFS.Open(filename)
-	if oserror.IsNotExist(err) {
-		return roachpb.Version{}, false, nil
-	}
-	if err != nil {
-		return roachpb.Version{}, false, err
-	}
-	defer f.Close()
-	b, err := io.ReadAll(f)
-	if err != nil {
-		return roachpb.Version{}, false, err
-	}
-	version := roachpb.Version{}
-	if err := protoutil.Unmarshal(b, &version); err != nil {
-		return roachpb.Version{}, false, err
-	}
-	return version, true, nil
-}
-
-const tempFileExtension = ".crdbtmp"
-
-// safeWriteToUnencryptedFile writes the byte slice to the filename, contained
-// in dir, using the given fs. It returns after both the file and the containing
-// directory are synced.
-//
-// This function requires that the fs NOT be encrypted, because the
-// encryption-at-rest filesystem does NOT support atomic renames. See
-// pebble/vfs/atomicfs for a mechanism of atomically switching files on
-// encrypted filesystems.
-func safeWriteToUnencryptedFile(
-	fs vfs.FS, dir string, filename string, b []byte, category vfs.DiskWriteCategory,
-) error {
-	tempName := filename + tempFileExtension
-	f, err := fs.Create(tempName, category)
-	if err != nil {
-		return err
-	}
-	bReader := bytes.NewReader(b)
-	if _, err = io.Copy(f, bReader); err != nil {
-		f.Close()
-		return err
-	}
-	if err = f.Sync(); err != nil {
-		f.Close()
-		return err
-	}
-	if err = f.Close(); err != nil {
-		return err
-	}
-	if err = fs.Rename(tempName, filename); err != nil {
-		return err
-	}
-	fdir, err := fs.OpenDir(dir)
-	if err != nil {
-		return err
-	}
-	defer fdir.Close()
-	return fdir.Sync()
 }

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -7,7 +7,6 @@ package storage
 
 import (
 	"context"
-	"io"
 	"os"
 	"testing"
 
@@ -34,16 +33,16 @@ func TestMinVersion(t *testing.T) {
 	require.NoError(t, mem.MkdirAll(dir, os.ModeDir))
 
 	// Expect !ok min version file doesn't exist.
-	v, ok, err := getMinVersion(mem, dir)
+	v, ok, err := fs.GetMinVersion(mem, dir)
 	require.NoError(t, err)
 	require.Equal(t, roachpb.Version{}, v)
 	require.False(t, ok)
 
 	// Expect min version to not be at least any target version.
-	ok, err = MinVersionIsAtLeastTargetVersion(mem, dir, version1)
+	ok, err = fs.MinVersionIsAtLeastTargetVersion(mem, dir, version1)
 	require.NoError(t, err)
 	require.False(t, ok)
-	ok, err = MinVersionIsAtLeastTargetVersion(mem, dir, version2)
+	ok, err = fs.MinVersionIsAtLeastTargetVersion(mem, dir, version2)
 	require.NoError(t, err)
 	require.False(t, ok)
 
@@ -51,16 +50,16 @@ func TestMinVersion(t *testing.T) {
 	require.NoError(t, writeMinVersionFile(mem, dir, version1))
 
 	// Expect min version to be version1.
-	v, ok, err = getMinVersion(mem, dir)
+	v, ok, err = fs.GetMinVersion(mem, dir)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.True(t, version1.Equal(v))
 
 	// Expect min version to be at least version1 but not version2.
-	ok, err = MinVersionIsAtLeastTargetVersion(mem, dir, version1)
+	ok, err = fs.MinVersionIsAtLeastTargetVersion(mem, dir, version1)
 	require.NoError(t, err)
 	require.True(t, ok)
-	ok, err = MinVersionIsAtLeastTargetVersion(mem, dir, version2)
+	ok, err = fs.MinVersionIsAtLeastTargetVersion(mem, dir, version2)
 	require.NoError(t, err)
 	require.False(t, ok)
 
@@ -68,22 +67,22 @@ func TestMinVersion(t *testing.T) {
 	require.NoError(t, writeMinVersionFile(mem, dir, version2))
 
 	// Expect min version to be at least version1 and version2.
-	ok, err = MinVersionIsAtLeastTargetVersion(mem, dir, version1)
+	ok, err = fs.MinVersionIsAtLeastTargetVersion(mem, dir, version1)
 	require.NoError(t, err)
 	require.True(t, ok)
-	ok, err = MinVersionIsAtLeastTargetVersion(mem, dir, version2)
+	ok, err = fs.MinVersionIsAtLeastTargetVersion(mem, dir, version2)
 	require.NoError(t, err)
 	require.True(t, ok)
 
 	// Expect min version to be version2.
-	v, ok, err = getMinVersion(mem, dir)
+	v, ok, err = fs.GetMinVersion(mem, dir)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.True(t, version2.Equal(v))
 
 	// Expect no-op when trying to update min version to a lower version.
 	require.NoError(t, writeMinVersionFile(mem, dir, version1))
-	v, ok, err = getMinVersion(mem, dir)
+	v, ok, err = fs.GetMinVersion(mem, dir)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.True(t, version2.Equal(v))
@@ -131,7 +130,7 @@ func TestMinVersion_IsNotEncrypted(t *testing.T) {
 
 	// Reading the file directly through the unencrypted MemFS should
 	// succeed and yield the correct version.
-	v, ok, err := getMinVersion(env.UnencryptedFS, "")
+	v, ok, err := fs.GetMinVersion(env.UnencryptedFS, "")
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, st.Version.LatestVersion(), v)
@@ -199,48 +198,4 @@ func (f fauxEncryptedFile) ReadAt(p []byte, off int64) (int, error) {
 		p[i] = p[i] - 1
 	}
 	return n, err
-}
-
-func TestSafeWriteToFile(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	// Use an in-memory FS that strictly enforces syncs.
-	mem := vfs.NewCrashableMem()
-	syncDir := func(dir string) {
-		fdir, err := mem.OpenDir(dir)
-		require.NoError(t, err)
-		require.NoError(t, fdir.Sync())
-		require.NoError(t, fdir.Close())
-	}
-	readFile := func(mem *vfs.MemFS, filename string) []byte {
-		f, err := mem.Open("foo/bar")
-		require.NoError(t, err)
-		b, err := io.ReadAll(f)
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-		return b
-	}
-
-	require.NoError(t, mem.MkdirAll("foo", os.ModePerm))
-	syncDir("")
-	f, err := mem.Create("foo/bar", fs.UnspecifiedWriteCategory)
-	require.NoError(t, err)
-	_, err = io.WriteString(f, "Hello world")
-	require.NoError(t, err)
-	require.NoError(t, f.Sync())
-	require.NoError(t, f.Close())
-	syncDir("foo")
-
-	// Discard any unsynced writes to make sure we set up the test
-	// preconditions correctly.
-	crashFS := mem.CrashClone(vfs.CrashCloneCfg{})
-	require.Equal(t, []byte("Hello world"), readFile(crashFS, "foo/bar"))
-
-	// Use SafeWriteToFile to atomically, durably change the contents of the
-	// file.
-	require.NoError(t, safeWriteToUnencryptedFile(crashFS, "foo", "foo/bar", []byte("Hello everyone"), fs.UnspecifiedWriteCategory))
-
-	// Discard any unsynced writes.
-	crashFS = crashFS.CrashClone(vfs.CrashCloneCfg{})
-	require.Equal(t, []byte("Hello everyone"), readFile(crashFS, "foo/bar"))
 }

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -286,6 +286,7 @@ func makeExternalWALDir(
 	env, err := fs.InitEnv(context.Background(), defaultFS, externalDir.Path, fs.EnvConfig{
 		RW:                engineCfg.env.RWMode(),
 		EncryptionOptions: externalDir.Encryption,
+		Version:           engineCfg.settings.Version,
 	}, diskWriteStats)
 	if err != nil {
 		return wal.Dir{}, err

--- a/pkg/storage/open_test.go
+++ b/pkg/storage/open_test.go
@@ -50,10 +50,27 @@ func TestWALFailover(t *testing.T) {
 		return nil
 	}
 
+	var settings *cluster.Settings
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "wal_failover_config"),
 		func(t *testing.T, td *datadriven.TestData) string {
 			switch td.Cmd {
 			case "mkenv":
+				// Mock a cluster version, defaulting to latest.
+				version := clusterversion.Latest.Version()
+				if td.HasArg("min-version") {
+					var major, minor int
+					td.ScanArgs(t, "min-version", &major, &minor)
+					version = roachpb.Version{
+						Major: int32(major),
+						Minor: int32(minor),
+					}
+				}
+				// Match the current offsetting policy.
+				if clusterversion.Latest.Version().Major > clusterversion.DevOffset {
+					version.Major += clusterversion.DevOffset
+				}
+				settings = cluster.MakeTestingClusterSettingsWithVersions(version, version, true /* initializeVersion */)
+
 				dir := td.CmdArgs[0].String()
 				if e := getEnv(dir); e != nil {
 					return fmt.Sprintf("env %s already exists", e.Dir)
@@ -62,6 +79,7 @@ func TestWALFailover(t *testing.T) {
 				require.NoError(t, memfs.MkdirAll(dir, os.ModePerm))
 
 				var envConfig fs.EnvConfig
+				envConfig.Version = settings.Version
 				if td.HasArg("encrypted-at-rest") {
 					envConfig.EncryptionOptions = &storageconfig.EncryptionOptions{}
 				}
@@ -106,22 +124,6 @@ func TestWALFailover(t *testing.T) {
 					envs = append(envs, e)
 				}
 				openEnv.Ref()
-
-				// Mock a cluster version, defaulting to latest.
-				version := clusterversion.Latest.Version()
-				if td.HasArg("min-version") {
-					var major, minor int
-					td.ScanArgs(t, "min-version", &major, &minor)
-					version = roachpb.Version{
-						Major: int32(major),
-						Minor: int32(minor),
-					}
-				}
-				// Match the current offsetting policy.
-				if clusterversion.Latest.Version().Major > clusterversion.DevOffset {
-					version.Major += clusterversion.DevOffset
-				}
-				settings := cluster.MakeTestingClusterSettingsWithVersions(version, version, true /* initializeVersion */)
 
 				engine, err := Open(context.Background(), openEnv, settings, WALFailover(cfg, envs, defaultFS, nil))
 				if err != nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1075,54 +1075,25 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 			cfg.opts.Experimental.RemoteStorage = remoteStorageAdaptor{p: p, ctx: logCtx, factory: cfg.remoteStorageFactory}
 		}
 	}
+	// If the store cluster version is not empty, it means that we initialized
+	// the env using a min-version file. We can use that to determine if the
+	// store should already exist or not.
+	initFromMinVersionFile := cfg.env.StoreClusterVersion != (roachpb.Version{})
 
-	// Read the current store cluster version.
-	storeClusterVersion, minVerFileExists, err := fs.GetMinVersion(p.cfg.env.UnencryptedFS, cfg.env.Dir)
-	if err != nil {
-		return nil, err
+	if !initFromMinVersionFile && (cfg.opts.ErrorIfNotExists || cfg.opts.ReadOnly) {
+		filename := p.cfg.env.UnencryptedFS.PathJoin(cfg.env.Dir, fs.MinVersionFilename)
+		return nil, errors.Errorf(
+			"pebble: database %q does not exist (missing required file %q)",
+			cfg.env.Dir, filename,
+		)
 	}
-	if minVerFileExists {
-		// Avoid running a binary too new for this store. This is what you'd catch
-		// if, say, you restarted directly from v21.2 into v22.2 (bumping the min
-		// version) without going through v22.1 first.
-		//
-		// Note that "going through" above means that v22.1 successfully upgrades
-		// all existing stores. If v22.1 crashes half-way through the startup
-		// sequence (so now some stores have v21.2, but others v22.1) you are
-		// expected to run v22.1 again (hopefully without the crash this time) which
-		// would then rewrite all the stores.
-		if v := cfg.settings.Version; storeClusterVersion.Less(v.MinSupportedVersion()) {
-			if storeClusterVersion.Major < clusterversion.DevOffset && v.LatestVersion().Major >= clusterversion.DevOffset {
-				return nil, errors.Errorf(
-					"store last used with cockroach non-development version v%s "+
-						"cannot be opened by development version v%s",
-					storeClusterVersion, v.LatestVersion(),
-				)
-			}
-			return nil, errors.Errorf(
-				"store last used with cockroach version v%s "+
-					"is too old for running version v%s (which requires data from v%s or later)",
-				storeClusterVersion, v.LatestVersion(), v.MinSupportedVersion(),
-			)
-		}
-		cfg.opts.ErrorIfNotExists = true
-	} else {
-		if cfg.opts.ErrorIfNotExists || cfg.opts.ReadOnly {
-			// Make sure the message is not confusing if the store does exist but
-			// there is no min version file.
-			filename := p.cfg.env.UnencryptedFS.PathJoin(cfg.env.Dir, fs.MinVersionFilename)
-			return nil, errors.Errorf(
-				"pebble: database %q does not exist (missing required file %q)",
-				cfg.env.Dir, filename,
-			)
-		}
-		// If there is no min version file, there should be no store. If there is
-		// one, it's either 1) a store from a very old version (which we don't want
-		// to open) or 2) an empty store that was created from a previous bootstrap
-		// attempt that failed right before writing out the min version file. We set
-		// a flag to disallow the open in case 1.
-		cfg.opts.ErrorIfNotPristine = true
-	}
+	cfg.opts.ErrorIfNotExists = cfg.opts.ErrorIfNotExists || initFromMinVersionFile
+	// If there is no min version file, there should be no store. If there is
+	// one, it's either 1) a store from a very old version (which we don't want
+	// to open) or 2) an empty store that was created from a previous bootstrap
+	// attempt that failed right before writing out the min version file. We set
+	// a flag to disallow the open in case 1.
+	cfg.opts.ErrorIfNotPristine = !initFromMinVersionFile
 
 	if WorkloadCollectorEnabled {
 		p.replayer.Attach(cfg.opts)
@@ -1131,10 +1102,10 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	db, err := pebble.Open(cfg.env.Dir, cfg.opts)
 	if err != nil {
 		// Decorate the errors caused by the flags we set above.
-		if minVerFileExists && errors.Is(err, pebble.ErrDBDoesNotExist) {
+		if initFromMinVersionFile && errors.Is(err, pebble.ErrDBDoesNotExist) {
 			err = errors.Wrap(err, "min version file exists but store doesn't")
 		}
-		if !minVerFileExists && errors.Is(err, pebble.ErrDBNotPristine) {
+		if !initFromMinVersionFile && errors.Is(err, pebble.ErrDBNotPristine) {
 			err = errors.Wrap(err, "store has no min-version file; this can "+
 				"happen if the store was created by an old CockroachDB version that is no "+
 				"longer supported")
@@ -1143,7 +1114,8 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	}
 	p.db = db
 
-	if !minVerFileExists {
+	storeClusterVersion := cfg.env.StoreClusterVersion
+	if storeClusterVersion == (roachpb.Version{}) {
 		storeClusterVersion = cfg.settings.Version.ActiveVersionOrEmpty(ctx).Version
 		if storeClusterVersion == (roachpb.Version{}) {
 			// If there is no active version, use the minimum supported version.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1077,7 +1077,7 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	}
 
 	// Read the current store cluster version.
-	storeClusterVersion, minVerFileExists, err := getMinVersion(p.cfg.env.UnencryptedFS, cfg.env.Dir)
+	storeClusterVersion, minVerFileExists, err := fs.GetMinVersion(p.cfg.env.UnencryptedFS, cfg.env.Dir)
 	if err != nil {
 		return nil, err
 	}
@@ -1110,7 +1110,7 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		if cfg.opts.ErrorIfNotExists || cfg.opts.ReadOnly {
 			// Make sure the message is not confusing if the store does exist but
 			// there is no min version file.
-			filename := p.cfg.env.UnencryptedFS.PathJoin(cfg.env.Dir, MinVersionFilename)
+			filename := p.cfg.env.UnencryptedFS.PathJoin(cfg.env.Dir, fs.MinVersionFilename)
 			return nil, errors.Errorf(
 				"pebble: database %q does not exist (missing required file %q)",
 				cfg.env.Dir, filename,
@@ -2301,7 +2301,7 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 
 	// TODO(#90543, cockroachdb/pebble#2285): move spans info to Pebble manifest.
 	if len(spans) > 0 {
-		if err := safeWriteToUnencryptedFile(
+		if err := fs.SafeWriteToUnencryptedFile(
 			p.cfg.env.UnencryptedFS, dir, p.cfg.env.PathJoin(dir, "checkpoint.txt"),
 			checkpointSpansNote(spans),
 			fs.UnspecifiedWriteCategory,

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1310,6 +1310,7 @@ func TestIncompatibleVersion(t *testing.T) {
 	env = mustInitTestEnv(t, memFS, "")
 	_, err = Open(ctx, env, cluster.MakeTestingClusterSettings())
 	require.Error(t, err)
+	_, err = Open(ctx, env, cluster.MakeTestingClusterSettings())
 	msg := err.Error()
 	if !strings.Contains(msg, "is too old for running version") &&
 		!strings.Contains(msg, "cannot be opened by development version") {
@@ -1688,7 +1689,10 @@ func TestPebbleLoggingSlowReads(t *testing.T) {
 
 		memFS := vfs.NewMem()
 		dFS := delayFS{FS: memFS}
-		e, err := fs.InitEnv(context.Background(), dFS, "" /* dir */, fs.EnvConfig{}, nil /* statsCollector */)
+		settings := cluster.MakeTestingClusterSettings()
+		e, err := fs.InitEnv(context.Background(), dFS, "" /* dir */, fs.EnvConfig{
+			Version: settings.Version,
+		}, nil /* statsCollector */)
 		require.NoError(t, err)
 		// Tiny block cache, so all reads go to FS.
 		db, err := Open(ctx, e, cluster.MakeClusterSettings(), CacheSize(1024))
@@ -1763,7 +1767,10 @@ func TestPebbleCompactCancellation(t *testing.T) {
 	ctx := context.Background()
 	mem := vfs.NewMem()
 	bfs := &fs.BlockingWriteFSForTesting{FS: mem}
-	e, err := fs.InitEnv(ctx, bfs, "" /* dir */, fs.EnvConfig{}, nil /* statsCollector */)
+	settings := cluster.MakeTestingClusterSettings()
+	e, err := fs.InitEnv(ctx, bfs, "" /* dir */, fs.EnvConfig{
+		Version: settings.Version,
+	}, nil /* statsCollector */)
 	require.NoError(t, err)
 	db, err := Open(
 		ctx, e, cluster.MakeClusterSettings(), CacheSize(1024), MaxConcurrentCompactions(1),

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1302,10 +1302,10 @@ func TestIncompatibleVersion(t *testing.T) {
 	p.Close()
 
 	// Overwrite the min version file with an unsupported version.
-	version := roachpb.Version{Major: 21, Minor: 1}
-	b, err := protoutil.Marshal(&version)
+	ver := roachpb.Version{Major: 21, Minor: 1}
+	b, err := protoutil.Marshal(&ver)
 	require.NoError(t, err)
-	require.NoError(t, safeWriteToUnencryptedFile(memFS, "", MinVersionFilename, b, fs.UnspecifiedWriteCategory))
+	require.NoError(t, fs.SafeWriteToUnencryptedFile(memFS, "", fs.MinVersionFilename, b, fs.UnspecifiedWriteCategory))
 
 	env = mustInitTestEnv(t, memFS, "")
 	_, err = Open(ctx, env, cluster.MakeTestingClusterSettings())
@@ -1331,7 +1331,7 @@ func TestNoMinVerFile(t *testing.T) {
 	p.Close()
 
 	// Remove the min version filename.
-	require.NoError(t, memFS.Remove(MinVersionFilename))
+	require.NoError(t, memFS.Remove(fs.MinVersionFilename))
 
 	// We are still allowed the open the store if we haven't written anything to it.
 	// This is useful in case the initial Open crashes right before writinng the
@@ -1347,7 +1347,7 @@ func TestNoMinVerFile(t *testing.T) {
 	p.Close()
 
 	// Remove the min version filename.
-	require.NoError(t, memFS.Remove(MinVersionFilename))
+	require.NoError(t, memFS.Remove(fs.MinVersionFilename))
 
 	env = mustInitTestEnv(t, memFS, "")
 	_, err = Open(ctx, env, st)

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -73,6 +73,7 @@ func newTempEngine(
 		// Adopt the encryption options of the provided store spec so that
 		// temporary data is encrypted if the store is encrypted.
 		EncryptionOptions: storeSpec.EncryptionOptions,
+		Version:           tempStorage.Settings.Version,
 	}, diskWriteStats)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
### storage: move store version checks into fs pkg
Move functions to perform pebble compatibility checks into the fs pkg.

### storage: add cluster version to env config

### storage, fs: move pebble cluster version compat check to InitEnv

Previously, we performed the CRDB version compatibility check for pebble and the
currently running cluster in the pebble constructor. This commit moves that
check to the file system environment initialization so that we can  colocate
with fs encyrption initialization.

We also extend the version checking to validate that pebble's minversion is not
too high for the current cockroach version, to guard against backwards
incompatible changes.

Fixes: https://github.com/cockroachdb/cockroach/issues/148213

Epic: none
Release note: None