### PR TITLE
release-24.1: sql: fix TestRelocateNonVoters flake by speeding up allocator intervals

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -778,6 +778,7 @@ go_test(
         "//pkg/kv/kvclient/rangefeed",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",


### PR DESCRIPTION
Backport 1/1 commits from #151595 on behalf of @spilchen.

----

The test was failing due to race conditions between allocator operations and manual relocate commands. Set allocator intervals to 100ms to allow faster recovery from inconsistent replica states.

Fixes #150993

Release note: None

Epic: None

----

Release justification: test only fix