### PR TITLE
sql: fix unsafe authorization check on table descriptors

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -958,7 +958,7 @@ func (p *planner) objectIsUnsafe(ctx context.Context, privilegeObject privilege.
 
 	d, ok := privilegeObject.(catalog.TableDescriptor)
 	if !ok {
-		return true
+		return false
 	}
 
 	// All system descriptors are considered unsafe.


### PR DESCRIPTION
pr #151804 added a function, objectIsUnsafe, to communicate whether the object being observed was, considered unsafe, namely, in the crdb_internal schema or in the system database and unsupported.

This function aimed to only review table descriptors, but it accidentally marked all non-table descriptors as unsafe as a result, eg:

```
func objectIsUnsafe() {
    if !tableDescriptor {
        return true
		}
}
```

If released, this would improperly block query access to all non-table descriptors in the database for unauthorized users. This PR remediates this issue.

Fixes: #152305
Epic: CRDB-24527
Release note: none