### PR TITLE
sql/ttl: clarify TTL rate limiter notice

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -455,7 +455,7 @@ subtest notice_on_ttl_default_rate_limit
 query T noticetrace
 SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 90;
 ----
-NOTICE: The TTL rate limit is per leaseholder per table.
+NOTICE: The TTL rate limit is per node per table.
 DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
 
 statement ok
@@ -464,7 +464,7 @@ SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 100;
 query T noticetrace
 SET CLUSTER SETTING sql.ttl.default_select_rate_limit = 100;
 ----
-NOTICE: The TTL rate limit is per leaseholder per table.
+NOTICE: The TTL rate limit is per node per table.
 DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -906,7 +906,7 @@ CREATE TABLE tbl_set_ttl_params (
   ttl_disable_changefeed_replication = true
 )
 ----
-NOTICE: The TTL rate limit is per leaseholder per table.
+NOTICE: The TTL rate limit is per node per table.
 DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
 
 onlyif config schema-locked-disabled
@@ -933,7 +933,7 @@ skipif config local-read-committed local-repeatable-read
 query T noticetrace
 ALTER TABLE tbl_set_ttl_params SET (ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_row_stats_poll_interval = '2m0s')
 ----
-NOTICE: The TTL rate limit is per leaseholder per table.
+NOTICE: The TTL rate limit is per node per table.
 DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
 
 onlyif config local-read-committed local-repeatable-read

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -252,7 +252,7 @@ func printTTLRateLimitNotice(ctx context.Context, p eval.ClientNoticeSender) {
 	p.BufferClientNotice(
 		ctx,
 		errors.WithDetail(
-			pgnotice.Newf("The TTL rate limit is per leaseholder per table."),
+			pgnotice.Newf("The TTL rate limit is per node per table."),
 			ttlDocDetail,
 		),
 	)

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -234,6 +234,10 @@ func (t *ttlProcessor) work(ctx context.Context, output execinfra.RowReceiver) e
 	// involved in a TTL job.
 	log.Dev.Infof(ctx, "TTL processor started processorID=%d tableID=%d", t.ProcessorID, tableID)
 
+	// Each node sets up two rate limiters (one for SELECT, one for DELETE) per
+	// table. The limiters apply to all ranges assigned to this processor, whether
+	// or not the node is the leaseholder for those ranges.
+
 	selectRateLimit := ttlSpec.SelectRateLimit
 	// Default 0 value to "unlimited" in case job started on node <= v23.2.
 	// todo(sql-foundations): Remove this in 25.1 for consistency with


### PR DESCRIPTION
The TTL rate limiter notice incorrectly stated it applies "per leaseholder per table", when it actually applies "per node per table". This updates the message for accuracy.

Fixes #144463
Epic: none

Release note: none