### PR TITLE
sql: don't use t.Parallel() in TestQueryCache

### DIFF
--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -109,444 +108,420 @@ func TestQueryCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	parallel := func(t *testing.T) {
-		if !skip.Stress() {
-			t.Parallel() // SAFE FOR TESTING
+	t.Run("simple", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
+
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for _, r := range h.runners {
+				r.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+			}
 		}
-	}
+		// We should have 1 miss and the rest hits.
+		h.AssertStats(t, 5*numConns-1, 1)
+	})
 
-	// Grouping the parallel subtests into a non-parallel subtest allows the defer
-	// call above to work as expected.
-	t.Run("group", func(t *testing.T) {
-		t.Run("simple", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
+	t.Run("simple-prepare", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
 
-			// Alternate between the connections.
-			for i := 0; i < 5; i++ {
-				for _, r := range h.runners {
-					r.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-				}
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for _, r := range h.runners {
+				r.Exec(t, fmt.Sprintf("PREPARE a%d AS SELECT * FROM t", i))
 			}
-			// We should have 1 miss and the rest hits.
-			h.AssertStats(t, 5*numConns-1, 1)
-		})
+		}
+		// We should have 1 miss and the rest hits.
+		h.AssertStats(t, 5*numConns-1, 1)
 
-		t.Run("simple-prepare", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-
-			// Alternate between the connections.
-			for i := 0; i < 5; i++ {
-				for _, r := range h.runners {
-					r.Exec(t, fmt.Sprintf("PREPARE a%d AS SELECT * FROM t", i))
-				}
+		for i := 0; i < 5; i++ {
+			for _, r := range h.runners {
+				r.CheckQueryResults(
+					t,
+					fmt.Sprintf("EXECUTE a%d", i),
+					[][]string{{"1", "1"}},
+				)
 			}
-			// We should have 1 miss and the rest hits.
-			h.AssertStats(t, 5*numConns-1, 1)
+		}
+	})
 
-			for i := 0; i < 5; i++ {
-				for _, r := range h.runners {
-					r.CheckQueryResults(
-						t,
-						fmt.Sprintf("EXECUTE a%d", i),
-						[][]string{{"1", "1"}},
-					)
-				}
+	t.Run("simple-prepare-with-args", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
+
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for _, r := range h.runners {
+				r.Exec(t, fmt.Sprintf("PREPARE a%d AS SELECT a + $1, b + $2 FROM t", i))
 			}
-		})
+		}
+		// We should have 1 miss and the rest hits.
+		h.AssertStats(t, 5*numConns-1, 1)
 
-		t.Run("simple-prepare-with-args", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-
-			// Alternate between the connections.
-			for i := 0; i < 5; i++ {
-				for _, r := range h.runners {
-					r.Exec(t, fmt.Sprintf("PREPARE a%d AS SELECT a + $1, b + $2 FROM t", i))
-				}
+		for i := 0; i < 5; i++ {
+			for _, r := range h.runners {
+				r.CheckQueryResults(
+					t,
+					fmt.Sprintf("EXECUTE a%d (10, 100)", i),
+					[][]string{{"11", "101"}},
+				)
+				r.CheckQueryResults(
+					t,
+					fmt.Sprintf("EXECUTE a%d (20, 200)", i),
+					[][]string{{"21", "201"}},
+				)
 			}
-			// We should have 1 miss and the rest hits.
-			h.AssertStats(t, 5*numConns-1, 1)
+		}
+	})
 
-			for i := 0; i < 5; i++ {
-				for _, r := range h.runners {
-					r.CheckQueryResults(
-						t,
-						fmt.Sprintf("EXECUTE a%d (10, 100)", i),
-						[][]string{{"11", "101"}},
-					)
-					r.CheckQueryResults(
-						t,
-						fmt.Sprintf("EXECUTE a%d (20, 200)", i),
-						[][]string{{"21", "201"}},
-					)
-				}
-			}
-		})
+	// Verify that using a relative timestamp literal interacts correctly with
+	// the query cache (#48717).
+	t.Run("relative-timestamp", func(t *testing.T) {
+		h := makeQueryCacheTestHelper(t, 1 /* numConns */)
+		defer h.Stop()
 
-		// Verify that using a relative timestamp literal interacts correctly with
-		// the query cache (#48717).
-		t.Run("relative-timestamp", func(t *testing.T) {
-			parallel(t)
-			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
-			defer h.Stop()
+		r := h.runners[0]
+		res := r.QueryStr(t, "SELECT 'now'::TIMESTAMP")
+		time.Sleep(time.Millisecond)
+		res2 := r.QueryStr(t, "SELECT 'now'::TIMESTAMP")
+		if reflect.DeepEqual(res, res2) {
+			t.Error("expected different result")
+		}
+	})
 
-			r := h.runners[0]
-			res := r.QueryStr(t, "SELECT 'now'::TIMESTAMP")
-			time.Sleep(time.Millisecond)
-			res2 := r.QueryStr(t, "SELECT 'now'::TIMESTAMP")
-			if reflect.DeepEqual(res, res2) {
-				t.Error("expected different result")
-			}
-		})
+	t.Run("parallel", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
 
-		t.Run("parallel", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-
-			var group errgroup.Group
-			for connIdx := range h.conns {
-				c := h.conns[connIdx]
-				group.Go(func() error {
-					for j := 0; j < 10; j++ {
-						rows, err := c.QueryContext(context.Background(), "SELECT * FROM t")
-						if err != nil {
-							return err
-						}
-						res, err := sqlutils.RowsToStrMatrix(rows)
-						if err != nil {
-							return err
-						}
-						if !reflect.DeepEqual(res, [][]string{{"1", "1"}}) {
-							return errors.Errorf("incorrect results %v", res)
-						}
+		var group errgroup.Group
+		for connIdx := range h.conns {
+			c := h.conns[connIdx]
+			group.Go(func() error {
+				for j := 0; j < 10; j++ {
+					rows, err := c.QueryContext(context.Background(), "SELECT * FROM t")
+					if err != nil {
+						return err
 					}
-					return nil
-				})
-			}
-			if err := group.Wait(); err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("parallel-prepare", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-
-			var group errgroup.Group
-			for connIdx := range h.conns {
-				c := h.conns[connIdx]
-				group.Go(func() error {
-					ctx := context.Background()
-					for j := 0; j < 10; j++ {
-						// Query with a multi-use CTE (as a regression test for #44867). The
-						// left join condition never passes so this is really equivalent to:
-						//   SELECT a+$1,b+$2 FROM t
-						query := fmt.Sprintf(`PREPARE a%d AS
-WITH cte(x,y) AS (SELECT a+$1, b+$2 FROM t)
-SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
-
-						if _, err := c.ExecContext(ctx, query); err != nil {
-							return err
-						}
-						rows, err := c.QueryContext(ctx, fmt.Sprintf("EXECUTE a%d (10, 100)", j))
-						if err != nil {
-							return err
-						}
-						res, err := sqlutils.RowsToStrMatrix(rows)
-						if err != nil {
-							return err
-						}
-						if !reflect.DeepEqual(res, [][]string{{"11", "101"}}) {
-							return errors.Errorf("incorrect results %v", res)
-						}
+					res, err := sqlutils.RowsToStrMatrix(rows)
+					if err != nil {
+						return err
 					}
-					return nil
-				})
-			}
-			if err := group.Wait(); err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		// Test connections running the same statement but under different databases.
-		t.Run("multidb", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-
-			r0 := h.runners[0]
-			r0.Exec(t, "CREATE DATABASE db2")
-			r0.Exec(t, "CREATE TABLE db2.t (a INT)")
-			r0.Exec(t, "INSERT INTO db2.t VALUES (2)")
-			for i := range h.runners {
-				if i%2 == 1 {
-					h.runners[i].Exec(t, "SET DATABASE = db2")
-				}
-			}
-			// Alternate between the connections.
-			for i := 0; i < 5; i++ {
-				for j, r := range h.runners {
-					var res [][]string
-					if j%2 == 0 {
-						res = [][]string{{"1", "1"}}
-					} else {
-						res = [][]string{{"2"}}
+					if !reflect.DeepEqual(res, [][]string{{"1", "1"}}) {
+						return errors.Errorf("incorrect results %v", res)
 					}
-					r.CheckQueryResults(t, "SELECT * FROM t", res)
-				}
-			}
-		})
-
-		t.Run("multidb-prepare", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-
-			r0 := h.runners[0]
-			r0.Exec(t, "CREATE DATABASE db2")
-			r0.Exec(t, "CREATE TABLE db2.t (a INT)")
-			r0.Exec(t, "INSERT INTO db2.t VALUES (2)")
-			for i := range h.runners {
-				if i%2 == 1 {
-					h.runners[i].Exec(t, "SET DATABASE = db2")
-				}
-			}
-			// Alternate between the connections.
-			for i := 0; i < 5; i++ {
-				for j, r := range h.runners {
-					r.Exec(t, fmt.Sprintf("PREPARE a%d AS SELECT a + $1 FROM t", i))
-					var res [][]string
-					if j%2 == 0 {
-						res = [][]string{{"11"}}
-					} else {
-						res = [][]string{{"12"}}
-					}
-					r.CheckQueryResults(t, fmt.Sprintf("EXECUTE a%d (10)", i), res)
-				}
-			}
-		})
-
-		// Test that a schema change triggers cache invalidation.
-		t.Run("schemachange", func(t *testing.T) {
-			parallel(t)
-			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
-			defer h.Stop()
-			r0, r1 := h.runners[0], h.runners[1]
-			r0.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-			h.AssertStats(t, 0 /* hits */, 1 /* misses */)
-			r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
-			r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
-			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
-			r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1", "2"}})
-			h.AssertStats(t, 1 /* hits */, 2 /* misses */)
-		})
-
-		// Test that creating new statistics triggers cache invalidation.
-		t.Run("statschange", func(t *testing.T) {
-			parallel(t)
-			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
-			defer h.Stop()
-			r0, r1 := h.runners[0], h.runners[1]
-			r0.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-			h.AssertStats(t, 0 /* hits */, 1 /* misses */)
-			r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
-			r0.Exec(t, "CREATE STATISTICS s FROM t")
-			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
-			hits := 1
-			testutils.SucceedsSoon(t, func() error {
-				// The stats cache is updated asynchronously, so we may get some hits
-				// before we get a miss.
-				r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
-				if err := h.CheckStats(t, hits, 2 /* misses */); err != nil {
-					hits++
-					return err
 				}
 				return nil
 			})
+		}
+		if err := group.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("parallel-prepare", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
+
+		var group errgroup.Group
+		for connIdx := range h.conns {
+			c := h.conns[connIdx]
+			group.Go(func() error {
+				ctx := context.Background()
+				for j := 0; j < 10; j++ {
+					// Query with a multi-use CTE (as a regression test for #44867). The
+					// left join condition never passes so this is really equivalent to:
+					//   SELECT a+$1,b+$2 FROM t
+					query := fmt.Sprintf(`PREPARE a%d AS
+WITH cte(x,y) AS (SELECT a+$1, b+$2 FROM t)
+SELECT cte.x, cte.y FROM cte LEFT JOIN cte as cte2 on cte.y = cte2.x`, j)
+
+					if _, err := c.ExecContext(ctx, query); err != nil {
+						return err
+					}
+					rows, err := c.QueryContext(ctx, fmt.Sprintf("EXECUTE a%d (10, 100)", j))
+					if err != nil {
+						return err
+					}
+					res, err := sqlutils.RowsToStrMatrix(rows)
+					if err != nil {
+						return err
+					}
+					if !reflect.DeepEqual(res, [][]string{{"11", "101"}}) {
+						return errors.Errorf("incorrect results %v", res)
+					}
+				}
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test connections running the same statement but under different databases.
+	t.Run("multidb", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
+
+		r0 := h.runners[0]
+		r0.Exec(t, "CREATE DATABASE db2")
+		r0.Exec(t, "CREATE TABLE db2.t (a INT)")
+		r0.Exec(t, "INSERT INTO db2.t VALUES (2)")
+		for i := range h.runners {
+			if i%2 == 1 {
+				h.runners[i].Exec(t, "SET DATABASE = db2")
+			}
+		}
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for j, r := range h.runners {
+				var res [][]string
+				if j%2 == 0 {
+					res = [][]string{{"1", "1"}}
+				} else {
+					res = [][]string{{"2"}}
+				}
+				r.CheckQueryResults(t, "SELECT * FROM t", res)
+			}
+		}
+	})
+
+	t.Run("multidb-prepare", func(t *testing.T) {
+		const numConns = 4
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
+
+		r0 := h.runners[0]
+		r0.Exec(t, "CREATE DATABASE db2")
+		r0.Exec(t, "CREATE TABLE db2.t (a INT)")
+		r0.Exec(t, "INSERT INTO db2.t VALUES (2)")
+		for i := range h.runners {
+			if i%2 == 1 {
+				h.runners[i].Exec(t, "SET DATABASE = db2")
+			}
+		}
+		// Alternate between the connections.
+		for i := 0; i < 5; i++ {
+			for j, r := range h.runners {
+				r.Exec(t, fmt.Sprintf("PREPARE a%d AS SELECT a + $1 FROM t", i))
+				var res [][]string
+				if j%2 == 0 {
+					res = [][]string{{"11"}}
+				} else {
+					res = [][]string{{"12"}}
+				}
+				r.CheckQueryResults(t, fmt.Sprintf("EXECUTE a%d (10)", i), res)
+			}
+		}
+	})
+
+	// Test that a schema change triggers cache invalidation.
+	t.Run("schemachange", func(t *testing.T) {
+		h := makeQueryCacheTestHelper(t, 2 /* numConns */)
+		defer h.Stop()
+		r0, r1 := h.runners[0], h.runners[1]
+		r0.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+		h.AssertStats(t, 0 /* hits */, 1 /* misses */)
+		r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+		h.AssertStats(t, 1 /* hits */, 1 /* misses */)
+		r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
+		h.AssertStats(t, 1 /* hits */, 1 /* misses */)
+		r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1", "2"}})
+		h.AssertStats(t, 1 /* hits */, 2 /* misses */)
+	})
+
+	// Test that creating new statistics triggers cache invalidation.
+	t.Run("statschange", func(t *testing.T) {
+		h := makeQueryCacheTestHelper(t, 2 /* numConns */)
+		defer h.Stop()
+		r0, r1 := h.runners[0], h.runners[1]
+		r0.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+		h.AssertStats(t, 0 /* hits */, 1 /* misses */)
+		r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+		h.AssertStats(t, 1 /* hits */, 1 /* misses */)
+		r0.Exec(t, "CREATE STATISTICS s FROM t")
+		h.AssertStats(t, 1 /* hits */, 1 /* misses */)
+		hits := 1
+		testutils.SucceedsSoon(t, func() error {
+			// The stats cache is updated asynchronously, so we may get some hits
+			// before we get a miss.
+			r1.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1", "1"}})
+			if err := h.CheckStats(t, hits, 2 /* misses */); err != nil {
+				hits++
+				return err
+			}
+			return nil
 		})
+	})
 
-		// Test that a schema change triggers cache invalidation.
-		t.Run("schemachange-prepare", func(t *testing.T) {
-			parallel(t)
-			h := makeQueryCacheTestHelper(t, 2 /* numConns */)
-			defer h.Stop()
-			r0, r1 := h.runners[0], h.runners[1]
-			r0.Exec(t, "PREPARE a AS SELECT * FROM t")
-			r0.CheckQueryResults(t, "EXECUTE a", [][]string{{"1", "1"}})
-			r0.CheckQueryResults(t, "EXECUTE a", [][]string{{"1", "1"}})
-			r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
-			r1.Exec(t, "PREPARE b AS SELECT * FROM t")
-			r1.CheckQueryResults(t, "EXECUTE b", [][]string{{"1", "1", "2"}})
-		})
+	// Test that a schema change triggers cache invalidation.
+	t.Run("schemachange-prepare", func(t *testing.T) {
+		h := makeQueryCacheTestHelper(t, 2 /* numConns */)
+		defer h.Stop()
+		r0, r1 := h.runners[0], h.runners[1]
+		r0.Exec(t, "PREPARE a AS SELECT * FROM t")
+		r0.CheckQueryResults(t, "EXECUTE a", [][]string{{"1", "1"}})
+		r0.CheckQueryResults(t, "EXECUTE a", [][]string{{"1", "1"}})
+		r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
+		r1.Exec(t, "PREPARE b AS SELECT * FROM t")
+		r1.CheckQueryResults(t, "EXECUTE b", [][]string{{"1", "1", "2"}})
+	})
 
-		// Test a schema change where the other connections are running the query in
-		// parallel.
-		t.Run("schemachange-parallel", func(t *testing.T) {
-			parallel(t)
-			const numConns = 4
+	// Test a schema change where the other connections are running the query in
+	// parallel.
+	t.Run("schemachange-parallel", func(t *testing.T) {
+		const numConns = 4
 
-			h := makeQueryCacheTestHelper(t, numConns)
-			defer h.Stop()
-			var group errgroup.Group
-			for connIdx := 1; connIdx < numConns; connIdx++ {
-				c := h.conns[connIdx]
-				connIdx := connIdx
-				group.Go(func() error {
-					sawChanged := false
-					prepIdx := 0
-					doQuery := func() error {
-						// Some threads do prepare, others execute directly.
-						var rows *gosql.Rows
-						var err error
-						ctx := context.Background()
-						if connIdx%2 == 1 {
-							rows, err = c.QueryContext(ctx, "SELECT * FROM t")
-						} else {
-							prepIdx++
-							_, err = c.ExecContext(ctx, fmt.Sprintf("PREPARE a%d AS SELECT * FROM t", prepIdx))
-							if err == nil {
-								rows, err = c.QueryContext(ctx, fmt.Sprintf("EXECUTE a%d", prepIdx))
-								if err != nil {
-									// If the schema change happens in-between the PREPARE and
-									// EXECUTE, we will get an error. Tolerate this error if we
-									// haven't seen updated results already.
-									if !sawChanged && testutils.IsError(err, "cached plan must not change result type") {
-										t.Logf("thread %d hit race", connIdx)
-										return nil
-									}
+		h := makeQueryCacheTestHelper(t, numConns)
+		defer h.Stop()
+		var group errgroup.Group
+		for connIdx := 1; connIdx < numConns; connIdx++ {
+			c := h.conns[connIdx]
+			connIdx := connIdx
+			group.Go(func() error {
+				sawChanged := false
+				prepIdx := 0
+				doQuery := func() error {
+					// Some threads do prepare, others execute directly.
+					var rows *gosql.Rows
+					var err error
+					ctx := context.Background()
+					if connIdx%2 == 1 {
+						rows, err = c.QueryContext(ctx, "SELECT * FROM t")
+					} else {
+						prepIdx++
+						_, err = c.ExecContext(ctx, fmt.Sprintf("PREPARE a%d AS SELECT * FROM t", prepIdx))
+						if err == nil {
+							rows, err = c.QueryContext(ctx, fmt.Sprintf("EXECUTE a%d", prepIdx))
+							if err != nil {
+								// If the schema change happens in-between the PREPARE and
+								// EXECUTE, we will get an error. Tolerate this error if we
+								// haven't seen updated results already.
+								if !sawChanged && testutils.IsError(err, "cached plan must not change result type") {
+									t.Logf("thread %d hit race", connIdx)
+									return nil
 								}
 							}
 						}
-						if err != nil {
-							return err
-						}
-						res, err := sqlutils.RowsToStrMatrix(rows)
-						if err != nil {
-							return err
-						}
-						if reflect.DeepEqual(res, [][]string{{"1", "1"}}) {
-							if sawChanged {
-								return errors.Errorf("Saw updated results, then older results")
-							}
-						} else if reflect.DeepEqual(res, [][]string{{"1", "1", "2"}}) {
-							sawChanged = true
-						} else {
-							return errors.Errorf("incorrect results %v", res)
-						}
-						return nil
 					}
-
-					// Run the query until we see an updated result.
-					for !sawChanged {
-						if err := doQuery(); err != nil {
-							return err
-						}
+					if err != nil {
+						return err
 					}
-					t.Logf("thread %d saw changed results", connIdx)
-
-					// Now run the query a bunch more times to make sure we keep reading the
-					// updated version.
-					for i := 0; i < 10; i++ {
-						if err := doQuery(); err != nil {
-							return err
+					res, err := sqlutils.RowsToStrMatrix(rows)
+					if err != nil {
+						return err
+					}
+					if reflect.DeepEqual(res, [][]string{{"1", "1"}}) {
+						if sawChanged {
+							return errors.Errorf("Saw updated results, then older results")
 						}
+					} else if reflect.DeepEqual(res, [][]string{{"1", "1", "2"}}) {
+						sawChanged = true
+					} else {
+						return errors.Errorf("incorrect results %v", res)
 					}
 					return nil
-				})
-			}
-			r0 := h.runners[0]
-			r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
-			if err := group.Wait(); err != nil {
-				t.Fatal(err)
-			}
-		})
+				}
 
-		// Verify the case where a PREPARE encounters a query cache entry that was
-		// created by a direct execution (and hence has no Metadata).
-		t.Run("exec-and-prepare", func(t *testing.T) {
-			parallel(t)
-			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
-			defer h.Stop()
+				// Run the query until we see an updated result.
+				for !sawChanged {
+					if err := doQuery(); err != nil {
+						return err
+					}
+				}
+				t.Logf("thread %d saw changed results", connIdx)
 
-			r0 := h.runners[0]
-			r0.Exec(t, "SELECT * FROM t") // Should miss the cache.
-			h.AssertStats(t, 0 /* hits */, 1 /* misses */)
+				// Now run the query a bunch more times to make sure we keep reading the
+				// updated version.
+				for i := 0; i < 10; i++ {
+					if err := doQuery(); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		}
+		r0 := h.runners[0]
+		r0.Exec(t, "ALTER TABLE t ADD COLUMN c INT AS (a+b) STORED")
+		if err := group.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	})
 
-			r0.Exec(t, "SELECT * FROM t") // Should hit the cache.
-			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
+	// Verify the case where a PREPARE encounters a query cache entry that was
+	// created by a direct execution (and hence has no Metadata).
+	t.Run("exec-and-prepare", func(t *testing.T) {
+		h := makeQueryCacheTestHelper(t, 1 /* numConns */)
+		defer h.Stop()
 
-			r0.Exec(t, "PREPARE x AS SELECT * FROM t") // Should miss the cache.
-			h.AssertStats(t, 1 /* hits */, 2 /* misses */)
+		r0 := h.runners[0]
+		r0.Exec(t, "SELECT * FROM t") // Should miss the cache.
+		h.AssertStats(t, 0 /* hits */, 1 /* misses */)
 
-			r0.Exec(t, "PREPARE y AS SELECT * FROM t") // Should hit the cache.
-			h.AssertStats(t, 2 /* hits */, 2 /* misses */)
+		r0.Exec(t, "SELECT * FROM t") // Should hit the cache.
+		h.AssertStats(t, 1 /* hits */, 1 /* misses */)
 
-			r0.CheckQueryResults(t, "EXECUTE x", [][]string{{"1", "1"}})
-			r0.CheckQueryResults(t, "EXECUTE y", [][]string{{"1", "1"}})
-		})
+		r0.Exec(t, "PREPARE x AS SELECT * FROM t") // Should miss the cache.
+		h.AssertStats(t, 1 /* hits */, 2 /* misses */)
 
-		// Verify the case where we PREPARE the same statement with different hints.
-		t.Run("prepare-hints", func(t *testing.T) {
-			parallel(t)
-			h := makeQueryCacheTestHelper(t, 1 /* numConns */)
-			defer h.Stop()
+		r0.Exec(t, "PREPARE y AS SELECT * FROM t") // Should hit the cache.
+		h.AssertStats(t, 2 /* hits */, 2 /* misses */)
 
-			r0 := h.runners[0]
-			r0.Exec(t, "PREPARE a1 AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
-			h.AssertStats(t, 0 /* hits */, 1 /* misses */)
+		r0.CheckQueryResults(t, "EXECUTE x", [][]string{{"1", "1"}})
+		r0.CheckQueryResults(t, "EXECUTE y", [][]string{{"1", "1"}})
+	})
 
-			r0.Exec(t, "PREPARE a2 AS SELECT pg_typeof(1 + $1)") // Should hit the cache.
-			h.AssertStats(t, 1 /* hits */, 1 /* misses */)
+	// Verify the case where we PREPARE the same statement with different hints.
+	t.Run("prepare-hints", func(t *testing.T) {
+		h := makeQueryCacheTestHelper(t, 1 /* numConns */)
+		defer h.Stop()
 
-			r0.Exec(t, "PREPARE b1 (float) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
-			h.AssertStats(t, 1 /* hits */, 2 /* misses */)
+		r0 := h.runners[0]
+		r0.Exec(t, "PREPARE a1 AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
+		h.AssertStats(t, 0 /* hits */, 1 /* misses */)
 
-			r0.Exec(t, "PREPARE b2 (float) AS SELECT pg_typeof(1 + $1)") // Should hit the cache.
-			h.AssertStats(t, 2 /* hits */, 2 /* misses */)
+		r0.Exec(t, "PREPARE a2 AS SELECT pg_typeof(1 + $1)") // Should hit the cache.
+		h.AssertStats(t, 1 /* hits */, 1 /* misses */)
 
-			r0.Exec(t, "PREPARE c1 (decimal) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
-			h.AssertStats(t, 2 /* hits */, 3 /* misses */)
+		r0.Exec(t, "PREPARE b1 (float) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
+		h.AssertStats(t, 1 /* hits */, 2 /* misses */)
 
-			r0.Exec(t, "PREPARE c2 (decimal) AS SELECT pg_typeof(1 + $1)") // Should hit the cache.
-			h.AssertStats(t, 3 /* hits */, 3 /* misses */)
+		r0.Exec(t, "PREPARE b2 (float) AS SELECT pg_typeof(1 + $1)") // Should hit the cache.
+		h.AssertStats(t, 2 /* hits */, 2 /* misses */)
 
-			r0.Exec(t, "PREPARE a3 AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
-			h.AssertStats(t, 3 /* hits */, 4 /* misses */)
+		r0.Exec(t, "PREPARE c1 (decimal) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
+		h.AssertStats(t, 2 /* hits */, 3 /* misses */)
 
-			r0.Exec(t, "PREPARE b3 (float) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
-			h.AssertStats(t, 3 /* hits */, 5 /* misses */)
+		r0.Exec(t, "PREPARE c2 (decimal) AS SELECT pg_typeof(1 + $1)") // Should hit the cache.
+		h.AssertStats(t, 3 /* hits */, 3 /* misses */)
 
-			r0.Exec(t, "PREPARE c3 (decimal) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
-			h.AssertStats(t, 3 /* hits */, 6 /* misses */)
+		r0.Exec(t, "PREPARE a3 AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
+		h.AssertStats(t, 3 /* hits */, 4 /* misses */)
 
-			r0.CheckQueryResults(t, "EXECUTE a1 (1)", [][]string{{"bigint"}})
-			r0.CheckQueryResults(t, "EXECUTE a2 (1)", [][]string{{"bigint"}})
-			r0.CheckQueryResults(t, "EXECUTE a3 (1)", [][]string{{"bigint"}})
+		r0.Exec(t, "PREPARE b3 (float) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
+		h.AssertStats(t, 3 /* hits */, 5 /* misses */)
 
-			r0.CheckQueryResults(t, "EXECUTE b1 (1)", [][]string{{"double precision"}})
-			r0.CheckQueryResults(t, "EXECUTE b2 (1)", [][]string{{"double precision"}})
-			r0.CheckQueryResults(t, "EXECUTE b3 (1)", [][]string{{"double precision"}})
+		r0.Exec(t, "PREPARE c3 (decimal) AS SELECT pg_typeof(1 + $1)") // Should miss the cache.
+		h.AssertStats(t, 3 /* hits */, 6 /* misses */)
 
-			r0.CheckQueryResults(t, "EXECUTE c1 (1)", [][]string{{"numeric"}})
-			r0.CheckQueryResults(t, "EXECUTE c2 (1)", [][]string{{"numeric"}})
-			r0.CheckQueryResults(t, "EXECUTE c3 (1)", [][]string{{"numeric"}})
-		})
+		r0.CheckQueryResults(t, "EXECUTE a1 (1)", [][]string{{"bigint"}})
+		r0.CheckQueryResults(t, "EXECUTE a2 (1)", [][]string{{"bigint"}})
+		r0.CheckQueryResults(t, "EXECUTE a3 (1)", [][]string{{"bigint"}})
+
+		r0.CheckQueryResults(t, "EXECUTE b1 (1)", [][]string{{"double precision"}})
+		r0.CheckQueryResults(t, "EXECUTE b2 (1)", [][]string{{"double precision"}})
+		r0.CheckQueryResults(t, "EXECUTE b3 (1)", [][]string{{"double precision"}})
+
+		r0.CheckQueryResults(t, "EXECUTE c1 (1)", [][]string{{"numeric"}})
+		r0.CheckQueryResults(t, "EXECUTE c2 (1)", [][]string{{"numeric"}})
+		r0.CheckQueryResults(t, "EXECUTE c3 (1)", [][]string{{"numeric"}})
 	})
 }
 


### PR DESCRIPTION
We started running sub-tests of `TestQueryCache` in parallel long time ago in b1ebe33374c4a027be515ef9b8f1a4e1d35fd205. Later on we disabled the parallelism under stress in 1cf1edc529e687d645311336d59cedd2fb81e7b2.

Each sub-test starts an in-memory server, and we have about 15 sub-tests, so this could be problematic in "heavy" configs. Recently we saw some flakes after a change to the underlying test infra ("noisy neighbor" was introduced), and even though that change has been reverted, I don't see why we should be using `t.Parallel()` for this particular test at all - it's almost the only one within `sql` folder that does this. Thus, this commit removes the parallelization altogether. On my laptop I saw the time to run in a regular config increase from 1.5s to 4.5s, and we definitely have slower tests, so it shouldn't matter in practice.

Fixes: #152424.

Release note: None