### PR TITLE
release-25.3: backupsink: fix a resource leak in backupsink

### DIFF
--- a/pkg/backup/backupsink/file_sst_sink.go
+++ b/pkg/backup/backupsink/file_sst_sink.go
@@ -231,11 +231,13 @@ func (s *FileSSTSink) Close() error {
 	if s.cancel != nil {
 		s.cancel()
 	}
+
+	var err error
 	if s.out != nil {
-		return s.out.Close()
+		err = s.out.Close()
 	}
 	s.sst.Close()
-	return nil
+	return err
 }
 
 func (s *FileSSTSink) Flush(ctx context.Context) error {


### PR DESCRIPTION
Backport 1/1 commits from #150935.

/cc @cockroachdb/release

---

This fixes a bug in backupsink's Close implementation. If it was called with an un-flushed write (i.e. s.out != nil), Close would return early and leak the sstwriter.

Fixes: #150831
Release note: none

---

Release justification: Fixes a resource leak bug.