### PR TITLE
schemachanger: implement RENAME COLUMN in the declarative schema changer

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -428,6 +428,13 @@ func TestBackupRollbacks_base_alter_table_no_force_row_level_security(t *testing
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1139,6 +1146,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_no_force_row_level_securit
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1856,6 +1870,13 @@ func TestBackupSuccess_base_alter_table_no_force_row_level_security(t *testing.T
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2567,6 +2588,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_no_force_row_level_security(
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -986,7 +986,7 @@ func applyColumnMutation(
 			}
 			return pgerror.Newf(
 				pgcode.Syntax,
-				"computed column %q cannot also have a DEFAULT expression",
+				"computed column %q cannot also have a DEFAULT or ON UPDATE expression",
 				col.GetName())
 		}
 		if err := updateNonComputedColExpr(
@@ -1005,6 +1005,12 @@ func applyColumnMutation(
 		}
 
 	case *tree.AlterTableSetOnUpdate:
+		if col.IsComputed() {
+			return pgerror.Newf(
+				pgcode.Syntax,
+				"computed column %q cannot also have a DEFAULT or ON UPDATE expression",
+				col.GetName())
+		}
 		// We want to reject uses of ON UPDATE where there is also a foreign key ON
 		// UPDATE.
 		for _, fk := range tableDesc.OutboundFKs {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -804,7 +804,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				tableDesc.GetRowLevelTTL().HasDurationExpr() {
 				return pgerror.Newf(
 					pgcode.InvalidTableDefinition,
-					`cannot rename column %s while ttl_expire_after is set`,
+					`cannot alter column %s while ttl_expire_after is set`,
 					columnName,
 				)
 			}

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -963,7 +963,7 @@ func TestRemoveDefaultExprFromComputedColumn(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 
-	const expectedErrRE = `.*: computed column \"b\" cannot also have a DEFAULT expression`
+	const expectedErrRE = `.*: computed column \"b\" cannot also have a DEFAULT or ON UPDATE expression`
 	// Create a table with a computed column.
 	tdb.Exec(t, `CREATE DATABASE t`)
 	tdb.Exec(t, `CREATE TABLE t.tbl (a INT PRIMARY KEY, b INT AS (1) STORED)`)

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1319,7 +1319,7 @@ SELECT * FROM t69327
 f  f
 
 # Regression test for #72881. Computed columns can't have a DEFAULT expr.
-statement error pgcode 42601 computed column "v" cannot also have a DEFAULT expression
+statement error pgcode 42601 computed column "v" cannot also have a DEFAULT or ON UPDATE expression
 ALTER TABLE t69327 ALTER COLUMN v SET DEFAULT 'foo'
 
 # Regression test for #69665.Computed columns should be evaluated after
@@ -1379,10 +1379,13 @@ CREATE TABLE foooooo (
     gen INT AS (x + y) STORED
 );
 
-statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT expression
+statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT or ON UPDATE expression
 ALTER TABLE foooooo ALTER COLUMN gen SET DEFAULT 1;
 
-statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT expression
+statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT or ON UPDATE expression
+ALTER TABLE foooooo ALTER COLUMN gen SET ON UPDATE 1;
+
+statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT or ON UPDATE expression
 ALTER TABLE foooooo ALTER COLUMN gen SET DEFAULT NULL;
 
 statement error pgcode 42601 column "gen" of relation "foooooo" is a computed column

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -199,3 +199,34 @@ query II
 SELECT j, k FROM foo;
 ----
 1  2
+
+# Test that mixed-case column names are handled correctly for rename operations.
+statement ok
+CREATE TABLE mixed_case_table (
+    "CamelCase" INT PRIMARY KEY,
+    "snake_case" TEXT,
+    "UPPERCASE" DECIMAL
+);
+
+statement error column "UPPERCASE" of relation "mixed_case_table" already exists
+ALTER TABLE mixed_case_table RENAME COLUMN "CamelCase" TO "UPPERCASE";
+
+statement ok
+ALTER TABLE mixed_case_table RENAME COLUMN "CamelCase" TO "CamelCase";
+
+statement ok
+ALTER TABLE mixed_case_table RENAME COLUMN "CamelCase" TO "NewCamelCase";
+
+statement ok
+ALTER TABLE mixed_case_table RENAME COLUMN "snake_case" TO "SnakeCase";
+
+statement ok
+ALTER TABLE mixed_case_table RENAME COLUMN "UPPERCASE" TO "decimal_value";
+
+query T colnames
+SELECT column_name FROM [SHOW COLUMNS FROM mixed_case_table] ORDER BY column_name;
+----
+column_name
+NewCamelCase
+SnakeCase
+decimal_value

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -92,9 +92,8 @@ ALTER TABLE users RENAME COLUMN id TO uid
 statement error cannot rename column "username" because view "v1" depends on it
 ALTER TABLE users RENAME COLUMN username TO name
 
-# TODO(knz): restore test after #17269 / #10083 is fixed.
-#statement ok
-#ALTER TABLE users RENAME COLUMN species TO title
+statement ok
+ALTER TABLE users RENAME COLUMN species TO title
 
 statement ok
 CREATE VIEW v2 AS SELECT id from users
@@ -105,9 +104,8 @@ DROP VIEW v1
 statement error cannot rename column "id" because view "v2" depends on it
 ALTER TABLE users RENAME COLUMN id TO uid
 
-# TODO(knz): restore test after #17269 / #10083 is fixed.
-# statement ok
-# ALTER TABLE users RENAME COLUMN username TO name
+statement ok
+ALTER TABLE users RENAME COLUMN username TO name
 
 statement ok
 DROP VIEW v2
@@ -116,14 +114,14 @@ query T
 SELECT column_name FROM [SHOW COLUMNS FROM users] ORDER BY column_name
 ----
 id
-species
-username
+name
+title
 
 statement ok
 SET vectorize=on
 
 query T
-EXPLAIN ALTER TABLE users RENAME COLUMN species TO woo
+EXPLAIN ALTER TABLE users RENAME COLUMN title TO woo
 ----
 distribution: local
 vectorized: true
@@ -138,8 +136,8 @@ query T
 SELECT column_name FROM [SHOW COLUMNS FROM users] ORDER BY column_name
 ----
 id
-species
-username
+name
+title
 
 skipif config schema-locked-disabled
 statement ok
@@ -147,15 +145,15 @@ ALTER TABLE users SET (schema_locked=false);
 
 # Check that a column can be added and renamed in the same statement
 statement ok
-ALTER TABLE users RENAME COLUMN species TO species_old,
-                  ADD COLUMN species STRING AS (species_old || ' woo') STORED
+ALTER TABLE users RENAME COLUMN title TO title_old,
+                  ADD COLUMN title STRING AS (title_old || ' woo') STORED
 
 skipif config schema-locked-disabled
 statement ok
 ALTER TABLE users SET (schema_locked=true);
 
 query T rowsort
-SELECT species FROM users
+SELECT title FROM users
 ----
 cat woo
 rat woo

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -227,7 +227,7 @@ subtest alter_column_crdb_internal_expiration_rename
 statement ok
 CREATE TABLE alter_column_crdb_internal_expiration_rename() WITH (ttl_expire_after='10 minutes')
 
-statement error cannot rename column crdb_internal_expiration while ttl_expire_after is set
+statement error cannot alter column crdb_internal_expiration while ttl_expire_after is set
 ALTER TABLE alter_column_crdb_internal_expiration_rename RENAME COLUMN crdb_internal_expiration TO crdb_internal_expiration_2
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -253,7 +253,7 @@ ALTER TABLE tab3 SET (schema_locked=true)
 
 subtest alter_commands
 
-statement error pq: cannot rename system column "crdb_internal_mvcc_timestamp"
+statement error pq: cannot alter system column "crdb_internal_mvcc_timestamp"
 ALTER TABLE tab3 RENAME crdb_internal_mvcc_timestamp TO blah;
 
 statement error pq: cannot alter system column "crdb_internal_mvcc_timestamp"

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -105,7 +105,7 @@ func (p *planner) findColumnToRename(
 	if col.IsSystemColumn() {
 		return nil, pgerror.Newf(
 			pgcode.FeatureNotSupported,
-			"cannot rename system column %q", col.ColName(),
+			"cannot alter system column %q", col.ColName(),
 		)
 	}
 	for _, tableRef := range tableDesc.DependedOnBy {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "alter_table_alter_primary_key.go",
         "alter_table_drop_column.go",
         "alter_table_drop_constraint.go",
+        "alter_table_rename_column.go",
         "alter_table_set_rls_mode.go",
         "alter_table_validate_constraint.go",
         "comment_on.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -38,10 +38,11 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableDropConstraint)(nil)):     {fn: alterTableDropConstraint, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableValidateConstraint)(nil)): {fn: alterTableValidateConstraint, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableSetDefault)(nil)):         {fn: alterTableSetDefault, on: true, checks: nil},
-	reflect.TypeOf((*tree.AlterTableSetOnUpdate)(nil)):        {fn: alterTableSetOnUpdate, on: true, checks: isV254Active},
 	reflect.TypeOf((*tree.AlterTableAlterColumnType)(nil)):    {fn: alterTableAlterColumnType, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableSetRLSMode)(nil)):         {fn: alterTableSetRLSMode, on: true, checks: isV252Active},
 	reflect.TypeOf((*tree.AlterTableDropNotNull)(nil)):        {fn: alterTableDropNotNull, on: true, checks: isV253Active},
+	reflect.TypeOf((*tree.AlterTableSetOnUpdate)(nil)):        {fn: alterTableSetOnUpdate, on: true, checks: isV254Active},
+	reflect.TypeOf((*tree.AlterTableRenameColumn)(nil)):       {fn: alterTableRenameColumn, on: true, checks: isV254Active},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_drop_not_null.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_drop_not_null.go
@@ -23,7 +23,7 @@ func alterTableDropNotNull(
 	alterColumnPreChecks(b, tn, tbl, t.Column)
 	columnID := getColumnIDFromColumnName(b, tbl.TableID, t.Column, true /*required */)
 	// Block alters on system columns.
-	panicIfSystemColumn(mustRetrieveColumnElem(b, tbl.TableID, columnID), t.Column.String())
+	panicIfSystemColumn(mustRetrieveColumnElem(b, tbl.TableID, columnID), t.Column)
 	// Ensure that this column is not in the primary indexes key.
 	primaryIdx := getLatestPrimaryIndex(b, tbl.TableID)
 	idxColumns := mustRetrieveIndexColumnElements(b, tbl.TableID, primaryIdx.IndexID)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
@@ -25,7 +25,7 @@ func alterTableSetNotNull(
 		return
 	}
 	// Block alters on system columns.
-	panicIfSystemColumn(mustRetrieveColumnElem(b, tbl.TableID, columnID), t.Column.String())
+	panicIfSystemColumn(mustRetrieveColumnElem(b, tbl.TableID, columnID), t.Column)
 	b.Add(&scpb.ColumnNotNull{
 		TableID:  tbl.TableID,
 		ColumnID: columnID,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_on_update.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_on_update.go
@@ -24,10 +24,10 @@ func alterTableSetOnUpdate(
 	colType := mustRetrieveColumnTypeElem(b, tbl.TableID, colID)
 
 	// Block alters on system columns.
-	panicIfSystemColumn(col, t.Column.String())
+	panicIfSystemColumn(col, t.Column)
 
 	// Block disallowed operations on computed columns.
-	panicIfComputedColumn(b, tn.ObjectName, colType, t.Column.String(), t.Expr)
+	panicIfComputedColumn(b, tn.ObjectName, colType, t.Column, t.Expr)
 
 	// For DROP ON UPDATE.
 	if t.Expr == nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -42,7 +42,7 @@ func alterTableAlterColumnType(
 ) {
 	colID := getColumnIDFromColumnName(b, tbl.TableID, t.Column, true /* required */)
 	col := mustRetrieveColumnElem(b, tbl.TableID, colID)
-	panicIfSystemColumn(col, t.Column.String())
+	panicIfSystemColumn(col, t.Column)
 
 	// Setup for the new type ahead of any checking. As we need its resolved type
 	// for the checks.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -93,7 +93,7 @@ func alterTableAlterColumnType(
 		case *scpb.PolicyUsingExpr, *scpb.PolicyWithCheckExpr:
 			panic(sqlerrors.NewAlterDependsOnPolicyExprError(op, objType, t.Column.String()))
 		}
-	})
+	}, false /* allowPartialIdxPredicateRef */)
 
 	var err error
 	newColType.Type, err = schemachange.ValidateAlterColumnTypeChecks(
@@ -309,7 +309,7 @@ func handleGeneralColumnConversion(
 		case *scpb.SecondaryIndex:
 			panic(sqlerrors.NewAlterColumnTypeColInIndexNotSupportedErr())
 		}
-	})
+	}, false /* allowPartialIdxPredicateRef */)
 
 	// This code path should never be reached for virtual columns, as their values
 	// are always computed dynamically on access and are never stored on disk.
@@ -505,7 +505,7 @@ func maybeWriteNoticeForFKColTypeMismatch(b BuildCtx, col *scpb.Column, colType 
 		case *scpb.ForeignKeyConstraintUnvalidated:
 			writeNoticeHelper(e.ColumnIDs, e.ReferencedColumnIDs, e.ReferencedTableID)
 		}
-	})
+	}, false /* allowPartialIdxPredicateRef */)
 }
 
 func getComputeExpressionForBackfill(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -1149,7 +1149,7 @@ func checkIfColumnCanBeDropped(b BuildCtx, columnToDrop *scpb.Column) bool {
 				canBeDropped = false
 			}
 		}
-	})
+	}, false /* allowPartialIdxPredicateRef */)
 	return canBeDropped
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -109,7 +109,7 @@ func resolveColumnForDropColumn(
 		return nil, nil, true
 	}
 	// Block drops on system columns.
-	panicIfSystemColumn(col, n.Column.String())
+	panicIfSystemColumn(col, n.Column)
 	return col, elts, false
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -266,7 +266,7 @@ func dropColumn(
 		default:
 			b.Drop(e)
 		}
-	})
+	}, false /* allowPartialIdxPredicateRef */)
 	// TODO(ajwerner): Track the undropped backrefs to populate a detail
 	// message like postgres does. For example:
 	//  SET serial_normalization = sql_sequence;
@@ -290,7 +290,12 @@ func dropColumn(
 }
 
 func walkColumnDependencies(
-	b BuildCtx, col *scpb.Column, op, objType string, fn func(e scpb.Element, op, objType string),
+	b BuildCtx,
+	col *scpb.Column,
+	op string,
+	objType string,
+	fn func(e scpb.Element, op string, objType string),
+	allowPartialIdxPredicateRef bool,
 ) {
 	var sequenceDeps catalog.DescriptorIDSet
 	var indexDeps catid.IndexSet
@@ -300,7 +305,9 @@ func walkColumnDependencies(
 	// Panic if `col` is referenced in a predicate of an index or
 	// unique without index constraint.
 	// TODO (xiang): Remove this restriction when #97813 is fixed.
-	panicIfColReferencedInPredicate(b, col, tblElts, op, objType)
+	if !allowPartialIdxPredicateRef {
+		panicIfColReferencedInPredicate(b, col, tblElts, op, objType)
+	}
 
 	tblElts.
 		Filter(referencesColumnIDFilter(col.ColumnID)).

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_column.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/errors"
+)
+
+func alterTableRenameColumn(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	n *tree.AlterTable,
+	t *tree.AlterTableRenameColumn,
+) {
+	if len(n.Cmds) > 1 {
+		panic(scerrors.NotImplementedError(n))
+	}
+	alterColumnPreChecks(b, tn, tbl, t.Column)
+
+	// 1. Resolve the column by current name.
+	eltsFromColName := b.ResolveColumn(tbl.TableID, t.Column, ResolveParams{
+		RequiredPrivilege: privilege.CREATE,
+	})
+	colElt := eltsFromColName.FilterColumn().MustGetZeroOrOneElement()
+	colNameElt := eltsFromColName.FilterColumnName().MustGetZeroOrOneElement()
+
+	// 2. Validate column exists and the new name is valid..
+	if colElt == nil {
+		panic(pgerror.Newf(pgcode.UndefinedColumn, "column %q does not exist", tree.ErrString(&t.Column)))
+	}
+	if colNameElt == nil {
+		panic(errors.AssertionFailedf("column element resolved for %s, but column name element not found", tree.ErrString(&t.Column)))
+	}
+	renameColumnChecks(b, colElt, t.Column, t.NewName)
+
+	// Short circuit if the name is unchanged.
+	if colNameElt.Name == string(t.NewName) {
+		return
+	}
+
+	// Drop the old column name and add the new one to ensure proper rollback
+	// behavior.
+	b.Drop(colNameElt)
+	b.Add(&scpb.ColumnName{
+		TableID:  tbl.TableID,
+		ColumnID: colElt.ColumnID,
+		Name:     string(t.NewName),
+	})
+}
+
+// renameColumnChecks validates that a column can be renamed and performs
+// dependency checks. It ensures the new name is valid, verifies the column
+// is not a system or shard column, checks for blocking dependencies from
+// views and functions, and validates that inaccessible columns cannot be
+// renamed.
+func renameColumnChecks(b BuildCtx, col *scpb.Column, oldName, newName tree.Name) {
+	if newName == "" {
+		panic(pgerror.New(pgcode.Syntax, "empty column name"))
+	}
+
+	// Block renaming of system columns.
+	panicIfSystemColumn(col, oldName.String())
+
+	// Block renaming of shard columns.
+	if isShardColumn(b, col) {
+		panic(pgerror.Newf(pgcode.ReservedName, "cannot rename shard column"))
+	}
+
+	walkColumnDependencies(b, col, "rename", "column", func(e scpb.Element, op, objType string) {
+		switch e := e.(type) {
+		case *scpb.View:
+			ns := b.QueryByID(col.TableID).FilterNamespace().MustGetOneElement()
+			nsDep := b.QueryByID(e.ViewID).FilterNamespace().MustGetOneElement()
+			if nsDep.DatabaseID != ns.DatabaseID || nsDep.SchemaID != ns.SchemaID {
+				panic(sqlerrors.NewDependentBlocksOpError(op, objType, tree.ErrString(&oldName), "view", qualifiedName(b, e.ViewID)))
+			}
+			panic(sqlerrors.NewDependentBlocksOpError(op, objType, tree.ErrString(&oldName), "view", nsDep.Name))
+		case *scpb.FunctionBody:
+			_, _, fnName := scpb.FindFunctionName(b.QueryByID(e.FunctionID))
+			panic(sqlerrors.NewDependentObjectErrorf(
+				"cannot rename column %q because function %q depends on it",
+				tree.ErrString(&oldName), fnName.Name),
+			)
+		}
+	}, true /* allowPartialIdxPredicateRef */)
+
+	if col.IsInaccessible {
+		panic(pgerror.Newf(
+			pgcode.UndefinedColumn,
+			"column %q is inaccessible and cannot be renamed",
+			tree.ErrString(&oldName),
+		))
+	}
+	checkNewColumnNameConflicts(b, col.TableID, oldName, newName)
+}
+
+// checkNewColumnNameConflicts verifies that the new column name does not
+// conflict with existing columns in the table. It checks for naming conflicts
+// with system columns, columns currently being dropped, and columns being
+// added in the same transaction.
+func checkNewColumnNameConflicts(b BuildCtx, tableID catid.DescID, oldName, newName tree.Name) {
+	b.QueryByID(tableID).FilterColumnName().ForEach(func(current scpb.Status, target scpb.TargetStatus, e *scpb.ColumnName) {
+		// If an existing column on our table has the same name, panic.
+		if tree.Name(e.Name) == newName && tree.Name(e.Name) != oldName {
+			existingColWithSameName := b.QueryByID(tableID).FilterColumn().Filter(
+				func(_ scpb.Status, _ scpb.TargetStatus, ce *scpb.Column) bool {
+					return ce.ColumnID == e.ColumnID
+				}).MustGetOneElement()
+			if existingColWithSameName.IsSystemColumn {
+				panic(pgerror.Newf(pgcode.DuplicateColumn,
+					"column name %q conflicts with a system column name",
+					tree.ErrString(&newName)))
+			}
+			if current == scpb.Status_PUBLIC {
+				if target == scpb.ToAbsent {
+					panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "column %q being dropped, try again later", tree.ErrString(&newName)))
+				}
+				tableName := b.QueryByID(tableID).FilterNamespace().MustGetOneElement()
+				panic(sqlerrors.NewColumnAlreadyExistsInRelationError(tree.ErrString(&newName), tableName.Name))
+			}
+			if current == scpb.Status_ABSENT && target == scpb.ToPublic {
+				panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "column %q being dropped, try again later", tree.ErrString(&newName)))
+			}
+		}
+	})
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_column.go
@@ -71,7 +71,7 @@ func renameColumnChecks(b BuildCtx, col *scpb.Column, oldName, newName tree.Name
 	}
 
 	// Block renaming of system columns.
-	panicIfSystemColumn(col, oldName.String())
+	panicIfSystemColumn(col, oldName)
 
 	// Block renaming of shard columns.
 	if isShardColumn(b, col) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -2108,3 +2108,36 @@ func hasSubzonesForIndex(b BuildCtx, tableID descpb.ID, indexID catid.IndexID) b
 		}).Size()
 	return numIdxSubzones > 0 || numPartSubzones > 0
 }
+
+// isShardColumn checks if the given column is a shard column by examining
+// all indexes on the table to see if any sharded index uses this column name.
+func isShardColumn(b BuildCtx, col *scpb.Column) bool {
+	// Get the column name.
+	colNameElt := b.QueryByID(col.TableID).FilterColumnName().Filter(
+		func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.ColumnName) bool {
+			return e.ColumnID == col.ColumnID
+		}).MustGetZeroOrOneElement()
+
+	if colNameElt == nil {
+		return false
+	}
+
+	colName := colNameElt.Name
+
+	// Check all indexes on this table.
+	found := false
+	b.QueryByID(col.TableID).ForEach(func(current scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		switch idx := e.(type) {
+		case *scpb.PrimaryIndex:
+			if idx.Sharding != nil && idx.Sharding.IsSharded && idx.Sharding.Name == colName {
+				found = true
+			}
+		case *scpb.SecondaryIndex:
+			if idx.Sharding != nil && idx.Sharding.IsSharded && idx.Sharding.Name == colName {
+				found = true
+			}
+		}
+	})
+
+	return found
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1218,12 +1218,12 @@ func checkTableSchemaChangePrerequisites(
 }
 
 // panicIfSystemColumn blocks alter operations on system columns.
-func panicIfSystemColumn(column *scpb.Column, columnName string) {
+func panicIfSystemColumn(column *scpb.Column, columnName tree.Name) {
 	if column.IsSystemColumn {
 		// Block alter operations on system columns.
 		panic(pgerror.Newf(
 			pgcode.FeatureNotSupported,
-			"cannot alter system column %q", columnName))
+			"cannot alter system column %q", tree.ErrString(&columnName)))
 	}
 }
 

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -17,10 +17,6 @@ ALTER TABLE defaultdb.foo ALTER COLUMN i DROP STORED
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo RENAME COLUMN i TO j
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo RENAME CONSTRAINT foobar TO baz
 ----
 

--- a/pkg/sql/schemachanger/scpb/element_collection.go
+++ b/pkg/sql/schemachanger/scpb/element_collection.go
@@ -214,7 +214,7 @@ func (c *ElementCollection[E]) NotToAbsent() *ElementCollection[E] {
 	})
 }
 
-// TransientAbsent filters by elements targeting the TRANSIENT_ABSENT state.
+// Transient filters by elements targeting the TRANSIENT_ABSENT state.
 func (c *ElementCollection[E]) Transient() *ElementCollection[E] {
 	return c.FilterTarget(func(target TargetStatus, _ E) bool {
 		return target == TransientAbsent

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "dep_drop_policy.go",
         "dep_drop_trigger.go",
         "dep_garbage_collection.go",
+        "dep_rename_column.go",
         "dep_schema_locked.go",
         "dep_swap_index.go",
         "dep_two_version.go",

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_column.go
@@ -1,0 +1,35 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package current
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	. "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+)
+
+// These rules ensure that when renaming a column, the old ColumnName element
+// is dropped before the new ColumnName element is added. This prevents
+// conflicts and ensures proper rollback behavior.
+func init() {
+	registerDepRule(
+		"old column name is dropped before new column name is added",
+		scgraph.Precedence,
+		"old-column-name", "new-column-name",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.ColumnName)(nil)),
+				to.Type((*scpb.ColumnName)(nil)),
+				JoinOnColumnID(from, to, "table-id", "col-id"),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4170,6 +4170,20 @@ deprules
     - $referenced-column-name-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
     - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
+- name: old column name is dropped before new column name is added
+  from: old-column-name-Node
+  kind: Precedence
+  to: new-column-name-Node
+  query:
+    - $old-column-name[Type] = '*scpb.ColumnName'
+    - $new-column-name[Type] = '*scpb.ColumnName'
+    - joinOnColumnID($old-column-name, $new-column-name, $table-id, $col-id)
+    - $old-column-name-Target[TargetStatus] = ABSENT
+    - $old-column-name-Node[CurrentStatus] = ABSENT
+    - $new-column-name-Target[TargetStatus] = PUBLIC
+    - $new-column-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-column-name, $old-column-name-Target, $old-column-name-Node)
+    - joinTargetNode($new-column-name, $new-column-name-Target, $new-column-name-Node)
 - name: old index absent before new index public when swapping with transient
   from: old-primary-index-Node
   kind: Precedence
@@ -9065,6 +9079,20 @@ deprules
     - $referenced-column-name-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
     - joinTargetNode($referenced-column-name, $referenced-column-name-Target, $referenced-column-name-Node)
+- name: old column name is dropped before new column name is added
+  from: old-column-name-Node
+  kind: Precedence
+  to: new-column-name-Node
+  query:
+    - $old-column-name[Type] = '*scpb.ColumnName'
+    - $new-column-name[Type] = '*scpb.ColumnName'
+    - joinOnColumnID($old-column-name, $new-column-name, $table-id, $col-id)
+    - $old-column-name-Target[TargetStatus] = ABSENT
+    - $old-column-name-Node[CurrentStatus] = ABSENT
+    - $new-column-name-Target[TargetStatus] = PUBLIC
+    - $new-column-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-column-name, $old-column-name-Target, $old-column-name-Node)
+    - joinTargetNode($new-column-name, $new-column-name-Target, $new-column-name-Node)
 - name: old index absent before new index public when swapping with transient
   from: old-primary-index-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -428,6 +428,13 @@ func TestEndToEndSideEffects_alter_table_no_force_row_level_security(t *testing.
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1139,6 +1146,13 @@ func TestExecuteWithDMLInjection_alter_table_no_force_row_level_security(t *test
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1856,6 +1870,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_no_force_row_level_security(t *t
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2567,6 +2588,13 @@ func TestPause_alter_table_no_force_row_level_security(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3284,6 +3312,13 @@ func TestPauseMixedVersion_alter_table_no_force_row_level_security(t *testing.T)
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3995,6 +4030,13 @@ func TestRollback_alter_table_no_force_row_level_security(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_rename_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+----
+
+test
+ALTER TABLE t RENAME COLUMN j TO k;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.explain
@@ -1,0 +1,50 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE t RENAME COLUMN j TO k;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME COLUMN ‹j› TO ‹k›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC ColumnName:{DescID: 104 (t), Name: "k", ColumnID: 2 (j-k+)}
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-k+)}
+ │         └── 3 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":104}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              └── SetColumnName {"ColumnID":2,"Name":"k","TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── PUBLIC → ABSENT ColumnName:{DescID: 104 (t), Name: "k", ColumnID: 2 (j-k+)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │    │    │    └── ABSENT → PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── ABSENT → PUBLIC ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-k+)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC ColumnName:{DescID: 104 (t), Name: "k", ColumnID: 2 (j-k+)}
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-k+)}
+ │         └── 5 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":104}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"k","TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ └── PostCommitPhase
+      └── Stage 1 of 1 in PostCommitPhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE t RENAME COLUMN j TO k;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME COLUMN ‹j› TO ‹k›;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column.side_effects
@@ -1,0 +1,171 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+ALTER TABLE t RENAME COLUMN j TO k;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.rename_column
+## StatementPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         width: 64
+     - id: 2
+  -    name: j
+  +    name: k
+       nullable: true
+       type:
+  ...
+       columnNames:
+       - i
+  -    - j
+  +    - k
+       defaultColumnId: 2
+       name: primary
+  ...
+       - 2
+       storeColumnNames:
+  -    - j
+  +    - k
+       unique: true
+       vecConfig: {}
+  ...
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 5 MutationType ops
+upsert descriptor #104
+  ...
+         width: 64
+     - id: 2
+  -    name: j
+  +    name: k
+       nullable: true
+       type:
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "2": k
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "1": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME COLUMN ‹j› TO ‹k›
+  +        statement: ALTER TABLE t RENAME COLUMN j TO k
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       columnNames:
+       - i
+  -    - j
+  +    - k
+       defaultColumnId: 2
+       name: primary
+  ...
+       - 2
+       storeColumnNames:
+  -    - j
+  +    - k
+       unique: true
+       vecConfig: {}
+  ...
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t RENAME COLUMN j TO k"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "2": k
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "1": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME COLUMN ‹j› TO ‹k›
+  -        statement: ALTER TABLE t RENAME COLUMN j TO k
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     replacementOf:
+       time: {}
+  +  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #3
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column/alter_table_rename_column__rollback_1_of_1.explain
@@ -1,0 +1,26 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+
+/* test */
+ALTER TABLE t RENAME COLUMN j TO k;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t RENAME COLUMN j TO k;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── ABSENT → PUBLIC ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (k-j+)}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── PUBLIC → ABSENT ColumnName:{DescID: 104 (t), Name: "k", ColumnID: 2 (k-j+)}
+      │    └── 4 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}


### PR DESCRIPTION
This was a pretty straightforward copy of the logic from the legacy schema changer.

Only one new dependency rule was needed, to make sure the old column name is removed
before the new one is added.

fixes https://github.com/cockroachdb/cockroach/issues/148340
fixes #139840
Release note: None