### PR TITLE
changefeedccl: protect system tables with their own pts record 

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -281,6 +281,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
+        "//pkg/kv/kvserver/protectedts/ptutil",
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",

--- a/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
@@ -9,11 +9,20 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcp
 
 import "gogoproto/gogo.proto";
 
-// ProtectedTimestampRecords is a map from table descriptor IDs to protected timestamp record IDs.
+// ProtectedTimestampRecords contains the IDs of protected timestamps records
+// for a changefeed.
 message ProtectedTimestampRecords {
-  map<uint32, bytes> protected_timestamp_records = 1 [
+  // UserTables is a map from the ID of a user table to the protected timestamp
+  // record that protects it.
+  map<uint32, bytes> user_tables = 1 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID",
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
     (gogoproto.nullable) = false
+  ];
+  // SystemTables is the ID of PTS record that protects the system tables
+  // back to the changefeed's highwater.
+  bytes system_tables = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
   ];
 }

--- a/pkg/ccl/changefeedccl/changefeed_job_info_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_job_info_test.go
@@ -35,7 +35,7 @@ func TestChangefeedJobInfoRoundTrip(t *testing.T) {
 	uuid1 := uuid.MakeV4()
 	uuid2 := uuid.MakeV4()
 	ptsRecords := cdcprogresspb.ProtectedTimestampRecords{
-		ProtectedTimestampRecords: map[descpb.ID]uuid.UUID{
+		UserTables: map[descpb.ID]uuid.UUID{
 			descpb.ID(100): uuid1,
 			descpb.ID(200): uuid2,
 		},

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -12103,6 +12103,9 @@ func TestChangefeedAvroDecimalColumnWithDiff(t *testing.T) {
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
 }
 
+// TestChangefeedProtectedTimestampUpdate tests that a changefeed will update
+// its protected timestamp record when the high watermark advances and update
+// the related metrics.
 func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -12177,7 +12180,7 @@ WITH resolved='10ms', min_checkpoint_frequency='10ms', no_initial_scan`
 				); err != nil {
 					return err
 				}
-				ptsRecordID := ptsEntries.ProtectedTimestampRecords[descpb.ID(tableID)]
+				ptsRecordID := ptsEntries.UserTables[descpb.ID(tableID)]
 				ts = getTimestampFromPTSRecord(ptsRecordID)
 				return nil
 			})

--- a/pkg/kv/kvserver/protectedts/ptutil/testutils.go
+++ b/pkg/kv/kvserver/protectedts/ptutil/testutils.go
@@ -66,3 +66,14 @@ func GetPTSTarget(t *testing.T, db *sqlutils.SQLRunner, ptsID *uuid.UUID) *ptpb.
 	}
 	return ret
 }
+
+func GetPTSTimestamp(t *testing.T, db *sqlutils.SQLRunner, ptsRecordID uuid.UUID) hlc.Timestamp {
+	var tsStr string
+	tsQuery := `SELECT ts FROM system.protected_ts_records WHERE id = $1`
+	db.QueryRow(t, tsQuery, ptsRecordID).Scan(&tsStr)
+	ts, err := hlc.ParseHLC(tsStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
+}


### PR DESCRIPTION
Previously, we were relying on each pts record that protects
a user table to also protect system tables. This would mean
that we'd protect the system tables once for each table.

Now, we have a dedicated pts record for system tables that
protects back to the highwater and do not include the system
table protections in the table specific records. We only
protect the system tables once.

Fixes: #152446
Epic: CRDB-1421

Release note: None