### PR TITLE
release-25.3: changefeedccl: disable schema_locked in TestChangefeedTruncateOrDrop

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6001,8 +6001,9 @@ func TestChangefeedTruncateOrDrop(t *testing.T) {
 			return err
 		}
 
-		sqlDB.Exec(t, `CREATE TABLE truncate (a INT PRIMARY KEY)`)
-		sqlDB.Exec(t, `CREATE TABLE truncate_cascade (b INT PRIMARY KEY REFERENCES truncate (a))`)
+		// TODO(#151941): Re-enable auto schema_locked for this test.
+		sqlDB.Exec(t, `CREATE TABLE truncate (a INT PRIMARY KEY) WITH (schema_locked=false)`)
+		sqlDB.Exec(t, `CREATE TABLE truncate_cascade (b INT PRIMARY KEY REFERENCES truncate (a)) WITH (schema_locked=false)`)
 		sqlDB.Exec(t,
 			`BEGIN; INSERT INTO truncate VALUES (1); INSERT INTO truncate_cascade VALUES (1); COMMIT`)
 		truncate := feed(t, f, `CREATE CHANGEFEED FOR truncate`)


### PR DESCRIPTION
Backport 1/1 commits from #151944.

/cc @cockroachdb/release

---

This patch disables `schema_locked` on the tables used in
`TestChangefeedTruncateOrDrop` because of a known issue where
`schema_locked` does not block `TRUNCATE`, which could cause
this test to flake.

Informs #151523
Informs #151273

Release note: None

---

Release justification: test-only fix
