### PR TITLE
roachtest: deflake gopg

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -54,4 +54,7 @@ var gopgIgnoreList = blocklist{
 	`v10.TestColumnReuse`: "unknown",
 	// This test is flaky sometimes due to the use of temp tables.
 	`pg | soft delete with int column nil model ForceDelete | deletes the model`: "unknown",
+	// This test is sometimes flaky due to a small delta in the expected soft
+	// deletion timestamp (i.e. the test allows up to one seconds worth of difference).
+	`pg | soft delete with int column model | ForceDelete deletes the model`: "unknown",
 }


### PR DESCRIPTION
Previously, one of the soft deletion tests was flaking because of a timing issue where sometimes it could be slower then expected. This patch adds the problematic test on the ignore list.

Fixes: #151991

Release note: None