### PR TITLE
release-24.1: roachtest: test with sqlalchemy 2.0.43

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -24,7 +24,7 @@ import (
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
 var sqlAlchemyReleaseTagRegex = regexp.MustCompile(`^rel_(?P<major>\d+)_(?P<minor>\d+)_(?P<point>\d+)$`)
 
-var supportedSQLAlchemyTag = "2.0.23"
+var supportedSQLAlchemyTag = "2.0.43"
 
 // This test runs the SQLAlchemy dialect test suite against a single Cockroach
 // node.


### PR DESCRIPTION
Backport 1/1 commits from #152739 on behalf of @rafiss.

----

The tests need this upstream change to pass:
https://github.com/sqlalchemy/sqlalchemy/commit/c868afc090dde3ce5beac5cd3d6776567e9cf845

This is because of a recent change in the adapter: https://github.com/cockroachdb/sqlalchemy-cockroachdb/pull/274

fixes https://github.com/cockroachdb/cockroach/issues/152726
fixes https://github.com/cockroachdb/cockroach/issues/152732
informs https://github.com/cockroachdb/cockroach/issues/152727
informs https://github.com/cockroachdb/cockroach/issues/152725
informs https://github.com/cockroachdb/cockroach/issues/152720
informs https://github.com/cockroachdb/cockroach/issues/152722
fixes https://github.com/cockroachdb/cockroach/issues/152719
fixes https://github.com/cockroachdb/cockroach/issues/152718

Release note: None

----

Release justification: