### PR TITLE
sql/stats: ignore partial stats in `crdb_internal.table_row_statistics`

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -776,6 +776,7 @@ CREATE TABLE crdb_internal.table_row_statistics (
 			SELECT DISTINCT ON ("tableID") "tableID", "rowCount"
 			FROM system.table_statistics
 			AS OF SYSTEM TIME '%s'
+			WHERE "partialPredicate" IS NULL
 			ORDER BY "tableID", "createdAt" DESC, "rowCount" DESC`,
 			statsAsOfTimeClusterMode.String(&p.ExecCfg().Settings.SV))
 		statRows, err := p.ExtendedEvalContext().ExecCfg.InternalDB.Executor().QueryBufferedEx(

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -674,3 +674,23 @@ pr_check    CHECK ((price > 0))     true
 
 statement ok
 COMMIT;
+
+subtest end
+
+# Test that partial statistics are filtered out from table_row_statistics
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY)
+
+statement ok
+INSERT INTO t SELECT generate_series(0, 9)
+
+statement ok
+ANALYZE t
+
+statement ok
+CREATE STATISTICS partial FROM t USING EXTREMES
+
+query I
+SELECT estimated_row_count FROM crdb_internal.table_row_statistics WHERE table_name = 't'
+----
+10


### PR DESCRIPTION
Previously, the `crdb_internal.table_row_statistics` virtual table was being populated with the row count from the most recent table statistic. This caused incorrect row counts to be shown for `SHOW TABLES` when the most recent statistic was a partial collection. This change ignores partial stats when populating `crdb_internal.table_row_statistics` to fix this issue.

Fixes: #152024

Release note (bug fix): Previously, `SHOW TABLES` would show inaccurate row counts if the most recent statistic collection was partial, which is now fixed.