### PR TITLE
tests: improve random syntax tests a bit

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/concurrency",
+        "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/rpc/nodedialer",
         "//pkg/security/securityassets",


### PR DESCRIPTION
I just looked into a timeout and noticed that with the default test tenant we had many goroutines blocked on rate limiting. Given that our random syntax tests slam the server with huge load, I think it makes sense to disable the rate limiting for this test family.

Informs: #152417
Epic: None
Release note: None