### PR TITLE
release-25.3: kvpb: register error decoder for KeyCollisionError

### DIFF
--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//errorspb",
         "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",


### PR DESCRIPTION
Backport 1/1 commits from #152108 on behalf of @rafiss.

----

This will allow the error to be properly serialized and unredacted if it's sent across the network.

informs https://github.com/cockroachdb/cockroach/issues/117504
fixes #151688
Release note: None

----

Release justification: low risk error serialization change needed in order to debug errors seen in production 