### PR TITLE
sqlstatsccl: bump test pool size

### DIFF
--- a/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
@@ -2,12 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "sqlstatsccl_test",
-    # Explicitly indicate timeout as some of the tests (ie TestSQLStatsRegions) might take up to 3 min to run.
-    timeout = "moderate",
+    size = "medium",
     srcs = [
         "main_test.go",
         "sql_stats_test.go",
     ],
+    exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
This test has hit an OOM.

Epic: none
Release note: None