### PR TITLE
sqlstats: sync stats for flush bench plus reduce size

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -1354,7 +1354,8 @@ func BenchmarkSQLStatsFlush(b *testing.B) {
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					SQLStatsKnobs: &sqlstats.TestingKnobs{
-						StubTimeNow: fakeTime.Now,
+						StubTimeNow:         fakeTime.Now,
+						SynchronousSQLStats: true,
 					},
 				},
 			},
@@ -1386,7 +1387,7 @@ func BenchmarkSQLStatsFlush(b *testing.B) {
 
 		gen := genPermutations()
 
-		testutils.RunValues(b, "fingerprintCardinality", []int64{10, 100, 1000, 7000}, func(b *testing.B, uniqueFingerprintCount int64) {
+		testutils.RunValues(b, "fingerprintCardinality", []int64{10, 100, 1000}, func(b *testing.B, uniqueFingerprintCount int64) {
 			ctx := context.Background()
 			for iter := 0; iter < b.N; iter++ {
 				for i := int64(0); i < uniqueFingerprintCount; i++ {


### PR DESCRIPTION
The SQLStatsFlush benchmark was not updated along with the async sql stats changes in #143855 and was causing timeouts due to the stats not flushing. This change sets the stats to be collected synchronously.

Additionally, the `7000` cardinality case is removed to avoid timeouts.

Resolves: #151989
Epic: None
Release note: None