### PR TITLE
[DNM] sql: Add support for transaction bundle

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1170,6 +1170,7 @@ func (s *Server) newConnExecutor(
 			connCtx:                      ctx,
 			testingForceRealTracingSpans: s.cfg.TestingKnobs.ForceRealTracingSpans,
 			execType:                     executorType,
+			txnInstrumentationHelper:     &txnInstrumentationHelper{StmtDiagnosticsRecorder: s.cfg.StmtDiagnosticsRecorder},
 		},
 		transitionCtx: transitionCtx{
 			db:           s.cfg.DB,
@@ -3477,6 +3478,12 @@ func isCommit(stmt tree.Statement) bool {
 	return ok
 }
 
+// isRollback returns true if stmt is a "ROLLBACK" statement.
+func isRollback(stmt tree.Statement) bool {
+	_, ok := stmt.(*tree.RollbackTransaction)
+	return ok
+}
+
 var retryableMinTimestampBoundUnsatisfiableError = errors.Newf(
 	"retryable MinTimestampBoundUnsatisfiableError",
 )
@@ -3821,6 +3828,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			ConsistencyChecker:               p.execCfg.ConsistencyChecker,
 			RangeProber:                      p.execCfg.RangeProber,
 			StmtDiagnosticsRequestInserter:   ex.server.cfg.StmtDiagnosticsRecorder.InsertRequest,
+			TxnDiagnosticsRequestInserter:    ex.server.cfg.StmtDiagnosticsRecorder.InsertTxnRequest,
 			CatalogBuiltins:                  &p.evalCatalogBuiltins,
 			QueryCancelKey:                   ex.queryCancelKey,
 			DescIDGenerator:                  ex.getDescIDGenerator(),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -565,13 +565,8 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// This goroutine is the only one that can modify txnState.mu.priority and
 	// txnState.mu.autoRetryCounter, so we don't need to get a mutex here.
-	ctx = ih.Setup(
-		ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
-		&stmt, os.ImplicitTxn.Get(),
-		ex.state.mu.priority,
-		ex.extraTxnState.shouldCollectTxnExecutionStats,
-		ex.state.mu.autoRetryCounter,
-	)
+	ctx = ih.Setup(ctx, ex, p, &stmt, os.ImplicitTxn.Get(),
+		ex.state.mu.priority, ex.state.mu.autoRetryCounter)
 
 	// Note that here we always unconditionally defer a function that takes care
 	// of finishing the instrumentation helper. This is needed since in order to
@@ -590,6 +585,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				res,
 				retPayload,
 				retErr,
+				ex.state.txnInstrumentationHelper,
 			)
 		}
 	}()
@@ -1462,13 +1458,8 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	// This goroutine is the only one that can modify txnState.mu.priority and
 	// txnState.mu.autoRetryCounter, so we don't need to get a mutex here.
 	if !portal.isPausable() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
-		ctx = ih.Setup(
-			ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
-			&vars.stmt, os.ImplicitTxn.Get(),
-			ex.state.mu.priority,
-			ex.extraTxnState.shouldCollectTxnExecutionStats,
-			ex.state.mu.autoRetryCounter,
-		)
+		ctx = ih.Setup(ctx, ex, p, &vars.stmt, os.ImplicitTxn.Get(),
+			ex.state.mu.priority, ex.state.mu.autoRetryCounter)
 	} else {
 		ctx = portal.pauseInfo.execStmtInOpenState.ihWrapper.ctx
 	}
@@ -1519,6 +1510,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 				curRes,
 				retPayload,
 				retErr,
+				ex.state.txnInstrumentationHelper,
 			)
 		}
 	})

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -554,6 +554,7 @@ func internalExtendedEvalCtx(
 			IndexUsageStatsController:      indexUsageStatsController,
 			ConsistencyChecker:             execCfg.ConsistencyChecker,
 			StmtDiagnosticsRequestInserter: execCfg.StmtDiagnosticsRecorder.InsertRequest,
+			TxnDiagnosticsRequestInserter:  execCfg.StmtDiagnosticsRecorder.InsertTxnRequest,
 			RangeStatsFetcher:              execCfg.RangeStatsFetcher,
 		},
 		Tracing:           &SessionTracing{},

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2859,6 +2859,7 @@ var builtinOidsArray = []string{
 	2904: `lca(ltree[]: ltree[]) -> ltree`,
 	2905: `levenshtein_less_equal(source: string, target: string, max_d: int) -> int`,
 	2906: `levenshtein_less_equal(source: string, target: string, ins_cost: int, del_cost: int, sub_cost: int, max_d: int) -> int`,
+	2907: `crdb_internal.request_txn_bundle(txn_fingerprint_id: string) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -245,6 +245,7 @@ type Context struct {
 	// crdb_internal.request_statement_bundle builtin to insert a statement
 	// bundle request.
 	StmtDiagnosticsRequestInserter StmtDiagnosticsRequestInsertFunc
+	TxnDiagnosticsRequestInserter  TxnDiagnosticsRequestInsertFunc
 
 	// CatalogBuiltins is used by various builtins which depend on looking up
 	// catalog information. Unlike the Planner, it is available in DistSQL.

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -765,6 +765,20 @@ type StmtDiagnosticsRequestInsertFunc func(
 	username string,
 ) error
 
+// TxnDiagnosticsRequestInsertFunc is an interface embedded in EvalCtx that can
+// be used by the builtins to insert a statement diagnostics request. This
+// interface is introduced to avoid circular dependency.
+type TxnDiagnosticsRequestInsertFunc func(
+	ctx context.Context,
+	txnFingerprintId uint64,
+	stmtFingerprintIds []uint64,
+	username string,
+	samplingProbability float64,
+	minExecutionLatency time.Duration,
+	expiresAfter time.Duration,
+	redacted bool,
+) error
+
 // AsOfSystemTime represents the result from the evaluation of AS OF SYSTEM TIME
 // clause.
 type AsOfSystemTime struct {

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -145,6 +145,10 @@ type txnState struct {
 
 	// execType records the executor type for the transaction.
 	execType executorType
+
+	// txnInstrumentationHelper contains state used to manage transaction
+	// bundle collection.
+	txnInstrumentationHelper *txnInstrumentationHelper
 }
 
 // txnType represents the type of a SQL transaction.
@@ -317,6 +321,7 @@ func (ts *txnState) finishSQLTxn() (txnID uuid.UUID, commitTimestamp hlc.Timesta
 		}
 	}
 
+	ts.txnInstrumentationHelper.Finalize(ts.Ctx, txnID)
 	sp.Finish()
 	if ts.txnCancelFn != nil {
 		ts.txnCancelFn()


### PR DESCRIPTION
 - Adds a new built in for requesting a transaction bundle by txn id - This currently only accepts a txn fingerprint id and no other request parameters
 - Adds logic to the instrumentiation helpers and statement diagnostic reporter to start collecting txn bundles based on prefix matching. If txn ends up not being the expected txn based on statement fingerprints, the request goes back into the pool to be picked up by another txn
 - TODO: once a txn completes and the txn bundle is finalized, it should update a new  and table accordingly.
 - TODO: Adding logic to poll the table in each node to ensure that each node tries to capture the txn bundle
 - TODO: add support for more request parameters in the built-in
 - TODO: add a new  API for requesting a statement bundle

Release note: None
Epic: None