### PR TITLE
storage: inline `recordStats` function in `linux_parse.go` to fix lint

### DIFF
--- a/pkg/storage/disk/linux_parse.go
+++ b/pkg/storage/disk/linux_parse.go
@@ -149,7 +149,11 @@ func parseDiskStats(
 		} else if ok {
 			stats.FlushesDuration = time.Duration(millis) * time.Millisecond
 		}
-		disks[diskIdx].recordStats(measuredAt, stats)
+		disks[diskIdx].tracer.RecordEvent(traceEvent{
+			time:  measuredAt,
+			stats: stats,
+			err:   nil,
+		})
 		countCollected++
 	}
 	return countCollected, nil

--- a/pkg/storage/disk/monitor.go
+++ b/pkg/storage/disk/monitor.go
@@ -195,14 +195,6 @@ type monitoredDisk struct {
 	refCount int
 }
 
-func (m *monitoredDisk) recordStats(t time.Time, stats Stats) {
-	m.tracer.RecordEvent(traceEvent{
-		time:  t,
-		stats: stats,
-		err:   nil,
-	})
-}
-
 // StatsWindow is a wrapper around a rolling window of disk stats, used to
 // apply common rudimentary computations or custom aggregation functions.
 type StatsWindow struct {


### PR DESCRIPTION
`./dev lint` runs a series of lint checks, which includes `TestLint/TestStaticCheck`; `TestLint/TestStaticCheck` throws an an error:
```log
=== RUN   TestLint/TestStaticCheck
    gen-lint_test.go:2119:
        pkg/storage/disk/monitor.go:198:25: func (*monitoredDisk).recordStats is unused (U1000)
```

However, `recordStats` is used in `pkg/storage/disk/linux_parse.go` which has a `//go:build linux` constraint, so it is actually not "unused". 

This PR resolves the linter error by inlining the behaviour in `linux_parse.go` and removing the function from `monitor.go`.

Epic: None
Release note: None