### PR TITLE
server: switch to test knob for disabling drain assertion

### DIFF
--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -342,7 +342,15 @@ func TestCheckRestartSafe_Criticality(t *testing.T) {
 
 	ctx := context.Background()
 
-	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &TestingKnobs{
+					DisableAssertOnLeakedDescriptor: true,
+				},
+			},
+		},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	ts1 := testCluster.Server(0)
@@ -376,7 +384,15 @@ func TestCheckRestartSafe_RangeStatus(t *testing.T) {
 	ctx := context.Background()
 	var err error
 
-	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &TestingKnobs{
+					DisableAssertOnLeakedDescriptor: true,
+				},
+			},
+		},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	ts0 := testCluster.Server(0)
@@ -441,7 +457,15 @@ func TestCheckRestartSafe_AllowMinimumQuorum_Pass(t *testing.T) {
 	ctx := context.Background()
 	var err error
 
-	testCluster := serverutils.StartCluster(t, 5, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 5, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &TestingKnobs{
+					DisableAssertOnLeakedDescriptor: true,
+				},
+			},
+		},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	// need to set RF=5 on all the ranges
@@ -482,7 +506,15 @@ func TestCheckRestartSafe_AllowMinimumQuorum_Fail(t *testing.T) {
 	ctx := context.Background()
 	var err error
 
-	testCluster := serverutils.StartCluster(t, 5, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 5, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &TestingKnobs{
+					DisableAssertOnLeakedDescriptor: true,
+				},
+			},
+		},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	// need to set RF=5 on all the ranges
@@ -517,7 +549,15 @@ func TestCheckRestartSafe_Integration(t *testing.T) {
 	ctx := context.Background()
 	var err error
 
-	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &TestingKnobs{
+					DisableAssertOnLeakedDescriptor: true,
+				},
+			},
+		},
+	})
 	defer testCluster.Stopper().Stop(ctx)
 
 	ts0 := testCluster.Server(0)
@@ -547,7 +587,7 @@ func drain(ctx context.Context, ts1 serverutils.TestServerInterface, t *testing.
 	timeoutCtx, cancel := context.WithTimeout(ctx, testutils.SucceedsSoonDuration())
 	defer cancel()
 
-	err := ts1.DrainClientsWithoutLeakCheck(ctx)
+	err := ts1.DrainClients(ctx)
 	require.NoError(t, err)
 
 	for timeoutCtx.Err() == nil {

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -149,6 +149,10 @@ type TestingKnobs struct {
 
 	// EnvironmentSampleInterval overrides base.DefaultMetricsSampleInterval when used to construct sampleEnvironmentCfg.
 	EnvironmentSampleInterval time.Duration
+
+	// DisableAssertOnLeakedDescriptor permits a test to disable the
+	// assertion that checks for descriptor leaks during drain.
+	DisableAssertOnLeakedDescriptor bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1242,11 +1242,6 @@ func (t *testTenant) DrainClients(ctx context.Context) error {
 	return t.drain.drainClients(ctx, nil /* reporter */)
 }
 
-// DrainClients exports the drainClientsInternal() method for use by tests.
-func (t *testTenant) DrainClientsWithoutLeakCheck(ctx context.Context) error {
-	return t.drain.drainClientsInternal(ctx, nil /* reporter */, false)
-}
-
 // Readiness is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) Readiness(ctx context.Context) error {
 	return t.t.admin.checkReadinessForHealthCheck(ctx)
@@ -1946,13 +1941,6 @@ func (ts *testServer) SQLAddr() string {
 // DrainClients exports the drainClients() method for use by tests.
 func (ts *testServer) DrainClients(ctx context.Context) error {
 	return ts.drain.drainClients(ctx, nil /* reporter */)
-}
-
-// DrainClientsWithoutLeakCheck exports the drainClients() method for use by tests
-// with descriptor leak checking disabled. This is useful for tests that focus on
-// restart safety logic rather than lease management correctness.
-func (ts *testServer) DrainClientsWithoutLeakCheck(ctx context.Context) error {
-	return ts.drain.drainClientsInternal(ctx, nil, false /* assertOnLeakedDescriptor */)
 }
 
 // Readiness is part of the serverutils.ApplicationLayerInterface.

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -405,11 +405,6 @@ type ApplicationLayerInterface interface {
 	// DrainClients shuts down client connections.
 	DrainClients(ctx context.Context) error
 
-	// DrainClientsWithoutLeakCheck shuts down client connections but will
-	// skip the assertion that checks for descriptor leaks. This is meant
-	// to enable specific tests that may drain unsafely.
-	DrainClientsWithoutLeakCheck(ctx context.Context) error
-
 	// SystemConfigProvider provides access to the system config.
 	SystemConfigProvider() config.SystemConfigProvider
 


### PR DESCRIPTION
We need to disable asserting on leaked descriptors for all `TestCheckRestartSafe*` tests. Previously, this was done by adding a new test server API, but was inadequate because the `drain` method in the `api_v2_test.go` also calls `Drain` on the `AdminClient` which has an interface that must conform to the gRPC service. The disabling of the assertion is moved to a testing knob instead and configured during each test's setup.

This also has the nice side effect of reducing test interface pollution.


Resolves: #151676
Epic: None
Release note: None