### PR TITLE
cloud: add optional http request logging

### DIFF
--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cloud",
     srcs = [
         "cloud_io.go",
+        "cloud_logging_transport.go",
         "external_storage.go",
         "impl_registry.go",
         "kms.go",
@@ -31,7 +32,9 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/sysutil",
         "//pkg/util/tracing",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//require",
     ],
@@ -41,6 +44,7 @@ go_test(
     name = "cloud_test",
     srcs = [
         "cloud_io_test.go",
+        "cloud_logging_transport_test.go",
         "options_test.go",
         "uris_test.go",
     ],
@@ -48,7 +52,9 @@ go_test(
     deps = [
         "//pkg/cloud/cloudpb",
         "//pkg/util/ioctx",
+        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -100,7 +100,7 @@ func MakeHTTPClient(
 	if err != nil {
 		return nil, err
 	}
-	return MakeHTTPClientForTransport(t)
+	return MakeHTTPClientForTransport(maybeAddLogging(t))
 }
 
 // MakeHTTPClientForTransport creates a new http.Client with the given

--- a/pkg/cloud/cloud_logging_transport.go
+++ b/pkg/cloud/cloud_logging_transport.go
@@ -1,0 +1,167 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/redact"
+)
+
+// maybeAddLogging wraps the provided http.RoundTripper with a logging
+// transport if verbose logging is enabled.
+func maybeAddLogging(inner http.RoundTripper) http.RoundTripper {
+	if log.V(1) {
+		return &loggingTransport{inner: inner}
+	}
+	return inner
+}
+
+type loggingTransport struct {
+	inner http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper.
+func (l *loggingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+
+	// NOTE: Body can be nil if the request has no body.
+	requestWatcher := &requestBodyTracker{inner: request.Body}
+	if request.Body != nil {
+		// Make a shallow clone of the request because the request object itself is
+		// supposed to be immutable.
+		request = request.Clone(request.Context())
+		request.Body = requestWatcher
+	}
+
+	now := crtime.NowMono()
+	resp, err := l.inner.RoundTrip(request)
+	if err != nil {
+		log.Dev.Warningf(request.Context(), "%s %s: %v", redact.SafeString(request.Method), request.URL.String(), err)
+		return resp, err
+	}
+
+	logCtx, span := tracing.ForkSpan(request.Context(), "cloud-logging-transport")
+
+	resp.Body = &responseBodyTracker{
+		inner: resp.Body,
+		ctx:   logCtx,
+		span:  span,
+
+		status:         redact.SafeString(resp.Status),
+		method:         redact.SafeString(request.Method),
+		url:            request.URL.String(),
+		requestLatency: now.Elapsed(),
+		requestBytes:   requestWatcher.readBytes.Load(),
+		responseBytes:  resp.ContentLength,
+	}
+	return resp, nil
+}
+
+var _ http.RoundTripper = &loggingTransport{}
+
+// requestBodyTracker is a wrapper around io.ReadCloser that tracks the number of
+// bytes read from the request body.
+type requestBodyTracker struct {
+	inner io.ReadCloser
+	// readBytes is the number of bytes returned by the underlying Read calls.
+	// NOTE(jeffswenson): in practice, I don't think this actually needs to be an
+	// atomic value. By the time we observe the value, the request body should be
+	// fully consumed. But syscalls in golang are not defined to be memory
+	// barriers. So from the perspective of the go race detector there is no
+	// synchronization between the goroutine reading the request body and the
+	// goroutine sending the request.
+	readBytes atomic.Int64
+}
+
+func (s *requestBodyTracker) Read(p []byte) (int, error) {
+	n, err := s.inner.Read(p)
+	s.readBytes.Add(int64(n))
+	return n, err
+}
+
+func (s *requestBodyTracker) Close() error {
+	return s.inner.Close()
+}
+
+// responseBodyTracker is an io.ReadCloser that wraps the original response
+// body. It counts the number of bytes read from the response body and logs
+// stats about the request when the body is closed.
+type responseBodyTracker struct {
+	inner io.ReadCloser
+	ctx   context.Context
+	span  *tracing.Span
+
+	// status is the HTTP status code of the response. (e.g. "200 OK", "404 Not Found").
+	status redact.SafeString
+	// method is the HTTP method of the request (e.g., GET, POST).
+	method redact.SafeString
+	// url is the URL of the request.
+	url string
+	// requestLatency is the amount of time spent waiting for the response header.
+	requestLatency time.Duration
+	// requestBytes is the number of bytes sent in the request body.
+	requestBytes int64
+	// number of bytes in the response body. We often do not read the entire
+	// body.
+	responseBytes int64
+
+	// readErr is the error returned by the last Read() call on the response body. This is
+	// expected to be io.EOF when the body is fully read, but may also be `nil` if we are closing
+	// an incomplete response body or some network error that occurred after receiving the response
+	// header but before reading the whole body.
+	readErr error
+	// readBytes is the number of bytes read from the response body. This is tracked
+	// because we often close a request before reading the entire body.
+	readBytes int64
+	// readTime is the amount of time spent waiting in Read() calls.
+	readTime time.Duration
+
+	// closeOnce ensures Close() logic is only called once. Some callers of
+	// Close() are sloppy and call it multiple times. The double log lines are
+	// annoying, but the real issue is the *tracing.Span. The tracing
+	// infrastructure reuses memory internally, so it is essential that
+	// span.Finish is called exactly once.
+	closeOnce sync.Once
+}
+
+func (l *responseBodyTracker) Read(p []byte) (int, error) {
+	start := crtime.NowMono()
+
+	n, err := l.inner.Read(p)
+
+	l.readBytes += int64(n)
+	l.readTime += start.Elapsed()
+	l.readErr = err
+	return n, err
+}
+
+func (l *responseBodyTracker) Close() error {
+	l.closeOnce.Do(func() {
+		if l.readErr == io.EOF || (l.readErr == nil && l.readBytes == l.responseBytes) {
+			log.Dev.Infof(l.ctx, "%s %s (%s) sent=%d,recv=%d,request_latency=%s,read_latency=%s",
+				l.method, l.url, l.status,
+				l.requestBytes, l.readBytes, l.requestLatency, l.readTime)
+		} else if l.readErr != nil {
+			log.Dev.Warningf(l.ctx, "%s %s (%s) sent=%d,recv=(%d/%d),request_latency=%s,read_latency=%s: %v",
+				l.method, l.url, l.status,
+				l.requestBytes, l.readBytes, l.responseBytes, l.requestLatency, l.readTime, l.readErr)
+		} else {
+			log.Dev.Infof(l.ctx, "%s %s (%s) sent=%d,recv=(%d/%d),request_latency=%s,read_latency=%s: closed early",
+				l.method, l.url, l.status,
+				l.requestBytes, l.readBytes, l.responseBytes, l.requestLatency, l.readTime)
+		}
+		l.span.Finish()
+	})
+	return l.inner.Close()
+}

--- a/pkg/cloud/cloud_logging_transport_test.go
+++ b/pkg/cloud/cloud_logging_transport_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeAddLogging(t *testing.T) {
+	// Test that logging is only added when log.V(1) is true
+	originalVModule := log.GetVModule()
+	defer func() { _ = log.SetVModule(originalVModule) }()
+
+	t.Run("logging-disabled", func(t *testing.T) {
+		_ = log.SetVModule("")
+		inner := &http.Transport{}
+		result := maybeAddLogging(inner)
+		require.Equal(t, inner, result, "should return inner transport when logging is disabled")
+	})
+
+	t.Run("logging-enabled", func(t *testing.T) {
+		_ = log.SetVModule("*=1")
+		inner := &http.Transport{}
+		result := maybeAddLogging(inner)
+		require.NotEqual(t, inner, result, "should return wrapped transport when logging is enabled")
+
+		loggingTransport, ok := result.(*loggingTransport)
+		require.True(t, ok, "should return loggingTransport type")
+		require.Equal(t, inner, loggingTransport.inner)
+	})
+}
+
+func TestCloudLoggingTransport(t *testing.T) {
+	// Set up logging scope for testing
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	ctx := context.Background()
+
+	// Create a test server that echoes back the request body
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Read the request body to test request body tracking
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			http.Error(w, "failed to read body", http.StatusBadRequest)
+			return
+		}
+		r.Body.Close()
+
+		// Echo back the request body
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(reqBody)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create a client with the logging transport
+	client := &http.Client{
+		Transport: &loggingTransport{inner: http.DefaultTransport},
+	}
+
+	// Test POST request with body
+	reqBody := "test request body content"
+	req, err := http.NewRequestWithContext(ctx, "POST", server.URL+"/echo", strings.NewReader(reqBody))
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the response body to trigger logging
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, reqBody, string(respBody))
+	resp.Body.Close()
+
+	closer := resp.Body.(*responseBodyTracker)
+
+	require.NotZero(t, closer.requestLatency)
+	require.Equal(t, closer.status, redact.SafeString("200 OK"))
+	require.Equal(t, closer.method, redact.SafeString("POST"))
+	require.Equal(t, closer.url, server.URL+"/echo")
+	require.Equal(t, closer.requestBytes, int64(len(reqBody)))
+	require.Equal(t, closer.responseBytes, int64(len(respBody)))
+	require.Equal(t, closer.readBytes, int64(len(respBody)))
+	require.ErrorIs(t, closer.readErr, io.EOF)
+	require.NotZero(t, closer.readTime)
+}

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -453,7 +453,6 @@ func newTestingRangeHandler(
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}
-
 }
 
 // TestReadFileAtReturnsSize tests that ReadFileAt returns

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -180,8 +180,12 @@ type backupDriver struct {
 }
 
 func (bd *backupDriver) prepareCluster(ctx context.Context) {
+	startOptions := option.NewStartOpts(option.NoBackupSchedule)
+	startOptions.RoachprodOpts.ExtraArgs = append(
+		startOptions.RoachprodOpts.ExtraArgs,
+		"--vmodule=cloud_logging_transport=1")
 	bd.c.Start(
-		ctx, bd.t.L(), option.NewStartOpts(option.NoBackupSchedule),
+		ctx, bd.t.L(), startOptions,
 		install.MakeClusterSettings(
 			install.ClusterSettingsOption{
 				// Large imports can run into a death spiral where splits fail because

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -141,7 +141,7 @@ func backupRestoreRoundTrip(
 	})
 
 	startOpts := roachtestutil.MaybeUseMemoryBudget(t, 50)
-	startOpts.RoachprodOpts.ExtraArgs = []string{"--vmodule=split_queue=3"}
+	startOpts.RoachprodOpts.ExtraArgs = []string{"--vmodule=split_queue=3,cloud_logging_transport=1"}
 	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(envOption), c.CRDBNodes())
 	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -700,9 +700,6 @@ type restoreSpecs struct {
 
 	setUpStmts []string
 
-	// extraArgs are passed to the cockroach binary at startup.
-	extraArgs []string
-
 	// skip, if non-empty, skips the test with the given reason.
 	skip string
 
@@ -790,7 +787,7 @@ func (rd *restoreDriver) defaultClusterSettings() []install.ClusterSettingOption
 
 func (rd *restoreDriver) roachprodOpts() option.StartOpts {
 	opts := option.NewStartOpts(option.NoBackupSchedule)
-	opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs, rd.sp.extraArgs...)
+	opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs, "--vmodule=cloud_logging_transport=1")
 	if rd.c.Spec().SSDs > 1 && !rd.c.Spec().RAID0 {
 		opts.RoachprodOpts.StoreCount = rd.c.Spec().SSDs
 	}


### PR DESCRIPTION
This adds optional http level logging to the cloud package. The logs can be enabled using "--vmodule=cloud_logging_transport=1". Here is an example log line:

```
 GET ‹https://cockroach-fixtures-us-east-2.s3.us-east-2.amazonaws.com/roachtest/master/tpcc-5k/20250820-055653.397/2025/08/20-061143.99/data/1099694952495284225.sst?x-id=GetObject› (206 Partial Content) sent=0,recv=(143/2787880),request_latency=31.38703ms,read_latency=9.694µs: closed early
```

The immediate motivation of these logs is to troubleshoot roachtests. But recent experience has shown that client request logs may be essential when trying to troubleshoot unexpected cloud provider issues.

Informs: #151982
Release note: none