### PR TITLE
multiregionccl: update comments in test after a bug was fixed

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -632,12 +632,11 @@ func TestDropRegionFromUserDatabaseCleansUpSystemTables(t *testing.T) {
 	// Drop a region from the USER database (not system database)
 	sDB.Exec(t, `ALTER DATABASE userdb DROP REGION "us-east2"`)
 
-	// BUG: sql_instances table is now empty, but it shouldn't be
-	// The region still exists in the system database, so instances should remain
+	// Verify that dropping a region from a user database doesn't affect system.sql_instances.
+	// The region still exists in the system database, so instances should remain unchanged.
 	finalCount := sDB.QueryStr(t, `SELECT count(*) FROM system.sql_instances`)
 	require.NotEmpty(t, finalCount)
-	// This assertion will fail, demonstrating the bug.
-	// The count should remain the same since we only dropped from userdb, not system
+	// The count should remain the same since we only dropped from userdb, not system.
 	require.Equal(t, initialCount[0][0], finalCount[0][0],
 		"sql_instances count should not change when dropping region from user database")
 }


### PR DESCRIPTION
The test had comments that described the buggy behavior. bb61a2248bf29d7e26351a765418b8fccbb8606f fixed the bug, so the comment needed updating.

Epic: None
Release note: None