### PR TITLE
catalog/lease: fix assertion for no outstanding leases

### DIFF
--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -547,7 +547,7 @@ func drain(ctx context.Context, ts1 serverutils.TestServerInterface, t *testing.
 	timeoutCtx, cancel := context.WithTimeout(ctx, testutils.SucceedsSoonDuration())
 	defer cancel()
 
-	err := ts1.DrainClientsWithoutLeakCheck(ctx)
+	err := ts1.DrainClients(ctx)
 	require.NoError(t, err)
 
 	for timeoutCtx.Err() == nil {

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -492,7 +492,7 @@ func (s *drainServer) drainClientsInternal(
 	// Drain all SQL table leases. This must be done after the pgServer has
 	// given sessions a chance to finish ongoing work and after the background
 	// tasks that may issue SQL statements have shut down.
-	s.sqlServer.leaseMgr.SetDraining(ctx, true /* drain */, reporter, assertOnLeakedDescriptor)
+	s.sqlServer.leaseMgr.SetDraining(ctx, true, reporter)
 
 	session, err := s.sqlServer.sqlLivenessProvider.Release(ctx)
 	if err != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1242,11 +1242,6 @@ func (t *testTenant) DrainClients(ctx context.Context) error {
 	return t.drain.drainClients(ctx, nil /* reporter */)
 }
 
-// DrainClients exports the drainClientsInternal() method for use by tests.
-func (t *testTenant) DrainClientsWithoutLeakCheck(ctx context.Context) error {
-	return t.drain.drainClientsInternal(ctx, nil /* reporter */, false)
-}
-
 // Readiness is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) Readiness(ctx context.Context) error {
 	return t.t.admin.checkReadinessForHealthCheck(ctx)
@@ -1946,13 +1941,6 @@ func (ts *testServer) SQLAddr() string {
 // DrainClients exports the drainClients() method for use by tests.
 func (ts *testServer) DrainClients(ctx context.Context) error {
 	return ts.drain.drainClients(ctx, nil /* reporter */)
-}
-
-// DrainClientsWithoutLeakCheck exports the drainClients() method for use by tests
-// with descriptor leak checking disabled. This is useful for tests that focus on
-// restart safety logic rather than lease management correctness.
-func (ts *testServer) DrainClientsWithoutLeakCheck(ctx context.Context) error {
-	return ts.drain.drainClientsInternal(ctx, nil, false /* assertOnLeakedDescriptor */)
 }
 
 // Readiness is part of the serverutils.ApplicationLayerInterface.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1133,7 +1133,7 @@ type Manager struct {
 	// that we have all the updates for.
 	closeTimestamp atomic.Value
 
-	draining atomic.Value
+	draining atomic.Bool
 
 	// names is a cache for name -> id mappings. A mapping for the cache
 	// should only be used if we currently have an active lease on the respective
@@ -1283,6 +1283,7 @@ func NewLeaseManager(
 	lm.storage.regionPrefix.Store(enum.One)
 	lm.storage.writer = newKVWriter(codec, db.KV(), keys.LeaseTableID, settingsWatcher)
 	lm.stopper.AddCloser(lm.sem.Closer("stopper"))
+	lm.stopper.AddCloser(stop.CloserFn(lm.AssertAllLeasesAreReleasedAfterDrain))
 	lm.mu.descriptors = make(map[descpb.ID]*descriptorState)
 	lm.waitForInit = make(chan struct{})
 	// We are going to start the range feed later when StartRefreshLeasesTask
@@ -1597,7 +1598,7 @@ func (m *Manager) removeOnceDereferenced() bool {
 
 // IsDraining returns true if this node's lease manager is draining.
 func (m *Manager) IsDraining() bool {
-	return m.draining.Load().(bool)
+	return m.draining.Load()
 }
 
 // SetDraining (when called with 'true') removes all inactive leases. Any leases
@@ -1608,10 +1609,7 @@ func (m *Manager) IsDraining() bool {
 // been done by the time this call returns. See the explanation in
 // pkg/server/drain.go for details.
 func (m *Manager) SetDraining(
-	ctx context.Context,
-	drain bool,
-	reporter func(int, redact.SafeString),
-	assertOnLeakedDescriptor bool,
+	ctx context.Context, drain bool, reporter func(int, redact.SafeString),
 ) {
 	m.draining.Store(drain)
 	if !drain {
@@ -1625,15 +1623,6 @@ func (m *Manager) SetDraining(
 			t.mu.Lock()
 			defer t.mu.Unlock()
 			leasesToRelease := t.removeInactiveVersions(ctx)
-			// Ensure that all leases are released at this time. Ignore any descriptors
-			// that have acquisitions in progress.
-			if buildutil.CrdbTestBuild &&
-				assertOnLeakedDescriptor &&
-				len(t.mu.active.data) > 0 &&
-				t.mu.acquisitionsInProgress == 0 {
-				// Panic that a descriptor may have leaked.
-				panic(errors.AssertionFailedf("descriptor leak was detected for: %d (%s)", t.id, t.mu.active))
-			}
 			return leasesToRelease
 		}()
 		for _, l := range leases {
@@ -1643,6 +1632,45 @@ func (m *Manager) SetDraining(
 			// Report progress through the Drain RPC.
 			reporter(len(leases), "descriptor leases")
 		}
+	}
+}
+
+// AssertAllLeasesAreReleasedAfterDrain asserts that all leases are released after
+// draining.
+func (m *Manager) AssertAllLeasesAreReleasedAfterDrain() {
+	if !buildutil.CrdbTestBuild || !m.draining.Load() {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.mu.descriptors {
+		func() {
+			descriptorStr := strings.Builder{}
+			panicWithErr := false
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			// Ensure that all leases are released at this time.
+			if len(t.mu.active.data) > 0 {
+				// Check if any of these have a non-zero ref count indicating some type of
+				// leak. It may be possible for the entry to exist if we were interrupted
+				// mid-acquisition by the draining process. But the reference count should
+				// *never* be non-zero.
+				for _, l := range t.mu.active.data {
+					if l.refcount.Load() == 0 {
+						continue
+					}
+					panicWithErr = true
+					if descriptorStr.Len() > 0 {
+						descriptorStr.WriteString(",")
+					}
+					descriptorStr.WriteString(fmt.Sprintf("{%s}", l.String()))
+				}
+				if panicWithErr {
+					panic(errors.AssertionFailedf("descriptor leak was detected for ID: %d, "+
+						"with versions [%s]", t.id, descriptorStr.String()))
+				}
+			}
+		}()
 	}
 }
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -522,8 +522,8 @@ func TestLeaseManagerDrain(testingT *testing.T) {
 		// starts draining.
 		l1RemovalTracker := leaseRemovalTracker.TrackRemoval(l1.Underlying())
 
-		t.node(1).SetDraining(ctx, true, nil /* reporter */, false)
-		t.node(2).SetDraining(ctx, true, nil /* reporter */, false)
+		t.node(1).SetDraining(ctx, true, nil /* reporter */)
+		t.node(2).SetDraining(ctx, true, nil)
 
 		// Leases cannot be acquired when in draining mode.
 		if _, err := t.acquire(1, descID); !testutils.IsError(err, "cannot acquire lease when draining") {
@@ -546,7 +546,7 @@ func TestLeaseManagerDrain(testingT *testing.T) {
 	{
 		// Check that leases with a refcount of 0 are correctly kept in the
 		// store once the drain mode has been exited.
-		t.node(1).SetDraining(ctx, false, nil /* reporter */, false /* assertOnLeakedDescriptor */)
+		t.node(1).SetDraining(ctx, false, nil)
 		l1 := t.mustAcquire(1, descID)
 		t.mustRelease(1, l1, nil)
 		t.expectLeases(descID, "/1/1")

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -405,11 +405,6 @@ type ApplicationLayerInterface interface {
 	// DrainClients shuts down client connections.
 	DrainClients(ctx context.Context) error
 
-	// DrainClientsWithoutLeakCheck shuts down client connections but will
-	// skip the assertion that checks for descriptor leaks. This is meant
-	// to enable specific tests that may drain unsafely.
-	DrainClientsWithoutLeakCheck(ctx context.Context) error
-
 	// SystemConfigProvider provides access to the system config.
 	SystemConfigProvider() config.SystemConfigProvider
 


### PR DESCRIPTION
Previously, the assertion confirming that no leases were outstanding was too strict because it checked for remaining descriptor versions immediately after setting the drain flag. While all user queries should be drained by this point, this check was too strict for internal operations. To address this, this patch moves the assertion into a closure and ensures that anything remaining has a reference count of zero.

Fixes: #151902

Release note: None