### PR TITLE
sql: prohibit CITEXT as column type in 25.2-25.3 mixed version state

### DIFF
--- a/pkg/sql/catalog/colinfo/BUILD.bazel
+++ b/pkg/sql/catalog/colinfo/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/oidext",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catconstants",

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_citext
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_citext
@@ -1,0 +1,49 @@
+# LogicTest: cockroach-go-testserver-25.2
+
+# Sanity check that CITEXT type is only allowed to be used once the cluster is
+# upgraded to 25.3.
+
+statement error pgcode 42704 type \"citext\" does not exist
+CREATE TABLE c (c CITEXT);
+
+statement error pgcode 42704 type \"citext\" does not exist
+CREATE TABLE ca (ca CITEXT[]);
+
+statement error pgcode 42704 type \"citext\" does not exist
+SELECT 'A'::CITEXT
+
+statement error pgcode 42704 type \"citext\" does not exist
+SELECT ARRAY['A', 'B']::CITEXT[]
+
+upgrade 0
+
+statement error pgcode 0A000 citext not supported until version 25.3
+CREATE TABLE c (c CITEXT);
+
+statement error pgcode 0A000 citext not supported until version 25.3
+CREATE TABLE ca (ca CITEXT[]);
+
+statement error pgcode 0A000 citext not supported until version 25.3
+SELECT 'A'::CITEXT
+
+statement error pgcode 0A000 citext\[\] not supported until version 25.3
+SELECT ARRAY['A', 'B']::CITEXT[]
+
+upgrade 1
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+statement ok
+CREATE TABLE c (c CITEXT);
+
+statement ok
+CREATE TABLE ca (ca CITEXT[]);
+
+statement ok
+SELECT 'A'::CITEXT
+
+statement ok
+SELECT ARRAY['A', 'B']::CITEXT[]

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 9,
+    shard_count = 10,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
@@ -94,6 +94,13 @@ func TestLogic_mixed_version_can_login(
 	runLogicTest(t, "mixed_version_can_login")
 }
 
+func TestLogic_mixed_version_citext(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_citext")
+}
+
 func TestLogic_mixed_version_ltree(
 	t *testing.T,
 ) {

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",
+        "//pkg/sql/oidext",
         "//pkg/sql/parser",
         "//pkg/sql/physicalplan",
         "//pkg/sql/randgen",

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -689,11 +690,24 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 	collatedStringType := types.MakeCollatedString(types.String, "en" /* locale */)
 	var indexableTyps []*types.T
 	for _, typ := range append(types.Scalar, collatedStringType) {
+		if !colinfo.ColumnTypeIsIndexable(typ) {
+			continue
+		}
+		switch typ.Family() {
+		case types.DateFamily:
 		// TODO(#76419): DateFamily has a broken `-infinity` case.
-		// TODO(#99432): JsonFamily has broken cases. This is because the test is wrapping JSON
-		//   objects in multiple single quotes which causes parsing errors.
-		if colinfo.ColumnTypeIsIndexable(typ) && typ.Family() != types.DateFamily &&
-			typ.Family() != types.JsonFamily {
+		case types.JsonFamily:
+		// TODO(#99432): JsonFamily has broken cases. This is because the
+		// test is wrapping JSON objects in multiple single quotes which
+		// causes parsing errors.
+		case types.CollatedStringFamily:
+			if typ.Oid() != oidext.T_citext && typ.Oid() != oidext.T__citext {
+				// TODO(foundations): CITEXT should only be prohibited when
+				// running with mixed 25.2 version where the type is not
+				// supported.
+				indexableTyps = append(indexableTyps, typ)
+			}
+		default:
 			indexableTyps = append(indexableTyps, typ)
 		}
 	}


### PR DESCRIPTION
This commit fixes an oversight from fd50f230e593a2d952ba40de8d0c2a673f6aa99e where we forgot to prohibit usage of (new in 25.3) CITEXT type as a column type. The impact should be minor since this type is simply implemented as collated string with fixed locale, yet it seems prudent to disable the type's usage until 25.3 version is finalized.

Epic: None
Release note: None