### PR TITLE
logictest: fix flake in a recently added test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los !metamorphic-batch-sizes
 
 statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
@@ -1672,6 +1672,8 @@ subtest end
 # ==============================================================================
 # Show implicit locking behavior.
 # ==============================================================================
+
+# TODO(yuzefovich): EXPLAIN tests should be moved to execbuilder.
 
 subtest rbr_implicit_locking
 


### PR DESCRIPTION
One of the tests added in b845bd8573dd8787becad6df17424df2772c3940 previously could be flaky due to `parallelScanResultThreshold` being metamorphic. Namely, if that value is very small (like 2), then we won't parallelize remote region scans. The flake is now fixed by requiring non-metamorphic batch sizes.

Fixes: #151374.

Release note: None