### PR TITLE
logictest: deflake test by removing IDs from assertion

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -184,13 +184,14 @@ CREATE USER user5 NOLOGIN
 
 user root
 
-query TTTO rowsort
-SELECT * FROM system.role_options
+query TTT rowsort,colnames
+SELECT username, option, value FROM system.role_options
 ----
-testuser  CREATEROLE  NULL  100
-user4     CREATEROLE  NULL  108
-user4     NOLOGIN     NULL  108
-user5     NOLOGIN     NULL  109
+username  option      value
+testuser  CREATEROLE  NULL
+user4     CREATEROLE  NULL
+user4     NOLOGIN     NULL
+user5     NOLOGIN     NULL
 
 user testuser
 


### PR DESCRIPTION
These IDs are not determinstic since they can change if an internal retry happens.

fixes #152192
Release note: None