### PR TITLE
sqlsmith: add support for DO block

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1692,6 +1692,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 			sqlsmith.DisableWith(),
 			sqlsmith.DisableMutations(),
 			sqlsmith.DisableLimits(),
+			sqlsmith.DisableDoBlocks(),
 			sqlsmith.DisableAggregateFuncs(),
 			sqlsmith.DisableWindowFuncs(),
 			sqlsmith.DisableJoins(),

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -66,6 +66,7 @@ var (
 		"DisableCrossJoins":          sqlsmith.DisableCrossJoins(),
 		"DisableDDLs":                sqlsmith.DisableDDLs(),
 		"DisableDecimals":            sqlsmith.DisableDecimals(),
+		"DisableDoBlocks":            sqlsmith.DisableDoBlocks(),
 		"DisableEverything":          sqlsmith.DisableEverything(),
 		"DisableIndexHints":          sqlsmith.DisableIndexHints(),
 		"DisableInsertSelect":        sqlsmith.DisableInsertSelect(),

--- a/pkg/internal/sqlsmith/plpgsql.go
+++ b/pkg/internal/sqlsmith/plpgsql.go
@@ -141,6 +141,7 @@ var (
 		{2, makePLpgSQLReturn},
 		{2, makePLpgSQLIf},
 		{2, makePLpgSQLWhile},
+		{2, makeDoBlockWithinScope},
 		{2, makePLpgSQLForLoop},
 		{5, makePLpgSQLNull},
 		{10, makePLpgSQLAssign},
@@ -394,4 +395,21 @@ func (s *plpgsqlBlockScope) addVariable(name string, typ *types.T, constant bool
 	if constant {
 		s.constants[name] = struct{}{}
 	}
+}
+
+func (s *Smither) makeDoBlockTreeStmt() (*tree.DoBlock, bool) {
+	scope := makeBlockScope(0, types.Unknown, tree.RoutineVolatile)
+	doBlock, ok := makeDoBlockWithinScope(s, scope)
+	if !ok {
+		return nil, false
+	}
+	return &tree.DoBlock{Code: doBlock.(*ast.DoBlock)}, true
+}
+
+func makeDoBlockWithinScope(s *Smither, scope plpgsqlBlockScope) (ast.Statement, bool) {
+	if s.disableDoBlock {
+		return nil, false
+	}
+	block := s.makePLpgSQLBlock(scope)
+	return &ast.DoBlock{Block: block}, true
 }

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -110,9 +110,11 @@ var (
 		{1, makeImport},
 		{1, makeCreateStats},
 		{1, makeSetSessionCharacteristics},
+		{1, makeDoBlock},
 	}
 	nonMutatingStatements = []statementWeight{
 		{10, makeSelect},
+		{1, makeDoBlock},
 	}
 	allStatements = append(mutatingStatements, nonMutatingStatements...)
 
@@ -926,6 +928,10 @@ func makeCreateFunc(s *Smither) (tree.Statement, bool) {
 		return nil, false
 	}
 	return s.makeCreateFunc()
+}
+
+func makeDoBlock(s *Smither) (tree.Statement, bool) {
+	return s.makeDoBlockTreeStmt()
 }
 
 func makeDropFunc(s *Smither) (tree.Statement, bool) {

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -118,7 +118,11 @@ type Smither struct {
 	// disableUDFCreation indicates whether we're not allowed to create UDFs.
 	// It follows that if we haven't created any UDFs, we have no UDFs to invoke
 	// too.
-	disableUDFCreation     bool
+	disableUDFCreation bool
+	// disableDoBlock indicates whether we're not allowed to create DO blocks,
+	// both as top level statements and inside plpgsql function body
+	// definition.
+	disableDoBlock         bool
 	disableIsolationChange bool
 
 	bulkSrv     *httptest.Server
@@ -610,6 +614,11 @@ var DisableOIDs = simpleOption("disable OIDs", func(s *Smither) {
 // DisableUDFs causes the Smither to disable user-defined functions.
 var DisableUDFs = simpleOption("disable udfs", func(s *Smither) {
 	s.disableUDFCreation = true
+})
+
+// DisableDoBlocks causes the Smither to disable DO blocks.
+var DisableDoBlocks = simpleOption("disable do block", func(s *Smither) {
+	s.disableDoBlock = true
 })
 
 // DisableIsolationChange causes the Smither to disable stmts that modify the


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/106368

A `DO` block can be either a top-level sql statement or be part of the plpgsql function body. In this commit we introduce the DO block for both of these 2 usages. We also introduced `DisableDoBlocks` which disables both usages of a DO block.

Release note: None