### PR TITLE
release-25.2: sql/catalog: exempt views from crdb_region validation

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1659,4 +1659,29 @@ SELECT * FROM chgme ORDER BY C1;
 statement ok
 DROP TABLE chgme;
 
+# Regression test for issue #151216
+# Tests that CREATE VIEW with references to crdb_region column in expressions
+# (but not directly returned) should not trigger validation assertion errors.
+subtest issue_151216_view_crdb_region_reference
+
+statement ok
+CREATE DATABASE bank_151216 PRIMARY REGION "us-east-1" REGIONS "us-east-1", "ca-central-1", "ap-southeast-2" SURVIVE REGION FAILURE;
+
+statement ok
+USE bank_151216;
+
+statement ok
+CREATE TABLE t1 (c1 INT) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE MATERIALIZED VIEW mv1 AS SELECT c1, CASE WHEN crdb_region = 'us-east-1' THEN 'east' ELSE 'other' END AS region_type FROM t1;
+
+statement ok
+CREATE VIEW v2 AS SELECT c1, crdb_region = 'us-east-1' AS is_us_east1 FROM t1;
+
+statement ok
+SET sql_safe_updates = false;
+DROP DATABASE bank_151216;
+SET sql_safe_updates = true
+
 subtest end

--- a/pkg/sql/catalog/multiregion/validate_table.go
+++ b/pkg/sql/catalog/multiregion/validate_table.go
@@ -121,7 +121,8 @@ func ValidateTableLocalityConfig(
 	switch lc := lc.Locality.(type) {
 	case *catpb.LocalityConfig_Global_:
 		if regionEnumIDReferenced {
-			if !columnTypesTypeIDs.Contains(regionsEnumID) {
+			// Omit views since they may reference the multi-region enum type of the base table.
+			if !columnTypesTypeIDs.Contains(regionsEnumID) && !desc.IsView() {
 				return errors.AssertionFailedf(
 					"expected no region Enum ID to be referenced by a GLOBAL TABLE: %q"+
 						" but found: %d",
@@ -233,8 +234,9 @@ func ValidateTableLocalityConfig(
 			if regionEnumIDReferenced {
 				// It may be the case that the multi-region type descriptor is used
 				// as the type of the table column. Validations should only fail if
-				// that is not the case.
-				if !columnTypesTypeIDs.Contains(regionsEnumID) {
+				// that is not the case. We omit views since they may reference the
+				// multi-region enum type of the base table.
+				if !columnTypesTypeIDs.Contains(regionsEnumID) && !desc.IsView() {
 					return errors.AssertionFailedf(
 						"expected no region Enum ID to be referenced by a REGIONAL BY TABLE: %q homed in the "+
 							"primary region, but found: %d",


### PR DESCRIPTION
Backport 1/1 commits from #152670 on behalf of @spilchen.

----

Previously, views using `crdb_region` in expressions were incorrectly rejected by multi-region validation. The logic assumed that region enums must correspond to explicit columns in the descriptor, failing to account for views that reference `crdb_region` from underlying tables.

This change updates the validation to allow such expressions in views.

Fixes #151216
Fixes #152197

Release note (bug fix): views can now reference the `crdb_region` column from underlying tables in expressions.

----

Release justification: low-risk bug fix that surfaced through a sentry report to prevent false positives when identifying descriptor corruptions, which could interfere with normal cluster operation.