### PR TITLE
changefeedccl: fix roachtest using too much memory

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2907,7 +2907,7 @@ func registerCDC(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			params := multiTablePTSBenchmarkParams{
 				numTables: 500,
-				numRows:   10_000,
+				numRows:   100,
 				duration:  "20m",
 			}
 			runCDCMultiTablePTSBenchmark(ctx, t, c, params)


### PR DESCRIPTION
This roachtest would fail on workload initialization with an error like: ```Error: importing fixture: importing table <table_name>: pq: not enough memory available ...```

We decrease the number of rows per table to decrease memory usage since it should not effect the effectiveness of the test.

Epic: none
Fixes: #151009

Release note: None