### PR TITLE
cloud: add fault injection test for gcs and azure

### DIFF
--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//:azcore",
         "@com_github_azure_azure_sdk_for_go_sdk_azidentity//:azidentity",
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//service",

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -100,7 +100,7 @@ func MakeHTTPClient(
 	if err != nil {
 		return nil, err
 	}
-	return MakeHTTPClientForTransport(maybeAddLogging(t))
+	return MakeHTTPClientForTransport(t)
 }
 
 // MakeHTTPClientForTransport creates a new http.Client with the given
@@ -146,6 +146,7 @@ func MakeTransport(
 	if config.HttpMiddleware != nil {
 		roundTripper = config.HttpMiddleware(roundTripper)
 	}
+	roundTripper = maybeAddLogging(roundTripper)
 	return roundTripper, nil
 }
 

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_googleapis_gax_go_v2//apierror",


### PR DESCRIPTION
This adds fault injection tests for the Google and Azure blobstorage
clients. The logging injection hook was moved to a call path to ensure
it covers the GCP client.

Release note: none
Epic: [CRDB-53946](https://cockroachlabs.atlassian.net/browse/CRDB-53946)