### PR TITLE
changefeedccl/resolvedspan: update table ID partitioner

### DIFF
--- a/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/sql/catalog/descpb",
+        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
This patch updates the table ID partitioner so that it's able to handle
spans where the end key is the next table's start key (e.g. full table
spans like `/Table/1{0-1}`).

Part of #148119

Release note: None