### PR TITLE
server: add RPC-to-REST bridge for status endpoints

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4232,6 +4232,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_gorilla_schema",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/gorilla/schema",
+        sha256 = "63885f95be210851d623d464698326a202274e191f53f7b7905a150e9cf04494",
+        strip_prefix = "github.com/gorilla/schema@v1.4.1",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/schema/com_github_gorilla_schema-v1.4.1.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_gorilla_securecookie",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/gorilla/securecookie",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -591,6 +591,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/css/com_github_gorilla_css-v1.0.0.zip": "d854362b9d723daf613b26aae0254723a4ed1bff680683c3e2a01aeb398168e5",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/handlers/com_github_gorilla_handlers-v1.4.2.zip": "9e47491112a46d32e372be827899e8678a881f6407f290564c63e8725b5e9a19",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/mux/com_github_gorilla_mux-v1.8.0.zip": "7641911e00af9c91f089868333067c9cb9a58702d2c9ea821ee374940091c385",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/schema/com_github_gorilla_schema-v1.4.1.zip": "63885f95be210851d623d464698326a202274e191f53f7b7905a150e9cf04494",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/securecookie/com_github_gorilla_securecookie-v1.1.1.zip": "dd83a4230e11568159756bbea4d343c88df0cd1415bbbc7cd5badad6cd2ed903",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/sessions/com_github_gorilla_sessions-v1.2.1.zip": "2c6aeebfef8062537fd7778067e5e99d4c13f79ac63114e905c97040a6e6b523",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/gorilla/websocket/com_github_gorilla_websocket-v1.4.2.zip": "d0d1728deaa06dac190bf4964c9c6395923403eae337cb3305d6dda18ef07337",

--- a/go.mod
+++ b/go.mod
@@ -179,6 +179,7 @@ require (
 	github.com/google/skylark v0.0.0-20181101142754-a5f7082aabed
 	github.com/googleapis/gax-go/v2 v2.7.1
 	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/schema v1.4.1
 	github.com/goware/modvendor v0.5.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240215164046-eb0e60d27cb7
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1307,6 +1307,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
+github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1777,6 +1777,7 @@ GO_TARGETS = [
     "//pkg/security:security",
     "//pkg/security:security_test",
     "//pkg/server/apiconstants:apiconstants",
+    "//pkg/server/apiinternal:apiinternal",
     "//pkg/server/apiutil:apiutil",
     "//pkg/server/apiutil:apiutil_test",
     "//pkg/server/application_api:application_api",

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -659,8 +659,17 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 	params := base.TestServerArgs{
 		SSLCertsDir:       certsDir,
 		InsecureWebAccess: true,
-
 		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109498),
+		// Disable DRPC for this test because it exposes a certificate
+		// validation issue: The test removes ca-client.crt and ca-ui.crt to
+		// test fallback to ca.crt, but the client certificates
+		// (client.node.crt, client.root.crt) were signed by the removed
+		// ca-client.crt. When DRPC tries to establish connections during
+		// startup for internal APIs, it fails with "tls: unknown certificate
+		// authority". This is a test infrastructure issue, not a production
+		// concern, as production deployments don't remove CA certificates after
+		// generating client certificates. See issue #153507.
+		DefaultDRPCOption: base.TestDRPCDisabled,
 	}
 	srv, _, db := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.Background())

--- a/pkg/security/main_test.go
+++ b/pkg/security/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -25,6 +26,9 @@ func ResetTest() {
 func TestMain(m *testing.M) {
 	ResetTest()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -177,6 +177,7 @@ go_library(
         "//pkg/security/clientsecopts",
         "//pkg/security/username",
         "//pkg/server/apiconstants",
+        "//pkg/server/apiinternal",
         "//pkg/server/apiutil",
         "//pkg/server/authserver",
         "//pkg/server/debug",

--- a/pkg/server/apiinternal/BUILD.bazel
+++ b/pkg/server/apiinternal/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "apiinternal",
+    srcs = [
+        "api_internal.go",
+        "api_internal_status.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/server/apiinternal",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
+        "//pkg/server/authserver",
+        "//pkg/server/serverpb",
+        "//pkg/server/srverrors",
+        "//pkg/settings/cluster",
+        "//pkg/util/httputil",
+        "//pkg/util/log",
+        "//pkg/util/protoutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//jsonpb",
+        "@com_github_gogo_protobuf//proto",
+        "@com_github_gorilla_mux//:mux",
+        "@com_github_gorilla_schema//:schema",
+        "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/pkg/server/apiinternal/api_internal.go
+++ b/pkg/server/apiinternal/api_internal.go
@@ -1,0 +1,269 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package apiinternal
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/schema"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// httpMethod represents HTTP methods supported by the API.
+type httpMethod string
+
+// Supported HTTP methods for the internal API.
+const (
+	GET  httpMethod = http.MethodGet
+	POST httpMethod = http.MethodPost
+)
+
+var decoder = schema.NewDecoder()
+
+// route defines a REST endpoint with its handler and HTTP method.
+type route struct {
+	method  httpMethod
+	path    string
+	handler http.HandlerFunc
+}
+
+// apiInternalServer provides REST endpoints that proxy to RPC services. It
+// serves as a bridge between HTTP REST clients and internal RPC services.
+type apiInternalServer struct {
+	mux    *mux.Router
+	status serverpb.RPCStatusClient
+}
+
+// NewAPIInternalServer creates a new REST API server that proxies to internal
+// RPC services. It establishes connections to the RPC services and registers
+// all REST endpoints.
+func NewAPIInternalServer(
+	ctx context.Context, nd rpcbase.NodeDialer, localNodeID roachpb.NodeID, cs *cluster.Settings,
+) (*apiInternalServer, error) {
+	status, err := serverpb.DialStatusClient(nd, ctx, localNodeID, cs)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &apiInternalServer{
+		status: status,
+		mux:    mux.NewRouter(),
+	}
+
+	r.registerStatusRoutes()
+
+	decoder.SetAliasTag("json")
+	decoder.IgnoreUnknownKeys(true)
+
+	return r, nil
+}
+
+// ServeHTTP implements http.Handler interface
+func (r *apiInternalServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mux.ServeHTTP(w, req)
+}
+
+// createHandler creates an HTTP handler function that proxies requests to the
+// given RPC method.
+func createHandler[TReq, TResp protoutil.Message](
+	rpcMethod func(context.Context, TReq) (TResp, error),
+) http.HandlerFunc {
+	var zero TReq
+	msgName := proto.MessageName(zero)
+	msgType := proto.MessageType(msgName)
+	if msgType == nil {
+		panic(errors.AssertionFailedf("failed to determine request protobuf type: %s", msgName))
+	}
+	return func(w http.ResponseWriter, req *http.Request) {
+		newReq := reflect.New(msgType.Elem()).Interface().(TReq)
+		if err := executeRPC(w, req, rpcMethod, newReq); err != nil {
+			ctx := req.Context()
+			writeHTTPError(ctx, w, req, err)
+		}
+	}
+}
+
+// executeRPC is a generic function that handles the common pattern of:
+// 1. Decoding HTTP request parameters (query string for GET, body for POST)
+// 2. Forwarding HTTP auth information to the RPC context
+// 3. Calling the RPC method
+// 4. Writing the response back to the HTTP client
+//
+// This eliminates boilerplate code across all endpoint handlers.
+func executeRPC[TReq, TResp protoutil.Message](
+	w http.ResponseWriter,
+	req *http.Request,
+	rpcMethod func(context.Context, TReq) (TResp, error),
+	rpcReq TReq,
+) error {
+	ctx := req.Context()
+	ctx = authserver.ForwardHTTPAuthInfoToRPCCalls(ctx, req)
+
+	if err := decoder.Decode(rpcReq, req.URL.Query()); err != nil {
+		return err
+	}
+	if err := decodePathVars(rpcReq, mux.Vars(req)); err != nil {
+		return err
+	}
+	// For POST requests, decode the request body (JSON or protobuf)
+	if req.Method == http.MethodPost {
+		if err := decodeRequest(req, rpcReq); err != nil {
+			return status.Errorf(codes.InvalidArgument, "failed to decode request body: %v", err)
+		}
+	}
+
+	resp, err := rpcMethod(ctx, rpcReq)
+	if err != nil {
+		return err
+	}
+	return writeResponse(ctx, w, req, http.StatusOK, resp)
+}
+
+func decodePathVars[TReq protoutil.Message](rpcReq TReq, vars map[string]string) error {
+	pathParams := make(url.Values)
+	for k, v := range vars {
+		pathParams[k] = []string{v}
+	}
+	return decoder.Decode(rpcReq, pathParams)
+}
+
+// writeHTTPError converts an error to an HTTP error response. It handles gRPC
+// status codes and converts them to appropriate HTTP status codes. Internal
+// errors are masked to avoid leaking implementation details.
+func writeHTTPError(ctx context.Context, w http.ResponseWriter, req *http.Request, err error) {
+	s, ok := status.FromError(err)
+	if !ok {
+		s = status.New(codes.Unknown, err.Error())
+	}
+
+	message := s.Message()
+	if s.Code() == codes.Internal {
+		message = srverrors.ErrAPIInternalErrorString
+		log.Dev.Errorf(ctx, "failed internal API [%s] %s - %v", req.Method, req.URL.Path, err)
+	} else {
+		log.Ops.Errorf(ctx, "failed internal API [%s] %s - %v", req.Method, req.URL.Path, err)
+	}
+
+	data := &serverpb.ResponseError{
+		Error:   message,
+		Message: message,
+		Code:    int32(s.Code()),
+		// Details field is intentionally not populated as it's unused
+	}
+
+	// Convert gRPC status code to HTTP status code
+	// TODO(server): eliminate this dependency on grpc-gateway when
+	// migrating away from it
+	httpCode := runtime.HTTPStatusFromCode(s.Code())
+
+	if err := writeResponse(ctx, w, req, httpCode, data); err != nil {
+		log.Dev.Errorf(ctx, "failed to respond with error: %v", err)
+		const fallback = `{"code": 13, "message": "failed to marshal error message"}`
+		if _, err := io.WriteString(w, fallback); err != nil {
+			log.Dev.Errorf(ctx, "failed to write fallback error: %v", err)
+		}
+	}
+}
+
+// writeResponse writes a protobuf message as an HTTP response. It supports both
+// JSON and protobuf content types based on the request headers.
+func writeResponse(
+	ctx context.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	code int,
+	payload protoutil.Message,
+) error {
+	// Determine the response content type by checking Accept header first, then
+	// falling back to Content-Type header. Default to JSON if neither specifies
+	// a supported type.
+	resContentType := selectContentType(append(
+		req.Header[httputil.AcceptEncodingHeader],
+		req.Header[httputil.ContentTypeHeader]...))
+
+	var buf []byte
+	switch resContentType {
+	case httputil.ProtoContentType:
+		b, err := protoutil.Marshal(payload)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to marshal the protobuf response: %v", err)
+		}
+		buf = b
+	case httputil.JSONContentType, httputil.MIMEWildcard:
+		jsonpb := &protoutil.JSONPb{
+			EnumsAsInts:  true,
+			EmitDefaults: true,
+			Indent:       "  ",
+		}
+		b, err := jsonpb.Marshal(payload)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to marshal the JSON response: %v", err)
+		}
+		buf = b
+	}
+
+	w.Header().Set("Content-Type", resContentType)
+	w.WriteHeader(code)
+	if _, err := w.Write(buf); err != nil {
+		return status.Errorf(codes.Internal, "failed to write HTTP response: %v", err)
+	}
+	return nil
+}
+
+// decodeRequest decodes the request body into a protobuf message. It supports
+// both JSON and protobuf content types, defaulting to JSON.
+func decodeRequest(req *http.Request, target protoutil.Message) error {
+	if req.Body == nil {
+		return nil
+	}
+	reqContentType := selectContentType(req.Header[httputil.ContentTypeHeader])
+	switch reqContentType {
+	case httputil.JSONContentType, httputil.MIMEWildcard:
+		return jsonpb.Unmarshal(req.Body, target)
+	case httputil.ProtoContentType:
+		bytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
+		return protoutil.Unmarshal(bytes, target)
+	default:
+		return jsonpb.Unmarshal(req.Body, target)
+	}
+}
+
+// selectContentType chooses the appropriate content type from a list of
+// options. It prefers protobuf or JSON if available, defaulting to JSON if none
+// match.
+func selectContentType(contentTypes []string) string {
+	for _, c := range contentTypes {
+		switch c {
+		case httputil.ProtoContentType:
+			return httputil.ProtoContentType
+		case httputil.JSONContentType, httputil.MIMEWildcard:
+			return httputil.JSONContentType
+		}
+	}
+	return httputil.JSONContentType
+}

--- a/pkg/server/apiinternal/api_internal_status.go
+++ b/pkg/server/apiinternal/api_internal_status.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package apiinternal
+
+// registerStatusRoutes sets up all the status REST endpoints.
+func (r *apiInternalServer) registerStatusRoutes() {
+	routes := []route{
+		// Node information
+		{GET, "/_status/nodes", createHandler(r.status.Nodes)},
+		{GET, "/_status/nodes/{node_id}", createHandler(r.status.Node)},
+		{GET, "/_status/nodes_ui", createHandler(r.status.NodesUI)},
+		{GET, "/_status/nodes_ui/{node_id}", createHandler(r.status.NodeUI)},
+
+		// Node details and diagnostics
+		{GET, "/_status/details/{node_id}", createHandler(r.status.Details)},
+		{GET, "/_status/certificates/{node_id}", createHandler(r.status.Certificates)},
+		{GET, "/_status/gossip/{node_id}", createHandler(r.status.Gossip)},
+		{GET, "/_status/metrics/{node_id}", createHandler(r.status.Metrics)},
+		{GET, "/_status/diagnostics/{node_id}", createHandler(r.status.Diagnostics)},
+		{GET, "/_status/stores/{node_id}", createHandler(r.status.Stores)},
+
+		// Node profiling and debugging
+		{GET, "/_status/profile/{node_id}", createHandler(r.status.Profile)},
+		{GET, "/_status/stacks/{node_id}", createHandler(r.status.Stacks)},
+		{GET, "/_status/files/{node_id}", createHandler(r.status.GetFiles)},
+
+		// Node logs
+		{GET, "/_status/logfiles/{node_id}", createHandler(r.status.LogFilesList)},
+		{GET, "/_status/logfiles/{node_id}/{file}", createHandler(r.status.LogFile)},
+		{GET, "/_status/logs/{node_id}", createHandler(r.status.Logs)},
+
+		// Range information
+		{GET, "/_status/ranges/{node_id}", createHandler(r.status.Ranges)},
+		{GET, "/_status/range/{range_id}", createHandler(r.status.Range)},
+		{GET, "/_status/tenant_ranges", createHandler(r.status.TenantRanges)},
+		{POST, "/_status/v2/hotranges", createHandler(r.status.HotRangesV2)},
+		{GET, "/_status/problemranges", createHandler(r.status.ProblemRanges)},
+
+		{GET, "/_status/allocator/node/{node_id}", createHandler(r.status.Allocator)},
+		{GET, "/_status/allocator/range/{range_id}", createHandler(r.status.AllocatorRange)},
+
+		{GET, "/_status/enginestats/{node_id}", createHandler(r.status.EngineStats)},
+		{GET, "/_status/downloadspans", createHandler(r.status.DownloadSpan)},
+
+		// Statement statistics
+		{GET, "/_status/statements", createHandler(r.status.Statements)},
+		{GET, "/_status/combinedstmts", createHandler(r.status.CombinedStatementStats)},
+		{GET, "/_status/stmtdetails/{fingerprint_id}", createHandler(r.status.StatementDetails)},
+		{POST, "/_status/resetsqlstats", createHandler(r.status.ResetSQLStats)},
+
+		// Statement diagnostics
+		{GET, "/_status/stmtdiagreports", createHandler(r.status.StatementDiagnosticsRequests)},
+		{POST, "/_status/stmtdiagreports", createHandler(r.status.CreateStatementDiagnosticsReport)},
+		{POST, "/_status/stmtdiagreports/cancel", createHandler(r.status.CancelStatementDiagnosticsReport)},
+		{GET, "/_status/stmtdiag/{statement_diagnostics_id}", createHandler(r.status.StatementDiagnostics)},
+
+		// Index statistics
+		{GET, "/_status/indexusagestatistics", createHandler(r.status.IndexUsageStatistics)},
+		{POST, "/_status/resetindexusagestats", createHandler(r.status.ResetIndexUsageStats)},
+		{GET, "/_status/databases/{database}/tables/{table}/indexstats", createHandler(r.status.TableIndexStats)},
+
+		// SQL sessions and queries
+		{GET, "/_status/sessions", createHandler(r.status.ListSessions)},
+		{GET, "/_status/local_sessions", createHandler(r.status.ListLocalSessions)},
+		{POST, "/_status/cancel_query/{node_id}", createHandler(r.status.CancelQuery)},
+		{POST, "/_status/cancel_session/{node_id}", createHandler(r.status.CancelSession)},
+
+		// SQL roles and permissions
+		{GET, "/_status/sqlroles", createHandler(r.status.UserSQLRoles)},
+
+		// Contention events
+		{GET, "/_status/contention_events", createHandler(r.status.ListContentionEvents)},
+		{GET, "/_status/local_contention_events", createHandler(r.status.ListLocalContentionEvents)},
+		{GET, "/_status/transactioncontentionevents", createHandler(r.status.TransactionContentionEvents)},
+
+		{GET, "/_status/distsql_flows", createHandler(r.status.ListDistSQLFlows)},
+		{GET, "/_status/local_distsql_flows", createHandler(r.status.ListLocalDistSQLFlows)},
+
+		// Job management
+		{GET, "/_status/job_registry/{node_id}", createHandler(r.status.JobRegistryStatus)},
+		{GET, "/_status/job/{job_id}", createHandler(r.status.JobStatus)},
+
+		// Job profiler
+		{GET, "/_status/request_job_profiler_execution_details/{job_id}", createHandler(r.status.RequestJobProfilerExecutionDetails)},
+		{GET, "/_status/job_profiler_execution_details/{job_id}", createHandler(r.status.GetJobProfilerExecutionDetails)},
+		{GET, "/_status/list_job_profiler_execution_details/{job_id}", createHandler(r.status.ListJobProfilerExecutionDetails)},
+
+		{GET, "/_status/raft", createHandler(r.status.RaftDebug)},
+		{GET, "/_status/tenant_service_status", createHandler(r.status.TenantServiceStatus)},
+		{GET, "/_status/connectivity", createHandler(r.status.NetworkConnectivity)},
+		{GET, "/_status/throttling", createHandler(r.status.GetThrottlingMetadata)},
+		{POST, "/_status/span", createHandler(r.status.SpanStats)},
+		{POST, "/_status/critical_nodes", createHandler(r.status.CriticalNodes)},
+		{POST, "/_status/keyvissamples", createHandler(r.status.KeyVisSamples)},
+	}
+
+	// Register all routes
+	for _, route := range routes {
+		r.mux.HandleFunc(route.path, route.handler).Methods(string(route.method))
+	}
+}

--- a/pkg/server/application_api/activity_test.go
+++ b/pkg/server/application_api/activity_test.go
@@ -28,7 +28,9 @@ func TestListActivitySecurity(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 

--- a/pkg/server/application_api/contention_test.go
+++ b/pkg/server/application_api/contention_test.go
@@ -149,7 +149,9 @@ func TestTransactionContentionEvents(t *testing.T) {
 
 	ctx := context.Background()
 
-	srv, conn1, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, conn1, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 

--- a/pkg/server/application_api/main_test.go
+++ b/pkg/server/application_api/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -24,6 +25,9 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	rangetestutils.InitRangeTestServerFactory(server.TestServerFactory)
 	kvtenant.InitTestConnectorFactory()
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/application_api/sessions_test.go
+++ b/pkg/server/application_api/sessions_test.go
@@ -34,7 +34,9 @@ import (
 func TestListSessionsSecurity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer srv.Stopper().Stop(context.Background())
 
 	s := srv.ApplicationLayer()
@@ -110,7 +112,9 @@ func TestListSessionsPrivileges(t *testing.T) {
 	// Skip under stress race as the sleep query might finish before the stress race can finish.
 	skip.UnderRace(t, "list sessions privileges")
 
-	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer srv.Stopper().Stop(context.Background())
 	ts := srv.ApplicationLayer()
 
@@ -230,7 +234,9 @@ func TestStatusCancelSessionGatewayMetadataPropagation(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	s0 := testCluster.Server(0).ApplicationLayer()
@@ -257,7 +263,9 @@ func TestStatusAPIListSessions(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	testCluster := serverutils.StartCluster(t, 1, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	s0 := testCluster.Server(0).ApplicationLayer()

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -416,6 +416,7 @@ func TestStatusAPIStatements(t *testing.T) {
 	statsKnobs.SynchronousSQLStats = true
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: statsKnobs,
 				SpanConfig: &spanconfig.TestingKnobs{
@@ -535,7 +536,8 @@ func TestStatusAPICombinedStatementsTotalLatency(t *testing.T) {
 	sqlStatsKnobs.SynchronousSQLStats = true
 	// Start the cluster.
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: true,
+		DefaultDRPCOption: base.TestDRPCDisabled,
+		Insecure:          true,
 		Knobs: base.TestingKnobs{
 			SQLStatsKnobs: sqlStatsKnobs,
 		},
@@ -697,6 +699,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	statsKnobs.SynchronousSQLStats = true
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: statsKnobs,
 				SpanConfig: &spanconfig.TestingKnobs{
@@ -865,6 +868,7 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	statsKnobs.SynchronousSQLStats = true
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: statsKnobs,
 				SpanConfig: &spanconfig.TestingKnobs{
@@ -1036,6 +1040,7 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	statsKnobs.SynchronousSQLStats = true
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: statsKnobs,
 				SpanConfig: &spanconfig.TestingKnobs{

--- a/pkg/server/application_api/stmtdiag_test.go
+++ b/pkg/server/application_api/stmtdiag_test.go
@@ -115,7 +115,9 @@ func TestCreateStatementDiagnosticsReportWithViewActivityOptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer s.Stopper().Stop(context.Background())
 	db := sqlutils.MakeSQLRunner(sqlDB)
 

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -143,6 +143,10 @@ var virtualClustersHandler = http.HandlerFunc(func(w http.ResponseWriter, req *h
 	}
 })
 
+// setupRoutes configures HTTP routes for the server.
+//
+// TODO(shubham,server): Remove unauthenticatedGWMux once apiinternal supports
+// all RPC prefixes.
 func (s *httpServer) setupRoutes(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
@@ -150,7 +154,8 @@ func (s *httpServer) setupRoutes(
 	adminAuthzCheck privchecker.CheckerForRPCHandlers,
 	metricSource metricMarshaler,
 	runtimeStatSampler *status.RuntimeStatSampler,
-	handleRequestsUnauthenticated http.Handler,
+	unauthenticatedGWMux http.Handler,
+	unauthenticatedAPIInternalServer http.Handler,
 	handleDebugUnauthenticated http.Handler,
 	handleInspectzUnauthenticated http.Handler,
 	apiServer http.Handler,
@@ -190,17 +195,24 @@ func (s *httpServer) setupRoutes(
 		authnServer, assetHandler, true /* allowAnonymous */)
 	s.mux.Handle("/", authenticatedUIHandler)
 
+	authenticatedAPIInternalServer := unauthenticatedAPIInternalServer
+	if !s.cfg.InsecureWebAccess() {
+		authenticatedAPIInternalServer = authserver.NewMux(
+			authnServer, authenticatedAPIInternalServer, false /* allowAnonymous */)
+	}
+	s.mux.Handle(apiconstants.StatusPrefix, authenticatedAPIInternalServer)
+
 	// Add HTTP authentication to the gRPC-gateway endpoints used by the UI,
 	// if not disabled by configuration.
-	var authenticatedHandler = handleRequestsUnauthenticated
+	var authenticatedGWMux = unauthenticatedGWMux
 	if !s.cfg.InsecureWebAccess() {
-		authenticatedHandler = authserver.NewMux(authnServer, authenticatedHandler, false /* allowAnonymous */)
+		authenticatedGWMux = authserver.NewMux(authnServer, authenticatedGWMux, false /* allowAnonymous */)
 	}
 
 	// Login and logout paths.
 	// The /login endpoint is, by definition, available pre-authentication.
-	s.mux.Handle(authserver.LoginPath, handleRequestsUnauthenticated)
-	s.mux.Handle(authserver.LogoutPath, authenticatedHandler)
+	s.mux.Handle(authserver.LoginPath, unauthenticatedGWMux)
+	s.mux.Handle(authserver.LogoutPath, authenticatedGWMux)
 	s.mux.Handle(virtualClustersPath, virtualClustersHandler)
 	// The login path for 'cockroach demo', if we're currently running
 	// that.
@@ -208,16 +220,14 @@ func (s *httpServer) setupRoutes(
 		s.mux.Handle(authserver.DemoLoginPath, http.HandlerFunc(authnServer.DemoLogin))
 	}
 
-	// Admin/Status servers. These are used by the UI via RPC-over-HTTP.
-	s.mux.Handle(apiconstants.StatusPrefix, authenticatedHandler)
-	s.mux.Handle(apiconstants.AdminPrefix, authenticatedHandler)
+	s.mux.Handle(apiconstants.AdminPrefix, authenticatedGWMux)
 
 	// The timeseries endpoint, used to produce graphs.
-	s.mux.Handle(ts.URLPrefix, authenticatedHandler)
+	s.mux.Handle(ts.URLPrefix, authenticatedGWMux)
 
 	// Exempt the 2nd health check endpoint from authentication.
 	// (This simply mirrors /health and exists for backward compatibility.)
-	s.mux.Handle(apiconstants.AdminHealth, handleRequestsUnauthenticated)
+	s.mux.Handle(apiconstants.AdminHealth, unauthenticatedGWMux)
 	// The /_status/vars and /metrics endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(apiconstants.StatusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings, false /* useStaticLabels */}.handleVars))
 	s.mux.Handle(apiconstants.MetricsPath, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings, true /* useStaticLabels */}.handleVars))

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -26,6 +26,8 @@ const (
 	ContentDispositionHeader = "Content-Disposition"
 	// ContentEncodingHeader is the canonical header name for content type.
 	ContentEncodingHeader = "Content-Encoding"
+	// MIMEWildcard represents the wildcard MIME type that accepts any content type.
+	MIMEWildcard = "*"
 	// ContentTypeHeader is the canonical header name for content type.
 	ContentTypeHeader = "Content-Type"
 	// JSONContentType is the JSON content type.


### PR DESCRIPTION
Introduce new REST API infrastructure that serves RPCs as REST endpoints,
using either gRPC or DRPC clients based on cluster settings. This bridge
implements the same features as grpc-gateway that we currently use, but
works with both RPC frameworks.

This new implementation replaces grpc-gateway when DRPC is enabled
(currently only for status endpoints). API behavior should remain
identical.

It's part of the broader gRPC to DRPC migration and will eventually replace
grpc-gateway entirely.

The experience of making an RPC available as an HTTP endpoint will be
different going forward. You need to add endpoint registration and its
handler. Everything else should remain the same.

There are still a few gaps compared to grpc-gateway features that will be
addressed in the epic.

Epic: CRDB-48924
Release note: None
Fixes: #151396
Fixes: #151395
Fixes: #152822
Fixes: #152826