### PR TITLE
changefeedccl: return error for dtimestamptz case in protobuf encoder

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_protobuf.go
+++ b/pkg/ccl/changefeedccl/encoder_protobuf.go
@@ -400,6 +400,7 @@ func datumToProtoValue(
 					Value: &changefeedpb.Value_StringValue{StringValue: v.Time.Format(time.RFC3339Nano)},
 				}, nil
 			}
+			return nil, err
 		}
 		return &changefeedpb.Value{
 			Value: &changefeedpb.Value_TimestampValue{


### PR DESCRIPTION
When the protobuf encoder encounters an error when parsing the DTimestampTZ type, it does special handling if the code is being run in a benchmark, but neglects to return the error otherwise. This fixes the issue.

Bug found with AI.

Epic: none

Release note: None