### PR TITLE
release-25.2: cli/interactive_tests: use interrupt_and_wait helper everywhere

### DIFF
--- a/pkg/cli/interactive_tests/test_encryption.tcl
+++ b/pkg/cli/interactive_tests/test_encryption.tcl
@@ -44,8 +44,7 @@ end_test
 start_test "Start normal node."
 send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "node starting"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 send "$argv debug encryption-status $storedir\r"
 eexpect ""
 end_test
@@ -58,22 +57,19 @@ end_test
 start_test "Restart with plaintext."
 send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
 eexpect "node starting"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=plain,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"Plaintext\","
 # Try starting without the encryption flag.
 send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "node starting"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 end_test
 
 start_test "Restart with AES-128."
 send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
 eexpect "node starting"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 file_not_exists "$storedir/COCKROACHDB_REGISTRY"
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-128.key,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"AES128_CTR\","
@@ -88,14 +84,13 @@ end_test
 start_test "Restart with AES-256."
 send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=$keydir/aes-128.key\r"
 eexpect "node starting"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 send "$argv debug encryption-status $storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
 eexpect "    \"Active\": true,\r\n    \"Type\": \"AES256_CTR\","
 # Startup again, but don't specify the old key, it's no longer in use.
 send "$argv start-single-node --insecure --store=$storedir --enterprise-encryption=path=$storedir,key=$keydir/aes-256.key,old-key=plain\r"
 eexpect "node starting"
-interrupt
+interrupt_and_wait
 # Try starting without the encryption flag.
 send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "encryption was used on this store before, but no encryption flags specified."

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -9,22 +9,19 @@ eexpect ":/# "
 start_test "Check that --max-disk-temp-storage works."
 send "$argv start-single-node --insecure --store=path=logs/mystore --max-disk-temp-storage=10GiB\r"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that --max-disk-temp-storage can be expressed as a percentage."
 send "$argv start-single-node --insecure --store=path=logs/mystore --max-disk-temp-storage=10%\r"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that --max-disk-temp-storage percentage works when the store is in-memory."
 send "$argv start-single-node --insecure --store=type=mem,size=1GB --max-disk-temp-storage=10%\r"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that memory max flags do not exceed available RAM."
@@ -34,16 +31,14 @@ eexpect "is larger than"
 eexpect "of total RAM"
 eexpect "increased risk"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that not using --host nor --advertise causes a user warning."
 send "$argv start-single-node --insecure\r"
 eexpect "WARNING: neither --listen-addr nor --advertise-addr was specified"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that using --advertise-addr does not cause a user warning."
@@ -55,16 +50,14 @@ expect {
   }
 }
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that --listening-url-file gets created with the right data"
 send "$argv start-single-node --insecure --listening-url-file=foourl\r"
 eexpect "node starting"
 system "grep -q 'postgresql://.*@.*:\[0-9\]\[0-9\]*' foourl"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test {Check that the "failed running SUBCOMMAND" message does not consider a flag the subcommand}
@@ -109,8 +102,7 @@ end_test
 start_test "Check that locality flags without a region tier warn"
 send "$argv start-single-node --insecure --locality=data-center=us-east,zone=a\r"
 eexpect "WARNING: The --locality flag does not contain a"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_server $argv
@@ -170,8 +162,7 @@ send "export GOMEMLIMIT=1GiB;\r"
 eexpect ":/# "
 send "$argv start-single-node --insecure --store=path=logs/mystore\r"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 stop_server $argv
 end_test
 
@@ -180,8 +171,7 @@ send "export GOGC=500;\r"
 eexpect ":/# "
 send "$argv start-single-node --insecure --store=path=logs/mystore\r"
 eexpect "node starting"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 stop_server $argv
 end_test
 

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -33,8 +33,7 @@ eexpect ":/# "
 # is has been broken, and that may be the secondary logger.
 send "tail -F `find logs/db/logs -type l`\r"
 eexpect "error: write */dev/stderr*: broken pipe"
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 end_test
 
 start_test "Check that a broken log file prints a message to stderr."
@@ -52,8 +51,7 @@ eexpect "CockroachDB node starting"
 end_test
 
 # Stop it.
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 
 # Disable replication so as to avoid spurious purgatory errors.
 start_server $argv
@@ -68,9 +66,7 @@ eexpect "CockroachDB node starting"
 end_test
 
 # Stop it.
-interrupt
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 system "rm -rf logs/db"
 
 start_test "Check that --logtostderr can override the threshold but no error is printed on startup"
@@ -79,9 +75,7 @@ eexpect "marker\r\nCockroachDB node starting"
 end_test
 
 # Stop it.
-interrupt
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 system "rm -rf logs/db"
 
 

--- a/pkg/cli/interactive_tests/test_socket_name.tcl
+++ b/pkg/cli/interactive_tests/test_socket_name.tcl
@@ -50,14 +50,12 @@ system "test -r .s.PGSQL.$sql_port.lock"
 end_test
 
 # Stop the server that was started above.
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 send "exit\r"
 eexpect eof
 
 set spawn_id $shell1_spawn_id
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 
 start_test "Check that the socket-dir flag checks the length of the directory."
 send "$argv start-single-node --insecure --socket-dir=$longname\r"

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -97,8 +97,7 @@ expect {
     timeout { handle_timeout "memory allocation error" }
 }
 # Stop the tail command.
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 
 # Check that the client got a bad connection error
 set spawn_id $client_spawn_id
@@ -137,8 +136,6 @@ send_eof
 eexpect eof
 
 set spawn_id $shell_spawn_id
-interrupt
-interrupt
-eexpect ":/# "
+interrupt_and_wait
 send "exit\r"
 eexpect eof

--- a/pkg/cli/interactive_tests/test_temp_dir.tcl
+++ b/pkg/cli/interactive_tests/test_temp_dir.tcl
@@ -62,8 +62,7 @@ if {! [string match "$cwd/$tempdir/$tempprefix*" [gets $rfile]]} {
   exit 1
 }
 close $rfile
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 # Verify the temp directory is removed.
 glob_not_exists "$tempdir/$tempprefix*"
 # Verify temp directory path is removed from record file.
@@ -80,8 +79,7 @@ eexpect "node starting"
 eexpect "temp dir:*$tempdir/$tempprefix"
 # Verify the temp directory under first store is created.
 glob_exists "$tempdir/$tempprefix*"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 # Verify the temp directory is removed.
 glob_not_exists "$tempdir/$tempprefix*"
 end_test
@@ -97,8 +95,7 @@ eexpect "temp dir:*$cwd/$tempdir/$tempprefix"
 # Verify temp1 and temp2 are removed shortly after startup.
 file_not_exists "$storedir/temp1"
 file_not_exists "$storedir/temp2"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 # Verify the temp directory is removed.
 glob_not_exists "$tempdir/$tempprefix*"
 # Verify store directory still exists.
@@ -111,8 +108,7 @@ eexpect "node starting"
 eexpect "temp dir:*$cwd/$storedir/$tempprefix"
 # Verify the temp directory under first store is created.
 glob_exists "$storedir/$tempprefix*"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 # Verify the temp directory is removed.
 glob_not_exists "$storedir/$tempprefix*"
 # Verify the store file still exists.
@@ -131,6 +127,5 @@ send "pkill -9 cockroach\r"
 # We should be able to start the cockroach instance again.
 send "$argv start-single-node --insecure --store=$storedir\r"
 eexpect "node starting"
-interrupt
-eexpect "shutdown completed"
+interrupt_and_wait
 end_test


### PR DESCRIPTION
Backport 1/1 commits from #152537.

/cc @cockroachdb/release

---

This helper was added in 799f5ab9d7d135814def077e80a8f14492808768 to reduce flakiness by waiting for process termination. This patch applies the same change to other tests that benefit.

fixes https://github.com/cockroachdb/cockroach/issues/152482
Release note: None

Release justification: test only change
