### PR TITLE
release-24.3: kvpb: register error decoder for KeyCollisionError

### DIFF
--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//errorspb",
         "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -7,6 +7,7 @@ package kvpb
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"slices"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/errorspb"
 	_ "github.com/cockroachdb/errors/extgrpc" // register EncodeError support for gRPC Status
 	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/proto"
@@ -1808,10 +1810,50 @@ func init() {
 	errors.RegisterWrapperDecoder(typeName, decode)
 }
 
+func encodeKeyCollisionError(
+	_ context.Context, err error,
+) (msgPrefix string, safe []string, details proto.Message) {
+	t := err.(*KeyCollisionError)
+	details = &errorspb.StringsPayload{
+		Details: []string{
+			base64.StdEncoding.EncodeToString(t.Key),
+			base64.StdEncoding.EncodeToString(t.Value),
+		},
+	}
+	msgPrefix = "ingested key collides with an existing one"
+	return msgPrefix, nil, details
+}
+
+func decodeKeyCollisionError(_ context.Context, _ string, _ []string, payload proto.Message) error {
+	m, ok := payload.(*errorspb.StringsPayload)
+	if !ok || len(m.Details) < 2 {
+		// If this ever happens, this means some version of the library
+		// (presumably future) changed the payload type, and we're
+		// receiving this here. In this case, give up and let
+		// DecodeError use the opaque type.
+		return nil
+	}
+	key, decodeErr := base64.StdEncoding.DecodeString(m.Details[0])
+	if decodeErr != nil {
+		return nil //nolint:returnerrcheck
+	}
+	value, decodeErr := base64.StdEncoding.DecodeString(m.Details[1])
+	if decodeErr != nil {
+		return nil //nolint:returnerrcheck
+	}
+	return &KeyCollisionError{
+		Key:   key,
+		Value: value,
+	}
+}
+
 func init() {
 	errors.RegisterLeafDecoder(errors.GetTypeKey((*MissingRecordError)(nil)), func(_ context.Context, _ string, _ []string, _ proto.Message) error {
 		return &MissingRecordError{}
 	})
+	collisionErrorKey := errors.GetTypeKey((*KeyCollisionError)(nil))
+	errors.RegisterLeafEncoder(collisionErrorKey, encodeKeyCollisionError)
+	errors.RegisterLeafDecoder(collisionErrorKey, decodeKeyCollisionError)
 	errorutilpath := reflect.TypeOf(errorutil.TempSentinel{}).PkgPath()
 	errors.RegisterTypeMigration(errorutilpath, "*errorutil.descriptorNotFound", &DescNotFoundError{})
 }


### PR DESCRIPTION
Backport 1/1 commits from #152108 on behalf of @rafiss.

----

This will allow the error to be properly serialized and unredacted if it's sent across the network.

informs https://github.com/cockroachdb/cockroach/issues/117504
fixes #151688
Release note: None

----

Release justification: low risk error serialization change needed in order to debug errors seen in production 