### PR TITLE
roachtest: adjust LoadWarehouses logic and thresholds for tpccbench

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1499,10 +1499,10 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehousesGCE:   5000,
-		LoadWarehousesAWS:   5000,
-		LoadWarehousesAzure: 5000,
-		LoadWarehousesIBM:   5000,
+		LoadWarehousesGCE:   5500,
+		LoadWarehousesAWS:   5500,
+		LoadWarehousesAzure: 5500,
+		LoadWarehousesIBM:   5500,
 		EstimatedMaxGCE:     4500,
 		EstimatedMaxAWS:     4500,
 		EstimatedMaxAzure:   4500,
@@ -1514,10 +1514,10 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehousesGCE:   5000,
-		LoadWarehousesAWS:   5000,
-		LoadWarehousesAzure: 5000,
-		LoadWarehousesIBM:   5000,
+		LoadWarehousesGCE:   5500,
+		LoadWarehousesAWS:   5500,
+		LoadWarehousesAzure: 5500,
+		LoadWarehousesIBM:   5500,
 		EstimatedMaxGCE:     4500,
 		EstimatedMaxAWS:     4500,
 		EstimatedMaxAzure:   4500,
@@ -1584,10 +1584,10 @@ func registerTPCC(r registry.Registry) {
 		Chaos:      true,
 		LoadConfig: singlePartitionedLoadgen,
 
-		LoadWarehousesGCE:   3000,
-		LoadWarehousesAWS:   3000,
-		LoadWarehousesAzure: 3000,
-		LoadWarehousesIBM:   3000,
+		LoadWarehousesGCE:   3500,
+		LoadWarehousesAWS:   3500,
+		LoadWarehousesAzure: 3500,
+		LoadWarehousesIBM:   3500,
 		EstimatedMaxGCE:     2500,
 		EstimatedMaxAWS:     2500,
 		EstimatedMaxAzure:   2500,
@@ -1620,10 +1620,10 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehousesGCE:   5000,
-		LoadWarehousesAWS:   5000,
-		LoadWarehousesAzure: 5000,
-		LoadWarehousesIBM:   5000,
+		LoadWarehousesGCE:   5500,
+		LoadWarehousesAWS:   5500,
+		LoadWarehousesAzure: 5500,
+		LoadWarehousesIBM:   5500,
 		EstimatedMaxGCE:     4500,
 		EstimatedMaxAWS:     4500,
 		EstimatedMaxAzure:   4500,
@@ -1710,10 +1710,10 @@ func registerTPCC(r registry.Registry) {
 			Nodes: 3,
 			CPUs:  16,
 
-			LoadWarehousesGCE:   5000,
-			LoadWarehousesAWS:   5000,
-			LoadWarehousesAzure: 5000,
-			LoadWarehousesIBM:   5000,
+			LoadWarehousesGCE:   5500,
+			LoadWarehousesAWS:   5500,
+			LoadWarehousesAzure: 5500,
+			LoadWarehousesIBM:   5500,
 			EstimatedMaxGCE:     4500,
 			EstimatedMaxAWS:     4500,
 			EstimatedMaxAzure:   4500,
@@ -1731,10 +1731,10 @@ func registerTPCC(r registry.Registry) {
 			Nodes: 3,
 			CPUs:  16,
 
-			LoadWarehousesGCE:   5000,
-			LoadWarehousesAWS:   5000,
-			LoadWarehousesAzure: 5000,
-			LoadWarehousesIBM:   5000,
+			LoadWarehousesGCE:   5500,
+			LoadWarehousesAWS:   5500,
+			LoadWarehousesAzure: 5500,
+			LoadWarehousesIBM:   5500,
 			EstimatedMaxGCE:     4500,
 			EstimatedMaxAWS:     4500,
 			EstimatedMaxAzure:   4500,
@@ -2331,6 +2331,13 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 			}
 			res = tpcc.MergeResults(results...)
 			failErr = res.FailureError()
+		}
+
+		// Print the result.
+		if failErr == nil {
+			ttycolor.Stdout(ttycolor.Green)
+			t.L().Printf("--- SEARCH ITER PASS: TPCC %d resulted in %.1f tpmC (%.1f%% of max tpmC)\n\n",
+				warehouses, res.TpmC(), res.Efficiency())
 			// If the active warehouses have reached the load warehouses, fail the test;
 			// it needs to be updated to allow for more warehouses. Note that the line
 			// search assumes that the test fails at the number of load warehouses, so it
@@ -2346,13 +2353,6 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 				)
 				t.Fatal(err)
 			}
-		}
-
-		// Print the result.
-		if failErr == nil {
-			ttycolor.Stdout(ttycolor.Green)
-			t.L().Printf("--- SEARCH ITER PASS: TPCC %d resulted in %.1f tpmC (%.1f%% of max tpmC)\n\n",
-				warehouses, res.TpmC(), res.Efficiency())
 		} else {
 			ttycolor.Stdout(ttycolor.Red)
 			t.L().Printf("--- SEARCH ITER FAIL: TPCC %d resulted in %.1f tpmC and failed due to %v",


### PR DESCRIPTION
Previously, the TPC-C bench tests would fail if the maximum number of warehouses (`LoadWarehouses`) was reached as part of the line search. The logic to do so was flawed: the test would detect this condition in cases where it didn't pass that last step (by failing either the latency of efficiency check). Instead, the test should fail when the maximum number of warehouses is reached AND the last iteration (at the maximum number of warehouses) passed.

This commit fixes the logic and also adjusts some of the `LoadWarehouses` maxima for tests that have recently failed.

Fixes: #151909
Fixes: #151876
Fixes: #151863
Fixes: #151862
Fixes: #151786
Fixes: #151781
Fixes: #151739
Fixes: #151407
Fixes: #150093

Release note: None