### PR TITLE
lookup join: add a cast when mapping references in computed columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1708,8 +1708,10 @@ SELECT col1_6 FROM table_1_124732 INNER HASH JOIN table_3_124732 ON col3_0 = col
 ----
 -
 
-statement error pgcode XXUUU pq: could not produce a query plan conforming to the LOOKUP JOIN hint
+query T
 SELECT col1_6 FROM table_1_124732 INNER LOOKUP JOIN table_3_124732 ON col3_0 = col1_6;
+----
+-
 
 # Regression test for incorrectly remapping columns in a composite-sensitive
 # expression to produce a lookup join (#124732).

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -175,7 +175,11 @@ lookup expression:
 lookup-constraints left=(a regclass, b int) right=(x oid, v string not null as (x::string) stored) index=(v, x)
 x = a
 ----
-lookup join not possible
+key cols:
+  v = v_eq
+  x = a
+input projections:
+  v_eq = a::OID::STRING [type=STRING]
 
 # Computed columns cannot be remapped if the expression is composite-sensitive.
 lookup-constraints left=(a decimal, b int) right=(x decimal, v int not null as (x::int) stored) index=(v, x)


### PR DESCRIPTION
Previously, when using a lookup join on an index with a virtual column,
we would require the references inside that virtual column to be typed
identically on the left and right side. This was a change from our
previous behavior, which was to require they be equivalent, but not
identical. This tightening of the requirements was done to address issue
124732, which pertains to virtual columns using functions that are
senstive to the actual type of the input (e.g. 'pg_typeof').

By tightening the reference requirement, we excluded a set of queries
from using lookup joins that had previously been able to do so safely,
regressing their performance.

In this patch, we add a cast around the left hand side reference to the
right hand side's type, so that type sensitive functions return the
correct type. This allows us to go back to the old behavior of allowing
the types of these references to be equivalent rather than identical.

Fixes: https://github.com/cockroachdb/cockroach/issues/124732
Release note (performance improvement): Lookup joins can now be used on
tables with virtual columns even if the type of the search argument is
not identical to the column type referenced in the virtual column.