### PR TITLE
sql: replace a few context.Background() with what we have in scope

### DIFF
--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -1491,7 +1491,6 @@ type SystemTable struct {
 func makeSystemTable(
 	createTableStmt string, tbl descpb.TableDescriptor, fns ...func(tbl *descpb.TableDescriptor),
 ) SystemTable {
-	ctx := context.Background()
 	{
 		nameInfo := descpb.NameInfo{
 			ParentID:       tbl.ParentID,
@@ -1500,7 +1499,7 @@ func makeSystemTable(
 		}
 		privs := catprivilege.SystemSuperuserPrivileges(nameInfo)
 		if privs == nil {
-			log.Dev.Fatalf(ctx, "no superuser privileges found when building descriptor of system table %q", tbl.Name)
+			log.Dev.Fatalf(context.Background(), "no superuser privileges found when building descriptor of system table %q", tbl.Name)
 		}
 		tbl.Privileges = catpb.NewCustomSuperuserPrivilegeDescriptor(privs, username.NodeUserName())
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -92,32 +92,6 @@ var errorOnConcurrentCreateStats = settings.RegisterBoolSetting(
 
 const nonIndexColHistogramBuckets = 2
 
-// StubTableStats generates "stub" statistics for a table which are missing
-// statistics on virtual computed columns, multi-column stats, and histograms,
-// and have 0 for all values.
-func StubTableStats(
-	desc catalog.TableDescriptor, name string,
-) ([]*stats.TableStatisticProto, error) {
-	colStats, err := createStatsDefaultColumns(
-		context.Background(), desc,
-		false /* virtColEnabled */, false, /* multiColEnabled */
-		false /* nonIndexJSONHistograms */, false, /* partialStats */
-		nonIndexColHistogramBuckets, nil, /* evalCtx */
-	)
-	if err != nil {
-		return nil, err
-	}
-	statistics := make([]*stats.TableStatisticProto, len(colStats))
-	for i, colStat := range colStats {
-		statistics[i] = &stats.TableStatisticProto{
-			TableID:   desc.GetID(),
-			Name:      name,
-			ColumnIDs: colStat.ColumnIDs,
-		}
-	}
-	return statistics, nil
-}
-
 // createStatsNode is a planNode implemented in terms of a function. The
 // runJob function starts a Job during Start, and the remainder of the
 // CREATE STATISTICS planning and execution is performed within the jobs

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1170,7 +1170,7 @@ func (ie *InternalExecutor) execInternal(
 		// TODO(andrei): Properly clone (deep copy) ie.sessionData.
 		sd = ie.sessionDataStack.Top().Clone()
 	} else {
-		sd = NewInternalSessionData(context.Background(), ie.s.cfg.Settings, "" /* opName */)
+		sd = NewInternalSessionData(ctx, ie.s.cfg.Settings, "" /* opName */)
 	}
 	if globalOverride := ieMultiOverride.Get(&ie.s.cfg.Settings.SV); globalOverride != "" {
 		globalOverride = strings.TrimSpace(globalOverride)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -314,7 +314,7 @@ func (b *Builder) wrapFunctionImpl(
 	if lookup != nil {
 		unresolved := tree.MakeUnresolvedName(fnName)
 		fnDef, err := lookup(
-			context.Background(),
+			b.ctx,
 			tree.MakeUnresolvedFunctionName(&unresolved),
 			&b.evalCtx.SessionData().SearchPath,
 		)

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -6,8 +6,6 @@
 package norm
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -663,8 +661,10 @@ func (c *CustomFuncs) FoldFunction(
 	if c.f.evalCtx != nil && c.f.catalog != nil { // Some tests leave those unset.
 		unresolved := tree.MakeUnresolvedName(private.Name)
 		def, err := c.f.catalog.ResolveFunction(
-			context.Background(), tree.MakeUnresolvedFunctionName(&unresolved),
-			&c.f.evalCtx.SessionData().SearchPath)
+			c.f.ctx,
+			tree.MakeUnresolvedFunctionName(&unresolved),
+			&c.f.evalCtx.SessionData().SearchPath,
+		)
 		if err != nil {
 			log.Dev.Warningf(c.f.ctx, "function %s() not defined: %v", redact.Safe(private.Name), err)
 			return nil, false

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -395,6 +395,8 @@ func newInternalPlanner(
 	// asking the caller for one is hard to explain. What we need is better and
 	// separate interfaces for planning and running plans, which could take
 	// suitable contexts.
+	// TODO(yuzefovich): this comment is outdated - we no longer store context
+	// within EvalCtx. Re-evaluate the situation.
 	ctx := logtags.AddTag(context.Background(), string(opName), "")
 
 	sd = sd.Clone()


### PR DESCRIPTION
**sql: remove no longer used StubTableStats function**

**sql: replace a few context.Background() with what we have in scope**

I was looking into a timeout where we seemingly didn't respect the
context cancellation and noticed a couple of places where we use
`context.Backround()` that were easy to fix.

Touches: #152417.
Epic: None
