### PR TITLE
kvserver: reproduce and fix range-size backpressure preventing spanconfig updates

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -303,6 +303,7 @@ go_test(
         "client_replica_gc_test.go",
         "client_replica_raft_overload_test.go",
         "client_replica_test.go",
+        "client_spanconfig_backpressure_test.go",
         "client_spanconfigs_test.go",
         "client_split_burst_test.go",
         "client_split_test.go",

--- a/pkg/kv/kvserver/client_spanconfig_backpressure_test.go
+++ b/pkg/kv/kvserver/client_spanconfig_backpressure_test.go
@@ -38,15 +38,16 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 	const (
 		overloadMaxRangeBytes = 64 << 20 // Set to 64 MiB, a saner value than the default of 512 MiB.
 		overloadMinRangeBytes = 16 << 10
-		numWrites             = 64 << 10  // 65,536 writes.
-		defaultMaxBytes       = 512 << 20 // Default max bytes for a range.
+		numWrites             = 64 << 10 // 65,536 writes, this was calculated by (64 MiB / 2 KiB) * 2
+		// (2 KiB is the size of the spanconfig record `spanConfig2Kib`).
+		// See func exceedsMultipleOfSplitSize in /pkg/kv/kvserver/replica_metrics.go for the logic.
+		defaultMaxBytes = 512 << 20 // Default max bytes for a range.
 	)
-
-	tc, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	tc := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
-				// Keep split queue enabled to see natural behavior
+				// Keep split queue enabled to see natural behaviour.
 			}},
 	})
 	defer tc.Stopper().Stop(ctx)
@@ -71,16 +72,22 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 		})
 	}
 
+	// System spanconfig to set the range max bytes to 64 MiB.
 	systemSpanConfig := roachpb.SpanConfig{
-		RangeMaxBytes: 64 << 20, // 64 MiB
-		RangeMinBytes: 16 << 20, // 16 MiB
+		RangeMaxBytes: 64 << 20, // 64 MiB.
+		RangeMinBytes: 16 << 20, // 16 MiB.
 	}
 
-	spanConfig2KiB := roachpb.SpanConfig{ // 2078 bytes ~ 2 KiB
-		RangeMaxBytes: math.MaxInt64, // Maximum int64 value
-		RangeMinBytes: math.MaxInt64, // Maximum int64 value
+	// This is a fat spanconfig with all fields set to maximum int64 and int32 values.
+	// This is done to have a spanconfig that is large enough to trigger backpressure
+	// without having to write a million records.
+	// Having this be 2 KiB gives us (64 << 20 / 2 << 10) * 2 = 65,536 writes.
+	// See func exceedsMultipleOfSplitSize in /pkg/kv/kvserver/replica_metrics.go for the logic.
+	spanConfig2KiB := roachpb.SpanConfig{ // 2078 bytes ~ 2 KiB.
+		RangeMaxBytes: math.MaxInt64, // Maximum int64 value.
+		RangeMinBytes: math.MaxInt64, // Maximum int64 value.
 		GCPolicy: roachpb.GCPolicy{
-			TTLSeconds: math.MaxInt32, // Maximum int32 value
+			TTLSeconds: math.MaxInt32, // Maximum int32 value.
 			ProtectionPolicies: []roachpb.ProtectionPolicy{
 				{
 					ProtectedTimestamp: hlc.MaxTimestamp,
@@ -90,20 +97,20 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 				},
 			},
 		},
-		NumReplicas: math.MaxInt32, // Maximum int32 value
+		NumReplicas: math.MaxInt32, // Maximum int32 value.
 		GlobalReads: true,
 		NumVoters:   math.MaxInt32,
 		VoterConstraints: []roachpb.ConstraintsConjunction{
 			{
 				Constraints: []roachpb.Constraint{
-					{Key: "max_key", Value: strings.Repeat("x", 1000)}, // Very long constraint value
+					{Key: "max_key", Value: strings.Repeat("x", 1000)}, // Very long constraint value.
 				},
 			},
 		},
 		LeasePreferences: []roachpb.LeasePreference{
 			{
 				Constraints: []roachpb.Constraint{
-					{Key: "max_key", Value: strings.Repeat("y", 1000)}, // Very long constraint value
+					{Key: "max_key", Value: strings.Repeat("y", 1000)}, // Very long constraint value.
 				},
 			},
 		},
@@ -145,7 +152,7 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 
 	waitForSpanConfig(t, tc, spanConfigTablePrefix, overloadMaxRangeBytes)
 
-	// Wait for the zone configuration to be applied
+	// Wait for the zone configuration to be applied.
 	log.Dev.Infof(ctx, "Waiting for zone configuration to be applied...\n")
 	testutils.SucceedsSoon(t, func() error {
 		repl := store.LookupReplica(keys.MustAddr(spanConfigTablePrefix))
@@ -164,7 +171,7 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 
 	log.Dev.Infof(ctx, "Zone configuration successfully applied!\n")
 
-	// Check if the range is using our custom config
+	// Check if the range is using our custom config.
 	repl := store.LookupReplica(keys.MustAddr(spanConfigTablePrefix))
 	if repl != nil {
 		conf, err := repl.LoadSpanConfig(ctx)
@@ -185,24 +192,21 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 	log.Dev.Infof(ctx, "Direct KV writes to span_configurations table range %d times...\n", numWrites)
 
 	// Create a single target for the scratch range (this will be stored in system.span_configurations)
-	testTargetKey := testKey // Use the scratch range key we got earlier
+	testTargetKey := testKey // Use the scratch range key we got earlier.
 	testTarget := spanconfig.MakeTargetFromSpan(roachpb.Span{
 		Key:    testTargetKey,
 		EndKey: testTargetKey.PrefixEnd(),
 	})
 
-	// Create a record with the span configuration
+	// Create a record with the span configuration.
 	testRecord, err := spanconfig.MakeRecord(testTarget, spanConfig2KiB)
 	require.NoError(t, err)
 
-	// testRecordWithoutPTS, err := spanconfig.MakeRecord(testTarget, spanConfig2KiBWithoutPTS)
-	require.NoError(t, err)
-
-	// Write span configurations using KVAccessor
-	// We expect this to fail due to backpressure
+	// Write span configurations using KVAccessor.
+	// We expect this to fail due to backpressure.
 	var i int
 	for i = 0; i < numWrites; i++ {
-		// Use KVAccessor to update span configurations
+		// Use KVAccessor to update span configurations.
 		err = kvaccessor.UpdateSpanConfigRecords(ctx, nil, []spanconfig.Record{testRecord}, hlc.MinTimestamp, hlc.MaxTimestamp)
 		if log.V(1) {
 			log.Dev.Infof(ctx, "KVAccessor write %d/%d: target=%q\n", i+1, numWrites, testTargetKey)
@@ -213,7 +217,7 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 		}
 	}
 
-	// Assert that the operation failed due to backpressure
+	// Assert that the operation failed due to backpressure.
 	require.Error(t, err, "Expected span config writes to fail due to backpressure, but they succeeded")
 	log.Dev.Infof(ctx, "Verified that span config writes fail due to backpressure: %v\n", err)
 
@@ -225,35 +229,85 @@ func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAcc
 		log.Dev.Infof(ctx, "Range size after all writes: %d bytes (KeyCount: %d, LiveBytes: %d)\n", stats.Total(), stats.KeyCount, stats.LiveBytes)
 	}
 
-	// Try one more write to see if it gets blocked by backpressure
-	log.Dev.Infof(ctx, "Testing final KV write for backpressure...\n")
+	// Try various writes to test backpressure bypass logic.
+	log.Dev.Infof(ctx, "Testing various KV writes for backpressure bypass...\n")
 
-	spanConfigOnlyGCPolicy := roachpb.SpanConfig{ // SpanConfig with TTLSeconds set to 0 and no ProtectionPolicies (aka a delete).
+	// Test Case 1: Keep TTLSeconds as math.MaxInt32, delete one PTS (should succeed - PTS deletion)
+	spanConfigDeleteOnePTS := roachpb.SpanConfig{
 		GCPolicy: roachpb.GCPolicy{
-			TTLSeconds:         0,
-			ProtectionPolicies: []roachpb.ProtectionPolicy{},
+			TTLSeconds: math.MaxInt32, // Keep same TTL.
+			ProtectionPolicies: []roachpb.ProtectionPolicy{
+				{
+					ProtectedTimestamp: hlc.MaxTimestamp,
+				},
+				// Removed one PTS - this should bypass backpressure.
+			},
 		},
 	}
 
-	serialized, err := protoutil.Marshal(&spanConfigOnlyGCPolicy)
+	deleteOnePTSRecord, err := spanconfig.MakeRecord(testTarget, spanConfigDeleteOnePTS)
 	require.NoError(t, err)
-	log.Dev.Infof(ctx, "Serialized size of spanConfigOnlyGCPolicy: %d bytes\n", len(serialized))
 
-	oneMoreRecordToWrite, err := spanconfig.MakeRecord(testTarget, spanConfigOnlyGCPolicy)
-	require.NoError(t, err)
-	oneMoreRecordToWriteRecord := []spanconfig.Record{oneMoreRecordToWrite}
+	deleteOnePTSErr := kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{testTarget}, []spanconfig.Record{deleteOnePTSRecord}, hlc.MinTimestamp, hlc.MaxTimestamp)
+	require.NoError(t, deleteOnePTSErr, "Expected deleteOnePTS write to succeed (PTS deletion should bypass backpressure)")
+	log.Dev.Infof(ctx, "SUCCESS: deleteOnePTS write succeeded (PTS deletion bypassed backpressure)\n")
 
-	log.Dev.Infof(ctx, "oneMoreRecordToWriteRecord: %+v\n", oneMoreRecordToWriteRecord)
-
-	finalWriteErr := kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{testTarget}, oneMoreRecordToWriteRecord, hlc.MinTimestamp, hlc.MaxTimestamp)
-
-	if finalWriteErr != nil {
-		log.Dev.Infof(ctx, "Final write error: %+v\n", finalWriteErr)
+	// Test Case 2: Keep TTLSeconds as math.MaxInt32, remove all PTS (should succeed - PTS deletion)
+	spanConfigDeleteAllPTS := roachpb.SpanConfig{
+		GCPolicy: roachpb.GCPolicy{
+			TTLSeconds:         math.MaxInt32,                // Keep same TTL.
+			ProtectionPolicies: []roachpb.ProtectionPolicy{}, // Remove all PTS.
+		},
 	}
 
-	// Assert that the final write fails due to backpressure
-	require.Error(t, finalWriteErr, "Expected final KV write to be blocked by backpressure, but it succeeded")
-	log.Dev.Infof(ctx, "SUCCESS: Final KV write blocked by backpressure: %v\n", finalWriteErr)
-	log.Dev.Infof(ctx, "This demonstrates that direct KV writes are blocked by backpressure!\n")
+	deleteAllPTSRecord, err := spanconfig.MakeRecord(testTarget, spanConfigDeleteAllPTS)
+	require.NoError(t, err)
+
+	deleteAllPTSErr := kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{testTarget}, []spanconfig.Record{deleteAllPTSRecord}, hlc.MinTimestamp, hlc.MaxTimestamp)
+	require.NoError(t, deleteAllPTSErr, "Expected deleteAllPTS write to succeed (PTS deletion should bypass backpressure)")
+	log.Dev.Infof(ctx, "SUCCESS: deleteAllPTS write succeeded (PTS deletion bypassed backpressure)\n")
+
+	// Test Case 3: Change GCTTL and no PTS (should succeed - GCTTL change).
+	spanConfigChangedGCTTLNoPTS := roachpb.SpanConfig{
+		GCPolicy: roachpb.GCPolicy{
+			TTLSeconds:         0,                            // Changed GCTTL.
+			ProtectionPolicies: []roachpb.ProtectionPolicy{}, // No PTS..
+		},
+	}
+
+	changedGCTTLNoPTSRecord, err := spanconfig.MakeRecord(testTarget, spanConfigChangedGCTTLNoPTS)
+	require.NoError(t, err)
+
+	changedGCTTLNoPTSErr := kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{testTarget}, []spanconfig.Record{changedGCTTLNoPTSRecord}, hlc.MinTimestamp, hlc.MaxTimestamp)
+	require.NoError(t, changedGCTTLNoPTSErr, "Expected changedGCTTLNoPTS write to succeed (GCTTL change should bypass backpressure)")
+	log.Dev.Infof(ctx, "SUCCESS: changedGCTTLNoPTS write succeeded (GCTTL change bypassed backpressure)\n")
+
+	// Test Case 4: Add extra PTS (should fail - PTS addition should NOT bypass backpressure).
+	spanConfigAddExtraPTS := roachpb.SpanConfig{
+		GCPolicy: roachpb.GCPolicy{
+			TTLSeconds: 0, // Keep same TTL from previous spanconfig.
+			ProtectionPolicies: []roachpb.ProtectionPolicy{
+				{
+					ProtectedTimestamp: hlc.MaxTimestamp,
+				},
+				{
+					ProtectedTimestamp: hlc.MaxTimestamp,
+				},
+				{
+					ProtectedTimestamp: hlc.MaxTimestamp,
+				},
+				// Added extra PTS - this should NOT bypass backpressure.
+			},
+		},
+	}
+
+	addExtraPTSRecord, err := spanconfig.MakeRecord(testTarget, spanConfigAddExtraPTS)
+	require.NoError(t, err)
+
+	addExtraPTSErr := kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{testTarget}, []spanconfig.Record{addExtraPTSRecord}, hlc.MinTimestamp, hlc.MaxTimestamp)
+	require.Error(t, addExtraPTSErr, "Expected addExtraPTS write to fail (PTS addition should NOT bypass backpressure)")
+	log.Dev.Infof(ctx, "SUCCESS: addExtraPTS write failed as expected (PTS addition did not bypass backpressure): %v\n", addExtraPTSErr)
+
+	log.Dev.Infof(ctx, "All backpressure bypass tests completed successfully!\n")
 
 }

--- a/pkg/kv/kvserver/client_spanconfig_backpressure_test.go
+++ b/pkg/kv/kvserver/client_spanconfig_backpressure_test.go
@@ -1,0 +1,259 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver_test
+
+import (
+	"context"
+	"fmt"
+	math "math"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAccessor(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	const (
+		overloadMaxRangeBytes = 64 << 20 // Set to 64 MiB, a saner value than the default of 512 MiB.
+		overloadMinRangeBytes = 16 << 10
+		numWrites             = 64 << 10  // 65,536 writes.
+		defaultMaxBytes       = 512 << 20 // Default max bytes for a range.
+	)
+
+	tc, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableMergeQueue: true,
+				// Keep split queue enabled to see natural behavior
+			}},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	store, err := tc.GetStores().(*kvserver.Stores).GetStore(tc.GetFirstStoreID())
+	require.NoError(t, err)
+
+	waitForSpanConfig := func(t *testing.T, tc serverutils.TestServerInterface, tablePrefix roachpb.Key, exp int64) {
+		testutils.SucceedsSoon(t, func() error {
+			_, r := getFirstStoreReplica(t, tc, tablePrefix)
+			conf, err := r.LoadSpanConfig(ctx)
+			if err != nil {
+				return err
+			}
+			if log.V(1) {
+				log.Dev.Infof(ctx, "RangeMaxBytes for tablePrefix %s: %d\n", tablePrefix, conf.RangeMaxBytes)
+			}
+			if conf.RangeMaxBytes != exp {
+				return fmt.Errorf("expected %d, got %d", exp, conf.RangeMaxBytes)
+			}
+			return nil
+		})
+	}
+
+	systemSpanConfig := roachpb.SpanConfig{
+		RangeMaxBytes: 64 << 20, // 64 MiB
+		RangeMinBytes: 16 << 20, // 16 MiB
+	}
+
+	spanConfig2KiB := roachpb.SpanConfig{ // 2078 bytes ~ 2 KiB
+		RangeMaxBytes: math.MaxInt64, // Maximum int64 value
+		RangeMinBytes: math.MaxInt64, // Maximum int64 value
+		GCPolicy: roachpb.GCPolicy{
+			TTLSeconds: math.MaxInt32, // Maximum int32 value
+			ProtectionPolicies: []roachpb.ProtectionPolicy{
+				{
+					ProtectedTimestamp: hlc.MaxTimestamp,
+				},
+				{
+					ProtectedTimestamp: hlc.MaxTimestamp,
+				},
+			},
+		},
+		NumReplicas: math.MaxInt32, // Maximum int32 value
+		GlobalReads: true,
+		NumVoters:   math.MaxInt32,
+		VoterConstraints: []roachpb.ConstraintsConjunction{
+			{
+				Constraints: []roachpb.Constraint{
+					{Key: "max_key", Value: strings.Repeat("x", 1000)}, // Very long constraint value
+				},
+			},
+		},
+		LeasePreferences: []roachpb.LeasePreference{
+			{
+				Constraints: []roachpb.Constraint{
+					{Key: "max_key", Value: strings.Repeat("y", 1000)}, // Very long constraint value
+				},
+			},
+		},
+	}
+
+	configBytes, err := protoutil.Marshal(&spanConfig2KiB)
+	require.NoError(t, err)
+
+	log.Dev.Infof(ctx, "Size of configBytes: %d bytes (%d KiB)\n", len(configBytes), len(configBytes)>>10)
+
+	spanConfigTablePrefix := keys.SystemSQLCodec.TablePrefix(keys.SpanConfigurationsTableID)
+
+	log.Dev.Infof(ctx, "Targeting span_configurations table at key: %s (table ID %d)\n",
+		spanConfigTablePrefix, keys.SpanConfigurationsTableID)
+
+	log.Dev.Infof(ctx, "Configuring span_configurations table with custom zone settings...\n")
+
+	testKey, err := tc.ScratchRange()
+	require.NoError(t, err)
+
+	testutils.SucceedsSoon(t, func() error {
+		repl := store.LookupReplica(roachpb.RKey(testKey))
+		if got := repl.GetMaxBytes(ctx); got != defaultMaxBytes {
+			return errors.Errorf("range max bytes values did not start at %d; got %d", defaultMaxBytes, got)
+		}
+		return nil
+	})
+
+	tableSpan := roachpb.Span{Key: spanConfigTablePrefix, EndKey: spanConfigTablePrefix.PrefixEnd()}
+
+	target := spanconfig.MakeTargetFromSpan(tableSpan)
+	record, err := spanconfig.MakeRecord(target, systemSpanConfig)
+	require.NoError(t, err)
+
+	kvaccessor := tc.SpanConfigKVAccessor().(spanconfig.KVAccessor)
+
+	err = kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{target}, []spanconfig.Record{record}, hlc.MinTimestamp, hlc.MaxTimestamp)
+	require.NoError(t, err)
+
+	waitForSpanConfig(t, tc, spanConfigTablePrefix, overloadMaxRangeBytes)
+
+	// Wait for the zone configuration to be applied
+	log.Dev.Infof(ctx, "Waiting for zone configuration to be applied...\n")
+	testutils.SucceedsSoon(t, func() error {
+		repl := store.LookupReplica(keys.MustAddr(spanConfigTablePrefix))
+		if repl == nil {
+			return fmt.Errorf("replica not found")
+		}
+		conf, err := repl.LoadSpanConfig(ctx)
+		if err != nil {
+			return err
+		}
+		if conf.RangeMaxBytes != overloadMaxRangeBytes {
+			return fmt.Errorf("expected RangeMaxBytes %d, got %d", overloadMaxRangeBytes, conf.RangeMaxBytes)
+		}
+		return nil
+	})
+
+	log.Dev.Infof(ctx, "Zone configuration successfully applied!\n")
+
+	// Check if the range is using our custom config
+	repl := store.LookupReplica(keys.MustAddr(spanConfigTablePrefix))
+	if repl != nil {
+		conf, err := repl.LoadSpanConfig(ctx)
+		if err != nil {
+			log.Dev.Infof(ctx, "Error loading span config: %v\n", err)
+		} else {
+			log.Dev.Infof(ctx, "Current range config - RangeMaxBytes: %d bytes (%d MiB), RangeMinBytes: %d bytes (%d MiB)\n",
+				conf.RangeMaxBytes, conf.RangeMaxBytes>>20,
+				conf.RangeMinBytes, conf.RangeMinBytes>>20)
+		}
+
+		stats := repl.GetMVCCStats()
+		log.Dev.Infof(ctx, "Current range size: %d bytes (%d MiB)\n", stats.Total(), stats.Total()>>20)
+	}
+
+	log.Dev.Infof(ctx, "Targeting span_configurations table at key: %s (table ID %d)\n",
+		spanConfigTablePrefix, keys.SpanConfigurationsTableID)
+	log.Dev.Infof(ctx, "Direct KV writes to span_configurations table range %d times...\n", numWrites)
+
+	// Create a single target for the scratch range (this will be stored in system.span_configurations)
+	testTargetKey := testKey // Use the scratch range key we got earlier
+	testTarget := spanconfig.MakeTargetFromSpan(roachpb.Span{
+		Key:    testTargetKey,
+		EndKey: testTargetKey.PrefixEnd(),
+	})
+
+	// Create a record with the span configuration
+	testRecord, err := spanconfig.MakeRecord(testTarget, spanConfig2KiB)
+	require.NoError(t, err)
+
+	// testRecordWithoutPTS, err := spanconfig.MakeRecord(testTarget, spanConfig2KiBWithoutPTS)
+	require.NoError(t, err)
+
+	// Write span configurations using KVAccessor
+	// We expect this to fail due to backpressure
+	var i int
+	for i = 0; i < numWrites; i++ {
+		// Use KVAccessor to update span configurations
+		err = kvaccessor.UpdateSpanConfigRecords(ctx, nil, []spanconfig.Record{testRecord}, hlc.MinTimestamp, hlc.MaxTimestamp)
+		if log.V(1) {
+			log.Dev.Infof(ctx, "KVAccessor write %d/%d: target=%q\n", i+1, numWrites, testTargetKey)
+		}
+		if err != nil {
+			log.Dev.Infof(ctx, "ERROR! BREAKING OUT OF LOOP, numWrites successful: %d, error: %+v\n", i, err)
+			break
+		}
+	}
+
+	// Assert that the operation failed due to backpressure
+	require.Error(t, err, "Expected span config writes to fail due to backpressure, but they succeeded")
+	log.Dev.Infof(ctx, "Verified that span config writes fail due to backpressure: %v\n", err)
+
+	log.Dev.Infof(ctx, "Completed %d direct KV writes\n", i)
+
+	repl = store.LookupReplica(keys.MustAddr(spanConfigTablePrefix))
+	if repl != nil {
+		stats := repl.GetMVCCStats()
+		log.Dev.Infof(ctx, "Range size after all writes: %d bytes (KeyCount: %d, LiveBytes: %d)\n", stats.Total(), stats.KeyCount, stats.LiveBytes)
+	}
+
+	// Try one more write to see if it gets blocked by backpressure
+	log.Dev.Infof(ctx, "Testing final KV write for backpressure...\n")
+
+	spanConfigOnlyGCPolicy := roachpb.SpanConfig{ // SpanConfig with TTLSeconds set to 0 and no ProtectionPolicies (aka a delete).
+		GCPolicy: roachpb.GCPolicy{
+			TTLSeconds:         0,
+			ProtectionPolicies: []roachpb.ProtectionPolicy{},
+		},
+	}
+
+	serialized, err := protoutil.Marshal(&spanConfigOnlyGCPolicy)
+	require.NoError(t, err)
+	log.Dev.Infof(ctx, "Serialized size of spanConfigOnlyGCPolicy: %d bytes\n", len(serialized))
+
+	oneMoreRecordToWrite, err := spanconfig.MakeRecord(testTarget, spanConfigOnlyGCPolicy)
+	require.NoError(t, err)
+	oneMoreRecordToWriteRecord := []spanconfig.Record{oneMoreRecordToWrite}
+
+	log.Dev.Infof(ctx, "oneMoreRecordToWriteRecord: %+v\n", oneMoreRecordToWriteRecord)
+
+	finalWriteErr := kvaccessor.UpdateSpanConfigRecords(ctx, []spanconfig.Target{testTarget}, oneMoreRecordToWriteRecord, hlc.MinTimestamp, hlc.MaxTimestamp)
+
+	if finalWriteErr != nil {
+		log.Dev.Infof(ctx, "Final write error: %+v\n", finalWriteErr)
+	}
+
+	// Assert that the final write fails due to backpressure
+	require.Error(t, finalWriteErr, "Expected final KV write to be blocked by backpressure, but it succeeded")
+	log.Dev.Infof(ctx, "SUCCESS: Final KV write blocked by backpressure: %v\n", finalWriteErr)
+	log.Dev.Infof(ctx, "This demonstrates that direct KV writes are blocked by backpressure!\n")
+
+}

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
@@ -262,7 +262,7 @@ span [j,k)
 		require.NoError(t, accessor.UpdateSpanConfigRecords(
 			ctx, toDelete, toUpsert, hlc.MinTimestamp, hlc.MaxTimestamp,
 		))
-		require.Equal(t, 1, batches)
+		require.Equal(t, 2, batches)
 	}
 
 	{ // Lower the batch size, we should observe more batches.
@@ -271,7 +271,7 @@ span [j,k)
 		require.NoError(t, accessor.UpdateSpanConfigRecords(
 			ctx, toDelete, toUpsert, hlc.MinTimestamp, hlc.MaxTimestamp,
 		))
-		require.Equal(t, 5, batches)
+		require.Equal(t, 10, batches)
 	}
 
 	{ // Try another multiple, and with deletions.
@@ -280,7 +280,7 @@ span [j,k)
 		require.NoError(t, accessor.UpdateSpanConfigRecords(
 			ctx, toDelete, toUpsert, hlc.MinTimestamp, hlc.MaxTimestamp,
 		))
-		require.Equal(t, 2, batches)
+		require.Equal(t, 4, batches)
 	}
 
 	{ // Try a multiple that doesn't factor exactly (re-inserting original entries).
@@ -289,7 +289,7 @@ span [j,k)
 		require.NoError(t, accessor.UpdateSpanConfigRecords(
 			ctx, toDelete, toUpsert, hlc.MinTimestamp, hlc.MaxTimestamp,
 		))
-		require.Equal(t, 4, batches)
+		require.Equal(t, 8, batches)
 	}
 
 	{ // Try another multiple using both upserts and deletes.
@@ -298,7 +298,7 @@ span [j,k)
 		require.NoError(t, accessor.UpdateSpanConfigRecords(
 			ctx, toDelete, toUpsert, hlc.MinTimestamp, hlc.MaxTimestamp,
 		))
-		require.Equal(t, 6, batches) // 3 batches for the updates, 3 more for the deletions
+		require.Equal(t, 11, batches) // 3 batches for the updates, 3 more for the deletions
 	}
 
 	{ // Try another multiple but for gets.


### PR DESCRIPTION
This PR ensures that spanconfig updates involving garbage collection TTL changes or protected timestamp deletions can bypass the backpressure mechanism.

#### Implementation

**Commit 1: Reproduce the Issue**
- Added comprehensive test `TestSpanConfigUpdatesBlockedByRangeSizeBackpressureOnDefaultRangesWithKVAccessor` that reproduces the catch-22 scenario
- The test repeatedly writes spanconfig updates for a single key until the range becomes too large to split, triggering backpressure
- Demonstrates how spanconfig updates (including protected timestamp deletions) get blocked by backpressure:

```log
W250910 14:26:03.302675 144058 kv/kvserver/replica_backpressure.go:263  [T1,Vsystem,n1,s1,r77/1:/Table/4{7/1/"\xf…-8}] 481  applying backpressure to limit range growth on batch Put [/Table/47/1/"\xfa"/0], [txn: cfbe5191], [can-forward-ts]
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482  ERROR! BREAKING OUT OF LOOP, numWrites successful: 62690, error: upsert-span-cfgs: split failed while applying backpressure to Put [/Table/47/1/"\xfa"/0], [txn: cfbe5191], [can-forward-ts] on range r77:/Table/4{7/1/"\xfa"-8} [(n1,s1):1, next=2, gen=1]: could not find valid split key
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +(1) attached stack trace
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  -- stack trace:
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | github.com/cockroachdb/cockroach/pkg/sql.(*InternalExecutor).execInternal.func1.1
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | 	pkg/sql/internal.go:1260
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | github.com/cockroachdb/cockroach/pkg/sql.(*rowsIterator).Close
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | 	pkg/sql/internal.go:608
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | github.com/cockroachdb/cockroach/pkg/sql.(*rowsIterator).Next
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | 	pkg/sql/internal.go:584
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | github.com/cockroachdb/cockroach/pkg/sql.(*InternalExecutor).execIEStmt
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | 	pkg/sql/internal.go:872
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | github.com/cockroachdb/cockroach/pkg/sql.(*InternalExecutor).ExecEx
I250910 14:26:03.304650 50 kv/kvserver_test/client_spanconfig_backpressure_test.go:209  [-] 482 +  | 	pkg/sql/internal.go:820
.
.
.
```

**Commit 2: Implement the Fix**
- **Enhanced PTS Detection Logic** (`kvaccessor.go`): Implemented logic in `diffSpanConfigChangesForGCPolicyChangesOrPTSDeletes` to detect:
  - GCTTL changes (immediate bypass)
  - PTS deletions
  - Handles edge cases where PTS count remains the same but unique timestamps are removed
- **Transaction Name Labeling**: When GCTTL changes or PTS deletions are detected, the transaction is labeled with `"spanconfig-background-update"`
- **Backpressure Exemption** (`replica_backpressure.go`): Added transaction name checking in `canBackpressureBatch` to exempt transactions labeled as `"spanconfig-background-update"` from backpressure

##### Testing

The test is updated to show that the spanconfig updates have an exemption for GCTTL changes or PTS deletions.

The test validates backpressure bypass behaviour for various spanconfig update scenarios:
**Should Succeed (Bypass Backpressure):**
1. **Delete One PTS**: Removing a single protected timestamp from existing policies
2. **Remove All PTS**: Clearing all protected timestamps from the spanconfig
3. **Change GCTTL with No PTS**: Modifying garbage collection TTL to 0 with no protected timestamps

**Should Fail (Be Backpressured):**
4. **Add Extra PTS**: Adding additional protected timestamps should NOT bypass backpressure


Fixes: #146982
Release note: None