### PR TITLE
log,*: require explicit channel selection for logging API

### DIFF
--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -317,10 +317,10 @@ func (c *Container) WaitUntilNotRunning(ctx context.Context) error {
 			// NB: TEST_UNDECLARED_OUTPUTS_DIR is set for remote Bazel tests.
 			undeclaredOutsDir := os.Getenv("TEST_UNDECLARED_OUTPUTS_DIR")
 			if undeclaredOutsDir != "" {
-				log.Shoutf(ctx, severity.INFO, "command left-over files in %s",
+				log.Dev.Shoutf(ctx, severity.INFO, "command left-over files in %s",
 					strings.Replace(volumesDir, undeclaredOutsDir, "outputs.zip", 1))
 			} else {
-				log.Shoutf(ctx, severity.INFO, "command left-over files in %s", volumesDir)
+				log.Dev.Shoutf(ctx, severity.INFO, "command left-over files in %s", volumesDir)
 			}
 		}
 

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -259,7 +259,7 @@ func restoreWithRetry(
 					ctx, txn, "error", fmt.Sprintf("restore encountered error: %v", err),
 				)
 			}); err != nil {
-				log.Warningf(ctx, "failed to record job error message: %v", err)
+				log.Dev.Warningf(ctx, "failed to record job error message: %v", err)
 			}
 		}
 
@@ -330,7 +330,7 @@ func maybeResetRetry(
 		// If the previous persisted spans are different than the current, it
 		// implies that further progress has been persisted.
 		rt.Reset()
-		log.Infof(ctx, "restored frontier has advanced since last retry, resetting retry counter")
+		log.Dev.Infof(ctx, "restored frontier has advanced since last retry, resetting retry counter")
 	}
 	return currProgress
 }

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
@@ -128,9 +128,9 @@ func (filter tableEventFilter) shouldFilter(
 	et := classifyTableEvent(e)
 
 	if log.V(2) {
-		log.Infof(ctx, "table event %v classified as %v", e, et)
+		log.Dev.Infof(ctx, "table event %v classified as %v", e, et)
 		defer func() {
-			log.Infof(ctx, "should filter table event %v: %t", e, ok)
+			log.Dev.Infof(ctx, "should filter table event %v: %t", e, ok)
 		}()
 	}
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -356,7 +356,7 @@ func debugSignalSetup() func() {
 				case <-exit:
 					return
 				case <-debugSignalCh:
-					log.Shout(ctx, severity.INFO, "setting up localhost debugging endpoint...")
+					log.Dev.Shout(ctx, severity.INFO, "setting up localhost debugging endpoint...")
 					mux := http.NewServeMux()
 					mux.HandleFunc("/debug/pprof/", pprof.Index)
 					mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -367,7 +367,7 @@ func debugSignalSetup() func() {
 					listenAddr := "localhost:0"
 					listener, err := net.Listen("tcp", listenAddr)
 					if err != nil {
-						log.Shoutf(ctx, severity.WARNING, "debug server could not start listening on %s: %v", listenAddr, err)
+						log.Dev.Shoutf(ctx, severity.WARNING, "debug server could not start listening on %s: %v", listenAddr, err)
 						continue
 					}
 
@@ -377,7 +377,7 @@ func debugSignalSetup() func() {
 							log.Dev.Warningf(ctx, "debug server: %v", err)
 						}
 					}()
-					log.Shoutf(ctx, severity.INFO, "debug server listening on %s", listener.Addr())
+					log.Dev.Shoutf(ctx, severity.INFO, "debug server listening on %s", listener.Addr())
 					<-exit
 					if err := server.Shutdown(ctx); err != nil {
 						log.Dev.Warningf(ctx, "error shutting down debug server: %s", err)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1472,7 +1472,7 @@ func setupAndInitializeLoggingAndProfiling(
 				"to databases, the --locality flag must contain a \"region\" tier.\n" +
 				"For more information, see:\n\n" +
 				"- %s"
-			log.Shoutf(ctx, severity.WARNING, warningString,
+			log.Dev.Shoutf(ctx, severity.WARNING, warningString,
 				redact.Safe(docs.URL("cockroach-start.html#locality")))
 		}
 	}

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -348,7 +348,7 @@ func (r *logicalReplicationResumer) ingest(
 			case <-t.C:
 				newDest, err := reloadDest(ctx, ingestionJob.ID(), jobExecCtx.ExecCfg())
 				if err != nil {
-					log.Warningf(ctx, "failed to check for updated configuration: %v", err)
+					log.Dev.Warningf(ctx, "failed to check for updated configuration: %v", err)
 				} else if newDest != resolvedDest {
 					return errors.Mark(errors.Newf("replan due to detail change: old=%s, new=%s", resolvedDest, newDest), sql.ErrPlanChanged)
 				}

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -312,7 +312,7 @@ func (s *Watcher[E]) Run(ctx context.Context) error {
 		rangefeed.WithDiff(s.withPrevValue),
 		rangefeed.WithRowTimestampInInitialScan(s.withRowTSInInitialScan),
 		rangefeed.WithOnInitialScanError(func(ctx context.Context, err error) (shouldFail bool) {
-			log.VInfof(ctx, 1, "initial scan error: %s", err)
+			log.Dev.VInfof(ctx, 1, "initial scan error: %s", err)
 			// TODO(irfansharif): Consider if there are other errors which we
 			// want to treat as permanent. This was cargo culted from the
 			// settings watcher.

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -966,9 +966,9 @@ func (a *Allocator) ComputeAction(
 	// priority inversion. If the priority is not -1, the range might be re-queued
 	// to be processed with the correct priority.
 	if priority == -1 && buildutil.CrdbTestBuild {
-		log.Fatalf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+		log.Dev.Fatalf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
 	} else {
-		log.Warningf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+		log.Dev.Warningf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
 	}
 	return action, priority
 }

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -475,7 +475,7 @@ func computeSSTStatsDiffWithFallback(
 	stats, err := storage.ComputeSSTStatsDiff(
 		ctx, sst, readWriter, nowNanos, start, end)
 	if errors.IsAny(err, storage.ComputeSSTStatsDiffReaderHasRangeKeys, storage.ComputeStatsDiffViolation) {
-		log.Warningf(ctx, "computing SST stats as estimates because of ComputeSSTStatsDiff error: %s", err)
+		log.Dev.Warningf(ctx, "computing SST stats as estimates because of ComputeSSTStatsDiff error: %s", err)
 		sstStats, err := computeSSTStats(ctx, sst, nowNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, errors.Wrap(err, "error computing SST stats during fallback")

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -128,7 +128,7 @@ func maybeImportTS(ctx context.Context, s *topLevelServer) (returnErr error) {
 			}
 			storeToNode[roachpb.StoreID(si)] = roachpb.NodeID(ni)
 		}
-		log.Infof(ctx, "Using embedded store-to-node mapping from the tsdump file itself. "+
+		log.Dev.Infof(ctx, "Using embedded store-to-node mapping from the tsdump file itself. "+
 			"Skipped check for explicit store-to-node mapping file.")
 	} else {
 		// Reset file to beginning for subsequent decoding.
@@ -136,7 +136,7 @@ func maybeImportTS(ctx context.Context, s *topLevelServer) (returnErr error) {
 			return err
 		}
 		dec = gob.NewDecoder(f)
-		log.Infof(ctx, "Embedded metadata not found in the tsdump file. "+
+		log.Dev.Infof(ctx, "Embedded metadata not found in the tsdump file. "+
 			"Reading from the store-to-node mapping file.")
 
 		// Fallback to explicit YAML mapping file.

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -185,7 +185,7 @@ func (s *SettingsWatcher) Start(ctx context.Context) error {
 		defer s.mu.Unlock()
 		s.mu.updater.ResetRemaining(ctx)
 		if !initialScan.done {
-			log.VInfof(ctx, 1, "initial settings scan complete")
+			log.Dev.VInfof(ctx, 1, "initial settings scan complete")
 			initialScan.done = true
 			close(initialScan.ch)
 		}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -617,9 +617,9 @@ func (m *Manager) WaitForNewVersion(
 
 				if regionStaleSessionCount != 0 { // quit early
 					if region == "" {
-						log.Infof(ctx, "%d sessions holding stale descriptor", regionStaleSessionCount)
+						log.Dev.Infof(ctx, "%d sessions holding stale descriptor", regionStaleSessionCount)
 					} else {
-						log.Infof(ctx, "Region '%s' has %d sessions holding stale descriptor", region, regionStaleSessionCount)
+						log.Dev.Infof(ctx, "Region '%s' has %d sessions holding stale descriptor", region, regionStaleSessionCount)
 					}
 					break
 				}
@@ -1211,13 +1211,13 @@ func (m *Manager) purgeOldVersions(
 		// Otherwise, we ran into some type of transient issue, where the sqllivness
 		// session was expired. This could happen if the sqlliveness range is slow
 		// for some reason.
-		log.Infof(ctx, "unable to acquire lease on latest descriptor "+
+		log.Dev.Infof(ctx, "unable to acquire lease on latest descriptor "+
 			"version of ID: %d, retrying...", id)
 	}
 	// As a last resort, we will release all versions of the descriptor. This is
 	// suboptimal, but the safest option.
 	if errors.Is(err, errRenewLease) {
-		log.Warningf(ctx, "unable to acquire lease on latest descriptor "+
+		log.Dev.Warningf(ctx, "unable to acquire lease on latest descriptor "+
 			"version of ID: %d, cleaning up all versions from storage.", id)
 		err = nil
 	}

--- a/pkg/sql/index_split_scatter.go
+++ b/pkg/sql/index_split_scatter.go
@@ -189,7 +189,7 @@ func (is *indexSplitAndScatter) getSplitPointsWithStats(
 	// we generated any split points above
 	if len(splitPoints) > 0 {
 		splitPoints = append(splitPoints, is.codec.IndexPrefix(uint32(table.GetID()), uint32(indexToBackfill.GetID())))
-		log.Infof(ctx, "generated %d split points from statistics for tableId=%d index=%d", len(splitPoints), table.GetID(), indexToBackfill.GetID())
+		log.Dev.Infof(ctx, "generated %d split points from statistics for tableId=%d index=%d", len(splitPoints), table.GetID(), indexToBackfill.GetID())
 	}
 	return splitPoints, nil
 }
@@ -272,7 +272,7 @@ func (is *indexSplitAndScatter) MaybeSplitIndexSpans(
 	if len(splitPoints) == 0 {
 		splitPoints, err = is.getSplitPointsWithStats(ctx, table, indexToBackfill, nSplits)
 		if err != nil {
-			log.Warningf(ctx, "unable to get split points for stats for tableID=%d index=%d due to %v", tableID, indexToBackfill.GetID(), err)
+			log.Dev.Warningf(ctx, "unable to get split points for stats for tableID=%d index=%d due to %v", tableID, indexToBackfill.GetID(), err)
 		}
 	}
 

--- a/pkg/util/log/gen/main.go
+++ b/pkg/util/log/gen/main.go
@@ -353,11 +353,7 @@ func (logger{{.Name}}) {{with $sev}}{{.Name}}{{end}}fDepth(ctx context.Context, 
 //
 {{with $sev}}{{.Comment}}{{end -}}
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.{{with $sev}}{{.Name}}{{end}}f instead
 func {{with $sev}}{{.Name}}{{end}}f(ctx context.Context, format string, args ...interface{}) {
   logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, format, args...)
 }
@@ -370,11 +366,7 @@ func {{with $sev}}{{.Name}}{{end}}f(ctx context.Context, format string, args ...
 //
 {{with $sev}}{{.Comment}}{{end -}}
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.V{{with $sev}}{{.Name}}{{end}}f instead
 func V{{with $sev}}{{.Name}}{{end}}f(ctx context.Context, level Level, format string, args ...interface{}) {
   if VDepth(level, 1) {
     logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, format, args...)
@@ -389,11 +381,7 @@ func V{{with $sev}}{{.Name}}{{end}}f(ctx context.Context, level Level, format st
 //
 {{with $sev}}{{.Comment}}{{end -}}
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.{{with $sev}}{{.Name}}{{end}} instead
 func {{with $sev}}{{.Name}}{{end}}(ctx context.Context, msg string) {
   logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, msg)
 }
@@ -407,11 +395,7 @@ func {{with $sev}}{{.Name}}{{end}}(ctx context.Context, msg string) {
 //
 {{with $sev}}{{.Comment}}{{end -}}
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.{{with $sev}}{{.Name}}{{end}}fDepth instead
 func {{with $sev}}{{.Name}}{{end}}fDepth(ctx context.Context, depth int, format string, args ...interface{}) {
   logfDepth(ctx, depth+1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, format, args...)
 }
@@ -466,11 +450,7 @@ func (logger{{.Name}}) VEventfDepth(ctx context.Context, depth int, level Level,
 //
 {{.Comment -}}
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Shout instead
 func Shout(ctx context.Context, sev Severity, msg string) {
   shoutfDepth(ctx, 1, sev, channel.{{.NAME}}, msg)
 }
@@ -481,11 +461,7 @@ func Shout(ctx context.Context, sev Severity, msg string) {
 //
 {{.Comment -}}
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Shoutf instead
 func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
   shoutfDepth(ctx, 1, sev, channel.{{.NAME}}, format, args...)
 }

--- a/pkg/util/log/log_channels_generated.go
+++ b/pkg/util/log/log_channels_generated.go
@@ -274,11 +274,7 @@ func (loggerDev) InfofDepth(ctx context.Context, depth int, format string, args 
 // The `INFO` severity is used for informational messages that do not
 // require action.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Infof instead
 func Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.DEV, format, args...)
 }
@@ -302,11 +298,7 @@ func Infof(ctx context.Context, format string, args ...interface{}) {
 // The `INFO` severity is used for informational messages that do not
 // require action.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.VInfof instead
 func VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.DEV, format, args...)
@@ -332,11 +324,7 @@ func VInfof(ctx context.Context, level Level, format string, args ...interface{}
 // The `INFO` severity is used for informational messages that do not
 // require action.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Info instead
 func Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.DEV, msg)
 }
@@ -361,11 +349,7 @@ func Info(ctx context.Context, msg string) {
 // The `INFO` severity is used for informational messages that do not
 // require action.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.InfofDepth instead
 func InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.DEV, format, args...)
 }
@@ -484,11 +468,7 @@ func (loggerDev) WarningfDepth(ctx context.Context, depth int, format string, ar
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Warningf instead
 func Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.DEV, format, args...)
 }
@@ -512,11 +492,7 @@ func Warningf(ctx context.Context, format string, args ...interface{}) {
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.VWarningf instead
 func VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.DEV, format, args...)
@@ -542,11 +518,7 @@ func VWarningf(ctx context.Context, level Level, format string, args ...interfac
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Warning instead
 func Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.DEV, msg)
 }
@@ -571,11 +543,7 @@ func Warning(ctx context.Context, msg string) {
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.WarningfDepth instead
 func WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.DEV, format, args...)
 }
@@ -699,11 +667,7 @@ func (loggerDev) ErrorfDepth(ctx context.Context, depth int, format string, args
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Errorf instead
 func Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.DEV, format, args...)
 }
@@ -728,11 +692,7 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.VErrorf instead
 func VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.ERROR, channel.DEV, format, args...)
@@ -759,11 +719,7 @@ func VErrorf(ctx context.Context, level Level, format string, args ...interface{
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Error instead
 func Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.DEV, msg)
 }
@@ -789,11 +745,7 @@ func Error(ctx context.Context, msg string) {
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.ErrorfDepth instead
 func ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.DEV, format, args...)
 }
@@ -917,11 +869,7 @@ func (loggerDev) FatalfDepth(ctx context.Context, depth int, format string, args
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Fatalf instead
 func Fatalf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.FATAL, channel.DEV, format, args...)
 }
@@ -946,11 +894,7 @@ func Fatalf(ctx context.Context, format string, args ...interface{}) {
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.VFatalf instead
 func VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.FATAL, channel.DEV, format, args...)
@@ -977,11 +921,7 @@ func VFatalf(ctx context.Context, level Level, format string, args ...interface{
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Fatal instead
 func Fatal(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.FATAL, channel.DEV, msg)
 }
@@ -1007,11 +947,7 @@ func Fatal(ctx context.Context, msg string) {
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.FatalfDepth instead
 func FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.FATAL, channel.DEV, format, args...)
 }
@@ -1121,11 +1057,7 @@ func (loggerDev) VEventfDepth(ctx context.Context, depth int, level Level, forma
 // sensitive operational data.
 // See [Configure logs](configure-logs.html#dev-channel).
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Shout instead
 func Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.DEV, msg)
 }
@@ -1146,11 +1078,7 @@ func Shout(ctx context.Context, sev Severity, msg string) {
 // sensitive operational data.
 // See [Configure logs](configure-logs.html#dev-channel).
 //
-// TODO: to avoid linting failures, we don't include details about
-// alternative usage. Once all usages have been replaced, update the
-// deprecation comment to describe the replacement functions
-//
-// Deprecated
+// Deprecated: use log.Dev.Shoutf instead
 func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.DEV, format, args...)
 }

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -412,10 +412,10 @@ func SendReport(
 
 	res := sentry.CaptureEvent(event)
 	if res != nil {
-		log.Shoutf(ctx, severity.ERROR, "Queued as error %v", string(*res))
+		log.Dev.Shoutf(ctx, severity.ERROR, "Queued as error %v", string(*res))
 	}
 	if !sentry.Flush(10 * time.Second) {
-		log.Shout(ctx, severity.ERROR, "Timeout trying to submit crash report")
+		log.Dev.Shout(ctx, severity.ERROR, "Timeout trying to submit crash report")
 	}
 }
 

--- a/pkg/util/log/testshout/shout_test.go
+++ b/pkg/util/log/testshout/shout_test.go
@@ -40,7 +40,7 @@ func Example_shout_before_log() {
 	log.OrigStderr = os.Stdout
 	defer func() { log.OrigStderr = origStderr }()
 
-	log.Shout(context.Background(), severity.INFO, "hello world")
+	log.Dev.Shout(context.Background(), severity.INFO, "hello world")
 
 	// output:
 	// *


### PR DESCRIPTION
Updated the deprecation comment on the generated logging
APIS to adhere to the golang documentation. As a result,
usage of these APIs will now cause lint failures due to
lint check: SA1019.

Epic: [CRDB-53410](https://cockroachlabs.atlassian.net/browse/CRDB-53410)
Release note: None