### PR TITLE
kvcoord: allow SetBufferedWritesEnabled(false) on the LeafTxn

### DIFF
--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -134,10 +134,13 @@ type TxnSender interface {
 	SetOmitInRangefeeds()
 
 	// SetBufferedWritesEnabled toggles whether the writes are buffered on the
-	// gateway node until the commit time. Only allowed on the RootTxn. Buffered
-	// writes cannot be enabled on a txn that performed any requests. When
-	// disabling buffered writes, if there are any writes in the buffer, they
-	// are flushed with the next BatchRequest.
+	// gateway node until the commit time. Buffered writes cannot be enabled on
+	// a txn that performed any requests. When disabling buffered writes, if
+	// there are any writes in the buffer, they are flushed with the next
+	// BatchRequest.
+	//
+	// Disabling buffered writes is allowed on both the RootTxn and the LeafTxn
+	// whereas enabling them is only allowed on the RootTxn.
 	SetBufferedWritesEnabled(bool)
 
 	// BufferedWritesEnabled returns whether the buffered writes are enabled.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -444,8 +444,8 @@ func (txn *Txn) debugNameLocked() string {
 }
 
 func (txn *Txn) SetBufferedWritesEnabled(enabled bool) {
-	if txn.typ != RootTxn {
-		panic(errors.AssertionFailedf("SetBufferedWritesEnabled() called on leaf txn"))
+	if enabled && txn.typ != RootTxn {
+		panic(errors.AssertionFailedf("SetBufferedWritesEnabled(true) called on leaf txn"))
 	}
 
 	txn.mu.Lock()

--- a/pkg/sql/logictest/testdata/logic_test/distsql_buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_buffered_writes
@@ -1,0 +1,65 @@
+# LogicTest: 5node
+
+subtest regression_151325
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+INSERT INTO kv VALUES (1, 1), (2, 2);
+
+statement ok
+ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1, 2) AS g(i)
+
+retry
+statement ok
+ALTER TABLE kv EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[i+1], i FROM generate_series(0, 2) AS g(i)
+
+statement ok
+BEGIN;
+
+# The row inserted in the subquery is initially buffered by the KV client, but
+# usage of the MVCC timestamp system column disables write buffering. That row
+# isn't visible by the main query.
+statement count 2
+SELECT
+  crdb_internal_mvcc_timestamp
+FROM
+  [
+    INSERT INTO kv VALUES (3, 3) RETURNING NULL
+  ],
+  kv;
+
+# Now all rows are visible.
+statement count 3
+SELECT crdb_internal_mvcc_timestamp FROM kv;
+
+statement ok
+COMMIT;
+
+# Try another txn where the flushed write should be observed by the following
+# stmt which should encounter an error.
+
+statement ok
+BEGIN;
+
+statement count 3
+SELECT
+  crdb_internal_mvcc_timestamp
+FROM
+  [
+    INSERT INTO kv VALUES (4, 4) RETURNING NULL
+  ],
+  kv;
+
+statement error duplicate key value violates unique constraint \"kv_pkey\"
+INSERT INTO kv VALUES (4, 4);
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT count(*) FROM kv;
+----
+3
+
+subtest end

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 21,
+    shard_count = 22,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -94,6 +94,13 @@ func TestLogic_distsql_agg(
 	runLogicTest(t, "distsql_agg")
 }
 
+func TestLogic_distsql_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_buffered_writes")
+}
+
 func TestLogic_distsql_builtin(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Previously, if we attempted to call `SetBufferedWritesEnabled(false)` on the LeafTxn, it would result in a panic. However, this could happen in a scenario when buffered writes are enabled, we buffered some rows, and then we issue a query that is executed in distributed fashion and attempts to use one of the unsupported features (like accessing `crdb_internal_mvcc_timestamp` system column). In order to prevent the panic in this case we relax the condition to allow explicitly disabling buffered writes on the LeafTxn.

This will have an effect that the buffer will be flushed on the next batch (if there is one) issued against the LeafTxn. This seems somewhat fragile for two reasons:
- LeafTxns don't allow writes, and here we'll be flushing the write requests that are currently buffered by the RootTxn to the KV server. Maybe it's fine.
- the RootTxn will be unaware that the buffer was flushed (furthermore, due to "reads tree", only part of the buffer might be flushed). So the RootTxn on COMMIT might attempt to write things that have already been written. Also maybe it's fine.

I decided to omit the release note given it's an edge case in disabled by default feature.

Fixes: #151325.

Release note: None