### PR TITLE
crosscluster/physical: always destroy reader tenant on cutover

### DIFF
--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
-	"time"
 
 	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationtestutils"
@@ -217,16 +216,9 @@ INSERT INTO a VALUES (1);
 `)
 
 		waitForPollerJobToStartDest(t, c, ingestionJobID)
-		if cutoverToLatest {
-			observeValueInReaderTenant(t, c.ReaderTenantSQL)
-			c.Cutover(ctx, producerJobID, ingestionJobID, time.Time{}, false)
-			jobutils.WaitForJobToSucceed(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-			observeValueInReaderTenant(t, c.ReaderTenantSQL)
-		} else {
-			c.Cutover(ctx, producerJobID, ingestionJobID, c.SrcCluster.Server(0).Clock().Now().GoTime(), false)
-			waitToRemoveTenant(t, c.DestSysSQL, readerTenantName)
-			jobutils.WaitForJobToSucceed(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-		}
+		c.Cutover(ctx, producerJobID, ingestionJobID, c.SrcCluster.Server(0).Clock().Now().GoTime(), false)
+		waitToRemoveTenant(t, c.DestSysSQL, readerTenantName)
+		jobutils.WaitForJobToSucceed(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 	})
 }
 


### PR DESCRIPTION
Previously, a reader tenant would only get automatically destroyed if a user specified an explicit cutover time. This UX is confusing. Now, the reader tenant will always get destroyed on cutover.

Fixes #149684

Release note (ops change): the PCR reader tenant is always destroyed on cutover