### PR TITLE
changefeedccl: ignore context canceled error in tests

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -938,6 +938,7 @@ func requireNoFeedsFail(t *testing.T) (fn updateKnobsFn) {
 		`connection reset by peer`,
 		`knobs.RaiseRetryableError`,
 		`test error`,
+		`context canceled`,
 	}
 	shouldIgnoreErr := func(err error) bool {
 		if err == nil || errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Context canceled errors is causing flakes in tests, and should be ignored.

Fixes: #151726 #152510
Release note: None