### PR TITLE
cloud: add fault testing to S3 client

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/uuid",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/request",

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -114,6 +114,7 @@ type s3Storage struct {
 	bucket         *string
 	conf           *cloudpb.ExternalStorage_S3
 	ioConf         base.ExternalIODirConfig
+	middleware     cloud.HttpMiddleware
 	settings       *cluster.Settings
 	prefix         string
 	metrics        *cloud.Metrics
@@ -514,6 +515,7 @@ func MakeS3Storage(
 		bucket:         aws.String(conf.Bucket),
 		conf:           conf,
 		ioConf:         args.IOConf,
+		middleware:     args.HttpMiddleware,
 		prefix:         conf.Prefix,
 		metrics:        args.MetricsRecorder,
 		settings:       args.Settings,
@@ -611,6 +613,7 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 			Client:             s.storageOptions.ClientName,
 			Cloud:              "aws",
 			InsecureSkipVerify: s.opts.skipTLSVerify,
+			HttpMiddleware:     s.middleware,
 		})
 	if err != nil {
 		return s3Client{}, "", err

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -30,13 +31,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 func makeS3Storage(
-	ctx context.Context, uri string, user username.SQLUsername,
+	ctx context.Context, uri string, user username.SQLUsername, middleware cloud.HttpMiddleware,
 ) (cloud.ExternalStorage, error) {
 	conf, err := cloud.ExternalStorageConfFromURI(uri, user)
 	if err != nil {
@@ -44,18 +46,19 @@ func makeS3Storage(
 	}
 	testSettings := cluster.MakeTestingClusterSettings()
 
-	// Setup a sink for the given args.
-	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		blobs.TestEmptyBlobClientFactory,
-		nil, /* db */
-		nil, /* limiters */
-		cloud.NilMetrics,
-	)
-	if err != nil {
-		return nil, err
+	// TODO(jeffswenson): remove this once we change the default to false.
+	enableClientRetryTokenBucket.Override(ctx, &testSettings.SV, false)
+
+	args := cloud.EarlyBootExternalStorageContext{
+		IOConf:          base.ExternalIODirConfig{},
+		Settings:        testSettings,
+		Options:         nil,
+		Limiters:        nil,
+		MetricsRecorder: cloud.NilMetrics,
+		HttpMiddleware:  middleware,
 	}
 
-	return s, nil
+	return MakeS3Storage(ctx, args, conf)
 }
 
 // You can create an IAM that can access S3 in the AWS console, then
@@ -70,6 +73,7 @@ func skipIfNoDefaultConfig(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	_, err = cfg.Credentials.Retrieve(ctx)
 	if err != nil {
+		t.Logf("config: %+v", cfg)
 		skip.IgnoreLintf(t, "%s: %s", helpMsg, err)
 	}
 }
@@ -192,7 +196,7 @@ func TestPutS3(t *testing.T) {
 					cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 					"unsupported-algorithm")
 
-				_, err = makeS3Storage(ctx, invalidSSEModeURI, user)
+				_, err = makeS3Storage(ctx, invalidSSEModeURI, user, nil)
 				require.True(t, testutils.IsError(err, "unsupported server encryption mode unsupported-algorithm. Supported values are `aws:kms` and `AES256"))
 
 				// Specify aws:kms encryption mode but don't specify kms ID.
@@ -201,11 +205,42 @@ func TestPutS3(t *testing.T) {
 					bucket, "backup-test-sse-256",
 					cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 					"aws:kms")
-				_, err = makeS3Storage(ctx, invalidKMSURI, user)
+				_, err = makeS3Storage(ctx, invalidKMSURI, user, nil)
 				require.True(t, testutils.IsError(err, "AWS_SERVER_KMS_ID param must be set when using aws:kms server side encryption mode."))
 			})
 		})
 	}
+}
+
+func TestS3FaultInjection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	skipIfNoDefaultConfig(t, ctx)
+
+	baseBucket := os.Getenv("AWS_S3_BUCKET")
+	if baseBucket == "" {
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
+	}
+
+	// Enable cloud transport logging.
+	defer log.Scope(t).Close(t)
+	prevVModule := log.GetVModule()
+	defer func() { _ = log.SetVModule(prevVModule) }()
+	require.NoError(t, log.SetVModule("cloud_logging_transport=1"))
+
+	uri := fmt.Sprintf(
+		"s3://%s/%d-fault-injection-test?AUTH=implicit",
+		baseBucket, cloudtestutils.NewTestID(),
+	)
+
+	// Inject faults for 15-45 seconds after the storage is opened.
+	middleware := cloudtestutils.BrownoutMiddleware(time.Second*15, time.Second*45)
+	storage, err := makeS3Storage(ctx, uri, username.RootUserName(), middleware)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	cloudtestutils.RunCloudNemesisTest(t, storage)
 }
 
 func TestPutS3AssumeRole(t *testing.T) {

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -223,9 +223,10 @@ func makeAzureStorage(
 	options := args.ExternalStorageOptions()
 	t, err := cloud.MakeHTTPClient(args.Settings, args.MetricsRecorder,
 		cloud.HTTPClientConfig{
-			Bucket: dest.AzureConfig.Container,
-			Client: options.ClientName,
-			Cloud:  "azure",
+			Bucket:         dest.AzureConfig.Container,
+			Client:         options.ClientName,
+			Cloud:          "azure",
+			HttpMiddleware: args.HttpMiddleware,
 		})
 	if err != nil {
 		return nil, errors.Wrap(err, "azure: unable to create transport")

--- a/pkg/cloud/cloudtestutils/BUILD.bazel
+++ b/pkg/cloud/cloudtestutils/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "cloudtestutils",
-    srcs = ["cloud_test_helpers.go"],
+    srcs = [
+        "cloud_nemesis.go",
+        "cloud_test_helpers.go",
+        "http_middleware.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/cloudtestutils",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,8 +20,11 @@ go_library(
         "//pkg/testutils",
         "//pkg/util/ioctx",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/util/sysutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/cloud/cloudtestutils/cloud_nemesis.go
+++ b/pkg/cloud/cloudtestutils/cloud_nemesis.go
@@ -1,0 +1,271 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cloudtestutils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// RunCloudNemesisTest writes random objects to the provided storage instance
+// and validates they can be read back correctly. It is intended to be used in
+// tandem with HTTP fault injection to ensure our retry logic can handle
+// transient errors from the cloud storage providers without propagating errors
+// or corrupting data.
+//
+// TODO(jeffswenson): use this to test GCS and Azure
+// TODO(jeffswenson): add a list operation
+func RunCloudNemesisTest(t *testing.T, storage cloud.ExternalStorage) {
+	nemesis := &cloudNemesis{
+		storage:          storage,
+		writeConcurrency: 1,
+		readConcurrency:  40,
+	}
+
+	// We create a context here because we don't want to support a caller supplied
+	// cancelation signal.
+	ctx := context.Background()
+	if err := nemesis.run(ctx, 2*time.Minute); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	require.Greater(t, nemesis.writeSuccesses.Load(), int64(5), "not enough completed writes")
+	require.Greater(t, nemesis.readSuccesses.Load(), int64(200), "not enough completed reads")
+}
+
+type cloudNemesis struct {
+	storage          cloud.ExternalStorage
+	writeConcurrency int
+	readConcurrency  int
+
+	readSuccesses  atomic.Int64
+	writeSuccesses atomic.Int64
+
+	mu struct {
+		syncutil.Mutex
+		objects []cloudObject
+	}
+}
+
+type cloudObject struct {
+	index int
+	name  string
+
+	size int
+
+	finished bool
+}
+
+func (c *cloudNemesis) run(ctx context.Context, duration time.Duration) error {
+	// NOTE: we don't use the context to cancel operations because we want to
+	// ensure that in-flight operations running during fault injection eventually
+	// run to completion.
+	done := make(chan struct{})
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		time.Sleep(duration)
+		close(done)
+		return nil
+	})
+
+	for i := 0; i < c.writeConcurrency; i++ {
+		g.Go(func() error {
+			for {
+				time.Sleep(time.Millisecond)
+				select {
+				case <-done:
+					return nil
+				default:
+					if err := c.writeObject(ctx); err != nil {
+						return err
+					}
+				}
+			}
+		})
+	}
+
+	for i := 0; i < c.readConcurrency; i++ {
+		g.Go(func() error {
+			for {
+				time.Sleep(time.Millisecond)
+				select {
+				case <-done:
+					return nil
+				default:
+					if err := c.readObject(ctx); err != nil {
+						return err
+					}
+				}
+			}
+		})
+	}
+
+	// We shouldn't observe any errors from the client. We are injecting errors
+	// that should be transparently retried.
+	return g.Wait()
+}
+
+func (c *cloudNemesis) writeObject(ctx context.Context) (err error) {
+	// We test objects that are ~128 MiB in size because that is roughly the size
+	// of a single SSTable in a backup.
+	o := c.newObject()
+
+	w, err := c.storage.Writer(ctx, o.name)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.CombineErrors(err, w.Close())
+		if err == nil {
+			c.finishObject(o)
+			c.writeSuccesses.Add(1)
+		}
+	}()
+
+	content := &generatedObject{
+		seed:   int64(o.index),
+		cursor: 0,
+		size:   o.size,
+	}
+
+	_, err = io.Copy(w, content)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *cloudNemesis) readObject(ctx context.Context) (err error) {
+	obj := c.randomObject()
+	if !obj.finished {
+		// We only read finished objects
+		return nil
+	}
+
+	// Generate a random read range that is at most ~4 KiB in size. We keep the
+	// reads small so that we can execute them quickly and with high concurrency
+	// to get more fault coverage. If we read the entire object we would risk
+	// OOMs.
+	start := rand.Intn(obj.size - 1)
+	end := min(start+rand.Intn(4096)+1, obj.size)
+
+	r, size, err := c.storage.ReadFile(ctx, obj.name, cloud.ReadOptions{
+		Offset: int64(start),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to read %s", obj.name)
+	}
+	defer func() {
+		err = errors.CombineErrors(err, r.Close(ctx))
+	}()
+
+	if size != int64(obj.size) {
+		return errors.AssertionFailedf("expected size %d, got %d", obj.size, size)
+	}
+
+	buf := make([]byte, end-start)
+	readSize, err := io.ReadAtLeast(ioctx.ReaderCtxAdapter(ctx, r), buf[:], len(buf))
+	if err != nil {
+		return err
+	}
+
+	if readSize != len(buf) {
+		return errors.AssertionFailedf("only read (%d/%d) bytes from %s", readSize, len(buf), obj.name)
+	}
+
+	expected := &generatedObject{
+		seed:   int64(obj.index),
+		cursor: start,
+		size:   obj.size,
+	}
+
+	expectedBuf := make([]byte, end-start)
+	_, err = expected.Read(expectedBuf)
+	if err != nil {
+		return errors.Wrap(err, "unable to read from expected generated object")
+	}
+
+	if !bytes.Equal(buf, expectedBuf) {
+		return errors.AssertionFailedf("data mismatch for object %s [%d:%d]", obj.name, start, end)
+	}
+
+	c.readSuccesses.Add(1)
+
+	return nil
+}
+
+func (c *cloudNemesis) newObject() cloudObject {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Objects are [0, 128 MiB) in size to match the size exported by backups.
+	objectSize := max(1, rand.Intn(128*1024*1024))
+
+	i := len(c.mu.objects)
+	o := cloudObject{
+		index:    i,
+		name:     fmt.Sprintf("object-%d", i),
+		size:     objectSize,
+		finished: false,
+	}
+
+	c.mu.objects = append(c.mu.objects, o)
+	return o
+}
+
+func (c *cloudNemesis) finishObject(o cloudObject) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.objects[o.index].finished = true
+}
+
+func (c *cloudNemesis) randomObject() cloudObject {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.mu.objects) == 0 {
+		return cloudObject{}
+	}
+
+	return c.mu.objects[rand.Intn(len(c.mu.objects))]
+}
+
+// generatedObject is a deterministic implementation of io.Reader.
+type generatedObject struct {
+	seed   int64
+	cursor int
+	size   int
+}
+
+func (g *generatedObject) Read(p []byte) (n int, err error) {
+	if g.cursor >= g.size {
+		return 0, io.EOF
+	}
+
+	// Every byte is pos*seed % 256
+	n = min(len(p), g.size-g.cursor)
+	for i := 0; i < n; i++ {
+		p[i] = byte((g.cursor + i) * int(g.seed) % 256)
+	}
+	g.cursor += n
+	return n, nil
+}

--- a/pkg/cloud/cloudtestutils/http_middleware.go
+++ b/pkg/cloud/cloudtestutils/http_middleware.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cloudtestutils
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// BrownoutMiddleware creates an HTTP middleware that injects 500 errors during
+// a specific time window relative to when the middleware was created.
+func BrownoutMiddleware(startAfter, endAfter time.Duration) cloud.HttpMiddleware {
+	now := timeutil.Now()
+	return func(next http.RoundTripper) http.RoundTripper {
+		return &brownoutRoundTripper{
+			next:      next,
+			startTime: now.Add(startAfter),
+			endTime:   now.Add(endAfter),
+		}
+	}
+}
+
+type brownoutRoundTripper struct {
+	next      http.RoundTripper
+	startTime time.Time
+	endTime   time.Time
+}
+
+func (b *brownoutRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	now := timeutil.Now()
+	if now.After(b.startTime) && now.Before(b.endTime) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Injected Server Error",
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	}
+
+	return b.next.RoundTrip(req)
+}

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"io"
+	"net/http"
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -187,6 +188,7 @@ type EarlyBootExternalStorageContext struct {
 	Options         []ExternalStorageOption
 	Limiters        Limiters
 	MetricsRecorder *Metrics
+	HttpMiddleware  HttpMiddleware
 }
 
 // ExternalStorageOptions rolls up the Options into a struct.
@@ -206,6 +208,8 @@ type ExternalStorageOptions struct {
 	AzureStorageTestingKnobs base.ModuleTestingKnobs
 	ClientName               string
 }
+
+type HttpMiddleware func(http.RoundTripper) http.RoundTripper
 
 // ExternalStorageConstructor is a function registered to create instances
 // of a given external storage implementation.

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -187,9 +187,10 @@ func makeGCSStorage(
 
 	clientName := args.ExternalStorageOptions().ClientName
 	baseTransport, err := cloud.MakeTransport(args.Settings, args.MetricsRecorder, cloud.HTTPClientConfig{
-		Bucket: conf.Bucket,
-		Client: clientName,
-		Cloud:  "gcs",
+		Bucket:         conf.Bucket,
+		Client:         clientName,
+		Cloud:          "gcs",
+		HttpMiddleware: args.HttpMiddleware,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create http transport")


### PR DESCRIPTION
This adds a cloud nemisis test suite and uses it to ensure the S3 client
is tolerant of 30 second brown outs. This test is designed to be a
general purpose fault injection test and it is confirmed to reliably
reproduce the token bucket exhaustion errors that are caused by the S3
client.

Release note: none
Informs: https://github.com/cockroachdb/cockroach/issues/151748