### PR TITLE
kvserver: rm unnecessary Replica.mu locking

### DIFF
--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -353,7 +353,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// commits by handleMergeResult() to finish the removal.
 		rhsRepl.readOnlyCmdMu.Lock()
 		rhsRepl.mu.Lock()
-		rhsRepl.mu.destroyStatus.Set(
+		rhsRepl.shMu.destroyStatus.Set(
 			kvpb.NewRangeNotFoundError(rhsRepl.RangeID, rhsRepl.store.StoreID()),
 			destroyReasonRemoved)
 		rhsRepl.mu.Unlock()
@@ -443,7 +443,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// application.
 		b.r.readOnlyCmdMu.Lock()
 		b.r.mu.Lock()
-		b.r.mu.destroyStatus.Set(
+		b.r.shMu.destroyStatus.Set(
 			kvpb.NewRangeNotFoundError(b.r.RangeID, b.r.store.StoreID()),
 			destroyReasonRemoved)
 		span := b.r.descRLocked().RSpan()

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -149,6 +149,8 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 		// should there be a command in the raft log (i.e. some errant lease request
 		// or whatnot) this will fire assertions because it will conflict with the
 		// log index that we pulled out of thin air above.
+		r.readOnlyCmdMu.Lock()
+		defer r.readOnlyCmdMu.Unlock()
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		r.mu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
@@ -231,14 +233,16 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 		_, err = sm.ApplySideEffects(checkedCmd.Ctx(), checkedCmd)
 		require.NoError(t, err)
 		func() {
-			r.mu.Lock()
-			defer r.mu.Unlock()
 			// Set a destroyStatus to make sure there won't be any raft processing once
 			// we release raftMu. We applied a command but not one from the raft log, so
 			// should there be a command in the raft log (i.e. some errant lease request
 			// or whatnot) this will fire assertions because it will conflict with the
 			// log index that we pulled out of thin air above.
+			r.readOnlyCmdMu.Lock()
+			r.mu.Lock()
+			defer r.mu.Unlock()
 			r.mu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
+			r.readOnlyCmdMu.Unlock()
 
 			require.Equal(t, raftAppliedIndex+1, r.shMu.state.RaftAppliedIndex)
 			require.Equal(t, truncatedIndex+1, ls.shMu.trunc.Index)
@@ -427,7 +431,13 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 	defer r.raftMu.Unlock()
 	// Avoid additional raft processing after we're done with this replica because
 	// we've applied entries that aren't in the log.
-	defer r.mu.destroyStatus.Set(errors.New("boom"), destroyReasonRemoved)
+	defer func() {
+		r.readOnlyCmdMu.Lock()
+		defer r.readOnlyCmdMu.Unlock()
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.mu.destroyStatus.Set(errors.New("boom"), destroyReasonRemoved)
+	}()
 
 	sm := r.getStateMachine()
 

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -153,7 +153,7 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 		defer r.readOnlyCmdMu.Unlock()
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		r.mu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
+		r.shMu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
 	})
 }
 
@@ -241,7 +241,7 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 			r.readOnlyCmdMu.Lock()
 			r.mu.Lock()
 			defer r.mu.Unlock()
-			r.mu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
+			r.shMu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
 			r.readOnlyCmdMu.Unlock()
 
 			require.Equal(t, raftAppliedIndex+1, r.shMu.state.RaftAppliedIndex)
@@ -436,7 +436,7 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 		defer r.readOnlyCmdMu.Unlock()
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		r.mu.destroyStatus.Set(errors.New("boom"), destroyReasonRemoved)
+		r.shMu.destroyStatus.Set(errors.New("boom"), destroyReasonRemoved)
 	}()
 
 	sm := r.getStateMachine()

--- a/pkg/kv/kvserver/replica_command_test.go
+++ b/pkg/kv/kvserver/replica_command_test.go
@@ -677,9 +677,13 @@ func TestWaitForLeaseAppliedIndex(t *testing.T) {
 	stopper.Stop(ctx)
 
 	destroyErr := errors.New("destroyed")
-	tc.repl.mu.Lock()
-	tc.repl.mu.destroyStatus.Set(destroyErr, destroyReasonRemoved)
-	tc.repl.mu.Unlock()
+	func() {
+		tc.repl.readOnlyCmdMu.Lock()
+		defer tc.repl.readOnlyCmdMu.Unlock()
+		tc.repl.mu.Lock()
+		defer tc.repl.mu.Unlock()
+		tc.repl.mu.destroyStatus.Set(destroyErr, destroyReasonRemoved)
+	}()
 
 	_, err = tc.repl.WaitForLeaseAppliedIndex(ctx, maxLAI)
 	require.Error(t, err)

--- a/pkg/kv/kvserver/replica_command_test.go
+++ b/pkg/kv/kvserver/replica_command_test.go
@@ -682,7 +682,7 @@ func TestWaitForLeaseAppliedIndex(t *testing.T) {
 		defer tc.repl.readOnlyCmdMu.Unlock()
 		tc.repl.mu.Lock()
 		defer tc.repl.mu.Unlock()
-		tc.repl.mu.destroyStatus.Set(destroyErr, destroyReasonRemoved)
+		tc.repl.shMu.destroyStatus.Set(destroyErr, destroyReasonRemoved)
 	}()
 
 	_, err = tc.repl.WaitForLeaseAppliedIndex(ctx, maxLAI)

--- a/pkg/kv/kvserver/replica_corruption.go
+++ b/pkg/kv/kvserver/replica_corruption.go
@@ -43,7 +43,7 @@ func (r *Replica) setCorruptRaftMuLocked(
 
 	log.Dev.ErrorfDepth(ctx, 1, "stalling replica due to: %s", cErr.ErrorMsg)
 	cErr.Processed = true
-	r.mu.destroyStatus.Set(cErr, destroyReasonRemoved)
+	r.shMu.destroyStatus.Set(cErr, destroyReasonRemoved)
 
 	auxDir := r.store.TODOEngine().GetAuxiliaryDir()
 	_ = r.store.TODOEngine().Env().MkdirAll(auxDir, os.ModePerm)

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -167,7 +167,7 @@ func (r *Replica) disconnectReplicationRaftMuLocked(ctx context.Context) {
 		p.finishApplication(ctx, makeProposalResultErr(kvpb.NewAmbiguousResultError(apply.ErrRemoved)))
 	}
 
-	if !r.mu.destroyStatus.Removed() {
+	if !r.shMu.destroyStatus.Removed() {
 		log.Dev.Fatalf(ctx, "removing raft group before destroying replica %s", r)
 	}
 	r.mu.internalRaftGroup = nil

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1116,7 +1116,7 @@ func (rp *replicaProposer) getReplicaID() roachpb.ReplicaID {
 }
 
 func (rp *replicaProposer) destroyed() destroyStatus {
-	return rp.mu.destroyStatus
+	return rp.shMu.destroyStatus
 }
 
 func (rp *replicaProposer) leaseAppliedIndex() kvpb.LeaseAppliedIndex {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1648,7 +1648,7 @@ func (r *Replica) refreshProposalsLocked(
 	}
 
 	r.mu.slowProposalCount = slowProposalCount
-	destroyed := r.mu.destroyStatus.Removed()
+	destroyed := r.shMu.destroyStatus.Removed()
 
 	// If the breaker isn't tripped yet but we've detected commands that have
 	// taken too long to replicate, and the replica is not destroyed, trip the
@@ -2222,7 +2222,7 @@ func (s pendingCmdSlice) Less(i, j int) bool {
 func (r *Replica) withRaftGroupLocked(
 	f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
 ) error {
-	if r.mu.destroyStatus.Removed() {
+	if r.shMu.destroyStatus.Removed() {
 		// Callers know to detect errRemoved as non-fatal.
 		return errRemoved
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -577,7 +577,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 		// erroneously return empty data.
 		sr.readOnlyCmdMu.Lock()
 		sr.mu.Lock()
-		sr.mu.destroyStatus.Set(
+		sr.shMu.destroyStatus.Set(
 			kvpb.NewRangeNotFoundError(sr.RangeID, sr.store.StoreID()),
 			destroyReasonRemoved)
 		sr.mu.Unlock()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13786,7 +13786,7 @@ func TestAdminScatterDestroyedReplica(t *testing.T) {
 		defer tc.repl.readOnlyCmdMu.Unlock()
 		tc.repl.mu.Lock()
 		defer tc.repl.mu.Unlock()
-		tc.repl.mu.destroyStatus.Set(errBoom, destroyReasonMergePending)
+		tc.repl.shMu.destroyStatus.Set(errBoom, destroyReasonMergePending)
 	}()
 
 	desc := tc.repl.Desc()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13781,9 +13781,13 @@ func TestAdminScatterDestroyedReplica(t *testing.T) {
 	tc.Start(ctx, t, stopper)
 
 	errBoom := errors.New("boom")
-	tc.repl.mu.Lock()
-	tc.repl.mu.destroyStatus.Set(errBoom, destroyReasonMergePending)
-	tc.repl.mu.Unlock()
+	func() {
+		tc.repl.readOnlyCmdMu.Lock()
+		defer tc.repl.readOnlyCmdMu.Unlock()
+		tc.repl.mu.Lock()
+		defer tc.repl.mu.Unlock()
+		tc.repl.mu.destroyStatus.Set(errBoom, destroyReasonMergePending)
+	}()
 
 	desc := tc.repl.Desc()
 	resp, err := tc.repl.adminScatter(ctx, kvpb.AdminScatterRequest{

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -567,7 +567,7 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 		// can still happen with this code.
 		rs.visited++
 		repl.mu.RLock()
-		destroyed := repl.mu.destroyStatus
+		destroyed := repl.shMu.destroyStatus
 		initialized := repl.IsInitialized()
 		repl.mu.RUnlock()
 		if initialized && destroyed.IsAlive() && !visitor(repl) {
@@ -4250,7 +4250,7 @@ func (s *storeForTruncatorImpl) acquireReplicaForTruncator(
 	if isAlive := func() bool {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		return r.mu.destroyStatus.IsAlive()
+		return r.shMu.destroyStatus.IsAlive()
 	}(); !isAlive {
 		r.raftMu.Unlock()
 		return nil

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -95,7 +95,7 @@ func (s *Store) tryGetReplica(
 	repl.mu.RLock()
 
 	// The current replica is removed, go back around.
-	if repl.mu.destroyStatus.Removed() {
+	if repl.shMu.destroyStatus.Removed() {
 		repl.mu.RUnlock()
 		repl.raftMu.Unlock()
 		return nil, errRetry

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -90,20 +90,16 @@ func (s *Store) tryGetReplica(
 	if !found {
 		return nil, nil
 	}
-
 	repl.raftMu.Lock() // not unlocked on success
-	repl.mu.RLock()
 
 	// The current replica is removed, go back around.
 	if repl.shMu.destroyStatus.Removed() {
-		repl.mu.RUnlock()
 		repl.raftMu.Unlock()
 		return nil, errRetry
 	}
 
 	// Drop messages from replicas we know to be too old.
-	if fromReplicaIsTooOldRLocked(repl, creatingReplica) {
-		repl.mu.RUnlock()
+	if fromReplicaIsTooOldRaftMuLocked(repl, creatingReplica) {
 		repl.raftMu.Unlock()
 		return nil, kvpb.NewReplicaTooOldError(creatingReplica.ReplicaID)
 	}
@@ -115,7 +111,6 @@ func (s *Store) tryGetReplica(
 				id.ReplicaID, repl)
 		}
 
-		repl.mu.RUnlock()
 		if err := s.removeReplicaRaftMuLocked(
 			ctx, repl, id.ReplicaID, "superseded by newer Replica",
 		); err != nil {
@@ -124,7 +119,6 @@ func (s *Store) tryGetReplica(
 		repl.raftMu.Unlock()
 		return nil, errRetry
 	}
-	defer repl.mu.RUnlock()
 
 	if repl.replicaID > id.ReplicaID {
 		// The sender is behind and is sending to an old replica.
@@ -224,11 +218,15 @@ func (s *Store) tryGetOrCreateReplica(
 	return repl, true, nil
 }
 
-// fromReplicaIsTooOldRLocked returns true if the creatingReplica is deemed to
-// be a member of the range which has been removed.
-// Assumes toReplica.mu is locked for (at least) reading.
-func fromReplicaIsTooOldRLocked(toReplica *Replica, fromReplica *roachpb.ReplicaDescriptor) bool {
-	toReplica.mu.AssertRHeld()
+// fromReplicaIsTooOldRaftMuLocked returns true if the creatingReplica is deemed
+// to be a member of the range which has been removed.
+//
+// Assumes toReplica.raftMu is locked. This could be relaxed to Replica.mu
+// locked for reads, but the only user of it holds raftMu.
+func fromReplicaIsTooOldRaftMuLocked(
+	toReplica *Replica, fromReplica *roachpb.ReplicaDescriptor,
+) bool {
+	toReplica.raftMu.AssertHeld()
 	if fromReplica == nil {
 		return false
 	}

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -620,7 +620,7 @@ func (s *Store) HandleRaftResponse(
 				// that case, we don't want to add it to the replicaGCQueue.
 				// If the replica is not alive then we also should ignore this error.
 				if tErr.ReplicaID != repl.replicaID ||
-					!repl.mu.destroyStatus.IsAlive() ||
+					!repl.shMu.destroyStatus.IsAlive() ||
 					// Ignore if we want to test the replicaGC queue.
 					s.TestingKnobs().DisableEagerReplicaRemoval {
 					repl.mu.Unlock()

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -91,13 +91,13 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 
 		if opts.DestroyData {
 			// Detect if we were already removed.
-			if rep.mu.destroyStatus.Removed() {
+			if rep.shMu.destroyStatus.Removed() {
 				return nil, nil // already removed, noop
 			}
 		} else {
 			// If the caller doesn't want to destroy the data because it already
 			// has done so, then it must have already also set the destroyStatus.
-			if !rep.mu.destroyStatus.Removed() {
+			if !rep.shMu.destroyStatus.Removed() {
 				return nil, errors.AssertionFailedf("replica not marked as destroyed but data already destroyed: %v", rep)
 			}
 		}
@@ -129,7 +129,7 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 		}
 
 		// Sanity checks passed. Mark the replica as removed before deleting data.
-		rep.mu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
+		rep.shMu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
 			destroyReasonRemoved)
 		return desc, nil
 	}()
@@ -242,7 +242,7 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 		// Detect if we were already removed, this is a fatal error
 		// because we should have already checked this under the raftMu
 		// before calling this method.
-		if rep.mu.destroyStatus.Removed() {
+		if rep.shMu.destroyStatus.Removed() {
 			rep.mu.Unlock()
 			rep.readOnlyCmdMu.Unlock()
 			log.Dev.Fatalf(ctx, "uninitialized replica unexpectedly already removed")
@@ -255,7 +255,7 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 		}
 
 		// Mark the replica as removed before deleting data.
-		rep.mu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
+		rep.shMu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
 			destroyReasonRemoved)
 
 		rep.mu.Unlock()

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -349,7 +349,7 @@ func (s *Store) canAcceptSnapshotLocked(
 	existingRepl.mu.RLock()
 	existingDesc := existingRepl.shMu.state.Desc
 	existingIsInitialized := existingDesc.IsInitialized()
-	existingDestroyStatus := existingRepl.mu.destroyStatus
+	existingDestroyStatus := existingRepl.shMu.destroyStatus
 	existingRepl.mu.RUnlock()
 
 	if existingIsInitialized {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -776,7 +776,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	require.Equal(t, errRemoved, err)
 
 	repl1.mu.RLock()
-	expErr := repl1.mu.destroyStatus.err
+	expErr := repl1.shMu.destroyStatus.err
 	repl1.mu.RUnlock()
 
 	if expErr == nil {


### PR DESCRIPTION
This PR removes the unnecessary `Replica.mu.RLock()` in `Store.tryGetReplica()`. This function is on the critical path - every raft message [processing](https://github.com/cockroachdb/cockroach/blob/d1af030c8b9894306710132a253bd7c2c9145623/pkg/kv/kvserver/store_raft.go#L699) calls it. So this should have a non-zero performance impact.

Presumably, `Replica.mu` used to be locked for reading `destroyStatus`, but the latter can be read with only `raftMu` held. To emphasize that this field can be read under either mutex, this PR also moves `destroyStatus` from the `Replica.mu` to `Replica.shMu` section.

Technically, `destroyStatus` doesn't fit either of `Replica.{mu,shMu}` sections, because it must be mutated with also `readOnlyCmdMu` locked. But `shMu` is strictly closer by semantics.

Epic: none
Release note: none