### PR TITLE
rangefeed: update BufferedSenderQueueSize metric correctly

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -131,10 +131,10 @@ func (bs *BufferedSender) run(
 		case <-bs.notifyDataC:
 			for {
 				e, success := bs.popFront()
-				bs.metrics.BufferedSenderQueueSize.Dec(1)
 				if !success {
 					break
 				}
+				bs.metrics.BufferedSenderQueueSize.Dec(1)
 				err := bs.sender.Send(e.ev)
 				e.alloc.Release(ctx)
 				if e.ev.Error != nil {


### PR DESCRIPTION
Previously, we were decrementing the buffered sender queue size before checking if we successfully popped an event, leading to the metric becoming a negative value.

<img width="872" height="614" alt="Screenshot 2025-08-18 at 5 54 10 PM" src="https://github.com/user-attachments/assets/42735b2b-bbc2-47dd-94b5-701ce6772999" />

Epic: None
Release note: None