### PR TITLE
kvnemesis: disable read transforms in buffered writes variants

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -46,7 +46,7 @@ var BufferedWritesEnabled = settings.RegisterBoolSetting(
 
 var unsupportedInProductionBuildErr = errors.New("this option is not supported in production builds")
 
-var bufferedWritesScanTransformEnabled = settings.RegisterBoolSetting(
+var BufferedWritesScanTransformEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.transformations.scans.enabled",
 	"if enabled, locking scans and reverse scans with replicated durability are transformed to unreplicated durability",
@@ -59,7 +59,7 @@ var bufferedWritesScanTransformEnabled = settings.RegisterBoolSetting(
 	}),
 )
 
-var bufferedWritesGetTransformEnabled = settings.RegisterBoolSetting(
+var BufferedWritesGetTransformEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.transformations.get.enabled",
 	"if enabled, locking get requests with replicated durability are transformed to unreplicated durability",
@@ -294,8 +294,8 @@ func (twb *txnWriteBuffer) SendLocked(
 	// We check if scan transforms are enabled once and use that answer until the
 	// end of SendLocked.
 	cfg := transformConfig{
-		transformScans: bufferedWritesScanTransformEnabled.Get(&twb.st.SV),
-		transformGets:  bufferedWritesGetTransformEnabled.Get(&twb.st.SV),
+		transformScans: BufferedWritesScanTransformEnabled.Get(&twb.st.SV),
+		transformGets:  BufferedWritesGetTransformEnabled.Get(&twb.st.SV),
 	}
 
 	if twb.batchRequiresFlush(ctx, ba, cfg) {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_client_test.go
@@ -61,7 +61,7 @@ func TestTxnCoordSenderWriteBufferingDisablesPipelining(t *testing.T) {
 	// buffered.
 	require.NoError(t, db.Put(ctx, "test-key-a", "hello"))
 
-	bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, false)
+	BufferedWritesScanTransformEnabled.Override(ctx, &st.SV, false)
 	BufferedWritesMaxBufferSize.Override(ctx, &st.SV, defaultBufferSize)
 
 	// Without write buffering
@@ -144,7 +144,7 @@ func TestTxnWriteBufferFlushedWithMaxKeysOnBatch(t *testing.T) {
 
 	// The bug requires that we transform Gets. Here, we disable it to prove that
 	// this tets passes.
-	bufferedWritesGetTransformEnabled.Override(ctx, &st.SV, false)
+	BufferedWritesGetTransformEnabled.Override(ctx, &st.SV, false)
 
 	// The locks need to actually be taken, so let's write to every key we are
 	// going to lock.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -31,8 +31,8 @@ func makeMockTxnWriteBuffer(
 ) (txnWriteBuffer, *mockLockedSender, *cluster.Settings) {
 	metrics := MakeTxnMetrics(time.Hour)
 	st := cluster.MakeClusterSettings()
-	bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
-	bufferedWritesGetTransformEnabled.Override(ctx, &st.SV, true)
+	BufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
+	BufferedWritesGetTransformEnabled.Override(ctx, &st.SV, true)
 	BufferedWritesMaxBufferSize.Override(ctx, &st.SV, defaultBufferSize)
 
 	mockSender := &mockLockedSender{}
@@ -1733,7 +1733,7 @@ func TestTxnWriteBufferLimitsSizeOfScans(t *testing.T) {
 				txn := makeTxnProto()
 				txn.Sequence = 10
 
-				bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
+				BufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
 				BufferedWritesMaxBufferSize.Override(ctx, &st.SV, tc.bufferSize)
 
 				ba := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -347,6 +347,10 @@ func TestKVNemesisMultiNode_BufferedWrites(t *testing.T) {
 		bufferedWriteProb:            0.70,
 		testSettings: func(ctx context.Context, st *cluster.Settings) {
 			kvcoord.BufferedWritesEnabled.Override(ctx, &st.SV, true)
+			// Read transforms are disabled on release-25.3 because of known issues
+			// such as #150239 which are only fixed in 25.4+.
+			kvcoord.BufferedWritesGetTransformEnabled.Override(ctx, &st.SV, false)
+			kvcoord.BufferedWritesScanTransformEnabled.Override(ctx, &st.SV, false)
 			concurrency.UnreplicatedLockReliabilityLeaseTransfer.Override(ctx, &st.SV, true)
 			concurrency.UnreplicatedLockReliabilityMerge.Override(ctx, &st.SV, true)
 			concurrency.UnreplicatedLockReliabilitySplit.Override(ctx, &st.SV, true)
@@ -372,6 +376,10 @@ func TestKVNemesisMultiNode_BufferedWritesNoPipelining(t *testing.T) {
 		testSettings: func(ctx context.Context, st *cluster.Settings) {
 			kvcoord.BufferedWritesEnabled.Override(ctx, &st.SV, true)
 			kvcoord.PipelinedWritesEnabled.Override(ctx, &st.SV, false)
+			// Read transforms are disabled on release-25.3 because of known issues
+			// such as #150239 which are only fixed in 25.4+.
+			kvcoord.BufferedWritesGetTransformEnabled.Override(ctx, &st.SV, false)
+			kvcoord.BufferedWritesScanTransformEnabled.Override(ctx, &st.SV, false)
 			concurrency.UnreplicatedLockReliabilityLeaseTransfer.Override(ctx, &st.SV, true)
 			concurrency.UnreplicatedLockReliabilityMerge.Override(ctx, &st.SV, true)
 			concurrency.UnreplicatedLockReliabilitySplit.Override(ctx, &st.SV, true)


### PR DESCRIPTION
We have some known issues with read transforms. Read transforms are disabled by default and only allowed in test builds for 25.3. To avoid test noise because of these known issues, we disable read transformations in the buffered writes KVNemesis tests.

Fixes #152235

Release justification: Test-only change. Changes to production code file only change setting variables visibility.

Epic: none
Release note: None