### PR TITLE
release-25.3: sql: prohibit CITEXT as column type in 25.2-25.3 mixed version state

### DIFF
--- a/pkg/sql/catalog/colinfo/BUILD.bazel
+++ b/pkg/sql/catalog/colinfo/BUILD.bazel
@@ -16,11 +16,13 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/oidext",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catconstants",

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
@@ -71,6 +73,14 @@ func (ti ColTypeInfo) Type(idx int) *types.T {
 func ValidateColumnDefType(ctx context.Context, st *cluster.Settings, t *types.T) error {
 	switch t.Family() {
 	case types.StringFamily, types.CollatedStringFamily:
+		if t.Oid() == oidext.T_citext {
+			if !st.Version.IsActive(ctx, clusterversion.V25_3) {
+				return pgerror.Newf(
+					pgcode.FeatureNotSupported,
+					"citext not supported until version 25.3",
+				)
+			}
+		}
 		if t.Family() == types.CollatedStringFamily {
 			if _, err := language.Parse(t.Locale()); err != nil {
 				return pgerror.Newf(pgcode.Syntax, `invalid locale %s`, t.Locale())

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_citext
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_citext
@@ -1,0 +1,49 @@
+# LogicTest: cockroach-go-testserver-25.2
+
+# Sanity check that CITEXT type is only allowed to be used once the cluster is
+# upgraded to 25.3.
+
+statement error pgcode 42704 type \"citext\" does not exist
+CREATE TABLE c (c CITEXT);
+
+statement error pgcode 42704 type \"citext\" does not exist
+CREATE TABLE ca (ca CITEXT[]);
+
+statement error pgcode 42704 type \"citext\" does not exist
+SELECT 'A'::CITEXT
+
+statement error pgcode 42704 type \"citext\" does not exist
+SELECT ARRAY['A', 'B']::CITEXT[]
+
+upgrade 0
+
+statement error pgcode 0A000 citext not supported until version 25.3
+CREATE TABLE c (c CITEXT);
+
+statement error pgcode 0A000 citext not supported until version 25.3
+CREATE TABLE ca (ca CITEXT[]);
+
+statement error pgcode 0A000 citext not supported until version 25.3
+SELECT 'A'::CITEXT
+
+statement error pgcode 0A000 citext\[\] not supported until version 25.3
+SELECT ARRAY['A', 'B']::CITEXT[]
+
+upgrade 1
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+statement ok
+CREATE TABLE c (c CITEXT);
+
+statement ok
+CREATE TABLE ca (ca CITEXT[]);
+
+statement ok
+SELECT 'A'::CITEXT
+
+statement ok
+SELECT ARRAY['A', 'B']::CITEXT[]

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 8,
+    shard_count = 9,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
@@ -94,6 +94,13 @@ func TestLogic_mixed_version_can_login(
 	runLogicTest(t, "mixed_version_can_login")
 }
 
+func TestLogic_mixed_version_citext(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_citext")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -100,6 +100,7 @@ go_test(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",
+        "//pkg/sql/oidext",
         "//pkg/sql/parser",
         "//pkg/sql/physicalplan",
         "//pkg/sql/randgen",


### PR DESCRIPTION
Backport 1/1 commits from #152476 on behalf of @yuzefovich.

----

Backport 1/1 commits from #152372.

/cc @cockroachdb/release

---

This commit fixes an oversight from fd50f230e593a2d952ba40de8d0c2a673f6aa99e where we forgot to prohibit usage of (new in 25.3) CITEXT type as a column type. The impact should be minor since this type is simply implemented as collated string with fixed locale, yet it seems prudent to disable the type's usage until 25.3 version is finalized.

Epic: None
Release note: None

Release justification: minor fix to a new feature.