### PR TITLE
kvserver: default PriorityInversionRequeue to true

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -106,13 +106,12 @@ var EnqueueProblemRangeInReplicateQueueInterval = settings.RegisterDurationSetti
 // PriorityInversionRequeue is a setting that controls whether to requeue
 // replicas when their priority at enqueue time and processing time is inverted
 // too much (e.g. dropping from a repair action to AllocatorConsiderRebalance).
-// TODO(wenyihu6): flip default to true after landing 152596 to bake
 var PriorityInversionRequeue = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.priority_inversion_requeue_replicate_queue.enabled",
 	"whether the requeue replicas should requeue when enqueued for "+
 		"repair action but ended up consider rebalancing during processing",
-	false,
+	true,
 )
 
 // ReplicateQueueMaxSize is a setting that controls the max size of the


### PR DESCRIPTION
Previously, we introduced PriorityInversionRequeue to handle cases where a range
is enqueued with a high-priority action but computes a lower-priority action at
processing, re-adding the range with its updated priority. We plan to backport
this setting soon. To allow some bake time, we enable it on true in master,
while the backport will include only the previous PR with the default value set
to false.

Epic: none 
Release note: none 
