### PR TITLE
roachtest: fix client retry token bucket setting

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -188,9 +188,9 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 				// there is a snapshot backlog, which makes the snapshot backlog worse
 				// because add sst causes ranges to fall behind and need recovery snapshots
 				// to catch up.
-				"kv.snapshot_rebalance.max_rate":                   "256 MiB",
-				"server.debug.default_vmodule":                     "s3_storage=2",
-				"cloudstorage.s3.enable_client_retry_token_bucket": "false",
+				"kv.snapshot_rebalance.max_rate":                    "256 MiB",
+				"server.debug.default_vmodule":                      "s3_storage=2",
+				"cloudstorage.s3.client_retry_token_bucket.enabled": "false",
 			},
 			install.EnvOption{
 				fmt.Sprintf("COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE=%s", azureCredentialsFilePath),


### PR DESCRIPTION
Previously, backup fixtures were failing to generate due to a misnamed setting. The setting was originally correct, but became incorrect when I renamed the setting to fix the setting name lint.

We don't have to backport this because the roachtest change hit a merge conflict during the backport and I removed the roachtest changes from the backport since they were non-essential.

Release note: none
Informs: #148334