### PR TITLE
sql: temporarily switch back to WaitForOneVersion for table version bump

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -558,8 +558,8 @@ func (m *Manager) WaitForOneVersion(
 func (m *Manager) WaitForNewVersion(
 	ctx context.Context,
 	descriptorId descpb.ID,
-	retryOpts retry.Options,
 	regions regionliveness.CachedDatabaseRegions,
+	retryOpts retry.Options,
 ) (catalog.Descriptor, error) {
 	if retryOpts.MaxRetries != 0 {
 		return nil, errors.New("The MaxRetries option shouldn't be set in WaitForNewVersion")

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -557,6 +557,8 @@ func TestWaitForNewVersion(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	defer log.Scope(testingT).Close(testingT)
 
+	skip.WithIssue(testingT, 152051)
+
 	var params base.TestClusterArgs
 	params.ServerArgs.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &lease.ManagerTestingKnobs{
@@ -586,7 +588,7 @@ func TestWaitForNewVersion(testingT *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		_, err := leaseMgr.WaitForNewVersion(timeoutCtx, descID, retry.Options{}, nil)
+		_, err := leaseMgr.WaitForNewVersion(timeoutCtx, descID, nil, retry.Options{})
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	}
 
@@ -597,7 +599,7 @@ func TestWaitForNewVersion(testingT *testing.T) {
 		require.NoError(t, t.node(2).AcquireFreshestFromStore(ctx, descID))
 		t.expectLeases(descID, "/1/1 /1/2 /2/1 /2/2 /2/3")
 
-		desc, err := leaseMgr.WaitForNewVersion(context.Background(), descID, retry.Options{}, nil)
+		desc, err := leaseMgr.WaitForNewVersion(context.Background(), descID, nil, retry.Options{})
 		require.NoError(t, err)
 		require.Equal(t, desc.GetVersion(), descpb.DescriptorVersion(2))
 	}

--- a/pkg/sql/conn_executor_jobs.go
+++ b/pkg/sql/conn_executor_jobs.go
@@ -84,11 +84,13 @@ func (ex *connExecutor) waitForNewVersionPropagation(
 			continue
 		}
 
-		if _, err := ex.planner.LeaseMgr().WaitForNewVersion(ex.Ctx(), idVersion.ID, retry.Options{
+		// TODO(sql-foundations): Change this back to WaitForNewVersion once we
+		// address the flaky behavior around privilege and role membership caching.
+		if _, err := ex.planner.LeaseMgr().WaitForOneVersion(ex.Ctx(), idVersion.ID, cachedRegions, retry.Options{
 			InitialBackoff: time.Millisecond,
 			MaxBackoff:     time.Second,
 			Multiplier:     1.5,
-		}, cachedRegions); err != nil {
+		}); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/tests/allow_user_create_during_transaction_test.go
+++ b/pkg/sql/tests/allow_user_create_during_transaction_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -23,6 +24,8 @@ import (
 func TestAllowUserCreateDuringTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 152043)
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})


### PR DESCRIPTION
65c953be7f838a06bede7de7b3501191b31f9d63 changed the waiting logic for schema changes that were version-bump-only to wait for the new version to be published to all nodes, rather than waiting for all nodes to converge to one version. That change appears to have made tests flaky, so we temporarily go back to the old logic to unblock CI.

This also skips the related flaky tests.

informs https://github.com/cockroachdb/cockroach/issues/152051
informs https://github.com/cockroachdb/cockroach/issues/152043

informs https://github.com/cockroachdb/cockroach/issues/152042
informs https://github.com/cockroachdb/cockroach/issues/152293
informs https://github.com/cockroachdb/cockroach/issues/152049
informs https://github.com/cockroachdb/cockroach/issues/152083
informs https://github.com/cockroachdb/cockroach/issues/152279
informs https://github.com/cockroachdb/cockroach/issues/152278
informs https://github.com/cockroachdb/cockroach/issues/152274
informs https://github.com/cockroachdb/cockroach/issues/152230
informs https://github.com/cockroachdb/cockroach/issues/152226
informs https://github.com/cockroachdb/cockroach/issues/152148
informs https://github.com/cockroachdb/cockroach/issues/152204
informs https://github.com/cockroachdb/cockroach/issues/152191
informs https://github.com/cockroachdb/cockroach/issues/152155
informs https://github.com/cockroachdb/cockroach/issues/152098
informs https://github.com/cockroachdb/cockroach/issues/152144
informs https://github.com/cockroachdb/cockroach/issues/152072
informs https://github.com/cockroachdb/cockroach/issues/152073

Release note: None