### PR TITLE
workload/schemachange: fix error code for unknown type

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1319,10 +1319,13 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	opStmt.potentialExecErrors.addAll(codesWithConditions{
 		{code: pgcode.Syntax, condition: hasVectorType},
 		{code: pgcode.FeatureNotSupported, condition: hasVectorType},
+		{code: pgcode.UndefinedObject, condition: hasVectorType},
 		{code: pgcode.Syntax, condition: hasCitextType},
 		{code: pgcode.FeatureNotSupported, condition: hasCitextType},
+		{code: pgcode.UndefinedObject, condition: hasCitextType},
 		{code: pgcode.Syntax, condition: hasLtreeType},
 		{code: pgcode.FeatureNotSupported, condition: hasLtreeType},
+		{code: pgcode.UndefinedObject, condition: hasLtreeType},
 	})
 	opStmt.sql = tree.Serialize(stmt)
 	return opStmt, nil


### PR DESCRIPTION
There is another error that can occur when creating a table with an unknown type, so this commit teaches the workload to handle it.

informs #150547
Release note: None