### PR TITLE
persistedsqlstats: Fix flakey TestSQLStatsDataDriven test

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -76,6 +76,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 	knobs.StubTimeNow = stubTime.Now
 	knobs.OnStmtStatsFlushFinished = injector.invokePostStmtStatsFlushCallback
 	knobs.OnTxnStatsFlushFinished = injector.invokePostTxnStatsFlushCallback
+	knobs.SynchronousSQLStats = true
 	params.Knobs.SQLStatsKnobs = knobs
 
 	cluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{


### PR DESCRIPTION
This test became flakey after changing sql stats to be an async processes. Now we set SynchronousSQLStats=true on the testing knob to make this test deterministic.

Fixes: #152213
Epic: None
Release note: None