### PR TITLE
upgrades: one-time rewrite of all descriptors

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2537,11 +2537,8 @@ func (t *T) Unmarshal(data []byte) error {
 // setting required values. This is necessary to preserve backwards-
 // compatibility with older formats (e.g. restoring database from old backup).
 //
-// This can be removed once we can ensure that all descriptors have been
-// rewritten with the newer format. Note that the migration in first_upgrade.go
-// is not sufficient to ensure that all descriptors have been rewritten, since
-// that migration is only based on post-deserialization changes, but the type
-// upgrade logic happens _during_ deserialization.
+// This can be removed once we no longer need compatibility with v25.3 or
+// earlier. See https://github.com/cockroachdb/cockroach/issues/152629.
 func (t *T) upgradeType() error {
 	switch t.Family() {
 	case IntFamily:

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -43,7 +43,6 @@ go_library(
         "//pkg/sql/catalog/descidgen",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
-        "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/nstree",
         "//pkg/sql/catalog/replication",
         "//pkg/sql/catalog/systemschema",

--- a/pkg/upgrade/upgrades/first_upgrade_test.go
+++ b/pkg/upgrade/upgrades/first_upgrade_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -164,7 +163,6 @@ func TestFirstUpgradeRepair(t *testing.T) {
 	// also holds a lease on the system database descriptor, which we will wait to
 	// be released. Reducing the lease duration makes this part of the test speed
 	// up.
-	lease.LeaseDuration.Override(ctx, &settings.SV, time.Second*30)
 	require.NoError(t, clusterversion.Initialize(ctx, v0, &settings.SV))
 	upgradePausePoint := make(chan struct{})
 	upgradeResumePoint := make(chan struct{})
@@ -377,7 +375,6 @@ func TestFirstUpgradeRepairBatchSize(t *testing.T) {
 	// also holds a lease on the system database descriptor, which we will wait to
 	// be released. Reducing the lease duration makes this part of the test speed
 	// up.
-	lease.LeaseDuration.Override(ctx, &settings.SV, time.Second*30)
 	require.NoError(t, clusterversion.Initialize(ctx, v0, &settings.SV))
 	testServer, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Settings: settings,


### PR DESCRIPTION
This will allow us to safely remove the upgradeType logic when we drop
25.3 compatibility.

informs https://github.com/cockroachdb/cockroach/issues/152629
Release note: None

