### PR TITLE
changefeedccl: fix db-level feed error handling in changefeed processors

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -43,12 +43,8 @@ type ChangefeedConfig struct {
 // makeChangefeedConfigFromJobDetails creates a ChangefeedConfig struct from any
 // version of the ChangefeedDetails protobuf.
 func makeChangefeedConfigFromJobDetails(
-	ctx context.Context, d jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig,
+	d jobspb.ChangefeedDetails, targets changefeedbase.Targets,
 ) (ChangefeedConfig, error) {
-	targets, err := AllTargets(ctx, d, execCfg)
-	if err != nil {
-		return ChangefeedConfig{}, err
-	}
 	return ChangefeedConfig{
 		SinkURI:  d.SinkURI,
 		Opts:     changefeedbase.MakeStatementOptions(d.Opts),

--- a/pkg/ccl/changefeedccl/event_processing_test.go
+++ b/pkg/ccl/changefeedccl/event_processing_test.go
@@ -153,16 +153,16 @@ func TestTopicForEvent(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := makeChangefeedConfigFromJobDetails(context.Background(), tc.details, nil)
+			// Can pass in nil for execCfg to AllTargets because we're not testing
+			// database-level targets.
+			targets, err := AllTargets(context.Background(), tc.details, nil)
+			require.NoError(t, err)
+			cfg, err := makeChangefeedConfigFromJobDetails(tc.details, targets)
 			require.NoError(t, err)
 			c := kvEventToRowConsumer{
 				details:              cfg,
 				topicDescriptorCache: make(map[TopicIdentifier]TopicDescriptor),
 			}
-			// Can pass in nil for execCfg to AllTargets because we're not testing
-			// database-level targets.
-			targets, err := AllTargets(context.Background(), tc.details, nil)
-			require.NoError(t, err)
 			tn, err := MakeTopicNamer(targets)
 			require.NoError(t, err)
 


### PR DESCRIPTION
AllTargets can error when called from the changefeed processor due to
flakes unrelated to changefeeds. This commit fixes the error handling 
so that it doesn't result in a panic.

Part of: #147371
Epic: CRDB-1421

Release note: none