### PR TITLE
spanconfigkvsubscriber: use IsSortedFunc return value

### DIFF
--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -113,9 +113,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
 				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp42)
 				require.NoError(t, err)
-				slices.IsSortedFunc(protections, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
-				})
+				require.True(t, slices.IsSortedFunc(protections, hlc.Timestamp.Compare))
 				require.Equal(t, []hlc.Timestamp{ts1, ts2}, protections)
 			},
 		},
@@ -124,9 +122,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
 				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp43)
 				require.NoError(t, err)
-				slices.IsSortedFunc(protections, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
-				})
+				require.True(t, slices.IsSortedFunc(protections, hlc.Timestamp.Compare))
 				require.Equal(t, []hlc.Timestamp{ts4}, protections)
 			},
 		},
@@ -135,9 +131,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
 				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp4243)
 				require.NoError(t, err)
-				slices.IsSortedFunc(protections, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
-				})
+				require.True(t, slices.IsSortedFunc(protections, hlc.Timestamp.Compare))
 				require.Equal(t, []hlc.Timestamp{ts1, ts2, ts4}, protections)
 			},
 		},
@@ -146,9 +140,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
 				protections, _, err := subscriber.GetProtectionTimestamps(ctx, keys.ExcludeFromBackupSpan)
 				require.NoError(t, err)
-				slices.IsSortedFunc(protections, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
-				})
+				require.True(t, slices.IsSortedFunc(protections, hlc.Timestamp.Compare))
 				require.Empty(t, protections)
 			},
 		},
@@ -157,9 +149,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
 				protections, _, err := subscriber.GetProtectionTimestamps(ctx, keys.NodeLivenessSpan)
 				require.NoError(t, err)
-				slices.IsSortedFunc(protections, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
-				})
+				require.True(t, slices.IsSortedFunc(protections, hlc.Timestamp.Compare))
 				require.Empty(t, protections)
 			},
 		},
@@ -171,9 +161,7 @@ func TestGetProtectionTimestamps(t *testing.T) {
 					roachpb.Span{Key: keys.MinKey, EndKey: sp43.EndKey},
 				)
 				require.NoError(t, err)
-				slices.IsSortedFunc(protections, func(a, b hlc.Timestamp) int {
-					return a.Compare(b)
-				})
+				require.True(t, slices.IsSortedFunc(protections, hlc.Timestamp.Compare))
 				require.Equal(t, []hlc.Timestamp{ts1, ts2, ts4}, protections)
 			},
 		},


### PR DESCRIPTION
Previously TestGetProtectionTimestamps called IsSortedFunc without using the return value. This commit updates these calls into assertions.

This got picked up by CI on #152102—I assume nonblockingly, but I figured I'd put up a fix.