### PR TITLE
kvserver: default ReplicateQueueMaxSize to math.MaxInt64

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -8,6 +8,7 @@ package kvserver
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -109,7 +110,7 @@ var ReplicateQueueMaxSize = settings.RegisterIntSetting(
 	"maximum number of replicas that can be queued for replicate queue processing; "+
 		"when this limit is exceeded, lower priority (not guaranteed to be the lowest) "+
 		"replicas are dropped from the queue",
-	defaultQueueMaxSize,
+	math.MaxInt64,
 	settings.WithValidateInt(func(v int64) error {
 		if v < defaultQueueMaxSize {
 			return errors.Errorf("cannot be set to a value lower than %d: %d", defaultQueueMaxSize, v)


### PR DESCRIPTION
Previously, the maximum size of the replicate queue was made configurable via a
cluster setting, since replica item structs are small and enforcing the a max
size seemed unnecessary. This commit sets the default replicate queue size to
MaxInt64. This allows more baking time on the master since we plan to backport
the change and give customers the option to set it to MaxInt64. If this behavior
proves stable, MaxInt64 will become the default replicate queue size in future
releases as well.

Epic: none 
Release note: none 