### PR TITLE
sql/importer: fix duplicated row count and lost update for progress

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -109,6 +109,7 @@ FROM system.jobs AS j
 INNER JOIN latestpayload AS payload ON j.id = payload.job_id
 LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
 WHERE id = $1
+FOR UPDATE
 `
 	row, err := u.txn.QueryRowEx(
 		ctx, "select-job", u.txn.KV(),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4226,7 +4226,7 @@ func (ex *connExecutor) waitForTxnJobs() error {
 	if !queryTimedout.Load() && len(ex.extraTxnState.jobs.created) > 0 {
 		if err := ex.server.cfg.JobRegistry.WaitForJobs(jobWaitCtx,
 			ex.extraTxnState.jobs.created); err != nil {
-			if errors.Is(err, context.Canceled) && queryTimedout.Load() {
+			if (errors.Is(err, context.Canceled) || errors.Is(err, cancelchecker.QueryCanceledError)) && queryTimedout.Load() {
 				retErr = sqlerrors.QueryTimeoutError
 				err = nil
 			} else {

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -123,12 +123,13 @@ func distImport(
 	// accumulatedBulkSummary accumulates the BulkOpSummary returned from each
 	// processor in their progress updates. It stores stats about the amount of
 	// data written since the last time we update the job progress.
+	// TODO(janexing): update comments.
 	accumulatedBulkSummary := struct {
 		syncutil.Mutex
 		kvpb.BulkOpSummary
 	}{}
 	accumulatedBulkSummary.Lock()
-	accumulatedBulkSummary.BulkOpSummary = getLastImportSummary(job)
+	accumulatedBulkSummary.BulkOpSummary = kvpb.BulkOpSummary{}
 	accumulatedBulkSummary.Unlock()
 
 	importDetails := job.Progress().Details.(*jobspb.Progress_Import).Import
@@ -282,12 +283,6 @@ func distImport(
 	}
 
 	return res, nil
-}
-
-func getLastImportSummary(job *jobs.Job) kvpb.BulkOpSummary {
-	progress := job.Progress()
-	importProgress := progress.GetImport()
-	return importProgress.Summary
 }
 
 func makeImportReaderSpecs(


### PR DESCRIPTION
## sql/importer: initialize bulk summary with empty state to prevent duplication

Fixes https://github.com/cockroachdb/cockroach/issues/152543

Previously, the accumulated bulk summary was initialized using `getLastImportSummary(job)`, which could carry over stats from previous import attempts (i.e. resuming the same import job). This caused duplication of bulk operation statistics across different attempts of the same import statement execution.

Now initialize `accumulatedBulkSummary` with an empty `kvpb.BulkOpSummary{}` to ensure each import attempt starts with a clean state and prevents duplicate entry counts in the job progress summary.

Release note (bug fix): deduplicate import job bulk op summaries in case of import retries.

----

## jobs: add SELECT FOR UPDATE to prevent race conditions in job updates

Fixes https://github.com/cockroachdb/cockroach/issues/152519

Previously, concurrent job updates (e.g., progress updates and pause/cancel requests) could result in lost updates due to
read-then-write race conditions. Both operations would SELECT job data, modify it in memory, then UPDATE back to the database using separate transactions, causing the later transaction to overwrite changes from the earlier one.

This was particularly problematic for import jobs where: 
1. A progress update routine periodically updates job progress every 10 seconds;
2. Pause/cancel requests can occur concurrently during job execution. 
Both use `job.NoTxn()` which creates independent transactions that can interfere.

An example timeline would be:

```
-- Transaction 1 (Progress)        -- Transaction 2 (Pause)
BEGIN;
SELECT progress WHERE job_id=123;
-- reads ResumePos[0] = 10
                                   BEGIN;
                                   SELECT progress WHERE job_id=123;
                                   -- reads ResumePos[0] = 10
UPDATE progress
SET ResumePos[0] = 20
WHERE job_id=123;
COMMIT;
                                   UPDATE jobs
                                   SET status='pause', progress=old_progress
                                   WHERE job_id=123;
                                   -- overwrites with ResumePos[0] = 10
                                   COMMIT;

-- Result: Progress update (20) LOST!
```

The race condition was reproducible by stress testing `TestImportDefaultWithResume`.

This commit fixes it by changing the job selection query to a `SELECT FOR UPDATE` statement in Updater.update(), ensuring that concurrent transactions serialize access to job records. While this introduces some performance overhead due to row-level locking, it prevents silent data corruption and ensures job progress accuracy.

Release notes (bug fix): change job selection query to a SELECT FOR UPDATE statementin Updater.update(), ensuring that concurrent transactions serialize access to job records. While this introduces some performance overhead due to row-level locking, it prevents silent data corruption and ensures job progress accuracy.