### PR TITLE
ttljob: use COLLATED STRING in TestRowLevelTTLJobRandomEntries

### DIFF
--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -204,8 +204,8 @@ func (d *deleteRangeNode) processResults(
 			// Make a copy of curRowPrefix to avoid referencing the memory from
 			// the now-old BatchRequest.
 			//
-			// When auto-commit is enabled, we expect to see any resume spans,
-			// so we won't need to access d.curRowPrefix later.
+			// When auto-commit is enabled, we expect to not see any resume
+			// spans, so we won't need to access d.curRowPrefix later.
 			curRowPrefix := make([]byte, len(d.curRowPrefix))
 			copy(curRowPrefix, d.curRowPrefix)
 			d.curRowPrefix = curRowPrefix


### PR DESCRIPTION
In a recently merged change where we prohibited usage of CITEXT type in the mixed-version state in `TestRowLevelTTLJobRandomEntries`, I made the mistake of also excluding non-CITEXT COLLATED STRING type. This is now fixed.

Additionally, fix a typo in the comment from another change.

Epic: None
Release note: None