### PR TITLE
release-24.3: ccl/multiregionccl: deflake TestRegionLivenessProber

### DIFF
--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -76,7 +76,6 @@ func TestRegionLivenessProber(t *testing.T) {
 	// multi-region. and enable region liveness for testing.
 	makeSettings := func() *cluster.Settings {
 		cs := cluster.MakeTestingClusterSettings()
-		instancestorage.ReclaimLoopInterval.Override(ctx, &cs.SV, 150*time.Millisecond)
 		regionliveness.RegionLivenessEnabled.Override(ctx, &cs.SV, true)
 		return cs
 	}
@@ -241,7 +240,6 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 	// multi-region. and enable region liveness for testing.
 	makeSettings := func() *cluster.Settings {
 		cs := cluster.MakeTestingClusterSettings()
-		instancestorage.ReclaimLoopInterval.Override(ctx, &cs.SV, 150*time.Millisecond)
 		regionliveness.RegionLivenessEnabled.Override(ctx, &cs.SV, true)
 		return cs
 	}
@@ -478,7 +476,6 @@ func TestRegionLivenessProberForSQLInstances(t *testing.T) {
 	// multi-region. and enable region liveness for testing.
 	makeSettings := func() *cluster.Settings {
 		cs := cluster.MakeTestingClusterSettings()
-		//	instancestorage.ReclaimLoopInterval.Override(ctx, &cs.SV, 150*time.Millisecond)
 		regionliveness.RegionLivenessEnabled.Override(ctx, &cs.SV, true)
 		instancestorage.PreallocatedCount.Override(ctx, &cs.SV, 1)
 		return cs


### PR DESCRIPTION
Backport 1/1 commits from #152474 on behalf of @fqazi.

----

Previously, TestRegionLivenessProber could flake because the synthetic region probe timeout in this test could have been hit by the instance reclaim logic.  This test was incorrectly running this logic every 150ms increasing the risk of flakes. To address this, this patch leaves this setting on the default setting of 10 minutes, so the region failure should only be detected by the intentionally executed test logic.

Fixes: #151747

Release note: None

----

Release justification: test only change