### PR TITLE
kvserver/rangefeed,inspectz: add inspectz support for rangefeeds

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1593,6 +1593,7 @@ GO_TARGETS = [
     "//pkg/kv/kvserver/rafttrace:rafttrace_test",
     "//pkg/kv/kvserver/raftutil:raftutil",
     "//pkg/kv/kvserver/raftutil:raftutil_test",
+    "//pkg/kv/kvserver/rangefeed/rangefeedpb:rangefeedpb",
     "//pkg/kv/kvserver/rangefeed:rangefeed",
     "//pkg/kv/kvserver/rangefeed:rangefeed_test",
     "//pkg/kv/kvserver/rangelog/internal/genrangelogdatapb:genrangelogdatapb",

--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -38,6 +38,7 @@ PROTOBUF_SRCS = [
     "//pkg/kv/kvserver/loqrecovery/loqrecoverypb:loqrecoverypb_go_proto",
     "//pkg/kv/kvserver/protectedts/ptpb:ptpb_go_proto",
     "//pkg/kv/kvserver/protectedts/ptstorage:ptstorage_go_proto",
+    "//pkg/kv/kvserver/rangefeed/rangefeedpb:rangefeedpb_go_proto",
     "//pkg/kv/kvserver/rangelog/internal/rangelogtestpb:rangelogtestpb_go_proto",
     "//pkg/kv/kvserver/readsummary/rspb:rspb_go_proto",
     "//pkg/kv/kvserver/storeliveness/storelivenesspb:storelivenesspb_go_proto",

--- a/pkg/inspectz/BUILD.bazel
+++ b/pkg/inspectz/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
+        "//pkg/kv/kvserver/rangefeed/rangefeedpb",
         "//pkg/kv/kvserver/storeliveness/storelivenesspb",
         "//pkg/roachpb",
         "//pkg/util/errorutil",

--- a/pkg/inspectz/inspectzpb/BUILD.bazel
+++ b/pkg/inspectz/inspectzpb/BUILD.bazel
@@ -9,6 +9,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb:kvflowinspectpb_proto",
+        "//pkg/kv/kvserver/rangefeed/rangefeedpb:rangefeedpb_proto",
         "//pkg/kv/kvserver/storeliveness/storelivenesspb:storelivenesspb_proto",
     ],
 )
@@ -24,6 +25,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
+        "//pkg/kv/kvserver/rangefeed/rangefeedpb",
         "//pkg/kv/kvserver/storeliveness/storelivenesspb",
     ],
 )

--- a/pkg/inspectz/inspectzpb/inspectz.proto
+++ b/pkg/inspectz/inspectzpb/inspectz.proto
@@ -9,6 +9,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/inspectz/inspectzpb";
 
 import "kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.proto";
 import "kv/kvserver/storeliveness/storelivenesspb/service.proto";
+import "kv/kvserver/rangefeed/rangefeedpb/service.proto";
 
 // Inspectz exposes in-memory state of various CRDB components.
 //
@@ -40,6 +41,10 @@ service Inspectz {
   rpc StoreLivenessSupportFor(kv.kvserver.storeliveness.storelivenesspb.InspectStoreLivenessRequest)
       returns (kv.kvserver.storeliveness.storelivenesspb.InspectStoreLivenessResponse) {}
 
+  // Rangefeeds exposes the in-memory state of all rangefeed.baseRegistration(s).
+  // It's housed under /inspectz/rangefeeds.
+  rpc Rangefeeds(kv.kvserver.rangefeed.rangefeedpb.InspectRangefeedsRequest)
+      returns (kv.kvserver.rangefeed.rangefeedpb.InspectRangefeedsResponse) {}
 }
 
 // As of 04/23, we're not invoking these RPC interfaces as RPCs. But they're

--- a/pkg/inspectz/unsupported.go
+++ b/pkg/inspectz/unsupported.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/inspectz/inspectzpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 )
@@ -59,5 +60,12 @@ func (u Unsupported) StoreLivenessSupportFrom(
 func (u Unsupported) StoreLivenessSupportFor(
 	_ context.Context, _ *slpb.InspectStoreLivenessRequest,
 ) (*slpb.InspectStoreLivenessResponse, error) {
+	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
+}
+
+// Rangefeeds is part of the inspectzpb.InspectzServer interface.
+func (u Unsupported) Rangefeeds(
+	_ context.Context, _ *rangefeedpb.InspectRangefeedsRequest,
+) (*rangefeedpb.InspectRangefeedsResponse, error) {
 	return nil, errorutil.UnsupportedUnderClusterVirtualization(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 }

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "raft_transport_metrics.go",
         "raft_truncator_replica.go",
         "range_log.go",
+        "rangefeed.go",
         "rebalance_objective.go",
         "replica.go",
         "replica_app_batch.go",
@@ -176,6 +177,7 @@ go_library(
         "//pkg/kv/kvserver/rafttrace",
         "//pkg/kv/kvserver/raftutil",
         "//pkg/kv/kvserver/rangefeed",
+        "//pkg/kv/kvserver/rangefeed/rangefeedpb",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/readsummary",
         "//pkg/kv/kvserver/readsummary/rspb",
@@ -269,6 +271,7 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_time//rate",
     ],
 )

--- a/pkg/kv/kvserver/rangefeed.go
+++ b/pkg/kv/kvserver/rangefeed.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
+
+// InspectAllRangefeeds is an interface that allows for per-store Rangefeed
+// state to be combined into a per-node view. It powers the inspectz Rangefeeds
+// functionality.
+type InspectAllRangefeeds interface {
+	Inspect() ([]rangefeedpb.RangefeedInfoPerStore, error)
+}
+
+// StoresForRangefeeds is a wrapper around Stores that implements
+// InspectAllRangefeeds.
+type StoresForRangefeeds Stores
+
+var _ InspectAllRangefeeds = (*StoresForRangefeeds)(nil)
+
+// MakeStoresForRangefeeds casts Stores into StoresForRangefeeds.
+func MakeStoresForRangefeeds(stores *Stores) *StoresForRangefeeds {
+	return (*StoresForRangefeeds)(stores)
+}
+
+// Inspect implements the InspectAllRangefeeds interface.
+// It iterates over all stores and aggregates their RangefeedInfo.
+func (sfr *StoresForRangefeeds) Inspect() ([]rangefeedpb.RangefeedInfoPerStore, error) {
+	stores := (*Stores)(sfr)
+	var rangefeeds []rangefeedpb.RangefeedInfoPerStore
+	err := stores.VisitStores(
+		func(s *Store) error {
+			rangefeeds = append(rangefeeds, s.VisitRangefeeds())
+			return nil
+		},
+	)
+	return rangefeeds, err
+}

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/kv/kvserver/rangefeed/rangefeedpb",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -105,7 +105,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 		streams[i] = &noopStream{ctx: ctx, done: make(chan *kvpb.Error, 1)}
 		ok, _, _ := p.Register(ctx, span, hlc.MinTimestamp, nil,
 			withDiff, withFiltering, false /* withOmitRemote */, noBulkDelivery,
-			streams[i])
+			streams[i], 0, 0)
 		require.True(b, ok)
 	}
 

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -195,6 +196,8 @@ type Processor interface {
 		withOmitRemote bool,
 		bulkDeliverySize int,
 		stream Stream,
+		streamID int64,
+		consumerID int64,
 	) (bool, Disconnector, *Filter)
 
 	// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap
@@ -205,6 +208,9 @@ type Processor interface {
 	Filter() *Filter
 	// Len returns the number of registrations attached to the processor.
 	Len() int
+	// CollectAllRegistrationStates returns the state of all rangefeed
+	// registrations attached to the processor.
+	CollectAllRegistrationStates() []rangefeedpb.RegistrationState
 
 	// Data flow.
 

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -71,6 +71,8 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r1Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		require.True(t, r1OK)
 		h.syncEventAndRegistrations()
@@ -206,6 +208,8 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r2Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		require.True(t, r2OK)
 		h.syncEventAndRegistrations()
@@ -319,6 +323,8 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r3Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		require.True(t, r30K)
 		r3Stream.SendError(kvpb.NewError(fmt.Errorf("disconnection error")))
@@ -341,6 +347,8 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r4Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		require.False(t, r4OK)
 	})
@@ -367,6 +375,8 @@ func TestProcessorOmitRemote(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r1Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		require.True(t, r1OK)
 		h.syncEventAndRegistrations()
@@ -393,6 +403,8 @@ func TestProcessorOmitRemote(t *testing.T) {
 			true,  /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r2Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		require.True(t, r2OK)
 		h.syncEventAndRegistrations()
@@ -451,6 +463,8 @@ func TestProcessorSlowConsumer(t *testing.T) {
 				false, /* withOmitRemote */
 				noBulkDelivery,
 				h.toBufferedStreamIfNeeded(r1Stream),
+				0, /* streamID */
+				0, /* consumerID */
 			)
 			r2Stream := newTestStream()
 			p.Register(
@@ -463,6 +477,8 @@ func TestProcessorSlowConsumer(t *testing.T) {
 				false, /* withOmitRemote */
 				noBulkDelivery,
 				h.toBufferedStreamIfNeeded(r2Stream),
+				0, /* streamID */
+				0, /* consumerID */
 			)
 			h.syncEventAndRegistrations()
 			require.Equal(t, 2, p.Len())
@@ -559,6 +575,8 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r1Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		h.syncEventAndRegistrations()
 
@@ -615,6 +633,8 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r1Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		h.syncEventAndRegistrations()
 
@@ -697,6 +717,8 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r1Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		h.syncEventAndRegistrations()
 		require.Equal(t, 1, p.Len())
@@ -1005,7 +1027,10 @@ func TestProcessorConcurrentStop(t *testing.T) {
 				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 					noBulkDelivery,
-					h.toBufferedStreamIfNeeded(s))
+					h.toBufferedStreamIfNeeded(s),
+					0, /* streamID */
+					0, /* consumerID */
+				)
 			}()
 			go func() {
 				defer wg.Done()
@@ -1079,7 +1104,10 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 					noBulkDelivery,
-					h.toBufferedStreamIfNeeded(s))
+					h.toBufferedStreamIfNeeded(s),
+					0, /* streamID */
+					0, /* consumerID */
+				)
 				regDone <- struct{}{}
 			}
 		}()
@@ -1141,6 +1169,8 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(rStream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		h.syncEventAndRegistrations()
 
@@ -1222,6 +1252,8 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(rStream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		h.syncEventAndRegistrations()
 
@@ -1293,6 +1325,8 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r1Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 
 		// Non-blocking registration that would consume all events.
@@ -1306,6 +1340,8 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			false, /* withFiltering */
 			false /* withOmitRemote */, noBulkDelivery,
 			h.toBufferedStreamIfNeeded(r2Stream),
+			0, /* streamID */
+			0, /* consumerID */
 		)
 		h.syncEventAndRegistrations()
 
@@ -1475,7 +1511,10 @@ func TestProcessorBackpressure(t *testing.T) {
 		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpIter */
 			false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 			noBulkDelivery,
-			h.toBufferedStreamIfNeeded(stream))
+			h.toBufferedStreamIfNeeded(stream),
+			0, /* streamID */
+			0, /* consumerID */
+		)
 		require.True(t, ok)
 
 		// Wait for the initial checkpoint.

--- a/pkg/kv/kvserver/rangefeed/rangefeedpb/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/rangefeedpb/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "rangefeedpb_proto",
+    srcs = ["service.proto"],
+    strip_import_prefix = "/pkg",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb:roachpb_proto",
+        "//pkg/util/hlc:hlc_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+go_proto_library(
+    name = "rangefeedpb_go_proto",
+    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb",
+    proto = ":rangefeedpb_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
+)
+
+go_library(
+    name = "rangefeedpb",
+    embed = [":rangefeedpb_go_proto"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kv/kvserver/rangefeed/rangefeedpb/service.proto
+++ b/pkg/kv/kvserver/rangefeed/rangefeedpb/service.proto
@@ -1,0 +1,62 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.kv.kvserver.rangefeed.rangefeedpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb";
+
+import "gogoproto/gogo.proto";
+import "roachpb/data.proto";
+import "util/hlc/timestamp.proto";
+import "google/protobuf/timestamp.proto";
+
+// RegistrationState represents the state of a single active rangefeed
+// registration.
+message RegistrationState {
+  // StreamID is set by the client when starting the rangefeed.
+  int64 stream_id = 1 [(gogoproto.customname) = "StreamID"];
+  // ConsumerID is set by the client when starting the rangefeed.
+  int64 consumer_id = 2 [(gogoproto.customname) = "ConsumerID"];
+  // ID of the range being watched by this rangefeed.
+  int32 range_id = 3 [(gogoproto.customname) = "RangeID",
+                      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+  // Span being watched by this rangefeed.
+  roachpb.Span span = 4 [(gogoproto.nullable) = false];
+  // The starting timestamp of catch-up scans. Historical events with timestamp > catchup_ts 
+  // will be replayed before the feed switches to live updates. 
+  util.hlc.Timestamp catchup_ts = 5 [(gogoproto.nullable) = false,
+                                     (gogoproto.customname) = "CatchUpTS"];
+  // Whether this rangefeed is configured to emit diffs.
+  bool diff = 6;
+  // Time that this rangefeed registration was created at.
+  google.protobuf.Timestamp created = 7 [(gogoproto.nullable) = false,
+                                          (gogoproto.stdtime) = true];
+  // Frontier of the stream. All key-value events with timestamp <= resolved_ts
+  // have already been emitted.
+  util.hlc.Timestamp resolved_ts = 8 [(gogoproto.nullable) = false,
+                                      (gogoproto.customname) = "ResolvedTS"];
+  // Whether the rangefeed is currently running a catch-up scan.
+  bool catchup_running = 9 [(gogoproto.customname) = "CatchUpRunning"];
+  // Tags set in the stream context when starting the rangefeed.
+  string tags = 10;
+}
+
+// InspectRangefeedsRequest is used to power the Rangefeeds /inspectz
+// functionality. The request doesn't take any parameters.
+message InspectRangefeedsRequest {}
+
+// InspectRangefeedsResponse is used to power the Rangefeeds /inspectz
+// functionality. The response is a list of RangefeedInfoPerStore.
+message InspectRangefeedsResponse {
+  repeated RangefeedInfoPerStore rangefeed_info_per_store = 1 [(gogoproto.nullable) = false];
+}
+
+message RangefeedInfoPerStore {
+  // Identity of the store these states belong to.
+  roachpb.StoreIdent store_ident = 1 [(gogoproto.nullable) = false,
+                                      (gogoproto.customname) = "StoreIdent"];
+  // Collection of rangefeed registration states active on that store.
+  repeated RegistrationState registrations = 2 [(gogoproto.nullable) = false];
+}

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
@@ -53,6 +55,8 @@ type registration interface {
 	setID(int64)
 	// setSpanAsKeys sets the keys field to the span of the registration.
 	setSpanAsKeys()
+	// getState returns a snapshot of all the fields of the registration.
+	getState() rangefeedpb.RegistrationState
 	// getSpan returns the span of the registration.
 	getSpan() roachpb.Span
 	// getCatchUpTimestamp returns the catchUpTimestamp of the registration.
@@ -81,22 +85,28 @@ type registration interface {
 // baseRegistration is a common base for all registration types. It is intended
 // to be embedded in an actual registration struct.
 type baseRegistration struct {
-	streamCtx      context.Context
-	span           roachpb.Span
-	withDiff       bool
-	withFiltering  bool
-	withOmitRemote bool
-	bulkDelivery   int
+	// The following fields are immutable and are initialized upon registration.
+	id               int64 // internal
+	streamCtx        context.Context
+	span             roachpb.Span
+	catchUpTimestamp hlc.Timestamp // exclusive
+	withDiff         bool
+	withFiltering    bool
+	withOmitRemote   bool
+	bulkDelivery     int
+	rangeID          roachpb.RangeID
+	streamID         int64
+	consumerID       int64
+	createdTime      time.Time
 	// removeRegFromProcessor is called to remove the registration from its
 	// processor. This is provided by the creator of the registration and called
 	// during disconnect(). Since it is called during disconnect it must be
 	// non-blocking.
 	removeRegFromProcessor func(registration)
 
-	catchUpTimestamp hlc.Timestamp // exclusive
-	id               int64         // internal
-	keys             interval.Range
-	shouldUnreg      atomic.Bool
+	// The following fields are mutable.
+	shouldUnreg atomic.Bool
+	keys        interval.Range // see setSpanAsKeys
 }
 
 // ID implements interval.Interface.
@@ -388,6 +398,21 @@ func (reg *registry) PublishToOverlapping(
 // https://github.com/cockroachdb/cockroach/issues/110634
 func (reg *registry) DisconnectAllOnShutdown(ctx context.Context, pErr *kvpb.Error) {
 	reg.DisconnectWithErr(ctx, all, pErr)
+}
+
+func (reg *registry) CollectAllStates(ctx context.Context) []rangefeedpb.RegistrationState {
+	return reg.CollectStates(ctx, all)
+}
+
+func (reg *registry) CollectStates(
+	ctx context.Context, span roachpb.Span,
+) []rangefeedpb.RegistrationState {
+	states := make([]rangefeedpb.RegistrationState, 0, reg.tree.Len())
+	reg.forOverlappingRegs(ctx, span, func(r registration) (bool, *kvpb.Error) {
+		states = append(states, r.getState())
+		return false, nil
+	})
+	return states
 }
 
 // DisconnectWithErr disconnects all registrations that overlap the specified

--- a/pkg/kv/kvserver/rangefeed/registry_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helper_test.go
@@ -356,6 +356,9 @@ type testRegistrationConfig struct {
 	withBulkDelivery          int
 	withRegistrationTestTypes registrationType
 	metrics                   *Metrics
+	rangeID                   roachpb.RangeID
+	streamID                  int64
+	consumerID                int64
 }
 
 func newTestRegistration(s *testStream, opts ...registrationOption) testRegistration {
@@ -382,6 +385,9 @@ func newTestRegistration(s *testStream, opts ...registrationOption) testRegistra
 			false, /* blockWhenFull */
 			cfg.metrics,
 			s,
+			cfg.rangeID,
+			cfg.streamID,
+			cfg.consumerID,
 			func(registration) {},
 		)
 	case unbuffered:
@@ -397,6 +403,9 @@ func newTestRegistration(s *testStream, opts ...registrationOption) testRegistra
 			5,
 			cfg.metrics,
 			&testBufferedStream{Stream: s},
+			cfg.rangeID,
+			cfg.streamID,
+			cfg.consumerID,
 			func(registration) {},
 		)
 	default:

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -340,6 +341,8 @@ func (p *ScheduledProcessor) Register(
 	withOmitRemote bool,
 	bulkDeliverySize int,
 	stream Stream,
+	streamID int64,
+	consumerID int64,
 ) (bool, Disconnector, *Filter) {
 	// Synchronize the event channel so that this registration doesn't see any
 	// events that were consumed before this registration was called. Instead,
@@ -353,11 +356,11 @@ func (p *ScheduledProcessor) Register(
 	if isBufferedStream {
 		r = newUnbufferedRegistration(
 			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
-			p.Config.EventChanCap, p.Metrics, bufferedStream, p.unregisterClientAsync)
+			p.Config.EventChanCap, p.Metrics, bufferedStream, p.Config.RangeID, streamID, consumerID, p.unregisterClientAsync)
 	} else {
 		r = newBufferedRegistration(
 			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
-			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, p.unregisterClientAsync)
+			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, p.Config.RangeID, streamID, consumerID, p.unregisterClientAsync)
 	}
 
 	filter := runRequest(p, func(ctx context.Context, p *ScheduledProcessor) *Filter {
@@ -822,6 +825,12 @@ func (p *ScheduledProcessor) publishDeleteRange(
 		Timestamp: timestamp,
 	})
 	p.reg.PublishToOverlapping(ctx, span, &event, logicalOpMetadata{}, alloc)
+}
+
+func (p *ScheduledProcessor) CollectAllRegistrationStates() []rangefeedpb.RegistrationState {
+	return runRequest(p, func(ctx context.Context, p *ScheduledProcessor) []rangefeedpb.RegistrationState {
+		return p.reg.CollectAllStates(ctx)
+	})
 }
 
 func (p *ScheduledProcessor) publishSSTable(

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -189,7 +189,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 		stopper := stop.NewStopper()
 		defer stopper.Stop(ctx)
 		require.NoError(t, sm.Start(ctx, stopper))
-		const sID, rID = int64(0), 1
+		const sID, rID, cid = int64(0), 1, 2
 		disconnectErr := kvpb.NewError(fmt.Errorf("disconnection error"))
 
 		expectErrorHandlingInvariance := func(p Processor) {
@@ -223,7 +223,8 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 				stream := sm.NewStream(sID, rID)
 				registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-					stream)
+					stream, sID, cid,
+				)
 				require.True(t, registered)
 				go p.StopWithErr(disconnectErr)
 				require.Equal(t, int64(0), smMetrics.ActiveMuxRangeFeed.Value())
@@ -237,7 +238,8 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			defer stopper.Stop(ctx)
 			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-				stream)
+				stream, sID, cid,
+			)
 			require.True(t, registered)
 			sm.AddStream(sID, d)
 			require.Equal(t, 1, p.Len())
@@ -252,7 +254,8 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			defer stopper.Stop(ctx)
 			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-				stream)
+				stream, sID, cid,
+			)
 			require.True(t, registered)
 			sm.AddStream(sID, d)
 			require.Equal(t, int64(1), smMetrics.ActiveMuxRangeFeed.Value())

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -85,6 +86,13 @@ type unbufferedRegistration struct {
 		// Used for testing only. Indicates that all events in catchUpBuf have been
 		// sent to BufferedStream.
 		caughtUp bool
+
+		// catchUpRunning indicates that a catch-up scan is running.
+		catchUpRunning bool
+
+		// resolvedTimestamp is the timestamp of the last checkpoint event sent to the
+		// client.
+		resolvedTimestamp hlc.Timestamp
 	}
 }
 
@@ -102,9 +110,12 @@ func newUnbufferedRegistration(
 	bufferSz int,
 	metrics *Metrics,
 	stream BufferedStream,
+	rangeID roachpb.RangeID,
+	streamID int64,
+	consumerID int64,
 	removeRegFromProcessor func(registration),
 ) *unbufferedRegistration {
-	br := &unbufferedRegistration{
+	ubr := &unbufferedRegistration{
 		baseRegistration: baseRegistration{
 			streamCtx:              streamCtx,
 			span:                   span,
@@ -112,21 +123,41 @@ func newUnbufferedRegistration(
 			withDiff:               withDiff,
 			withFiltering:          withFiltering,
 			withOmitRemote:         withOmitRemote,
-			removeRegFromProcessor: removeRegFromProcessor,
 			bulkDelivery:           bulkDeliverySize,
+			rangeID:                rangeID,
+			streamID:               streamID,
+			consumerID:             consumerID,
+			createdTime:            timeutil.Now(),
+			removeRegFromProcessor: removeRegFromProcessor,
 		},
 		metrics: metrics,
 		stream:  stream,
 	}
-	br.mu.catchUpIter = catchUpIter
-	br.mu.caughtUp = true
-	if br.mu.catchUpIter != nil {
+	ubr.mu.catchUpIter = catchUpIter
+	ubr.mu.caughtUp = true
+	if ubr.mu.catchUpIter != nil {
 		// A nil catchUpIter indicates we don't need a catch-up scan. We avoid
 		// initializing catchUpBuf in this case, which will result in publish()
 		// sending all events to the underlying stream immediately.
-		br.mu.catchUpBuf = make(chan *sharedEvent, bufferSz)
+		ubr.mu.catchUpBuf = make(chan *sharedEvent, bufferSz)
 	}
-	return br
+	return ubr
+}
+
+func (ubr *unbufferedRegistration) getState() rangefeedpb.RegistrationState {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	return rangefeedpb.RegistrationState{
+		StreamID:       ubr.streamID,
+		ConsumerID:     ubr.consumerID,
+		RangeID:        ubr.rangeID,
+		Span:           ubr.span,
+		CatchUpTS:      ubr.catchUpTimestamp,
+		Diff:           ubr.withDiff,
+		Created:        ubr.createdTime,
+		ResolvedTS:     ubr.mu.resolvedTimestamp,
+		CatchUpRunning: ubr.mu.catchUpRunning,
+	}
 }
 
 // publish sends a single event to this registration. It is called by the
@@ -144,6 +175,11 @@ func (ubr *unbufferedRegistration) publish(
 	}
 
 	ubr.assertEvent(ctx, event)
+
+	if event.Checkpoint != nil {
+		ubr.mu.resolvedTimestamp = event.Checkpoint.ResolvedTS
+	}
+
 	strippedEvent := ubr.maybeStripEvent(ctx, event)
 
 	// Disconnected or catchUpOverflowed is not set and catchUpBuf
@@ -350,6 +386,12 @@ func (ubr *unbufferedRegistration) detachCatchUpIter() *CatchUpIterator {
 	return catchUpIter
 }
 
+func (ubr *unbufferedRegistration) setCatchupRunning(running bool) {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	ubr.mu.catchUpRunning = running
+}
+
 // maybeRunCatchUpScan runs the catch-up scan if catchUpIter is not nil. It
 // promises to close catchUpIter once detached. It returns an error if catch-up
 // scan fails. Note that catch up scan bypasses BufferedStream and are sent to
@@ -360,9 +402,11 @@ func (ubr *unbufferedRegistration) maybeRunCatchUpScan(ctx context.Context) erro
 		return nil
 	}
 	start := timeutil.Now()
+	ubr.setCatchupRunning(true)
 	defer func() {
 		catchUpIter.Close()
 		ubr.metrics.RangeFeedCatchUpScanNanos.Inc(timeutil.Since(start).Nanoseconds())
+		ubr.setCatchupRunning(false)
 	}()
 
 	return catchUpIter.CatchUpScan(ctx, ubr.stream.SendUnbuffered, ubr.withDiff, ubr.withFiltering,

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -39,6 +39,7 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 	require.NoError(t, sm.Start(ctx, stopper))
 
 	const r1 = 1
+	const c1 = 1
 	t.Run("no events sent before registering streams", func(t *testing.T) {
 		p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: 1}))
 		require.Equal(t, 0, testServerStream.totalEventsSent())
@@ -47,7 +48,8 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 		for id := int64(0); id < 50; id++ {
 			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-				sm.NewStream(id, r1))
+				sm.NewStream(id, r1), id, c1,
+			)
 			require.True(t, registered)
 			sm.AddStream(id, d)
 		}
@@ -116,6 +118,7 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	catchUpIter := newTestIterator(keyValues, roachpb.Key("w"))
 	const r1 = 1
 	const s1 = 1
+	const c1 = 1
 
 	key := roachpb.Key("d")
 	val1 := roachpb.Value{RawBytes: []byte("val1"), Timestamp: hlc.Timestamp{WallTime: 5}}
@@ -140,7 +143,8 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	registered, d, _ := p.Register(ctx, h.span, startTs,
 		makeCatchUpIterator(catchUpIter, span, startTs), /* catchUpIter */
 		true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-		sm.NewStream(s1, r1))
+		sm.NewStream(s1, r1), s1, c1,
+	)
 	sm.AddStream(s1, d)
 	require.True(t, registered)
 	require.Equal(t, int64(1), smMetrics.ActiveMuxRangeFeed.Value())

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/multiqueue"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed/rangefeedpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
@@ -108,6 +109,7 @@ import (
 	"github.com/cockroachdb/redact"
 	"github.com/prometheus/client_golang/prometheus"
 	prometheusgo "github.com/prometheus/client_model/go"
+	"golang.org/x/exp/maps"
 	"golang.org/x/time/rate"
 )
 
@@ -4271,4 +4273,32 @@ func (s *storeForTruncatorImpl) getEngine() storage.Engine {
 
 func init() {
 	tracing.RegisterTagRemapping("s", "store")
+}
+
+// VisitRangefeeds visits all rangefeeds on this store and returns a list of
+// rangefeed states.
+func (s *Store) VisitRangefeeds() (res rangefeedpb.RangefeedInfoPerStore) {
+	res.StoreIdent = *s.Ident
+
+	// We don't use VisitReplicas because we only want replicas with rangefeeds
+	// on them and these are directly available in the rangefeedReplicas map.
+	s.rangefeedReplicas.Lock()
+	rangeIDs := maps.Keys(s.rangefeedReplicas.m)
+	s.rangefeedReplicas.Unlock()
+
+	res.Registrations = make([]rangefeedpb.RegistrationState, 0, len(rangeIDs))
+	for _, id := range rangeIDs {
+		repl := s.GetReplicaIfExists(id)
+		if repl == nil {
+			continue
+		}
+		p := repl.getRangefeedProcessor()
+		if p == nil {
+			continue
+		}
+		states := p.CollectAllRegistrationStates()
+		res.Registrations = append(res.Registrations, states...)
+	}
+
+	return res
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1187,6 +1187,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		storesForRACv2,
 		node.storeCfg.KVFlowStreamTokenProvider,
 		kvserver.MakeStoresForStoreLiveness(stores),
+		kvserver.MakeStoresForRangefeeds(stores),
 	)
 	if err = cfg.CidrLookup.Start(ctx, stopper); err != nil {
 		return nil, err


### PR DESCRIPTION
This patch introduces the /inspectz/rangefeeds endpoint, which exposes the state of all actively running rangefeed registrations on the kv server.

Part of: #146462
Epic: CRDB-50533
Release note: None