### PR TITLE
workflows: improve logging and search criteria for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -51,6 +51,12 @@ jobs:
             const result = await github.graphql(query);
             const prs = result.search.nodes;
 
+            if (prs.length === 0) {
+              console.log('No backport PRs found matching criteria');
+            } else {
+              console.log(`Found ${prs.length} backport PR(s) to evaluate`);
+            }
+
             for (const pr of prs) {
               const createdAt = new Date(pr.createdAt);
               const isOldEnough = createdAt <= iso24HoursAgo;

--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -24,7 +24,7 @@ jobs:
 
             const query = `
               query SearchPRs() {
-                search(query: "repo:${context.repo.owner}/${context.repo.repo} is:pr is:open label:backport label:blathers-backport label:backport-test-only -author:blathers-crl[bot]", type: ISSUE, first: 100) {
+                search(query: "repo:${context.repo.owner}/${context.repo.repo} is:pr is:open label:backport label:backport-test-only", type: ISSUE, first: 100) {
                   nodes {
                     ... on PullRequest {
                       number


### PR DESCRIPTION
### workflows: log when auto-merge workflow has nothing to do

### workflows: broaden criteria for auto-merge workflow

Previously, the search excluded PRs made by the blathers bot account as
well as PRs that didn't have the blathers-backport label.

In practice, this meant it only found PRs that were made by blathers
_and also_ only if the original PR author had set up oauth to allow
blathers to automatically backport it using their account.

Now, the search will find any test only backport PR, regardless of
author.

Epic: None
Release note: None