### PR TITLE
roachprod: add SSH config export

### DIFF
--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -53,6 +53,7 @@ var (
 	virtualClusterName    string
 	sqlInstance           int
 	extraSSHOptions       = ""
+	exportSSHConfig       string
 	nodeEnv               []string
 	tag                   string
 	external              = false
@@ -217,6 +218,8 @@ func initListCmdFlags(listCmd *cobra.Command) {
 		"mine", "m", false, "Show only clusters belonging to the current user")
 	listCmd.Flags().StringVar(&listPattern,
 		"pattern", "", "Show only clusters matching the regex pattern. Empty string matches everything.")
+	listCmd.Flags().StringVar(&exportSSHConfig,
+		"export-ssh-config", os.Getenv("ROACHPROD_EXPORT_SSH_CONFIG"), "export the SSH config for listed clusters (only when pattern or mine is specified")
 }
 
 func initAdminurlCmdFlags(adminurlCmd *cobra.Command) {
@@ -271,7 +274,6 @@ func initSyncCmdFlags(syncCmd *cobra.Command) {
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
 	syncCmd.Flags().StringArrayVarP(&listOpts.IncludeProviders, "clouds", "c",
 		make([]string, 0), "Specify the cloud providers when syncing. Important: Use this flag only if you are certain that you want to sync with a specific cloud. All DNS host entries for other clouds will be erased from the DNS zone.")
-
 }
 
 func initStageCmdFlags(stageCmd *cobra.Command) {


### PR DESCRIPTION
This change introduces a new option to `roachprod list` that exports an SSH configuration file for the listed clusters. This configuration enables direct SSH access to roachprod-created clusters using any SSH client, removing the need to run `roachprod ssh`.

This feature is useful for tools, such as IDEs, that support remote SSH connections.

Epic: None
Release note: None