### PR TITLE
workflows: enable `workflow_dispatch` for GitHub Actions Essential CI

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -48,6 +48,7 @@ on:
       - "!staging-v22.2*"
       - "!staging-v23.1*"
       - "!staging-v23.2*"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
To support development on `tiered` prototype branch.

Epic: none
Release note: None