### PR TITLE
stmtdiagnostics: Add support for transaction diagnostics

### DIFF
--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "stmtdiagnostics",
-    srcs = ["statement_diagnostics.go"],
+    srcs = [
+        "statement_diagnostics.go",
+        "txn_diagnostics.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics",
     visibility = ["//visibility:public"],
     deps = [
@@ -29,12 +32,14 @@ go_test(
         "main_test.go",
         "statement_diagnostics_helpers_test.go",
         "statement_diagnostics_test.go",
+        "txn_diagnostics_test.go",
     ],
     embed = [":stmtdiagnostics"],
     tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/roachpb",
@@ -44,6 +49,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/isql",
         "//pkg/sql/sqlerrors",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
@@ -53,6 +59,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -210,6 +210,33 @@ func (r *Registry) poll(ctx context.Context) {
 	}
 }
 
+type StmtDiagnostic struct {
+	requestID       RequestID
+	req             Request
+	stmtFingerprint string
+	stmt            string
+	bundle          []byte
+	collectionErr   error
+}
+
+func NewStmtDiagnostic(
+	requestID RequestID,
+	req Request,
+	stmtFingerprint string,
+	stmt string,
+	bundle []byte,
+	collectionErr error,
+) StmtDiagnostic {
+	return StmtDiagnostic{
+		requestID:       requestID,
+		req:             req,
+		stmtFingerprint: stmtFingerprint,
+		stmt:            stmt,
+		bundle:          bundle,
+		collectionErr:   collectionErr,
+	}
+}
+
 // RequestID is the ID of a diagnostics request, corresponding to the id
 // column in statement_diagnostics_requests.
 // A zero ID is invalid.
@@ -553,127 +580,137 @@ func (r *Registry) InsertStatementDiagnostics(
 	var diagID CollectedInstanceID
 	err := r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		txn.KV().SetDebugName("stmt-diag-insert-bundle")
-		if requestID != 0 {
-			row, err := txn.QueryRowEx(ctx, "stmt-diag-check-completed", txn.KV(),
-				sessiondata.NodeUserSessionDataOverride,
-				"SELECT count(1) FROM system.statement_diagnostics_requests WHERE id = $1 AND completed = false",
-				requestID)
-			if err != nil {
-				return err
-			}
-			if row == nil {
-				return errors.New("failed to check completed statement diagnostics")
-			}
-			cnt := int(*row[0].(*tree.DInt))
-			if cnt == 0 {
-				// Someone else already marked the request as completed. We've traced for nothing.
-				// This can only happen once per node, per request since we're going to
-				// remove the request from the registry.
-				return nil
-			}
-		}
-
-		// Generate the values that will be inserted.
-		errorVal := tree.DNull
-		if collectionErr != nil {
-			errorVal = tree.NewDString(collectionErr.Error())
-		}
-
-		bundleChunksVal := tree.NewDArray(types.Int)
-		bundleToUpload := bundle
-		for len(bundleToUpload) > 0 {
-			chunkSize := int(bundleChunkSize.Get(&r.st.SV))
-			chunk := bundleToUpload
-			if len(chunk) > chunkSize {
-				chunk = chunk[:chunkSize]
-			}
-			bundleToUpload = bundleToUpload[len(chunk):]
-
-			// Insert the chunk into system.statement_bundle_chunks.
-			row, err := txn.QueryRowEx(
-				ctx, "stmt-bundle-chunks-insert", txn.KV(),
-				sessiondata.NodeUserSessionDataOverride,
-				"INSERT INTO system.statement_bundle_chunks(description, data) VALUES ($1, $2) RETURNING id",
-				"statement diagnostics bundle",
-				tree.NewDBytes(tree.DBytes(chunk)),
-			)
-			if err != nil {
-				return err
-			}
-			if row == nil {
-				return errors.New("failed to check statement bundle chunk")
-			}
-			chunkID := row[0].(*tree.DInt)
-			if err := bundleChunksVal.Append(chunkID); err != nil {
-				return err
-			}
-		}
-
-		collectionTime := timeutil.Now()
-
-		// Insert the collection metadata into system.statement_diagnostics.
-		row, err := txn.QueryRowEx(
-			ctx, "stmt-diag-insert", txn.KV(),
-			sessiondata.NodeUserSessionDataOverride,
-			"INSERT INTO system.statement_diagnostics "+
-				"(statement_fingerprint, statement, collected_at, bundle_chunks, error) "+
-				"VALUES ($1, $2, $3, $4, $5) RETURNING id",
-			stmtFingerprint, stmt, collectionTime, bundleChunksVal, errorVal,
-		)
+		id, err := r.innerInsertStatementDiagnostics(ctx, NewStmtDiagnostic(requestID, req, stmtFingerprint, stmt, bundle, collectionErr), txn)
 		if err != nil {
 			return err
 		}
-		if row == nil {
-			return errors.New("failed to insert statement diagnostics")
-		}
-		diagID = CollectedInstanceID(*row[0].(*tree.DInt))
-
-		if requestID != 0 {
-			// Link the request from system.statement_diagnostics_request to the
-			// diagnostic ID we just collected, marking it as completed if we're
-			// able.
-			shouldMarkCompleted := true
-			if collectUntilExpiration.Get(&r.st.SV) {
-				// Two other conditions need to hold true for us to continue
-				// capturing future traces, i.e. not mark this request as
-				// completed.
-				// - Requests need to be of the sampling sort (also implies
-				//   there's a latency threshold) -- a crude measure to prevent
-				//   against unbounded collection;
-				// - Requests need to have an expiration set -- same reason as
-				// above.
-				if req.samplingProbability > 0 && !req.expiresAt.IsZero() {
-					shouldMarkCompleted = false
-				}
-			}
-			_, err := txn.ExecEx(ctx, "stmt-diag-mark-completed", txn.KV(),
-				sessiondata.NodeUserSessionDataOverride,
-				"UPDATE system.statement_diagnostics_requests "+
-					"SET completed = $1, statement_diagnostics_id = $2 WHERE id = $3",
-				shouldMarkCompleted, diagID, requestID)
-			if err != nil {
-				return err
-			}
-		} else {
-			// Insert a completed request into system.statement_diagnostics_request.
-			// This is necessary because the UI uses this table to discover completed
-			// diagnostics.
-			//
-			// This bundle was collected via explicit EXPLAIN ANALYZE (DEBUG).
-			_, err := txn.ExecEx(ctx, "stmt-diag-add-completed", txn.KV(),
-				sessiondata.NodeUserSessionDataOverride,
-				"INSERT INTO system.statement_diagnostics_requests"+
-					" (completed, statement_fingerprint, statement_diagnostics_id, requested_at)"+
-					" VALUES (true, $1, $2, $3)",
-				stmtFingerprint, diagID, collectionTime)
-			if err != nil {
-				return err
-			}
-		}
+		diagID = id
 		return nil
 	})
+
+	return diagID, err
+}
+
+func (r *Registry) innerInsertStatementDiagnostics(
+	ctx context.Context, diagnostic StmtDiagnostic, txn isql.Txn,
+) (CollectedInstanceID, error) {
+	var diagID CollectedInstanceID
+	if diagnostic.requestID != 0 {
+		row, err := txn.QueryRowEx(ctx, "stmt-diag-check-completed", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			"SELECT count(1) FROM system.statement_diagnostics_requests WHERE id = $1 AND completed = false",
+			diagnostic.requestID)
+		if err != nil {
+			return diagID, err
+		}
+		if row == nil {
+			return diagID, errors.New("failed to check completed statement diagnostics")
+		}
+		cnt := int(*row[0].(*tree.DInt))
+		if cnt == 0 {
+			// Someone else already marked the request as completed. We've traced for nothing.
+			// This can only happen once per node, per request since we're going to
+			// remove the request from the registry.
+			return diagID, nil
+		}
+	}
+
+	// Generate the values that will be inserted.
+	errorVal := tree.DNull
+	if diagnostic.collectionErr != nil {
+		errorVal = tree.NewDString(diagnostic.collectionErr.Error())
+	}
+
+	bundleChunksVal := tree.NewDArray(types.Int)
+	bundleToUpload := diagnostic.bundle
+	for len(bundleToUpload) > 0 {
+		chunkSize := int(bundleChunkSize.Get(&r.st.SV))
+		chunk := bundleToUpload
+		if len(chunk) > chunkSize {
+			chunk = chunk[:chunkSize]
+		}
+		bundleToUpload = bundleToUpload[len(chunk):]
+
+		// Insert the chunk into system.statement_bundle_chunks.
+		row, err := txn.QueryRowEx(
+			ctx, "stmt-bundle-chunks-insert", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			"INSERT INTO system.statement_bundle_chunks(description, data) VALUES ($1, $2) RETURNING id",
+			"statement diagnostics bundle",
+			tree.NewDBytes(tree.DBytes(chunk)),
+		)
+		if err != nil {
+			return diagID, err
+		}
+		if row == nil {
+			return diagID, errors.New("failed to check statement bundle chunk")
+		}
+		chunkID := row[0].(*tree.DInt)
+		if err := bundleChunksVal.Append(chunkID); err != nil {
+			return diagID, err
+		}
+	}
+
+	collectionTime := timeutil.Now()
+
+	// Insert the collection metadata into system.statement_diagnostics.
+	row, err := txn.QueryRowEx(
+		ctx, "stmt-diag-insert", txn.KV(),
+		sessiondata.NodeUserSessionDataOverride,
+		"INSERT INTO system.statement_diagnostics "+
+			"(statement_fingerprint, statement, collected_at, bundle_chunks, error) "+
+			"VALUES ($1, $2, $3, $4, $5) RETURNING id",
+		diagnostic.stmtFingerprint, diagnostic.stmt, collectionTime, bundleChunksVal, errorVal,
+	)
 	if err != nil {
-		return 0, err
+		return diagID, err
+	}
+	if row == nil {
+		return diagID, errors.New("failed to insert statement diagnostics")
+	}
+	diagID = CollectedInstanceID(*row[0].(*tree.DInt))
+
+	if diagnostic.requestID != 0 {
+		// Link the request from system.statement_diagnostics_request to the
+		// diagnostic ID we just collected, marking it as completed if we're
+		// able.
+		shouldMarkCompleted := true
+		if collectUntilExpiration.Get(&r.st.SV) {
+			// Two other conditions need to hold true for us to continue
+			// capturing future traces, i.e. not mark this request as
+			// completed.
+			// - Requests need to be of the sampling sort (also implies
+			//   there's a latency threshold) -- a crude measure to prevent
+			//   against unbounded collection;
+			// - Requests need to have an expiration set -- same reason as
+			// above.
+			if diagnostic.req.samplingProbability > 0 && !diagnostic.req.expiresAt.IsZero() {
+				shouldMarkCompleted = false
+			}
+		}
+		_, err := txn.ExecEx(ctx, "stmt-diag-mark-completed", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			"UPDATE system.statement_diagnostics_requests "+
+				"SET completed = $1, statement_diagnostics_id = $2 WHERE id = $3",
+			shouldMarkCompleted, diagID, diagnostic.requestID)
+		if err != nil {
+			return diagID, err
+		}
+	} else {
+		// Insert a completed request into system.statement_diagnostics_request.
+		// This is necessary because the UI uses this table to discover completed
+		// diagnostics.
+		//
+		// This bundle was collected via explicit EXPLAIN ANALYZE (DEBUG).
+		_, err := txn.ExecEx(ctx, "stmt-diag-add-completed", txn.KV(),
+			sessiondata.NodeUserSessionDataOverride,
+			"INSERT INTO system.statement_diagnostics_requests"+
+				" (completed, statement_fingerprint, statement_diagnostics_id, requested_at)"+
+				" VALUES (true, $1, $2, $3)",
+			diagnostic.stmtFingerprint, diagID, collectionTime)
+		if err != nil {
+			return diagID, err
+		}
 	}
 	return diagID, nil
 }

--- a/pkg/sql/stmtdiagnostics/txn_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/txn_diagnostics.go
@@ -1,0 +1,284 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package stmtdiagnostics
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+// TxnRequest describes a transaction diagnostic request for which a diagnostic
+// bundle should be collected.
+type TxnRequest struct {
+	txnFingerprintId    uint64
+	stmtFingerprintsId  []uint64
+	redacted            bool
+	username            string
+	expiresAt           time.Time
+	minExecutionLatency time.Duration
+	samplingProbability float64
+}
+
+func (t *TxnRequest) StmtFingerprintIds() []uint64 {
+	return t.stmtFingerprintsId
+}
+
+func (t *TxnRequest) IsRedacted() bool {
+	return t.redacted
+}
+
+func (t *TxnRequest) Username() string {
+	return t.username
+}
+
+func (t *TxnRequest) isExpired(now time.Time) bool {
+	return !t.expiresAt.IsZero() && t.expiresAt.Before(now)
+}
+
+func (t *TxnRequest) isConditional() bool {
+	return t.minExecutionLatency != 0
+}
+
+// TxnDiagnostic is a container for all the diagnostic data that has been
+// collected and will be persisted for a transaction. This will be downloadable
+// as a transaction diagnostic bundle
+type TxnDiagnostic struct {
+	stmtDiagnostics []StmtDiagnostic
+}
+
+func NewTxnDiagnostic(stmtDiagnostics []StmtDiagnostic) TxnDiagnostic {
+	return TxnDiagnostic{stmtDiagnostics: stmtDiagnostics}
+}
+
+// TxnRegistry maintains a view on the transactions on which a diagnostic
+// bundle should be collected. It is responsible for saving new requests
+// to the transaction diagnostics requests table, deciding whether a
+// diagnostic bundle should be collected for a transaction, and persisting
+// recorded diagnostics to the transaction diagnostics table.
+type TxnRegistry struct {
+	st           *cluster.Settings
+	db           isql.DB
+	StmtRegistry *Registry
+	mu           struct {
+		// NOTE: This lock can't be held while the registry runs any statements
+		// internally; it'd deadlock.
+		syncutil.Mutex
+		// requests is a map of all the transaction diagnostic requests that are
+		// pending to be collected. Requests will be removed from this map once
+		// it has been fulfilled, has expired, or if moved to the
+		// unconditionalOngoingRequests map.
+		requests map[RequestID]TxnRequest
+		// unconditionalOngoingRequests contains requests that are currently being
+		// recorded and expected to be recorded unconditionally. This means that
+		// these requests should be recorded on their next execution, regardless
+		// of the transaction's latency or other conditions.
+		unconditionalOngoingRequests map[RequestID]TxnRequest
+		rand                         *rand.Rand
+	}
+}
+
+func NewTxnRegistry(
+	db isql.DB, st *cluster.Settings, stmtDiagnosticsRegistry *Registry,
+) *TxnRegistry {
+	r := &TxnRegistry{
+		db:           db,
+		st:           st,
+		StmtRegistry: stmtDiagnosticsRegistry,
+	}
+	r.mu.rand = rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	r.mu.requests = make(map[RequestID]TxnRequest)
+	r.mu.unconditionalOngoingRequests = make(map[RequestID]TxnRequest)
+	return r
+}
+
+// ShouldStartTxnDiagnostic returns the first txn request whose first
+// statement fingerprint id matches the provided stmtFingerprintId. There may
+// be multiple transaction diagnostic requests that the stmtFingerprintId
+// matches, in which case we will stop at the first one we find.
+func (r *TxnRegistry) ShouldStartTxnDiagnostic(
+	ctx context.Context, stmtFingerprintId uint64,
+) (shouldCollect bool, reqID RequestID, req TxnRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.mu.requests) == 0 {
+		return false, 0, req
+	}
+
+	for id, f := range r.mu.requests {
+		if len(f.stmtFingerprintsId) > 0 && f.stmtFingerprintsId[0] == stmtFingerprintId {
+			if f.isExpired(timeutil.Now()) {
+				delete(r.mu.requests, id)
+				return false, 0, req
+			}
+			req = f
+			reqID = id
+			break
+		}
+	}
+	if reqID == 0 {
+		return false, 0, TxnRequest{}
+	}
+
+	// Unconditional requests are those that will be recorded on the next
+	// execution. In this case, we move the request to the unconditional
+	// ongoing requests map, so that it is not considered for future
+	// transactions until it is reset.
+	if !req.isConditional() {
+		r.mu.unconditionalOngoingRequests[reqID] = req
+		delete(r.mu.requests, reqID)
+	}
+
+	if req.samplingProbability == 0 || r.mu.rand.Float64() < req.samplingProbability {
+		return true, reqID, req
+	}
+	return false, 0, TxnRequest{}
+}
+
+func (r *TxnRegistry) InsertTxnRequest(
+	ctx context.Context,
+	txnFingerprintId uint64,
+	stmtFingerprintIds []uint64,
+	username string,
+	samplingProbability float64,
+	minExecutionLatency time.Duration,
+	expiresAfter time.Duration,
+	redacted bool,
+) error {
+	if samplingProbability != 0 {
+		if samplingProbability < 0 || samplingProbability > 1 {
+			return errors.Newf(
+				"expected sampling probability in range [0.0, 1.0], got %f",
+				samplingProbability)
+		}
+		if minExecutionLatency == 0 {
+			return errors.Newf(
+				"got non-zero sampling probability %f and empty min exec latency",
+				samplingProbability)
+		}
+	}
+
+	var reqID RequestID = RequestID(rand.Int())
+	var expiresAt time.Time
+	if expiresAfter != 0 {
+		expiresAt = timeutil.Now().Add(expiresAfter)
+	}
+	// TODO: insert the request into system.txn_diagnostics_requests once the table is made
+	func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.addTxnRequestInternalLocked(
+			ctx, reqID, txnFingerprintId, stmtFingerprintIds, samplingProbability,
+			minExecutionLatency, expiresAt, redacted, username,
+		)
+	}()
+
+	return nil
+}
+
+// ResetTxnRequest moves the TxnRequest of the given requestID from the ongoing
+// requests map back to the requests map, which makes it available to be picked
+// up to be recorded again.
+func (r *TxnRegistry) ResetTxnRequest(requestID RequestID) (req TxnRequest, ok bool) {
+	if requestID == 0 {
+		return TxnRequest{}, false
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	req, ok = r.mu.unconditionalOngoingRequests[requestID]
+	if !ok {
+		return TxnRequest{}, false
+	}
+
+	delete(r.mu.unconditionalOngoingRequests, requestID)
+	r.mu.requests[requestID] = req
+
+	return req, true
+}
+
+// InsertTxnDiagnostic persists the collected transaction diagnostic bundle. It
+// will persist all the collected statement diagnostic bundles as well as the
+// transaction trace, and update the request as completed.
+func (r *TxnRegistry) InsertTxnDiagnostic(
+	ctx context.Context, requestId RequestID, request TxnRequest, diagnostic TxnDiagnostic,
+) (CollectedInstanceID, error) {
+	var txnDiagnosticId CollectedInstanceID
+	err := r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		txn.KV().SetDebugName("txn-diag-insert-bundle")
+		stmtDiagnostics := tree.NewDArray(types.Int)
+		for _, sd := range diagnostic.stmtDiagnostics {
+			id, err := r.StmtRegistry.innerInsertStatementDiagnostics(ctx, sd, txn)
+			if err != nil {
+				return err
+			}
+			if err = stmtDiagnostics.Append(tree.NewDInt(tree.DInt(id))); err != nil {
+				return err
+			}
+		}
+
+		txnDiagnosticId = CollectedInstanceID(rand.Int())
+
+		// TODO: insert into txn_diagnostics once the table is made
+
+		// TODO: mark request complete in txn_diagnostics_requests once the table is made
+
+		return nil
+	})
+
+	return txnDiagnosticId, err
+}
+
+func (r *TxnRegistry) addTxnRequestInternalLocked(
+	ctx context.Context,
+	id RequestID,
+	txnFingerprintId uint64,
+	stmtFingerprintsId []uint64,
+	samplingProbability float64,
+	minExecutionLatency time.Duration,
+	expiresAt time.Time,
+	redacted bool,
+	username string,
+) {
+	if r.findTxnRequestLocked(id) {
+		return
+	}
+	if r.mu.requests == nil {
+		r.mu.requests = make(map[RequestID]TxnRequest)
+	}
+	request := TxnRequest{
+		txnFingerprintId:    txnFingerprintId,
+		stmtFingerprintsId:  stmtFingerprintsId,
+		redacted:            redacted,
+		username:            username,
+		expiresAt:           expiresAt,
+		minExecutionLatency: minExecutionLatency,
+		samplingProbability: samplingProbability,
+	}
+	r.mu.requests[id] = request
+}
+
+func (r *TxnRegistry) findTxnRequestLocked(requestID RequestID) bool {
+	f, ok := r.mu.requests[requestID]
+	if ok {
+		if f.isExpired(timeutil.Now()) {
+			delete(r.mu.requests, requestID)
+		}
+		return true
+	}
+	_, ok = r.mu.unconditionalOngoingRequests[requestID]
+	return ok
+}

--- a/pkg/sql/stmtdiagnostics/txn_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/txn_diagnostics_test.go
@@ -1,0 +1,337 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package stmtdiagnostics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxnRegistry_ShouldStartTxnDiagnostic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("request_found", func(t *testing.T) {
+		registry := NewTxnRegistry(noopDb{}, nil, nil)
+		requestId := RequestID(1)
+		expectedRequest := TxnRequest{
+			txnFingerprintId:    1111,
+			stmtFingerprintsId:  []uint64{1111, 2222, 3333},
+			redacted:            false,
+			username:            "",
+			expiresAt:           time.Time{},
+			minExecutionLatency: 0,
+			samplingProbability: 0,
+		}
+		registry.mu.requests[requestId] = expectedRequest
+		shouldCollect, id, actual := registry.ShouldStartTxnDiagnostic(context.Background(), 1111)
+		require.Equal(t, expectedRequest, actual)
+		require.Equal(t, requestId, id)
+		require.True(t, shouldCollect)
+		require.Empty(t, registry.mu.requests)
+		require.Contains(t, registry.mu.unconditionalOngoingRequests, requestId)
+	})
+
+	t.Run("request_not_found", func(t *testing.T) {
+		registry := NewTxnRegistry(noopDb{}, nil, nil)
+		requestId := RequestID(1)
+		expectedRequest := TxnRequest{
+			txnFingerprintId:    1111,
+			stmtFingerprintsId:  []uint64{1111, 2222, 3333},
+			redacted:            false,
+			username:            "",
+			expiresAt:           time.Time{},
+			minExecutionLatency: 0,
+			samplingProbability: 0,
+		}
+		registry.mu.requests[requestId] = expectedRequest
+		shouldCollect, id, actual := registry.ShouldStartTxnDiagnostic(context.Background(), 2222)
+		require.Equal(t, TxnRequest{}, actual)
+		require.Equal(t, RequestID(0), id)
+		require.False(t, shouldCollect)
+	})
+	t.Run("request_expired", func(t *testing.T) {
+		registry := NewTxnRegistry(noopDb{}, nil, nil)
+		requestId := RequestID(1)
+		expectedRequest := TxnRequest{
+			txnFingerprintId:    1111,
+			stmtFingerprintsId:  []uint64{1111, 2222, 3333},
+			redacted:            false,
+			username:            "",
+			expiresAt:           timeutil.Now().Add(-time.Hour),
+			minExecutionLatency: 0,
+			samplingProbability: 0,
+		}
+		registry.mu.requests[requestId] = expectedRequest
+		shouldCollect, id, actual := registry.ShouldStartTxnDiagnostic(context.Background(), 1111)
+		require.Equal(t, TxnRequest{}, actual)
+		require.Equal(t, RequestID(0), id)
+		require.False(t, shouldCollect)
+		require.Empty(t, registry.mu.requests)
+		require.Empty(t, registry.mu.unconditionalOngoingRequests)
+	})
+
+	t.Run("request_notCondition", func(t *testing.T) {
+		registry := NewTxnRegistry(noopDb{}, nil, nil)
+		requestId := RequestID(1)
+		expectedRequest := TxnRequest{
+			txnFingerprintId:    1111,
+			stmtFingerprintsId:  []uint64{1111, 2222, 3333},
+			redacted:            false,
+			username:            "",
+			expiresAt:           time.Time{},
+			minExecutionLatency: 1,
+			samplingProbability: .01,
+		}
+		registry.mu.requests[requestId] = expectedRequest
+		testutils.SucceedsSoon(t, func() error {
+			shouldCollect, id, actual := registry.ShouldStartTxnDiagnostic(context.Background(), 1111)
+			if shouldCollect {
+				// Ensure that the registry still contains the request, even if we are collecting
+				require.Contains(t, registry.mu.requests, id)
+				return errors.New("waiting till we don't find")
+			}
+
+			require.Equal(t, RequestID(0), id)
+			require.Equal(t, TxnRequest{}, actual)
+			require.Contains(t, registry.mu.requests, requestId)
+			return nil
+		})
+	})
+}
+
+func TestTxnRegistry_InsertTxnRequest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	registry := NewTxnRegistry(s.InternalDB().(isql.DB), s.ClusterSettings(), nil)
+
+	t.Run("valid request", func(t *testing.T) {
+		err := registry.InsertTxnRequest(
+			ctx,
+			1111,
+			[]uint64{1111, 2222, 3333},
+			"testuser",
+			0.5,
+			time.Millisecond*100,
+			time.Hour,
+			false,
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, registry.mu.requests)
+	})
+
+	t.Run("invalid sampling probability", func(t *testing.T) {
+		err := registry.InsertTxnRequest(
+			ctx,
+			1111,
+			[]uint64{1111, 2222, 3333},
+			"testuser",
+			1.5,
+			time.Millisecond*100,
+			time.Hour,
+			false,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected sampling probability in range [0.0, 1.0]")
+	})
+
+	t.Run("sampling without latency", func(t *testing.T) {
+		err := registry.InsertTxnRequest(
+			ctx,
+			1111,
+			[]uint64{1111, 2222, 3333},
+			"testuser",
+			0.5,
+			0,
+			time.Hour,
+			false,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "got non-zero sampling probability")
+	})
+
+}
+
+func TestTxnRegistry_InsertTxnRequest_Polling(t *testing.T) {
+	// TODO: create a multi-node cluster to test that it propagates correctly, once persistence is added.
+}
+
+func TestTxnRegistry_ResetTxnRequest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("request_reset", func(t *testing.T) {
+		registry := NewTxnRegistry(noopDb{}, nil, nil)
+		requestId := RequestID(1)
+		expectedRequest := TxnRequest{
+			txnFingerprintId:    1111,
+			stmtFingerprintsId:  []uint64{1111, 2222, 3333},
+			redacted:            false,
+			username:            "",
+			expiresAt:           time.Time{},
+			minExecutionLatency: 0,
+			samplingProbability: 0,
+		}
+		registry.mu.unconditionalOngoingRequests[requestId] = expectedRequest
+
+		require.Empty(t, registry.mu.requests)
+		actualReq, ok := registry.ResetTxnRequest(requestId)
+		require.True(t, ok)
+		require.Equal(t, expectedRequest, actualReq)
+		// unconditionalOngoingRequests should be empty now
+		require.Empty(t, registry.mu.unconditionalOngoingRequests)
+
+		// Should be in the requests map now
+		req, ok := registry.mu.requests[requestId]
+		require.True(t, ok)
+		require.Equal(t, expectedRequest, req)
+	})
+
+	t.Run("request_not_found", func(t *testing.T) {
+		registry := NewTxnRegistry(noopDb{}, nil, nil)
+		requestId := RequestID(1)
+		expectedRequest := TxnRequest{
+			txnFingerprintId:    1111,
+			stmtFingerprintsId:  []uint64{1111, 2222, 3333},
+			redacted:            false,
+			username:            "",
+			expiresAt:           time.Time{},
+			minExecutionLatency: 0,
+			samplingProbability: 0,
+		}
+		registry.mu.unconditionalOngoingRequests[requestId] = expectedRequest
+		actualReq, ok := registry.ResetTxnRequest(RequestID(2))
+		require.False(t, ok)
+		require.Equal(t, TxnRequest{}, actualReq)
+		require.Contains(t, registry.mu.unconditionalOngoingRequests, requestId)
+	})
+}
+
+func TestTxnRegistry_InsertTxnDiagnostic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	// Create a statement registry for testing
+	stmtRegistry := NewRegistry(s.InternalDB().(isql.DB), s.ClusterSettings())
+	registry := NewTxnRegistry(s.InternalDB().(isql.DB), s.ClusterSettings(), stmtRegistry)
+
+	runner := sqlutils.MakeSQLRunner(srv.SQLConn(t))
+
+	// Verify table is initially empty
+	var count int
+	runner.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics").Scan(&count)
+	initialCount := count
+	require.Zero(t, initialCount)
+	// Create test data
+	requestID := RequestID(123)
+	request := TxnRequest{
+		txnFingerprintId:    1111,
+		stmtFingerprintsId:  []uint64{1111, 2222},
+		redacted:            false,
+		username:            "testuser",
+		expiresAt:           time.Time{},
+		minExecutionLatency: 0,
+		samplingProbability: 0,
+	}
+
+	// Create mock statement diagnostics for the transaction
+	req1 := Request{
+		fingerprint:         "SELECT _ FROM test",
+		planGist:            "test-gist-1",
+		antiPlanGist:        false,
+		samplingProbability: 0,
+		minExecutionLatency: 0,
+		expiresAt:           time.Time{},
+		redacted:            false,
+		username:            "testuser",
+	}
+	req2 := Request{
+		fingerprint:         "INSERT INTO test VALUES (_)",
+		planGist:            "test-gist-2",
+		antiPlanGist:        false,
+		samplingProbability: 0,
+		minExecutionLatency: 0,
+		expiresAt:           time.Time{},
+		redacted:            false,
+		username:            "testuser",
+	}
+
+	stmtDiag1 := NewStmtDiagnostic(
+		RequestID(0),
+		req1,
+		"SELECT _ FROM test",
+		"SELECT 1 FROM test",
+		[]byte("mock bundle data 1"),
+		nil,
+	)
+	stmtDiag2 := NewStmtDiagnostic(
+		RequestID(0),
+		req2,
+		"INSERT INTO test VALUES (_)",
+		"INSERT INTO test VALUES (1)",
+		[]byte("mock bundle data 2"),
+		nil,
+	)
+
+	txnDiagnostic := NewTxnDiagnostic([]StmtDiagnostic{stmtDiag1, stmtDiag2})
+
+	// Insert the transaction diagnostic
+	diagID, err := registry.InsertTxnDiagnostic(ctx, requestID, request, txnDiagnostic)
+	require.NoError(t, err)
+	require.NotZero(t, diagID)
+
+	// Verify that statement_diagnostics table now has entries
+	runner.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics").Scan(&count)
+	require.Greater(t, count, initialCount, "statement_diagnostics table should have new entries")
+
+	// Verify we have exactly 2 new statement diagnostic entries (one for each statement in the transaction)
+	require.Equal(t, initialCount+2, count, "should have added 2 statement diagnostic entries")
+
+	// TODO: Verify that data is in the txn_diagnostics table once it is created
+
+}
+
+type noopDb struct{}
+
+func (n noopDb) KV() *kv.DB {
+	return nil
+}
+
+func (n noopDb) Txn(
+	ctx context.Context, f func(context.Context, isql.Txn) error, option ...isql.TxnOption,
+) error {
+	return nil
+}
+
+func (n noopDb) Executor(option ...isql.ExecutorOption) isql.Executor {
+	return nil
+}
+
+var _ isql.DB = noopDb{}


### PR DESCRIPTION
Adds a new TxnRegistry and other supporting structs to support
the collection of transaction diagnostic bundles. The TxnRegistry
adds functionality to:
 - Register a TxnRequest
    - defines the criteria for collecting a transaction
      diagnostic bundle
 - Start collecting a transaction bundle
    - This is done by checking that a statement fingerprint id
      matches the first statement fingerprint id in a TxnRequest
 - Save a transaction diagnostic bundle upon completion to be
   downloaded in the future

Since the system tables to persist transaction diagnostics and
transaction diagnostics requests don't exist yet, this commit
only registers requests in the local registry. A future
commit will add request and diagnostic persistence, as well
as add polling logic to register requests created in other
gateway nodes.

Part of: [CRDB-5342](https://cockroachlabs.atlassian.net/browse/CRDB-5342)
Epic: [CRDB-53541](https://cockroachlabs.atlassian.net/browse/CRDB-53541)
Release note: None