### PR TITLE
workload/schemachange: handle LTREE in mixed version CREATE TYPE

### DIFF
--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -40,7 +40,7 @@ func MakeSchemaName(ifNotExists bool, schema string, authRole tree.RoleSpec) *tr
 // RandCreateEnumType creates a random CREATE TYPE <type_name> AS ENUM statement.
 // The resulting type's name will be name, the enum members will
 // be random strings generated from alphabet.
-func RandCreateEnumType(rng *rand.Rand, name, alphabet string) tree.Statement {
+func RandCreateEnumType(rng *rand.Rand, name, alphabet string) *tree.CreateType {
 	numLabels := rng.Intn(6) + 1
 	labels := make(tree.EnumValueList, numLabels)
 	labelsMap := make(map[string]struct{})
@@ -66,7 +66,7 @@ func RandCreateEnumType(rng *rand.Rand, name, alphabet string) tree.Statement {
 }
 
 // RandCreateCompositeType creates a random composite type statement.
-func RandCreateCompositeType(rng *rand.Rand, name, alphabet string) tree.Statement {
+func RandCreateCompositeType(rng *rand.Rand, name, alphabet string) *tree.CreateType {
 	var compositeTypeList []tree.CompositeTypeElem
 
 	numTypes := rng.Intn(6) + 1


### PR DESCRIPTION
Using this type in a composite type in a mixed version cluster will cause UndefinedObject errors, so we need to make the workload aware of that.

informs https://github.com/cockroachdb/cockroach/issues/150547
Release note: None