### PR TITLE
storage: fix pebble benchmarks

### DIFF
--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -107,6 +107,11 @@ func getInitialStateEngine(
 	require.NoError(b, err)
 	require.True(b, ok)
 
+	// Validate and set the minversion for the env after copy.
+	settings := cluster.MakeClusterSettings()
+	env.StoreClusterVersion, err = fs.ValidateMinVersionFile(env.UnencryptedFS, env.Dir, settings.Version)
+	require.NoError(b, err)
+
 	if !inMemory {
 		// Load all the files into the OS buffer cache for better determinism.
 		testutils.ReadAllFiles(filepath.Join(env.Dir, "*"))


### PR DESCRIPTION
Some benchmarks copy over initial fs state, which includes the min version file,
 after fs/env initialization. Make sure to set and validate the store cluster
version after the copy.

Epic: none

Release note: None