### PR TITLE
changefeedccl: db-level changefeeds: notice newly added tables

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/changefeedccl/resolvedspan",
         "//pkg/ccl/changefeedccl/schemafeed",
+        "//pkg/ccl/changefeedccl/tableset",
         "//pkg/ccl/changefeedccl/timers",
         "//pkg/ccl/kvccl/kvfollowerreadsccl",
         "//pkg/ccl/utilccl",
@@ -204,6 +205,7 @@ go_test(
     size = "enormous",
     srcs = [
         "alter_changefeed_test.go",
+        "changefeed_database_watcher_test.go",
         "changefeed_dist_test.go",
         "changefeed_job_info_test.go",
         "changefeed_memory_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_database_watcher_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_database_watcher_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+type drainHelperFalse struct{}
+
+func (drainHelperFalse) IsDraining() bool { return false }
+
+// TestDatabaseLevelChangefeedRestartsOnNewTableAdded ensures that database-level changefeeds
+// restarts when a new table is added to include new data in the changefeed.
+func TestDatabaseLevelChangefeedRestartsOnNewTableAdded(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		// Create database and an initial table.
+		sqlDB.Exec(t, `CREATE DATABASE IF NOT EXISTS d`)
+		sqlDB.Exec(t, `CREATE TABLE IF NOT EXISTS d.t1 (a INT PRIMARY KEY)`)
+
+		// Capture distributed flow errors.
+		matchedCh := make(chan struct{}, 1)
+		knobs := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+		knobs.HandleDistChangefeedError = func(err error) error {
+			if testutils.IsError(err, errDatabaseTargetsChanged.Error()) {
+				// Assert non-terminal via default classification.
+				term := changefeedbase.AsTerminalError(context.Background(), drainHelperFalse{}, err)
+				if term != nil {
+					t.Errorf("expected non-terminal error, got %v", term)
+				} else {
+					select {
+					case matchedCh <- struct{}{}:
+					default:
+					}
+				}
+			}
+			return err
+		}
+
+		// Start a database-level changefeed with frequent checkpoint attempts.
+		feed := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d WITH initial_scan='no', min_checkpoint_frequency='100ms'`)
+		defer closeFeed(t, feed)
+
+		// Generate some traffic.
+		sqlDB.Exec(t, `INSERT INTO d.t1 VALUES (1)`)
+		assertPayloads(t, feed, []string{
+			`t1: [1]->{"after": {"a": 1}}`,
+		})
+
+		// Add a new table to trigger watcher diffs around checkpointing.
+		sqlDB.Exec(t, `CREATE TABLE d.t2 (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO d.t2 VALUES (1)`)
+
+		// Expect the specific non-terminal error to be observed soon.
+		select {
+		case <-matchedCh:
+		case <-time.After(30 * time.Second):
+			t.Fatal("expected watcher checkpoint guard error, timed out")
+		}
+
+		// The feed should start back up again and emit the new table and not miss any data.
+		assertPayloads(t, feed, []string{
+			`t2: [1]->{"after": {"a": 1}}`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/resolvedspan"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/tableset"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobfrontier"
@@ -66,6 +68,8 @@ import (
 const EnableCloudBillingAccountingEnvVar = "COCKROACH_ENABLE_CLOUD_BILLING_ACCOUNTING"
 
 var EnableCloudBillingAccounting = envutil.EnvOrDefaultBool(EnableCloudBillingAccountingEnvVar, false)
+
+var errDatabaseTargetsChanged = changefeedbase.MarkRetryableError(errors.New("database targets changed"))
 
 type changeAggregator struct {
 	execinfra.ProcessorBase
@@ -1107,6 +1111,15 @@ type changeFrontier struct {
 	usageWgCancel context.CancelFunc
 
 	targets changefeedbase.Targets
+
+	// tsWatcher watches the namespace for database-level changefeeds to ensure
+	// no new tables are added before we checkpoint/update the high watermark.
+	tsWatcher       *tableset.Watcher
+	tsWatcherCancel context.CancelFunc
+	tsWatcherWg     sync.WaitGroup
+	// We're not allowed to move the processor to draining from the tsWatcher's goroutine,
+	// so we use an atomic pointer to store the error and check it in Next().
+	tsDiedErr atomic.Value
 }
 
 const (
@@ -1515,6 +1528,41 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 		cf.knobs.AfterCoordinatorFrontierRestore(cf.frontier)
 	}
 
+	// If this is a database-level changefeed, start a tableset watcher that
+	// lets us know of any tableset changes.
+	if cf.spec.Feed.IsDatabaseLevelChangefeed() {
+		wFilter, err := tableset.NewFilterFromChangefeedDetails(cf.spec.Feed)
+		if err != nil {
+			log.Changefeed.Warningf(cf.Ctx(), "moving to draining due to error getting database target specification filter list: %v", err)
+			cf.MoveToDraining(err)
+			return
+		}
+		execCfg := cf.FlowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig)
+		cf.tsWatcher = tableset.NewWatcher(wFilter, execCfg, cf.FlowCtx.Cfg.ChangefeedMonitor, int64(cf.spec.JobID))
+
+		wctx, cancel := context.WithCancel(ctx)
+		cf.tsWatcherCancel = cancel
+		cf.tsWatcherWg.Add(1)
+		// Start the watcher at the frontier timestamp, or, if it's zero, the
+		// statement time. (The frontier ts can be zero if the changefeed is
+		// just starting up, but we don't want to use that for the tableset
+		// watcher).
+		startWatcherTS := cf.frontier.Frontier()
+		if startWatcherTS.IsEmpty() {
+			startWatcherTS = cf.spec.Feed.StatementTime
+		}
+		go func(initialTS hlc.Timestamp) {
+			defer cf.tsWatcherWg.Done()
+			log.Changefeed.Infof(cf.Ctx(), "starting tableset watcher with initialTS=%s", initialTS)
+			if err := cf.tsWatcher.Start(wctx, initialTS); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					cf.tsDiedErr.Store(err)
+					return
+				}
+			}
+		}(startWatcherTS)
+	}
+
 	func() {
 		cf.metrics.mu.Lock()
 		defer cf.metrics.mu.Unlock()
@@ -1601,6 +1649,12 @@ func (cf *changeFrontier) close() {
 	cf.usageWgCancel()
 	cf.usageWg.Wait()
 
+	// Stop tableset watcher if running.
+	if cf.tsWatcherCancel != nil {
+		cf.tsWatcherCancel()
+		cf.tsWatcherWg.Wait()
+	}
+
 	if cf.InternalClose() {
 		if cf.metrics != nil {
 			cf.closeMetrics()
@@ -1630,6 +1684,13 @@ func (cf *changeFrontier) closeMetrics() {
 // Next is part of the RowSource interface.
 func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 	for cf.State == execinfra.StateRunning {
+		// Check for errors from the tableset watcher.
+		if err := cf.tsDiedErr.Load(); err != nil {
+			log.Dev.Warningf(cf.Ctx(), "moving to draining due to error in tableset watcher: %v", err)
+			cf.MoveToDraining(err.(error))
+			break
+		}
+
 		if !cf.passthroughBuf.IsEmpty() {
 			return cf.ProcessRowHelper(cf.passthroughBuf.Pop()), nil
 		} else if !cf.resolvedBuf.IsEmpty() {
@@ -1873,6 +1934,44 @@ func (cf *changeFrontier) checkpointJobProgress(
 			return changefeedbase.MarkRetryableError(errors.New("cf.knobs.RaiseRetryableError"))
 		}
 	}
+	// For database-level changefeeds, before advancing the high-water (or
+	// writing span-level checkpoints), ensure that no new tables have been
+	// added up to the frontier timestamp. This guarantees we don't persist a
+	// checkpoint that would cause us to miss data from newly added tables.
+	var tablesToAdd []tableset.AddedTable
+	// NOTE: cf.tsWatcher is only set for db-level changefeeds.
+	if cf.tsWatcher != nil {
+		// N.B. this call is not idempotent. If this code changes to be in a
+		// place where it might be retried during the lifetime of the watcher,
+		// things will be wrong. The watcher makes a best-effort attempt to
+		// catch this error but even so.
+		unchanged, diffs, err := cf.tsWatcher.PopUnchangedUpTo(ctx, frontier)
+		if err != nil {
+			return err
+		}
+		if !unchanged {
+			tablesToAdd = diffs.Adds()
+			// Add new tables to the frontier and persist it, if there are any.
+			if len(tablesToAdd) > 0 {
+				// If there are changes, we'll only advance the frontier to the creation time of the first added table.
+				frontier = tablesToAdd[0].AsOf
+				for _, table := range tablesToAdd {
+					tableKey := cf.FlowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig).Codec.TablePrefix(uint32(table.Table.ID))
+					rs := jobspb.ResolvedSpan{
+						Timestamp: table.AsOf,
+						Span:      roachpb.Span{Key: tableKey, EndKey: tableKey.PrefixEnd()},
+					}
+					// Sanity check: table doesn't currently exist in tableFrontier.
+					if tableFrontier := cf.frontier.GetFrontier(table.Table.ID); tableFrontier != nil {
+						return errors.AssertionFailedf("table %d (%+v) already exists in frontier with timestamp %s", table.Table.ID, table.Table.NameInfo, tableFrontier.Frontier())
+					}
+					if _, err := cf.frontier.ForwardResolvedSpan(rs); err != nil {
+						return errors.Wrapf(err, "forwarding resolved span for newly added table in db-level feed")
+					}
+				}
+			}
+		}
+	}
 
 	updateRunStatus := timeutil.Since(cf.js.lastRunStatusUpdate) > runStatusUpdateFrequency
 	if updateRunStatus {
@@ -1912,6 +2011,13 @@ func (cf *changeFrontier) checkpointJobProgress(
 
 			ju.UpdateProgress(progress)
 
+			// Persist new tables to the frontier.
+			if len(tablesToAdd) > 0 {
+				if err := cf.persistFrontier(ctx, txn); err != nil {
+					return err
+				}
+			}
+
 			return nil
 		}); err != nil {
 			return err
@@ -1928,6 +2034,10 @@ func (cf *changeFrontier) checkpointJobProgress(
 	cf.localState.SetHighwater(frontier)
 	cf.localState.SetCheckpoint(spanLevelCheckpoint)
 
+	if len(tablesToAdd) > 0 {
+		return errors.Wrapf(errDatabaseTargetsChanged, "(progress saved) before checkpoint at %s: %v", frontier, tablesToAdd)
+	}
+
 	return nil
 }
 
@@ -1943,13 +2053,17 @@ func (cf *changeFrontier) maybePersistFrontier(ctx context.Context) error {
 
 	timer := cf.sliMetrics.Timers.FrontierPersistence.Start()
 	if err := cf.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jobfrontier.Store(ctx, txn, cf.spec.JobID, "coordinator", cf.frontier)
+		return cf.persistFrontier(ctx, txn)
 	}); err != nil {
 		return err
 	}
 	persistDuration := timer.End()
 	cf.frontierPersistenceLimiter.doneSave(persistDuration)
 	return nil
+}
+
+func (cf *changeFrontier) persistFrontier(ctx context.Context, txn isql.Txn) error {
+	return jobfrontier.Store(ctx, txn, cf.spec.JobID, "coordinator", cf.frontier)
 }
 
 // manageProtectedTimestamps periodically advances the protected timestamp for

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1262,9 +1262,9 @@ func getFullyQualifiedTableNames(
 			// Table name is fully qualfied e.g. foo.bar.fizz. This will resolve to
 			// foo.bar.fizz unless foo != <targetDatabase>, in which case it would fail.
 			if tableName.CatalogName != tree.Name(targetDatabase) {
-				return nil, errors.AssertionFailedf(
+				return nil, changefeedbase.WithTerminalError(errors.Newf(
 					"table %q must be in target database %q", tableName.FQString(), targetDatabase,
-				)
+				))
 			}
 		}
 		fqTableNames = append(fqTableNames, tableName)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -939,6 +939,7 @@ func requireNoFeedsFail(t *testing.T) (fn updateKnobsFn) {
 		`knobs.RaiseRetryableError`,
 		`test error`,
 		`context canceled`,
+		errDatabaseTargetsChanged.Error(),
 	}
 	shouldIgnoreErr := func(err error) bool {
 		if err == nil || errors.Is(err, context.Canceled) {

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -446,6 +446,8 @@ type maybeTablePartitionedFrontier interface {
 	// on a per-table basis, the iterator will return a single frontier
 	// with descpb.InvalidID.
 	Frontiers() iter.Seq2[descpb.ID, span.ReadOnlyFrontier]
+	// GetFrontier returns the frontier for the given partition if it is present.
+	GetFrontier(partition descpb.ID) span.ReadOnlyFrontier
 }
 
 var _ maybeTablePartitionedFrontier = (*span.MultiFrontier[descpb.ID])(nil)
@@ -467,6 +469,11 @@ func (f notTablePartitionedFrontier) Frontiers() iter.Seq2[descpb.ID, span.ReadO
 	return func(yield func(descpb.ID, span.ReadOnlyFrontier) bool) {
 		yield(descpb.InvalidID, f.spanFrontier)
 	}
+}
+
+// GetFrontier implements maybeTablePartitionedFrontier.
+func (f notTablePartitionedFrontier) GetFrontier(partition descpb.ID) span.ReadOnlyFrontier {
+	return nil
 }
 
 // A TableCodec does table-related decoding/encoding.

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -172,3 +172,9 @@ var _ redact.SafeFormatter = (*RowLevelTTLProcessorProgress)(nil)
 func (r *RowLevelTTLProcessorProgress) SafeFormat(p redact.SafePrinter, _ rune) {
 	p.SafeString(redact.SafeString(r.String()))
 }
+
+// IsDatabaseLevelChangefeed returns true if the changefeed is a database-level changefeed.
+func (d *ChangefeedDetails) IsDatabaseLevelChangefeed() bool {
+	return len(d.TargetSpecifications) == 1 &&
+		d.TargetSpecifications[0].Type == ChangefeedTargetSpecification_DATABASE
+}

--- a/pkg/util/span/multi_frontier.go
+++ b/pkg/util/span/multi_frontier.go
@@ -255,6 +255,15 @@ func (f *MultiFrontier[P]) Frontiers() iter.Seq2[P, ReadOnlyFrontier] {
 	}
 }
 
+// GetFrontier returns the frontier for the given partition if it is present
+// in the heap and nil otherwise.
+func (f *MultiFrontier[P]) GetFrontier(partition P) ReadOnlyFrontier {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.mu.frontiers.get(partition)
+}
+
 // partitionedMultiFrontierHeap is a wrapper around multiFrontierHeap
 // that provides convenience methods so that frontiers can be
 // accessed by their partition. It is not safe for concurrent use.


### PR DESCRIPTION
Add a table watcher check to the change frontier
before saving progress. If we encounter a new
table, save progress up to that point and then
die.

Fixes: #148834
Release note: None
