### PR TITLE
storage: add cluster setting to use old compaction eligibility

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -198,6 +198,22 @@ var UnhealthyWriteDuration = settings.RegisterDurationSetting(
 	20*time.Second,
 	settings.WithPublic)
 
+// useDeprecatedCompensatedScore is a temporary setting that provides a
+// mechanism for reverting Pebble's compaction picking heuristic to the previous
+// (25.3 and earlier) behavior for deciding when a level is eligible for
+// compaction. See the pebble.Options Experimental UseDeprecatedCompensatedScore
+// setting for details.
+//
+// We anticipate not needing to use this setting, but it's provided as an escape
+// hatch in case the heuristic change has an unforeseen impact on some
+// workloads.
+var useDeprecatedCompensatedScore = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"storage.deprecated_compensated_score.enabled",
+	"if enabled, this setting reverts the storage engine's compaction picking heuristic",
+	false,
+)
+
 // SSTableCompressionProfile is an enumeration of compression algorithms
 // available for compressing SSTables (e.g. for backup or transport).
 type SSTableCompressionProfile int64
@@ -945,6 +961,11 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	}
 	cfg.opts.TargetByteDeletionRate = func() int {
 		return int(baselineDeletionRate.Get(&cfg.settings.SV))
+	}
+	if cfg.opts.Experimental.UseDeprecatedCompensatedScore == nil {
+		cfg.opts.Experimental.UseDeprecatedCompensatedScore = func() bool {
+			return useDeprecatedCompensatedScore.Get(&cfg.settings.SV)
+		}
 	}
 
 	cfg.opts.EnsureDefaults()


### PR DESCRIPTION
In cockroachdb/pebble#5187 we altered the default compaction picking logic that determines whether a level is elgible for a default compaction. We added a knob to allow the configuration of this value at runtime in case the change has some unforeseen impact on some workloads. This commit connects this knob to a new cluster setting. This cluster setting is just an escape hatch that we don't anticipate needing.

Epic: none
Release note: none