### PR TITLE
crosscluster/physical: deflake TestStreamingRegionalConstraint

### DIFF
--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -1353,6 +1353,8 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 		c, cleanup := replicationtestutils.CreateMultiTenantStreamingCluster(ctx, t, args)
 		defer cleanup()
 
+		c.SrcSysSQL.Exec(t, "SET CLUSTER SETTING kv.rangefeed.lagging_closed_timestamp_cancel_min_lagging_duration = '5s';")
+
 		producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 		jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 		jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))


### PR DESCRIPTION
We observed a rangefeed at the processor level stalling for over 45 seconds because the closed timestamp did not advance. This patch reduces the interval a rangefeed is restarted from 1 minute to 5 seconds.

Epic: none

Release note: none