### PR TITLE
catalog/rewrite: handle UDF references from computed columns and ON UPDATE

### DIFF
--- a/pkg/backup/testdata/backup-restore/user-defined-functions-in-computed
+++ b/pkg/backup/testdata/backup-restore/user-defined-functions-in-computed
@@ -1,0 +1,469 @@
+# Test computed columns with UDFs.
+new-cluster name=s
+----
+
+exec-sql
+CREATE DATABASE computed_col_db;
+----
+
+exec-sql
+USE computed_col_db;
+----
+
+exec-sql
+CREATE FUNCTION public.add_tax(price DECIMAL) RETURNS DECIMAL IMMUTABLE AS $$
+BEGIN
+  RETURN price * 1.1;
+END;
+$$ LANGUAGE PLpgSQL;
+----
+
+# Test if computed columns with UDFs are supported.
+exec-sql
+CREATE TABLE public.products (
+  id INT PRIMARY KEY,
+  price DECIMAL,
+  price_with_tax DECIMAL GENERATED ALWAYS AS (add_tax(price)) STORED
+);
+----
+
+exec-sql
+INSERT INTO products (id, price) VALUES (1, 100.00);
+----
+
+query-sql
+SELECT * FROM products;
+----
+1 100.00 110.000
+
+exec-sql
+BACKUP DATABASE computed_col_db INTO 'nodelocal://1/computed_col_backup/';
+----
+
+exec-sql
+DROP DATABASE computed_col_db;
+----
+
+# Test restore without skip_missing_udfs - should succeed since function is in backup
+exec-sql
+RESTORE DATABASE computed_col_db FROM LATEST IN 'nodelocal://1/computed_col_backup/' WITH new_db_name='computed_col_new';
+----
+
+exec-sql
+USE computed_col_new;
+----
+
+query-sql
+SELECT * FROM products;
+----
+1 100.00 110.000
+
+# Make sure that the computed column expression still works.
+exec-sql
+INSERT INTO products (id, price) VALUES (2, 200.00);
+----
+
+query-sql
+SELECT * FROM products ORDER BY id;
+----
+1 100.00 110.000
+2 200.00 220.000
+
+exec-sql
+DROP DATABASE computed_col_new;
+----
+
+# Now test with skip_missing_udfs when function is not present.
+exec-sql
+CREATE DATABASE computed_col_test;
+----
+
+exec-sql
+USE computed_col_test;
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://1/computed_col_backup/'
+)
+SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+----
+<nil> <nil> computed_col_db database false
+computed_col_db <nil> public schema false
+computed_col_db public add_tax function false
+computed_col_db public products table false
+
+exec-sql expect-error-regex=(cannot restore table "products" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
+RESTORE TABLE computed_col_db.public.products FROM LATEST IN 'nodelocal://1/computed_col_backup/' WITH into_db='computed_col_test';
+----
+regex matches error
+
+# With skip_missing_udfs, the column should be restored as a regular column, not computed.
+exec-sql
+RESTORE TABLE computed_col_db.public.products FROM LATEST IN 'nodelocal://1/computed_col_backup/' WITH into_db='computed_col_test', skip_missing_udfs;
+----
+
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE products];
+----
+CREATE TABLE public.products (
+	id INT8 NOT NULL,
+	price DECIMAL NULL,
+	price_with_tax DECIMAL NULL,
+	CONSTRAINT products_pkey PRIMARY KEY (id ASC)
+) WITH (schema_locked = true);
+
+exec-sql
+DROP DATABASE computed_col_test;
+----
+
+
+# Test ON UPDATE expression only.
+exec-sql
+CREATE DATABASE on_update_test;
+----
+
+exec-sql
+USE on_update_test;
+----
+
+exec-sql
+CREATE FUNCTION public.get_constant() RETURNS INT IMMUTABLE AS $$
+BEGIN
+  RETURN 42;
+END;
+$$ LANGUAGE PLpgSQL;
+----
+
+exec-sql
+CREATE TABLE public.on_update_table (
+  id INT PRIMARY KEY,
+  data TEXT,
+  counter INT DEFAULT 1 ON UPDATE get_constant()
+);
+----
+
+exec-sql
+INSERT INTO on_update_table (id, data) VALUES (1, 'test');
+----
+
+exec-sql
+BACKUP DATABASE on_update_test INTO 'nodelocal://1/on_update_backup/';
+----
+
+exec-sql
+DROP DATABASE on_update_test;
+----
+
+exec-sql
+CREATE DATABASE on_update_restore_test;
+----
+
+# Test error without skip_missing_udfs for ON UPDATE expression.
+exec-sql expect-error-regex=(cannot restore table "on_update_table" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
+RESTORE TABLE on_update_test.public.on_update_table FROM LATEST IN 'nodelocal://1/on_update_backup/' WITH into_db='on_update_restore_test';
+----
+regex matches error
+
+# Test with skip_missing_udfs - ON UPDATE should be dropped.
+exec-sql
+RESTORE TABLE on_update_test.public.on_update_table FROM LATEST IN 'nodelocal://1/on_update_backup/' WITH into_db='on_update_restore_test', skip_missing_udfs;
+----
+
+exec-sql
+USE on_update_restore_test;
+----
+
+# Verify ON UPDATE expression was removed.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE on_update_table];
+----
+CREATE TABLE public.on_update_table (
+	id INT8 NOT NULL,
+	data STRING NULL,
+	counter INT8 NULL DEFAULT 1:::INT8,
+	CONSTRAINT on_update_table_pkey PRIMARY KEY (id ASC)
+) WITH (schema_locked = true);
+
+exec-sql
+DROP DATABASE on_update_restore_test;
+----
+
+# Test stored computed column only.
+exec-sql
+CREATE DATABASE stored_computed_test;
+----
+
+exec-sql
+USE stored_computed_test;
+----
+
+exec-sql
+CREATE FUNCTION public.format_display(id INT, data TEXT) RETURNS TEXT IMMUTABLE AS $$
+BEGIN
+  RETURN 'ID: ' || id || ', Data: ' || data;
+END;
+$$ LANGUAGE PLpgSQL;
+----
+
+exec-sql
+CREATE TABLE public.virtual_col_table (
+  id INT PRIMARY KEY,
+  data TEXT,
+  display_value TEXT AS (format_display(id, data)) STORED
+);
+----
+
+exec-sql
+INSERT INTO virtual_col_table (id, data) VALUES (1, 'test');
+----
+
+query-sql
+SELECT * FROM virtual_col_table;
+----
+1 test ID: 1, Data: test
+
+exec-sql
+BACKUP DATABASE stored_computed_test INTO 'nodelocal://1/stored_computed_backup/';
+----
+
+exec-sql
+DROP DATABASE stored_computed_test;
+----
+
+exec-sql
+CREATE DATABASE stored_computed_restore_test;
+----
+
+# Test error without skip_missing_udfs for stored computed column.
+exec-sql expect-error-regex=(cannot restore table "virtual_col_table" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
+RESTORE TABLE stored_computed_test.public.virtual_col_table FROM LATEST IN 'nodelocal://1/stored_computed_backup/' WITH into_db='stored_computed_restore_test';
+----
+regex matches error
+
+# Test with skip_missing_udfs - stored computed column should become regular column.
+exec-sql
+RESTORE TABLE stored_computed_test.public.virtual_col_table FROM LATEST IN 'nodelocal://1/stored_computed_backup/' WITH into_db='stored_computed_restore_test', skip_missing_udfs;
+----
+
+exec-sql
+USE stored_computed_restore_test;
+----
+
+# Verify stored computed column was converted to regular column.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE virtual_col_table];
+----
+CREATE TABLE public.virtual_col_table (
+	id INT8 NOT NULL,
+	data STRING NULL,
+	display_value STRING NULL,
+	CONSTRAINT virtual_col_table_pkey PRIMARY KEY (id ASC)
+) WITH (schema_locked = true);
+
+exec-sql
+DROP DATABASE stored_computed_restore_test;
+----
+
+# Test virtual computed column only.
+exec-sql
+CREATE DATABASE virtual_computed_test;
+----
+
+exec-sql
+USE virtual_computed_test;
+----
+
+exec-sql
+CREATE FUNCTION public.format_display(id INT, data TEXT) RETURNS TEXT IMMUTABLE AS $$
+BEGIN
+  RETURN 'ID: ' || id || ', Data: ' || data;
+END;
+$$ LANGUAGE PLpgSQL;
+----
+
+exec-sql
+CREATE TABLE public.virtual_col_table (
+  id INT PRIMARY KEY,
+  data TEXT,
+  display_value TEXT AS (format_display(id, data)) VIRTUAL
+);
+----
+
+exec-sql
+INSERT INTO virtual_col_table (id, data) VALUES (1, 'test');
+----
+
+query-sql
+SELECT * FROM virtual_col_table;
+----
+1 test ID: 1, Data: test
+
+exec-sql
+BACKUP DATABASE virtual_computed_test INTO 'nodelocal://1/virtual_computed_backup/';
+----
+
+exec-sql
+DROP DATABASE virtual_computed_test;
+----
+
+exec-sql
+CREATE DATABASE virtual_computed_restore_test;
+----
+
+# Test error without skip_missing_udfs for virtual computed column.
+exec-sql expect-error-regex=(cannot restore table "virtual_col_table" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
+RESTORE TABLE virtual_computed_test.public.virtual_col_table FROM LATEST IN 'nodelocal://1/virtual_computed_backup/' WITH into_db='virtual_computed_restore_test';
+----
+regex matches error
+
+# Test with skip_missing_udfs - virtual computed column should return an error.
+exec-sql expect-error-regex=(virtual computed column "display_value" cannot be restored when referenced UDF is missing \(even with skip_missing_udfs option\))
+RESTORE TABLE virtual_computed_test.public.virtual_col_table FROM LATEST IN 'nodelocal://1/virtual_computed_backup/' WITH into_db='virtual_computed_restore_test', skip_missing_udfs;
+----
+regex matches error
+
+exec-sql
+DROP DATABASE virtual_computed_restore_test;
+----
+
+# Test restore without skip_missing_udfs - should succeed since function is in backup
+exec-sql
+RESTORE DATABASE virtual_computed_test FROM LATEST IN 'nodelocal://1/virtual_computed_backup/' WITH new_db_name='virtual_computed_new';
+----
+
+exec-sql
+USE virtual_computed_new;
+----
+
+query-sql
+SELECT * FROM virtual_col_table;
+----
+1 test ID: 1, Data: test
+
+# Make sure that the virtual computed column expression still works.
+exec-sql
+INSERT INTO virtual_col_table (id, data) VALUES (2, 'example');
+----
+
+query-sql
+SELECT * FROM virtual_col_table ORDER BY id;
+----
+1 test ID: 1, Data: test
+2 example ID: 2, Data: example
+
+exec-sql
+DROP DATABASE virtual_computed_new;
+----
+
+# Test mixed expressions - DEFAULT, ON UPDATE, and computed column.
+exec-sql
+CREATE DATABASE mixed_expressions_test;
+----
+
+exec-sql
+USE mixed_expressions_test;
+----
+
+exec-sql
+CREATE FUNCTION public.get_default_timestamp() RETURNS TEXT IMMUTABLE AS $$
+BEGIN
+  RETURN '2024-01-01 00:00:00';
+END;
+$$ LANGUAGE PLpgSQL;
+----
+
+exec-sql
+CREATE FUNCTION public.calculate_total(base DECIMAL, tax_rate DECIMAL) RETURNS DECIMAL IMMUTABLE AS $$
+BEGIN
+  RETURN base * (1 + tax_rate);
+END;
+$$ LANGUAGE PLpgSQL;
+----
+
+exec-sql
+CREATE TABLE public.mixed_table (
+  id INT PRIMARY KEY,
+  base_amount DECIMAL,
+  tax_rate DECIMAL DEFAULT 0.1,
+  created_at TEXT DEFAULT get_default_timestamp() ON UPDATE get_default_timestamp(),
+  total_amount DECIMAL AS (calculate_total(base_amount, tax_rate)) STORED
+);
+----
+
+exec-sql
+INSERT INTO mixed_table (id, base_amount) VALUES (1, 100.00);
+----
+
+exec-sql
+BACKUP DATABASE mixed_expressions_test INTO 'nodelocal://1/mixed_expressions_backup/';
+----
+
+exec-sql
+DROP DATABASE mixed_expressions_test;
+----
+
+# Test restore without skip_missing_udfs - should succeed since functions are in backup.
+exec-sql
+RESTORE DATABASE mixed_expressions_test FROM LATEST IN 'nodelocal://1/mixed_expressions_backup/' WITH new_db_name='mixed_expressions_new';
+----
+
+exec-sql
+USE mixed_expressions_new;
+----
+
+query-sql
+SELECT * FROM mixed_table;
+----
+1 100.00 0.1 2024-01-01 00:00:00 110.000
+
+# Make sure that the stored computed column expression still works.
+exec-sql
+INSERT INTO mixed_table (id, base_amount) VALUES (2, 50.00);
+----
+
+query-sql
+SELECT * FROM mixed_table ORDER BY id;
+----
+1 100.00 0.1 2024-01-01 00:00:00 110.000
+2 50.00 0.1 2024-01-01 00:00:00 55.000
+
+exec-sql
+DROP DATABASE mixed_expressions_new;
+----
+
+exec-sql
+CREATE DATABASE mixed_expressions_restore_test;
+----
+
+# Test error without skip_missing_udfs for mixed expressions.
+exec-sql expect-error-regex=(cannot restore table "mixed_table" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
+RESTORE TABLE mixed_expressions_test.public.mixed_table FROM LATEST IN 'nodelocal://1/mixed_expressions_backup/' WITH into_db='mixed_expressions_restore_test';
+----
+regex matches error
+
+# Test with skip_missing_udfs - all UDF expressions should be dropped.
+exec-sql
+RESTORE TABLE mixed_expressions_test.public.mixed_table FROM LATEST IN 'nodelocal://1/mixed_expressions_backup/' WITH into_db='mixed_expressions_restore_test', skip_missing_udfs;
+----
+
+exec-sql
+USE mixed_expressions_restore_test;
+----
+
+# Verify all UDF expressions were removed, but non-UDF DEFAULT remains.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE mixed_table];
+----
+CREATE TABLE public.mixed_table (
+	id INT8 NOT NULL,
+	base_amount DECIMAL NULL,
+	tax_rate DECIMAL NULL DEFAULT 0.1:::DECIMAL,
+	created_at STRING NULL,
+	total_amount DECIMAL NULL,
+	CONSTRAINT mixed_table_pkey PRIMARY KEY (id ASC)
+) WITH (schema_locked = true);
+
+exec-sql
+DROP DATABASE mixed_expressions_restore_test;
+----

--- a/pkg/backup/testdata/backup-restore/user-defined-functions-in-defaults
+++ b/pkg/backup/testdata/backup-restore/user-defined-functions-in-defaults
@@ -19,7 +19,7 @@ CREATE FUNCTION sc1.f1() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 ----
 
 exec-sql
-CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1());
+CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1() ON UPDATE sc1.f1());
 ----
 
 exec-sql
@@ -46,13 +46,13 @@ exec-sql
 USE db1_new
 ----
 
-# Make sure function ids in DEFAULT are rewritten.
+# Make sure function ids in DEFAULT and ON UPDATE are rewritten.
 query-sql
 SELECT create_statement FROM [SHOW CREATE TABLE sc1.t1]
 ----
 CREATE TABLE sc1.t1 (
 	a INT8 NOT NULL,
-	b INT8 NULL DEFAULT sc1.f1(),
+	b INT8 NULL DEFAULT sc1.f1() ON UPDATE sc1.f1(),
 	CONSTRAINT t1_pkey PRIMARY KEY (a ASC)
 ) WITH (schema_locked = true);
 
@@ -62,10 +62,27 @@ INSERT INTO sc1.t1 VALUES (1), (2);
 ----
 
 query-sql
+INSERT INTO sc1.t1 VALUES (3, 3);
+----
+
+query-sql
 SELECT * FROM sc1.t1 ORDER BY a;
 ----
 1 1
 2 1
+3 3
+
+# Make sure that the ON UPDATE expression still works.
+query-sql
+UPDATE sc1.t1 SET a = 10 WHERE a = 3;
+----
+
+query-sql
+SELECT * FROM sc1.t1 ORDER BY a;
+----
+1 1
+2 1
+10 1
 
 # Make sure that depenency IDs are rewritten by checking DROP FUNCTION errors.
 # Note that technically this only tests forward-reference IDs in depended-on
@@ -97,7 +114,7 @@ CREATE FUNCTION sc1.f1() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 ----
 
 exec-sql cluster=s1
-CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1());
+CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1() ON UPDATE sc1.f1());
 ----
 
 exec-sql
@@ -133,13 +150,13 @@ exec-sql
 USE db1
 ----
 
-# Make sure function ids in DEFAULT are rewritten.
+# Make sure function ids in DEFAULT and ON UPDATE are rewritten.
 query-sql
 SELECT create_statement FROM [SHOW CREATE TABLE sc1.t1]
 ----
 CREATE TABLE sc1.t1 (
 	a INT8 NOT NULL,
-	b INT8 NULL DEFAULT sc1.f1(),
+	b INT8 NULL DEFAULT sc1.f1() ON UPDATE sc1.f1(),
 	CONSTRAINT t1_pkey PRIMARY KEY (a ASC)
 ) WITH (schema_locked = true);
 
@@ -149,10 +166,27 @@ INSERT INTO sc1.t1 VALUES (1), (2);
 ----
 
 query-sql
+INSERT INTO sc1.t1 VALUES (3, 3);
+----
+
+query-sql
 SELECT * FROM sc1.t1 ORDER BY a;
 ----
 1 1
 2 1
+3 3
+
+# Make sure that the ON UPDATE expression still works.
+query-sql
+UPDATE sc1.t1 SET a = 10 WHERE a = 3;
+----
+
+query-sql
+SELECT * FROM sc1.t1 ORDER BY a;
+----
+1 1
+2 1
+10 1
 
 # Make sure that depenency IDs are rewritten by checking DROP FUNCTION errors.
 # Note that technically this only tests forward-reference IDs in depended-on
@@ -193,7 +227,7 @@ CREATE FUNCTION sc1.f1() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 ----
 
 exec-sql cluster=s3
-CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1());
+CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1() ON UPDATE sc1.f1());
 ----
 
 exec-sql


### PR DESCRIPTION
When restoring a backup that has computed columns or ON UPDATE expressions that reference UDFs, we need to check if the function descriptor is available or needs to be rewritten. If it's not available, the computed column expression or ON UPDATE expression is discarded. We already had this behavior in place for DEFAULT exprssions, but did not have this for other expressions when we added support for referencing UDFs in de08f528268389d26fc5ac506d11aa10454c2f01 (v25.3.0).

fixes https://github.com/cockroachdb/cockroach/issues/152178
Release note (bug fix): Fixed a bug that prevented RESTORE from working if there were computed columns or ON UPDATE expressions that referenced user-defined functions. This bug was introduced in v25.3.0.