### PR TITLE
sql: remove LTREE from mixed version clusters previous to 25.4

### DIFF
--- a/pkg/sql/catalog/colinfo/BUILD.bazel
+++ b/pkg/sql/catalog/colinfo/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",

--- a/pkg/sql/logictest/testdata/logic_test/ltree
+++ b/pkg/sql/logictest/testdata/logic_test/ltree
@@ -1,3 +1,5 @@
+# LogicTest: !local-mixed-25.2 !local-mixed-25.3
+
 statement ok
 CREATE TABLE l (lt LTREE);
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_ltree
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_ltree
@@ -1,0 +1,49 @@
+# LogicTest: cockroach-go-testserver-configs
+
+# Sanity check that LTREE type is only allowed to be used once the cluster is
+# upgraded to 25.4.
+
+statement error pgcode 42704 type \"ltree\" does not exist
+CREATE TABLE l (lt LTREE);
+
+statement error pgcode 42704 type \"ltree\" does not exist
+CREATE TABLE la (lta LTREE[]);
+
+statement error pgcode 42704 type \"ltree\" does not exist
+SELECT 'A.B'::LTREE
+
+statement error pgcode 42704 type \"ltree\" does not exist
+SELECT ARRAY['A', 'A.B']::LTREE[]
+
+upgrade 0
+
+statement error pgcode 0A000 ltree not supported until version 25.4
+CREATE TABLE l (lt LTREE);
+
+statement error pgcode 0A000 ltree not supported until version 25.4
+CREATE TABLE la (lta LTREE[]);
+
+statement error pgcode 0A000 ltree not supported until version 25.4
+SELECT 'A.B'::LTREE
+
+statement error pgcode 0A000 ltree\[\] not supported until version 25.4
+SELECT ARRAY['A', 'A.B']::LTREE[]
+
+upgrade 1
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+statement ok
+CREATE TABLE l (lt LTREE);
+
+statement ok
+CREATE TABLE la (lta LTREE[]);
+
+statement ok
+SELECT 'A.B'::LTREE
+
+statement ok
+SELECT ARRAY['A', 'A.B']::LTREE[]

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 8,
+    shard_count = 9,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
@@ -94,6 +94,13 @@ func TestLogic_mixed_version_can_login(
 	runLogicTest(t, "mixed_version_can_login")
 }
 
+func TestLogic_mixed_version_ltree(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_ltree")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 7,
+    shard_count = 8,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/generated_test.go
@@ -94,6 +94,13 @@ func TestLogic_mixed_version_can_login(
 	runLogicTest(t, "mixed_version_can_login")
 }
 
+func TestLogic_mixed_version_ltree(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_ltree")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
@@ -1228,13 +1228,6 @@ func TestLogic_lookup_join_spans(
 	runLogicTest(t, "lookup_join_spans")
 }
 
-func TestLogic_ltree(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "ltree")
-}
-
 func TestLogic_manual_retry(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.3/generated_test.go
@@ -1235,13 +1235,6 @@ func TestLogic_lookup_join_spans(
 	runLogicTest(t, "lookup_join_spans")
 }
 
-func TestLogic_ltree(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "ltree")
-}
-
 func TestLogic_manual_retry(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/arith",
         "//pkg/util/bitarray",
+        "//pkg/util/buildutil",
         "//pkg/util/cidr",
         "//pkg/util/duration",
         "//pkg/util/encoding",


### PR DESCRIPTION
#### sql: remove LTREE from mixed version clusters previous to 25.4

Currently, we hit internal panics for randomized mixed version testing. This PR
prevents this by blocking LTREE usage in mixed version clusters.

Epic: None

Release note: None
