### PR TITLE
workload_generator: Fixes and enhancements

### DIFF
--- a/pkg/workload/workload_generator/column_generator_test.go
+++ b/pkg/workload/workload_generator/column_generator_test.go
@@ -62,7 +62,7 @@ func TestSplitmix64AndBatchSeed(t *testing.T) {
 }
 
 func TestSequenceGenerator(t *testing.T) {
-	col := ColumnMeta{Args: map[string]interface{}{"start": 5}}
+	col := &ColumnMeta{Args: map[string]interface{}{"start": 5}}
 	gen := buildSequenceGenerator(col, 2, 10)
 	assert.Equal(t, "25", gen.Next(), "first value")
 	assert.Equal(t, "26", gen.Next(), "second value")
@@ -70,7 +70,7 @@ func TestSequenceGenerator(t *testing.T) {
 
 func TestIntegerAndFloatGenerators(t *testing.T) {
 	rng := rand.New(rand.NewSource(0))
-	icol := ColumnMeta{Args: map[string]interface{}{"min": 1, "max": 3, "null_pct": 0.0}}
+	icol := &ColumnMeta{Args: map[string]interface{}{"min": 1, "max": 3, "null_pct": 0.0}}
 	igen := buildIntegerGenerator(icol, rng)
 	for i := 0; i < 10; i++ {
 		v := igen.Next()
@@ -79,7 +79,7 @@ func TestIntegerAndFloatGenerators(t *testing.T) {
 		assert.GreaterOrEqual(t, n, 1)
 		assert.LessOrEqual(t, n, 3)
 	}
-	fcol := ColumnMeta{Args: map[string]interface{}{"min": 1.0, "max": 2.0, "round": 1, "null_pct": 0.0}}
+	fcol := &ColumnMeta{Args: map[string]interface{}{"min": 1.0, "max": 2.0, "round": 1, "null_pct": 0.0}}
 	fgen := buildFloatGenerator(fcol, rng)
 	for i := 0; i < 10; i++ {
 		v := fgen.Next()
@@ -88,7 +88,7 @@ func TestIntegerAndFloatGenerators(t *testing.T) {
 }
 
 func TestTimestampGenerator(t *testing.T) {
-	col := ColumnMeta{Args: map[string]interface{}{"start": "2000-01-02", "end": "2000-01-03", "format": "%Y-%m-%d"}}
+	col := &ColumnMeta{Args: map[string]interface{}{"start": "2000-01-02", "end": "2000-01-03", "format": "%Y-%m-%d"}}
 	rng := rand.New(rand.NewSource(0))
 	gen := buildTimestampGenerator(col, rng)
 	v := gen.Next()
@@ -98,7 +98,7 @@ func TestTimestampGenerator(t *testing.T) {
 
 func TestUuidGenerator(t *testing.T) {
 	rng := rand.New(rand.NewSource(0))
-	col := ColumnMeta{}
+	col := &ColumnMeta{}
 	gen := buildUuidGenerator(col, rng)
 	v1 := gen.Next()
 	v2 := gen.Next()
@@ -110,20 +110,20 @@ func TestUuidGenerator(t *testing.T) {
 
 func TestStringBoolJsonGenerators(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
-	scol := ColumnMeta{Args: map[string]interface{}{"min": 2, "max": 4, "null_pct": 0.0}}
+	scol := &ColumnMeta{Args: map[string]interface{}{"min": 2, "max": 4, "null_pct": 0.0}}
 	sgen := buildStringGenerator(scol, rng)
 	for i := 0; i < 5; i++ {
 		v := sgen.Next()
 		assert.GreaterOrEqual(t, len(v), 2)
 		assert.LessOrEqual(t, len(v), 4)
 	}
-	bcol := ColumnMeta{Args: map[string]interface{}{"null_pct": 0.0}}
+	bcol := &ColumnMeta{Args: map[string]interface{}{"null_pct": 0.0}}
 	bgen := buildBooleanGenerator(bcol, rng)
 	for i := 0; i < 5; i++ {
 		v := bgen.Next()
 		assert.Contains(t, []string{"0", "1"}, v)
 	}
-	jcol := ColumnMeta{Args: map[string]interface{}{"min": 1, "max": 1, "null_pct": 0.0}}
+	jcol := &ColumnMeta{Args: map[string]interface{}{"min": 1, "max": 1, "null_pct": 0.0}}
 	jgen := buildJsonGenerator(jcol, rng)
 	v := jgen.Next()
 	assert.True(t, strings.HasPrefix(v, "{\"k\":\"") && strings.HasSuffix(v, "\"}"), "JSON object")
@@ -177,7 +177,7 @@ func TestMakeGeneratorAllTypes(t *testing.T) {
 		}},
 	}
 	for _, tt := range types {
-		gen := buildGenerator(ColumnMeta{Type: tt.typ, Args: tt.args}, 0, 1, schema)
+		gen := buildGenerator(&ColumnMeta{Type: tt.typ, Args: tt.args}, 0, 1, schema)
 		v := gen.Next()
 		assert.True(t, tt.checker(v), "%s generator produced %q", tt.typ, v)
 	}

--- a/pkg/workload/workload_generator/run_utils.go
+++ b/pkg/workload/workload_generator/run_utils.go
@@ -91,16 +91,14 @@ func setNullType(placeholder Placeholder) interface{} {
 // getTableName checks if the name field of placeholder is a column in the TableName column in the allSchema map inside d.
 // If yes, then returns that table name. otherwise looks for a table with that column and returns that.
 func getTableName(p Placeholder, d *workloadGenerator) string {
-	for _, block := range d.workloadSchema[p.TableName] {
-		for colName := range block.Columns {
-			if colName == p.Name {
-				return p.TableName
-			}
+	block := d.workloadSchema[p.TableName]
+	for colName := range block.Columns {
+		if colName == p.Name {
+			return p.TableName
 		}
 	}
-	for tableName, blocks := range d.workloadSchema {
-		block := blocks[0]
-		for colName := range block.Columns {
+	for tableName, blk := range d.workloadSchema {
+		for colName := range blk.Columns {
 			if colName == p.Name {
 				return tableName
 			}
@@ -118,38 +116,45 @@ func getColumnValue(
 	indexes []int,
 	i int,
 ) string {
-	var raw string
-	if allPksAreFK && (p.Clause == insert || p.Clause == update) {
-		tableName := getTableName(p, d)
-		key := fmt.Sprintf("%s.%s", tableName, p.Name)
-		fk := d.columnGens[key].columnMeta.FK
-		parts := strings.Split(fk, ".")
-		parentCol := parts[len(parts)-1] // The last part is the column name.
-		if vals, ok := inserted[parentCol]; ok && len(vals) > 0 {
-			raw = vals[0].(string)         // Using the first value from the inserted map.
-			inserted[parentCol] = vals[1:] // Remove the first value from the map.
-		} else {
-			//Fallback that shouldn't really happen.
-			raw = d.getRegularColumnValue(p, indexes[i])
-		}
-	} else {
-		raw = d.getRegularColumnValue(p, indexes[i])
+	// If not all PKs are FKs or if the clause is not insert/update, use regular column value
+	if !allPksAreFK || (p.Clause != insert && p.Clause != update) {
+		return d.getRegularColumnValue(p, indexes[i])
 	}
-	return raw
+
+	// Handle the case where all PKs are FKs and clause is insert/update
+	tableName := getTableName(p, d)
+	key := fmt.Sprintf("%s.%s", tableName, p.Name)
+	fk := d.columnGens[key].columnMeta.FK
+	parts := strings.Split(fk, ".")
+	parentCol := parts[len(parts)-1] // The last part is the column name.
+
+	// Check if we have inserted values for this parent column
+	if vals, ok := inserted[parentCol]; ok && len(vals) > 0 {
+		raw := vals[0].(string)        // Using the first value from the inserted map.
+		inserted[parentCol] = vals[1:] // Remove the first value from the map.
+		return raw
+	}
+
+	// Fallback that shouldn't really happen
+	return d.getRegularColumnValue(p, indexes[i])
 }
 
 // checkIfAllPkAreFk checks if all primary keys in the SQL query are foreign keys.
 func checkIfAllPkAreFk(sqlQuery SQLQuery, d *workloadGenerator) bool {
-	allPksAreFK := true
+	pkCount := 0
+	pkWithFkCount := 0
 	for _, p := range sqlQuery.Placeholders {
 		tableName := getTableName(p, d)
 		key := fmt.Sprintf("%s.%s", tableName, p.Name)
-		if p.IsPrimaryKey && !d.columnGens[key].columnMeta.HasForeignKey {
-			allPksAreFK = false
-			break
+		if p.IsPrimaryKey {
+			// Here we check if the column is a primary key and if it has a foreign key.
+			pkCount++
+			if d.columnGens[key].columnMeta.HasForeignKey {
+				pkWithFkCount++
+			}
 		}
 	}
-	return allPksAreFK
+	return pkCount == pkWithFkCount && pkCount > 0
 }
 
 // readSQL reads <dbName><read/write>.sql and returns a slice of Transactions.
@@ -172,39 +177,48 @@ func readSQL(path, typ string) ([]Transaction, error) {
 	// Each transaction block
 	blocks := txnRe.FindAllStringSubmatch(text, -1)
 
-	// Currently we are defining two types of transactions - read and write.
-	var txns []Transaction
+	// Pre-allocate the transactions slice with the expected capacity
+	txns := make([]Transaction, 0, len(blocks))
+
 	// For every transaction block.
 	for _, blk := range blocks {
 		body := blk[1]
 		lines := strings.Split(body, "\n")
-		var txn Transaction
-		var curr SQLQuery
+		txn := Transaction{typ: typ} // Set the type immediately
+
+		var currBuilder strings.Builder
+
 		// For every sql query line.
 		for _, line := range lines {
 			line = strings.TrimSpace(line)
 			if line == "" || line == "BEGIN;" || line == "COMMIT;" {
 				continue
 			}
+
 			// build up the SQL text
-			curr.SQL += line + " "
+			currBuilder.WriteString(line)
+			currBuilder.WriteString(" ")
+
 			if strings.HasSuffix(line, ";") {
 				// once we hit the end of a statement, re-number from $1
 				stmtPos := 1
 				var placeholders []Placeholder
-				// sqlOut is the rewritten SQL where the placeholders have been replaced with $x.
-				sqlOut := placeholderRe.ReplaceAllStringFunc(curr.SQL, getPlaceholderReplacer(&placeholders, &stmtPos))
+				currSQL := currBuilder.String()
 
-				curr.SQL = strings.TrimSpace(sqlOut)
-				curr.Placeholders = placeholders
-				txn.Queries = append(txn.Queries, curr)
+				// sqlOut is the rewritten SQL where the placeholders have been replaced with $x.
+				sqlOut := placeholderRe.ReplaceAllStringFunc(currSQL, getPlaceholderReplacer(&placeholders, &stmtPos))
+
+				// Create a new SQLQuery and add it to the transaction
+				txn.Queries = append(txn.Queries, SQLQuery{
+					SQL:          strings.TrimSpace(sqlOut),
+					Placeholders: placeholders,
+				})
 
 				// reset for next statement
-				curr = SQLQuery{}
+				currBuilder.Reset()
 			}
 		}
-		// Decide whether the transaction is a read type or write type.
-		txn.typ = typ
+
 		txns = append(txns, txn)
 	}
 
@@ -218,26 +232,51 @@ func getPlaceholderReplacer(placeholders *[]Placeholder, stmtPos *int) func(stri
 		inner := placeholderRe.FindStringSubmatch(match)[1]
 		parts := splitQuoted(inner)
 
-		var p Placeholder
-		//Set all the fields in the placeholder struct based on the information from the sql.
-		p.Name = trimQuotes(parts[0])
-		p.ColType = trimQuotes(parts[1])
-		p.IsNullable = trimQuotes(parts[2]) == "NULL"
-		p.IsPrimaryKey = strings.Contains(trimQuotes(parts[3]), "PRIMARY KEY")
-		if d := trimQuotes(parts[4]); d != "" {
-			p.Default = &d
+		// Pre-allocate the placeholder with the expected fields
+		p := Placeholder{
+			Position: *stmtPos,
 		}
-		p.IsUnique = trimQuotes(parts[5]) == "UNIQUE"
-		if fk := trimQuotes(parts[6]); fk != "" {
-			fkParts := strings.Split(strings.TrimPrefix(fk, "FK→"), ".")
-			p.FKReference = &FKRef{Table: fkParts[0], Column: fkParts[1]}
+
+		// Process parts in a single pass
+		if len(parts) > 0 {
+			p.Name = trimQuotes(parts[0])
 		}
-		if chk := trimQuotes(parts[7]); chk != "" {
-			p.InlineCheck = &chk
+		if len(parts) > 1 {
+			p.ColType = trimQuotes(parts[1])
 		}
-		p.Clause = trimQuotes(parts[8])
-		p.Position = *stmtPos
-		p.TableName = trimQuotes(parts[9])
+		if len(parts) > 2 {
+			p.IsNullable = trimQuotes(parts[2]) == "NULL"
+		}
+		if len(parts) > 3 {
+			p.IsPrimaryKey = strings.Contains(trimQuotes(parts[3]), "PRIMARY KEY")
+		}
+		if len(parts) > 4 {
+			if d := trimQuotes(parts[4]); d != "" {
+				p.Default = &d
+			}
+		}
+		if len(parts) > 5 {
+			p.IsUnique = trimQuotes(parts[5]) == "UNIQUE"
+		}
+		if len(parts) > 6 {
+			if fk := trimQuotes(parts[6]); fk != "" {
+				fkParts := strings.Split(strings.TrimPrefix(fk, "FK→"), ".")
+				if len(fkParts) > 1 {
+					p.FKReference = &FKRef{Table: fkParts[0], Column: fkParts[1]}
+				}
+			}
+		}
+		if len(parts) > 7 {
+			if chk := trimQuotes(parts[7]); chk != "" {
+				p.InlineCheck = &chk
+			}
+		}
+		if len(parts) > 8 {
+			p.Clause = trimQuotes(parts[8])
+		}
+		if len(parts) > 9 {
+			p.TableName = trimQuotes(parts[9])
+		}
 
 		*stmtPos++
 		*placeholders = append(*placeholders, p)
@@ -248,27 +287,30 @@ func getPlaceholderReplacer(placeholders *[]Placeholder, stmtPos *int) func(stri
 // splitQuoted splits a string like "'a','b','c'" into ["'a'", "'b'", "'c'"].
 func splitQuoted(s string) []string {
 	var out []string
-	buf := ""
+	var buf strings.Builder
 	inQuote := false
+
 	for _, r := range s {
 		switch r {
 		case '\'':
 			inQuote = !inQuote
-			buf += string(r)
+			buf.WriteRune(r)
 		case ',':
 			if inQuote {
-				buf += string(r)
+				buf.WriteRune(r)
 			} else {
-				out = append(out, strings.TrimSpace(buf))
-				buf = ""
+				out = append(out, strings.TrimSpace(buf.String()))
+				buf.Reset()
 			}
 		default:
-			buf += string(r)
+			buf.WriteRune(r)
 		}
 	}
-	if buf != "" {
-		out = append(out, strings.TrimSpace(buf))
+
+	if buf.Len() > 0 {
+		out = append(out, strings.TrimSpace(buf.String()))
 	}
+
 	return out
 }
 

--- a/pkg/workload/workload_generator/schema_designs.go
+++ b/pkg/workload/workload_generator/schema_designs.go
@@ -188,16 +188,20 @@ type ColumnMeta struct {
 
 	Default     string  `yaml:"default,omitempty"`
 	DefaultProb float64 `yaml:"default_prob,omitempty"`
+
+	// LastValue is used for sequence columns to store the last value generated.
+	// This is useful when the workload is restarted.
+	LastValue string `yaml:"last_value,omitempty"`
 }
 
 // TableBlock stores extra information at table level that is used by the per batch generator.
 type TableBlock struct {
-	Count         int                   `yaml:"count"`
-	Columns       map[string]ColumnMeta `yaml:"columns"`
-	PK            []string              `yaml:"pk"`
-	SortBy        []string              `yaml:"sort-by"`
-	Unique        [][]string            `yaml:"unique,omitempty"`
-	OriginalTable string                `yaml:"original_table"`
-	ColumnOrder   []string              `yaml:"column_order"`
-	TableNumber   int                   `yaml:"table_number"`
+	Count         int                    `yaml:"count"`
+	Columns       map[string]*ColumnMeta `yaml:"columns"`
+	PK            []string               `yaml:"pk"`
+	SortBy        []string               `yaml:"sort-by"`
+	Unique        [][]string             `yaml:"unique,omitempty"`
+	OriginalTable string                 `yaml:"original_table"`
+	ColumnOrder   []string               `yaml:"column_order"`
+	TableNumber   int                    `yaml:"table_number"`
 }

--- a/pkg/workload/workload_generator/sql_generator.go
+++ b/pkg/workload/workload_generator/sql_generator.go
@@ -19,11 +19,37 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// internalSchemas is a slice of schema names that are considered internal.
+// If more names are identified later, just this variable can be updated.
+var internalSchemas = []string{"information_schema"}
+
+// columnName represents a column in a table, with its name and an optional tableAlias.
+type columnName struct {
+	name       string
+	tableAlias string
+}
+
+// newColumnName creates a new columnName instance from column name only.
+func newColumnNameWithName(colName string) *columnName {
+	return &columnName{name: colName}
+}
+
+// newColumnName creates a new columnName instance from tree.UnresolvedName.
+func newColumnName(u *tree.UnresolvedName) *columnName {
+	c := &columnName{name: u.Parts[0]}
+	if u.NumParts > 1 {
+		c.tableAlias = u.Parts[1]
+	}
+	return c
+}
+
 // placeholderRewriter handles both simple comparisons and IN-lists.
 // It is the visitor interface implementation for walking the AST.
 type placeholderRewriter struct {
-	schemas   map[string]*TableSchema
-	tableName string
+	schemas    map[string]*TableSchema
+	tableNames []string
+	// tableAliases is a map of table aliases to their names.
+	tableAliases map[string]string
 }
 
 // generateWorkload extracts and organizes SQL workload from CockroachDB debug logs.
@@ -99,7 +125,9 @@ func generateWorkload(
 		for scanner.Scan() {
 			row := strings.Split(scanner.Text(), "\t")
 			// 5a) Filtering by database_name.
-			if row[columnIndex[databaseName]] != dbName {
+			if row[columnIndex[databaseName]] != dbName &&
+				(!strings.Contains(row[columnIndex[keyColumnName]], dbName+".") ||
+					isInternalTable(row, dbName, columnIndex)) {
 				continue
 			}
 			// 5b) Internal “job id=” lines are skipped.
@@ -110,7 +138,7 @@ func generateWorkload(
 			// 5c) txnID and raw SQL are extracted.
 			txnID := row[columnIndex[txnFingerprintID]]
 			rawSQL := row[columnIndex[keyColumnName]]
-			// The TSV’s string literal are unquoted if present:
+			// The TSV’s string literals are unquoted if present:
 			if len(rawSQL) >= 2 && rawSQL[0] == '"' && rawSQL[len(rawSQL)-1] == '"' {
 				// Outer quotes are stripped and every "" is turned into ".
 				rawSQL = rawSQL[1 : len(rawSQL)-1]
@@ -118,7 +146,7 @@ func generateWorkload(
 			}
 
 			// 5d) The sql query is processed to replace _ and __more__ with new placeholders which contain information about the column they refer to.
-			rewritten, err := replacePlaceholders(rawSQL, allSchemas)
+			rewritten, err := replacePlaceholders(rawSQL, allSchemas, dbName)
 			if err != nil {
 				if errClose := f.Close(); errClose != nil {
 					// Wrap the original placeholder-rewrite error, then attach the close error.
@@ -128,6 +156,11 @@ func generateWorkload(
 					)
 				}
 				return errors.Wrapf(err, "rewriting SQL %q", rawSQL)
+			}
+			if rewritten == "" {
+				// rewritten SQL will be empty if the query is for another database
+				// e.g., select * from system.user;
+				continue // If the rewritten SQL is empty, skip this row.
 			}
 
 			// 5e) Grouping into txnMap, tracking first-seen order.
@@ -155,7 +188,9 @@ func generateWorkload(
 
 // replacePlaceholders parses the given SQL and locates all the _, __more__ placeholders.
 // The placeholders are then matched to what column's data do they represent and are replaced with information about that column for data generation.
-func replacePlaceholders(rawSQL string, allSchemas map[string]*TableSchema) (string, error) {
+func replacePlaceholders(
+	rawSQL string, allSchemas map[string]*TableSchema, dbName string,
+) (string, error) {
 	stmts, err := parser.Parse(rawSQL)
 	if err != nil {
 		return "", err
@@ -165,12 +200,12 @@ func replacePlaceholders(rawSQL string, allSchemas map[string]*TableSchema) (str
 	for _, stmt := range stmts {
 		// INSERT…VALUES (<placeholders>) is rewritten.
 		if ins, ok := stmt.AST.(*tree.Insert); ok {
-			handleInsert(ins, allSchemas)
+			handleInsert(ins, allSchemas, dbName)
 		}
 		// UPDATE ... SET is rewritten.
 		if upd, ok := stmt.AST.(*tree.Update); ok {
 			// 1) Everything in the SET clause is rewritten.
-			handleUpdateSet(upd, allSchemas)
+			handleUpdateSet(upd, allSchemas, dbName)
 		}
 		// Handling limit _
 		if sel, ok := stmt.AST.(*tree.Select); ok {
@@ -178,7 +213,10 @@ func replacePlaceholders(rawSQL string, allSchemas map[string]*TableSchema) (str
 		}
 
 		// Setting up the rewriter with the required table name and schemas.
-		rewriter := buildPlaceholderRewriter(stmt, allSchemas)
+		rewriter := buildPlaceholderRewriter(stmt, allSchemas, dbName)
+		if rewriter == nil {
+			continue // If no tables are found, we cannot rewrite placeholders.
+		}
 		// Wiring in for the join (col = __) case
 		if sel, ok := stmt.AST.(*tree.Select); ok {
 			// The SelectClause is unboxed from the Select statement.
@@ -202,7 +240,7 @@ func replacePlaceholders(rawSQL string, allSchemas map[string]*TableSchema) (str
 		rewritten := fmtCtx.CloseAndGetString()
 		// Cleaning up crdb_internal.force_error() calls.
 		// This is most probably used for development purposes to throw particular errors.
-		// In our case, since we will never be executing those parts, we are replacing with constant values of error code and error message.
+		// In our case, since we will never be executing those parts, we are replacing it with constant values of error code and error message.
 		rewritten = forceErrorRe.ReplaceAllString(rewritten, fmt.Sprintf("crdb_internal.force_error(%s, %s)", forceErrorCode, forceErrorMessage))
 		out = append(out, rewritten)
 	}
@@ -210,31 +248,103 @@ func replacePlaceholders(rawSQL string, allSchemas map[string]*TableSchema) (str
 	return strings.Join(out, "\n"), nil
 }
 
+// extractTablesFromExpr recursively extracts table names from a table expression,
+// including those in nested JOINs.
+// It appends the table names to the provided slice and maps aliases to their corresponding table names.
+// Returns false if no table name is found in the expression. This is possible if the table belongs to a
+// different database.
+func extractTablesFromExpr(
+	expr tree.TableExpr, tables *[]string, aliases map[string]string, dbName string,
+) bool {
+	switch t := expr.(type) {
+	case *tree.TableName, *tree.AliasedTableExpr:
+		if name, alias := extractTableName(expr, dbName); name != "" {
+			*tables = append(*tables, name)
+			aliases[alias] = name
+			return true
+		}
+		// skipped as the table name does not belong to the current dbName.
+		return false
+	case *tree.JoinTableExpr:
+		// Recursively extract tables from both sides of the join
+		return extractTablesFromExpr(t.Left, tables, aliases, dbName) &&
+			extractTablesFromExpr(t.Right, tables, aliases, dbName)
+	}
+	// skipped as the table name does not belong to the current dbName.
+	return false
+}
+
 // buildPlaceholderRewriter creates a placeholderRewriter for the given statement.
 // It extracts the table name from the statement and initializes the rewriter with the schema map.
 func buildPlaceholderRewriter(
-	stmt statements.Statement[tree.Statement], allSchemas map[string]*TableSchema,
+	stmt statements.Statement[tree.Statement], allSchemas map[string]*TableSchema, dbName string,
 ) *placeholderRewriter {
-	var tableName string
-	switch stmt := stmt.AST.(type) {
+	tables := make([]string, 0)
+	aliases := make(map[string]string)
+	switch s := stmt.AST.(type) {
 	case *tree.Insert:
 		// ins.Table is a TableName or AliasedTableExpr
-		tableName = extractTableName(stmt.Table)
+		table, alias := extractTableName(s.Table, dbName)
+		if table == "" {
+			// skipped as the table name does not belong to the current dbName.
+			return nil
+		}
+		tables = append(tables, table)
+		aliases[alias] = table
 	case *tree.Update:
-		tableName = extractTableName(stmt.Table)
+		table, alias := extractTableName(s.Table, dbName)
+		if table == "" {
+			// skipped as the table name does not belong to the current dbName.
+			return nil
+		}
+		tables = append(tables, table)
+		aliases[alias] = table
 	case *tree.Delete:
-		tableName = extractTableName(stmt.Table)
+		table, alias := extractTableName(s.Table, dbName)
+		if table == "" {
+			// If the table is not specified, we cannot rewrite placeholders.
+			return nil
+		}
+		tables = append(tables, table)
+		aliases[alias] = table
 	case *tree.Select:
-		// Pulling from the first FROM table (skip joins/withs)
-		if sc, ok := stmt.Select.(*tree.SelectClause); ok {
-			if len(sc.From.Tables) > 0 {
-				tableName = extractTableName(sc.From.Tables[0])
+		// Pulling from all FROM tables and joins (including nested joins)
+		if sc, ok := s.Select.(*tree.SelectClause); ok {
+			for _, tblExpr := range sc.From.Tables {
+				if !extractTablesFromExpr(tblExpr, &tables, aliases, dbName) {
+					return nil
+				}
 			}
 		}
 	}
 	// Expression-level rewrites (WHERE, IN, BETWEEN, comparisons) are handled using this visitor.
 	return &placeholderRewriter{
-		schemas:   allSchemas,
-		tableName: tableName,
+		schemas:      allSchemas,
+		tableNames:   tables,
+		tableAliases: aliases,
 	}
+}
+
+// newPlaceholderRewriter creates a new placeholderRewriter with the provided schemas, table name, and alias.
+func newPlaceholderRewriter(
+	schemas map[string]*TableSchema, tableName, tableAlias string,
+) *placeholderRewriter {
+	return &placeholderRewriter{
+		schemas:      schemas,
+		tableNames:   []string{tableName},
+		tableAliases: map[string]string{tableAlias: tableName},
+	}
+}
+
+// isInternalTable checks if a row represents an internal table by examining if the key column
+// contains "<dbName>.<internalSchema>" for any schema in internalSchemas.
+func isInternalTable(row []string, dbName string, columnIndex map[string]int) bool {
+	keyValue := row[columnIndex[keyColumnName]]
+	// Check if the key column contains "<dbName>.<internalSchema>" for any internal schema
+	for _, schema := range internalSchemas {
+		if strings.Contains(keyValue, dbName+"."+schema) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/workload/workload_generator/sql_test.go
+++ b/pkg/workload/workload_generator/sql_test.go
@@ -66,6 +66,11 @@ func TestReplacePlaceholders_AllCases(t *testing.T) {
 		{"Select between Tuple", "SELECT * FROM orders WHERE amount BETWEEN (_ ) AND (__more__);", "orders", "WHERE"},
 		{"Select between with binary expr", "SELECT * FROM orders WHERE amount BETWEEN (_-_) AND (_-_);", "orders", "WHERE"},
 		{"Select Limit", "SELECT * FROM orders WHERE amount > _ LIMIT _;", "orders", "LIMIT"},
+		{"Select Join", "SELECT o.id, r.c2 FROM orders o JOIN ref_data r ON o.acc_no = r.acc_no WHERE o.amount > _;", "orders", "WHERE"},
+		{"Select Multi Join", "SELECT o.id, r.c2, r.c3 FROM orders o JOIN ref_data r ON o.acc_no = r.acc_no JOIN ref_data r2 ON o.acc_no = r2.acc_no WHERE r.c2 = _;", "orders", "WHERE"},
+		{"Select Multi Tables", "SELECT o.id, r.c2 FROM orders o, ref_data r WHERE o.acc_no = r.acc_no AND o.amount > _ AND r.acc_no = _ OR o.acc_no = _;", "orders", "WHERE"},
+		{"Select Table names with schema", "SELECT id FROM cct_tpcc.orders WHERE acc_no = _;", "orders", "WHERE"},
+
 		{"When Then SET", "UPDATE orders SET status = CASE amount WHEN _ THEN _ WHEN _ THEN _ ELSE _ END WHERE id = _;", "orders", "UPDATE"},
 		{"Update tuple CASE", "UPDATE orders SET amount = CASE (amount, status) WHEN (_, __more__) THEN _ ELSE _ END;", "orders", "UPDATE"},
 
@@ -91,10 +96,8 @@ func TestReplacePlaceholders_AllCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := replacePlaceholders(tt.input, schemas)
-			if err != nil {
-				t.Fatalf("replacePlaceholders(%q) error: %v", tt.input, err)
-			}
+			out, err := replacePlaceholders(tt.input, schemas, "cct_tpcc")
+			require.Nil(t, err, "replacePlaceholders(%q) error: %v", tt.input, err)
 
 			// Remove all metadata tags, leaving regular SQL
 			cleaned := tagRE.ReplaceAllString(out, "")
@@ -104,30 +107,27 @@ func TestReplacePlaceholders_AllCases(t *testing.T) {
 
 			if hadPlaceholder {
 				// After stripping tags, no standalone "_" or "__more__" should remain
-				if placeholderRE.MatchString(cleaned) {
-					t.Errorf("raw placeholder remains after cleaning: %q", cleaned)
-				}
+				require.False(t, placeholderRE.MatchString(cleaned), "raw placeholder remains after cleaning: %q", cleaned)
 				// We expect at least one tag delimiter in the output
-				if !strings.Contains(out, ":-:|") {
-					t.Errorf("expected placeholder tags in output: %q", out)
-				}
+				require.Contains(t, out, ":-:|", "expected placeholder tags in output: %q", out)
 				// And the clause and table names should both appear somewhere in those tags
-				if !strings.Contains(out, tt.clause) {
-					t.Errorf("expected clause %q in tags: %q", tt.clause, out)
-				}
-				if !strings.Contains(out, tt.table) {
-					t.Errorf("expected table %q in tags: %q", tt.table, out)
-				}
+				require.Contains(t, out, tt.clause, "expected clause %q in tags: %q", tt.clause, out)
+				require.Contains(t, out, tt.table, "expected table %q in tags: %q", tt.table, out)
 			} else {
 				// No placeholders → output should be unchanged (ignoring whitespace)
 				normalizedIn := strings.Join(strings.Fields(tt.input), " ")
 				normalizedOut := strings.Join(strings.Fields(out), " ")
-				if normalizedIn != normalizedOut {
-					t.Errorf("expected no change for %q, got %q", tt.input, out)
-				}
+				require.Equal(t, normalizedIn, normalizedOut, "expected no change for %q, got %q", tt.input, out)
 			}
 		})
 	}
+	t.Run("Select Table names with different schema", func(t *testing.T) {
+		query := "SELECT id FROM db2.orders WHERE acc_no = _;"
+		out, err := replacePlaceholders(query, schemas, "cct_tpcc")
+		require.Nil(t, err, "replacePlaceholders(%q) error: %v", query, err)
+		require.Empty(t, out, "expected empty output for query with different schema: %q", query)
+	},
+	)
 }
 
 func TestIsWriteTransaction(t *testing.T) {
@@ -154,7 +154,9 @@ func TestGetColumnIndexes_Success(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(header), 0644))
 	f, err := os.Open(path)
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	// Advance scanner to header row
 	scanner := bufio.NewScanner(f)

--- a/pkg/workload/workload_generator/sql_utils.go
+++ b/pkg/workload/workload_generator/sql_utils.go
@@ -49,19 +49,33 @@ var (
 	forceErrorRe = regexp.MustCompile(forceErrorPattern)
 )
 
-// extractTableName returns the unaliased table name for a
+// extractTableName returns the table name along with the table alias for a
 // simple TableExpr (either a bare *tree.TableName or an *tree.AliasedTableExpr).
-// If the expr is something else (JOIN, subquery, etc.) it returns "".
-func extractTableName(tbl tree.TableExpr) string {
+// The table alias is returned as an empty string if there is no alias.
+// If the table name in the expression does not belong to the database, the table name is returned as "".
+func extractTableName(tbl tree.TableExpr, dbName string) (string, string) {
 	switch t := tbl.(type) {
 	case *tree.TableName:
-		return t.String() // exactly how it prints in SQL, with quotes if needed
+		// table name can be with or without quotes - e.g. "order" or `customer`.
+		return removeSchemaPrefix(strings.Trim(t.String(), `"`), dbName), ""
 	case *tree.AliasedTableExpr:
 		if tn, ok := t.Expr.(*tree.TableName); ok {
-			return tn.String()
+			return removeSchemaPrefix(strings.Trim(tn.String(), `"`), dbName), t.As.Alias.String()
 		}
 	}
-	return "" // unknown or a subquery/join
+	return "", "" // unknown
+}
+
+// removeSchemaPrefix removes the schema prefix from a table name.
+func removeSchemaPrefix(tn, dbName string) string {
+	tableDetails := strings.Split(tn, ".")
+	if len(tableDetails) > 1 {
+		// If the table name has a schema prefix, the dbName must match.
+		if tableDetails[0] != dbName {
+			return ""
+		}
+	}
+	return tableDetails[len(tableDetails)-1]
 }
 
 // VisitPre handles any expr type of nodes with _ or __more__ inside them
@@ -71,21 +85,16 @@ func (v *placeholderRewriter) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 		switch key := ce.Expr.(type) {
 		// ── scalar CASE: CASE col WHEN _ THEN _ …
 		case *tree.UnresolvedName:
-			rewriteCaseExpr(
+			v.rewriteCaseExpr(
 				ce,
-				reconstructName(key), // e.g. "c_credit"
-				v.schemas,
-				"", //return type is unknown
+				newColumnName(key), // e.g. "c_credit"
 			)
 		// ── tuple CASE: CASE (col1,col2) WHEN … THEN …
 		case *tree.Tuple:
 			// rewriteCaseExpr’s tuple‐branch ignores the target string.
 			// It uses the Tuple directly to regenerate each WHEN/THEN.
-			rewriteCaseExpr(
-				ce,
-				"", // unused for tuple‐mode
-				v.schemas,
-				"", //return type is unknown
+			v.rewriteCaseExpr(
+				ce, nil, // unused for tuple‐mode
 			)
 		}
 
@@ -96,12 +105,12 @@ func (v *placeholderRewriter) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 
 	if co, ok := expr.(*tree.CoalesceExpr); ok && strings.EqualFold(co.Name, "IFNULL") {
 		// Not recursing into the old IFNULL; swapping it out now.
-		return false, handleIfNull(co, v.schemas, v.tableName)
+		return false, v.handleIfNull(co)
 	}
 
 	//Handling BETWEEN … AND …
 	if rc, ok := expr.(*tree.RangeCond); ok {
-		if newExpr := handleRangeCondition(rc, v.schemas, v.tableName); newExpr != nil {
+		if newExpr := v.handleRangeCondition(rc); newExpr != nil {
 			return false, newExpr
 		}
 	}
@@ -112,7 +121,7 @@ func (v *placeholderRewriter) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 	}
 	// Handling IN operator.
 	if cmp.Operator.Symbol == treecmp.In {
-		if newTuple := handleInOperator(cmp, v.schemas, v.tableName); newTuple != nil {
+		if newTuple := v.handleInOperator(cmp); newTuple != nil {
 			cmp.Right = newTuple
 			// Not recursing further into the old RHS
 			return false, cmp
@@ -121,7 +130,7 @@ func (v *placeholderRewriter) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 	// Handling tuple comparisons.
 	if lt, lok := cmp.Left.(*tree.Tuple); lok {
 		if rt, rok := cmp.Right.(*tree.Tuple); rok {
-			if newRt := handleTupleComparison(lt, rt, v.schemas, v.tableName); newRt != nil {
+			if newRt := v.handleTupleComparison(lt, rt); newRt != nil {
 				cmp.Right = newRt
 				return false, cmp
 			}
@@ -129,7 +138,7 @@ func (v *placeholderRewriter) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 	}
 
 	// Handling simple one-column comparisons.
-	b, t, done := handleComparisonOperator(cmp, v.schemas, v.tableName)
+	b, t, done := v.handleComparisonOperator(cmp)
 	if done {
 		return b, t
 	}
@@ -138,9 +147,7 @@ func (v *placeholderRewriter) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 }
 
 // handleIfNull is for rewriting IFNULL(a, b) or IFNULL(func(a),b) where b is a placeholder.
-func handleIfNull(
-	co *tree.CoalesceExpr, allSchemas map[string]*TableSchema, tableName string,
-) tree.Expr {
+func (v *placeholderRewriter) handleIfNull(co *tree.CoalesceExpr) tree.Expr {
 	// It should be only IFNULL(a, b).
 	if len(co.Exprs) != 2 {
 		return co
@@ -148,30 +155,30 @@ func handleIfNull(
 
 	// Second arg must be a placeholder.
 	rhs, ok := co.Exprs[1].(*tree.UnresolvedName)
-	if !ok || reconstructName(rhs) != "_" {
+	if !ok || rhs.Parts[0] != "_" {
 		return co
 	}
 
 	// Trying to extract the “key” column from the first arg.
 	// It should be either a bare column, or any single‐arg FuncExpr(col).
-	var keyCol string
+	var keyCol *columnName
 	switch first := co.Exprs[0].(type) {
 	case *tree.UnresolvedName:
-		keyCol = reconstructName(first)
+		keyCol = newColumnName(first)
 	case *tree.FuncExpr:
 		if len(first.Exprs) == 1 {
 			if col, ok := first.Exprs[0].(*tree.UnresolvedName); ok {
-				keyCol = reconstructName(col)
+				keyCol = newColumnName(col)
 			}
 		}
 	}
 
-	if keyCol == "" {
+	if keyCol == nil {
 		return co
 	}
 
 	// The _ is now tagged with the placeholder made using the keyCol.
-	parts := getFieldCol(keyCol, "WHERE", allSchemas, tableName)
+	parts := v.getFieldCol(keyCol, "WHERE")
 	rhs.NumParts = len(parts)
 	copy(rhs.Parts[:], parts)
 	return co
@@ -180,45 +187,39 @@ func handleIfNull(
 // handleRangeCondition rewrites any RangeCond (a BETWEEN b AND c or NOT BETWEEN)
 // where b and/or c embed "_" or "__more__" placeholders. Supports both single-col
 // and tuple-col BETWEEN.
-func handleRangeCondition(
-	rc *tree.RangeCond, allSchemas map[string]*TableSchema, tableName string,
-) tree.Expr {
+func (v *placeholderRewriter) handleRangeCondition(rc *tree.RangeCond) tree.Expr {
 	// Single-column: col1 BETWEEN a AND b.
 	if colUn, ok := rc.Left.(*tree.UnresolvedName); ok {
-		return rewriteSingleRange(rc, colUn, allSchemas, tableName)
+		return v.rewriteSingleRange(rc, colUn)
 	}
 
 	// Tuple-column: (col1,col2) BETWEEN (a,b) AND (c,d).
 	if tpl, ok := rc.Left.(*tree.Tuple); ok {
-		return rewriteTupleRange(rc, tpl, allSchemas, tableName)
+		return v.rewriteTupleRange(rc, tpl)
 	}
 
 	return nil
 }
 
 // rewriteSingleRange handles the single-column BETWEEN case.
-func rewriteSingleRange(
-	rc *tree.RangeCond,
-	colUn *tree.UnresolvedName,
-	allSchemas map[string]*TableSchema,
-	tableName string,
+func (v *placeholderRewriter) rewriteSingleRange(
+	rc *tree.RangeCond, colUn *tree.UnresolvedName,
 ) tree.Expr {
-	rc.From = rewriteRangeBound(rc.From, colUn, allSchemas, tableName)
-	rc.To = rewriteRangeBound(rc.To, colUn, allSchemas, tableName)
+	rc.From = v.rewriteRangeBound(rc.From, colUn)
+	rc.To = v.rewriteRangeBound(rc.To, colUn)
 	return rc
 }
 
 // rewriteRangeBound rewrites a single bound expression, replacing "_" or "__more__"
 // with a tagged placeholder for the given column.
-func rewriteRangeBound(
-	expr tree.Expr, colUn *tree.UnresolvedName, allSchemas map[string]*TableSchema, tableName string,
+func (v *placeholderRewriter) rewriteRangeBound(
+	expr tree.Expr, colUn *tree.UnresolvedName,
 ) tree.Expr {
 	switch t := expr.(type) {
 	case *tree.UnresolvedName:
 		// It should be a direct "_" or "__more__" to get replaced.
-		if name := reconstructName(t); isBarePlaceholder(name) {
-			colName := reconstructName(colUn)
-			parts := getFieldCol(colName, "WHERE", allSchemas, tableName)
+		if name := t.Parts[0]; isBarePlaceholder(name) {
+			parts := v.getFieldCol(newColumnName(colUn), "WHERE")
 			t.NumParts = len(parts)
 			copy(t.Parts[:], parts)
 		}
@@ -226,21 +227,20 @@ func rewriteRangeBound(
 
 	case *tree.ParenExpr:
 		// We call the same function on the inner expression.
-		t.Expr = rewriteRangeBound(t.Expr, colUn, allSchemas, tableName)
+		t.Expr = v.rewriteRangeBound(t.Expr, colUn)
 		return t
 
 	case *tree.BinaryExpr:
 		// Recursing into both sides of any arithmetic.
-		left := rewriteRangeBound(t.Left, colUn, allSchemas, tableName)
-		right := rewriteRangeBound(t.Right, colUn, allSchemas, tableName)
+		left := v.rewriteRangeBound(t.Left, colUn)
+		right := v.rewriteRangeBound(t.Right, colUn)
 
 		// If both sides turned into placeholders, collapse into one.
 		// Eg: col1 between (_ - _) and (_ + _). This eventually gets converted to col1 between ($1 - $2) and ($3 + $4).
 		// This throws an error because sql compiler cannot figure out type of the expression inside parenthesis.
 		if _, lok := left.(*tree.UnresolvedName); lok {
 			if _, rok := right.(*tree.UnresolvedName); rok {
-				colName := reconstructName(colUn)
-				parts := getFieldCol(colName, "WHERE", allSchemas, tableName)
+				parts := v.getFieldCol(newColumnName(colUn), "WHERE")
 				var np tree.NameParts
 				copy(np[:], parts)
 				return &tree.UnresolvedName{
@@ -257,9 +257,7 @@ func rewriteRangeBound(
 }
 
 // rewriteTupleRange handles the tuple-column BETWEEN case.
-func rewriteTupleRange(
-	rc *tree.RangeCond, keyTpl *tree.Tuple, allSchemas map[string]*TableSchema, tableName string,
-) tree.Expr {
+func (v *placeholderRewriter) rewriteTupleRange(rc *tree.RangeCond, keyTpl *tree.Tuple) tree.Expr {
 	// It must have tuple bounds.
 	fromTpl, fromOk := rc.From.(*tree.Tuple)
 	toTpl, toOk := rc.To.(*tree.Tuple)
@@ -271,7 +269,7 @@ func rewriteTupleRange(
 	for _, bound := range []*tree.Tuple{fromTpl, toTpl} {
 		for _, e := range bound.Exprs {
 			u, ok := e.(*tree.UnresolvedName)
-			colName := reconstructName(u)
+			colName := u.Parts[0]
 			if !ok || (colName != "_" && colName != "__more__") {
 				return nil
 			}
@@ -288,8 +286,7 @@ func rewriteTupleRange(
 	build := func() *tree.Tuple {
 		out := &tree.Tuple{Exprs: make(tree.Exprs, len(cols))}
 		for j, colNode := range cols {
-			colName := reconstructName(colNode)
-			parts := getFieldCol(colName, "WHERE", allSchemas, tableName)
+			parts := v.getFieldCol(newColumnName(colNode), "WHERE")
 			var np tree.NameParts
 			copy(np[:], parts)
 			out.Exprs[j] = &tree.UnresolvedName{
@@ -306,15 +303,15 @@ func rewriteTupleRange(
 }
 
 // handleComparisonOperator is for rewriting simple comparison expressions: col = _ or col > __more__ etc.
-func handleComparisonOperator(
-	cmp *tree.ComparisonExpr, allSchemas map[string]*TableSchema, tableName string,
+func (v *placeholderRewriter) handleComparisonOperator(
+	cmp *tree.ComparisonExpr,
 ) (bool, tree.Expr, bool) {
 	lhs, lok := cmp.Left.(*tree.UnresolvedName)
 	rhs, rok := cmp.Right.(*tree.UnresolvedName)
 	if lok && rok {
-		rhsName := reconstructName(rhs)
+		rhsName := rhs.Parts[0]
 		if isBarePlaceholder(rhsName) {
-			parts := getFieldCol(lhs.Parts[0], "WHERE", allSchemas, tableName)
+			parts := v.getFieldCol(newColumnName(lhs), "WHERE")
 
 			rhs.NumParts = len(parts)
 			var np tree.NameParts
@@ -334,16 +331,14 @@ func (v *placeholderRewriter) VisitPost(expr tree.Expr) tree.Expr {
 // handleTupleComparison rewrites ANY tuple-vs-tuple ComparisonExpr
 // whose RHS is all "_" or "__more__", remapping it to a new tuple
 // with exactly one placeholder per LHS column.
-func handleTupleComparison(
-	lt, rt *tree.Tuple, allSchemas map[string]*TableSchema, tableName string,
-) *tree.Tuple {
+func (v *placeholderRewriter) handleTupleComparison(lt, rt *tree.Tuple) *tree.Tuple {
 	// 1) Verifying RHS is purely placeholders (any length).
 	for _, e := range rt.Exprs {
 		u, ok := e.(*tree.UnresolvedName)
 		if !ok {
 			return nil
 		}
-		if n := reconstructName(u); n != "_" && n != "__more__" {
+		if n := u.Parts[0]; n != "_" && n != "__more__" {
 			return nil
 		}
 	}
@@ -356,7 +351,7 @@ func handleTupleComparison(
 			return nil // safety, though LHS should always be a tuple of names
 		}
 		// A tagged placeholder is built for this column.
-		parts := getFieldCol(col.Parts[0], "WHERE", allSchemas, tableName) // preserves qualifiers, wraps part0
+		parts := v.getFieldCol(newColumnName(col), "WHERE")
 		var np tree.NameParts
 		copy(np[:], parts)
 		newExprs[i] = &tree.UnresolvedName{
@@ -371,9 +366,7 @@ func handleTupleComparison(
 }
 
 // handleInOperator dispatches single-col vs multi-col IN (…) cases.
-func handleInOperator(
-	cmp *tree.ComparisonExpr, allSchemas map[string]*TableSchema, tableName string,
-) *tree.Tuple {
+func (v *placeholderRewriter) handleInOperator(cmp *tree.ComparisonExpr) *tree.Tuple {
 	orig, ok := cmp.Right.(*tree.Tuple)
 	if !ok {
 		return nil
@@ -382,11 +375,11 @@ func handleInOperator(
 	switch lhs := cmp.Left.(type) {
 	case *tree.UnresolvedName:
 		// Single-col IN: requires every orig.Exprs[i] be an UnresolvedName.
-		return handleSingleColIn(lhs, orig, allSchemas, tableName)
+		return v.handleSingleColIn(lhs, orig)
 
 	case *tree.Tuple:
 		// Multi-col IN: requires every orig.Exprs[i] be a *tree.Tuple of UnresolvedNames.
-		return handleMultiColIn(lhs, orig, allSchemas, tableName)
+		return v.handleMultiColIn(lhs, orig)
 
 	default:
 		return nil
@@ -394,24 +387,24 @@ func handleInOperator(
 }
 
 // handleSingleColIn rebuilds “col IN (_,__more__)” → col IN (p, p, …).
-func handleSingleColIn(
-	col *tree.UnresolvedName, orig *tree.Tuple, allSchemas map[string]*TableSchema, tableName string,
+func (v *placeholderRewriter) handleSingleColIn(
+	col *tree.UnresolvedName, orig *tree.Tuple,
 ) *tree.Tuple {
 
 	// 1) Verifying that each element is an UnresolvedName placeholder.
 	for _, e := range orig.Exprs {
 		u, ok := e.(*tree.UnresolvedName)
-		if !ok || (reconstructName(u) != "_" && reconstructName(u) != "__more__") {
+		if !ok || (u.Parts[0] != "_" && u.Parts[0] != "__more__") {
 			return nil
 		}
 	}
 
-	parts := getFieldCol(col.Parts[0], "WHERE", allSchemas, tableName) // wraps part0, preserves qualifiers
+	parts := v.getFieldCol(newColumnName(col), "WHERE")
 	// New flat list of placeholders is built.
 	var newExprs tree.Exprs
 	for _, e := range orig.Exprs {
 		uOld := e.(*tree.UnresolvedName)
-		name := reconstructName(uOld)
+		name := uOld.Parts[0]
 
 		// 1) One copy for every original placeholder.
 		var np tree.NameParts
@@ -439,9 +432,7 @@ func handleSingleColIn(
 
 // handleMultiColIn rebuilds “(a,b,…) IN ((_,__more__), __more__)” →
 // (a,b,…) IN ((p_a,p_b,…), (p_a,p_b,…), …).
-func handleMultiColIn(
-	lhs *tree.Tuple, orig *tree.Tuple, allSchemas map[string]*TableSchema, tableName string,
-) *tree.Tuple {
+func (v *placeholderRewriter) handleMultiColIn(lhs *tree.Tuple, orig *tree.Tuple) *tree.Tuple {
 	// 1) Must have at least one tuple‐row.
 	if len(orig.Exprs) == 0 {
 		return nil
@@ -456,7 +447,7 @@ func handleMultiColIn(
 		if !ok {
 			return nil
 		}
-		name := reconstructName(u)
+		name := u.Parts[0]
 		if name != "_" && name != "__more__" {
 			return nil
 		}
@@ -464,7 +455,7 @@ func handleMultiColIn(
 	// 3) Any further elements must be single "__more__" markers.
 	for i := 1; i < len(orig.Exprs); i++ {
 		u, ok := orig.Exprs[i].(*tree.UnresolvedName)
-		if !ok || reconstructName(u) != "__more__" {
+		if !ok || u.Parts[0] != "__more__" {
 			return nil
 		}
 	}
@@ -483,7 +474,7 @@ func handleMultiColIn(
 	for i := 0; i < rowCount; i++ {
 		tpl := &tree.Tuple{Exprs: make(tree.Exprs, len(cols))}
 		for j, col := range cols {
-			parts := getFieldCol(col.Parts[0], "WHERE", allSchemas, tableName)
+			parts := v.getFieldCol(newColumnName(col), "WHERE")
 			var np tree.NameParts
 			copy(np[:], parts)
 			tpl.Exprs[j] = &tree.UnresolvedName{
@@ -496,58 +487,44 @@ func handleMultiColIn(
 	return &tree.Tuple{Exprs: rows}
 }
 
-// reconstructName joins the first NumParts entries of an UnresolvedName.
-func reconstructName(u *tree.UnresolvedName) string {
-	parts := u.Parts[:u.NumParts]
-	clean := parts[:0]
-	for _, p := range parts {
-		if p != "" {
-			clean = append(clean, p)
-		}
-	}
-	return strings.Join(clean, ".")
-}
-
 // getFieldCol returns a string that can be used to make UnresolvedName type of node.
 // The string basically consists of col related schema information, the sql clause(WHERE , INSERT, or UPDATE) and the table name.
-func getFieldCol(
-	col string, clause string, allSchemas map[string]*TableSchema, tableName string,
-) []string {
-	numParts := 1
-	parts := make([]string, numParts)
+func (v *placeholderRewriter) getFieldCol(col *columnName, clause string) []string {
+	var foundTable string
 	var placeholder string
-	for tn, schema := range allSchemas {
-		matched := false
-		for _, column := range schema.Columns {
-			if column.Name == col && tn == tableName {
-				placeholder = column.String()
-				placeholder = placeholder[1 : len(placeholder)-1]
-				matched = true
-				break
+	if col.tableAlias != "" {
+		// If the column has a table alias, use it to find the table name.
+		foundTable = v.tableAliases[col.tableAlias]
+	} else {
+		for _, tbl := range v.tableNames {
+			if ts, ok := v.schemas[tbl]; ok {
+				if c, exists := ts.Columns[col.name]; exists {
+					placeholder = c.String()
+					placeholder = placeholder[1 : len(placeholder)-1]
+					foundTable = tbl
+					break
+				}
 			}
 		}
-		if matched {
-			break
-		}
 	}
-	parts[0] = fmt.Sprintf(":-:|'%s','%s','%s'|:-:", placeholder, clause, tableName)
-	return parts
+
+	return []string{
+		fmt.Sprintf(":-:|'%s','%s','%s'|:-:", placeholder, clause, foundTable),
+	}
 }
 
 // rewriteCaseExpr tags every WHEN … THEN … and the final ELSE if it’s
 // an UnresolvedName placeholder. You may already have a
 // placeholderRewriter for WHERE/IN/BETWEEN—this is just the SET‐specific
 // pass so you know the targetCol.
-func rewriteCaseExpr(
-	c *tree.CaseExpr, targetCol string, allSchemas map[string]*TableSchema, tableName string,
-) {
+func (v *placeholderRewriter) rewriteCaseExpr(c *tree.CaseExpr, targetCol *columnName) {
 	// Detecting as tuple‐CASE if c.Expr is a Tuple of key columns.
 	if keyTpl, ok := c.Expr.(*tree.Tuple); ok {
 		// Gather the key column names.
-		var keyCols []string
+		var keyCols []*tree.UnresolvedName
 		for _, ke := range keyTpl.Exprs {
 			if un, ok := ke.(*tree.UnresolvedName); ok {
-				keyCols = append(keyCols, reconstructName(un))
+				keyCols = append(keyCols, un)
 			}
 		}
 		// For each WHEN arm: both Cond (tuple) and Val are rewritten.
@@ -556,7 +533,7 @@ func rewriteCaseExpr(
 				// Rebuild cond tuple with placeholders per keyCol.
 				newCond := &tree.Tuple{Exprs: make(tree.Exprs, len(keyCols))}
 				for i, col := range keyCols {
-					parts := getFieldCol(col, "WHERE", allSchemas, tableName)
+					parts := v.getFieldCol(newColumnName(col), "WHERE")
 					var np tree.NameParts
 					copy(np[:], parts)
 					newCond.Exprs[i] = &tree.UnresolvedName{
@@ -568,12 +545,12 @@ func rewriteCaseExpr(
 			}
 			// THEN arm.Val → placeholder for targetCol
 			if u, ok := arm.Val.(*tree.UnresolvedName); ok {
-				populatePlaceholder(u, targetCol, allSchemas, tableName)
+				v.populatePlaceholder(u, targetCol)
 			}
 		}
 		// ELSE branch can be a placeholder or force_error; handle simple placeholder.
 		if u, ok := c.Else.(*tree.UnresolvedName); ok {
-			populatePlaceholder(u, targetCol, allSchemas, tableName)
+			v.populatePlaceholder(u, targetCol)
 		}
 		return
 	}
@@ -582,32 +559,30 @@ func rewriteCaseExpr(
 	// Finding the column on which the CASE depends on.
 	condCol := targetCol
 	if un, ok := c.Expr.(*tree.UnresolvedName); ok {
-		condCol = reconstructName(un)
+		condCol = newColumnName(un)
 	}
 	for _, arm := range c.Whens {
 		// Handling the WHEN arm.
 		if u, ok := arm.Cond.(*tree.UnresolvedName); ok {
-			populatePlaceholder(u, condCol, allSchemas, tableName)
+			v.populatePlaceholder(u, condCol)
 		}
 		// Handling the THEN arm.
 		if u, ok := arm.Val.(*tree.UnresolvedName); ok {
-			populatePlaceholder(u, targetCol, allSchemas, tableName)
+			v.populatePlaceholder(u, targetCol)
 		}
 	}
 	// Handling the ELSE arm.
 	if u, ok := c.Else.(*tree.UnresolvedName); ok {
-		populatePlaceholder(u, targetCol, allSchemas, tableName)
+		v.populatePlaceholder(u, targetCol)
 	}
 }
 
 // populatePlaceholder checks if u is a bare "_" or "__more__" placeholder.
 // If so, it uses getFieldCol to build the parts for targetCol in the given clause
 // and copies them into u.
-func populatePlaceholder(
-	u *tree.UnresolvedName, targetCol string, allSchemas map[string]*TableSchema, tableName string,
-) {
-	if name := reconstructName(u); isBarePlaceholder(name) {
-		parts := getFieldCol(targetCol, "INSERT", allSchemas, tableName)
+func (v *placeholderRewriter) populatePlaceholder(u *tree.UnresolvedName, targetCol *columnName) {
+	if name := u.Parts[0]; isBarePlaceholder(name) {
+		parts := v.getFieldCol(targetCol, "INSERT")
 		u.NumParts = len(parts)
 		copy(u.Parts[:], parts)
 	}
@@ -623,7 +598,7 @@ func handleSelectLimit(sel *tree.Select) {
 	if sel.Limit == nil || sel.Limit.Count == nil {
 		return
 	}
-	if u, ok := sel.Limit.Count.(*tree.UnresolvedName); ok && reconstructName(u) == "_" {
+	if u, ok := sel.Limit.Count.(*tree.UnresolvedName); ok && u.Parts[0] == "_" {
 		// A random number between minSelectLimit and maxSelectLimit is picked. The range is 1-100 currently.
 		n := rand.Intn(maxSelectLimit-minSelectLimit) + minSelectLimit
 		lit := fmt.Sprintf("%d", n)
@@ -637,11 +612,12 @@ func handleSelectLimit(sel *tree.Select) {
 }
 
 // handleInsert focuses on INSERT … VALUES type of sqls.
-func handleInsert(ins *tree.Insert, allSchemas map[string]*TableSchema) {
+func handleInsert(ins *tree.Insert, allSchemas map[string]*TableSchema, dbName string) {
 	// 1) The table name is extracted.
-	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
-	ins.Table.Format(fmtCtx)
-	tableName := fmtCtx.CloseAndGetString()
+	tn, ta := extractTableName(ins.Table, dbName)
+	if tn == "" {
+		return // skipped as the table name does not belong to the current dbName.
+	}
 
 	// 2) Only raw VALUES clauses are rewritten.
 	vals, ok := ins.Rows.Select.(*tree.ValuesClause)
@@ -649,23 +625,22 @@ func handleInsert(ins *tree.Insert, allSchemas map[string]*TableSchema) {
 		return
 	}
 
+	v := newPlaceholderRewriter(allSchemas, tn, ta)
 	// 3) Gathering columns and rebuilding the placeholder rows.
-	cols := collectInsertCols(ins, allSchemas, tableName)
-	ins.Rows.Select.(*tree.ValuesClause).Rows = buildInsertPlaceholderRows(
-		cols, len(vals.Rows), allSchemas, tableName,
+	cols := v.collectInsertCols(ins)
+	ins.Rows.Select.(*tree.ValuesClause).Rows = v.buildInsertPlaceholderRows(
+		cols, len(vals.Rows),
 	)
 }
 
 // collectInsertCols returns the ordered list of column names for this INSERT.
 // If ins.Columns are non-empty, use that; otherwise look up the TableSchema.
-func collectInsertCols(
-	ins *tree.Insert, allSchemas map[string]*TableSchema, tableName string,
-) []string {
-	// If column names are explicitly mentioned then those are extracted.
+func (v *placeholderRewriter) collectInsertCols(ins *tree.Insert) []*columnName {
+	// If column names are explicitly mentioned, then those are extracted.
 	if len(ins.Columns) > 0 {
-		cols := make([]string, len(ins.Columns))
+		cols := make([]*columnName, len(ins.Columns))
 		for i, n := range ins.Columns {
-			cols[i] = string(n)
+			cols[i] = newColumnNameWithName(string(n))
 		}
 		return cols
 	}
@@ -680,10 +655,10 @@ func collectInsertCols(
 			tblKey = strings.Trim(tn.String(), `"`)
 		}
 	}
-	if ts, ok := allSchemas[tblKey]; ok {
-		cols := make([]string, 0, len(ts.Columns))
+	if ts, ok := v.schemas[tblKey]; ok {
+		cols := make([]*columnName, 0, len(ts.Columns))
 		for col := range ts.Columns {
-			cols = append(cols, col)
+			cols = append(cols, newColumnNameWithName(col))
 		}
 		return cols
 	}
@@ -695,14 +670,14 @@ func collectInsertCols(
 // buildPlaceholderRows creates exactly rowCount placeholder tuples,
 // one per original VALUES row.
 // Ex: INSERT INTO tbl(col1,col2) VALUES ( _ ,__more__ ) , (__, __more__).. k times becomes INSERT INTO tbl(col1,col2) VALUES (:-:col1:-:,:-:col2:-:) , (:-:col1:-:,:-:col2:-:)).. k times
-func buildInsertPlaceholderRows(
-	cols []string, rowCount int, allSchemas map[string]*TableSchema, tableName string,
+func (v *placeholderRewriter) buildInsertPlaceholderRows(
+	cols []*columnName, rowCount int,
 ) []tree.Exprs {
 	newRows := make([]tree.Exprs, 0, rowCount)
 	for i := 0; i < rowCount; i++ {
 		base := make(tree.Exprs, len(cols))
 		for j, col := range cols {
-			parts := getFieldCol(col, "INSERT", allSchemas, tableName)
+			parts := v.getFieldCol(col, "INSERT")
 			var np tree.NameParts
 			copy(np[:], parts)
 			base[j] = &tree.UnresolvedName{
@@ -716,30 +691,33 @@ func buildInsertPlaceholderRows(
 }
 
 // handleUpdateSet orchestrates rewriting the placeholders in the SET clause of an UPDATE statement.
-func handleUpdateSet(upd *tree.Update, allSchemas map[string]*TableSchema) {
-	tableName := extractTableName(upd.Table)
+func handleUpdateSet(upd *tree.Update, allSchemas map[string]*TableSchema, dbName string) {
+	tn, ta := extractTableName(upd.Table, dbName)
+	if tn == "" {
+		return // skipped as the table name does not belong to the current dbName.
+	}
+
+	v := newPlaceholderRewriter(allSchemas, tn, ta)
 	for _, setExpr := range upd.Exprs {
 		if !setExpr.Tuple {
 			// Single‐column SET: "col = …"
 			targetCol := string(setExpr.Names[0])
-			setExpr.Expr = rewriteSingleColSetRHS(setExpr.Expr, targetCol, allSchemas, tableName)
+			setExpr.Expr = v.rewriteSingleColSetRHS(setExpr.Expr, newColumnNameWithName(targetCol))
 		} else {
 			// Tuple‐form SET: "(a,b,…) = (…)"
 			// A new RHS tuple, one placeholder per LHS column are built.
-			setExpr.Expr = rewriteMultiColSet(setExpr, allSchemas, tableName)
+			setExpr.Expr = v.rewriteMultiColSet(setExpr)
 		}
 	}
 }
 
 // rewriteMultiColSet rewrites the multi-column SET clause of an UPDATE statement.
-func rewriteMultiColSet(
-	setExpr *tree.UpdateExpr, allSchemas map[string]*TableSchema, tableName string,
-) *tree.Tuple {
+func (v *placeholderRewriter) rewriteMultiColSet(setExpr *tree.UpdateExpr) *tree.Tuple {
 	cols := setExpr.Names
 	newTuple := &tree.Tuple{Exprs: make(tree.Exprs, len(cols))}
 	for i, name := range cols {
 		col := string(name)
-		parts := getFieldCol(col, "UPDATE", allSchemas, tableName)
+		parts := v.getFieldCol(newColumnNameWithName(col), "UPDATE")
 		var np tree.NameParts
 		copy(np[:], parts)
 		newTuple.Exprs[i] = &tree.UnresolvedName{
@@ -751,33 +729,33 @@ func rewriteMultiColSet(
 }
 
 // rewriteSingleColSetRHS rewrites the RHS of a single-column SET clause.
-func rewriteSingleColSetRHS(
-	expr tree.Expr, targetCol string, allSchemas map[string]*TableSchema, tableName string,
+func (v *placeholderRewriter) rewriteSingleColSetRHS(
+	expr tree.Expr, targetCol *columnName,
 ) tree.Expr {
 	switch t := expr.(type) {
 	case *tree.UnresolvedName:
 		// It has to be a bare placeholder "_" or "__more__".
-		name := reconstructName(t)
+		name := t.Parts[0]
 		if isBarePlaceholder(name) {
-			parts := getFieldCol(targetCol, "UPDATE", allSchemas, tableName)
+			parts := v.getFieldCol(targetCol, "UPDATE")
 			t.NumParts = len(parts)
 			copy(t.Parts[:], parts)
 		}
 
 	case *tree.BinaryExpr:
 		// e.g. col + _  or deeper nested expressions.
-		t.Left = rewriteSingleColSetRHS(t.Left, targetCol, allSchemas, tableName)
-		t.Right = rewriteSingleColSetRHS(t.Right, targetCol, allSchemas, tableName)
+		t.Left = v.rewriteSingleColSetRHS(t.Left, targetCol)
+		t.Right = v.rewriteSingleColSetRHS(t.Right, targetCol)
 
 	case *tree.Tuple:
 		// e.g. CASE tuple‐arm might embed a Tuple
 		for i, elt := range t.Exprs {
-			t.Exprs[i] = rewriteSingleColSetRHS(elt, targetCol, allSchemas, tableName)
+			t.Exprs[i] = v.rewriteSingleColSetRHS(elt, targetCol)
 		}
 
 	case *tree.CaseExpr:
 		// Both tuple‐CASE and scalar‐CASE are handled here.
-		rewriteCaseExpr(t, targetCol, allSchemas, tableName)
+		v.rewriteCaseExpr(t, targetCol)
 	}
 	return expr
 }


### PR DESCRIPTION
This is a continuation of the effort for the workload generator which was worked on as an intern project. 
This PR addresses multiple issues and enhancements as mentioned:
1. Columns were not identified properly in case there were Joins because only 1 table name was considered from a statement.
e.g. SELECT o.id, r.c2, r.c3 FROM orders o JOIN ref_data r ON o.acc_no = r.acc_no JOIN ref_data r2 ON o.acc_no = r2.acc_no WHERE r.c2 = _

2. Columns with table_alias.column_name is not handled as table aliases were not maintained.
e.g. SELECT o.id, r.c2 FROM orders o, ref_data r WHERE o.acc_no = r.acc_no AND o.amount > _ AND r.acc_no = _ OR o.acc_no = _;

3. table names prefixed with database name in it were not parsed correctly. In this case, the database_name column in the `crdb_internal.node_statement_statistics.txt` file, can have a different database name and not the actual database name.
e.g. select a,b,c from db_1.table_name.

4. If a query is run from the current database scope, the queries are marked as the current database even if the query is run for another database.
e.g. SQL> use db1;
SQL> select * from db2.table_in_db2;
The query for db is marked under the database name db1 in the `crdb_internal.node_statement_statistics.txt` file. This causes an issue as unsupported queries also get added for run.

5. Currently, the workload cannot be re-run as the last value of a sequence column is not maintained from the previous run. So, we had to fresh import the data before each run. Now, the last_value is stored in the YAML so that it can be reused in the next run.

6. There are some additional cleanup changes:
 - Use references instead of pass by value
 - The block for each table was a list, which was unnecessary.
 - checkIfAllPkAreFk had a bug where the function used to return true if there were no primary key in the query.
- Ensure that we use import instead of insert during dataload. This is fixed by initializing the workload schema in tha Tables call, which ensures that the "support fixtures" check is set to true.

Fixes: CRDB-51572
Epic: None