### PR TITLE
rpc, server: add loopback dialer support for DRPC

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -183,6 +183,8 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@io_storj_drpc//drpcctx",
         "@io_storj_drpc//drpcmetadata",
+        "@io_storj_drpc//drpcmux",
+        "@io_storj_drpc//drpcserver",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials",

--- a/pkg/server/drpc_test.go
+++ b/pkg/server/drpc_test.go
@@ -220,16 +220,13 @@ func TestDialDRPC_InterceptorsAreSet(t *testing.T) {
 	args := base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
-			Settings: cluster.MakeClusterSettings(),
-			Insecure: true,
+			Settings:          cluster.MakeClusterSettings(),
+			DefaultDRPCOption: base.TestDRPCEnabled,
 		},
 	}
 
-	rpc.ExperimentalDRPCEnabled.Override(ctx, &args.ServerArgs.Settings.SV, true)
 	c := testcluster.StartTestCluster(t, numNodes, args)
 	defer c.Stopper().Stop(ctx)
-	require.True(t, c.Server(0).RPCContext().Insecure)
-
 	rpcAddr := c.Server(0).RPCAddr()
 
 	// Client setup
@@ -238,9 +235,10 @@ func TestDialDRPC_InterceptorsAreSet(t *testing.T) {
 	rpcContextOptions.Stopper = c.Stopper()
 	rpcContextOptions.Settings = c.Server(0).ClusterSettings()
 	rpcCtx := rpc.NewContext(ctx, rpcContextOptions)
-	rpcCtx.ContextOptions = rpc.ContextOptions{Insecure: true}
+
 	// Adding test interceptors
 	rpcCtx.Knobs = rpc.ContextTestingKnobs{
+		NoLoopbackDialer: true,
 		UnaryClientInterceptorDRPC: func(target string, class rpcbase.ConnectionClass) drpcclient.UnaryClientInterceptor {
 			return mockUnaryInterceptor
 		},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1659,7 +1659,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// and dispatches the server worker for the RPC.
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
-	pgL, loopbackPgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(
+	pgL, loopbackPgL, grpcLoopbackDialFn, drpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(
 		ctx, workersCtx, s.cfg.BaseConfig,
 		s.stopper, s.grpc, s.drpc, ListenAndUpdateAddrs, true /* enableSQLListener */, s.cfg.AcceptProxyProtocolHeaders)
 	if err != nil {
@@ -1669,7 +1669,8 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	s.loopbackPgL = loopbackPgL
 
 	// Tell the RPC context how to connect in-memory.
-	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
+	s.rpcContext.SetLoopbackDialer(grpcLoopbackDialFn)
+	s.rpcContext.SetLoopbackDRPCDialer(drpcLoopbackDialFn)
 
 	if s.cfg.TestingKnobs.Server != nil {
 		knobs := s.cfg.TestingKnobs.Server.(*TestingKnobs)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -604,7 +604,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		lf = s.sqlServer.cfg.RPCListenerFactory
 	}
 
-	pgL, loopbackPgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(
+	pgL, loopbackPgL, grpcLoopbackDialFn, drpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(
 		ctx, workersCtx, *s.sqlServer.cfg, s.stopper,
 		s.grpc, s.drpc, lf, enableSQLListener, s.cfg.AcceptProxyProtocolHeaders)
 	if err != nil {
@@ -616,7 +616,8 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	s.loopbackPgL = loopbackPgL
 
 	// Tell the RPC context how to connect in-memory.
-	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
+	s.rpcContext.SetLoopbackDialer(grpcLoopbackDialFn)
+	s.rpcContext.SetLoopbackDRPCDialer(drpcLoopbackDialFn)
 
 	// NB: This is where (*Server).PreStart() reports the listener readiness
 	// via testing knobs: PauseAfterGettingRPCAddress, SignalAfterGettingRPCAddress.


### PR DESCRIPTION
Observed a performance regression in the sysbench `oltp_read_only` microbenchmark when DRPC was enabled by default (ref: https://github.com/cockroachdb/cockroach/issues/151312). No such regression was seen in `oltp_read_write`. Root cause analysis traced it to missing loopback dialer support in DRPC.

Epic: CRDB-51459
Fixes: #148493
Release note: None