### PR TITLE
changefeedccl: allow changefeed err in rand expr test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1620,7 +1620,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 
 	}
 
-	cdcTest(t, testFn, feedTestForceSink(`kafka`))
+	cdcTest(t, testFn, feedTestForceSink(`kafka`), withAllowChangefeedErr("changefeed may have parsing failure on some queries"))
 }
 
 // getWhereClause extracts the predicate from a randomly generated SQL statement.


### PR DESCRIPTION
Previously, TestChangefeedRandomExpressions could fail even if a changefeed error was in the allowlist because the feed factory was created such that no changefeed errors were allowed. This change allows changefeed errors.

Fixes: #152036
Epic: none

Release note: none