### PR TITLE
sql: fix first contains/contained by array op null panic

### DIFF
--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -349,6 +349,9 @@ func (e *evaluator) EvalFirstContainedByLTreeOp(
 	array := tree.MustBeDArray(a)
 	elem := tree.MustBeDLTree(b)
 
+	if array.HasNulls {
+		return nil, pgerror.New(pgcode.NullValueNotAllowed, "array must not contain nulls")
+	}
 	for _, d := range array.Array {
 		if elem.LTree.Contains(tree.MustBeDLTree(d).LTree) {
 			return tree.MustBeDLTree(d), nil
@@ -408,6 +411,9 @@ func (e *evaluator) EvalFirstContainsLTreeOp(
 	array := tree.MustBeDArray(a)
 	elem := tree.MustBeDLTree(b)
 
+	if array.HasNulls {
+		return nil, pgerror.New(pgcode.NullValueNotAllowed, "array must not contain nulls")
+	}
 	for _, d := range array.Array {
 		if tree.MustBeDLTree(d).LTree.Contains(elem.LTree) {
 			return tree.MustBeDLTree(d), nil

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -351,6 +351,8 @@ func TestEvalError(t *testing.T) {
 		{`B'1001' & B'101'`, `cannot AND bit strings of different sizes`},
 		{`B'1001' | B'101'`, `cannot OR bit strings of different sizes`},
 		{`B'1001' # B'101'`, `cannot XOR bit strings of different sizes`},
+		{`ARRAY['A.B.C', NULL]::LTREE[] ?@> 'A.B.C'`, `array must not contain nulls`},
+		{`ARRAY['A.B.C', NULL]::LTREE[] ?<@ 'A.B.C'`, `array must not contain nulls`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
#### sql: fix first contains/contained by array op null panic

We encountered an error in the binary op evaluator for NULL values in an array
with the first contains (?@>) and first contained by (?<@) operators for ltree.
This is now handled, returning the appropriate `pgerror`.

Fixes: cockroachdb#152323
Epic: None

Release note: None
