### PR TITLE
sql: fix a flake in TestSavepoints

### DIFF
--- a/pkg/sql/conn_executor_savepoints_test.go
+++ b/pkg/sql/conn_executor_savepoints_test.go
@@ -33,6 +33,9 @@ func TestSavepoints(t *testing.T) {
 		s, origConn, _ := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(ctx)
 
+		if _, err := origConn.Exec(`SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '2KiB';`); err != nil {
+			t.Fatal(err)
+		}
 		if _, err := origConn.Exec(`CREATE TABLE progress(
       conn STRING,
     	n INT, 


### PR DESCRIPTION
The test can have a flake with txnWriteBuffer buffer size in certain range, and when working on eec520b76cfdcc83e24192f5c0d27e39d0779f6d I only tried very small values like 1-3B, so I didn't catch this flake. (Additionally, that commit reduced the range of allowed values making the flake much more likely.) Require 2KiB buffer size minimum to de-flake it.

Fixes: #152039.

Release note: None