### PR TITLE
span: update MultiFrontier.Frontiers to only return timestamps

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1855,8 +1855,8 @@ func (cf *changeFrontier) checkpointJobProgress(
 				resolvedTables := &changefeedpb.ResolvedTables{
 					Tables: make(map[descpb.ID]hlc.Timestamp),
 				}
-				for tableID, tableFrontier := range cf.frontier.Frontiers() {
-					resolvedTables.Tables[tableID] = tableFrontier.Frontier()
+				for id, ts := range cf.frontier.Frontiers() {
+					resolvedTables.Tables[id] = ts
 				}
 
 				if err := writeChangefeedJobInfo(ctx, resolvedTablesFilename, resolvedTables, txn, cf.spec.JobID); err != nil {

--- a/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/util/span",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier_test.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -176,7 +175,7 @@ type frontier interface {
 	InBackfill(jobspb.ResolvedSpan) bool
 	AtBoundary() (bool, jobspb.ResolvedSpan_BoundaryType, hlc.Timestamp)
 	All() iter.Seq[jobspb.ResolvedSpan]
-	Frontiers() iter.Seq2[descpb.ID, span.Frontier]
+	Frontiers() iter.Seq2[descpb.ID, hlc.Timestamp]
 }
 
 func testBackfillSpan(
@@ -404,8 +403,8 @@ func TestFrontierPerTableResolvedTimestamps(t *testing.T) {
 
 			// Verify per-table resolved timestamps.
 			perTableResolved := make(map[uint32]hlc.Timestamp)
-			for tableID, frontier := range f.Frontiers() {
-				perTableResolved[uint32(tableID)] = frontier.Frontier()
+			for id, ts := range f.Frontiers() {
+				perTableResolved[uint32(id)] = ts
 			}
 			require.Equal(t, makeTS(10), perTableResolved[10])
 			require.Equal(t, makeTS(15), perTableResolved[20])
@@ -423,8 +422,8 @@ func TestFrontierPerTableResolvedTimestamps(t *testing.T) {
 
 			// Verify per-table resolved timestamps again.
 			perTableResolved = make(map[uint32]hlc.Timestamp)
-			for tableID, frontier := range f.Frontiers() {
-				perTableResolved[uint32(tableID)] = frontier.Frontier()
+			for id, ts := range f.Frontiers() {
+				perTableResolved[uint32(id)] = ts
 			}
 			require.Equal(t, makeTS(10), perTableResolved[10])
 			require.Equal(t, makeTS(15), perTableResolved[20])

--- a/pkg/util/span/multi_frontier.go
+++ b/pkg/util/span/multi_frontier.go
@@ -241,14 +241,15 @@ func (f *MultiFrontier[P]) String() string {
 	return buf.String()
 }
 
-// Frontiers returns an iterator over the sub-frontiers.
-func (f *MultiFrontier[P]) Frontiers() iter.Seq2[P, Frontier] {
-	return func(yield func(P, Frontier) bool) {
+// Frontiers returns an iterator over the partition and minimum timestamp
+// for each sub-frontier.
+func (f *MultiFrontier[P]) Frontiers() iter.Seq2[P, hlc.Timestamp] {
+	return func(yield func(P, hlc.Timestamp) bool) {
 		f.mu.Lock()
 		defer f.mu.Unlock()
 
 		for partition, frontier := range f.mu.frontiers.all() {
-			if !yield(partition, frontier) {
+			if !yield(partition, frontier.Frontier()) {
 				return
 			}
 		}


### PR DESCRIPTION
Previously, the `Frontiers` method on `MultiFrontier` returned an iterator
over the actual sub-frontiers. However, this introduces the possibility
that the caller could directly call methods on a sub-frontier and cause
a heap invariant violation. The `Frontiers` method has now been updated
so that it only returns an iterator over each sub-frontier's minimum
timestamp (i.e. its frontier timestamp).

Part of #148119

Release note: None