### PR TITLE
sql: include isolation level in SHOW TRANSACTIONS, SHOW QUERIES, SHOW SESSIONS

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2315,6 +2315,7 @@ Session represents one SQL session.
 | trace_id | [uint64](#cockroach.server.serverpb.ListSessionsResponse-uint64) |  | The ID of the session's active trace. It will be 0 if tracing is off. | [reserved](#support-status) |
 | goroutine_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | The ID of the session's goroutine. | [reserved](#support-status) |
 | authentication_method | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
+| default_isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The session's default transaction isolation level. | [reserved](#support-status) |
 
 
 
@@ -2465,6 +2466,7 @@ Session represents one SQL session.
 | trace_id | [uint64](#cockroach.server.serverpb.ListSessionsResponse-uint64) |  | The ID of the session's active trace. It will be 0 if tracing is off. | [reserved](#support-status) |
 | goroutine_id | [int64](#cockroach.server.serverpb.ListSessionsResponse-int64) |  | The ID of the session's goroutine. | [reserved](#support-status) |
 | authentication_method | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  |  | [reserved](#support-status) |
+| default_isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The session's default transaction isolation level. | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -142,15 +142,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTBTT colnames
+query TTITTTTTTBTBTTT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
 
-query TTITTTTTTBTBTT colnames
+query TTITTTTTTBTBTTT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
 
 query TITTTTIIITTTT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0
@@ -162,15 +162,15 @@ SELECT  * FROM crdb_internal.cluster_transactions WHERE node_id < 0
 ----
 id  node_id  session_id  start  txn_string  application_name  num_stmts  num_retries  num_auto_retries  last_auto_retry_reason  isolation_level  priority  quality_of_service
 
-query ITTTTTTTITTTIITTIII colnames
+query ITTTTTTTITTTIITTIIIT colnames
 SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0
 ----
-node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method
+node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method  isolation_level
 
-query ITTTTTTTITTTIITTIII colnames
+query ITTTTTTTITTTIITTIIIT colnames
 SELECT * FROM crdb_internal.cluster_sessions WHERE node_id < 0
 ----
-node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method
+node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method  isolation_level
 
 query IIITTTI colnames
 SELECT * FROM crdb_internal.node_contention_events WHERE table_id < 0

--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -680,3 +680,82 @@ read committed
 
 statement ok
 COMMIT
+
+subtest show
+
+# Test isolation level column in SHOW TRANSACTIONS, SHOW QUERIES, SHOW SESSIONS.
+
+user testuser2
+
+statement ok
+SET default_transaction_isolation = 'READ COMMITTED'
+
+user testuser
+
+statement ok
+SET default_transaction_isolation = 'READ COMMITTED'
+
+query T rowsort
+SELECT isolation_level FROM [SHOW TRANSACTIONS]
+----
+READ COMMITTED
+
+query TT colnames
+SELECT isolation_level, query FROM [SHOW QUERIES] ORDER BY isolation_level, query
+----
+isolation_level  query
+READ COMMITTED   SELECT isolation_level, query FROM [SHOW CLUSTER STATEMENTS] ORDER BY isolation_level, query
+
+query TTT colnames
+SELECT DISTINCT isolation_level, user_name, active_queries FROM [SHOW SESSIONS]
+ORDER BY isolation_level, user_name, active_queries
+----
+isolation_level  user_name  active_queries
+READ COMMITTED   testuser   SELECT DISTINCT isolation_level, user_name, active_queries FROM [SHOW CLUSTER SESSIONS] ORDER BY isolation_level, user_name, active_queries
+READ COMMITTED   testuser2  ·
+SERIALIZABLE     root       ·
+
+statement ok
+SET default_transaction_isolation = 'SERIALIZABLE'
+
+query TT colnames
+SELECT isolation_level, query FROM [SHOW QUERIES] ORDER BY isolation_level, query
+----
+isolation_level  query
+SERIALIZABLE     SELECT isolation_level, query FROM [SHOW CLUSTER STATEMENTS] ORDER BY isolation_level, query
+
+# If there is no active query for a session, use the default transaction
+# isolation level. Otherwise, use the isolation level of the active query.
+query TTT colnames
+SELECT DISTINCT isolation_level, user_name, active_queries FROM [SHOW SESSIONS]
+ORDER BY isolation_level, user_name, active_queries
+----
+isolation_level  user_name  active_queries
+READ COMMITTED   testuser2  ·
+SERIALIZABLE     root       ·
+SERIALIZABLE     testuser   SELECT DISTINCT isolation_level, user_name, active_queries FROM [SHOW CLUSTER SESSIONS] ORDER BY isolation_level, user_name, active_queries
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+query TTT colnames
+SELECT DISTINCT isolation_level, user_name, active_queries FROM [SHOW SESSIONS]
+ORDER BY isolation_level, user_name, active_queries
+----
+isolation_level  user_name  active_queries
+READ COMMITTED   testuser   SELECT DISTINCT isolation_level, user_name, active_queries FROM [SHOW CLUSTER SESSIONS] ORDER BY isolation_level, user_name, active_queries
+READ COMMITTED   testuser2  ·
+SERIALIZABLE     root       ·
+
+statement ok
+COMMIT
+
+statement ok
+RESET default_transaction_isolation
+
+user testuser2
+
+statement ok
+RESET default_transaction_isolation
+
+subtest end

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1118,6 +1118,9 @@ message Session {
   string authentication_method = 22 [
     (gogoproto.casttype) = "github.com/cockroachdb/redact.SafeString"
   ];
+
+  // The session's default transaction isolation level.
+  string default_isolation_level = 23;
 }
 
 // An error wrapper object for ListSessionsResponse.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4534,6 +4534,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		TraceID:                    uint64(ex.planner.extendedEvalCtx.Tracing.connSpan.TraceID()),
 		GoroutineID:                ex.ctxHolder.goroutineID,
 		AuthenticationMethod:       sd.AuthenticationMethod,
+		DefaultIsolationLevel:      tree.IsolationLevel(sd.DefaultTxnIsolationLevel).String(),
 	}
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2249,7 +2249,8 @@ CREATE TABLE crdb_internal.%s (
   phase            STRING,         -- the current execution phase
   full_scan        BOOL,           -- whether the query contains a full table or index scan
   plan_gist        STRING,         -- Compressed logical plan.
-  database         STRING          -- the database the statement was executed on
+  database         STRING,         -- the database the statement was executed on
+  isolation_level  STRING          -- the isolation level of the query's transaction
 )`
 
 func (p *planner) makeSessionsRequest(
@@ -2414,6 +2415,13 @@ func populateQueriesTable(
 			if shouldRedactOtherUserQuery && session.Username != p.SessionData().User().Normalized() {
 				sql = query.SqlNoConstants
 			}
+
+			// Get isolation level from session's active transaction, or use NULL if none.
+			var isolationLevelDatum tree.Datum = tree.DNull
+			if session.ActiveTxn != nil {
+				isolationLevelDatum = tree.NewDString(session.ActiveTxn.IsolationLevel)
+			}
+
 			if err := addRow(
 				tree.NewDString(query.ID),
 				txnID,
@@ -2429,6 +2437,7 @@ func populateQueriesTable(
 				isFullScanDatum,
 				planGistDatum,
 				tree.NewDString(query.Database),
+				isolationLevelDatum,
 			); err != nil {
 				return err
 			}
@@ -2455,6 +2464,7 @@ func populateQueriesTable(
 				tree.DNull,                             // full_scan
 				tree.DNull,                             // plan_gist
 				tree.DNull,                             // database
+				tree.DNull,                             // isolation_level
 			); err != nil {
 				return err
 			}
@@ -2510,7 +2520,8 @@ CREATE TABLE crdb_internal.%s (
   pg_backend_pid     INT,            -- the numerical ID attached to the session which is used to mimic a Postgres backend PID
   trace_id           INT,            -- the ID of the trace of the session
   goroutine_id       INT,            -- the ID of the goroutine of the session
-  authentication_method STRING       -- the method used to authenticate the session
+  authentication_method STRING,      -- the method used to authenticate the session
+  isolation_level       STRING       -- the isolation level of the session's active transaction or default isolation level if no active transaction
 )
 `
 
@@ -2634,6 +2645,16 @@ func populateSessionsTable(
 				return err
 			}
 		}
+
+		// Get isolation level from session's active transaction, or fall back to
+		// default.
+		var isolationLevelDatum tree.Datum = tree.DNull
+		if session.ActiveTxn != nil {
+			isolationLevelDatum = tree.NewDString(session.ActiveTxn.IsolationLevel)
+		} else if session.DefaultIsolationLevel != "" {
+			isolationLevelDatum = tree.NewDString(session.DefaultIsolationLevel)
+		}
+
 		if err := addRow(
 			tree.NewDInt(tree.DInt(session.NodeID)),
 			sessionID,
@@ -2654,6 +2675,7 @@ func populateSessionsTable(
 			tree.NewDInt(tree.DInt(session.TraceID)),
 			tree.NewDInt(tree.DInt(session.GoroutineID)),
 			tree.NewDString(string(session.AuthenticationMethod)),
+			isolationLevelDatum,
 		); err != nil {
 			return err
 		}
@@ -2684,6 +2706,7 @@ func populateSessionsTable(
 				tree.DNull,                             // trace_id
 				tree.DNull,                             // goroutine_id
 				tree.DNull,                             // authentication_method
+				tree.DNull,                             // isolation_level
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/delegate/show_queries.go
+++ b/pkg/sql/delegate/show_queries.go
@@ -25,7 +25,8 @@ SELECT
   application_name,
   distributed,
   full_scan,
-  phase
+  phase,
+  isolation_level
 FROM crdb_internal.`
 	table := `node_queries`
 	if n.Cluster {

--- a/pkg/sql/delegate/show_sessions.go
+++ b/pkg/sql/delegate/show_sessions.go
@@ -14,7 +14,7 @@ import (
 
 func (d *delegator) delegateShowSessions(n *tree.ShowSessions) (tree.Statement, error) {
 	columns := `node_id, session_id, status, user_name, authentication_method, client_address, application_name, active_queries,
-       last_active_query, session_start, active_query_start, num_txns_executed, trace_id, goroutine_id`
+       last_active_query, session_start, active_query_start, num_txns_executed, trace_id, goroutine_id, isolation_level`
 
 	query := fmt.Sprintf(`SELECT %s FROM crdb_internal.`, columns)
 	table := `node_sessions`

--- a/pkg/sql/delegate/show_transactions.go
+++ b/pkg/sql/delegate/show_transactions.go
@@ -19,7 +19,8 @@ SELECT
   num_stmts,
   num_retries,
   num_auto_retries, 
-  last_auto_retry_reason
+  last_auto_retry_reason,
+  isolation_level
 FROM `
 	table := `"".crdb_internal.node_transactions`
 	if n.Cluster {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -276,15 +276,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTBTT colnames
+query TTITTTTTTBTBTTT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
 
-query TTITTTTTTBTBTT colnames
+query TTITTTTTTBTBTTT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
 
 query TITTTTIIITTTT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0
@@ -349,15 +349,15 @@ user root
 statement ok
 REVOKE SYSTEM VIEWACTIVITYREDACTED FROM testuser
 
-query ITTTTTTTITTTIITTIII colnames
+query ITTTTTTTITTTIITTIIIT colnames
 SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0
 ----
-node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method
+node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method  isolation_level
 
-query ITTTTTTTITTTIITTIII colnames
+query ITTTTTTTITTTIITTIIIT colnames
 SELECT * FROM crdb_internal.cluster_sessions WHERE node_id < 0
 ----
-node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method
+node_id  session_id  user_name  client_address  application_name  active_queries  last_active_query  num_txns_executed  session_start  active_query_start  kv_txn  alloc_bytes  max_alloc_bytes  status  session_end  pg_backend_pid  trace_id  goroutine_id  authentication_method  isolation_level
 
 query IIITTTI colnames
 SELECT * FROM crdb_internal.node_contention_events WHERE table_id < 0


### PR DESCRIPTION
This change adds isolation level information to the output of `SHOW
TRANSACTIONS`, `SHOW QUERIES`, and `SHOW SESSIONS` commands. The isolation level
is obtained from the session's active transaction information that is already
collected by the underlying gRPC endpoints.

Changes:
- Added `isolation_level` column to `SHOW TRANSACTIONS` output
- Updated `crdb_internal.node_queries` and `cluster_queries` table schemas to
  include `isolation_level` column
- Updated `populateQueriesTable` to populate isolation level from session's
  active transaction, or fall back to session's default isolation level
- Added `isolation_level` column to `SHOW QUERIES` output
- Updated `crdb_internal.node_sessions` and `cluster_sessions` table schemas to
  include `isolation_level` column
- Updated `populateSessionsTable` to populate isolation level from session's
  active transaction, or fall back to session's default isolation level
- Added `isolation_level` column to `SHOW SESSIONS` output
- Added `default_isolation_level` field to `Session` protobuf message
- Modified session serialization to include the session's default isolation
  level

The isolation level now displays the session's default isolation level when
there is no active transaction, instead of NULL. This provides more useful
information to users about the transaction isolation level that would be used
for new transactions.

Fixes https://github.com/cockroachdb/cockroach/issues/150779

Release note (sql change): SQL observability commands `SHOW TRANSACTIONS`,
`SHOW QUERIES`, and `SHOW SESSIONS` now include an `isolation_level` column showing
the isolation level of the active transaction, or the session's default
isolation level when there is no active transaction.