### PR TITLE
opt: add table ID qualifier to EXPLAIN (OPT, VERBOSE)

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -108,6 +108,10 @@ const (
 	// due to the fact that they are not actually executed.
 	ExprFmtHideFastPathChecks
 
+	// ExprFmtHideTableIDs hides the :tableID qualification from table@index
+	// labels.
+	ExprFmtHideTableIDs
+
 	// ExprFmtHideAll shows only the basic structure of the expression.
 	// Note: this flag should be used judiciously, as its meaning changes whenever
 	// we add more flags.
@@ -1509,6 +1513,10 @@ func (f *ExprFmtCtx) formatIndex(tabID opt.TableID, idxOrd cat.IndexOrdinal, rev
 		fmt.Fprintf(f.Buffer, " %s", tableName(f, tabID))
 	} else {
 		fmt.Fprintf(f.Buffer, " %s@%s", tableName(f, tabID), index.Name())
+	}
+	if !f.HasFlags(ExprFmtHideTableIDs) {
+		f.Buffer.WriteRune(':')
+		f.Buffer.WriteString(tabID.Pretty())
 	}
 	if reverse {
 		f.Buffer.WriteString(",rev")

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -8,6 +8,7 @@ package opt
 import (
 	"context"
 	"math/rand"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -79,6 +80,11 @@ func (t TableID) firstColID() ColumnID {
 // that TableID 0 can be be reserved to mean "unknown table".
 func (t TableID) index() int {
 	return int((t>>32)&tableIDMask) - 1
+}
+
+// Pretty returns a pretty string representation of the TableID.
+func (t TableID) Pretty() string {
+	return strconv.FormatUint(uint64((t>>32)&tableIDMask), 10)
 }
 
 // TableAnnID uniquely identifies an annotation on an instance of table


### PR DESCRIPTION
To match the column ID qualifier, add table ID qualifier to `EXPLAIN (OPT, VERBOSE)` output.

Epic: None

Release note: None