### PR TITLE
release-25.3: sql/schemachanger: fix incorrect clean up of sequence ownership

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2536,3 +2536,39 @@ SELECT substring(sequence_schema FOR 7), sequence_name FROM [SHOW SEQUENCES] WHE
 pg_temp  temp_seq
 
 subtest end
+
+
+subtest incorrect_cleanup_of_owned_by
+
+statement ok
+CREATE TABLE t_seq_owner (id BIGSERIAL NOT NULL);
+
+statement ok
+CREATE SEQUENCE id_seq_owned OWNED BY t_seq_owner.id;
+
+statement ok
+ALTER TABLE t_seq_owner ALTER COLUMN id SET DEFAULT nextval('id_seq_owned');
+
+# Confirm the sequence still exists.
+query I
+SELECT count(*) FROM pg_sequences WHERE sequencename='id_seq_owned';
+----
+1
+
+
+statement ok
+drop table t_seq_owner;
+
+# Confirm the sequence is dropped.
+query I
+SELECT count(*) FROM pg_sequences WHERE sequencename='id_seq_owned';
+----
+0
+
+# Confirm the table is dropped.
+query I
+SELECT count(*) FROM pg_tables WHERE tablename='t_seq_owner';
+----
+0
+
+subtest end

--- a/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
@@ -280,7 +280,6 @@ func updateColumnExprSequenceUsage(d *descpb.ColumnDescriptor) error {
 		ids.ForEach(all.Add)
 	}
 	d.UsesSequenceIds = all.Ordered()
-	d.OwnsSequenceIds = all.Ordered()
 	return nil
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #151947 on behalf of @fqazi.

----

Previously, when a default expression was cleaned up the sequence ownerships would be incorrectly cleaned up. This meant when we added support for setting default expressions in the declarative schema changer, any updates could wipe out sequence ownership information. To address this, this patch removes the incorrect clean up logic.

Fixes: #151925

Release note (bug fix): Updating column default expressions would incorrectly remove sequence ownerships for the affected column.

----

Release justification: low risk bug fix to prevent leaving an orphaned sequence in an invalid state.