### PR TITLE
roachprod: insecure cluster warn log

### DIFF
--- a/pkg/roachprod/install/cluster_settings.go
+++ b/pkg/roachprod/install/cluster_settings.go
@@ -7,6 +7,7 @@ package install
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
@@ -109,7 +110,7 @@ func (o ComplexSecureOption) overrideBasedOnClusterSettings(c *SyncedCluster) er
 		// we make it insecure by default. This is to avoid dealing with certificates
 		// for ephemeral engineering test clusters.
 		if len(c.Clouds()) == 1 && c.Clouds()[0] == fmt.Sprintf("%s:%s", gce.ProviderName, gce.DefaultProjectID) {
-			fmt.Printf("WARN: cluster %s defaults to insecure, because it is in project %s\n",
+			fmt.Fprintf(os.Stderr, "WARN: cluster %s defaults to insecure, because it is in project %s\n",
 				c.Name,
 				gce.DefaultProjectID,
 			)


### PR DESCRIPTION
As of #151230, roachprod's default behavior is to provision secure clusters unless provisioning is in the cockroach-ephemeral GCP project. To warn the user about the fact that the cluster is insecure in this configuration, a log was added to stdout.

The addition of this log message broke some K/V performance scripts, so this patch moves the warning to stderr instead.

Epic: none
Release note: None