### PR TITLE
crosscluster/producer: extend table level auth to VIEWSYSTEMTABLE

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2183,7 +2183,7 @@ func TestUserPrivileges(t *testing.T) {
 		dbA.Exec(t, fmt.Sprintf("REVOKE SYSTEM REPLICATIONDEST FROM %s", username.TestUser))
 	})
 	t.Run("replication-src", func(t *testing.T) {
-		dbA.ExpectErr(t, "user testuser3 does not have REPLICATIONSOURCE privilege on relation tab", createStmt, dbBURL2.String())
+		dbA.ExpectErr(t, "user testuser3 does not have either REPLICATIONSOURCE or VIEWSYSTEMTABLE system privilege", createStmt, dbBURL2.String())
 		sourcePriv := "REPLICATIONSOURCE"
 		if rng.Intn(3) == 0 {
 			// Test deprecated privilege name.
@@ -2195,7 +2195,7 @@ func TestUserPrivileges(t *testing.T) {
 		dbB.Exec(t, fmt.Sprintf("REVOKE SYSTEM %s FROM %s", sourcePriv, username.TestUser+"3"))
 	})
 	t.Run("table-level-replication-src", func(t *testing.T) {
-		dbA.ExpectErr(t, "user testuser3 does not have REPLICATIONSOURCE privilege on relation tab", createStmt, dbBURL2.String())
+		dbA.ExpectErr(t, "user testuser3 does not have either REPLICATIONSOURCE or VIEWSYSTEMTABLE system privilege", createStmt, dbBURL2.String())
 
 		dbB.Exec(t, fmt.Sprintf("GRANT REPLICATIONSOURCE ON TABLE tab TO %s", username.TestUser+"3"))
 		dbA.QueryRow(t, createStmt, dbBURL2.String()).Scan(&jobAID)

--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -86,7 +86,7 @@ func TestPCRPrivs(t *testing.T) {
 	c.DestSysSQL.Exec(t, fmt.Sprintf("GRANT SYSTEM REPLICATIONDEST TO %s", username.TestUser))
 
 	// Ensure the source user has the REPLICATION privilege.
-	testuser.ExpectErr(t, "user testuser2 does not have REPLICATIONSOURCE system privilege", streamReplStmt)
+	testuser.ExpectErr(t, "user testuser2 does not have either REPLICATIONSOURCE or VIEWSYSTEMTABLE system privilege", streamReplStmt)
 	sourcePriv := "REPLICATIONSOURCE"
 	if c.Rng.Intn(3) == 0 {
 		// Test deprecated privilege name.

--- a/pkg/crosscluster/producer/replication_manager_test.go
+++ b/pkg/crosscluster/producer/replication_manager_test.go
@@ -73,6 +73,9 @@ func TestReplicationManagerRequiresReplicationPrivilege(t *testing.T) {
 	tDB.Exec(t, "GRANT SYSTEM REPLICATIONSOURCE TO somebody")
 	tDB.Exec(t, "CREATE ROLE anybody")
 
+	tDB.Exec(t, "CREATE ROLE someone")
+	tDB.Exec(t, "GRANT SYSTEM VIEWSYSTEMTABLE TO someone")
+
 	for _, tc := range []struct {
 		user   string
 		expErr string
@@ -80,7 +83,8 @@ func TestReplicationManagerRequiresReplicationPrivilege(t *testing.T) {
 		{user: "admin", expErr: ""},
 		{user: "root", expErr: ""},
 		{user: "somebody", expErr: ""},
-		{user: "anybody", expErr: "user anybody does not have REPLICATIONSOURCE system privilege"},
+		{user: "someone", expErr: ""},
+		{user: "anybody", expErr: "user anybody does not have either REPLICATIONSOURCE or VIEWSYSTEMTABLE system privilege"},
 		{user: "nobody", expErr: `role/user "nobody" does not exist`},
 	} {
 		t.Run(tc.user, func(t *testing.T) {


### PR DESCRIPTION
Previously, authorization layer was ensuring that the provided user has the `REPLICATIONSOUCE/REPLICATION` privileges. The debug.zip generation flow is executing `select` queries on below tables as of today:
	* crdb_internal.logical_replication_node_processors
	* crdb_internal.cluster_replication_node_streams
	* crdb_internal.cluster_replication_node_stream_spans
	* crdb_internal.cluster_replication_node_stream_checkpoints
 The user used in debug.zip generation should have either `ADMIN` or ` REPLICATIONSOUCE/REPLICATION` privileges. We have received a customer request for relying on restricted access privileges in debug.zip generation. To address this, this patch updates the authorization layer to extend the check to `VIEWSYSTEMTABLE` privilege.

Epic: CRDB-49078
Part of: CRDB-53397
Release note (ops change): Previously, provided user required `REPLICATIONSOURCE/REPLICATION` privilege on table. This change extends privilege to `VIEWSYSTEMTABLE` which is used in debug.zip generation flow.