### PR TITLE
sql: disable DistSQL when txn buffered writes and MVCC decoding is required

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1689,6 +1689,13 @@ func (tc *TxnCoordSender) HasPerformedWrites() bool {
 	return tc.hasPerformedWritesLocked()
 }
 
+// HasBufferedWrites is part of the TxnSender interface.
+func (tc *TxnCoordSender) HasBufferedWrites() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.hasBufferedWritesLocked()
+}
+
 // TestingShouldRetry is part of the TxnSender interface.
 func (tc *TxnCoordSender) TestingShouldRetry() bool {
 	tc.mu.Lock()
@@ -1712,4 +1719,8 @@ func (tc *TxnCoordSender) hasPerformedReadsLocked() bool {
 
 func (tc *TxnCoordSender) hasPerformedWritesLocked() bool {
 	return tc.mu.txn.Sequence != 0
+}
+
+func (tc *TxnCoordSender) hasBufferedWritesLocked() bool {
+	return tc.interceptorAlloc.txnWriteBuffer.hasBufferedWrites()
 }

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -282,6 +282,11 @@ func (m *MockTransactionalSender) HasPerformedWrites() bool {
 	panic("unimplemented")
 }
 
+// HasBufferedWrites is part of TxnSenderFactory.
+func (m *MockTransactionalSender) HasBufferedWrites() bool {
+	return false
+}
+
 // TestingShouldRetry is part of TxnSenderFactory.
 func (m *MockTransactionalSender) TestingShouldRetry() bool {
 	return false

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -134,10 +134,12 @@ type TxnSender interface {
 	SetOmitInRangefeeds()
 
 	// SetBufferedWritesEnabled toggles whether the writes are buffered on the
-	// gateway node until the commit time. Only allowed on the RootTxn. Buffered
-	// writes cannot be enabled on a txn that performed any requests. When
-	// disabling buffered writes, if there are any writes in the buffer, they
-	// are flushed with the next BatchRequest.
+	// gateway node until the commit time. Buffered writes cannot be enabled on
+	// a txn that performed any requests. When disabling buffered writes, if
+	// there are any writes in the buffer, they are flushed with the next
+	// BatchRequest.
+	//
+	// Only allowed on the RootTxn.
 	SetBufferedWritesEnabled(bool)
 
 	// BufferedWritesEnabled returns whether the buffered writes are enabled.
@@ -378,6 +380,10 @@ type TxnSender interface {
 	// HasPerformedWrites returns true if a write has been performed in the
 	// transaction's current epoch.
 	HasPerformedWrites() bool
+
+	// HasBufferedWrites returns true if a write has been buffered for the
+	// transaction's current epoch.
+	HasBufferedWrites() bool
 
 	// TestingShouldRetry returns true if transaction retry errors should be
 	// randomly returned to callers. Note that it is the responsibility of

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -315,10 +315,7 @@ func runPlanInsidePlan(
 		}
 	}
 
-	distributePlan, distSQLProhibitedErr := getPlanDistribution(
-		ctx, plannerCopy.Descriptors().HasUncommittedTypes(),
-		plannerCopy.SessionData(), plan.main, &plannerCopy.distSQLVisitor,
-	)
+	distributePlan, distSQLProhibitedErr := plannerCopy.getPlanDistribution(ctx, plan.main)
 	distributeType := DistributionType(LocalDistribution)
 	if distributePlan.WillDistribute() {
 		distributeType = FullDistribution

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -467,6 +467,15 @@ func (cf *cFetcher) Init(
 	// MVCC decoding.
 	if cf.mvccDecodeStrategy == storage.MVCCDecodingRequired {
 		if cf.txn != nil && cf.txn.BufferedWritesEnabled() {
+			if cf.txn.Type() == kv.LeafTxn {
+				// We're only allowed to disable buffered writes on the RootTxn.
+				// If we have a LeafTxn, we'll return an assertion error instead
+				// of crashing.
+				//
+				// Note that we might have a LeafTxn with no buffered writes, in
+				// which case BufferedWritesEnabled() is false.
+				return errors.AssertionFailedf("got LeafTxn when MVCC decoding is required")
+			}
 			cf.txn.SetBufferedWritesEnabled(false /* enabled */)
 		}
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2847,10 +2847,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			}
 		}
 	}
-	distributePlan, distSQLProhibitedErr := getPlanDistribution(
-		ctx, planner.Descriptors().HasUncommittedTypes(),
-		ex.sessionData(), planner.curPlan.main, &planner.distSQLVisitor,
-	)
+	distributePlan, distSQLProhibitedErr := planner.getPlanDistribution(ctx, planner.curPlan.main)
 	if afterGetPlanDistribution != nil {
 		afterGetPlanDistribution()
 	}

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -94,7 +94,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 	// fetch kvs.
 	var spec fetchpb.IndexFetchSpec
 	if err := rowenc.InitIndexFetchSpec(
-		&spec, params.ExecCfg().Codec, d.desc, d.desc.GetPrimaryIndex(), nil, /* columnIDs */
+		&spec, params.ExecCfg().Codec, d.desc, d.desc.GetPrimaryIndex(), nil, /* fetchColumnIDs */
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1901,10 +1901,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	skipDistSQLDiagramGeneration bool,
 	mustUseLeafTxn bool,
 ) error {
-	subqueryDistribution, distSQLProhibitedErr := getPlanDistribution(
-		ctx, planner.Descriptors().HasUncommittedTypes(),
-		planner.SessionData(), subqueryPlan.plan, &planner.distSQLVisitor,
-	)
+	subqueryDistribution, distSQLProhibitedErr := planner.getPlanDistribution(ctx, subqueryPlan.plan)
 	distribute := DistributionType(LocalDistribution)
 	if subqueryDistribution.WillDistribute() {
 		distribute = FullDistribution
@@ -2512,10 +2509,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	associateNodeWithComponents func(exec.Node, execComponents),
 	addTopLevelQueryStats func(stats *topLevelQueryStats),
 ) error {
-	postqueryDistribution, distSQLProhibitedErr := getPlanDistribution(
-		ctx, planner.Descriptors().HasUncommittedTypes(),
-		planner.SessionData(), postqueryPlan, &planner.distSQLVisitor,
-	)
+	postqueryDistribution, distSQLProhibitedErr := planner.getPlanDistribution(ctx, postqueryPlan)
 	distribute := DistributionType(LocalDistribution)
 	if postqueryDistribution.WillDistribute() {
 		distribute = FullDistribution

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2220,12 +2220,8 @@ func shouldDistributeGivenRecAndMode(
 // remote node to the gateway.
 // TODO(yuzefovich): this will be easy to solve once the DistSQL spec factory is
 // completed but is quite annoying to do at the moment.
-func getPlanDistribution(
-	ctx context.Context,
-	txnHasUncommittedTypes bool,
-	sd *sessiondata.SessionData,
-	plan planMaybePhysical,
-	distSQLVisitor *distSQLExprCheckVisitor,
+func (p *planner) getPlanDistribution(
+	ctx context.Context, plan planMaybePhysical,
 ) (_ physicalplan.PlanDistribution, distSQLProhibitedErr error) {
 	if plan.isPhysicalPlan() {
 		// TODO(#47473): store the distSQLProhibitedErr for DistSQL spec factory
@@ -2236,10 +2232,11 @@ func getPlanDistribution(
 	// If this transaction has modified or created any types, it is not safe to
 	// distribute due to limitations around leasing descriptors modified in the
 	// current transaction.
-	if txnHasUncommittedTypes {
+	if p.Descriptors().HasUncommittedDescriptors() {
 		return physicalplan.LocalPlan, nil
 	}
 
+	sd := p.SessionData()
 	if sd.DistSQLMode == sessiondatapb.DistSQLOff {
 		return physicalplan.LocalPlan, nil
 	}
@@ -2249,7 +2246,7 @@ func getPlanDistribution(
 		return physicalplan.LocalPlan, nil
 	}
 
-	rec, err := checkSupportForPlanNode(ctx, plan.planNode, distSQLVisitor, sd)
+	rec, err := checkSupportForPlanNode(ctx, plan.planNode, &p.distSQLVisitor, sd)
 	if err != nil {
 		// Don't use distSQL for this request.
 		log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -58,10 +58,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// Note that we delay adding the annotation about the distribution until
 		// after the plan is finalized (when the physical plan is successfully
 		// created).
-		distribution, _ := getPlanDistribution(
-			params.ctx, params.p.Descriptors().HasUncommittedTypes(),
-			params.extendedEvalCtx.SessionData(), plan.main, &params.p.distSQLVisitor,
-		)
+		distribution, _ := params.p.getPlanDistribution(params.ctx, plan.main)
 
 		outerSubqueries := params.p.curPlan.subqueryPlans
 		distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -36,10 +36,7 @@ type explainVecNode struct {
 func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	distribution, _ := getPlanDistribution(
-		params.ctx, params.p.Descriptors().HasUncommittedTypes(),
-		params.extendedEvalCtx.SessionData(), n.plan.main, &params.p.distSQLVisitor,
-	)
+	distribution, _ := params.p.getPlanDistribution(params.ctx, n.plan.main)
 	outerSubqueries := params.p.curPlan.subqueryPlans
 	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, n.plan.subqueryPlans, distribution)
 	defer func() {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_buffered_writes
@@ -1,0 +1,111 @@
+# LogicTest: 5node
+
+statement ok
+SET kv_transaction_buffered_writes_enabled=true
+
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '2KiB';
+
+subtest regression_151325
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+INSERT INTO kv VALUES (1, 1), (2, 2);
+
+statement ok
+ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1, 2) AS g(i)
+
+retry
+statement ok
+ALTER TABLE kv EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[i+1], i FROM generate_series(0, 2) AS g(i)
+
+# First txn performs a write that is buffered and then a stmt for which we
+# should disable DistSQL.
+
+statement ok
+BEGIN;
+
+# No writes have been buffered yet, so we shouldn't disable DistSQL.
+query T
+SELECT info FROM [EXPLAIN SELECT crdb_internal_mvcc_timestamp FROM kv] WHERE info LIKE 'distribution%'
+----
+distribution: full
+
+statement ok
+INSERT INTO kv VALUES (3, 3);
+
+query T
+SELECT info FROM [EXPLAIN SELECT crdb_internal_mvcc_timestamp FROM kv] WHERE info LIKE 'distribution%'
+----
+distribution: local
+
+# The tableoid system column doesn't require MVCC decoding, so it doesn't
+# disable DistSQL.
+query T
+SELECT info FROM [EXPLAIN SELECT tableoid FROM kv] WHERE info LIKE 'distribution%'
+----
+distribution: full
+
+# Executing this query will flush the buffer and disable buffered writes for the
+# txn.
+statement count 3
+SELECT crdb_internal_mvcc_timestamp FROM kv;
+
+statement ok
+COMMIT;
+
+# Another txn where the system column is fetched via the lookup join.
+statement ok
+BEGIN;
+
+# No writes have been buffered yet, so we shouldn't disable DistSQL.
+query T
+SELECT info FROM [EXPLAIN SELECT kv2.crdb_internal_mvcc_timestamp FROM kv AS kv1 INNER LOOKUP JOIN kv AS kv2 ON kv1.v = kv2.k] WHERE info LIKE 'distribution%'
+----
+distribution: full
+
+statement ok
+INSERT INTO kv VALUES (4, 4);
+
+query T
+SELECT info FROM [EXPLAIN SELECT kv2.crdb_internal_mvcc_timestamp FROM kv AS kv1 INNER LOOKUP JOIN kv AS kv2 ON kv1.v = kv2.k] WHERE info LIKE 'distribution%'
+----
+distribution: local
+
+# Executing this query will flush the buffer and disable buffered writes for the
+# txn.
+statement count 4
+SELECT kv2.crdb_internal_mvcc_timestamp FROM kv AS kv1 INNER LOOKUP JOIN kv AS kv2 ON kv1.v = kv2.k;
+
+statement ok
+COMMIT;
+
+# Try another txn where the subquery in the first stmt buffers a write and
+# DistSQL is disabled for the main query, but then the next stmt should
+# encounter an error.
+
+statement ok
+BEGIN;
+
+statement count 4
+SELECT
+  crdb_internal_mvcc_timestamp
+FROM
+  [
+    INSERT INTO kv VALUES (5, 5) RETURNING NULL
+  ],
+  kv;
+
+statement error duplicate key value violates unique constraint \"kv_pkey\"
+INSERT INTO kv VALUES (5, 5);
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT count(*) FROM kv;
+----
+4
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/do
+++ b/pkg/sql/logictest/testdata/logic_test/do
@@ -306,3 +306,23 @@ END;
 $$;
 
 subtest end
+
+statement ok
+CREATE TABLE seed (_int8 INT8, _float8 FLOAT8);
+
+statement ok
+INSERT INTO seed DEFAULT VALUES;
+
+statement ok
+CREATE INDEX on seed (_int8, _float8);
+
+# Use the DO block to trigger runPlanInsidePlan code path, where we must disable
+# usage of the Streamer for the SELECT query that uses
+# 'crdb_internal_mvcc_timestamp' column after we've buffered some writes.
+statement ok
+DO $$
+BEGIN
+  UPDATE seed SET _int8 = 1;
+  SELECT _float8, _int8, crdb_internal_mvcc_timestamp FROM seed@seed__int8__float8_idx;
+END;
+$$;

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 21,
+    shard_count = 22,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -94,6 +94,13 @@ func TestLogic_distsql_agg(
 	runLogicTest(t, "distsql_agg")
 }
 
+func TestLogic_distsql_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_buffered_writes")
+}
+
 func TestLogic_distsql_builtin(
 	t *testing.T,
 ) {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -528,11 +528,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 					}
 				}
 			}
-			planDistribution, _ := getPlanDistribution(
-				ctx, localPlanner.Descriptors().HasUncommittedTypes(),
-				localPlanner.extendedEvalCtx.SessionData(),
-				localPlanner.curPlan.main, &localPlanner.distSQLVisitor,
-			)
+			planDistribution, _ := localPlanner.getPlanDistribution(ctx, localPlanner.curPlan.main)
 			isLocal := !planDistribution.WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
 				Table: *table.TableDesc(),


### PR DESCRIPTION
**sql: make `getPlanDistribution` a method on `planner`**

This will simplify the following commit a bit.

**sql: disable DistSQL when txn buffered writes and MVCC decoding is required**

Previously, if we buffered some writes on the RootTxn and then issued
a query that touches system columns that require MVCC decoding (like
`crdb_internal_mvcc_timestamp`) that is executed via DistSQL, it would
crash the process. The reason is that MVCC decoding is currently not
supported by the txnWriteBuffer, so we disable buffered writes, which is
only allowed on the RootTxn but we'd have the LeafTxn due to the plan
being distributed.

This commit fixes this issue by disabling DistSQL if
- the txn has buffered some writes, and
- one of the system columns that requires MVCC decoding is requested.

Executing the query will proceed with the "local" execution model which
will flush the buffer since we'll still disable buffered writes because
of MVCC decoding.

There are a couple of other complications to keep in mind:
- we're deciding on the plan distribution for the main query _before_ we
execute any of the subqueries. Thus, to be safe in that case, if the
query as a whole has a mutation AND it has at least one subquery, we'll
"assume the worst" and will treat the subquery as if it's guaranteed to
buffer some writes.
- usage of LeafTxn can also be forced due to parallel processors. One
such case is "parallelize scans if local", and now we'll prohibit
parallelization if one of the system columns is requested. Another case
is when we use the streamer - we now also prohibit its usage if one of
the system columns is requested.

I decided to omit the release note given it's an edge case in disabled
by default feature.

Fixes: #151325