### PR TITLE
Import progress debug

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -247,6 +247,7 @@ func (u Updater) started(ctx context.Context) error {
 		traceID = sp.TraceID()
 	}
 	return u.Update(ctx, func(_ isql.Txn, md JobMetadata, ju *JobUpdater) error {
+		*md.Tag = "updater started"
 		if md.State != StatePending && md.State != StateRunning {
 			return errors.Errorf("job with state %s cannot be marked started", md.State)
 		}
@@ -312,6 +313,9 @@ func (u Updater) FractionProgressed(ctx context.Context, progressedFn FractionPr
 		}
 		fractionCompleted := progressedFn(ctx, md.Progress.Details)
 
+		if importProg := md.Progress.GetImport(); importProg != nil {
+			*md.Tag = "import update"
+		}
 		if !build.IsRelease() {
 			// We allow for slight floating-point rounding
 			// inaccuracies. We only want to error in non-release

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -123,12 +123,13 @@ func distImport(
 	// accumulatedBulkSummary accumulates the BulkOpSummary returned from each
 	// processor in their progress updates. It stores stats about the amount of
 	// data written since the last time we update the job progress.
+	// TODO(janexing): update comments.
 	accumulatedBulkSummary := struct {
 		syncutil.Mutex
 		kvpb.BulkOpSummary
 	}{}
 	accumulatedBulkSummary.Lock()
-	accumulatedBulkSummary.BulkOpSummary = getLastImportSummary(job)
+	accumulatedBulkSummary.BulkOpSummary = kvpb.BulkOpSummary{}
 	accumulatedBulkSummary.Unlock()
 
 	importDetails := job.Progress().Details.(*jobspb.Progress_Import).Import

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -3850,7 +3850,7 @@ func TestImportDefaultWithResume(t *testing.T) {
 	defer setImportReaderParallelism(1)()
 	const batchSize = 5
 	defer TestingSetParallelImporterReaderBatchSize(batchSize)()
-	defer row.TestingSetDatumRowConverterBatchSize(2 * batchSize)()
+	defer row.TestingSetDatumRowConverterBatchSize(3 * batchSize)()
 
 	s, db, _ := serverutils.StartServer(t,
 		base.TestServerArgs{

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -3828,6 +3828,22 @@ func TestImportDefaultNextVal(t *testing.T) {
 	})
 }
 
+// TestImportDefaultWithResume tests import job resumption with sequence default values
+// and verifies that bulk operation summaries are correctly handled across multiple
+// pause/resume cycles without duplication or data loss.
+//
+// The test specifically validates:
+//  1. Sequence value allocation and chunk management during import pauses/resumes
+//  2. Bulk operation summary consistency - ensuring row counts are not duplicated
+//     across different attempts of the same import execution
+//  3. Job progress tracking remains accurate through multiple retry attempts
+//
+// The test uses two breakpoints during CSV processing:
+// - First breakpoint at 7*batchSize (35 rows with batchSize=5)
+// - Second breakpoint at 9*batchSize (45 rows with batchSize=5)
+// This creates three execution attempts, allowing verification that at the very end of
+// the execution, the accumulated bulk summary correctly tracks progress without losing
+// or duplicating row counts.
 func TestImportDefaultWithResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3901,9 +3917,14 @@ func TestImportDefaultWithResume(t *testing.T) {
 
 			expectedNumRows := 10*batchSize + 1
 			testBarrier, csvBarrier := newSyncBarrier()
+			testBarrier2, csvBarrier2 := newSyncBarrier()
 			csv1 := newCsvGenerator(0, expectedNumRows, &intGenerator{}, &strGenerator{})
 			csv1.addBreakpoint(7*batchSize, func() (bool, error) {
 				defer csvBarrier.Enter()()
+				return false, nil
+			})
+			csv1.addBreakpoint(9*batchSize, func() (bool, error) {
+				defer csvBarrier2.Enter()()
 				return false, nil
 			})
 
@@ -3956,6 +3977,40 @@ func TestImportDefaultWithResume(t *testing.T) {
 			var seqValOnPause int64
 			sqlDB.QueryRow(t, fmt.Sprintf(`SELECT last_value FROM %s`, test.sequence)).Scan(&seqValOnPause)
 
+			// Check summary counts after first pause - should have partial data
+			require.Equal(t, 1, len(js.prog.Summary.EntryCounts))
+
+			// Unpause the job and wait for it to hit the second breakpoint.
+			if err := registry.Unpause(ctx, nil, jobID); err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait until we hit the second breakpoint
+			unblockImport2 := testBarrier2.Enter()
+			// Wait until we have recorded more job progress.
+			js = queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool {
+				return js.prog.ResumePos[0] > 5*batchSize
+			})
+
+			// Pause the job again for the second time
+			if err := registry.PauseRequested(ctx, nil, jobID, ""); err != nil {
+				t.Fatal(err)
+			}
+			unblockImport2()
+
+			// Wait for the job to be paused again
+			js = queryJobUntil(t, sqlDB.DB, jobID, func(js jobState) bool {
+				return jobs.StatePaused == js.status
+			})
+
+			// Check summary counts after second pause - should still be consistent
+			require.Equal(t, 1, len(js.prog.Summary.EntryCounts))
+
+			// Check sequence value hasn't changed during the second pause
+			var seqValOnSecondPause int64
+			sqlDB.QueryRow(t, fmt.Sprintf(`SELECT last_value FROM %s`, test.sequence)).Scan(&seqValOnSecondPause)
+			require.Equal(t, seqValOnPause, seqValOnSecondPause)
+
 			// Unpause the job and wait for it to complete.
 			if err := registry.Unpause(ctx, nil, jobID); err != nil {
 				t.Fatal(err)
@@ -3971,6 +4026,14 @@ func TestImportDefaultWithResume(t *testing.T) {
 			sqlDB.QueryRow(t, fmt.Sprintf(`SELECT last_value FROM %s`,
 				test.sequence)).Scan(&seqValOnSuccess)
 			require.Equal(t, seqValOnPause, seqValOnSuccess)
+
+			// Verify final summary counts - should contain exactly the expected number of rows
+			// with no duplication despite multiple pause/resume cycles
+			require.Equal(t, 1, len(js.prog.Summary.EntryCounts))
+
+			for _, entry := range js.prog.Summary.EntryCounts {
+				require.Equal(t, int64(expectedNumRows), entry)
+			}
 		})
 	}
 }

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -14,6 +14,8 @@ import (
 	"io"
 	"math"
 	"net/url"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -52,6 +54,16 @@ var importElasticCPUControlEnabled = settings.RegisterBoolSetting(
 	"determines whether import operations integrate with elastic CPU control",
 	false, // TODO(dt): enable this by default after more benchmarking.
 )
+
+// getGID returns the goroutine ID for debugging purposes
+func getGID() uint64 {
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	b = bytes.TrimPrefix(b, []byte("goroutine "))
+	b = b[:bytes.IndexByte(b, ' ')]
+	n, _ := strconv.ParseUint(string(b), 10, 64)
+	return n
+}
 
 func runImport(
 	ctx context.Context,


### PR DESCRIPTION
`./dev test pkg/sql/importer -f TestImportDefaultWithResume --ignore-cache --stress > out.log`

---- 
```
[time: 2025-08-27 20:03:47.57048 +0000 UTC m=+0.765433584] [GOROUTINE 2839] [tag: import update] [progressBytes != nil :true]before WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.563219+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

[time: 2025-08-27 20:03:47.571187 +0000 UTC m=+0.766140001] [GOROUTINE 2839] [tag: import update] [progressBytes != nil :true]after WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.569195+00', progress={DataSize:1070 SSTDataSize:2294 EntryCounts:map[450971566081:30]}

[time: 2025-08-27 20:03:47.571406 +0000 UTC m=+0.766359334] [GOROUTINE 2368] [tag: pause for fun] [progressBytes != nil :false]before WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.563219+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

[time: 2025-08-27 20:03:47.572015 +0000 UTC m=+0.766967834] [GOROUTINE 2368] [tag: pause for fun] [progressBytes != nil :false]after WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.563219+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

[time: 2025-08-27 20:03:47.76204 +0000 UTC m=+0.956993209] [GOROUTINE 2839] [tag: import update] [progressBytes != nil :true]before WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.563219+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

[time: 2025-08-27 20:03:47.762942 +0000 UTC m=+0.957895667] [GOROUTINE 2839] [tag: import update] [progressBytes != nil :true]after WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.577463+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

[time: 2025-08-27 20:03:47.777933 +0000 UTC m=+0.972886334] [GOROUTINE 2368] [tag: pause for fun] [progressBytes != nil :false]before WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.577463+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

[time: 2025-08-27 20:03:47.778695 +0000 UTC m=+0.973648417] [GOROUTINE 2368] [tag: pause for fun] [progressBytes != nil :false]after WriteLegacyProgressjob, 1101839163339407361 info rows:
job_id=1101839163339407361, info_key='legacy_progress', written='2025-08-27 20:03:47.577463+00', progress={DataSize:530 SSTDataSize:1148 EntryCounts:map[450971566081:15]}

```

The `written='2025-08-27 20:03:47.569195+00'` entry is missed