### PR TITLE
CODEOWNERS: add /pkg/server/storage_api to obs-prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -251,6 +251,7 @@
 /pkg/server/status*go                    @cockroachdb/obs-prs
 /pkg/server/status/                      @cockroachdb/obs-prs
 /pkg/server/sticky_vfs*                  @cockroachdb/storage
+/pkg/server/storage_api/                 @cockroachdb/obs-prs
 /pkg/server/structlogging/               @cockroachdb/obs-prs
 /pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs
 /pkg/server/telemetry/                   @cockroachdb/obs-prs


### PR DESCRIPTION
Epic: None
Release note: None