### PR TITLE
kvserverbase: add COCKROACH_ALLOW_MMA env var

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/buildutil",
         "//pkg/util/debugutil",
+        "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/redact"
@@ -114,6 +115,8 @@ var MVCCGCQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
+var allowMMA = envutil.EnvOrDefaultBool("COCKROACH_ALLOW_MMA", false)
+
 // LoadBasedRebalancingMode controls whether range rebalancing takes
 // additional variables such as write load and disk usage into account.
 // If disabled, rebalancing is done purely based on replica count.
@@ -130,7 +133,7 @@ var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
 	},
 	settings.WithPublic,
 	settings.WithValidateEnum(func(enumStr string) error {
-		if buildutil.CrdbTestBuild || enumStr != "multi-metric" {
+		if buildutil.CrdbTestBuild || enumStr != "multi-metric" || allowMMA {
 			return nil
 		}
 		return unimplemented.NewWithIssue(


### PR DESCRIPTION
This env var opts into allowing the use of `kv.allocator.load_based_rebalancing = multi-metric`.

Epic: CRDB-49117
