### PR TITLE
allocator: correct logging for priority assertion

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -965,10 +965,12 @@ func (a *Allocator) ComputeAction(
 	// the caller expects the processing logic to be invoked even if there's a
 	// priority inversion. If the priority is not -1, the range might be re-queued
 	// to be processed with the correct priority.
-	if priority == -1 && buildutil.CrdbTestBuild {
-		log.Dev.Fatalf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
-	} else {
-		log.Dev.Warningf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+	if priority == -1 {
+		if buildutil.CrdbTestBuild {
+			log.Dev.Fatalf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+		} else {
+			log.Dev.Warningf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+		}
 	}
 	return action, priority
 }


### PR DESCRIPTION
This commit fixes an incorrect log statement in computeAction for priority
assertions. The log was mistakenly emitted even when the priority was not -1.

Related: https://github.com/cockroachdb/cockroach/pull/152512
Epic: none 
Release note: none