### PR TITLE
jobs: mark a few auto partial stats metrics as essential

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -330,6 +330,39 @@ layers:
       essential: true
   - name: SQL
     metrics:
+    - name: jobs.auto_create_partial_stats.currently_paused
+      exported_name: jobs_auto_create_partial_stats_currently_paused
+      labeled_name: 'jobs{name: auto_create_partial_stats, status: currently_paused}'
+      description: Number of auto_create_partial_stats jobs currently considered Paused
+      y_axis_label: jobs
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This metric is a high-level indicator that automatically generated partial statistics jobs are paused which can lead to the query optimizer running with stale statistics. Stale statistics can cause suboptimal query plans to be selected leading to poor query performance.
+      essential: true
+    - name: jobs.auto_create_partial_stats.currently_running
+      exported_name: jobs_auto_create_partial_stats_currently_running
+      labeled_name: 'jobs{type: auto_create_partial_stats, status: currently_running}'
+      description: Number of auto_create_partial_stats jobs currently running in Resume or OnFailOrCancel state
+      y_axis_label: jobs
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: This metric tracks the number of active automatically generated partial statistics jobs that could also be consuming resources. Ensure that foreground SQL traffic is not impacted by correlating this metric with SQL latency and query volume metrics.
+      essential: true
+    - name: jobs.auto_create_partial_stats.resume_failed
+      exported_name: jobs_auto_create_partial_stats_resume_failed
+      labeled_name: 'jobs.resume{name: auto_create_partial_stats, status: failed}'
+      description: Number of auto_create_partial_stats jobs which failed with a non-retriable error
+      y_axis_label: jobs
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This metric is a high-level indicator that automatically generated partial table statistics is failing. Failed statistic creation can lead to the query optimizer running with stale statistics. Stale statistics can cause suboptimal query plans to be selected leading to poor query performance.
+      essential: true
     - name: jobs.auto_create_stats.currently_paused
       exported_name: jobs_auto_create_stats_currently_paused
       labeled_name: 'jobs{name: auto_create_stats, status: currently_paused}'
@@ -394,7 +427,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
-      how_to_use: This metric tracks the number of active create statistics jobs that may be consuming resources. Ensure that foreground SQL traffic is not impacted by correlating this metric with SQL latency and query volume metrics.
+      how_to_use: This metric tracks the number of active create statistics jobs that could also be consuming resources. Ensure that foreground SQL traffic is not impacted by correlating this metric with SQL latency and query volume metrics.
       essential: true
     - name: schedules.BACKUP.failed
       exported_name: schedules_BACKUP_failed
@@ -4055,24 +4088,6 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
-    - name: jobs.auto_create_partial_stats.currently_paused
-      exported_name: jobs_auto_create_partial_stats_currently_paused
-      labeled_name: 'jobs{name: auto_create_partial_stats, status: currently_paused}'
-      description: Number of auto_create_partial_stats jobs currently considered Paused
-      y_axis_label: jobs
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: jobs.auto_create_partial_stats.currently_running
-      exported_name: jobs_auto_create_partial_stats_currently_running
-      labeled_name: 'jobs{type: auto_create_partial_stats, status: currently_running}'
-      description: Number of auto_create_partial_stats jobs currently running in Resume or OnFailOrCancel state
-      y_axis_label: jobs
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
     - name: jobs.auto_create_partial_stats.expired_pts_records
       exported_name: jobs_auto_create_partial_stats_expired_pts_records
       labeled_name: 'jobs.expired_pts_records{type: auto_create_partial_stats}'
@@ -4131,15 +4146,6 @@ layers:
       exported_name: jobs_auto_create_partial_stats_resume_completed
       labeled_name: 'jobs.resume{name: auto_create_partial_stats, status: completed}'
       description: Number of auto_create_partial_stats jobs which successfully resumed to completion
-      y_axis_label: jobs
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: jobs.auto_create_partial_stats.resume_failed
-      exported_name: jobs_auto_create_partial_stats_resume_failed
-      labeled_name: 'jobs.resume{name: auto_create_partial_stats, status: failed}'
-      description: Number of auto_create_partial_stats jobs which failed with a non-retriable error
       y_axis_label: jobs
       type: COUNTER
       unit: COUNT

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -97,14 +97,18 @@ func makeMetaCurrentlyRunning(jt jobspb.Type) metric.Metadata {
 	}
 
 	switch jt {
-	case jobspb.TypeAutoCreateStats:
+	case jobspb.TypeCreateStats, jobspb.TypeAutoCreateStats, jobspb.TypeAutoCreatePartialStats:
 		m.Essential = true
 		m.Category = metric.Metadata_SQL
-		m.HowToUse = `This metric tracks the number of active automatically generated statistics jobs that could also be consuming resources. Ensure that foreground SQL traffic is not impacted by correlating this metric with SQL latency and query volume metrics.`
-	case jobspb.TypeCreateStats:
-		m.Essential = true
-		m.Category = metric.Metadata_SQL
-		m.HowToUse = `This metric tracks the number of active create statistics jobs that may be consuming resources. Ensure that foreground SQL traffic is not impacted by correlating this metric with SQL latency and query volume metrics.`
+		var detail string
+		if jt == jobspb.TypeCreateStats {
+			detail = "create"
+		} else if jt == jobspb.TypeAutoCreateStats {
+			detail = "automatically generated"
+		} else {
+			detail = "automatically generated partial"
+		}
+		m.HowToUse = fmt.Sprintf(`This metric tracks the number of active %s statistics jobs that could also be consuming resources. Ensure that foreground SQL traffic is not impacted by correlating this metric with SQL latency and query volume metrics.`, detail)
 	case jobspb.TypeBackup:
 		m.Essential = true
 		m.Category = metric.Metadata_SQL
@@ -151,10 +155,14 @@ func makeMetaCurrentlyPaused(jt jobspb.Type) metric.Metadata {
 		),
 	}
 	switch jt {
-	case jobspb.TypeAutoCreateStats:
+	case jobspb.TypeAutoCreateStats, jobspb.TypeAutoCreatePartialStats:
 		m.Essential = true
 		m.Category = metric.Metadata_SQL
-		m.HowToUse = `This metric is a high-level indicator that automatically generated statistics jobs are paused which can lead to the query optimizer running with stale statistics. Stale statistics can cause suboptimal query plans to be selected leading to poor query performance.`
+		var partialDetail string
+		if jt == jobspb.TypeAutoCreatePartialStats {
+			partialDetail = "partial "
+		}
+		m.HowToUse = fmt.Sprintf(`This metric is a high-level indicator that automatically generated %sstatistics jobs are paused which can lead to the query optimizer running with stale statistics. Stale statistics can cause suboptimal query plans to be selected leading to poor query performance.`, partialDetail)
 	case jobspb.TypeBackup:
 		m.Essential = true
 		m.Category = metric.Metadata_SQL
@@ -230,10 +238,14 @@ func makeMetaResumeFailed(jt jobspb.Type) metric.Metadata {
 	}
 
 	switch jt {
-	case jobspb.TypeAutoCreateStats:
+	case jobspb.TypeAutoCreateStats, jobspb.TypeAutoCreatePartialStats:
 		m.Essential = true
 		m.Category = metric.Metadata_SQL
-		m.HowToUse = `This metric is a high-level indicator that automatically generated table statistics is failing. Failed statistic creation can lead to the query optimizer running with stale statistics. Stale statistics can cause suboptimal query plans to be selected leading to poor query performance.`
+		var partialDetail string
+		if jt == jobspb.TypeAutoCreatePartialStats {
+			partialDetail = "partial "
+		}
+		m.HowToUse = fmt.Sprintf(`This metric is a high-level indicator that automatically generated %stable statistics is failing. Failed statistic creation can lead to the query optimizer running with stale statistics. Stale statistics can cause suboptimal query plans to be selected leading to poor query performance.`, partialDetail)
 	case jobspb.TypeRowLevelTTL:
 		m.Essential = true
 		m.Category = metric.Metadata_TTL

--- a/pkg/sql/mem_metrics.go
+++ b/pkg/sql/mem_metrics.go
@@ -87,7 +87,7 @@ func MakeBaseMemMetrics(endpoint string, histogramWindow time.Duration) BaseMemo
 	MetaMemMaxBytes := makeMemMetricMetadata(prefix+".max", "Memory usage per sql statement for "+endpoint)
 	MetaMemCurBytes := makeMemMetricMetadata(prefix+".current", "Current sql statement memory usage for "+endpoint)
 
-	// Add Essential flag and category if this is the 'root' endpoint
+	// Add Essential flag and category if this is the 'root' endpoint.
 	if endpoint == "root" {
 		MetaMemCurBytes.Essential = true
 		MetaMemCurBytes.Category = metric.Metadata_SQL


### PR DESCRIPTION
In order to match which metrics we mark as "essential" for AUTO CREATE STATS jobs, we now mark the following AUTO CREATE PARTIAL STATS job metrics:
- `jobs.auto_create_partial_stats.currently_paused`
- `jobs.auto_create_partial_stats.currently_running`
- `jobs.auto_create_partial_stats.resume_failed`.

Epic: CRDB-52656
Release note: None