### PR TITLE
jobs: ensure failure injection targets specific test job

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -869,10 +869,17 @@ func TestRegistryLifecycle(t *testing.T) {
 		defer rts.setUp(t)()
 		defer rts.tearDown()
 
+		// Pick an ID so we know which job to mess with.
+		id := rts.registry.MakeJobID()
+		rts.mockJob.JobID = id
+
 		// Inject an error in the update to move the job to "succeeded" one time.
 		var failed atomic.Value
 		failed.Store(false)
 		rts.beforeUpdate = func(orig, updated jobs.JobMetadata) error {
+			if orig.ID != id {
+				return nil
+			}
 			if updated.State == jobs.StateSucceeded && !failed.Load().(bool) {
 				failed.Store(true)
 				return errors.New("boom")

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -377,7 +377,7 @@ func (rts *registryTestSuite) checkStateChangeLog(
 				jobEventsLog.PreviousStatus == string(expectedPrevState) &&
 				jobEventsLog.NewStatus == string(expectedNewState) &&
 				strings.Contains(jobEventsLog.Error, expectedError) {
-				rts.statusChangeLogSpy.SetLastNLogsAsUnread(logpb.Channel_OPS, len(logs)-i+1)
+				rts.statusChangeLogSpy.SetLastNLogsAsUnread(logpb.Channel_OPS, len(logs)-i)
 				return nil
 			}
 		}

--- a/pkg/jobs/test_helpers.go
+++ b/pkg/jobs/test_helpers.go
@@ -44,6 +44,9 @@ func TestingCreateAndStartJob(
 	c := config{
 		jobID: r.MakeJobID(),
 	}
+	if record.JobID != 0 {
+		c.jobID = record.JobID
+	}
 	for _, opt := range opts {
 		opt(&c)
 	}


### PR DESCRIPTION
Add job ID filtering to beforeUpdate hook and allow TestingCreateAndStartJob
to respect JobID in record, ensuring failure injection only affects the
intended test job rather than any job in the system.

Release note: None

Fixes https://github.com/cockroachdb/cockroach/issues/152035.

Epic: None