### PR TITLE
tree: harden DArray with NULL elements

### DIFF
--- a/pkg/sql/execinfra/execexpr/expr_test.go
+++ b/pkg/sql/execinfra/execexpr/expr_test.go
@@ -96,11 +96,9 @@ func TestDeserializeExpressionConstantEval(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := &tree.DArray{
-		ParamTyp:    types.Int,
-		Array:       tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
-		HasNonNulls: true,
-	}
+	expected := tree.NewDArrayFromDatums(
+		types.Int, tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+	)
 	if !reflect.DeepEqual(expr, expected) {
 		t.Errorf("invalid expr '%v', expected '%v'", expr, expected)
 	}

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -223,7 +223,7 @@ func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
 
 	case opt.ContainsOp:
 		if arr, ok := datum.(*tree.DArray); ok {
-			if arr.HasNulls {
+			if arr.HasNulls() {
 				return contradiction, true
 			}
 		}

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -81,17 +81,11 @@ func ExtractConstDatum(e opt.Expr) tree.Datum {
 
 	case *ArrayExpr:
 		elementType := t.Typ.ArrayContents()
-		a := tree.NewDArray(elementType)
-		a.Array = make(tree.Datums, len(t.Elems))
-		for i := range a.Array {
-			a.Array[i] = ExtractConstDatum(t.Elems[i])
-			if a.Array[i] == tree.DNull {
-				a.HasNulls = true
-			} else {
-				a.HasNonNulls = true
-			}
+		elements := make(tree.Datums, len(t.Elems))
+		for i := range elements {
+			elements[i] = ExtractConstDatum(t.Elems[i])
 		}
-		return a
+		return tree.NewDArrayFromDatums(elementType, elements)
 	}
 	panic(errors.AssertionFailedf("non-const expression: %+v", e))
 }

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -68,20 +68,13 @@ func TestInterner(t *testing.T) {
 		Typ: tupleTyp3,
 	}
 
-	arr1 := tree.NewDArray(tupTyp1)
-	arr1.Array = tree.Datums{tup1, tup2}
-	arr2 := tree.NewDArray(tupTyp2)
-	arr2.Array = tree.Datums{tup2, tup1}
-	arr3 := tree.NewDArray(tupTyp3)
-	arr3.Array = tree.Datums{tup2, tup3}
-	arr4 := tree.NewDArray(types.Int)
-	arr4.Array = tree.Datums{tree.DNull}
-	arr5 := tree.NewDArray(types.String)
-	arr5.Array = tree.Datums{tree.DNull}
-	arr6 := tree.NewDArray(types.Int)
-	arr6.Array = tree.Datums{}
-	arr7 := tree.NewDArray(types.String)
-	arr7.Array = tree.Datums{}
+	arr1 := tree.NewDArrayFromDatums(tupTyp1, tree.Datums{tup1, tup2})
+	arr2 := tree.NewDArrayFromDatums(tupTyp2, tree.Datums{tup2, tup1})
+	arr3 := tree.NewDArrayFromDatums(tupTyp3, tree.Datums{tup2, tup3})
+	arr4 := tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.DNull})
+	arr5 := tree.NewDArrayFromDatums(types.String, tree.Datums{tree.DNull})
+	arr6 := tree.NewDArrayFromDatums(types.Int, tree.Datums{})
+	arr7 := tree.NewDArrayFromDatums(types.String, tree.Datums{})
 
 	dec1, _ := tree.ParseDDecimal("1.0")
 	dec2, _ := tree.ParseDDecimal("1.0")

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -182,17 +182,11 @@ func (c *CustomFuncs) IsListOfConstants(elems memo.ScalarListExpr) bool {
 // array as a Const datum with type TArray.
 func (c *CustomFuncs) FoldArray(elems memo.ScalarListExpr, typ *types.T) opt.ScalarExpr {
 	elemType := typ.ArrayContents()
-	a := tree.NewDArray(elemType)
-	a.Array = make(tree.Datums, len(elems))
-	for i := range a.Array {
-		a.Array[i] = memo.ExtractConstDatum(elems[i])
-		if a.Array[i] == tree.DNull {
-			a.HasNulls = true
-		} else {
-			a.HasNonNulls = true
-		}
+	elements := make(tree.Datums, len(elems))
+	for i := range elements {
+		elements[i] = memo.ExtractConstDatum(elems[i])
 	}
-	return c.f.ConstructConst(a, typ)
+	return c.f.ConstructConst(tree.NewDArrayFromDatums(elemType, elements), typ)
 }
 
 // IsConstValueOrGroupOfConstValues returns true if the input is a constant,

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -1178,10 +1178,9 @@ func BenchmarkHistogram(b *testing.B) {
 		case types.StringFamily:
 			return tree.NewDString(strconv.Itoa(i * 2))
 		case types.ArrayFamily:
-			arr := tree.NewDArray(t.ArrayContents())
-			arr.Array = make(tree.Datums, 1)
-			arr.HasNonNulls = true
-			arr.Array[0] = makeDatum(t.ArrayContents(), i)
+			arr := tree.NewDArrayFromDatums(
+				t.ArrayContents(), tree.Datums{makeDatum(t.ArrayContents(), i)},
+			)
 			return arr
 		}
 		panic(errors.AssertionFailedf("unsupported type"))

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2523,11 +2523,14 @@ https://www.postgresql.org/docs/9.6/view-pg-prepared-statements.html`,
 			paramNames := make([]string, len(placeholderTypes))
 
 			for i, placeholderType := range placeholderTypes {
+				// TODO(yuzefovich): we're including INT8 into array containing
+				// REGTYPE. Figure it out.
 				paramTypes.Array[i] = tree.NewDOidWithTypeAndName(
 					placeholderType.Oid(),
 					placeholderType,
 					placeholderType.SQLStandardName(),
 				)
+				paramTypes.SetHasNonNulls(true /* hasNonNulls */)
 				paramNames[i] = placeholderType.Name()
 			}
 
@@ -2624,7 +2627,7 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 		}
 
 		getVariadicStringArray := func() tree.Datum {
-			return &tree.DArray{ParamTyp: types.String, Array: tree.Datums{proArgModeVariadic}}
+			return tree.NewDArrayFromDatums(types.String, tree.Datums{proArgModeVariadic})
 		}
 
 		var argmodes tree.Datum

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -843,7 +843,7 @@ func writeBinaryDatumNotNull(
 		}
 		b.putInt32(ndims)
 		hasNulls := 0
-		if v.HasNulls {
+		if v.HasNulls() {
 			hasNulls = 1
 		}
 		oid := v.ParamTyp.Oid()

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -900,7 +900,7 @@ func encodeContainingArrayInvertedIndexSpans(
 		return invertedExpr, nil
 	}
 
-	if val.HasNulls {
+	if val.HasNulls() {
 		// If there are any nulls, return empty spans. This is needed to ensure
 		// that `SELECT ARRAY[NULL, 2] @> ARRAY[NULL, 2]` is false.
 		return &inverted.SpanExpression{Tight: true, Unique: true}, nil
@@ -981,7 +981,7 @@ func encodeOverlapsArrayInvertedIndexSpans(
 	// we cannot generate an inverted expression.
 
 	// TODO: This should be a contradiction which is treated as a no-op.
-	if val.Array.Len() == 0 || !val.HasNonNulls {
+	if val.Array.Len() == 0 || !val.HasNonNulls() {
 		return inverted.NonInvertedColExpression{}, nil
 	}
 

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -371,34 +371,22 @@ func TestInvertedIndexKey(t *testing.T) {
 		expectedKeysExcludingEmptyArray int
 	}{
 		{
-			value: &tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{},
-			},
+			value:                           tree.NewDArrayFromDatums(types.Int, tree.Datums{}),
 			expectedKeys:                    1,
 			expectedKeysExcludingEmptyArray: 0,
 		},
 		{
-			value: &tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.NewDInt(1)},
-			},
+			value:                           tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.NewDInt(1)}),
 			expectedKeys:                    1,
 			expectedKeysExcludingEmptyArray: 1,
 		},
 		{
-			value: &tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.NewDString("foo")},
-			},
+			value:                           tree.NewDArrayFromDatums(types.String, tree.Datums{tree.NewDString("foo")}),
 			expectedKeys:                    1,
 			expectedKeysExcludingEmptyArray: 1,
 		},
 		{
-			value: &tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.NewDInt(1), tree.NewDInt(2), tree.NewDInt(1)},
-			},
+			value: tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.NewDInt(1), tree.NewDInt(2), tree.NewDInt(1)}),
 			// The keys should be deduplicated.
 			expectedKeys:                    2,
 			expectedKeysExcludingEmptyArray: 2,
@@ -985,8 +973,8 @@ func TestEncodeOverlapsArrayInvertedIndexSpans(t *testing.T) {
 
 		rightArr, _ := right.(*tree.DArray)
 		// An inverted expression can only be generated if the value array is
-		// non-empty or contains atleast one non-NULL element.
-		ok := rightArr.Len() > 0 && rightArr.HasNonNulls
+		// non-empty or contains at least one non-NULL element.
+		ok := rightArr.Len() > 0 && rightArr.HasNonNulls()
 		// A unique span expression can be guaranteed when the input is of
 		// the form:
 		// Array A && Array containing one or more entries of same non-null

--- a/pkg/sql/rowenc/valueside/array_test.go
+++ b/pkg/sql/rowenc/valueside/array_test.go
@@ -18,7 +18,7 @@ import (
 
 type arrayEncodingTest struct {
 	name     string
-	datum    tree.DArray
+	datum    *tree.DArray
 	encoding []byte
 }
 
@@ -26,91 +26,87 @@ func TestArrayEncoding(t *testing.T) {
 	tests := []arrayEncodingTest{
 		{
 			"empty int array",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{},
-			},
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{},
+			),
 			[]byte{1, 3, 0},
 		}, {
 			"single int array",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.NewDInt(1)},
-			},
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{tree.NewDInt(1)},
+			),
 			[]byte{1, 3, 1, 2},
 		}, {
 			"multiple int array",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.NewDInt(1), tree.NewDInt(2), tree.NewDInt(3)},
-			},
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{tree.NewDInt(1), tree.NewDInt(2), tree.NewDInt(3)},
+			),
 			[]byte{1, 3, 3, 2, 4, 6},
 		}, {
 			"string array",
-			tree.DArray{
-				ParamTyp: types.String,
-				Array:    tree.Datums{tree.NewDString("foo"), tree.NewDString("bar"), tree.NewDString("baz")},
-			},
+			tree.NewDArrayFromDatums(
+				types.String,
+				tree.Datums{tree.NewDString("foo"), tree.NewDString("bar"), tree.NewDString("baz")},
+			),
 			[]byte{1, 6, 3, 3, 102, 111, 111, 3, 98, 97, 114, 3, 98, 97, 122},
 		}, {
 			"name array",
-			tree.DArray{
-				ParamTyp: types.Name,
-				Array:    tree.Datums{tree.NewDName("foo"), tree.NewDName("bar"), tree.NewDName("baz")},
-			},
+			tree.NewDArrayFromDatums(
+				types.Name,
+				tree.Datums{tree.NewDName("foo"), tree.NewDName("bar"), tree.NewDName("baz")},
+			),
 			[]byte{1, 6, 3, 3, 102, 111, 111, 3, 98, 97, 114, 3, 98, 97, 122},
 		},
 		{
 			"bool array",
-			tree.DArray{
-				ParamTyp: types.Bool,
-				Array:    tree.Datums{tree.MakeDBool(true), tree.MakeDBool(false)},
-			},
+			tree.NewDArrayFromDatums(
+				types.Bool,
+				tree.Datums{tree.MakeDBool(true), tree.MakeDBool(false)},
+			),
 			[]byte{1, 10, 2, 10, 11},
 		}, {
 			"array containing a single null",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.DNull},
-				HasNulls: true,
-			},
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{tree.DNull},
+			),
 			[]byte{17, 3, 1, 1},
 		}, {
 			"array containing multiple nulls",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array:    tree.Datums{tree.NewDInt(1), tree.DNull, tree.DNull},
-				HasNulls: true,
-			},
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{tree.NewDInt(1), tree.DNull, tree.DNull},
+			),
 			[]byte{17, 3, 3, 6, 2},
 		}, {
 			"array whose NULL bitmap spans exactly one byte",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array: tree.Datums{
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{
 					tree.NewDInt(1), tree.DNull, tree.DNull, tree.NewDInt(2), tree.NewDInt(3),
 					tree.NewDInt(4), tree.NewDInt(5), tree.NewDInt(6),
 				},
-				HasNulls: true,
-			},
+			),
 			[]byte{17, 3, 8, 6, 2, 4, 6, 8, 10, 12},
 		}, {
 			"array whose NULL bitmap spans more than one byte",
-			tree.DArray{
-				ParamTyp: types.Int,
-				Array: tree.Datums{
+			tree.NewDArrayFromDatums(
+				types.Int,
+				tree.Datums{
 					tree.NewDInt(1), tree.DNull, tree.DNull, tree.NewDInt(2), tree.NewDInt(3),
 					tree.NewDInt(4), tree.NewDInt(5), tree.NewDInt(6), tree.DNull,
 				},
-				HasNulls: true,
-			},
+			),
 			[]byte{17, 3, 9, 6, 1, 2, 4, 6, 8, 10, 12},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run("encode "+test.name, func(t *testing.T) {
-			enc, err := encodeArray(&test.datum, nil)
+			enc, err := encodeArray(test.datum, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -121,15 +117,15 @@ func TestArrayEncoding(t *testing.T) {
 
 		t.Run("decode "+test.name, func(t *testing.T) {
 			d, _, err := decodeArray(&tree.DatumAlloc{}, types.MakeArray(test.datum.ParamTyp), test.encoding)
-			hasNulls := d.(*tree.DArray).HasNulls
-			if test.datum.HasNulls != hasNulls {
-				t.Fatalf("expected %v to have HasNulls=%t, got %t", test.encoding, test.datum.HasNulls, hasNulls)
+			hasNulls := d.(*tree.DArray).HasNulls()
+			if test.datum.HasNulls() != hasNulls {
+				t.Fatalf("expected %v to have HasNulls=%t, got %t", test.encoding, test.datum.HasNulls(), hasNulls)
 			}
 			if err != nil {
 				t.Fatal(err)
 			}
 			evalContext := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			if cmp, err := d.Compare(context.Background(), evalContext, &test.datum); err != nil {
+			if cmp, err := d.Compare(context.Background(), evalContext, test.datum); err != nil {
 				t.Fatal(err)
 			} else if cmp != 0 {
 				t.Fatalf("expected %v to decode to %s, got %s", test.encoding, test.datum.String(), d.String())

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -206,9 +206,9 @@ func TestInvertedJoiner(t *testing.T) {
 		return tree.NewDInt(tree.DInt(row))
 	}
 	bFn := func(row int) tree.Datum {
-		arr := tree.NewDArray(types.Int)
-		arr.Array = tree.Datums{tree.NewDInt(tree.DInt(row / 10)), tree.NewDInt(tree.DInt(row % 10))}
-		return arr
+		return tree.NewDArrayFromDatums(
+			types.Int, tree.Datums{tree.NewDInt(tree.DInt(row / 10)), tree.NewDInt(tree.DInt(row % 10))},
+		)
 	}
 	cFn := func(row int) tree.Datum {
 		j, err := json.ParseJSON(fmt.Sprintf(`{"c1": %d, "c2": %d}`, row/10, row%10))
@@ -749,9 +749,9 @@ func TestInvertedJoinerDrain(t *testing.T) {
 		return tree.NewDInt(tree.DInt(row))
 	}
 	bFn := func(row int) tree.Datum {
-		arr := tree.NewDArray(types.Int)
-		arr.Array = tree.Datums{tree.NewDInt(tree.DInt(row / 10)), tree.NewDInt(tree.DInt(row % 10))}
-		return arr
+		return tree.NewDArrayFromDatums(
+			types.Int, tree.Datums{tree.NewDInt(tree.DInt(row / 10)), tree.NewDInt(tree.DInt(row % 10))},
+		)
 	}
 	sqlutils.CreateTable(t, sqlDB, "t",
 		"a INT PRIMARY KEY, b INT ARRAY, INVERTED INDEX bi (b)",

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -1996,7 +1996,7 @@ type arrayCatAggregate struct {
 	acc mon.BoundAccount
 	// seenNonNull tracks whether at least one non-NULL datum was added. This is
 	// needed to handle a case of only empty arrays added correctly (we want to
-	// return an empty array too rather that NULL).
+	// return an empty array too rather than NULL).
 	seenNonNull bool
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9670,14 +9670,11 @@ WHERE object_id = table_descriptor_id
 				if array.Len() == 0 {
 					return tree.DNull, nil
 				}
-				if array.HasNulls {
+				if array.HasNulls() {
 					return nil, pgerror.New(pgcode.NullValueNotAllowed, "array must not contain nulls")
 				}
 				ltrees := make([]ltree.T, array.Len())
 				for i, l := range array.Array {
-					if l == tree.DNull {
-						return l, nil
-					}
 					ltrees[i] = tree.MustBeDLTree(l).LTree
 				}
 				lca, isNull := ltree.LCA(ltrees) // lint: uppercase function OK
@@ -10442,7 +10439,7 @@ func darrayToStringSlice(d tree.DArray) (result []string, ok bool) {
 
 // checkHasNulls returns an appropriate error if the array contains a NULL.
 func checkHasNulls(ary tree.DArray) error {
-	if ary.HasNulls {
+	if ary.HasNulls() {
 		for i := range ary.Array {
 			if ary.Array[i] == tree.DNull {
 				return pgerror.Newf(pgcode.NullValueNotAllowed, "path element at position %d is null", i+1)

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1581,9 +1581,8 @@ func NullGenerator(typ *types.T) (eval.ValueGenerator, error) {
 		return nil, errors.AssertionFailedf("generator expected to return multiple columns")
 	}
 	arrs := make([]*tree.DArray, len(typ.TupleContents()))
-	for i := range typ.TupleContents() {
-		arrs[i] = &tree.DArray{}
-		arrs[i].Array = tree.Datums{tree.DNull}
+	for i, paramTyp := range typ.TupleContents() {
+		arrs[i] = tree.NewDArrayFromDatums(paramTyp, tree.Datums{tree.DNull})
 	}
 	return &multipleArrayValueGenerator{arrays: arrs}, nil
 }

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -349,7 +349,7 @@ func (e *evaluator) EvalFirstContainedByLTreeOp(
 	array := tree.MustBeDArray(a)
 	elem := tree.MustBeDLTree(b)
 
-	if array.HasNulls {
+	if array.HasNulls() {
 		return nil, pgerror.New(pgcode.NullValueNotAllowed, "array must not contain nulls")
 	}
 	for _, d := range array.Array {
@@ -411,7 +411,7 @@ func (e *evaluator) EvalFirstContainsLTreeOp(
 	array := tree.MustBeDArray(a)
 	elem := tree.MustBeDLTree(b)
 
-	if array.HasNulls {
+	if array.HasNulls() {
 		return nil, pgerror.New(pgcode.NullValueNotAllowed, "array must not contain nulls")
 	}
 	for _, d := range array.Array {

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -617,12 +617,12 @@ func performCastWithoutPrecisionTruncation(
 		case *tree.DArray:
 			switch d.ParamTyp.Family() {
 			case types.FloatFamily, types.IntFamily, types.DecimalFamily:
+				if d.HasNulls() {
+					return nil, pgerror.Newf(pgcode.NullValueNotAllowed,
+						"array must not contain nulls")
+				}
 				v := make(vector.T, len(d.Array))
 				for i, elem := range d.Array {
-					if elem == tree.DNull {
-						return nil, pgerror.Newf(pgcode.NullValueNotAllowed,
-							"array must not contain nulls")
-					}
 					datum, err := performCast(ctx, evalCtx, elem, types.Float4, false)
 					if err != nil {
 						return nil, err

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -857,13 +857,17 @@ func ensureExpectedType(exp *types.T, d tree.Datum) error {
 	return nil
 }
 
-// arrayOfType returns a fresh DArray of the input type.
-func arrayOfType(typ *types.T) (*tree.DArray, error) {
+// arrayOfType returns a fresh tree.DArray of the input type. 'elements'
+// argument is optional.
+func arrayOfType(typ *types.T, elements tree.Datums) (*tree.DArray, error) {
 	if typ.Family() != types.ArrayFamily {
 		return nil, errors.AssertionFailedf("array node type (%v) is not types.TArray", typ)
 	}
 	if err := types.CheckArrayElementType(typ.ArrayContents()); err != nil {
 		return nil, err
+	}
+	if elements != nil {
+		return tree.NewDArrayFromDatums(typ.ArrayContents(), elements), nil
 	}
 	return tree.NewDArray(typ.ArrayContents()), nil
 }

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -60,7 +60,7 @@ func (e *evaluator) EvalAndExpr(ctx context.Context, expr *tree.AndExpr) (tree.D
 }
 
 func (e *evaluator) EvalArray(ctx context.Context, t *tree.Array) (tree.Datum, error) {
-	array, err := arrayOfType(t.ResolvedType())
+	array, err := arrayOfType(t.ResolvedType(), nil /* elements */)
 	if err != nil {
 		return nil, err
 	}
@@ -80,11 +80,6 @@ func (e *evaluator) EvalArray(ctx context.Context, t *tree.Array) (tree.Datum, e
 func (e *evaluator) EvalArrayFlatten(
 	ctx context.Context, t *tree.ArrayFlatten,
 ) (tree.Datum, error) {
-	array, err := arrayOfType(t.ResolvedType())
-	if err != nil {
-		return nil, err
-	}
-
 	d, err := t.Subquery.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
@@ -94,7 +89,10 @@ func (e *evaluator) EvalArrayFlatten(
 	if !ok {
 		return nil, errors.AssertionFailedf("array subquery result (%v) is not DTuple", d)
 	}
-	array.Array = tuple.D
+	array, err := arrayOfType(t.ResolvedType(), tuple.D)
+	if err != nil {
+		return nil, err
+	}
 	return array, nil
 }
 

--- a/pkg/sql/sem/eval/json.go
+++ b/pkg/sql/sem/eval/json.go
@@ -33,14 +33,17 @@ func PopulateDatumWithJSON(
 		n := j.Len()
 		elementTyp := desiredType.ArrayContents()
 		d := tree.NewDArray(elementTyp)
-		d.Array = make(tree.Datums, n)
+		d.Array = make(tree.Datums, 0, n)
 		for i := 0; i < n; i++ {
 			elt, err := j.FetchValIdx(i)
 			if err != nil {
 				return nil, err
 			}
-			d.Array[i], err = PopulateDatumWithJSON(ctx, evalCtx, elt, elementTyp)
+			elem, err := PopulateDatumWithJSON(ctx, evalCtx, elt, elementTyp)
 			if err != nil {
+				return nil, err
+			}
+			if err = d.Append(elem); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/sql/sem/normalize/constant_eval_test.go
+++ b/pkg/sql/sem/normalize/constant_eval_test.go
@@ -48,12 +48,10 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 	left := tree.ColumnItem{
 		ColumnName: "a",
 	}
-	right := tree.DArray{
-		ParamTyp:    types.Int,
-		Array:       tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
-		HasNonNulls: true,
-	}
-	expected := tree.NewTypedComparisonExpr(treecmp.MakeComparisonOperator(treecmp.EQ), &left, &right)
+	right := tree.NewDArrayFromDatums(
+		types.Int, tree.Datums{tree.NewDInt(1), tree.NewDInt(2)},
+	)
+	expected := tree.NewTypedComparisonExpr(treecmp.MakeComparisonOperator(treecmp.EQ), &left, right)
 	if !reflect.DeepEqual(expr, expected) {
 		t.Errorf("invalid expr '%v', expected '%v'", expr, expected)
 	}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/collatedstring"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -5073,17 +5074,18 @@ func (d dNull) Size() uintptr {
 	return unsafe.Sizeof(d)
 }
 
-// DArray is the array Datum. Any Datum inserted into a DArray are treated as
-// text during serialization.
+// DArray is the array Datum.
 type DArray struct {
 	ParamTyp *types.T
-	Array    Datums
-	// HasNulls is set to true if any of the datums within the array are null.
-	// This is used in the binary array serialization format.
-	HasNulls bool
-	// HasNonNulls is set to true if any of the datums within the are non-null.
-	// This is used in expression serialization (FmtParsable).
-	HasNonNulls bool
+	// Array gives access to the underlying array. Using NewDArrayFromDatums or
+	// Append is preferrable for constructing the contents, but modifying the
+	// slice is also allowed - just be sure to update NULL-related flags via
+	// Set* methods accordingly.
+	Array Datums
+	// hasNulls is set to true if any of the datums within the array are null.
+	hasNulls bool
+	// hasNonNulls is set to true if any of the datums within the are non-null.
+	hasNonNulls bool
 
 	// customOid, if non-0, is the oid of this array datum.
 	customOid oid.Oid
@@ -5092,6 +5094,31 @@ type DArray struct {
 // NewDArray returns a DArray containing elements of the specified type.
 func NewDArray(paramTyp *types.T) *DArray {
 	return &DArray{ParamTyp: paramTyp}
+}
+
+// NewDArrayFromDatums returns a DArray containing the given datums that are
+// assumed to be of the specified type. It'll populate NULL-related fields
+// accordingly.
+func NewDArrayFromDatums(paramTyp *types.T, datums Datums) *DArray {
+	if buildutil.CrdbTestBuild {
+		for _, d := range datums {
+			if !d.ResolvedType().EquivalentOrNull(paramTyp, true /* allowNullTupleEquivalence */) {
+				panic(errors.AssertionFailedf(
+					"cannot include %s into array containing %s",
+					d.ResolvedType().SQLStringForError(), paramTyp.SQLStringForError(),
+				))
+			}
+		}
+	}
+	d := &DArray{ParamTyp: paramTyp, Array: datums}
+	for _, elem := range d.Array {
+		if elem == DNull {
+			d.hasNulls = true
+		} else {
+			d.hasNonNulls = true
+		}
+	}
+	return d
 }
 
 // AsDArray attempts to retrieve a *DArray from an Expr, returning a *DArray and
@@ -5116,6 +5143,34 @@ func MustBeDArray(e Expr) *DArray {
 		panic(errors.AssertionFailedf("expected *DArray, found %T", e))
 	}
 	return i
+}
+
+func (d *DArray) testOnlyValidation() {
+	if buildutil.CrdbTestBuild {
+		if err := d.Validate(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (d *DArray) HasNulls() bool {
+	d.testOnlyValidation()
+	return d.hasNulls
+}
+
+func (d *DArray) SetHasNulls(hasNulls bool) {
+	d.hasNulls = hasNulls
+	d.testOnlyValidation()
+}
+
+func (d *DArray) HasNonNulls() bool {
+	d.testOnlyValidation()
+	return d.hasNonNulls
+}
+
+func (d *DArray) SetHasNonNulls(hasNonNulls bool) {
+	d.hasNonNulls = hasNonNulls
+	d.testOnlyValidation()
 }
 
 // MaybeSetCustomOid checks whether t has a special oid that we want to set into
@@ -5206,10 +5261,10 @@ func (d *DArray) Prev(ctx context.Context, cmpCtx CompareContext) (Datum, bool) 
 
 // Next implements the Datum interface.
 func (d *DArray) Next(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
-	a := DArray{ParamTyp: d.ParamTyp, Array: make(Datums, d.Len()+1)}
-	copy(a.Array, d.Array)
-	a.Array[len(a.Array)-1] = DNull
-	return &a, true
+	elements := make(Datums, d.Len()+1)
+	copy(elements, d.Array)
+	elements[d.Len()] = DNull
+	return NewDArrayFromDatums(d.ParamTyp, elements), true
 }
 
 // Max implements the Datum interface.
@@ -5242,7 +5297,7 @@ func (d *DArray) AmbiguousFormat() bool {
 		// a valid type. So an array of unknown type is (paradoxically) unambiguous.
 		return false
 	}
-	return !d.HasNonNulls
+	return !d.HasNonNulls()
 }
 
 // Format implements the NodeFormatter interface.
@@ -5277,11 +5332,33 @@ const maxArrayLength = math.MaxInt32
 
 var errArrayTooLongError = errors.New("ARRAYs can be at most 2^31-1 elements long")
 
-// Validate checks that the given array is valid,
-// for example, that it's not too big.
+// Validate checks that the given array is valid, for example, that it's not too
+// big.
 func (d *DArray) Validate() error {
 	if d.Len() > maxArrayLength {
 		return errors.WithStack(errArrayTooLongError)
+	}
+	if buildutil.CrdbTestBuild {
+		// Additionally, in test builds ensure that NULL-related flags are set
+		// correctly.
+		var hasNulls, hasNonNulls bool
+		for _, elem := range d.Array {
+			if elem == DNull {
+				hasNulls = true
+			} else {
+				hasNonNulls = true
+			}
+		}
+		if hasNulls != d.hasNulls {
+			return errors.AssertionFailedf(
+				"found DArray with incorrect HasNulls (expected %t)", hasNulls,
+			)
+		}
+		if hasNonNulls != d.hasNonNulls {
+			return errors.AssertionFailedf(
+				"found DArray with incorrect HasNonNulls (expected %t)", hasNonNulls,
+			)
+		}
 	}
 	return nil
 }
@@ -5333,9 +5410,9 @@ func (d *DArray) Append(v Datum) error {
 		}
 	}
 	if v == DNull {
-		d.HasNulls = true
+		d.hasNulls = true
 	} else {
-		d.HasNonNulls = true
+		d.hasNonNulls = true
 	}
 	d.Array = append(d.Array, v)
 	return d.Validate()
@@ -6646,6 +6723,11 @@ func AdjustValueToType(typ *types.T, inVal Datum) (outVal Datum, err error) {
 				}
 			}
 			if outArr != nil {
+				if buildutil.CrdbTestBuild {
+					if err := outArr.Validate(); err != nil {
+						return nil, err
+					}
+				}
 				return outArr, nil
 			}
 		}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -389,11 +389,7 @@ func TestFormatExpr2(t *testing.T) {
 			tree.FmtParsable,
 			`(NULL, 'foo':::STRING)`,
 		},
-		{&tree.DArray{
-			ParamTyp: types.Int,
-			Array:    tree.Datums{tree.DNull, tree.DNull},
-			HasNulls: true,
-		},
+		{tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.DNull, tree.DNull}),
 			tree.FmtParsable,
 			`ARRAY[NULL,NULL]:::INT8[]`,
 		},

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2226,7 +2226,7 @@ func (d *DArray) TypeCheck(_ context.Context, _ *SemaContext, desired *types.T) 
 	// ARRAY[]
 	// ARRAY[NULL, NULL]
 	if (d.ParamTyp.Family() == types.UnknownFamily || d.ParamTyp.Family() == types.AnyFamily) &&
-		(!d.HasNonNulls) {
+		(!d.HasNonNulls()) {
 		if desired.Family() != types.ArrayFamily {
 			// We can't desire a non-array type here.
 			return d, nil

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -297,17 +297,16 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 				}
 
 				colIDs := r[columnIDsIdx].(*tree.DArray).Array
-				colNames := tree.NewDArray(types.String)
-				colNames.Array = make(tree.Datums, len(colIDs))
+				colNames := make(tree.Datums, len(colIDs))
 				ignoreStatsRowWithDroppedColumn := false
-				var colName string
 				for i, d := range colIDs {
+					var colName string
 					colName, err = statColumnString(desc, d)
 					if err != nil && sqlerrors.IsUndefinedColumnError(err) {
 						ignoreStatsRowWithDroppedColumn = true
 						break
 					}
-					colNames.Array[i] = tree.NewDString(colName)
+					colNames[i] = tree.NewDString(colName)
 				}
 				if ignoreStatsRowWithDroppedColumn {
 					continue
@@ -326,7 +325,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 
 				res := tree.Datums{
 					r[nameIdx],
-					colNames,
+					tree.NewDArrayFromDatums(types.String, colNames),
 					createdAtTZ,
 					r[rowCountIdx],
 					r[distinctCountIdx],

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -310,6 +310,7 @@ func readRowGroup[T parquetDatatypes](
 			// Deflevel 2 represents a null value in an array.
 			if defLevels[0] == 2 {
 				currentArrayDatum.Array = append(currentArrayDatum.Array, tree.DNull)
+				currentArrayDatum.SetHasNulls(true /* hasNulls */)
 				continue
 			}
 			// Deflevel 3 represents a non-null datum in an array.
@@ -318,6 +319,7 @@ func readRowGroup[T parquetDatatypes](
 				return nil, err
 			}
 			currentArrayDatum.Array = append(currentArrayDatum.Array, d)
+			currentArrayDatum.SetHasNonNulls(true /* hasNonNulls */)
 		} else if isTuple {
 			// Deflevel 0 represents a null tuple.
 			// Deflevel 1 represents a null value in a non null tuple.

--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -267,12 +267,9 @@ func TestBasicDatums(t *testing.T) {
 				columnNames: []string{"a", "b"},
 			},
 			datums: func() ([][]tree.Datum, error) {
-				da := tree.NewDArray(types.Int)
-				da.Array = tree.Datums{tree.NewDInt(0), tree.NewDInt(1)}
-				da2 := tree.NewDArray(types.Int)
-				da2.Array = tree.Datums{tree.NewDInt(2), tree.DNull}
-				da3 := tree.NewDArray(types.Int)
-				da3.Array = tree.Datums{}
+				da := tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.NewDInt(0), tree.NewDInt(1)})
+				da2 := tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.NewDInt(2), tree.DNull})
+				da3 := tree.NewDArrayFromDatums(types.Int, tree.Datums{})
 				return [][]tree.Datum{
 					{da, da2}, {da3, tree.DNull},
 				}, nil
@@ -700,9 +697,7 @@ func TestBufferedBytes(t *testing.T) {
 	sch, err := NewSchema([]string{"a", "b", "c", "d"}, []*types.T{types.Int, types.String, tupleTyp, types.IntArray})
 	require.NoError(t, err)
 	makeArray := func(vals ...tree.Datum) *tree.DArray {
-		da := tree.NewDArray(types.Int)
-		da.Array = vals
-		return da
+		return tree.NewDArrayFromDatums(types.Int, vals)
 	}
 
 	for _, tc := range []struct {


### PR DESCRIPTION
We've had `tree.DArray.HasNulls` and `tree.DArray.HasNonNulls` flags for many years, and they are used as a short-cut in some scenarios (initial use case was for pgwire serialization). However, we haven't had any validation of those flags, and given that we expose `DArray.Array` field, it's possible to construct a datum that doesn't have these flags set correctly (they do get set when using `DArray.Append`).

I did a quick audit of existing spots and found a few where we didn't set the flags, but none seem concerning. To avoid bugs like this from slipping in, this commit changes the API to expose Get and Set methods, and then on every Get for the flag we now do the validation in test-only builds (the validation includes verifying NULL-related flags as well as the length of the array not exceeding MaxInt32).

We could've taken this one step further and hidden `DArray.Array` altogether in favor of explicit Get and Set methods for elements, but I decided it's not worth the effort. I also decide to not force usage of `Append` method in a few places where we're appending to the underlying array in order to not have to deal with an explicit error checking.

Additionally, this commit does some minor cleanup like pulling out a NULL element check outside of the loop and adding missing periods.

Epic: None
Release note: None