### PR TITLE
changefeedccl: omit kafka sink for test running on ibm

### DIFF
--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -154,7 +154,8 @@ func TestChangefeedUpdateProtectedTimestamp(t *testing.T) {
 		}
 	}
 
-	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks)
+	// Skip kafka sink because it's not compatible with s390x/IBM architecture
+	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks, feedTestOmitSinks("kafka"))
 }
 
 // TestChangefeedProtectedTimestamps asserts the state of changefeed PTS records


### PR DESCRIPTION
We saw this test fail with the kafka sink on s390x, even though that architecture is incompatible with and should not be running kafka. Exclude kafka from this test.

Epic: none
Fixes: #152487

Release note: None