### PR TITLE
kvserver: estimate AddSStable stats if ComputeStatsDiff assuptions violated

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1987,6 +1987,7 @@ func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
 		`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
+		`SET CLUSTER SETTING bulkio.ingest.compute_stats_diff_in_stream_batcher.enabled = true;`,
 	)
 
 	if additionalDuration != 0 {

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -70,7 +70,7 @@ var (
 		settings.ApplicationLevel,
 		"bulkio.ingest.compute_stats_diff_in_stream_batcher.enabled",
 		"if set, kvserver will compute an accurate stats diff for every addsstable request",
-		metamorphic.ConstantWithTestBool("computeStatsDiffInStreamBatcher", true),
+		metamorphic.ConstantWithTestBool("computeStatsDiffInStreamBatcher", false),
 	)
 
 	sstBatcherElasticCPUControlEnabled = settings.RegisterBoolSetting(

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -474,12 +474,11 @@ func computeSSTStatsDiffWithFallback(
 ) (enginepb.MVCCStats, error) {
 	stats, err := storage.ComputeSSTStatsDiff(
 		ctx, sst, readWriter, nowNanos, start, end)
-	if errors.Is(err, storage.ComputeSSTStatsDiffReaderHasRangeKeys) {
-		// Fall back to stats estimates if there are range keys in the engine.
-		log.VEventf(ctx, 2, "computing SST stats as estimates after detecting range keys in engine")
+	if errors.IsAny(err, storage.ComputeSSTStatsDiffReaderHasRangeKeys, storage.ComputeStatsDiffViolation) {
+		log.Warningf(ctx, "computing SST stats as estimates because of ComputeSSTStatsDiff error: %s", err)
 		sstStats, err := computeSSTStats(ctx, sst, nowNanos)
 		if err != nil {
-			return enginepb.MVCCStats{}, errors.Wrap(err, "computing SST stats after detecting range keys in engine")
+			return enginepb.MVCCStats{}, errors.Wrap(err, "error computing SST stats during fallback")
 		}
 		sstStats.ContainsEstimates = 1
 		return sstStats, nil


### PR DESCRIPTION
Previously the request would fail-- now we internally retry the stats computation with estimates. We should further investigate why the ComputeStatsDiff assumptions are violated in the c2c/kv0 test though.

Fixes #151979
Release note: none