### PR TITLE
kvserver: enqueue decommissioning ranges at nudger with a higher priority

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -100,6 +100,17 @@ var EnqueueProblemRangeInReplicateQueueInterval = settings.RegisterDurationSetti
 	0,
 )
 
+// DecommissioningPriorityHighest is a setting that controls whether the
+// decommissioning nudger should enqueue decommissioning ranges with the highest
+// priority in replicate queue. EnqueueProblemRangeInReplicateQueueInterval
+// needs to be set for this to have an effect.
+var DecommissioningPriorityHighest = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.decommissioning.highest_priority.enabled",
+	"whether to process decommissioning replicas at highest priority in replicate queue",
+	false,
+)
+
 var (
 	metaReplicateQueueAddReplicaCount = metric.Metadata{
 		Name:        "queue.replicate.addreplica",


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/152022
Release note: none

---


**kvserver: add cluster setting DecommissioningPriorityHighest**

This commit adds a new cluster setting DecommissioningPriorityHighest that
controls whether the decommissioning nudger should enqueue decommissioning
ranges with the highest priority to the replicate queue.

---

**kvserver: enqueue decommissioning ranges with higher priority**

This commit adds a new cluster setting DecommissioningPriorityHighest that
controls whether the decommissioning nudger should enqueue decommissioning
ranges with high priority (1e5) to the replicate queue.
