### PR TITLE
release-25.2: schemachanger: don't run TestAlterTableDMLInjection with t.Parallel

### DIFF
--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -548,7 +548,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range testCases {
 		t.Run(tc.desc, tc.capture(func(t *testing.T, tc testCase) {
-			t.Parallel() // SAFE FOR TESTING
 			if issue := tc.skipIssue; issue != 0 {
 				skip.WithIssue(t, issue)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #152394 on behalf of @rafiss.

----

Under deadlock/race configurations, this can add too much load to the test runner.

fixes https://github.com/cockroachdb/cockroach/issues/152254
fixes https://github.com/cockroachdb/cockroach/issues/152339
fixes https://github.com/cockroachdb/cockroach/issues/152258
fixes https://github.com/cockroachdb/cockroach/issues/152255
fixes https://github.com/cockroachdb/cockroach/issues/152256
fixes https://github.com/cockroachdb/cockroach/issues/152252
fixes https://github.com/cockroachdb/cockroach/issues/152411
Release note: None

----

Release justification: test only change