### PR TITLE
sql: fix user lease tests

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -558,13 +558,6 @@ func TestWaitForNewVersion(testingT *testing.T) {
 	defer log.Scope(testingT).Close(testingT)
 
 	var params base.TestClusterArgs
-	params.ServerArgs.Knobs = base.TestingKnobs{
-		SQLLeaseManager: &lease.ManagerTestingKnobs{
-			LeaseStoreTestingKnobs: lease.StorageTestingKnobs{
-				LeaseAcquiredEvent: nil, // TODO
-			},
-		},
-	}
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
 
@@ -587,7 +580,10 @@ func TestWaitForNewVersion(testingT *testing.T) {
 		defer cancel()
 
 		_, err := leaseMgr.WaitForNewVersion(timeoutCtx, descID, retry.Options{}, nil)
-		require.ErrorIs(t, err, context.DeadlineExceeded)
+		if !(sqltestutils.IsClientSideQueryCanceledErr(err) ||
+			errors.Is(err, context.DeadlineExceeded)) {
+			t.Fatalf("The client or the context should have timed out. Unexpected error: %v", err)
+		}
 	}
 
 	t.mustAcquire(3, descID)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3461,12 +3461,6 @@ func (ex *connExecutor) makeExecPlan(
 		//
 		// In 50% cases, use nil catalog.
 		var catalog cat.Catalog
-		if ex.rng.internal.Float64() < 0.5 && !planner.SessionData().AllowRoleMembershipsToChangeDuringTransaction {
-			// For some reason, TestAllowRoleMembershipsToChangeDuringTransaction
-			// times out with non-nil catalog, so we'll keep it as nil when the
-			// session var is set to 'true' ('false' is the default).
-			catalog = planner.optPlanningCtx.catalog
-		}
 		_, err := explain.DecodePlanGistToRows(ctx, &planner.extendedEvalCtx.Context, ih.planGist.String(), catalog)
 		if err != nil {
 			return ctx, errors.NewAssertionErrorWithWrappedErrf(err, "failed to decode plan gist: %q", ih.planGist.String())

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4128,10 +4128,6 @@ func (m *sessionDataMutator) SetEnableCreateStatsUsingExtremesBoolEnum(val bool)
 	m.data.EnableCreateStatsUsingExtremesBoolEnum = val
 }
 
-func (m *sessionDataMutator) SetAllowRoleMembershipsToChangeDuringTransaction(val bool) {
-	m.data.AllowRoleMembershipsToChangeDuringTransaction = val
-}
-
 func (m *sessionDataMutator) SetDefaultTextSearchConfig(val string) {
 	m.data.DefaultTextSearchConfig = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3949,7 +3949,6 @@ ORDER BY variable
 variable                                                         value
 allow_create_trigger_function_with_argv_references               off
 allow_ordinal_column_references                                  off
-allow_role_memberships_to_change_during_transaction              off
 allow_unsafe_internals                                           on
 alter_primary_region_super_region_override                       off
 always_distribute_full_scans                                     off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2949,7 +2949,6 @@ ORDER BY name
 name                                                             setting             category  short_desc  extra_desc  vartype
 allow_create_trigger_function_with_argv_references               off                 NULL      NULL        NULL        string
 allow_ordinal_column_references                                  off                 NULL      NULL        NULL        string
-allow_role_memberships_to_change_during_transaction              off                 NULL      NULL        NULL        string
 allow_unsafe_internals                                           on                  NULL      NULL        NULL        string
 alter_primary_region_super_region_override                       off                 NULL      NULL        NULL        string
 always_distribute_full_scans                                     off                 NULL      NULL        NULL        string
@@ -3191,7 +3190,6 @@ ORDER BY name
 name                                                             setting             unit  context  enumvals  boot_val            reset_val
 allow_create_trigger_function_with_argv_references               off                 NULL  user     NULL      off                 off
 allow_ordinal_column_references                                  off                 NULL  user     NULL      off                 off
-allow_role_memberships_to_change_during_transaction              off                 NULL  user     NULL      off                 off
 allow_unsafe_internals                                           on                  NULL  user     NULL      on                  on
 alter_primary_region_super_region_override                       off                 NULL  user     NULL      off                 off
 always_distribute_full_scans                                     off                 NULL  user     NULL      off                 off
@@ -3417,7 +3415,6 @@ SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg
 name                                                             source  min_val  max_val  sourcefile  sourceline
 allow_create_trigger_function_with_argv_references               NULL    NULL     NULL     NULL        NULL
 allow_ordinal_column_references                                  NULL    NULL     NULL     NULL        NULL
-allow_role_memberships_to_change_during_transaction              NULL    NULL     NULL     NULL        NULL
 allow_unsafe_internals                                           NULL    NULL     NULL     NULL        NULL
 alter_primary_region_super_region_override                       NULL    NULL     NULL     NULL        NULL
 always_distribute_full_scans                                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -39,7 +39,6 @@ ORDER BY variable
 variable                                                         value
 allow_create_trigger_function_with_argv_references               off
 allow_ordinal_column_references                                  off
-allow_role_memberships_to_change_during_transaction              off
 allow_unsafe_internals                                           on
 alter_primary_region_super_region_override                       off
 always_distribute_full_scans                                     off

--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -105,8 +105,9 @@ testuser  /global/  {MODIFYCLUSTERSETTING}  {}
 statement ok
 REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
 
+# the cardinality check sidesteps a race condition where the cache holds a user with neither privilege nor grant
 query TTTT
-SELECT username, path, privileges, grant_options  FROM system.privileges ORDER BY 1, 2
+SELECT username, path, privileges, grant_options FROM system.privileges WHERE cardinality(privileges) > 0 OR cardinality(grant_options) > 0 ORDER BY 1, 2
 ----
 root  /global/  {MODIFYCLUSTERSETTING}  {}
 
@@ -123,7 +124,7 @@ statement ok
 REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
 
 query TTTT
-SELECT username, path, privileges, grant_options  FROM system.privileges ORDER BY 1, 2
+SELECT username, path, privileges, grant_options FROM system.privileges WHERE cardinality(privileges) > 0 OR cardinality(grant_options) > 0 ORDER BY 1, 2
 ----
 root  /global/  {MODIFYCLUSTERSETTING}  {}
 
@@ -162,7 +163,7 @@ SELECT * FROM crdb_internal.cluster_settings;
 user root
 
 query TTTT
-SELECT username, path, privileges, grant_options FROM system.privileges
+SELECT username, path, privileges, grant_options FROM system.privileges WHERE cardinality(privileges) > 0 OR cardinality(grant_options) > 0
 ----
 root  /global/  {MODIFYCLUSTERSETTING}  {}
 
@@ -201,7 +202,7 @@ SELECT * FROM crdb_internal.node_statement_statistics;
 user root
 
 query TTTT
-SELECT username, path, privileges, grant_options FROM system.privileges
+SELECT username, path, privileges, grant_options FROM system.privileges WHERE cardinality(privileges) > 0 OR cardinality(grant_options) > 0
 ----
 root  /global/  {MODIFYCLUSTERSETTING}  {}
 
@@ -240,7 +241,7 @@ SELECT * FROM crdb_internal.node_statement_statistics;
 user root
 
 query TTTT
-SELECT username, path, privileges, grant_options FROM system.privileges
+SELECT username, path, privileges, grant_options FROM system.privileges WHERE cardinality(privileges) > 0 OR cardinality(grant_options) > 0
 ----
 root  /global/  {MODIFYCLUSTERSETTING}  {}
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -5,10 +5,11 @@
 
 syntax = "proto3";
 package cockroach.sql.sessiondatapb;
-option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb";
 
 import "gogoproto/gogo.proto";
 import "util/hlc/timestamp.proto";
+
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb";
 
 // LocalOnlySessionData contains the serializable components of session
 // parameters that only influence execution on the gateway nodes.
@@ -230,7 +231,7 @@ message LocalOnlySessionData {
   bool cost_scans_with_default_col_size = 61;
   // DefaultTxnQualityOfService indicates the default QoSLevel/WorkPriority of
   // newly created transactions.
-  int32 default_txn_quality_of_service = 62 [(gogoproto.casttype)="QoSLevel"];
+  int32 default_txn_quality_of_service = 62 [(gogoproto.casttype) = "QoSLevel"];
   // OptSplitScanLimit indicates the maximum number of UNION ALL statements a
   // Scan may be split into during query optimization to avoid a sort.
   int32 opt_split_scan_limit = 63;
@@ -349,14 +350,7 @@ message LocalOnlySessionData {
   // EnableCreateStatsUsingExtremes, when true, allows the use of CREATE
   // STATISTICS .. USING EXTREMES.
   bool enable_create_stats_using_extremes = 95;
-  // AllowRoleMembershipsToChangeDuringTransaction, when true, means that
-  // operations which consult the role membership cache do not retain their
-  // lease on that version of the cache throughout the transaction. The
-  // consequence of this is that the transaction may not experience a singular
-  // view of role membership, and it may be able to commit after the revocation
-  // of a role membership which the transaction relied on has successfully been
-  // committed and acknowledged to the user.
-  bool allow_role_memberships_to_change_during_transaction = 96;
+  reserved 96;
   // PreparedStatementsCacheSize, when not equal to 0, causes the LRU prepared
   // statements in a session to be automatically deallocated when total prepared
   // statement memory usage for that session is more than the cache size.
@@ -407,9 +401,7 @@ message LocalOnlySessionData {
   // with a foreign key under serializable isolation. (Under weaker isolation
   // levels foreign key checks of the parent table always use FOR SHARE
   // locking.)
-  bool implicit_fk_locking_for_serializable = 108 [
-    (gogoproto.customname) = "ImplicitFKLockingForSerializable"
-  ];
+  bool implicit_fk_locking_for_serializable = 108 [(gogoproto.customname) = "ImplicitFKLockingForSerializable"];
   // DurableLockingForSerializable is true if we should use durable locking for
   // SELECT FOR UPDATE statements, SELECT FOR SHARE statements, and constraint
   // checks under serializable isolation. (Serializable isolation does not
@@ -462,7 +454,7 @@ message LocalOnlySessionData {
   bool disable_changefeed_replication = 116;
   // CopyTxnQualityOfService indicates the default QoSLevel/WorkPriority of the
   // transactions used to evaluate COPY commands.
-  int32 copy_txn_quality_of_service = 117 [(gogoproto.casttype)="QoSLevel"];
+  int32 copy_txn_quality_of_service = 117 [(gogoproto.casttype) = "QoSLevel"];
   // CopyWritePipeliningEnabled indicates whether the write pipelining is
   // enabled for implicit txns used by COPY.
   bool copy_write_pipelining_enabled = 118;
@@ -550,7 +542,7 @@ message LocalOnlySessionData {
   util.hlc.Timestamp origin_timestamp_for_logical_data_replication = 140 [(gogoproto.nullable) = false];
   // BypassPCRReaderCatalogAOST disables the AOST used by all user queries on
   // the PCR reader catalog.
-  bool bypass_pcr_reader_catalog_aost = 141  [(gogoproto.customname) = "BypassPCRReaderCatalogAOST"];
+  bool bypass_pcr_reader_catalog_aost = 141 [(gogoproto.customname) = "BypassPCRReaderCatalogAOST"];
   // UnsafeAllowTriggersModifyingCascades, when true, allows row-level BEFORE
   // triggers to modify or filter rows that are being updated or deleted as
   // part of a cascading foreign key action. This is unsafe because it can

--- a/pkg/sql/tests/allow_role_memberships_to_change_during_transaction_test.go
+++ b/pkg/sql/tests/allow_role_memberships_to_change_during_transaction_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -20,10 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAllowRoleMembershipsToChangeDuringTransaction ensures that when the
-// corresponding session variable is set for all sessions using cached
-// role memberships, performing new grants do not need to wait for open
-// transactions to complete.
+// TestAllowRoleMembershipsToChangeDuringTransaction ensures performing new
+// grants does not need to wait for open transactions to complete.
 func TestAllowRoleMembershipsToChangeDuringTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -41,10 +38,8 @@ func TestAllowRoleMembershipsToChangeDuringTransaction(t *testing.T) {
 	}
 
 	// Create three users: foo, bar, and baz.
-	// Use one of these users to hold open a transaction which uses a lease
-	// on the role_memberships table. Ensure that initially granting does
-	// wait on that transaction. Then set the session variable and ensure
-	// that it does not.
+	// Use one of these users to hold open a transaction which uses a lease on
+	// the role_memberships table.
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 	tdb.Exec(t, "CREATE USER foo PASSWORD 'foo'")
 	tdb.Exec(t, "CREATE USER bar")
@@ -56,43 +51,30 @@ func TestAllowRoleMembershipsToChangeDuringTransaction(t *testing.T) {
 	fooDB, cleanupFoo := openUser("foo", "db2")
 	defer cleanupFoo()
 
-	// In this first test, we want to make sure that the query cannot proceed
-	// until the outer transaction commits. We launch the grant while the
-	// transaction is open, wait a tad, make sure it hasn't made progress,
-	// then we commit the relevant transaction and ensure that it does finish.
-	t.Run("normal path waits", func(t *testing.T) {
+	t.Run("normal path isn't blocked", func(t *testing.T) {
 		fooTx, err := fooDB.BeginTx(ctx, nil)
 		require.NoError(t, err)
+		defer func() { _ = fooTx.Rollback() }()
 		var count int
 		require.NoError(t,
 			fooTx.QueryRow("SELECT count(*) FROM t").Scan(&count))
 		require.Equal(t, 0, count)
-		errCh := make(chan error, 1)
-		go func() {
-			_, err := sqlDB.Exec("GRANT bar TO baz;")
-			errCh <- err
-		}()
-		select {
-		case <-time.After(10 * time.Millisecond):
-			// Wait a tad and make sure nothing happens. This test will be
-			// flaky if we mess up the leasing.
-		case err := <-errCh:
-			t.Fatalf("expected transaction to block, got err: %v", err)
-		}
+
+		_, err = sqlDB.Exec("GRANT bar TO baz;")
+		require.NoError(t, err)
+
 		require.NoError(t, fooTx.Commit())
-		require.NoError(t, <-errCh)
 	})
 
 	// In this test we ensure that we can perform role grant and revoke
 	// operations while the transaction which uses the relevant roles
 	// remains open. We ensure that the transaction still succeeds and
 	// that the operations occur in a timely manner.
-	t.Run("session variable prevents waiting during GRANT and REVOKE", func(t *testing.T) {
+	t.Run("no waiting during GRANT and REVOKE", func(t *testing.T) {
 		fooConn, err := fooDB.Conn(ctx)
 		require.NoError(t, err)
 		defer func() { _ = fooConn.Close() }()
-		_, err = fooConn.ExecContext(ctx, "SET allow_role_memberships_to_change_during_transaction = true;")
-		require.NoError(t, err)
+
 		fooTx, err := fooConn.BeginTx(ctx, nil)
 		require.NoError(t, err)
 		var count int
@@ -122,8 +104,7 @@ func TestAllowRoleMembershipsToChangeDuringTransaction(t *testing.T) {
 		fooConn, err := fooDB.Conn(ctx)
 		require.NoError(t, err)
 		defer func() { _ = fooConn.Close() }()
-		_, err = fooConn.ExecContext(ctx, "SET allow_role_memberships_to_change_during_transaction = true;")
-		require.NoError(t, err)
+
 		fooTx, err := fooConn.BeginTx(ctx, nil)
 		require.NoError(t, err)
 		// We need to use show roles because that access the system.users table.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3167,21 +3167,8 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
-	`allow_role_memberships_to_change_during_transaction`: {
-		GetStringVal: makePostgresBoolGetStringValFn(`allow_role_memberships_to_change_during_transaction`),
-		Set: func(_ context.Context, m sessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar("allow_role_memberships_to_change_during_transaction", s)
-			if err != nil {
-				return err
-			}
-			m.SetAllowRoleMembershipsToChangeDuringTransaction(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowRoleMembershipsToChangeDuringTransaction), nil
-		},
-		GlobalDefault: globalFalse,
-	},
+	// This is only kept for backwards compatibility and no longer has any effect.
+	`allow_role_memberships_to_change_during_transaction`: makeBackwardsCompatBoolVar(`allow_role_memberships_to_change_during_transaction`, true),
 
 	// CockroachDB extension.
 	`prepared_statements_cache_size`: {


### PR DESCRIPTION
The test on `WaitForNewVersion` was flaking due to timeouts. The tests
around the `allow_role_memberships_to_change_during_transaction` session
variable were no longer valid from https://github.com/cockroachdb/cockroach/pull/150747.

Fixes: #152050
Fixes: #152051
Fixes: #152043

Fixes: #152094

Release note: None