### PR TITLE
sql: fix `BETWEEN SYMMETRIC` normalization to use matching typed lefts

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -222,3 +222,12 @@ statement error pq: AS OF SYSTEM TIME: timestamp '2090-05-08 12:00:00' is in the
 CREATE VIEW wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME '2090-05-08 12:00:00'
 
 subtest end
+
+# Regression test for #133395. Ensure that an invalid AS OF SYSTEM TIME clause
+# requiring normalization doesn't panic and returns an error.
+statement ok
+CREATE TABLE v00 (c01 INT)
+
+statement error pq: AS OF SYSTEM TIME: expected timestamp, decimal, or interval, got bool
+SELECT ALL FROM ( v00 AS ta1401 NATURAL JOIN v00 AS ta1402 ) WITH ORDINALITY AS ta1403
+AS OF SYSTEM TIME b'any_bytes' BETWEEN SYMMETRIC 'abc' AND 'abc';

--- a/pkg/sql/sem/normalize/normalize_exprs.go
+++ b/pkg/sql/sem/normalize/normalize_exprs.go
@@ -397,7 +397,7 @@ func normalizeRangeCond(v *Visitor, expr *tree.RangeCond) tree.TypedExpr {
 
 	// "a BETWEEN b AND c" -> "a >= b AND a <= c"
 	// "a NOT BETWEEN b AND c" -> "a < b OR a > c"
-	transform := func(from, to tree.TypedExpr) tree.TypedExpr {
+	transform := func(leftFrom, from, leftTo, to tree.TypedExpr) tree.TypedExpr {
 		var newLeft, newRight tree.TypedExpr
 		if from == tree.DNull {
 			newLeft = tree.DNull
@@ -425,14 +425,15 @@ func normalizeRangeCond(v *Visitor, expr *tree.RangeCond) tree.TypedExpr {
 		return normalizeExpr(v, tree.NewTypedAndExpr(newLeft, newRight))
 	}
 
-	out := transform(from, to)
+	out := transform(leftFrom, from, leftTo, to)
 	if expr.Symmetric {
+		symmetricOut := transform(leftTo, to, leftFrom, from)
 		if expr.Not {
 			// "a NOT BETWEEN SYMMETRIC b AND c" -> "(a < b OR a > c) AND (a < c OR a > b)"
-			out = normalizeExpr(v, tree.NewTypedAndExpr(out, transform(to, from)))
+			out = normalizeExpr(v, tree.NewTypedAndExpr(out, symmetricOut))
 		} else {
 			// "a BETWEEN SYMMETRIC b AND c" -> "(a >= b AND a <= c) OR (a >= c OR a <= b)"
-			out = normalizeExpr(v, tree.NewTypedOrExpr(out, transform(to, from)))
+			out = normalizeExpr(v, tree.NewTypedOrExpr(out, symmetricOut))
 		}
 	}
 	return out

--- a/pkg/sql/sem/normalize/normalize_test.go
+++ b/pkg/sql/sem/normalize/normalize_test.go
@@ -75,6 +75,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`a BETWEEN b AND NULL`, `(a >= b) AND NULL`},
 		{`a BETWEEN SYMMETRIC b AND NULL`, `((a >= b) AND NULL) OR (NULL AND (a <= b))`},
 		{`a BETWEEN NULL AND NULL`, `NULL`},
+		{`b'bytes' BETWEEN SYMMETRIC 'a' AND 'c'`, `true`},
 		{`NULL BETWEEN 1 AND 2`, `NULL`},
 		{`1+1`, `2`},
 		{`(1+1,2+2,3+3)`, `(2, 4, 6)`},


### PR DESCRIPTION
We normalize symmetric `RangeCond` expressions (`<left> BETWEEN SYMMETRIC <from> AND <to>`) by expanding them into 2 pairs of `ComparisonExpr`, covering both orderings of the BETWEEN bounds. When the type-checks for the left/from and left/to comparisons chose different coercions, the symmetric half could pair `leftFrom` with `to` (and `leftTo` with `from`) during normalization. This resulted in mixed-type comparisons on type-checked expressions and caused panics in some paths (e.g. AOST normalization).

This change ensures that the type-checked pairings are kept aligned when constructing `ComparisonExpr` in the symmetric case.

Fixes: https://github.com/cockroachdb/cockroach/issues/133395

Release note (bug fix): Previously, executing certain statements with `BETWEEN SYMMETRIC` expressions could panic if used with values of different types, such as `... b'bytes' BETWEEN SYMMETRIC 'a' AND 'c'`, which is now fixed.