### PR TITLE
fuzzystrmatch: fix out of bounds in LevenshteinLessEqual

### DIFF
--- a/pkg/util/fuzzystrmatch/leven.go
+++ b/pkg/util/fuzzystrmatch/leven.go
@@ -123,6 +123,9 @@ func LevenshteinLessEqualDistanceWithCost(
 				bestColumn = -netInserts
 			}
 			stopColumn = bestColumn + (slackDist / (insCost + delCost)) + 1
+			if stopColumn < 0 {
+				stopColumn = 0
+			}
 			if stopColumn > lenS {
 				stopColumn = lenS + 1
 			}

--- a/pkg/util/fuzzystrmatch/leven_test.go
+++ b/pkg/util/fuzzystrmatch/leven_test.go
@@ -5,7 +5,10 @@
 
 package fuzzystrmatch
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestLevenshteinDistance(t *testing.T) {
 	tt := []struct {
@@ -479,6 +482,36 @@ func TestLevenshteinLessEqualDistanceWithCost(t *testing.T) {
 			t.Fatalf("error checking Levenshtein distance with cost less than %d with "+
 				"source=%q target=%q: expected %d got %d",
 				tc.MaxDistance, tc.Source, tc.Target, tc.Expected, got)
+		}
+	}
+}
+
+func TestLevenshtein_ExtremeValues(t *testing.T) {
+	// Test all combinations of math.MinInt64 and math.MaxInt64 for integer
+	// arguments. This ensures the function handles extreme values correctly
+	// without panicking.
+	extremeValues := []int{math.MinInt64, math.MaxInt64, 0, 1, -1, -6503603920424974249, -3160545599026710833, 3234088755759361354}
+	testStrings := []string{"ab", "bc", "", "test"}
+
+	for _, source := range testStrings {
+		for _, target := range testStrings {
+			for _, insCost := range extremeValues {
+				for _, delCost := range extremeValues {
+					for _, subCost := range extremeValues {
+						for _, maxDist := range extremeValues {
+							// Call the functions and ensure it doesn't panic. We don't check
+							// the exact result since extreme values may cause integer
+							// overflow, but we ensure no panic occurs.
+							_ = LevenshteinLessEqualDistanceWithCost(
+								source, target, insCost, delCost, subCost, maxDist,
+							)
+							_ = LevenshteinDistanceWithCost(
+								source, target, insCost, delCost, subCost,
+							)
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes a bug that was added when this function was introduced in 7a538b398e3.

No release note since this bug was not released yet.

fixes https://github.com/cockroachdb/cockroach/issues/152418
Release note: None