### PR TITLE
storage: use slices, maps packages

### DIFF
--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -13,7 +13,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -2421,14 +2421,14 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		sort.Slice(kvPairs, func(i, j int) bool {
-			cmp := EngineComparer.Compare(kvPairs[i].key, kvPairs[j].key)
-			if cmp == 0 {
+		slices.SortFunc(kvPairs, func(i, j kvPair) int {
+			v := EngineComparer.Compare(i.key, j.key)
+			if v == 0 {
 				// Should not happen since we resolve in a different batch from the
 				// one where we wrote the intent.
-				b.Fatalf("found equal user keys in same batch")
+				b.Fatal("found equal user keys in same batch")
 			}
-			return cmp < 0
+			return v
 		})
 		sstFileName := fmt.Sprintf("tmp-ingest-%d", i)
 		sstFile, err := eng.Env().Create(sstFileName, fs.UnspecifiedWriteCategory)

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -763,7 +763,7 @@ func TestEngineScan1(t *testing.T) {
 	for i, t := range testCases {
 		sortedKeys[i] = string(t.key.Key)
 	}
-	sort.Strings(sortedKeys)
+	slices.Sort(sortedKeys)
 
 	keyvals, err := Scan(context.Background(), engine, roachpb.Key("chinese"), roachpb.Key("german"), 0)
 	if err != nil {
@@ -1311,7 +1311,7 @@ func TestEngineFS(t *testing.T) {
 			if err != nil {
 				break
 			}
-			sort.Strings(result)
+			slices.Sort(result)
 			got := strings.Join(result, ",")
 			want := s[3]
 			if got != want {
@@ -1460,7 +1460,7 @@ func TestFS(t *testing.T) {
 				t.Helper()
 
 				got, err := e.List(dir)
-				sort.Strings(got)
+				slices.Sort(got)
 				require.NoError(t, err)
 				if !reflect.DeepEqual(got, want) {
 					t.Fatalf("e.List(%q) = %#v, want %#v", dir, got, want)
@@ -1610,7 +1610,7 @@ func TestScanLocks(t *testing.T) {
 	for k := range locks {
 		keys = append(keys, roachpb.Key(k))
 	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+	slices.SortFunc(keys, roachpb.Key.Compare)
 
 	testcases := map[string]struct {
 		from        roachpb.Key

--- a/pkg/storage/fs/file_registry.go
+++ b/pkg/storage/fs/file_registry.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -191,9 +192,7 @@ func (r *FileRegistry) Load(ctx context.Context) error {
 				obsoleteFiles = append(obsoleteFiles, fileNum)
 			}
 		}
-		sort.Slice(obsoleteFiles, func(i, j int) bool {
-			return obsoleteFiles[i] < obsoleteFiles[j]
-		})
+		slices.Sort(obsoleteFiles)
 		r.writeMu.obsoleteRegistryFiles = make([]string, 0, r.NumOldRegistryFiles+1)
 		for _, f := range obsoleteFiles {
 			r.writeMu.obsoleteRegistryFiles = append(r.writeMu.obsoleteRegistryFiles, makeRegistryFilename(f))
@@ -306,11 +305,7 @@ func (r *FileRegistry) maybeElideEntries(ctx context.Context) error {
 	// recursively List each directory and walk two lists of sorted
 	// filenames. We should test a store with many files to see how much
 	// the current approach slows node start.
-	filenames := make([]string, 0, len(r.writeMu.mu.entries))
-	for filename := range r.writeMu.mu.entries {
-		filenames = append(filenames, filename)
-	}
-	sort.Strings(filenames)
+	filenames := slices.Sorted(maps.Keys(r.writeMu.mu.entries))
 
 	batch := &enginepb.RegistryUpdateBatch{}
 	for _, filename := range filenames {

--- a/pkg/storage/fs/file_registry_test.go
+++ b/pkg/storage/fs/file_registry_test.go
@@ -7,11 +7,12 @@ package fs
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -392,8 +393,8 @@ func TestFileRegistry(t *testing.T) {
 					entry: entry,
 				})
 			}
-			sort.Slice(fileEntries, func(i, j int) bool {
-				return fileEntries[i].name < fileEntries[j].name
+			slices.SortFunc(fileEntries, func(a, b fileEntry) int {
+				return cmp.Compare(a.name, b.name)
 			})
 			var b bytes.Buffer
 			for _, fe := range fileEntries {

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -7,11 +7,12 @@ package storage
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"flag"
 	"fmt"
 	"math/rand"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -555,15 +556,8 @@ func generateRandomData(
 			timestamps = append(timestamps, rng.Intn(1<<20)+1)
 		}
 		// Sort in descending order and make unique.
-		sort.Sort(sort.Reverse(sort.IntSlice(timestamps)))
-		last := 0
-		for j := 1; j < len(timestamps); j++ {
-			if timestamps[j] != timestamps[last] {
-				last++
-				timestamps[last] = timestamps[j]
-			}
-		}
-		timestamps = timestamps[:last+1]
+		slices.SortFunc(timestamps, func(a, b int) int { return cmp.Compare(b, a) })
+		timestamps = slices.Compact(timestamps)
 		for i, ts := range timestamps {
 			// Intent.
 			meta := enginepb.MVCCMetadata{

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	"math"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -6335,10 +6335,10 @@ func MVCCGarbageCollect(
 
 	// Sort the slice to both determine the bounds and ensure that we're seeking
 	// in increasing order.
-	sort.Slice(keys, func(i, j int) bool {
-		iKey := MVCCKey{Key: keys[i].Key, Timestamp: keys[i].Timestamp}
-		jKey := MVCCKey{Key: keys[j].Key, Timestamp: keys[j].Timestamp}
-		return iKey.Less(jKey)
+	slices.SortFunc(keys, func(a, b kvpb.GCRequest_GCKey) int {
+		aKey := MVCCKey{Key: a.Key, Timestamp: a.Timestamp}
+		bKey := MVCCKey{Key: b.Key, Timestamp: b.Timestamp}
+		return aKey.Compare(bKey)
 	})
 
 	// Bound the iterator appropriately for the set of keys we'll be garbage
@@ -6649,8 +6649,8 @@ func MVCCGarbageCollectRangeKeys(
 		}
 	}
 
-	sort.Slice(rks, func(i, j int) bool {
-		return rks[i].Compare(rks[j].MVCCRangeKey) < 0
+	slices.SortFunc(rks, func(i, j CollectableGCRangeKey) int {
+		return i.MVCCRangeKey.Compare(j.MVCCRangeKey)
 	})
 
 	// Validate that keys are non-overlapping.

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -9,8 +9,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -301,12 +303,7 @@ func TestMVCCHistories(t *testing.T) {
 
 			// Unreplicated locks.
 			if len(e.unreplLocks) > 0 {
-				var ks []string
-				for k := range e.unreplLocks {
-					ks = append(ks, k)
-				}
-				sort.Strings(ks)
-				for _, k := range ks {
+				for _, k := range slices.Sorted(maps.Keys(e.unreplLocks)) {
 					info := e.unreplLocks[k]
 					buf.Printf("lock (%s): %v/%s -> %+v\n",
 						lock.Unreplicated, k, info.str, info.txn)

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -12,7 +12,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
-	"sort"
+	"slices"
 	"testing"
 	"testing/quick"
 
@@ -57,7 +57,7 @@ func TestMVCCKeys(t *testing.T) {
 	sortKeys := make(mvccKeys, len(keys))
 	copy(sortKeys, keys)
 	shuffle.Shuffle(sortKeys)
-	sort.Sort(sortKeys)
+	slices.SortFunc(sortKeys, MVCCKey.Compare)
 	if !reflect.DeepEqual(sortKeys, keys) {
 		t.Errorf("expected keys to sort in order %s, but got %s", keys, sortKeys)
 	}
@@ -978,8 +978,8 @@ func BenchmarkMVCCRangeKeyStack_Clone(b *testing.B) {
 			}
 			stack.Versions = append(stack.Versions, version)
 		}
-		sort.Slice(stack.Versions, func(i, j int) bool {
-			return stack.Versions[i].Timestamp.Less(stack.Versions[j].Timestamp)
+		slices.SortFunc(stack.Versions, func(i, j MVCCRangeKeyVersion) int {
+			return i.Timestamp.Compare(j.Timestamp)
 		})
 		return stack
 	}
@@ -1082,7 +1082,7 @@ func rangeKeyVersions(v map[int]MVCCValue) MVCCRangeKeyVersions {
 	for i := range v {
 		timestamps = append(timestamps, i)
 	}
-	sort.Ints(timestamps)
+	slices.Sort(timestamps)
 	for i, ts := range timestamps {
 		versions[len(versions)-1-i] = rangeKeyVersion(ts, v[ts])
 	}

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -8,8 +8,9 @@ package storage
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -1845,10 +1846,7 @@ func (s *randomTest) step(t *testing.T) {
 	s.cycle++
 
 	if s.actionNames == nil {
-		for name := range s.actions {
-			s.actionNames = append(s.actionNames, name)
-		}
-		sort.Strings(s.actionNames)
+		s.actionNames = slices.Sorted(maps.Keys(s.actions))
 	}
 	actName := s.actionNames[s.rng.Intn(len(s.actionNames))]
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -13,7 +13,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -2325,7 +2325,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 		reverts[i] = rand.Intn(randTimeRange)
 	}
 	reverts[0] = swathTime - 1
-	sort.Ints(reverts)
+	slices.Sort(reverts)
 	const byteLimit = 1000
 	const keyLimit = 100
 	const clearRangeThreshold = 64
@@ -3906,8 +3906,8 @@ func TestRandomizedMVCCResolveWriteIntentRange(t *testing.T) {
 		}
 		puts = append(puts, put)
 	}
-	sort.Slice(puts, func(i, j int) bool {
-		return puts[i].key.Compare(puts[j].key) < 0
+	slices.SortFunc(puts, func(i, j putState) int {
+		return i.key.Compare(j.key)
 	})
 	// Do the puts to the engines.
 	for i := range engs {
@@ -4028,8 +4028,8 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 		}
 		puts = append(puts, put)
 	}
-	sort.Slice(puts, func(i, j int) bool {
-		return puts[i].key.Compare(puts[j].key) < 0
+	slices.SortFunc(puts, func(i, j putState) int {
+		return i.key.Compare(j.key)
 	})
 	txn := *txn1
 	txn.ReadTimestamp = timestamps[0]


### PR DESCRIPTION
This commit replaces some of usages of the sort package with uses of slices.{Sort,SortFunc,Sorted}, where doing so makes sense. As of Go 1.21, the docs on sort.Slice say:

> Note: in many situations, the newer slices.SortFunc function is
> more ergonomic and runs faster.

Epic: none
Release note: none