### PR TITLE
backup: remove mixed-version check for incremental path suffix

### DIFF
--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -237,41 +236,40 @@ func ResolveDest(
 	}
 	prevBackupURIs = append([]string{plannedBackupDefaultURI}, prevBackupURIs...)
 
-	// Within the chosenSuffix dir, differentiate incremental backups with partName.
-	partName := endTime.GoTime().Format(backupbase.DateBasedIncFolderName)
-	if execCfg.Settings.Version.IsActive(ctx, clusterversion.V25_2) {
-		if startTime.IsEmpty() {
-			baseEncryptionOptions, err := backupencryption.GetEncryptionFromBase(
-				ctx, user, execCfg.DistSQLSrv.ExternalStorageFromURI, prevBackupURIs[0],
-				encryption, kmsEnv,
-			)
-			if err != nil {
-				return ResolvedDestination{}, err
-			}
-
-			// TODO (kev-cao): Once we have completed the backup directory index work, we
-			// can remove the need to read an entire backup manifest just to fetch the
-			// start time. We can instead read the metadata protobuf.
-			mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
-			defer mem.Close(ctx)
-			precedingBackupManifest, size, err := backupinfo.ReadBackupManifestFromURI(
-				ctx, &mem, prevBackupURIs[len(prevBackupURIs)-1], user,
-				execCfg.DistSQLSrv.ExternalStorageFromURI, baseEncryptionOptions, kmsEnv,
-			)
-			if err != nil {
-				return ResolvedDestination{}, err
-			}
-			if err := mem.Grow(ctx, size); err != nil {
-				return ResolvedDestination{}, err
-			}
-			defer mem.Shrink(ctx, size)
-			startTime = precedingBackupManifest.EndTime
-			if startTime.IsEmpty() {
-				return ResolvedDestination{}, errors.Errorf("empty end time in prior backup manifest")
-			}
+	// If startTime is not already set, we will find it via the previous backup
+	// manifest.
+	if startTime.IsEmpty() {
+		baseEncryptionOptions, err := backupencryption.GetEncryptionFromBase(
+			ctx, user, execCfg.DistSQLSrv.ExternalStorageFromURI, prevBackupURIs[0],
+			encryption, kmsEnv,
+		)
+		if err != nil {
+			return ResolvedDestination{}, err
 		}
-		partName = partName + "-" + startTime.GoTime().Format(backupbase.DateBasedIncFolderNameSuffix)
+
+		// TODO (kev-cao): Once we have completed the backup directory index work, we
+		// can remove the need to read an entire backup manifest just to fetch the
+		// start time. We can instead read the metadata protobuf.
+		mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
+		defer mem.Close(ctx)
+		precedingBackupManifest, size, err := backupinfo.ReadBackupManifestFromURI(
+			ctx, &mem, prevBackupURIs[len(prevBackupURIs)-1], user,
+			execCfg.DistSQLSrv.ExternalStorageFromURI, baseEncryptionOptions, kmsEnv,
+		)
+		if err != nil {
+			return ResolvedDestination{}, err
+		}
+		if err := mem.Grow(ctx, size); err != nil {
+			return ResolvedDestination{}, err
+		}
+		defer mem.Shrink(ctx, size)
+		startTime = precedingBackupManifest.EndTime
+		if startTime.IsEmpty() {
+			return ResolvedDestination{}, errors.Errorf("empty end time in prior backup manifest")
+		}
 	}
+
+	partName := ConstructDateBasedIncrementalFolderName(startTime.GoTime(), endTime.GoTime())
 	defaultIncrementalsURI, urisByLocalityKV, err := GetURIsByLocalityKV(fullyResolvedIncrementalsLocation, partName)
 	if err != nil {
 		return ResolvedDestination{}, err

--- a/pkg/backup/backupdest/incrementals.go
+++ b/pkg/backup/backupdest/incrementals.go
@@ -7,10 +7,12 @@ package backupdest
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
@@ -247,4 +249,19 @@ func ResolveDefaultBaseIncrementalStorageLocation(
 	}
 
 	return defaultURI, nil
+}
+
+// ConstructDateBasedIncrementalFolderName constructs the name of a date-based
+// incremental backup folder relative to the full subdirectory it belongs to.
+//
+// /2025/07/30-120000.00/20250730/130000.00-20250730-120000.00
+//
+//	 	                 └─────────────────────────────────────┘
+//										               returns this
+func ConstructDateBasedIncrementalFolderName(start, end time.Time) string {
+	return fmt.Sprintf(
+		"%s-%s",
+		end.Format(backupbase.DateBasedIncFolderName),
+		start.Format(backupbase.DateBasedIncFolderNameSuffix),
+	)
 }


### PR DESCRIPTION
The `start_time` suffix was added to incremental backup paths in 25.2 A mixed version check was added to ensure backups written during the mixed-version state when ugprading to 25.2 would be written correctly. This check is no longer needed.

Epic: None

Release note: None