### PR TITLE
logical: shard logical test package

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -143,6 +143,7 @@ go_test(
     ],
     embed = [":logical"],
     exec_properties = {"test.Pool": "large"},
+    shard_count = 5,
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
We are seeing occasional package timeouts on CI. On my mac, sharding the package cuts the runtime from 110s to 44s which should eliminate the risk of bumping into the 5 minute timeouts on CI.

Fixes: #151634
Fixes: #151170
Fixes: #151571
Fixes: #151468
Fixes: #151623
Fixes: #150903
Fixes: #150116
Release note: none