### PR TITLE
release-25.2: storepool: lock individual storepool details instead of all details

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -480,59 +480,68 @@ func mockStorePool(
 	decommissionedStoreIDs []roachpb.StoreID,
 	suspectedStoreIDs []roachpb.StoreID,
 ) {
-	storePool.DetailsMu.Lock()
-	defer storePool.DetailsMu.Unlock()
-
 	liveNodeSet := map[roachpb.NodeID]livenesspb.NodeLivenessStatus{}
 	for _, storeID := range aliveStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range unavailableStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_UNAVAILABLE
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range deadStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_DEAD
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range decommissioningStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONING
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range decommissionedStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONED
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 
 	for _, storeID := range suspectedStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.LastUnavailable = storePool.Clock().Now()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 
 	// Set the node liveness function using the set we constructed.
@@ -1379,16 +1388,20 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 	}
 
 	// Initialize 8 stores: where store 6 is the target for rebalancing.
-	sp.DetailsMu.Lock()
-	sp.GetStoreDetailLocked(1).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(2).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(3).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(4).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(5).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(6).Desc.Capacity = ranges(0)
-	sp.GetStoreDetailLocked(7).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(8).Desc.Capacity = ranges(100)
-	sp.DetailsMu.Unlock()
+	updateDescCapacity := func(storeID roachpb.StoreID, capacity roachpb.StoreCapacity) {
+		sd := sp.GetStoreDetail(storeID)
+		sd.Lock()
+		sd.Desc.Capacity = capacity
+		sd.Unlock()
+	}
+	updateDescCapacity(1, ranges(100))
+	updateDescCapacity(2, ranges(100))
+	updateDescCapacity(3, ranges(100))
+	updateDescCapacity(4, ranges(100))
+	updateDescCapacity(5, ranges(100))
+	updateDescCapacity(6, ranges(0))
+	updateDescCapacity(7, ranges(100))
+	updateDescCapacity(8, ranges(100))
 
 	// Each test case should describe a repair situation which has a lower
 	// priority than the previous test case.

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -484,7 +484,6 @@ func mockStorePool(
 	defer storePool.DetailsMu.Unlock()
 
 	liveNodeSet := map[roachpb.NodeID]livenesspb.NodeLivenessStatus{}
-	storePool.DetailsMu.StoreDetails = map[roachpb.StoreID]*storepool.StoreDetail{}
 	for _, storeID := range aliveStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
 		detail := storePool.GetStoreDetailLocked(storeID)

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -118,9 +118,10 @@ func (o *OverrideStorePool) GetStoreList(
 	defer o.sp.DetailsMu.Unlock()
 
 	var storeIDs roachpb.StoreIDSlice
-	for storeID := range o.sp.DetailsMu.StoreDetails {
+	o.sp.DetailsMu.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetail) bool {
 		storeIDs = append(storeIDs, storeID)
-	}
+		return true
+	})
 	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -114,39 +114,31 @@ func (o *OverrideStorePool) DecommissioningReplicas(
 func (o *OverrideStorePool) GetStoreList(
 	filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	o.sp.DetailsMu.Lock()
-	defer o.sp.DetailsMu.Unlock()
-
 	var storeIDs roachpb.StoreIDSlice
-	o.sp.DetailsMu.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetail) bool {
+	o.sp.Details.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetailMu) bool {
 		storeIDs = append(storeIDs, storeID)
 		return true
 	})
-	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
 // GetStoreListFromIDs implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) GetStoreListFromIDs(
 	storeIDs roachpb.StoreIDSlice, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	o.sp.DetailsMu.Lock()
-	defer o.sp.DetailsMu.Unlock()
-	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
 // GetStoreListForTargets implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) GetStoreListForTargets(
 	candidates []roachpb.ReplicationTarget, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	o.sp.DetailsMu.Lock()
-	defer o.sp.DetailsMu.Unlock()
-
 	storeIDs := make(roachpb.StoreIDSlice, 0, len(candidates))
 	for _, tgt := range candidates {
 		storeIDs = append(storeIDs, tgt.StoreID)
 	}
 
-	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
 // LiveAndDeadReplicas implements the AllocatorStorePool interface.

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -330,11 +330,11 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 	livenessOverrides[decommissioningStore.Node.NodeID] = livenesspb.NodeLivenessStatus_DECOMMISSIONING
 
 	// Set suspectedStore as suspected.
-	testStorePool.DetailsMu.Lock()
-	val, ok := testStorePool.DetailsMu.StoreDetails.Load(suspectedStore.StoreID)
+	val, ok := testStorePool.Details.StoreDetails.Load(suspectedStore.StoreID)
 	require.True(t, ok)
+	val.Lock()
 	val.LastUnavailable = testStorePool.clock.Now()
-	testStorePool.DetailsMu.Unlock()
+	val.Unlock()
 
 	// No filter or limited set of store IDs.
 	require.NoError(t, verifyStoreList(

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -331,7 +331,9 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 
 	// Set suspectedStore as suspected.
 	testStorePool.DetailsMu.Lock()
-	testStorePool.DetailsMu.StoreDetails[suspectedStore.StoreID].LastUnavailable = testStorePool.clock.Now()
+	val, ok := testStorePool.DetailsMu.StoreDetails.Load(suspectedStore.StoreID)
+	require.True(t, ok)
+	val.LastUnavailable = testStorePool.clock.Now()
 	testStorePool.DetailsMu.Unlock()
 
 	// No filter or limited set of store IDs.

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -62,7 +62,7 @@ func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLive
 // StoreDetail groups together store-relevant details.
 // Note: When adding new fields to StoreDetail, make sure to add them in
 // StoreDetail.Copy() method as well.
-type StoreDetail struct {
+type StoreDetailMu struct {
 	syncutil.RWMutex
 	Desc *roachpb.StoreDescriptor
 	// ThrottledUntil is when a throttled store can be considered available again
@@ -121,13 +121,13 @@ func (ss storeStatus) String() string {
 // SafeValue implements the redact.SafeValue interface.
 func (ss storeStatus) SafeValue() {}
 
-// Copy returns a deep copy of the StoreDetail.
-func (sd *StoreDetail) Copy() *StoreDetail {
+// Copy returns a deep copy of the StoreDetailMu.
+func (sd *StoreDetailMu) Copy() *StoreDetailMu {
 	sd.RLock()
 	defer sd.RUnlock()
 
-	// Create a new StoreDetail with all fields copied
-	detailCopy := &StoreDetail{
+	// Create a new StoreDetailMu with all fields copied
+	detailCopy := &StoreDetailMu{
 		ThrottledUntil:   sd.ThrottledUntil,
 		throttledBecause: sd.throttledBecause,
 		LastUpdatedTime:  sd.LastUpdatedTime,
@@ -142,12 +142,14 @@ func (sd *StoreDetail) Copy() *StoreDetail {
 	return detailCopy
 }
 
-func (sd *StoreDetail) status(
+func (sd *StoreDetailMu) status(
 	now hlc.Timestamp,
 	deadThreshold time.Duration,
 	nl NodeLivenessFunc,
 	suspectDuration time.Duration,
 ) storeStatus {
+	sd.Lock()
+	defer sd.Unlock()
 	// During normal operation, we expect the state transitions for stores to look like the following:
 	//
 	//      +-----------------------+
@@ -359,10 +361,11 @@ type StorePool struct {
 	// nodeLocalities map is used in the critical code path of Replica.Send()
 	// and we'd rather not block that on something less important accessing
 	// storeDetails.
+	// Note that StoreDetails uses a mutex per detail, so we don't need to lock
+	// the whole map for every detail access.
 	// NB: Exported for use in tests and allocator simulator.
-	DetailsMu struct {
-		syncutil.RWMutex
-		StoreDetails syncutil.Map[roachpb.StoreID, StoreDetail]
+	Details struct {
+		StoreDetails syncutil.Map[roachpb.StoreID, StoreDetailMu]
 	}
 	localitiesMu struct {
 		syncutil.RWMutex
@@ -426,10 +429,8 @@ func (sp *StorePool) SafeFormat(w redact.SafePrinter, _ rune) {
 }
 
 func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
-	sp.DetailsMu.RLock()
-	defer sp.DetailsMu.RUnlock()
 	ids := make(roachpb.StoreIDSlice, sp.getStoreDetailsCount())
-	sp.DetailsMu.StoreDetails.Range(func(id roachpb.StoreID, _ *StoreDetail) bool {
+	sp.Details.StoreDetails.Range(func(id roachpb.StoreID, _ *StoreDetailMu) bool {
 		ids = append(ids, id)
 		return true
 	})
@@ -441,7 +442,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, id := range ids {
-		detail, ok := sp.DetailsMu.StoreDetails.Load(id)
+		detail, ok := sp.Details.StoreDetails.Load(id)
 		if !ok {
 			// If the store detail got deleted while we were iterating, skip it.
 			continue
@@ -451,6 +452,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 		if status != storeStatusAvailable {
 			buf.Printf(" (status=%s)", status)
 		}
+		detail.RLock()
 		if detail.Desc != nil {
 			buf.Printf(": range-count=%d fraction-used=%.2f",
 				detail.Desc.Capacity.RangeCount,
@@ -461,6 +463,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 				detail.ThrottledUntil.GoTime().Sub(now.GoTime())))
 		}
 		buf.SafeRune('\n')
+		detail.RUnlock()
 	}
 	return buf.RedactableString()
 }
@@ -489,14 +492,14 @@ func (sp *StorePool) storeDescriptorUpdate(storeDesc roachpb.StoreDescriptor) {
 
 	now := sp.clock.Now()
 
-	sp.DetailsMu.Lock()
-	detail := sp.GetStoreDetailLocked(storeID)
+	detail := sp.GetStoreDetail(storeID)
+	detail.Lock()
 	if detail.Desc != nil {
 		oldCapacity = detail.Desc.Capacity
 	}
 	detail.Desc = &storeDesc
 	detail.LastUpdatedTime = now
-	sp.DetailsMu.Unlock()
+	detail.Unlock()
 
 	sp.localitiesMu.Lock()
 	sp.localitiesMu.nodeLocalities[storeDesc.Node.NodeID] =
@@ -515,9 +518,9 @@ func (sp *StorePool) UpdateLocalStoreAfterRebalance(
 	rangeUsageInfo allocator.RangeUsageInfo,
 	changeType roachpb.ReplicaChangeType,
 ) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-	detail := *sp.GetStoreDetailLocked(storeID)
+	detail := sp.GetStoreDetail(storeID)
+	detail.Lock()
+	defer detail.Unlock()
 	if detail.Desc == nil {
 		// We don't have this store yet (this is normal when we're
 		// starting up and don't have full information from the gossip
@@ -558,7 +561,7 @@ func (sp *StorePool) UpdateLocalStoreAfterRebalance(
 	default:
 		return
 	}
-	sp.DetailsMu.StoreDetails.Store(storeID, &detail)
+	sp.Details.StoreDetails.Store(storeID, detail)
 }
 
 // UpdateLocalStoreAfterRelocate is used to update the local copy of the
@@ -580,30 +583,31 @@ func (sp *StorePool) UpdateLocalStoreAfterRelocate(
 	leaseTarget := voterTargets[0]
 	sp.UpdateLocalStoresAfterLeaseTransfer(localStore, leaseTarget.StoreID, rangeUsageInfo)
 
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
 	// Only apply the raft cpu delta on rebalance. This estimate assumes that
 	// the raft cpu usage is approximately equal across replicas for a range.
 	// TODO(kvoli): Separate into LH vs Replica, similar to the comment on
 	// range_usage_info.
 	updateTargets := func(targets []roachpb.ReplicationTarget) {
 		for _, target := range targets {
-			if toDetail := sp.GetStoreDetailLocked(target.StoreID); toDetail.Desc != nil {
+			if toDetail := sp.GetStoreDetail(target.StoreID); toDetail.Desc != nil {
+				toDetail.Lock()
 				toDetail.Desc.Capacity.RangeCount++
 				if toDetail.Desc.Capacity.CPUPerSecond >= 0 {
 					toDetail.Desc.Capacity.CPUPerSecond += rangeUsageInfo.RaftCPUNanosPerSecond
 				}
+				toDetail.Unlock()
 			}
 		}
 	}
 	updatePrevious := func(previous []roachpb.ReplicaDescriptor) {
 		for _, old := range previous {
-			if toDetail := sp.GetStoreDetailLocked(old.StoreID); toDetail.Desc != nil {
+			if toDetail := sp.GetStoreDetail(old.StoreID); toDetail.Desc != nil {
+				toDetail.Lock()
 				toDetail.Desc.Capacity.RangeCount--
 				// When CPU attribution is unsupported, the store will set the
 				// CPUPerSecond of its store capacity to be -1.
 				if toDetail.Desc.Capacity.CPUPerSecond < 0 {
+					toDetail.Unlock()
 					continue
 				}
 				if toDetail.Desc.Capacity.CPUPerSecond <= rangeUsageInfo.RaftCPUNanosPerSecond {
@@ -611,6 +615,7 @@ func (sp *StorePool) UpdateLocalStoreAfterRelocate(
 				} else {
 					toDetail.Desc.Capacity.CPUPerSecond -= rangeUsageInfo.RaftCPUNanosPerSecond
 				}
+				toDetail.Unlock()
 			}
 		}
 	}
@@ -626,10 +631,9 @@ func (sp *StorePool) UpdateLocalStoreAfterRelocate(
 func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 	from roachpb.StoreID, to roachpb.StoreID, rangeUsageInfo allocator.RangeUsageInfo,
 ) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
-	fromDetail := *sp.GetStoreDetailLocked(from)
+	fromDetail := sp.GetStoreDetail(from)
+	fromDetail.Lock()
+	defer fromDetail.Unlock()
 	if fromDetail.Desc != nil {
 		fromDetail.Desc.Capacity.LeaseCount--
 		if fromDetail.Desc.Capacity.QueriesPerSecond < rangeUsageInfo.QueriesPerSecond {
@@ -651,10 +655,12 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 			}
 		}
 
-		sp.DetailsMu.StoreDetails.Store(from, &fromDetail)
+		sp.Details.StoreDetails.Store(from, fromDetail)
 	}
 
-	toDetail := *sp.GetStoreDetailLocked(to)
+	toDetail := sp.GetStoreDetail(to)
+	toDetail.Lock()
+	defer toDetail.Unlock()
 	if toDetail.Desc != nil {
 		toDetail.Desc.Capacity.LeaseCount++
 		toDetail.Desc.Capacity.QueriesPerSecond += rangeUsageInfo.QueriesPerSecond
@@ -663,23 +669,23 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 		if toDetail.Desc.Capacity.CPUPerSecond >= 0 {
 			toDetail.Desc.Capacity.CPUPerSecond += rangeUsageInfo.RequestCPUNanosPerSecond
 		}
-		sp.DetailsMu.StoreDetails.Store(to, &toDetail)
+		sp.Details.StoreDetails.Store(to, toDetail)
 	}
 }
 
-// newStoreDetail makes a new StoreDetail struct.
-func newStoreDetail() *StoreDetail {
-	return &StoreDetail{}
+// newStoreDetail makes a new StoreDetailMu struct.
+func newStoreDetail() *StoreDetailMu {
+	return &StoreDetailMu{}
 }
 
 // GetStores returns information on all the stores with descriptor in the pool.
 // Stores without descriptor (a node that didn't come up yet after a cluster
 // restart) will not be part of the returned set.
 func (sp *StorePool) GetStores() map[roachpb.StoreID]roachpb.StoreDescriptor {
-	sp.DetailsMu.RLock()
-	defer sp.DetailsMu.RUnlock()
 	stores := make(map[roachpb.StoreID]roachpb.StoreDescriptor, sp.getStoreDetailsCount())
-	sp.DetailsMu.StoreDetails.Range(func(_ roachpb.StoreID, s *StoreDetail) bool {
+	sp.Details.StoreDetails.Range(func(_ roachpb.StoreID, s *StoreDetailMu) bool {
+		s.RLock()
+		defer s.RUnlock()
 		if s.Desc != nil {
 			stores[s.Desc.StoreID] = *s.Desc
 		}
@@ -688,11 +694,9 @@ func (sp *StorePool) GetStores() map[roachpb.StoreID]roachpb.StoreDescriptor {
 	return stores
 }
 
-// GetStoreDetailLocked returns the store detail for the given storeID. The
-// lock must be held *in write mode* even though this looks like a read-only
-// method. The store detail returned is a mutable reference.
-func (sp *StorePool) GetStoreDetailLocked(storeID roachpb.StoreID) *StoreDetail {
-	detail, ok := sp.DetailsMu.StoreDetails.Load(storeID)
+// GetStoreDetail returns the store detail for the given storeID.
+func (sp *StorePool) GetStoreDetail(storeID roachpb.StoreID) *StoreDetailMu {
+	detail, ok := sp.Details.StoreDetails.Load(storeID)
 	if !ok {
 		// We don't have this store yet (this is normal when we're
 		// starting up and don't have full information from the gossip
@@ -701,7 +705,7 @@ func (sp *StorePool) GetStoreDetailLocked(storeID roachpb.StoreID) *StoreDetail 
 		// time passes without updates from gossip.
 		detail = newStoreDetail()
 		detail.LastUpdatedTime = sp.startTime
-		sp.DetailsMu.StoreDetails.Store(storeID, detail)
+		sp.Details.StoreDetails.Store(storeID, detail)
 	}
 	return detail
 }
@@ -709,13 +713,16 @@ func (sp *StorePool) GetStoreDetailLocked(storeID roachpb.StoreID) *StoreDetail 
 // GetStoreDescriptor returns the latest store descriptor for the given
 // storeID.
 func (sp *StorePool) GetStoreDescriptor(storeID roachpb.StoreID) (roachpb.StoreDescriptor, bool) {
-	sp.DetailsMu.RLock()
-	defer sp.DetailsMu.RUnlock()
-
-	if detail, ok := sp.DetailsMu.StoreDetails.Load(storeID); ok && detail.Desc != nil {
-		return *detail.Desc, true
+	detail, ok := sp.Details.StoreDetails.Load(storeID)
+	if !ok {
+		return roachpb.StoreDescriptor{}, false
 	}
-	return roachpb.StoreDescriptor{}, false
+	detail.RLock()
+	defer detail.RUnlock()
+	if detail.Desc == nil {
+		return roachpb.StoreDescriptor{}, false
+	}
+	return *detail.Desc, true
 }
 
 // DecommissioningReplicas filters out replicas on decommissioning node/store
@@ -731,9 +738,6 @@ func (sp *StorePool) DecommissioningReplicas(
 func (sp *StorePool) decommissioningReplicasWithLiveness(
 	repls []roachpb.ReplicaDescriptor, nl NodeLivenessFunc,
 ) (decommissioningReplicas []roachpb.ReplicaDescriptor) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
 	now := sp.clock.Now()
@@ -741,7 +745,7 @@ func (sp *StorePool) decommissioningReplicasWithLiveness(
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, repl := range repls {
-		detail := sp.GetStoreDetailLocked(repl.StoreID)
+		detail := sp.GetStoreDetail(repl.StoreID)
 		switch detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect) {
 		case storeStatusDecommissioning:
 			decommissioningReplicas = append(decommissioningReplicas, repl)
@@ -771,13 +775,12 @@ func (sp *StorePool) IsDeterministic() bool {
 // not found in the store pool or the status is unknown. If the store is not dead,
 // it returns the time to death.
 func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
-	sd, ok := sp.DetailsMu.StoreDetails.Load(storeID)
+	sd, ok := sp.Details.StoreDetails.Load(storeID)
 	if !ok {
 		return false, 0, errors.Errorf("store %d was not found", storeID)
 	}
+	sd.RLock()
+	defer sd.RUnlock()
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
 	now := sp.clock.Now()
@@ -847,10 +850,7 @@ func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
 func (sp *StorePool) storeStatus(
 	storeID roachpb.StoreID, nl NodeLivenessFunc,
 ) (storeStatus, error) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
-	sd, ok := sp.DetailsMu.StoreDetails.Load(storeID)
+	sd, ok := sp.Details.StoreDetails.Load(storeID)
 	if !ok {
 		return storeStatusUnknown, errors.Errorf("store %d was not found", storeID)
 	}
@@ -887,15 +887,12 @@ func (sp *StorePool) LiveAndDeadReplicas(
 func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 	repls []roachpb.ReplicaDescriptor, nl NodeLivenessFunc, includeSuspectAndDrainingStores bool,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
 	now := sp.clock.Now()
 	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, repl := range repls {
-		detail := sp.GetStoreDetailLocked(repl.StoreID)
+		detail := sp.GetStoreDetail(repl.StoreID)
 		// Mark replica as dead if store is dead.
 		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
 		switch status {
@@ -944,7 +941,7 @@ func (sp *StorePool) capacityChanged(storeID roachpb.StoreID, prev, cur roachpb.
 // StorePool.
 func (sp *StorePool) getStoreDetailsCount() int {
 	count := 0
-	sp.DetailsMu.StoreDetails.Range(func(_ roachpb.StoreID, _ *StoreDetail) bool {
+	sp.Details.StoreDetails.Range(func(_ roachpb.StoreID, _ *StoreDetailMu) bool {
 		count++
 		return true
 	})
@@ -1144,15 +1141,12 @@ type ThrottledStoreReasons []string
 // alive stores and a list of throttled stores with a reason for why they're
 // throttled.
 func (sp *StorePool) GetStoreList(filter StoreFilter) (StoreList, int, ThrottledStoreReasons) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
 	storeIDs := make(roachpb.StoreIDSlice, 0, sp.getStoreDetailsCount())
-	sp.DetailsMu.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetail) bool {
+	sp.Details.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetailMu) bool {
 		storeIDs = append(storeIDs, storeID)
 		return true
 	})
-	return sp.getStoreListFromIDsLocked(storeIDs, sp.NodeLivenessFn, filter)
+	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, filter)
 }
 
 // GetStoreListFromIDs is the same function as GetStoreList but only returns stores
@@ -1160,9 +1154,7 @@ func (sp *StorePool) GetStoreList(filter StoreFilter) (StoreList, int, Throttled
 func (sp *StorePool) GetStoreListFromIDs(
 	storeIDs roachpb.StoreIDSlice, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-	return sp.getStoreListFromIDsLocked(storeIDs, sp.NodeLivenessFn, filter)
+	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, filter)
 }
 
 // GetStoreListForTargets is the same as GetStoreList, but only returns stores
@@ -1171,20 +1163,17 @@ func (sp *StorePool) GetStoreListFromIDs(
 func (sp *StorePool) GetStoreListForTargets(
 	candidates []roachpb.ReplicationTarget, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-
 	storeIDs := make(roachpb.StoreIDSlice, 0, len(candidates))
 	for _, tgt := range candidates {
 		storeIDs = append(storeIDs, tgt.StoreID)
 	}
 
-	return sp.getStoreListFromIDsLocked(storeIDs, sp.NodeLivenessFn, filter)
+	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, filter)
 }
 
-// getStoreListFromIDsRLocked is the same function as GetStoreList but requires
-// that the detailsMU read lock is held.
-func (sp *StorePool) getStoreListFromIDsLocked(
+// getStoreListFromIDs is the same as GetStoreListFromIDs, but takes a
+// NodeLivenessFunc as an argument.
+func (sp *StorePool) getStoreListFromIDs(
 	storeIDs roachpb.StoreIDSlice, nl NodeLivenessFunc, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
 	if sp.deterministic {
@@ -1202,7 +1191,7 @@ func (sp *StorePool) getStoreListFromIDsLocked(
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, storeID := range storeIDs {
-		detail, ok := sp.DetailsMu.StoreDetails.Load(storeID)
+		detail, ok := sp.Details.StoreDetails.Load(storeID)
 		if !ok {
 			// Do nothing; this store is not in the StorePool.
 			continue
@@ -1210,20 +1199,26 @@ func (sp *StorePool) getStoreListFromIDsLocked(
 		switch s := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect); s {
 		case storeStatusThrottled:
 			aliveStoreCount++
+			detail.RLock()
 			throttled = append(throttled, detail.throttledBecause)
 			if filter != StoreFilterThrottled {
 				storeDescriptors = append(storeDescriptors, *detail.Desc)
 			}
+			detail.RUnlock()
 		case storeStatusAvailable:
 			aliveStoreCount++
+			detail.RLock()
 			storeDescriptors = append(storeDescriptors, *detail.Desc)
+			detail.RUnlock()
 		case storeStatusDraining:
 			throttled = append(throttled, fmt.Sprintf("s%d: draining", storeID))
 		case storeStatusSuspect:
 			aliveStoreCount++
 			throttled = append(throttled, fmt.Sprintf("s%d: suspect", storeID))
 			if filter != StoreFilterThrottled && filter != StoreFilterSuspect {
+				detail.RLock()
 				storeDescriptors = append(storeDescriptors, *detail.Desc)
+				detail.RUnlock()
 			}
 		case storeStatusDead, storeStatusUnknown, storeStatusDecommissioning:
 			// Do nothing; this store cannot be used.
@@ -1250,9 +1245,9 @@ const (
 // has elapsed. Declined being true indicates that the remote store explicitly
 // declined a snapshot.
 func (sp *StorePool) Throttle(reason ThrottleReason, why string, storeID roachpb.StoreID) {
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-	detail := sp.GetStoreDetailLocked(storeID)
+	detail := sp.GetStoreDetail(storeID)
+	detail.Lock()
+	defer detail.Unlock()
 	detail.throttledBecause = why
 
 	// If a snapshot is declined, we mark the store detail as having been declined

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -647,7 +647,6 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 ) {
 	fromDetail := sp.GetStoreDetail(from)
 	fromDetail.Lock()
-	defer fromDetail.Unlock()
 	if fromDetail.Desc != nil {
 		fromDetail.Desc.Capacity.LeaseCount--
 		if fromDetail.Desc.Capacity.QueriesPerSecond < rangeUsageInfo.QueriesPerSecond {
@@ -671,10 +670,10 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 
 		sp.Details.StoreDetails.Store(from, fromDetail)
 	}
+	fromDetail.Unlock()
 
 	toDetail := sp.GetStoreDetail(to)
 	toDetail.Lock()
-	defer toDetail.Unlock()
 	if toDetail.Desc != nil {
 		toDetail.Desc.Capacity.LeaseCount++
 		toDetail.Desc.Capacity.QueriesPerSecond += rangeUsageInfo.QueriesPerSecond
@@ -685,6 +684,7 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 		}
 		sp.Details.StoreDetails.Store(to, toDetail)
 	}
+	toDetail.Unlock()
 }
 
 // newStoreDetail makes a new StoreDetailMu struct.

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -60,7 +60,10 @@ func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLive
 }
 
 // StoreDetail groups together store-relevant details.
+// Note: When adding new fields to StoreDetail, make sure to add them in
+// StoreDetail.Copy() method as well.
 type StoreDetail struct {
+	syncutil.RWMutex
 	Desc *roachpb.StoreDescriptor
 	// ThrottledUntil is when a throttled store can be considered available again
 	// due to a failed or declined snapshot.
@@ -117,6 +120,27 @@ func (ss storeStatus) String() string {
 
 // SafeValue implements the redact.SafeValue interface.
 func (ss storeStatus) SafeValue() {}
+
+// Copy returns a deep copy of the StoreDetail.
+func (sd *StoreDetail) Copy() *StoreDetail {
+	sd.RLock()
+	defer sd.RUnlock()
+
+	// Create a new StoreDetail with all fields copied
+	detailCopy := &StoreDetail{
+		ThrottledUntil:   sd.ThrottledUntil,
+		throttledBecause: sd.throttledBecause,
+		LastUpdatedTime:  sd.LastUpdatedTime,
+		LastUnavailable:  sd.LastUnavailable,
+	}
+
+	if sd.Desc != nil {
+		descCopy := *sd.Desc
+		detailCopy.Desc = &descCopy
+	}
+
+	return detailCopy
+}
 
 func (sd *StoreDetail) status(
 	now hlc.Timestamp,
@@ -338,7 +362,7 @@ type StorePool struct {
 	// NB: Exported for use in tests and allocator simulator.
 	DetailsMu struct {
 		syncutil.RWMutex
-		StoreDetails map[roachpb.StoreID]*StoreDetail
+		StoreDetails syncutil.Map[roachpb.StoreID, StoreDetail]
 	}
 	localitiesMu struct {
 		syncutil.RWMutex
@@ -380,7 +404,6 @@ func NewStorePool(
 		startTime:      clock.Now(),
 		deterministic:  deterministic,
 	}
-	sp.DetailsMu.StoreDetails = make(map[roachpb.StoreID]*StoreDetail)
 	sp.localitiesMu.nodeLocalities = make(map[roachpb.NodeID]localityWithString)
 	sp.changeMu.onChange = []CapacityChangeFn{}
 
@@ -405,11 +428,11 @@ func (sp *StorePool) SafeFormat(w redact.SafePrinter, _ rune) {
 func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 	sp.DetailsMu.RLock()
 	defer sp.DetailsMu.RUnlock()
-
-	ids := make(roachpb.StoreIDSlice, 0, len(sp.DetailsMu.StoreDetails))
-	for id := range sp.DetailsMu.StoreDetails {
+	ids := make(roachpb.StoreIDSlice, sp.getStoreDetailsCount())
+	sp.DetailsMu.StoreDetails.Range(func(id roachpb.StoreID, _ *StoreDetail) bool {
 		ids = append(ids, id)
-	}
+		return true
+	})
 	sort.Sort(ids)
 
 	var buf redact.StringBuilder
@@ -418,7 +441,11 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, id := range ids {
-		detail := sp.DetailsMu.StoreDetails[id]
+		detail, ok := sp.DetailsMu.StoreDetails.Load(id)
+		if !ok {
+			// If the store detail got deleted while we were iterating, skip it.
+			continue
+		}
 		buf.Print(id)
 		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
 		if status != storeStatusAvailable {
@@ -531,7 +558,7 @@ func (sp *StorePool) UpdateLocalStoreAfterRebalance(
 	default:
 		return
 	}
-	sp.DetailsMu.StoreDetails[storeID] = &detail
+	sp.DetailsMu.StoreDetails.Store(storeID, &detail)
 }
 
 // UpdateLocalStoreAfterRelocate is used to update the local copy of the
@@ -624,7 +651,7 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 			}
 		}
 
-		sp.DetailsMu.StoreDetails[from] = &fromDetail
+		sp.DetailsMu.StoreDetails.Store(from, &fromDetail)
 	}
 
 	toDetail := *sp.GetStoreDetailLocked(to)
@@ -636,7 +663,7 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 		if toDetail.Desc.Capacity.CPUPerSecond >= 0 {
 			toDetail.Desc.Capacity.CPUPerSecond += rangeUsageInfo.RequestCPUNanosPerSecond
 		}
-		sp.DetailsMu.StoreDetails[to] = &toDetail
+		sp.DetailsMu.StoreDetails.Store(to, &toDetail)
 	}
 }
 
@@ -651,12 +678,13 @@ func newStoreDetail() *StoreDetail {
 func (sp *StorePool) GetStores() map[roachpb.StoreID]roachpb.StoreDescriptor {
 	sp.DetailsMu.RLock()
 	defer sp.DetailsMu.RUnlock()
-	stores := make(map[roachpb.StoreID]roachpb.StoreDescriptor, len(sp.DetailsMu.StoreDetails))
-	for _, s := range sp.DetailsMu.StoreDetails {
+	stores := make(map[roachpb.StoreID]roachpb.StoreDescriptor, sp.getStoreDetailsCount())
+	sp.DetailsMu.StoreDetails.Range(func(_ roachpb.StoreID, s *StoreDetail) bool {
 		if s.Desc != nil {
 			stores[s.Desc.StoreID] = *s.Desc
 		}
-	}
+		return true
+	})
 	return stores
 }
 
@@ -664,7 +692,7 @@ func (sp *StorePool) GetStores() map[roachpb.StoreID]roachpb.StoreDescriptor {
 // lock must be held *in write mode* even though this looks like a read-only
 // method. The store detail returned is a mutable reference.
 func (sp *StorePool) GetStoreDetailLocked(storeID roachpb.StoreID) *StoreDetail {
-	detail, ok := sp.DetailsMu.StoreDetails[storeID]
+	detail, ok := sp.DetailsMu.StoreDetails.Load(storeID)
 	if !ok {
 		// We don't have this store yet (this is normal when we're
 		// starting up and don't have full information from the gossip
@@ -673,7 +701,7 @@ func (sp *StorePool) GetStoreDetailLocked(storeID roachpb.StoreID) *StoreDetail 
 		// time passes without updates from gossip.
 		detail = newStoreDetail()
 		detail.LastUpdatedTime = sp.startTime
-		sp.DetailsMu.StoreDetails[storeID] = detail
+		sp.DetailsMu.StoreDetails.Store(storeID, detail)
 	}
 	return detail
 }
@@ -684,7 +712,7 @@ func (sp *StorePool) GetStoreDescriptor(storeID roachpb.StoreID) (roachpb.StoreD
 	sp.DetailsMu.RLock()
 	defer sp.DetailsMu.RUnlock()
 
-	if detail, ok := sp.DetailsMu.StoreDetails[storeID]; ok && detail.Desc != nil {
+	if detail, ok := sp.DetailsMu.StoreDetails.Load(storeID); ok && detail.Desc != nil {
 		return *detail.Desc, true
 	}
 	return roachpb.StoreDescriptor{}, false
@@ -746,7 +774,7 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
 
-	sd, ok := sp.DetailsMu.StoreDetails[storeID]
+	sd, ok := sp.DetailsMu.StoreDetails.Load(storeID)
 	if !ok {
 		return false, 0, errors.Errorf("store %d was not found", storeID)
 	}
@@ -822,7 +850,7 @@ func (sp *StorePool) storeStatus(
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
 
-	sd, ok := sp.DetailsMu.StoreDetails[storeID]
+	sd, ok := sp.DetailsMu.StoreDetails.Load(storeID)
 	if !ok {
 		return storeStatusUnknown, errors.Errorf("store %d was not found", storeID)
 	}
@@ -910,6 +938,17 @@ func (sp *StorePool) capacityChanged(storeID roachpb.StoreID, prev, cur roachpb.
 	for _, fn := range sp.changeMu.onChange {
 		fn(storeID, prev, cur)
 	}
+}
+
+// getStoreDetailsCount returns the number of store details existing in the
+// StorePool.
+func (sp *StorePool) getStoreDetailsCount() int {
+	count := 0
+	sp.DetailsMu.StoreDetails.Range(func(_ roachpb.StoreID, _ *StoreDetail) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 // Stat provides a running sample size and running stats.
@@ -1108,10 +1147,11 @@ func (sp *StorePool) GetStoreList(filter StoreFilter) (StoreList, int, Throttled
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
 
-	storeIDs := make(roachpb.StoreIDSlice, 0, len(sp.DetailsMu.StoreDetails))
-	for storeID := range sp.DetailsMu.StoreDetails {
+	storeIDs := make(roachpb.StoreIDSlice, 0, sp.getStoreDetailsCount())
+	sp.DetailsMu.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetail) bool {
 		storeIDs = append(storeIDs, storeID)
-	}
+		return true
+	})
 	return sp.getStoreListFromIDsLocked(storeIDs, sp.NodeLivenessFn, filter)
 }
 
@@ -1162,7 +1202,7 @@ func (sp *StorePool) getStoreListFromIDsLocked(
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	for _, storeID := range storeIDs {
-		detail, ok := sp.DetailsMu.StoreDetails[storeID]
+		detail, ok := sp.DetailsMu.StoreDetails.Load(storeID)
 		if !ok {
 			// Do nothing; this store is not in the StorePool.
 			continue

--- a/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
@@ -57,19 +57,15 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 
-	sp.DetailsMu.RLock()
-	if _, ok := sp.DetailsMu.StoreDetails.Load(2); ok {
+	if _, ok := sp.Details.StoreDetails.Load(2); ok {
 		t.Fatalf("store 2 is already in the pool's store list")
 	}
-	sp.DetailsMu.RUnlock()
 
 	sg.GossipStores(uniqueStore, t)
 
-	sp.DetailsMu.RLock()
-	if _, ok := sp.DetailsMu.StoreDetails.Load(2); !ok {
+	if _, ok := sp.Details.StoreDetails.Load(2); !ok {
 		t.Fatalf("store 2 isn't in the pool's store list")
 	}
-	sp.DetailsMu.RUnlock()
 }
 
 // verifyStoreList ensures that the returned list of stores is correct.
@@ -200,16 +196,18 @@ func TestStorePoolGetStoreList(t *testing.T) {
 
 	// Set deadStore as dead.
 	mnl.SetNodeStatus(deadStore.Node.NodeID, livenesspb.NodeLivenessStatus_DEAD)
-	sp.DetailsMu.Lock()
 	// Set declinedStore as throttled.
-	val, ok := sp.DetailsMu.StoreDetails.Load(declinedStore.StoreID)
+	val, ok := sp.Details.StoreDetails.Load(declinedStore.StoreID)
 	require.True(t, ok)
+	val.Lock()
 	(*val).ThrottledUntil = sp.clock.Now().AddDuration(time.Hour)
+	val.Unlock()
 	// Set suspectedStore as suspected.
-	val, ok = sp.DetailsMu.StoreDetails.Load(suspectedStore.StoreID)
+	val, ok = sp.Details.StoreDetails.Load(suspectedStore.StoreID)
 	require.True(t, ok)
+	val.Lock()
 	(*val).LastUnavailable = sp.clock.Now()
-	sp.DetailsMu.Unlock()
+	val.Unlock()
 
 	// No filter or limited set of store IDs.
 	if err := verifyStoreList(
@@ -428,12 +426,10 @@ func TestStorePoolGetStoreDetails(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(uniqueStore, t)
 
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-	if detail := sp.GetStoreDetailLocked(roachpb.StoreID(1)); detail.Desc != nil {
+	if detail := sp.GetStoreDetail(roachpb.StoreID(1)); detail.Desc != nil {
 		t.Errorf("unexpected fetched store ID 1: %+v", detail.Desc)
 	}
-	if detail := sp.GetStoreDetailLocked(roachpb.StoreID(2)); detail.Desc == nil {
+	if detail := sp.GetStoreDetail(roachpb.StoreID(2)); detail.Desc == nil {
 		t.Errorf("failed to fetch store ID 2")
 	}
 }
@@ -592,13 +588,13 @@ func TestStorePoolThrottle(t *testing.T) {
 	expected := sp.clock.Now().AddDuration(FailedReservationsTimeout.Get(&sp.st.SV))
 	sp.Throttle(ThrottleFailed, "", 1)
 
-	sp.DetailsMu.Lock()
-	detail := sp.GetStoreDetailLocked(1)
-	sp.DetailsMu.Unlock()
+	detail := sp.GetStoreDetail(1)
+	detail.RLock()
 	if detail.ThrottledUntil.WallTime != expected.WallTime {
 		t.Errorf("expected store to have been throttled to %v, found %v",
 			expected, detail.ThrottledUntil)
 	}
+	detail.RUnlock()
 }
 
 // See state transition diagram in storeDetail.status() for a visual
@@ -619,7 +615,7 @@ func TestStorePoolSuspected(t *testing.T) {
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	// Verify a store that we haven't seen yet is unknown status.
-	detail := sp.GetStoreDetailLocked(0)
+	detail := sp.GetStoreDetail(0)
 	s := detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusUnknown)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
@@ -631,9 +627,7 @@ func TestStorePoolSuspected(t *testing.T) {
 
 	// Store starts in a live state if it hasn't been marked suspect yet.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
-	sp.DetailsMu.Lock()
-	detail = sp.GetStoreDetailLocked(store.StoreID)
-	defer sp.DetailsMu.Unlock()
+	detail = sp.GetStoreDetail(store.StoreID)
 
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusAvailable)
@@ -903,10 +897,10 @@ func TestStorePoolString(t *testing.T) {
 	mnl.SetNodeStatus(7, livenesspb.NodeLivenessStatus_DRAINING)
 	mnl.SetNodeStatus(8, livenesspb.NodeLivenessStatus_LIVE)
 	mnl.SetNodeStatus(9, livenesspb.NodeLivenessStatus_LIVE)
-	val, ok := sp.DetailsMu.StoreDetails.Load(8)
+	val, ok := sp.Details.StoreDetails.Load(8)
 	require.True(t, ok)
 	(*val).LastUnavailable = sp.clock.Now()
-	val, ok = sp.DetailsMu.StoreDetails.Load(9)
+	val, ok = sp.Details.StoreDetails.Load(9)
 	require.True(t, ok)
 	(*val).ThrottledUntil = sp.clock.Now().AddDuration(time.Second)
 

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -406,13 +406,13 @@ func TestAllocatorThrottled(t *testing.T) {
 
 	// Finally, set that store to be throttled and ensure we don't send the
 	// replica to purgatory.
-	sp.DetailsMu.Lock()
-	storeDetail, ok := sp.DetailsMu.StoreDetails.Load(singleStore[0].StoreID)
+	storeDetail, ok := sp.Details.StoreDetails.Load(singleStore[0].StoreID)
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}
+	storeDetail.Lock()
 	storeDetail.ThrottledUntil = hlc.Timestamp{WallTime: timeutil.Now().Add(24 * time.Hour).UnixNano()}
-	sp.DetailsMu.Unlock()
+	storeDetail.Unlock()
 	_, _, err = a.AllocateVoter(ctx, sp, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); ok {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -407,7 +407,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	// Finally, set that store to be throttled and ensure we don't send the
 	// replica to purgatory.
 	sp.DetailsMu.Lock()
-	storeDetail, ok := sp.DetailsMu.StoreDetails[singleStore[0].StoreID]
+	storeDetail, ok := sp.DetailsMu.StoreDetails.Load(singleStore[0].StoreID)
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}

--- a/pkg/kv/kvserver/asim/gossip/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/gossip/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/roachpb",
+        "//pkg/util/syncutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/gossip/exchange.go
+++ b/pkg/kv/kvserver/asim/gossip/exchange.go
@@ -38,11 +38,11 @@ func (u *fixedDelayExchange) put(tick time.Time, descs ...roachpb.StoreDescripto
 
 // updates returns back exchanged infos, wrapped as store details that have
 // completed between the last tick update was called and the tick given.
-func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetail {
+func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetailMu {
 	slices.SortStableFunc(u.pending, func(a, b exchangeInfo) int {
 		return a.created.Compare(b.created)
 	})
-	var ready []*storepool.StoreDetail
+	var ready []*storepool.StoreDetailMu
 	i := 0
 	for ; i < len(u.pending) && !tick.Before(u.pending[i].created.Add(u.settings.StateExchangeDelay)); i++ {
 		ready = append(ready, makeStoreDetail(&u.pending[i].desc, u.pending[i].created))
@@ -51,10 +51,10 @@ func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetail {
 	return ready
 }
 
-// makeStoreDetail wraps a store descriptor into a storepool StoreDetail at the
+// makeStoreDetail wraps a store descriptor into a storepool StoreDetailMu at the
 // given tick.
-func makeStoreDetail(desc *roachpb.StoreDescriptor, tick time.Time) *storepool.StoreDetail {
-	return &storepool.StoreDetail{
+func makeStoreDetail(desc *roachpb.StoreDescriptor, tick time.Time) *storepool.StoreDetailMu {
+	return &storepool.StoreDetailMu{
 		Desc:            desc,
 		LastUpdatedTime: hlc.Timestamp{WallTime: tick.UnixNano()},
 	}

--- a/pkg/kv/kvserver/asim/gossip/gossip.go
+++ b/pkg/kv/kvserver/asim/gossip/gossip.go
@@ -204,7 +204,7 @@ func (g *gossip) maybeUpdateState(tick time.Time, s state.State) {
 		return
 	}
 
-	updateMap := map[roachpb.StoreID]*storepool.StoreDetail{}
+	updateMap := map[roachpb.StoreID]*storepool.StoreDetailMu{}
 	for _, update := range updates {
 		updateMap[update.Desc.StoreID] = update
 	}

--- a/pkg/kv/kvserver/asim/gossip/gossip_test.go
+++ b/pkg/kv/kvserver/asim/gossip/gossip_test.go
@@ -7,6 +7,7 @@ package gossip
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +28,7 @@ func TestGossip(t *testing.T) {
 	for _, rng := range s.Ranges() {
 		s.TransferLease(rng.RangeID(), 1)
 	}
-	details := map[state.StoreID]*map[roachpb.StoreID]*storepool.StoreDetail{}
+	details := map[state.StoreID]*syncutil.Map[roachpb.StoreID, storepool.StoreDetail]{}
 
 	for _, store := range s.Stores() {
 		// Cast the storepool to a concrete storepool type in order to mutate
@@ -35,8 +37,8 @@ func TestGossip(t *testing.T) {
 		details[store.StoreID()] = &sp.DetailsMu.StoreDetails
 	}
 
-	assertStorePool := func(f func(prev, cur *map[roachpb.StoreID]*storepool.StoreDetail)) {
-		var prev *map[roachpb.StoreID]*storepool.StoreDetail
+	assertStorePool := func(f func(prev, cur *syncutil.Map[roachpb.StoreID, storepool.StoreDetail])) {
+		var prev *syncutil.Map[roachpb.StoreID, storepool.StoreDetail]
 		for _, cur := range details {
 			if prev != nil {
 				f(prev, cur)
@@ -45,13 +47,61 @@ func TestGossip(t *testing.T) {
 		}
 	}
 
-	assertEmptyFn := func(prev, cur *map[roachpb.StoreID]*storepool.StoreDetail) {
-		require.Len(t, *prev, 0)
-		require.Len(t, *cur, 0)
+	assertEmptyFn := func(prev, cur *syncutil.Map[roachpb.StoreID, storepool.StoreDetail]) {
+		prevCount, curCount := 0, 0
+		prev.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			prevCount++
+			return true
+		})
+		cur.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			curCount++
+			return true
+		})
+		require.Equal(t, 0, prevCount)
+		require.Equal(t, 0, curCount)
 	}
 
-	assertSameFn := func(prev, cur *map[roachpb.StoreID]*storepool.StoreDetail) {
-		require.Equal(t, *prev, *cur)
+	assertSameFn := func(prev, cur *syncutil.Map[roachpb.StoreID, storepool.StoreDetail]) {
+		var prevResults []struct {
+			StoreID roachpb.StoreID
+			Detail  *storepool.StoreDetail
+		}
+		var curResults []struct {
+			StoreID roachpb.StoreID
+			Detail  *storepool.StoreDetail
+		}
+
+		prev.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			prevResults = append(prevResults, struct {
+				StoreID roachpb.StoreID
+				Detail  *storepool.StoreDetail
+			}{
+				StoreID: key,
+				Detail:  value,
+			})
+			return true
+		})
+
+		cur.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			curResults = append(curResults, struct {
+				StoreID roachpb.StoreID
+				Detail  *storepool.StoreDetail
+			}{
+				StoreID: key,
+				Detail:  value,
+			})
+			return true
+		})
+
+		// Sort the results by StoreID to ensure that the order is the same.
+		sort.Slice(prevResults, func(i, j int) bool {
+			return prevResults[i].StoreID < prevResults[j].StoreID
+		})
+		sort.Slice(curResults, func(i, j int) bool {
+			return curResults[i].StoreID < curResults[j].StoreID
+		})
+
+		require.Equal(t, prevResults, curResults)
 	}
 
 	gossip := NewGossip(s, settings)
@@ -109,11 +159,18 @@ func TestGossip(t *testing.T) {
 	assertStorePool(assertSameFn)
 	// Assert that the lease counts are as expected after transferring all of
 	// the leases to s2.
-	require.Equal(t, int32(0), (*details[1])[1].Desc.Capacity.LeaseCount)
+	val, ok := (*details[1]).Load(1)
+	require.True(t, ok)
+	require.Equal(t, int32(0), val.Desc.Capacity.LeaseCount)
 	// Depending on the capacity delta threshold, s2 may not have gossiped
 	// exactly when it reached 100 leases, as it earlier gossiped at 90+ leases,
 	// so 100 may be < lastGossip * capacityDeltaThreshold, not triggering
 	// gossip. Assert that the lease count gossiped is at least 90.
-	require.Greater(t, (*details[1])[2].Desc.Capacity.LeaseCount, int32(90))
-	require.Equal(t, int32(0), (*details[1])[3].Desc.Capacity.LeaseCount)
+	val, ok = (*details[1]).Load(2)
+	require.True(t, ok)
+	require.Greater(t, val.Desc.Capacity.LeaseCount, int32(90))
+
+	val, ok = (*details[1]).Load(3)
+	require.True(t, ok)
+	require.Equal(t, int32(0), val.Desc.Capacity.LeaseCount)
 }

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1079,10 +1079,8 @@ func (s *state) UpdateStorePool(
 	sort.Sort(storeIDs)
 	for _, gossipStoreID := range storeIDs {
 		detail := storeDescriptors[gossipStoreID]
-		copiedDetail := *detail
-		copiedDesc := *detail.Desc
-		copiedDetail.Desc = &copiedDesc
-		s.stores[storeID].storepool.DetailsMu.StoreDetails[gossipStoreID] = &copiedDetail
+		copiedDetail := detail.Copy()
+		s.stores[storeID].storepool.DetailsMu.StoreDetails.Store(gossipStoreID, copiedDetail)
 	}
 }
 

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1070,7 +1070,7 @@ func (s *state) Clock() timeutil.TimeSource {
 // UpdateStorePool modifies the state of the StorePool for the Store with
 // ID StoreID.
 func (s *state) UpdateStorePool(
-	storeID StoreID, storeDescriptors map[roachpb.StoreID]*storepool.StoreDetail,
+	storeID StoreID, storeDescriptors map[roachpb.StoreID]*storepool.StoreDetailMu,
 ) {
 	var storeIDs roachpb.StoreIDSlice
 	for storeIDA := range storeDescriptors {
@@ -1080,7 +1080,7 @@ func (s *state) UpdateStorePool(
 	for _, gossipStoreID := range storeIDs {
 		detail := storeDescriptors[gossipStoreID]
 		copiedDetail := detail.Copy()
-		s.stores[storeID].storepool.DetailsMu.StoreDetails.Store(gossipStoreID, copiedDetail)
+		s.stores[storeID].storepool.Details.StoreDetails.Store(gossipStoreID, copiedDetail)
 	}
 }
 

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -154,7 +154,7 @@ type State interface {
 	Clock() timeutil.TimeSource
 	// UpdateStorePool modifies the state of the StorePool for the Store with
 	// ID StoreID.
-	UpdateStorePool(StoreID, map[roachpb.StoreID]*storepool.StoreDetail)
+	UpdateStorePool(StoreID, map[roachpb.StoreID]*storepool.StoreDetailMu)
 	// NextReplicasFn returns a function, that when called will return the current
 	// replicas that exist on the store.
 	NextReplicasFn(StoreID) func() []Replica

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -247,11 +247,11 @@ func BenchmarkStorePoolReadsWithConcurrentUpdates(b *testing.B) {
 					}
 					// Note that we have to lock the whole store pool just to update one
 					// store detail.
-					store.StorePool().DetailsMu.Lock()
-					detail := store.StorePool().GetStoreDetailLocked(roachpb.StoreID(i))
+					detail := store.StorePool().GetStoreDetail(roachpb.StoreID(i))
+					detail.Lock()
 					detail.LastUpdatedTime = detail.LastUpdatedTime.AddDuration(100 * time.Millisecond)
 					time.Sleep(100 * time.Millisecond)
-					store.StorePool().DetailsMu.Unlock()
+					detail.Unlock()
 				}
 			}
 		}

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -211,3 +211,60 @@ func TestStoreLoadReplicaQuiescent(t *testing.T) {
 		}
 	})
 }
+
+// BenchmarkStorePoolReadsWithConcurrentUpdates checks the performance of
+// querying the store pool while there are concurrent updates to the store
+// details.
+func BenchmarkStorePoolReadsWithConcurrentUpdates(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	// Create cluster with 3 nodes.
+	numNodes := 3
+	cluster := testcluster.StartTestCluster(b, numNodes, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer cluster.Stopper().Stop(ctx)
+
+	// Start a goroutine that continuously takes the write lock on storepool for
+	// updating the store details. This is to simulate the gossip callback that
+	// periodically updates the store details.
+	stopCh := make(chan struct{})
+	go func() {
+		store := cluster.GetFirstStoreFromServer(b, 0)
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				for i := range numNodes {
+					// Skip the updates to the store idx 1. This is to test the
+					// performance for updates to other stores while checking if the
+					// store is ready for routine replica transfer below.
+					if i == 1 {
+						continue
+					}
+					// Note that we have to lock the whole store pool just to update one
+					// store detail.
+					store.StorePool().DetailsMu.Lock()
+					detail := store.StorePool().GetStoreDetailLocked(roachpb.StoreID(i))
+					detail.LastUpdatedTime = detail.LastUpdatedTime.AddDuration(100 * time.Millisecond)
+					time.Sleep(100 * time.Millisecond)
+					store.StorePool().DetailsMu.Unlock()
+				}
+			}
+		}
+	}()
+
+	// Ensure the goroutine is stopped when the benchmark completes.
+	defer close(stopCh)
+
+	b.ResetTimer()
+	store := cluster.GetFirstStoreFromServer(b, 0)
+	for n := 0; n < b.N; n++ {
+		// Check if the store is ready for routine replica transfer. This function
+		// is periodically called from the replicate queue.
+		store.StorePool().IsStoreReadyForRoutineReplicaTransfer(ctx, roachpb.StoreID(1))
+	}
+}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -59,6 +59,10 @@ func (s *Store) StoreLivenessTransport() *storeliveness.Transport {
 	return s.cfg.StoreLiveness.Transport
 }
 
+func (s *Store) StorePool() *storepool.StorePool {
+	return s.cfg.StorePool
+}
+
 func (s *Store) FindTargetAndTransferLease(
 	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, conf *roachpb.SpanConfig,
 ) (bool, error) {

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -468,7 +468,7 @@ func (s *Store) receiveSnapshot(
 	ctx context.Context, header *kvserverpb.SnapshotRequest_Header, stream incomingSnapshotStream,
 ) error {
 	// Draining nodes will generally not be rebalanced to (see the filtering that
-	// happens in getStoreListFromIDsLocked()), but in case they are, they should
+	// happens in getStoreListFromIDs()), but in case they are, they should
 	// reject the incoming rebalancing snapshots.
 	if s.IsDraining() {
 		switch t := header.SenderQueueName; t {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3385,9 +3385,10 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 	desc.Capacity.Available = 1
 	desc.Capacity.Used = desc.Capacity.Capacity - desc.Capacity.Available
 
-	s.cfg.StorePool.DetailsMu.Lock()
-	s.cfg.StorePool.GetStoreDetailLocked(desc.StoreID).Desc = desc
-	s.cfg.StorePool.DetailsMu.Unlock()
+	sd := s.cfg.StorePool.GetStoreDetail(desc.StoreID)
+	sd.Lock()
+	sd.Desc = desc
+	sd.Unlock()
 
 	if n := s.ReservationCount(); n != 0 {
 		t.Fatalf("expected 0 reservations, but found %d", n)
@@ -3409,9 +3410,10 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 	// available disk space should be rejected.
 	desc.Capacity.Available = desc.Capacity.Capacity / 2
 	desc.Capacity.Used = desc.Capacity.Capacity - desc.Capacity.Available
-	s.cfg.StorePool.DetailsMu.Lock()
-	s.cfg.StorePool.GetStoreDetailLocked(desc.StoreID).Desc = desc
-	s.cfg.StorePool.DetailsMu.Unlock()
+	sd = s.cfg.StorePool.GetStoreDetail(desc.StoreID)
+	sd.Lock()
+	sd.Desc = desc
+	sd.Unlock()
 
 	if n := s.ReservationCount(); n != 0 {
 		t.Fatalf("expected 0 reservations, but found %d", n)


### PR DESCRIPTION
Backport 4/4 commits from #144303.

/cc @cockroachdb/release

---

This commit takes mutex locks for individual storePool details instead of
the whole storePool map. This should reduce the mutex contention
especially at high store count clusters. Previously, every gossip store
update callback used to lock the whole StorePool.DetailsMu. This blocked
other accesses to any storepool.Detail.

Benchmark results:
```
name                                    old time/op    new time/op    delta
StorePoolReadsWithConcurrentUpdates-12    1.79ms ±40%    0.00ms ± 7%   -99.99%  (p=0.000 n=10+10)

name                                    old alloc/op   new alloc/op   delta
StorePoolReadsWithConcurrentUpdates-12    10.8kB ±57%     0.0kB ±33%   -99.99%  (p=0.000 n=10+10)

name                                    old allocs/op  new allocs/op  delta
StorePoolReadsWithConcurrentUpdates-12      44.2 ±22%       0.0       -100.00%  (p=0.000 n=9+10)
```

Note that the benchmark basically tests that updating a specific store detail
doesn't block accessing other store details.

References: #143145

Release note: None

Release justification: improve gossip scalability in 25.2
