### PR TITLE
sql: prevent delegate behavior from being blocked by the unsafesql gate

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -952,6 +952,10 @@ func (p *planner) HasViewActivityOrViewActivityRedactedRole(
 // objectIsUnsafe checks if the privilege object is considered unsafe for external usage.
 // Unsafe objects are any system tables, and crdb_internal tables which are not listed as externally supported.
 func (p *planner) objectIsUnsafe(ctx context.Context, privilegeObject privilege.Object) bool {
+	if p.skipUnsafeInternalsCheck {
+		return false
+	}
+
 	d, ok := privilegeObject.(catalog.TableDescriptor)
 	if !ok {
 		return true

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -286,4 +286,7 @@ type Catalog interface {
 
 	// IsOwner returns true if user is the owner of the object o
 	IsOwner(ctx context.Context, o Object, user username.SQLUsername) (bool, error)
+
+	// DisableUnsafeInternalsCheck disables the check for unsafe internals in the catalog.
+	DisableUnsafeInternalCheck() func()
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -890,6 +890,10 @@ func (b *Builder) constructUnary(
 func (b *Builder) isUnsafeBuiltin(
 	overload *tree.Overload, def *tree.ResolvedFunctionDefinition,
 ) bool {
+	if b.skipUnsafeInternalsCheck {
+		return false
+
+	}
 	if overload.Type != tree.BuiltinRoutine {
 		return false
 	}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -551,6 +551,11 @@ func (tc *Catalog) ExecuteMultipleDDL(sql string) error {
 	return nil
 }
 
+// DisableUnsafeInternalCheck is part of the cat.Catalog interface.
+func (tc *Catalog) DisableUnsafeInternalCheck() func() {
+	return func() {}
+}
+
 // ExecuteDDL parses the given DDL SQL statement and creates objects in the test
 // catalog. This is used to test without spinning up a cluster.
 func (tc *Catalog) ExecuteDDL(sql string) (string, error) {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -742,6 +742,15 @@ func (oc *optCatalog) codec() keys.SQLCodec {
 	return oc.planner.ExecCfg().Codec
 }
 
+// DisableUnsafeInternalCheck sets the planners skipUnsafeInternalsCheck
+// to true, and returns a function which reverses it to false.
+func (oc *optCatalog) DisableUnsafeInternalCheck() func() {
+	oc.planner.skipUnsafeInternalsCheck = true
+	return func() {
+		oc.planner.skipUnsafeInternalsCheck = false
+	}
+}
+
 // optView is a wrapper around catalog.TableDescriptor that implements
 // the cat.Object, cat.DataSource, and cat.View interfaces.
 type optView struct {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -305,6 +305,10 @@ type planner struct {
 	// statement. It's similar to autoRetryCounter / txnState.mu.autoRetryCounter
 	// but for statement retries.
 	autoRetryStmtCounter int
+
+	// skipUnsafeInternalsCheck is used to skip the check that the
+	// planner is not used for unsafe internal statements.
+	skipUnsafeInternalsCheck bool
 }
 
 // hasFlowForPausablePortal returns true if the planner is for re-executing a


### PR DESCRIPTION
The epic below outlines a set of work to prevent users from unauthorized
access to what we deem unsafe internals. These unsafe internals lie
mostly in the crdb_internal schema and the system database. This PR
prevents that gate from being checked within delegate query behavior,
thus allowing users to issue delegates from commands like `SHOW
DATABASES`.

Fixes: #151406
Epic: CRDB-24527

Release note (ops change): Delegate queries (like SHOW etc) are excluded
from unsafesql checks to accessing the system or crdb_internal tables. 