### PR TITLE
release-24.2: internal: update TEAMS.yaml

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -73,9 +73,11 @@ cockroachdb/test-eng-prs:
   triage_column_id: 14041337
   label: T-testeng
 cockroachdb/security:
-  label: T-cross-product-security
+  label: T-security-engineering
 cockroachdb/prodsec:
-  label: T-cross-product-security
+  label: T-security-engineering
+cockroachdb/product-security:
+  label: T-product-security
 cockroachdb/disaster-recovery:
   triage_column_id: 3097123
   label: T-disaster-recovery

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -73,9 +73,11 @@ cockroachdb/test-eng-prs:
   triage_column_id: 14041337
   label: T-testeng
 cockroachdb/security:
-  label: T-cross-product-security
+  label: T-security-engineering
 cockroachdb/prodsec:
-  label: T-cross-product-security
+  label: T-security-engineering
+cockroachdb/product-security:
+  label: T-product-security
 cockroachdb/disaster-recovery:
   triage_column_id: 3097123
   label: T-disaster-recovery


### PR DESCRIPTION
Backport 1/1 commits from #129866.

/cc @cockroachdb/release

---

Previously, the `TEAMS.yaml` file referenced a label for the T-cross-product-security team. This change updates the reference to the newly created T-security-engineering label.

Epic: none

Release note: None

Release justification: Fixes issue label syncing errors
