### PR TITLE
sql: prep migration for sampled_query and sampled_transaction events

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3364,6 +3364,11 @@ Fields in this struct should be updated in sync with apps_stats.proto.
 An event of type `sampled_query` is the SQL query event logged to the telemetry channel. It
 contains common SQL event/execution details.
 
+Note: in version 26.1, these events will be moved to the `SQL_EXEC` channel.
+To test compatability before this, set the cluster setting
+`log.channel_compatibility_mode.enabled` to false. This will send the
+events to `SQL_EXEC` instead of `TELEMETRY`.
+
 
 | Field | Description | Sensitive |
 |--|--|--|
@@ -3471,6 +3476,11 @@ contains common SQL event/execution details.
 ### `sampled_transaction`
 
 An event of type `sampled_transaction` is the event logged to telemetry at the end of transaction execution.
+
+Note: in version 26.1, these events will be moved to the `SQL_EXEC` channel.
+To test compatability before this, set the cluster setting
+`log.channel_compatibility_mode.enabled` to false. This will send the
+events to `SQL_EXEC` instead of `TELEMETRY`.
 
 
 | Field | Description | Sensitive |

--- a/pkg/ccl/telemetryccl/BUILD.bazel
+++ b/pkg/ccl/telemetryccl/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings",
         "//pkg/sql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqltestutils",

--- a/pkg/sql/telemetry_datadriven_test.go
+++ b/pkg/sql/telemetry_datadriven_test.go
@@ -60,13 +60,12 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 
 	sc := log.Scope(t)
 	defer sc.Close(t)
-
 	appName := "telemetry-logging-datadriven"
 	ignoredAppname := "telemetry-datadriven-ignored-appname"
 	ctx := context.Background()
 	stmtSpy := logtestutils.NewStructuredLogSpy(
 		t,
-		[]logpb.Channel{logpb.Channel_TELEMETRY},
+		[]logpb.Channel{logpb.Channel_TELEMETRY, logpb.Channel_SQL_EXEC},
 		[]string{"sampled_query"},
 		logtestutils.FormatEntryAsJSON,
 		func(_ logpb.Entry, logStr string) bool {
@@ -79,7 +78,7 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 
 	txnsSpy := logtestutils.NewStructuredLogSpy(
 		t,
-		[]logpb.Channel{logpb.Channel_TELEMETRY},
+		[]logpb.Channel{logpb.Channel_TELEMETRY, logpb.Channel_SQL_EXEC},
 		[]string{"sampled_transaction"},
 		logtestutils.FormatEntryAsJSON,
 		func(_ logpb.Entry, logStr string) bool {
@@ -209,13 +208,13 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 				}
 
 				newStmtLogCount := stmtSpy.Count()
-				sb.WriteString(strings.Join(stmtSpy.GetLastNLogs(logpb.Channel_TELEMETRY, newStmtLogCount-stmtLogCount), "\n"))
+				sb.WriteString(strings.Join(stmtSpy.GetLastNLogs(getSampleQueryLoggingChannel(&s.ClusterSettings().SV), newStmtLogCount-stmtLogCount), "\n"))
 				if newStmtLogCount > stmtLogCount {
 					sb.WriteString("\n")
 				}
 
 				newTxnLogCount := txnsSpy.Count()
-				sb.WriteString(strings.Join(txnsSpy.GetLastNLogs(logpb.Channel_TELEMETRY, newTxnLogCount-txnLogCount), "\n"))
+				sb.WriteString(strings.Join(txnsSpy.GetLastNLogs(getSampleQueryLoggingChannel(&s.ClusterSettings().SV), newTxnLogCount-txnLogCount), "\n"))
 				return sb.String()
 			case "reset-last-sampled":
 				telemetryLogging.resetLastSampledTime()

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -22,9 +22,19 @@ import "util/log/logpb/event.proto";
 // The comment at the top has a specific format for the doc generator.
 // *Really look at doc.go before modifying this file.*
 
+// TODO (#151948): Move this event definition to
+// `pkg/util/log/eventpb/sql_audit_events.proto` to be in the
+// `SQL Execution Log` channel once the `log.channel_compatibility_mode.enabled`
+// cluster setting is set to false by default and cluster setting is set for
+// removal.
 
 // SampledQuery is the SQL query event logged to the telemetry channel. It
 // contains common SQL event/execution details.
+//
+// Note: in version 26.1, these events will be moved to the `SQL_EXEC` channel.
+// To test compatability before this, set the cluster setting
+// `log.channel_compatibility_mode.enabled` to false. This will send the
+// events to `SQL_EXEC` instead of `TELEMETRY`.
 message SampledQuery {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
@@ -406,7 +416,18 @@ message MVCCIteratorStats {
   int64 range_key_skipped_points = 13 [(gogoproto.jsontag) = ",includeempty"];
 }
 
+// TODO (#151948): Move this event definition to
+// `pkg/util/log/eventpb/sql_audit_events.proto` to be in the
+// `SQL Execution Log` channel once the `log.channel_compatibility_mode.enabled`
+// cluster setting is set to false by default and cluster setting is set for
+// removal.
+
 // SampledTransaction is the event logged to telemetry at the end of transaction execution.
+//
+// Note: in version 26.1, these events will be moved to the `SQL_EXEC` channel.
+// To test compatability before this, set the cluster setting
+// `log.channel_compatibility_mode.enabled` to false. This will send the
+// events to `SQL_EXEC` instead of `TELEMETRY`.
 message SampledTransaction {
   // Common contains common event details shared by all log events.
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];

--- a/pkg/util/log/logtestutils/structured_log_spy.go
+++ b/pkg/util/log/logtestutils/structured_log_spy.go
@@ -110,6 +110,11 @@ func FromLogEntry[T any](entry logpb.Entry) (T, error) {
 	return payload, err
 }
 
+func AsLogEntry(entry logpb.Entry) (logpb.Entry, error) {
+	entry.Message = entry.Message[entry.StructuredStart:entry.StructuredEnd]
+	return entry, nil
+}
+
 // StructuredLogSpy is a test utility that intercepts structured log entries
 // and stores them in memory. It can be used to verify the contents of log
 // entries in tests.


### PR DESCRIPTION
In v26.1, sampled_query and sampled_transaction events will be moved
from the TELEMETRY logging channel to the SQL_EXEC logging channel.

This commit gates this migration under the cluster setting:
`log.channel_compatibility_mode.enabled` and will log these events
to the SQL_EXEC channel if this setting is set to false. Users can
set this setting to false in their clusters to validate, test, and
identify potential downstream impacts to their logging setups and
pipelines.

Epic: [CRDB-53410](https://cockroachlabs.atlassian.net/browse/CRDB-53410)
Part of: [CRDB-53412](https://cockroachlabs.atlassian.net/browse/CRDB-53412)
Release note (ops change): sampled_query and sampled_transaction
events will be moved to the SQL_EXEC channel in 26.1. In order to
test the impact of these changes, users can set the setting:
`log.channel_compatibility_mode.enabled` to false. Note that this
will cause these logs to start logging in the SQL_EXEC channel so
this shouldn't be tested in a production environment.

----
This is a stacked PR, only the last commit in this PR should be reviewed