### PR TITLE
ci/nightly: stabilize UrlChecker

### DIFF
--- a/build/teamcity/cockroach/nightlies/url_check.sh
+++ b/build/teamcity/cockroach/nightlies/url_check.sh
@@ -14,5 +14,5 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run url check"
-run_bazel build/teamcity/cockroach/nightlies/url_check_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GITHUB_API_TOKEN -e GOOGLE_EPHEMERAL_CREDENTIALS -e TC_BUILD_BRANCH" run_bazel build/teamcity/cockroach/nightlies/url_check_impl.sh
 tc_end_block "Run url check"

--- a/build/teamcity/cockroach/nightlies/url_check_impl.sh
+++ b/build/teamcity/cockroach/nightlies/url_check_impl.sh
@@ -8,4 +8,7 @@
 
 set -xeuo pipefail
 
+echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
+gcloud auth activate-service-account --key-file=creds.json
+
 bazel run //pkg/cmd/urlcheck --run_under="cd $PWD && "

--- a/docs/RFCS/20160331_index_hints.md
+++ b/docs/RFCS/20160331_index_hints.md
@@ -84,7 +84,7 @@ More syntax and detailed information [here][1].
 PG does not provide support for hints. Instead they provide various knobs for
 tuning the optimizer to do the right thing. Details [here][2].
 
-[2]: http://blog.2ndquadrant.com/hinting_at_postgresql/
+[2]: https://web.archive.org/web/20221224144457/http://blog.2ndquadrant.com/hinting_at_postgresql 
 
 ### Oracle
 

--- a/docs/RFCS/20160425_drain_modes.md
+++ b/docs/RFCS/20160425_drain_modes.md
@@ -239,6 +239,6 @@ being if that seems opportune.
 * Change the lease transfer mechanism so a transferrer can transfer its
   timestamp cache's high water mark which would act as the low water mark of the
   recipient's timestamp cache. This is conditioned on not [inserting reads in
-  the command queue](https://forum.cockroachlabs.com/t/why-do-we-keep-read-commands-in-the-command-queue/360).
+  the command queue](https://web.archive.org/web/20210419190146/https://forum.cockroachlabs.com/t/why-do-we-keep-read-commands-in-the-command-queue/360).
 
 # Unresolved questions

--- a/docs/RFCS/20170117_enterprise.md
+++ b/docs/RFCS/20170117_enterprise.md
@@ -137,5 +137,5 @@ and/or in an email to the cluster administrator (address provided when they
 register for the license).
 
 [#14114]: https://github.com/cockroachdb/cockroach/pull/14114
-[business model]: https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/
+[business model]: https://web.archive.org/web/20240529205150/https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/
 [settings table]: https://github.com/cockroachdb/cockroach/pull/14230

--- a/docs/RFCS/20170517_algebraic_data_types.md
+++ b/docs/RFCS/20170517_algebraic_data_types.md
@@ -604,4 +604,4 @@ const (
 
   [\#16240]: https://github.com/cockroachdb/cockroach/pull/16240
   [separate RFC]: https://github.com/cockroachdb/cockroach/pull/10055
-  [Clang]: https://clang.llvm.org/docs/LibASTMatchers.html
+  [Clang]: https://web.archive.org/web/20250902012257/https://clang.llvm.org/docs/LibASTMatchers.html 

--- a/docs/RFCS/20170908_sql_optimizer_statistics.md
+++ b/docs/RFCS/20170908_sql_optimizer_statistics.md
@@ -538,7 +538,7 @@ efficient than retrieving each histogram separately).
   data retrieved by the query could also be used to update the
   statistics, though this complicates normal query execution. See also
   [self-tuning
-  histograms](https://ashraf.aboulnaga.me/pubs/sigmod99sthist.pdf).
+  histograms](https://web.archive.org/web/20240413134934/https://ashraf.aboulnaga.me/pubs/sigmod99sthist.pdf).
 
 * If the stats haven't been updated in a long time and we happen to be
   doing a full table-range scan for some query, we might as well

--- a/docs/RFCS/20171214_computed_columns.md
+++ b/docs/RFCS/20171214_computed_columns.md
@@ -168,4 +168,4 @@ contains the expression used to compute the column otherwise.
 # Unresolved Questions
 [Partitioning]: https://github.com/cockroachdb/cockroach/blob/aa61db043e9c54c0b83a405cd76ce0ec7cc6a35d/docs/RFCS/20170921_sql_partitioning.md
 [Query planning changes in the RFC]: https://github.com/cockroachdb/cockroach/blob/aa61db043e9c54c0b83a405cd76ce0ec7cc6a35d/docs/RFCS/20170921_sql_partitioning.md#query-planning-changes
-[MySQL's extension]: https://dev.mysql.com/doc/refman/5.7/en/columns-table.html
+[MySQL's extension]: https://dev.mysql.com/doc/refman/8.4/en/information-schema-columns-table.html 

--- a/docs/RFCS/20180501_change_data_capture.md
+++ b/docs/RFCS/20180501_change_data_capture.md
@@ -707,7 +707,7 @@ an alias if we build support for CockroachDB to CockroachDB replication.
 [kafka]: https://kafka.apache.org/intro
 [other cdc syntaxes]: #appendix-other-cdc-syntaxes
 [proposed and sent through raft]: https://github.com/cockroachdb/cockroach/blob/381e4dafa596c5f3621a48fcb5fce1f62b18c186/docs/RFCS/20160420_proposer_evaluated_kv.md
-[schema resolution]: http://avro.apache.org/docs/current/spec.html#Schema+Resolution
+[schema resolution]: https://avro.apache.org/docs/++version++/specification/#schema-resolution 
 [sql table sink]: #sql-table-sink
 [system jobs]: https://github.com/cockroachdb/cockroach/blob/381e4dafa596c5f3621a48fcb5fce1f62b18c186/docs/RFCS/20170215_system_jobs.md
 [transaction grouped changes]: #no-transaction-grouped-changes

--- a/docs/RFCS/20181204_copysets.md
+++ b/docs/RFCS/20181204_copysets.md
@@ -375,7 +375,7 @@ function. This design in this RFC is something simple and the respective
 algorithms can be tweaked independently later.
 
 ### Chainsets
-[Chainsets](http://hackingdistributed.com/2014/02/14/chainsets/) is one way
+[Chainsets](https://web.archive.org/web/20240714222832/https://hackingdistributed.com/2014/02/14/chainsets/) is one way
 to make incremental changes to copysets, but again potentially at the cost
 of reduced locality diversity. The length of the chain used in chainsets
 could be considered equivalent to replication factor in cockroach.

--- a/docs/RFCS/20191113_vectorized_external_storage.md
+++ b/docs/RFCS/20191113_vectorized_external_storage.md
@@ -68,7 +68,7 @@ sorts and GRACE hash joins. This ends up being a lot more performant
 
 The proposal in this RFC is to introduce an on-disk queue data structure
 backed by flat files where batches of columnar data are serialized
-using the [Arrow IPC format](https://arrow.apache.org/docs/ipc.html).
+using the [Arrow IPC format](https://arrow.apache.org/docs/format/IPC.html).
 This queue can be used directly by most operators that need to buffer
 unlimited data in FIFO order. There will also be an additional abstraction
 that will give the caller the option to use separate queues as distinct
@@ -145,7 +145,7 @@ case of orphaned files when `recover`ing from possible `panic`s).
 
 Thankfully, serialization of `coldata.Batch`es is already
 implemented in the `colserde` package using the [Arrow IPC
-format](https://arrow.apache.org/docs/ipc.html). These serialized bytes will
+format](https://arrow.apache.org/docs/format/IPC.html). These serialized bytes will
 be buffered until a flush is required, at which point they are written to a
 file with an accompanying file footer. The start offset of these written bytes
 as well as the number of bytes written will be stored for when the batches

--- a/docs/RFCS/20200421_geospatial.md
+++ b/docs/RFCS/20200421_geospatial.md
@@ -64,7 +64,7 @@ The specs we refer to in this document are:
 
 * OGC: [v1.1](http://portal.opengeospatial.org/files/?artifact_id=13228)
 ** NOTE: For 20.2, we will aim to support v1.1 as PostGIS does
-* SQL/MM: [ISO 13249-3](http://jtc1sc32.org/doc/N1101-1150/32N1107-WD13249-3--spatial.pdf)
+* SQL/MM: [ISO 13249-3](https://web.archive.org/web/20071212154300/http://jtc1sc32.org/doc/N1101-1150/32N1107-WD13249-3--spatial.pdf)
 
 Our approach will leverage the open-source geometry libraries used by
 PostGIS whenever possible. These libraries are widely used and tested,
@@ -843,7 +843,7 @@ Disadvantages of Divide the Objects:
   read latencies
 * Object insertions and balancing require locking
 * How to effectively horizontally distribute an R tree is an [open
-  question](https://www.anand-iyer.com/papers/sift-socc2017.pdf).
+  question](https://web.archive.org/web/20230526201606/https://www.anand-iyer.com/papers/sift-socc2017.pdf).
 * Bulk ingest (IMPORT) requires coordination between nodes as the
   tree's shape depends on its contents
 * A bounding box can return many false positives

--- a/docs/RFCS/20200811_non_blocking_txns.md
+++ b/docs/RFCS/20200811_non_blocking_txns.md
@@ -297,9 +297,9 @@ CockroachCloud.
 
 Wide area network (WAN) round-trip time (RTT) latencies can be as large as 200ms
 in the global deployment scenarios that we are interested in (ref:
-[AWS](https://docs.aviatrix.com/_images/inter_region_latency.png),
-[Azure](https://docs.aviatrix.com/_images/arm_inter_region_latency.png),
-[GCP](https://docs.aviatrix.com/_images/gcp_inter_region_latency.png)). The
+[AWS](https://web.archive.org/web/20210916044213/https://docs.aviatrix.com/_images/inter_region_latency.png),
+[Azure](https://web.archive.org/web/20200629231656/https://docs.aviatrix.com/_images/arm_inter_region_latency.png),
+[GCP](https://web.archive.org/web/20201027165100/https://docs.aviatrix.com/_images/gcp_inter_region_latency.png)). The
 current default clock uncertainty offset is 500ms. This proposal explores the
 half of the design space in which clock uncertainty bounds drop below WAN RTT
 time. Within this regime, it becomes cheaper to establish causality between
@@ -380,7 +380,7 @@ servable locally in all regions, not just in the single region that the tables'
 leaseholders happens to land. A common example of this arises with foreign keys
 on static tables.
 
-Until now, our best solution to this problem has been [duplicated indexes](https://www.cockroachlabs.com/docs/v19.1/pology-duplicate-indexes.html).
+Until now, our best solution to this problem has been [duplicated indexes](https://www.cockroachlabs.com/docs/v20.1/topology-duplicate-indexes).
 This solution requires users to create a collection of secondary SQL indexes that
 each contain every single column in the table. Users then use zone configurations
 to place a leaseholder for each of these indexes in every geographical locality.
@@ -623,7 +623,7 @@ call returns, no other node's HLC clock can have a value less that
 
 #### Commit Wait: Not Just for the Cool Kid With the Fancy Hardware
 
-The original [Spanner paper](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/65b514eda12d025585183a641b5a9e096a3c4be5.pdf)
+The original [Spanner paper](https://static.googleusercontent.com/media/research.google.com/en//archive/spanner-osdi2012.pdf)
 discussed how the system added a delay to all read-write transactions before
 returning to the client to ensure that all nodes in the system had clocks in
 excess of the commit timestamp of a transaction before that transaction was
@@ -1080,7 +1080,7 @@ complicates our consistency story, but may make a very useful option.
 
 ## References
 
-[1] Spanner: https://storage.googleapis.com/pub-tools-public-publication-data/pdf/65b514eda12d025585183a641b5a9e096a3c4be5.pdf
+[1] Spanner: https://static.googleusercontent.com/media/research.google.com/en//archive/spanner-osdi2012.pdf
   * Specifically, see _Section 4.2.3. Schema-Change Transactions_, which briefly mentions a scheme that sounds similar to this, although for the purpose of running large schema changes.
 
 [2] Logical Physical Clocks and Consistent Snapshots in Globally Distributed Databases: https://cse.buffalo.edu/tech-reports/2014-04.pdf
@@ -1091,6 +1091,6 @@ complicates our consistency story, but may make a very useful option.
 
 [5] SLOG: Serializable, Low-latency, Geo-replicated Transactions: https://www.cs.umd.edu/~abadi/papers/1154-Abadi.pdf
 
-[6] Large-scale Incremental Processing Using Distributed Transactions and Notifications: https://storage.googleapis.com/pub-tools-public-publication-data/pdf/36726.pdf
+[6] Large-scale Incremental Processing Using Distributed Transactions and Notifications: https://www.usenix.org/legacy/event/osdi10/tech/full_papers/Peng.pdf
 
 [7] KuaFu: Closing the Parallelism Gap in Database Replication: https://www.cs.cmu.edu/afs/cs/Web/People/dongz/papers/KuaFu.pdf

--- a/docs/RFCS/20220126_partial_statistics_collection.md
+++ b/docs/RFCS/20220126_partial_statistics_collection.md
@@ -451,7 +451,7 @@ the most relevant are:
 
 1. [Gibbons, Phillip B., Yossi Matias, and Viswanath Poosala. "Fast incremental
    maintenance of approximate histograms." In _VLDB_, vol. 97, pp. 466-475. 1997.](
-   http://www.mathcs.emory.edu/~cheung/Courses/584/Syllabus/papers/Histogram/Gibbons-fast-incr-histogram.pdf)
+   https://www.vldb.org/conf/1997/P466.PDF)
 
 The solution described in this paper enables keeping histograms quite fresh and
 up-to-date, but it requires maintaining a backing sample (similar to a partial
@@ -463,7 +463,7 @@ RFC.
 2. [Gibbons, Phillip B., and Yossi Matias. "New sampling-based summary statistics
    for improving approximate query answers." In _Proceedings of the 1998 ACM
    SIGMOD international conference on Management of data_, pp. 331-342. 1998.](
-   https://www.researchgate.net/profile/Yossi-Matias/publication/2634326_New_Sampling-Based_Summary_Statistics_for_Improving_Approximate_Query_Answers/links/0fcfd50baafa968854000000/New-Sampling-Based-Summary-Statistics-for-Improving-Approximate-Query-Answers.pdf)
+   https://www.cs.cmu.edu/~christos/courses/826-resources/PAPERS+BOOK/p331-gibbons.pdf)
 
 This paper is by the same authors as above, and builds on the prior work that
 uses a backing sample. This paper adds two additional types of summary
@@ -474,7 +474,7 @@ less relevant, although may be worth considering in the future.
 3. [Cormode, Graham, and Shan Muthukrishnan. "What's hot and what's not: tracking
    most frequent items dynamically." _ACM Transactions on Database Systems
    (TODS)_ 30, no. 1 (2005): 249-278.](
-   http://www.mathcs.emory.edu/~cheung/Courses/584/Syllabus/papers/Histogram/2005-Cormode-Histogram.pdf)
+   https://dimacs.rutgers.edu/~graham/pubs/papers/whatshot-tods.pdf)
 
 This is a solution for keeping track of “hot” values that appear many times in a
 table, and keeping the list of hot items up to date. Tracking hot items is not
@@ -484,7 +484,7 @@ paper may be useful at that point.
 4. [Aboulnaga, Ashraf, and Surajit Chaudhuri. "Self-tuning histograms: Building
    histograms without looking at data." _ACM SIGMOD Record_ 28, no. 2 (1999):
    181-192.](
-   https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.39.4864&rep=rep1&type=pdf)
+   https://sigmodrecord.org/publications/sigmodRecord/9906/Self-tuning%20histograms_%20building%20histograms%20without%20looking%20at%20data.pdf)
 
 This approach is somewhat similar to our idea of triggering automatic stats
 collection based on queries that have scans with stale stats. But instead of
@@ -511,7 +511,7 @@ above.
 6. [Thaper, Nitin, Sudipto Guha, Piotr Indyk, and Nick Koudas. "Dynamic
    multidimensional histograms." In _Proceedings of the 2002 ACM SIGMOD
    international conference on Management of data_, pp. 428-439. 2002.](
-   https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.132.2078&rep=rep1&type=pdf)
+   https://people.csail.mit.edu/indyk/thaper.pdf)
 
 This paper has many of the same authors as the previous, and also proposes using
 a sketch to maintain histograms over data streams. The difference here is that

--- a/docs/RFCS/20220602_fine_grained_cpu_attribution.md
+++ b/docs/RFCS/20220602_fine_grained_cpu_attribution.md
@@ -463,7 +463,7 @@ Comparison:
 ### eBPF probes
 
 Linux has the ability to define
-[probes](https://www.brendangregg.com/blog/2015-06-28/linux-ftrace-uprobe.html)
+[probes](https://web.archive.org/web/20250811074608/https://www.brendangregg.com/blog/2015-06-28/linux-ftrace-uprobe.html)
 at specific callsites in user-level code (which for us would include the Go
 runtime). This document is a good primer on
 [uprobes](https://github.com/jav/systemtap/blob/master/runtime/uprobes/uprobes.txt)
@@ -569,7 +569,7 @@ Comparison:
   in the eBPF + Go ecosystem might make things progressively less painful
   (libraries to read arguments from the Go stack, decoding Go structs).
     - The out-of-the-box `bpftrace` use of [thread
-      IDs](https://www.brendangregg.com/BPF/bpftrace-cheat-sheet.html) (`tid`
+      IDs](https://web.archive.org/web/20250809232702/https://www.brendangregg.com/BPF/bpftrace-cheat-sheet.html) (`tid`
       in the snippet above) don’t apply to Go, we need glue work to
       [access](https://github.com/surki/misc/blob/c343525e35a96497dd356c38921f25b22c77fcc9/go.stp#L5-L21)
       goroutine IDs.
@@ -614,4 +614,4 @@ Considerations:
   this document proposes.
 
 [release-go]: The official Go archives are built using the steps
-  [here](https://go.googlesource.com/build/+/refs/heads/master/cmd/release/release.go).
+  [here](https://go.dev/doc/install/source).

--- a/docs/RFCS/20220721_sso_authentication.md
+++ b/docs/RFCS/20220721_sso_authentication.md
@@ -283,7 +283,7 @@ Token validation will look like the following:
 CC Console will use the
 [JSON Web Key (JWK) specification](https://openid.net/specs/draft-jones-json-web-key-03.html).
 CC Console will sign tokens with a public/private key pair using
-[RS256 (RSA Digital Signature Algorithm with SHA-256)](https://ldapwiki.com/wiki/RS256).
+[RS256 (RSA Digital Signature Algorithm with SHA-256)](https://web.archive.org/web/20220817220301/https://ldapwiki.com/wiki/RS256).
 The private signing key will rotate once a year, and in the case of an emergency, could be rotated
 immediately. 
 

--- a/docs/RFCS/20230122_read_committed_isolation.md
+++ b/docs/RFCS/20230122_read_committed_isolation.md
@@ -134,7 +134,7 @@ While more complete, these definitions were still based on preventing
 conflicting operations that could lead to anomalies from executing concurrently.
 Adya's dissertation ["Weak Consistency: A Generalized Theory and Optimistic
 Implementations for Distributed
-Transactions"](https://pmg.csail.mit.edu/papers/adya-phd.pdf) (1999) argued that
+Transactions"](https://web.archive.org/web/20250820175955/http://pmg.csail.mit.edu/papers/adya-phd.pdf) (1999) argued that
 this _preventative_ approach is overly restrictive. The definitions were
 "disguised versions of locking" and therefore disallow optimistic and
 multi-versioning schemes. Adya's work generalizes existing isolation levels in
@@ -146,7 +146,7 @@ enough to allow both locking and optimistic transaction implementations (of
 which CockroachDB is a hybrid), we use its formalization where appropriate in
 this proposal. Readers are encouraged to familiarize themselves with the thesis.
 Once they notice the page count, they are encouraged to familiarize themselves
-with the [summary paper](https://pmg.csail.mit.edu/papers/icde00.pdf) instead.
+with the [summary paper](https://web.archive.org/web/20250820180305/http://pmg.csail.mit.edu/papers/icde00.pdf) instead.
 
 Conveniently, [Elle](https://github.com/jepsen-io/elle), a transactional
 consistency checker that we intend to use as part of the [testing for this

--- a/docs/cloud-resources.md
+++ b/docs/cloud-resources.md
@@ -105,4 +105,4 @@ avoid paying for this egress bandwidth, we colocate storage accounts with the
 VMs running the acceptance tests, as we do for test fixtures.
 
 [azcopy]: https://docs.microsoft.com/en-us/azure/storage/storage-use-azcopy-linux
-[azure-blob-storage]: https://docs.microsoft.com/en-us/azure/storage/storage-introduction#blob-storage
+[azure-blob-storage]: https://web.archive.org/web/20250719125806/https://docs.microsoft.com/en-us/azure/storage/storage-introduction#blob-storage

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -588,12 +588,12 @@ https://www.postgresql.org/docs/9.5/catalog-pg-seclabel.html"
 pg_catalog,pg_seclabels,table,node,permanent,prefix,"security labels (empty)
 https://www.postgresql.org/docs/9.6/view-pg-seclabels.html"
 pg_catalog,pg_sequence,table,node,permanent,prefix,"sequences (see also information_schema.sequences)
-https://www.postgresql.org/docs/9.5/catalog-pg-sequence.html"
+https://www.postgresql.org/docs/10/catalog-pg-sequence.html"
 pg_catalog,pg_sequences,table,node,permanent,prefix,"pg_sequences is very similar as pg_sequence.
 https://www.postgresql.org/docs/13/view-pg-sequences.html
 "
 pg_catalog,pg_settings,table,node,permanent,prefix,"session variables (incomplete)
-https://www.postgresql.org/docs/9.5/catalog-pg-settings.html"
+https://www.postgresql.org/docs/9.5/view-pg-settings.html"
 pg_catalog,pg_shadow,table,node,permanent,prefix,"pg_shadow lists properties for roles that are marked as rolcanlogin in pg_authid
 https://www.postgresql.org/docs/13/view-pg-shadow.html"
 pg_catalog,pg_shdepend,table,node,permanent,prefix,"Shared Dependencies (Roles depending on objects). 

--- a/pkg/cli/democluster/demo_locality_list.go
+++ b/pkg/cli/democluster/demo_locality_list.go
@@ -58,7 +58,7 @@ var defaultLocalities = DemoLocalityList{
 	{Tiers: []roachpb.Tier{{Key: "region", Value: "europe-west1"}, {Key: "az", Value: "d"}}},
 }
 
-// Round-trip latencies collected from http://cloudping.co on 2019-09-11.
+// Round-trip latencies collected from https://web.archive.org/web/20250808080622/https://cloudping.co/ on 2019-09-11.
 var localityLatencies = regionlatency.RoundTripPairs{
 	{A: "us-east1", B: "us-west1"}:     66 * time.Millisecond,
 	{A: "us-east1", B: "europe-west1"}: 64 * time.Millisecond,

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -269,7 +269,7 @@ func init() {
 
 // stmtSpec is needed for each top-level bnf file to process.
 // See the wiki page for more details about what these controls do.
-// https://github.com/cockroachdb/docs/wiki/SQL-Grammar-Railroad-Diagram-Changes#structure
+// https://cockroachlabs.atlassian.net/wiki/spaces/ED/pages/1134166645/SQL+Grammar+Documentation
 type stmtSpec struct {
 	name           string
 	stmt           string // if unspecified, uses name

--- a/pkg/cmd/urlcheck/BUILD.bazel
+++ b/pkg/cmd/urlcheck/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/urlcheck",
     visibility = ["//visibility:private"],
-    deps = ["//pkg/cmd/urlcheck/lib/urlcheck"],
+    deps = [
+        "//pkg/cmd/urlcheck/lib/urlcheck",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
 )
 
 go_binary(

--- a/pkg/cmd/urlcheck/lib/urlcheck/BUILD.bazel
+++ b/pkg/cmd/urlcheck/lib/urlcheck/BUILD.bazel
@@ -2,10 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "urlcheck",
-    srcs = ["urlcheck.go"],
+    srcs = [
+        "githubcheck.go",
+        "urlcheck.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_ghemawat_stream//:stream",
     ],

--- a/pkg/cmd/urlcheck/lib/urlcheck/githubcheck.go
+++ b/pkg/cmd/urlcheck/lib/urlcheck/githubcheck.go
@@ -1,0 +1,424 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package urlcheck
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func checkGithubRateLimit(client *http.Client) (limit int, untilReset time.Duration, err error) {
+	resp, err := client.Get("https://api.github.com/rate_limit")
+	if err != nil {
+		return 0, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, 0, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	limit, err = strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
+	if err != nil {
+		return 0, 0, err
+	}
+	sec, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	reset := timeutil.Unix(sec, 0)
+	if !reset.After(timeutil.Now()) {
+		return limit, 0, nil
+	}
+	return limit, timeutil.Until(reset), nil
+}
+
+func existsGitHubSitePath(client *http.Client, u *url.URL) error {
+	parts := splitPath(u.Path)
+	if len(parts) == 0 {
+		// Trivially, the root URL exists.
+		return nil
+	}
+
+	// 1) /<login>  → user/org exists
+	if len(parts) == 1 {
+		api := fmt.Sprintf("https://api.github.com/users/%s", parts[0])
+		return restExists(client, api)
+	}
+
+	owner, repo := parts[0], parts[1]
+
+	// 2) /<owner>/<repo> → repo exists
+	if len(parts) == 2 {
+		return repoExists(client, owner, repo)
+	}
+
+	// Normalize a couple of common typos/variants:
+	// - /pulls/<n> → /pull/<n>
+	// - /issue/<n> → /issues/<n>
+	isNumeric := func(s string) bool {
+		for _, r := range s {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return s != ""
+	}
+	if parts[2] == "pulls" && len(parts) >= 4 && isNumeric(parts[3]) {
+		parts[2] = "pull"
+	}
+	if parts[2] == "issue" && len(parts) >= 4 && isNumeric(parts[3]) {
+		parts[2] = "issues"
+	}
+
+	switch parts[2] {
+
+	// --- Wiki pages ---------------------------------------------------------
+	case "wiki":
+		// /<owner>/<repo>/wiki[/<Page...>[/<rev40>]]
+		// 1) root wiki → Home.*
+		if len(parts) == 3 || (len(parts) == 4 && parts[3] == "") {
+			if ok, err := existsWikiRaw(client, owner, repo, []string{}); err != nil {
+				return err
+			} else if !ok {
+				return errors.New("wiki page not found")
+			}
+			// found
+			return nil
+		}
+
+		// 2) page (optionally with a trailing 40-hex revision)
+		pageParts := parts[3:]
+		var rev string
+		if n := len(pageParts); n >= 1 && isHex40(pageParts[n-1]) {
+			rev = pageParts[n-1]
+			pageParts = pageParts[:n-1]
+		}
+		// Resolve the page via raw wiki (no API for wikis)
+		ok, err := existsWikiRaw(client, owner, repo, pageParts)
+		if err != nil || !ok {
+			return err
+		}
+		if rev == "" {
+			return nil
+		}
+		// If a specific revision was requested, HEAD the exact HTML URL as a last resort.
+		_, err = head200(client, u.String())
+		return err
+
+	// --- Releases & assets --------------------------------------------------
+	case "releases":
+		// /releases (list view) → treat as exists if repo exists
+		if len(parts) == 3 || (len(parts) == 4 && parts[3] == "") {
+			return repoExists(client, owner, repo)
+		}
+		// /releases/tag/<tag>
+		if len(parts) >= 5 && parts[3] == "tag" {
+			tag := parts[4]
+			return releaseTagExists(client, owner, repo, tag)
+		}
+		// /releases/download/<tag>/<name>
+		if len(parts) >= 6 && parts[3] == "download" {
+			tag := parts[4]
+			name := strings.Join(parts[5:], "/") // asset filename may contain slashes
+			return releaseAssetExistsByTag(client, owner, repo, tag, name)
+		}
+		// Fallback: repo exists
+		return repoExists(client, owner, repo)
+
+	// --- Archives -----------------------------------------------------------
+	case "archive":
+		// Supports:
+		//   /archive/<ref>.zip|tar.gz
+		//   /archive/refs/tags/<tag>.zip|tar.gz
+		var refWithExt string
+		if len(parts) >= 6 && parts[3] == "refs" && parts[4] == "tags" {
+			refWithExt = parts[5]
+		} else if len(parts) >= 4 {
+			refWithExt = parts[3]
+		} else {
+			return repoExists(client, owner, repo)
+		}
+		ref := strings.TrimSuffix(strings.TrimSuffix(refWithExt, ".zip"), ".tar.gz")
+
+		// Try commit SHA, then heads/tags.
+		if err := restExists(client,
+			fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", owner, repo, url.PathEscape(ref))); err == nil {
+			return nil
+		}
+		return gitRefExists(client, owner, repo, ref)
+
+	// --- PRs ----------------------------------------------------------------
+	case "pull":
+		if len(parts) >= 4 && isNumeric(parts[3]) {
+			return restExists(client,
+				fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%s", owner, repo, parts[3]))
+		}
+		// /pull (unexpected) → list view semantics
+		return repoExists(client, owner, repo)
+	case "pulls":
+		// List/search view → exists if repo exists
+		return repoExists(client, owner, repo)
+
+	// --- Issues -------------------------------------------------------------
+	case "issues":
+		// /issues/<n> or list/search view (/issues or /issues?q=...)
+		if len(parts) >= 4 && isNumeric(parts[3]) {
+			return restExists(client,
+				fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%s", owner, repo, parts[3]))
+		}
+		return repoExists(client, owner, repo)
+
+		// --- Commits (list view) and single commit --------------------------------
+	case "commits":
+		// /<owner>/<repo>/commits[/<ref>[/<path...>]]
+		// The web UI lets <ref> contain slashes and (optionally) a trailing path filter.
+		// We greedily match the longest existing ref; the path (if any) is ignored for existence.
+		if len(parts) == 3 {
+			// /commits → list view always exists if repo exists
+			return repoExists(client, owner, repo)
+		}
+		// Try to find the longest ref prefix from parts[3:].
+		if _, ok, err := findExistingRefPrefix(client, owner, repo, parts[3:]); err != nil {
+			return err
+		} else if ok {
+			return nil // ref exists → the commits page exists
+		}
+		// If there’s only a query (e.g., /commits?author=...), treat as list view.
+		if len(parts) == 3 && u.RawQuery != "" {
+			return repoExists(client, owner, repo)
+		}
+		return nil
+
+	case "commit":
+		if len(parts) >= 4 {
+			return restExists(client,
+				fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", owner, repo, parts[3]))
+		}
+		return repoExists(client, owner, repo)
+
+	// --- Releases by tag were handled above; Labels -------------------------
+	case "labels":
+		// If you care about label *existence*:
+		if len(parts) >= 4 {
+			lbl, _ := url.PathUnescape(strings.Join(parts[3:], "/"))
+			return restExists(client,
+				fmt.Sprintf("https://api.github.com/repos/%s/%s/labels/%s", owner, repo, url.PathEscape(lbl)))
+		}
+		// Otherwise, page exists if repo exists:
+		return repoExists(client, owner, repo)
+
+	// --- Actions tab --------------------------------------------------------
+	case "actions":
+		// UI tab → consider it existing if repo exists (optional: list workflows)
+		return repoExists(client, owner, repo)
+
+	// --- Blob/Tree (file/directory at ref) ---------------------------------
+	case "blob", "tree":
+		// /<owner>/<repo>/(blob|tree)/<ref>/<path...>
+		// If only /tree/<ref>, verify ref exists. If a path is present, use Contents API.
+		if len(parts) == 4 && parts[2] == "tree" {
+			ref := parts[3]
+			return gitRefExists(client, owner, repo, ref)
+		}
+		if len(parts) >= 5 {
+			ref := parts[3]
+			pth := escapePathSegments(parts[4:])
+			api := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s",
+				owner, repo, pth, url.QueryEscape(ref))
+			return restExists(client, api)
+		}
+		return repoExists(client, owner, repo)
+
+	// --- Attachments served under /assets/... (no public REST) --------------
+	case "assets":
+		return checkURL(client, u.String())
+
+	default:
+		// Many other tab/list/search views (e.g., /releases already handled, /contributors, /network, etc.)
+		// Treat as existing if the repo exists.
+		return repoExists(client, owner, repo)
+	}
+}
+
+func existsRawContent(client *http.Client, u *url.URL) error {
+	// raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
+	parts := splitPath(u.Path)
+	if len(parts) < 4 {
+		return fmt.Errorf("unsupported raw URL: %s", u)
+	}
+	owner, repo, ref := parts[0], parts[1], parts[2]
+	pth := escapePathSegments(parts[3:])
+	api := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s", owner, repo, pth, url.QueryEscape(ref))
+	return restExists(client, api)
+}
+
+func existsGist(client *http.Client, u *url.URL) error {
+	// gist.github.com/{user?}/{gist_id}[/{sha}]
+	parts := splitPath(u.Path)
+	var id, sha string
+	switch len(parts) {
+	case 1:
+		id = parts[0]
+	case 2:
+		id = parts[1]
+	default:
+		// /{user}/{id}/{sha}/...
+		id = parts[1]
+		sha = parts[2]
+	}
+	api := "https://api.github.com/gists/" + id
+	if sha != "" {
+		api += "/" + sha // specific revision
+	}
+	return restExists(client, api)
+}
+
+func restExists(client *http.Client, urlStr string) error {
+	resp, err := client.Get(urlStr)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNotModified:
+		return nil
+	case http.StatusNotFound:
+		return nil
+	default:
+		return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, urlStr)
+	}
+}
+
+func repoExists(client *http.Client, owner, repo string) error {
+	return restExists(client,
+		fmt.Sprintf("https://api.github.com/repos/%s/%s", owner, repo))
+}
+
+func releaseTagExists(client *http.Client, owner, repo, tag string) error {
+	return restExists(client,
+		fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s",
+			owner, repo, url.PathEscape(tag)))
+}
+
+func releaseAssetExistsByTag(client *http.Client, owner, repo, tag, name string) error {
+	// Fetch release by tag and scan assets for matching name
+	api := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s",
+		owner, repo, url.PathEscape(tag))
+	resp, err := client.Get(api)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 404 {
+		return nil
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected %d", resp.StatusCode)
+	}
+	var r struct {
+		Assets []struct{ Name string } `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return err
+	}
+	for _, a := range r.Assets {
+		if a.Name == name {
+			return nil
+		}
+	}
+	// If the release exists but asset name doesn't match exactly, treat as not found.
+	return errors.New("asset not found in release")
+}
+
+// Greedily try parts[3:], parts[3:len-1], ... to find the longest ref that exists
+func findExistingRefPrefix(
+	client *http.Client, owner, repo string, segs []string,
+) (string, bool, error) {
+	for i := len(segs); i >= 1; i-- {
+		candidate := strings.Join(segs[:i], "/") // allow slashes in branch names
+		if err := gitRefExists(client, owner, repo, candidate); err != nil {
+			continue
+		}
+		return candidate, true, nil
+	}
+	return "", false, nil
+}
+
+func gitRefExists(client *http.Client, owner, repo, ref string) error {
+	// Try heads/<branch> first, then tags/<tag>
+	if err := restExists(client,
+		fmt.Sprintf("https://api.github.com/repos/%s/%s/git/ref/heads/%s", owner, repo, url.PathEscape(ref))); err == nil {
+		return nil
+	}
+	if err := restExists(client,
+		fmt.Sprintf("https://api.github.com/repos/%s/%s/git/ref/tags/%s", owner, repo, url.PathEscape(ref))); err == nil {
+		return nil
+	}
+	// Fallback to matching-refs (prefix search) for branches and tags
+	for _, kind := range []string{"heads", "tags"} {
+		api := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/matching-refs/%s/%s",
+			owner, repo, kind, url.PathEscape(ref))
+		resp, err := client.Get(api)
+		if err != nil {
+			return err
+		}
+		func() { defer resp.Body.Close() }()
+		if resp.StatusCode == 200 {
+			var arr []any
+			if json.NewDecoder(resp.Body).Decode(&arr) == nil && len(arr) > 0 {
+				return nil
+			}
+		} else if resp.StatusCode != 404 {
+			return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, api)
+		}
+	}
+	return nil
+}
+
+// existsWikiRaw probes the *current* wiki page via the raw wiki host.
+// pageParts may be nil/empty → Home.*
+func existsWikiRaw(client *http.Client, owner, repo string, pageParts []string) (bool, error) {
+	page := "Home"
+	if len(pageParts) > 0 {
+		page = strings.Join(pageParts, "/")
+	}
+	// Try common extensions (exact case "Home" is important).
+	exts := []string{".md", ".markdown", ".rst", ".adoc"}
+	for _, ext := range exts {
+		raw := fmt.Sprintf("https://raw.githubusercontent.com/wiki/%s/%s/%s%s",
+			owner, repo, url.PathEscape(page), ext)
+		ok, err := head200(client, raw)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isHex40(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for i := 0; i < 40; i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
+++ b/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
@@ -12,11 +12,15 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/ghemawat/stream"
 )
@@ -58,12 +62,24 @@ var ignored = []string{
 	"https://localhost",
 	"https://myroach:8080",
 	"https://storage.googleapis.com/golang/go${GOVERSION}",
+	"https://storage.googleapis.com/SOME_BUCKET/SHA-bar.txt",
 	"https://%s.blob.core.windows.net/%s",
 	"https://roachfixtureseastus.blob.core.windows.net/$container",
 	"https://roachfixtureswestus.blob.core.windows.net/$container",
+	"https://example.com/",
+	"https://server-url-not-found-in-env.com",
+	"https://go.crdb.dev/issue-v/([0-9]+)/",
+	"https://www.cockroachlabs.com/docs/_version",
+	`https://github.com/cockroachdb/cockroach/commit/(\w+)\W`,
+	"https://api.github.com/search/issues?q=%s&per_page=100",
+	"https://api.github.com/gists/",
+	"https://cluster.example.com",
 	// These are cloud provider metadata endpoints.
 	"http://instance-data/latest/meta-data/public-ipv4",
+	"http://instance-data.ec2.internal/",
 	"http://metadata/",
+	"http://169.254.169.254/metadata/",
+	"http://metadata.google.internal/computeMetadata/v1/instance/",
 	// These are auto-generated and thus valid by definition.
 	"https://registry.yarnpkg.com/",
 	// XML namespace identifiers, these are not really HTTP endpoints.
@@ -71,17 +87,33 @@ var ignored = []string{
 	"http://www.w3.org/",
 	"https://www.w3.org/",
 	"http://maven.apache.org/POM/4.0.0",
-	// These report 404 for non-API GETs.
+	// These report 40x for non-API or non-browser GETs.
 	"http://ignored:ignored@errors.cockroachdb.com/",
 	"https://cockroachdb.github.io/distsqlplan/",
 	"https://ignored:ignored@errors.cockroachdb.com/",
 	"https://register.cockroachdb.com",
 	"https://www.googleapis.com/auth",
+	"https://ubuntu.pkgs.org/22.04/ubuntu-main-amd64/tcpdump_4.99.1-3build2_amd64.deb.html",
+	"https://segment.com/docs/connections/spec/track/",
+	"https://www.cloudping.co/",
+	"https://cloud.ibm.com",
+	"https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives",
+	"https://ignored@errors.cockroachdb.com/api/sentry/v2/1111",
+	"https://ignored@errors.cockroachdb.com/api/sentrydev/v2/1111",
 	// These require authentication.
 	"https://console.aws.amazon.com/",
 	"https://github.com/cockroachlabs/registration/",
 	"https://api.github.com/repos/cockroachdb/cockroach/issues",
 	"https://index.docker.io/v1/",
+	"https://github.com/cockroachlabs/managed-service",
+	"https://github.com/cockroachlabs/support/",
+	"https://storage.googleapis.com/cockroach-test-artifacts",
+	"https://www.googleapis.com/compute/v1/projects/",
+	"https://www.figma.com/proto/",
+	"https://sentry.io/api/0/organizations/cockroach-labs/issues/",
+	"https://observablehq.com/",
+	"https://cockroachlabs.udemy.com/course/general-onboarding/learn/lecture/22164146",
+	"https://support.cockroachlabs.com",
 }
 
 // chompUnbalanced truncates s before the first right rune to appear without an
@@ -103,25 +135,32 @@ func chompUnbalanced(left, right rune, s string) string {
 	return s
 }
 
-func checkURL(client *http.Client, url string) error {
-	resp, err := httpDo(client, "HEAD", url)
+func head200(client *http.Client, url string) (bool, error) {
+	resp, err := client.Head(url)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := resp.Body.Close(); err != nil {
-		return err
+		return false, err
 	}
-
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func checkURL(client *http.Client, url string) error {
+	if ok, err := head200(client, url); err != nil {
+		return err
+	} else if ok {
 		return nil
 	}
-
 	// The server doesn't like HEAD. Try GET. This is obviously the correct
 	// strategy for a 405 Method Not Allowed error, but a less-correct strategy
 	// for any other error. Still, we link to several misconfigured servers that
 	// return 403 Forbidden or 500 Internal Server Error for HEAD requests, but
 	// not for GET requests.
-	resp, err = httpDo(client, "GET", url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return err
 	}
@@ -136,24 +175,9 @@ func checkURL(client *http.Client, url string) error {
 	return errors.Newf("%s", errors.Safe(resp.Status))
 }
 
-// N.B. we set custom User-Agent header to avoid being blocked.
-// E.g., as of 08/25/25, Wikipedia blocks default UAs [1].
-// [1] https://phabricator.wikimedia.org/T400119
-func httpDo(c *http.Client, requestType string, url string) (resp *http.Response, err error) {
-	req, err := http.NewRequest(requestType, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	// This UA seems to comply with Wikipedia's policy [1].
-	// [1] https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
-	req.Header.Set("User-Agent", "MyGoApplication/1.0 (https://example.com/myapp; myapp@example.com)")
-
-	return c.Do(req)
-}
-
 func checkURLWithRetries(client *http.Client, url string) error {
 	for i := 0; i < timeoutRetries; i++ {
-		err := checkURL(client, url)
+		err := existsURL(client, url)
 		if netErr := (net.Error)(nil); errors.As(err, &netErr) && netErr.Timeout() {
 			// Back off exponentially if we hit a timeout.
 			time.Sleep((1 << uint(i)) * time.Second)
@@ -166,7 +190,8 @@ func checkURLWithRetries(client *http.Client, url string) error {
 
 // CheckURLsFromGrepOutput runs the specified cmd, which should be
 // grepping using the URLRE regular expression defined above.
-func CheckURLsFromGrepOutput(cmd *exec.Cmd) error {
+// The optional `cache` is used to skip URLs that have already been checked within a designated TTL (e.g., ~7 days).
+func CheckURLsFromGrepOutput(cmd *exec.Cmd, cache map[string]struct{}) ([]string, error) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)
@@ -187,7 +212,13 @@ func CheckURLsFromGrepOutput(cmd *exec.Cmd) error {
 	if err := cmd.Wait(); err != nil {
 		log.Fatalf("err=%s, stderr=%s", err, stderr.String())
 	}
-	return checkURLs(uniqueURLs)
+	if cache == nil {
+		cache = map[string]struct{}{}
+	}
+	checkedURLs, failedURLs, err := checkURLs(uniqueURLs, cache)
+
+	log.Printf("checked %d; failed %d; (%d unique)\n", len(checkedURLs), len(failedURLs), len(uniqueURLs))
+	return checkedURLs, err
 }
 
 // getURLs extracts URLs from the given filter.
@@ -215,7 +246,19 @@ func getURLs(filter stream.Filter) (map[string][]string, error) {
 				if strings.HasPrefix(match, ig) {
 					continue outer
 				}
+				if _, err := IsValidHTTPURL(match); err != nil {
+					log.Printf("skipping invalid URL %q: %v in %q\n", match, err, s)
+					continue outer
+				}
+				if strings.Contains(match, "{}") || strings.Contains(match, "$(") ||
+					strings.Contains(match, "${") || strings.Contains(match, "{{") ||
+					strings.Contains(match, "$ARCH") {
+					log.Printf("skipping templated URL %q in %q\n", match, s)
+					continue outer
+				}
 			}
+			// remove trailing ":", "'" which amount to a typo
+			match = strings.TrimSuffix(strings.TrimSuffix(match, ":"), "'")
 			uniqueURLs[match] = append(uniqueURLs[match], s)
 		}
 	}); err != nil {
@@ -226,49 +269,158 @@ func getURLs(filter stream.Filter) (map[string][]string, error) {
 }
 
 // checkURLs checks the provided unique URLs
-func checkURLs(uniqueURLs map[string][]string) error {
+func checkURLs(
+	uniqueURLs map[string][]string, cache map[string]struct{},
+) ([]string, []string, error) {
 	sem := make(chan struct{}, maxConcurrentRequests)
-	errChan := make(chan error, len(uniqueURLs))
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			// This test doesn't care that https certificates are invalid.
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-		Timeout: time.Minute,
+	client := newClient()
+	limit, untilReset, err := checkGithubRateLimit(client)
+	if err != nil {
+		return []string{}, []string{}, err
 	}
+	log.Printf("GitHub API rate limit: %d requests remaining; time until reset: %s\n", limit, untilReset)
+	checkedURLs := []string{}
+	failedURLs := []string{}
+	errs := []error{}
+	var mu syncutil.Mutex
+	var wg sync.WaitGroup
 
 	for url, locs := range uniqueURLs {
-		sem <- struct{}{}
+		if _, ok := cache[url]; ok {
+			log.Printf("Skipping cached %s\n", url)
+			continue
+		}
+		sem <- struct{}{} // concurrency limiter
+		wg.Add(1)
+
+		// nolint:deferunlockcheck
 		go func(url string, locs []string) {
-			defer func() { <-sem }()
-			log.Printf("Checking %s...", url)
+			defer func() { <-sem; wg.Done() }()
+			log.Printf("Checking %s", url)
 			if err := checkURLWithRetries(client, url); err != nil {
 				var buf bytes.Buffer
 				fmt.Fprintf(&buf, "%s : %s\n", url, err)
 				for _, loc := range locs {
 					fmt.Fprintln(&buf, "    ", loc)
 				}
-				errChan <- errors.Newf("%s", buf.String())
+				mu.Lock()
+				errs = append(errs, errors.Newf("%s", buf.String()))
+				failedURLs = append(failedURLs, url)
+				mu.Unlock()
 			} else {
-				errChan <- nil
+				mu.Lock()
+				checkedURLs = append(checkedURLs, url)
+				mu.Unlock()
 			}
 		}(url, locs)
 	}
+	wg.Wait()
 
-	var errs []error
-	for i := 0; i < len(uniqueURLs); i++ {
-		if err := <-errChan; err != nil {
-			errs = append(errs, err)
-		}
-	}
 	if len(errs) > 0 {
 		var buf bytes.Buffer
 		for _, err := range errs {
 			fmt.Fprintln(&buf, err)
 		}
 		fmt.Fprintf(&buf, "%d errors\n", len(errs))
-		return errors.Newf("%s", buf.String())
+		return checkedURLs, failedURLs, errors.Newf("%s", buf.String())
 	}
-	return nil
+	return checkedURLs, failedURLs, nil
+}
+
+type authTransport struct {
+	base  http.RoundTripper
+	token string
+	ua    string
+}
+
+func newClient() *http.Client {
+	token := os.Getenv("GITHUB_API_TOKEN")
+	if token == "" {
+		panic("set GITHUB_API_TOKEN")
+	}
+	// N.B. we set custom User-Agent header to avoid being blocked.
+	// E.g., as of 08/25/25, Wikipedia blocks default UAs [1].
+	// [1] https://phabricator.wikimedia.org/T400119
+	ua := "URLChecker/1.0 (https://example.com/myapp; myapp@example.com)"
+	base := &http.Transport{
+		// This test doesn't care that https certificates are invalid.
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{
+		Transport: &authTransport{base: base, token: token, ua: ua},
+		Timeout:   time.Minute,
+	}
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone to avoid mutating the caller’s request
+	r := req.Clone(req.Context())
+
+	// Add auth for github requests.
+	if r.URL.Host == "api.github.com" {
+		if t.token != "" {
+			r.Header.Set("Authorization", "Bearer "+t.token) // or "token "+t.token
+		}
+		r.Header.Set("Accept", "application/vnd.github+json")
+		r.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	}
+	if t.ua != "" {
+		r.Header.Set("User-Agent", t.ua)
+	}
+
+	return t.base.RoundTrip(r)
+}
+
+func IsValidHTTPURL(raw string) (bool, error) {
+	u, err := url.ParseRequestURI(raw)
+	if err != nil {
+		return false, err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false, errors.New("unsupported scheme (want http/https)")
+	}
+	if u.Host == "" {
+		return false, errors.New("missing host")
+	}
+	host := u.Hostname()
+	if net.ParseIP(host) == nil && !strings.Contains(host, ".") {
+		return false, errors.Newf("host(%q) is missing domain", host)
+	}
+	return true, nil
+}
+
+func existsURL(client *http.Client, rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	host := strings.ToLower(u.Host)
+	switch host {
+	case "github.com", "www.github.com":
+		return existsGitHubSitePath(client, u)
+	case "raw.githubusercontent.com":
+		return existsRawContent(client, u)
+	case "gist.github.com", "www.gist.github.com":
+		return existsGist(client, u)
+	default:
+		// Fallback
+		return checkURL(client, rawURL)
+	}
+}
+
+func splitPath(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+func escapePathSegments(segments []string) string {
+	escaped := make([]string, 0, len(segments))
+	for _, s := range segments {
+		escaped = append(escaped, url.PathEscape(s))
+	}
+	return strings.Join(escaped, "/")
 }

--- a/pkg/cmd/urlcheck/main.go
+++ b/pkg/cmd/urlcheck/main.go
@@ -6,17 +6,209 @@
 package main
 
 import (
+	"bufio"
+	"compress/gzip"
+	_ "embed"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// URL Cache is per-release branch and defaults to 7 days TTL.
+	CacheTTL        = 7 * 24 * time.Hour
+	CacheBlobPrefix = "gs://cockroach-nightly/urlchecker"
+	CacheFile       = "cache.txt.gz"
 )
 
 func main() {
-	cmd := exec.Command("git", "grep", "-nE", urlcheck.URLRE)
-	if err := urlcheck.CheckURLsFromGrepOutput(cmd); err != nil {
+	cmd := exec.Command("git", "grep", "-nE",
+		urlcheck.URLRE,
+		"--",
+		":!*.bzl",
+		":!*.config",
+		":!*.sh",
+		":!cloud/kubernetes/*",
+		":!scripts/*",
+		":!licenses/*",
+		":!*_test.go",
+		":!*/testdata/*",
+	)
+
+	// Let's derive the blob path for the optional cache abd try to load it.
+	var blobPath string
+
+	buildBranch := os.Getenv("TC_BUILD_BRANCH")
+	if buildBranch == "master" {
+		blobPath = fmt.Sprintf("%s/%s", CacheBlobPrefix, CacheFile)
+	} else {
+		blobPath = fmt.Sprintf("%s/%s/%s", CacheBlobPrefix, buildBranch, CacheFile)
+	}
+	// Try to load the cache.
+	log.Printf("Attemptign to fetch cache from: %s", blobPath)
+	cached, fresh, err := LoadURLCache(blobPath)
+	if err != nil {
+		log.Printf("WARN: URL cache load error: %+v", err)
+	} else if !fresh {
+		log.Printf("WARN: URL cache stale")
+	}
+	if fresh {
+		log.Printf("Loaded %d URLs from cache", len(cached))
+	}
+	uniqueURLs, err := urlcheck.CheckURLsFromGrepOutput(cmd, cached)
+	// Persist all URLs if cache was stale or missing.
+	if !fresh {
+		if err := SaveURLCache(blobPath, uniqueURLs); err != nil {
+			log.Printf("WARN: URL cache save error: %+v", err)
+		} else {
+			log.Printf("Saved %d URLs to cache: %q", len(uniqueURLs), blobPath)
+		}
+	}
+	if err != nil {
 		log.Fatalf("%+v\nFAIL", err)
 	}
 	fmt.Println("PASS")
+}
+
+// LoadURLCache downloads a gzipped flat-file from GCS (remoteGCSPath), checks TTL using
+// the gzip header ModTime, and if fresh returns (map, true, nil).
+// If the object is missing, unreadable, or stale, it returns (nil, false, nil).
+func LoadURLCache(remoteGCSPath string) (map[string]struct{}, bool, error) {
+	localPath, cleanup, err := tempPathCWD(remoteGCSPath, ".download")
+	if err != nil {
+		return nil, false, err
+	}
+	defer cleanup()
+
+	// Try to download. If it fails, treat as cache miss (not an error).
+	if err := runGsutilCp(remoteGCSPath, localPath); err != nil {
+		return nil, false, err
+	}
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return nil, false, err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		// Corrupt gzip? Treat as miss.
+		return nil, false, err
+	}
+	defer gr.Close()
+
+	mod := gr.Header.ModTime
+	if mod.IsZero() {
+		// Missing mtime. Treat as miss.
+		return nil, false, errors.New("missing gzip ModTime")
+	}
+
+	// Check if cache TTL expired.
+	if timeutil.Since(mod) > CacheTTL {
+		return nil, false, nil
+	}
+
+	// Cache is still fresh, let's parse it.
+	sc := bufio.NewScanner(gr)
+	buf := make([]byte, 0, 64*1024)
+	sc.Buffer(buf, len(buf))
+
+	urls := make(map[string]struct{}, 1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		urls[line] = struct{}{}
+	}
+	if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return nil, false, err
+	}
+	return urls, true, nil
+}
+
+// SaveURLCache writes the given set of URLs to a local gz file with gzip ModTime=now,
+// then uploads it to GCS (remoteGCSPath). It overwrites any existing object.
+func SaveURLCache(remoteGCSPath string, urls []string) error {
+	localPath, cleanup, err := tempPathCWD(remoteGCSPath, ".upload")
+	if err != nil {
+		return err
+	}
+	// Clean up local temp whether upload succeeds or not.
+	defer cleanup()
+
+	lf, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("create temp cache file: %w", err)
+	}
+	defer lf.Close()
+
+	gw, err := gzip.NewWriterLevel(lf, gzip.BestSpeed)
+	if err != nil {
+		return fmt.Errorf("gzip writer: %w", err)
+	}
+	// Record modtime inside gzip header to drive TTL checks later.
+	gw.ModTime = timeutil.Now()
+
+	w := bufio.NewWriter(gw)
+	for _, u := range urls {
+		if _, err := w.WriteString(u + "\n"); err != nil {
+			_ = gw.Close()
+			return fmt.Errorf("write cache contents: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = gw.Close()
+		return fmt.Errorf("flush writer: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return fmt.Errorf("close gzip writer: %w", err)
+	}
+	if err := lf.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	// Upload
+	if err := runGsutilCp(localPath, remoteGCSPath); err != nil {
+		return fmt.Errorf("gsutil cp upload: %w", err)
+	}
+	return nil
+}
+
+func runGsutilCp(src, dst string) error {
+	cmd := exec.Command("gsutil", "cp", src, dst)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "gsutil cp %s %s: %s", src, dst, out)
+	}
+	return nil
+}
+
+// tempPathCWD creates a temp file path in CWD derived from the remote name.
+// It returns (path, cleanup func, error).
+func tempPathCWD(remote, suffix string) (string, func(), error) {
+	base := filepath.Base(remote)
+	if base == "." || base == "/" || base == "" {
+		base = CacheFile
+	}
+	// Pattern must contain a * for uniqueness; remove slashes if any.
+	pattern := strings.ReplaceAll(base, string(filepath.Separator), "_") + ".*" + suffix
+	f, err := os.CreateTemp(".", pattern)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create temp file in cwd: %w", err)
+	}
+	path := f.Name()
+	_ = f.Close()
+	cleanup := func() { _ = os.Remove(path) }
+	return path, cleanup, nil
 }

--- a/pkg/kv/kvnemesis/doc.go
+++ b/pkg/kv/kvnemesis/doc.go
@@ -99,7 +99,7 @@
 // intersection of time intervals obtained from inspecting MVCC history[^3].
 //
 // [Elle]: https://arxiv.org/pdf/2003.10554.pdf
-// [^1]: https://dl.acm.org/doi/10.1145/322154.322158
+// [^1]: https://publications.csail.mit.edu/lcs/pubs/pdf/MIT-LCS-TR-210.pdf
 // [^2]: there is currently concurrency within the atomic unit in kvnemesis. It
 // could in theory carry out multiple reads concurrently while not also writing,
 // such as DistSQL does, but this is not implemented today. See:

--- a/pkg/kv/kvserver/concurrency/isolation/levels.proto
+++ b/pkg/kv/kvserver/concurrency/isolation/levels.proto
@@ -130,7 +130,7 @@ import "gogoproto/gogo.proto";
 //
 // [^2]: 1995, https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-95-51.pdf
 //
-// [^3]: 1999, https://pmg.csail.mit.edu/papers/adya-phd.pdf
+// [^3]: 1999, https://web.archive.org/web/20250820175955/http://pmg.csail.mit.edu/papers/adya-phd.pdf 
 //
 enum Level {
   option (gogoproto.goproto_enum_prefix) = false;
@@ -151,8 +151,8 @@ enum Level {
   // Serializable Isolation.
   //
   // [2PL]: https://en.wikipedia.org/wiki/Two-phase_locking
-  // [SSI]: https://dl.acm.org/doi/10.1145/1620585.1620587
-  // [WSI]: https://dl.acm.org/doi/10.1145/2168836.2168853
+  // [SSI]: https://web.archive.org/web/20250812103842/https://dl.acm.org/doi/10.1145/1620585.1620587 
+  // [WSI]: https://arxiv.org/pdf/2405.18393 
   Serializable = 0;
 
   // Snapshot provides moderately strict transaction isolation. A transaction

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -60,7 +60,7 @@ func Init() error {
 	// aws-cli version 1 automatically base64 encodes the string passed as --public-key-material.
 	// Version 2 supports file:// and fileb:// prefixes for text and binary files.
 	// The latter prefix will base64-encode the file contents. See
-	// https://docs.aws.amazon.//com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam
+	// https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam
 	const unsupportedAwsCliVersionPrefix = "aws-cli/1."
 	const unimplemented = "please install the AWS CLI utilities version 2+ " +
 		"(https://docs.aws.amazon.com/cli/latest/userguide/installing.html)"

--- a/pkg/rpc/heartbeat.proto
+++ b/pkg/rpc/heartbeat.proto
@@ -17,7 +17,7 @@ import "gogoproto/gogo.proto";
 // out, Offset = 0.
 //
 // Offset and Uncertainty are measured using the remote clock reading technique
-// described in http://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
+// described in https://web.archive.org/web/20221207190432/https://se.inf.tu-dresden.de/pubs/papers/SRDS1994.pdf, page 6.
 message RemoteOffset {
   option (gogoproto.goproto_stringer) = false;
 

--- a/pkg/security/tls_ciphersuites.go
+++ b/pkg/security/tls_ciphersuites.go
@@ -31,7 +31,7 @@ import (
 //
 // [1]: https://github.com/golang/go/blob/4aa1efed4853ea067d665a952eee77c52faac774/src/crypto/tls/cipher_suites.go#L215-L270
 // [2]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
-// [3]: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+// [3]: https://web.archive.org/web/20250906032848/https://wiki.mozilla.org/Security/Server_Side_TLS
 func RecommendedCipherSuites() []uint16 {
 	return []uint16{
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -175,7 +175,7 @@ var familyToAvroT = map[types.Family][]string{
 
 	// Time families with avro logical types. Avro logical type names pulled from:
 	// https://github.com/linkedin/goavro/blob/master/logical_type.go and
-	// https://avro.apache.org/docs/current/spec.html
+	// https://avro.apache.org/docs/++version++/specification/
 	types.DateFamily:      {"string", "int.date"},
 	types.TimeFamily:      {"string", "long.time-micros", "int.time-millis"},
 	types.TimestampFamily: {"string", "long.timestamp-micros", "long.timestamp-millis"},

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -841,7 +841,7 @@ https://www.postgresql.org/docs/9.5/infoschema-constraint-column-usage.html`,
 	},
 }
 
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/key-column-usage-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-key-column-usage-table.html
 var informationSchemaKeyColumnUsageTable = virtualSchemaTable{
 	comment: `column usage by indexes and key constraints
 ` + docs.URL("information-schema.html#key_column_usage") + `
@@ -893,7 +893,7 @@ https://www.postgresql.org/docs/9.5/infoschema-key-column-usage.html`,
 }
 
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-parameters.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/parameters-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-parameters-table.html
 var informationSchemaParametersTable = virtualSchemaView{
 	comment: `function parameters
 https://www.postgresql.org/docs/9.5/infoschema-parameters.html`,
@@ -968,7 +968,7 @@ func dStringForFKAction(action semenumpb.ForeignKeyAction) tree.Datum {
 	panic(errors.Errorf("unexpected ForeignKeyReference_Action: %v", action))
 }
 
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/referential-constraints-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-referential-constraints-table.html
 var informationSchemaReferentialConstraintsTable = virtualSchemaTable{
 	comment: `foreign key constraints
 ` + docs.URL("information-schema.html#referential_constraints") + `
@@ -1039,7 +1039,7 @@ https://www.postgresql.org/docs/9.5/infoschema-role-table-grants.html`,
 	populate: populateTablePrivileges,
 }
 
-// MySQL:    https://dev.mysql.com/doc/mysql-infoschema-excerpt/5.7/en/routines-table.html
+// MySQL:   https://dev.mysql.com/doc/refman/8.4/en/information-schema-routines-table.html
 var informationSchemaRoutineTable = virtualSchemaView{
 	comment: `built-in functions and user-defined functions
 https://www.postgresql.org/docs/15/infoschema-routines.html`,
@@ -1130,7 +1130,7 @@ https://www.postgresql.org/docs/15/infoschema-routines.html`,
 	},
 }
 
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schemata-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-table-reference.html
 var informationSchemaSchemataTable = virtualSchemaTable{
 	comment: `database schemas (may contain schemata without permission)
 ` + docs.URL("information-schema.html#schemata") + `
@@ -1229,7 +1229,7 @@ var informationSchemaTypePrivilegesTable = virtualSchemaTable{
 	},
 }
 
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schema-privileges-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-table-privileges-table.html
 var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 	comment: `schema privileges (incomplete; may contain excess users or roles)
 ` + docs.URL("information-schema.html#schema_privileges"),
@@ -1332,7 +1332,7 @@ https://www.postgresql.org/docs/9.5/infoschema-sequences.html`,
 }
 
 // Postgres: missing
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/statistics-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-statistics-table.html
 var informationSchemaStatisticsTable = virtualSchemaTable{
 	comment: `index metadata and statistics (incomplete)
 ` + docs.URL("information-schema.html#statistics"),
@@ -1443,7 +1443,7 @@ var informationSchemaStatisticsTable = virtualSchemaTable{
 	},
 }
 
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-constraints-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-table-constraints-table.html
 var informationSchemaTableConstraintTable = virtualSchemaTable{
 	comment: `table constraints
 ` + docs.URL("information-schema.html#table_constraints") + `
@@ -1553,7 +1553,7 @@ var informationSchemaUserDefinedTypesTable = virtualSchemaView{
 }
 
 // Postgres: not provided
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/user-privileges-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-user-privileges-table.html
 // TODO(knz): this introspection facility is of dubious utility.
 var informationSchemaUserPrivileges = virtualSchemaTable{
 	comment: `grantable privileges (incomplete)`,
@@ -1584,7 +1584,7 @@ var informationSchemaUserPrivileges = virtualSchemaTable{
 	},
 }
 
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-privileges-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-table-privileges-table.html
 var informationSchemaTablePrivileges = virtualSchemaTable{
 	comment: `privileges granted on table or views (incomplete; may contain excess users or roles)
 ` + docs.URL("information-schema.html#table_privileges") + `
@@ -1699,7 +1699,7 @@ https://www.postgresql.org/docs/9.5/infoschema-tables.html`,
 }
 
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-views.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/views-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-columns-table.html
 var informationSchemaViewsTable = virtualSchemaTable{
 	comment: `views (incomplete)
 ` + docs.URL("information-schema.html#views") + `

--- a/pkg/sql/opt/citations.md
+++ b/pkg/sql/opt/citations.md
@@ -6,7 +6,7 @@ further information, and in some cases proofs, can be found.
 [1] Galindo-Legaria, C.A. & Rosenthal, Arnon. (1997).
     Outerjoin Simplification and Reordering for Query Optimization.
     ACM Trans. Database Syst.. 22. 43-73. 10.1145/244810.244812.
-    https://www.researchgate.net/publication/220225172_Outerjoin_Simplification_and_Reordering_for_Query_Optimization
+    https://web.archive.org/web/20240615064523/https://dl.acm.org/doi/10.1145/244810.244812 
 
 [2] M. M. Joshi and C. A. Galindo-Legaria.
     Properties of the GroupBy/Aggregate relational operator.
@@ -15,7 +15,7 @@ further information, and in some cases proofs, can be found.
 [3] Galindo-Legaria, C.A. & Joshi, Milind. (2001).
     Orthogonal Optimization of Subqueries and Aggregation.
     Sigmod Record. 30. 571-581. 10.1145/375663.375748. 
-    http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.563.8492&rep=rep1&type=pdf
+    https://sigmodrecord.org/publications/sigmodRecord/0106/pdfs/Orthogonal%20Optimization%20of%20Subqueries%20and%20Aggregation.pdf
 
 [4] Galindo-Legaria, C.A.. (2001).
     Parameterized queries and nesting equivalences.
@@ -24,7 +24,7 @@ further information, and in some cases proofs, can be found.
 [5] Elhemali, Mostafa & Galindo-Legaria, C.A. & Grabs, Torsten & M. Joshi, Milind. (2007).
     Execution strategies for SQL subqueries.
     993-1004. 10.1145/1247480.1247598.
-    https://www.researchgate.net/profile/Mostafa_Elhemali/publication/221213885_Execution_strategies_for_SQL_subqueries/links/584f631308aecb6bd8d02aa4/Execution-strategies-for-SQL-subqueries.pdf
+    https://web.archive.org/web/20161020062359id_/http://www.cse.iitb.ac.in:80/infolab/Data/Courses/CS632/Papers/subquery-proc-elhemali-sigmod07.pdf 
 
 [6] Simmen, David & Shekita, Eugene & Malkemus, Timothy. (1996).
     Fundamental Techniques for Order Optimization.
@@ -33,16 +33,16 @@ further information, and in some cases proofs, can be found.
 
 [7] Ahmed, Rafi & W. Lee, Allison & Witkowski, Andrew & Das, Dinesh & Su, Hong & Zaït, Mohamed & Cruanes, Thierry. (2006).
     Cost-Based Query Transformation in Oracle.. 1026-1036.
-    https://www.researchgate.net/publication/221311318_Cost-Based_Query_Transformation_in_Oracle z
+    https://web.archive.org/web/20211220100644/https://www.researchgate.net/publication/221311318_Cost-Based_Query_Transformation_in_Oracle 
 
 [8] Moerkotte, Guido & Fender, Pit & Eich, Marius. (2013). 
     On the correct and complete enumeration of the core search space. 
     Proceedings of the ACM SIGMOD International Conference on Management of Data. 
     493-504. 10.1145/2463676.2465314. 
-    https://www.researchgate.net/publication/262216932_On_the_correct_and_complete_enumeration_of_the_core_search_space
+    https://web.archive.org/web/20230831112215/https://www.researchgate.net/publication/262216932_On_the_correct_and_complete_enumeration_of_the_core_search_space 
 
 [9] Denis Hirn and Torsten Grust. (2021).
     One WITH RECURSIVE is Worth Many GOTOs.
     In Proceedings of the 2021 International Conference on Management of Data (SIGMOD '21).
     Association for Computing Machinery, New York, NY, USA, 723–735.
-    https://doi.org/10.1145/3448016.3457272
+    https://web.archive.org/web/20240413181036/https://doi.org/10.1145/3448016.3457272 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1000,7 +1000,7 @@ func (b *Builder) buildSequenceSelect(
 func (b *Builder) buildWithOrdinality(inScope *scope) (outScope *scope) {
 	col := b.synthesizeColumn(inScope, scopeColName("ordinality"), types.Int, nil, nil /* scalar */)
 
-	// See https://www.cockroachlabs.com/docs/stable/query-order.html#order-preservation
+	// See https://web.archive.org/web/20201129203138/https://www.cockroachlabs.com/docs/stable/query-order.html
 	// for the semantics around WITH ORDINALITY and ordering.
 
 	input := inScope.expr

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3054,7 +3054,7 @@ https://www.postgresql.org/docs/9.6/view-pg-seclabels.html`,
 
 var pgCatalogSequenceTable = virtualSchemaTable{
 	comment: `sequences (see also information_schema.sequences)
-https://www.postgresql.org/docs/9.5/catalog-pg-sequence.html`,
+https://www.postgresql.org/docs/10/catalog-pg-sequence.html`,
 	schema: vtable.PGCatalogSequence,
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		opts := forEachTableDescOptions{virtualOpts: hideVirtual} /* virtual schemas do not have indexes */
@@ -3086,7 +3086,7 @@ var (
 
 var pgCatalogSettingsTable = virtualSchemaTable{
 	comment: `session variables (incomplete)
-https://www.postgresql.org/docs/9.5/catalog-pg-settings.html`,
+https://www.postgresql.org/docs/9.5/view-pg-settings.html`,
 	schema: vtable.PGCatalogSettings,
 	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1409,7 +1409,7 @@ func (s *Server) serveImpl(
 				// We're starting a batch here. If the client continues using the extended
 				// protocol and encounters an error, everything until the next sync
 				// message has to be skipped. See:
-				// https://www.postgresql.org/docs/current/10/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
+				// https://www.postgresql.org/docs/10/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 				return false, isSimpleQuery, c.stmtBuf.Push(ctx, sql.Sync{
 					// The client explicitly sent this Sync as part of the extended
 					// protocol.

--- a/pkg/sql/vecindex/cspann/kmeans.go
+++ b/pkg/sql/vecindex/cspann/kmeans.go
@@ -370,7 +370,7 @@ func (km *BalancedKmeans) selectInitialRightCentroid(
 //
 // "Algorithms for computing the sample variance: Analysis and recommendations",
 // by Chan, Tony F., Gene H. Golub, and Randall J. LeVeque.
-// URL: https://cpsc.yale.edu/sites/default/files/files/tr222.pdf
+// URL: https://web.archive.org/web/20240924181734/https://cpsc.yale.edu/sites/default/files/files/tr222.pdf
 //
 // See formula 1.7 in the paper:
 //

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -112,7 +112,7 @@ CREATE TABLE information_schema.column_udt_usage (
 // InformationSchemaColumns describes the schema of the
 // information_schema.columns table.
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-columns.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/columns-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-columns-table.html
 const InformationSchemaColumns = `
 CREATE TABLE information_schema.columns (
 	TABLE_CATALOG            STRING NOT NULL,
@@ -217,7 +217,7 @@ CREATE TABLE information_schema.check_constraints (
 // InformationSchemaColumnPrivileges describes the schema of the
 // information_schema.column_privileges table.
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-column-privileges.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/column-privileges-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-column-privileges-table.html
 const InformationSchemaColumnPrivileges = `
 CREATE TABLE information_schema.column_privileges (
 	GRANTOR        STRING,
@@ -244,7 +244,7 @@ CREATE TABLE information_schema.schemata (
 // InformationSchemaTables describes the schema of the
 // information_schema.tables table.
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-tables.html
-// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/tables-table.html
+// MySQL:    https://dev.mysql.com/doc/refman/8.4/en/information-schema-tables-table.html
 const InformationSchemaTables = `
 CREATE TABLE information_schema.tables (
 	TABLE_CATALOG      STRING NOT NULL,

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -682,7 +682,7 @@ CREATE TABLE pg_catalog.pg_seclabels (
 )`
 
 // PGCatalogSequence describes the schema of the pg_catalog.pg_sequence table.
-// https://www.postgresql.org/docs/9.5/catalog-pg-sequence.html,
+// https://www.postgresql.org/docs/10/catalog-pg-sequence.html,
 const PGCatalogSequence = `
 CREATE TABLE pg_catalog.pg_sequence (
 	seqrelid OID,
@@ -696,7 +696,7 @@ CREATE TABLE pg_catalog.pg_sequence (
 )`
 
 // PGCatalogSettings describes the schema of the pg_catalog.pg_settings table.
-// https://www.postgresql.org/docs/9.5/catalog-pg-settings.html,
+// https://www.postgresql.org/docs/9.5/view-pg-settings.html,
 const PGCatalogSettings = `
 CREATE TABLE pg_catalog.pg_settings (
     name STRING,

--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -40,7 +40,7 @@ func TestNightlyLint(t *testing.T) {
 		}
 		cmd := exec.Command("grep", "-nE", urlcheck.URLRE)
 		cmd.Stdin = &buf
-		if err := urlcheck.CheckURLsFromGrepOutput(cmd); err != nil {
+		if _, err := urlcheck.CheckURLsFromGrepOutput(cmd, nil); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -116,7 +116,7 @@ $ ./dev ui test
 The NPM registry (and the Yarn proxy in front of it, registry.yarnpkg.com)
 have historically proven quite flaky. Errors during `yarn install` were the
 leading cause of spurious CI failures in the first half of 2018. We used yarn's
-[offline mirror](https://classic.yarnpkg.com/blog/2016/11/24/ offline-mirror/)
+[offline mirror](https://classic.yarnpkg.com/blog/2016/11/24/offline-mirror/)
 functionality through December 2022 (and for the initial 22.2 release), but
 Bazel support for that feature was poor to non-existent and the workflow
 involved was complicated. Worse, upgrades to Bazel and the deprecation of

--- a/pkg/ui/workspaces/cluster-ui/src/api/safesql.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/safesql.ts
@@ -101,7 +101,7 @@ function QuoteLiteral(literal: string): string {
   // This follows the PostgreSQL internal algorithm for handling quoted literals
   // from libpq, which can be found in the "PQEscapeStringInternal" function,
   // which is found in the libpq/fe-exec.c source file:
-  // https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/interfaces/libpq/fe-exec.c
+  // https://github.com/postgres/postgres/blob/d814d7fc3d5257ae258b502229fc7ca97c97270a/src/interfaces/libpq/fe-exec.c#L4082
   //
   // substitute any single-quotes (') with two single-quotes ('')
 

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -240,7 +240,7 @@ jest_test(
         # Populate the global.gc() function during JS execution:
         # https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/flags/flag-definitions.h#L1484-L1487
         "--node_options=--expose-gc",
-        # Force jest workers to collect garbage after each suite: https://jestjs.io/docs/27.x/cli#--logheapusage
+        # Force jest workers to collect garbage after each suite: https://archive.jestjs.io/docs/en/cli#--logheapusage
         "--logHeapUsage",
         "--ci",
         "--bail",

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -55,7 +55,7 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
   contentRef = React.createRef<HTMLDivElement>();
 
   componentDidUpdate(prevProps: RouteComponentProps) {
-    // `react-router` doesn't handle scroll restoration (https://reactrouter.com/react-router/web/guides/scroll-restoration)
+    // `react-router` doesn't handle scroll restoration (https://reactrouter.com/6.30.1/components/scroll-restoration)
     // and when location changed with react-router's Link it preserves scroll position whenever it is.
     // AdminUI layout keeps left and top panels have fixed position on a screen and has internal scrolling for content div
     // element which has to be scrolled back on top with navigation change.

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -27,7 +27,7 @@ import {
 
 import "./debug.styl";
 
-const COMMUNITY_URL = "https://www.cockroachlabs.com/community/";
+const COMMUNITY_URL = "https://forum.cockroachlabs.com/";
 
 export function DebugTableLink(props: {
   name: string;

--- a/pkg/util/duration/parse.go
+++ b/pkg/util/duration/parse.go
@@ -684,8 +684,8 @@ func addFrac(d Duration, unit Duration, f float64) (Duration, error) {
 // when a naive conversion would incorrectly truncate due to floating point
 // inaccuracies. This function should match the semantics of rint() from
 // Postgres. See:
-// https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/utils/adt/timestamp.c;h=449164ae7e5b00f6580771017888d4922685a73c;hb=HEAD#l1511
-// https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/port/rint.c;h=d59d9ab774307b7db2f7cb2347815a30da563fc5;hb=HEAD
+// https://github.com/postgres/postgres/blob/REL9_1_STABLE/src/backend/utils/adt/timestamp.c
+// https://github.com/postgres/postgres/blob/REL9_1_STABLE/src/port/rint.c
 func floatToNanos(f float64) int64 {
 	return int64(math.Round(f * float64(time.Second.Nanoseconds())))
 }

--- a/pkg/util/quantile/stream.go
+++ b/pkg/util/quantile/stream.go
@@ -22,7 +22,7 @@
 //
 // # Effective Computation of Biased Quantiles over Data Streams
 //
-// http://www.cs.rutgers.edu/~muthu/bquant.pdf
+// [1] https://web.archive.org/web/20250506150208/https://www.cs.rutgers.edu/~muthu/bquant.pdf
 package quantile
 
 import (
@@ -56,7 +56,7 @@ type invariant func(s *stream, r float64) float64
 // The provided epsilon is a relative error, i.e. the true quantile of a value
 // returned by a query is guaranteed to be within (1±Epsilon)*Quantile.
 //
-// See http://www.cs.rutgers.edu/~muthu/bquant.pdf for time, space, and error
+// See [1] above for time, space, and error
 // properties.
 func NewLowBiased(epsilon float64) *Stream {
 	ƒ := func(s *stream, r float64) float64 {
@@ -73,7 +73,7 @@ func NewLowBiased(epsilon float64) *Stream {
 // The provided epsilon is a relative error, i.e. the true quantile of a value
 // returned by a query is guaranteed to be within 1-(1±Epsilon)*(1-Quantile).
 //
-// See http://www.cs.rutgers.edu/~muthu/bquant.pdf for time, space, and error
+// See [1] above for time, space, and error
 // properties.
 func NewHighBiased(epsilon float64) *Stream {
 	ƒ := func(s *stream, r float64) float64 {
@@ -88,7 +88,7 @@ func NewHighBiased(epsilon float64) *Stream {
 // their absolute errors, i.e. the true quantile of a value returned by a query
 // is guaranteed to be within (Quantile±Epsilon).
 //
-// See http://www.cs.rutgers.edu/~muthu/bquant.pdf for time, space, and error properties.
+// See [1] above for time, space, and error properties.
 func NewTargeted(targetMap map[float64]float64) *Stream {
 	// Convert map to slice to avoid slow iterations on a map.
 	// ƒ is called on the hot path, so converting the map to a slice

--- a/pkg/util/slidingwindow/sliding_window.go
+++ b/pkg/util/slidingwindow/sliding_window.go
@@ -25,7 +25,7 @@ import "time"
 // general class of aggregators that may be  associative, such as geometric
 // mean, bloom filters etc. These require special treatment with user defined
 // functions for lift(e), lower(a) and combine(v1,v2)
-// (https://dl.acm.org/doi/pdf/10.1145/3093742.3093925).
+// (https://web.archive.org/web/20240426074602/https://dl.acm.org/doi/pdf/10.1145/3093742.3093925).
 //
 // query: O(k), append: O(k), space O(k), k = |windows|.
 // The average case append is O(1), when no windows

--- a/pkg/util/timeutil/ptp/ptp_clock_linux.go
+++ b/pkg/util/timeutil/ptp/ptp_clock_linux.go
@@ -45,7 +45,7 @@ func MakeClock(ctx context.Context, clockDevicePath string) (Clock, error) {
 
 	clockDeviceFD := result.clockDevice.Fd()
 	// For clarification of how the clock id is computed:
-	// https://lore.kernel.org/patchwork/patch/868609/
+	// https://www.kernel.org/doc/html/v6.2/driver-api/ptp.html
 	// https://github.com/torvalds/linux/blob/7e63420847ae5f1036e4f7c42f0b3282e73efbc2/tools/testing/selftests/ptp/testptp.c#L87
 	clockID := (^clockDeviceFD << 3) | 3
 	log.Dev.Infof(


### PR DESCRIPTION
The `urlcheck` linter is intended to check for existence
of all URLs embedded in the sources. There are in fact two
different CI jobs which use the linter. `TestNightlyLint`
is executed by `Lint URLs (Bazel)` whereas
`URL Check (Bazel)` runs the linter directly (via main).
Both jobs are part of the same `Nightlies` flow. While
the latter checks _all_ URLs, the former checks only
URLs found directly in SQL `helpMessages`.

In the past year, exceedingly more websites are
now behind WAFs, many of which deny even a HEAD
request. The recent fix in [1] addressed the user-agent
to be compliant with Wikipedia's WAF, which restored
the `Lint URLs (Bazel)` CI job. Meanwhile, `URL Check (Bazel)`
has been (silently) failing for several months.

This PR fixes `URL Check (Bazel)` by extending the linter
to use the Github APIs for _all_ github URLs [2]. We also
added a simple cache of checked urls, stored in a gcs bucket.
The cache has a 7-day TTL and avoids thousands of redundant
URL requests. (Upon expiry, _all_ URLs are rechecked.)
A number of broken as well as paywalled URLs have been
updated with the corresponding archive.org URL.
A small number of paywalled URLs have been added to the
ignore list.

[1] https://github.com/cockroachdb/cockroach/pull/152764
[2] https://github.com/orgs/community/discussions/159123

Resolves: https://github.com/cockroachdb/cockroach/issues/146319
Epic: none
Release note: None