### PR TITLE
tiered: [tiering prototype] add storage tiering to index descriptor, add system column

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -343,7 +343,7 @@ func (e *familyEvaluator) setupProjection(presentation colinfo.ResultColumns) {
 func inputSpecForEventDescriptor(
 	ed *cdcevent.EventDescriptor, prevCol catalog.Column,
 ) ([]*types.T, catalog.TableColMap, error) {
-	numCols := len(ed.ResultColumns()) + len(colinfo.AllSystemColumnDescs)
+	numCols := len(ed.ResultColumns()) + len(ed.TableDescriptor().SystemColumns())
 	inputTypes := make([]*types.T, 0, numCols)
 	var inputCols catalog.TableColMap
 	for i, c := range ed.ResultColumns() {
@@ -356,9 +356,9 @@ func inputSpecForEventDescriptor(
 	}
 
 	// Add system columns.
-	for _, sc := range colinfo.AllSystemColumnDescs {
-		inputCols.Set(sc.ID, inputCols.Len())
-		inputTypes = append(inputTypes, sc.Type)
+	for _, sc := range ed.TableDescriptor().SystemColumns() {
+		inputCols.Set(sc.GetID(), inputCols.Len())
+		inputTypes = append(inputTypes, sc.GetType())
 	}
 
 	// Setup cdc_prev if needed.

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -280,11 +280,7 @@ func makeDropColumn(s *Smither) (tree.Statement, bool) {
 	var col *tree.ColumnTableDef
 	for {
 		col = tableRef.Columns[s.rnd.Intn(len(tableRef.Columns))]
-		var isSystemCol bool
-		for _, systemColDesc := range colinfo.AllSystemColumnDescs {
-			isSystemCol = isSystemCol || string(col.Name) == systemColDesc.Name
-		}
-		if !isSystemCol {
+		if !colinfo.IsSystemColumnName(string(col.Name)) {
 			break
 		}
 	}

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -460,12 +460,11 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 		prevEndKey = span.EndKey
 	}
 
-	// The prototype special-cases a table by its name. In a real implementation,
-	// the table descriptor would contain the relevant information.
-	if table.GetName() == "tieredtable" {
-		// This is not an inherent limitation, we just don't want to add more
-		// complicated logic in the prototype.
+	// TODO(radu): support secondary indexes.
+	if table.GetPrimaryIndex().UsesStorageTiering() {
 		if len(zone.SubzoneSpans) != 0 {
+			// This is not an inherent limitation, we just don't want to add more
+			// complicated logic in the prototype.
 			return nil, errors.AssertionFailedf("subzone spans not supported with tiered storage")
 		}
 		pkStartKey := s.codec.IndexPrefix(uint32(table.GetID()), uint32(table.GetPrimaryIndexID()))

--- a/pkg/sql/catalog/catalog.go
+++ b/pkg/sql/catalog/catalog.go
@@ -101,7 +101,7 @@ func (p ResolvedObjectPrefix) NamePrefix() tree.ObjectNamePrefix {
 // NumSystemColumns defines the number of supported system columns and must be
 // equal to colinfo.numSystemColumns (enforced in colinfo package to avoid an
 // import cycle).
-const NumSystemColumns = 4
+const NumSystemColumns = 5
 
 // SmallestSystemColumnColumnID is a descpb.ColumnID with the smallest value
 // among all system columns (enforced in colinfo package to avoid an import

--- a/pkg/sql/catalog/catpb/enum.proto
+++ b/pkg/sql/catalog/catpb/enum.proto
@@ -26,11 +26,14 @@ enum SystemColumnKind {
   // A system column containing the OID of the table that the row came from.
   TABLEOID = 2;
   // A system column containing the value of the OriginID field of the
-  // MVCCValueHeader associated with the kv's corresponding to the row.
+  // MVCCValueHeader associated with the KVs corresponding to the row.
   ORIGINID = 3;
   // A system column containing the value of the OriginTimestamp field of the
-  // MVCCValueHeader associated with the KV's coressponding to the row.
+  // MVCCValueHeader associated with the KVs corresponding to the row.
   ORIGINTIMESTAMP = 4;
+  // A system column containing the value of the TieringAttribute field of the
+  // MVCCValueHeader associated with the KVs corresponding to the row.
+  TIERINGATTR = 5;
 }
 
 // InvertedIndexColumnKind is the kind of the inverted index on a column. The

--- a/pkg/sql/catalog/colinfo/system_columns.go
+++ b/pkg/sql/catalog/colinfo/system_columns.go
@@ -48,13 +48,18 @@ const (
 	// MVCCValueHeader.
 	//
 	// In the presence of multiple column families, this column
-	// will only be non-NULL if the latest OriginTimstamp is
+	// will only be non-NULL if the latest OriginTimestamp is
 	// larger than then MVCC timestamp of all column families
 	// _without_ and OriginTimestamp.
 	//
 	// NB: The semantics of this column are subject to change and
 	// should not be relied upon.
 	OriginTimestampColumnID
+
+	// TieringAttrColumnID is the ColumnID of a tiering attribute system column
+	// which returns the TieringAttribute from the MVCCValueHeader. All KVs
+	// associated with the same row have the same TieringAttribute value.
+	TieringAttrColumnID
 
 	numSystemColumns = iota
 )
@@ -82,6 +87,7 @@ var AllSystemColumnDescs = []descpb.ColumnDescriptor{
 	TableOIDColumnDesc,
 	OriginIDColumnDesc,
 	OriginTimestampColumnDesc,
+	TieringAttrColumnDesc,
 }
 
 // MVCCTimestampColumnDesc is a column descriptor for the MVCC system column.
@@ -121,7 +127,7 @@ var OriginTimestampColumnDesc = descpb.ColumnDescriptor{
 	Name:             OriginTimestampColumnName,
 	Type:             OriginTimestampColumnType,
 	Hidden:           true,
-	Nullable:         true,
+	Nullable:         false,
 	SystemColumnKind: catpb.SystemColumnKind_ORIGINTIMESTAMP,
 	ID:               OriginTimestampColumnID,
 }
@@ -144,6 +150,21 @@ var TableOIDColumnDesc = descpb.ColumnDescriptor{
 
 // TableOIDColumnName is the name of the tableoid system column.
 const TableOIDColumnName = "tableoid"
+
+// TieringAttrColumnDesc is the descriptor for the tiering attribute column,
+// only usable with tables that use storage tiering.
+var TieringAttrColumnDesc = descpb.ColumnDescriptor{
+	Name:             TieringAttrColumnName,
+	Type:             TieringAttrColumnType,
+	Hidden:           true,
+	Nullable:         true,
+	SystemColumnKind: catpb.SystemColumnKind_TIERINGATTR,
+	ID:               TieringAttrColumnID,
+}
+
+const TieringAttrColumnName = "crdb_internal_tiering_attr"
+
+var TieringAttrColumnType = types.Int
 
 // IsColIDSystemColumn returns whether a column ID refers to a system column.
 func IsColIDSystemColumn(colID descpb.ColumnID) bool {

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -508,8 +508,38 @@ message IndexDescriptor {
   // this vector index.
   optional vecindex.vecpb.Config vec_config = 30 [(gogoproto.nullable) = false];
 
-  // Next ID: 31
+  optional StorageTieringDescriptor storage_tiering = 31;
+
+  // Next ID: 32
 }
+
+// StorageTieringDescriptor contains the configuration for storage tiering on an
+// index.
+//
+// Storage tiering is a feature that allows moving data for certain rows to
+// cheaper storage.
+message StorageTieringDescriptor {
+  option (gogoproto.equal) = true;
+
+  // TieringColumnID is the ID of the column that is used to determine the
+  // storage tier for a given row in the index. The column must be part of the
+  // index (either as the key or as a stored column).
+  //
+  // Currently, only columns of type Timestamp or TimestampTZ are supported.
+  optional uint32 tiering_column_id = 1 [(gogoproto.casttype) = "ColumnID", (gogoproto.customname) = "TieringColumnID", (gogoproto.nullable) = false];
+
+  // Threshold determines the threshold for moving data to the secondary tier.
+  oneof threshold {
+    // AgeSeconds is used when tiering column is a timestamp and the threshold
+    // is relative to the current time.
+    int32 age_seconds = 2;
+    // Fixed is used when the threshold is an absolute value. For timestamps,
+    // this is a Unix timestamp (the number of seconds elapsed since January 1,
+    // 1970 UTC).
+    int64 fixed = 3;
+  }
+}
+
 
 // TriggerDescriptor describes a trigger on a table.
 message TriggerDescriptor {

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -284,6 +284,13 @@ type Index interface {
 	// an index being used as the temporary index being used by an
 	// in-progress index backfill.
 	IsTemporaryIndexForBackfill() bool
+
+	// UsesStorageTiering returns true if the index uses storage tiering.
+	UsesStorageTiering() bool
+
+	// StorageTieringColumnID returns the column ID of the column that is used as
+	// the tiering attribute. Panics if the index does not use storage tiering.
+	StorageTieringColumnID() descpb.ColumnID
 }
 
 // Column is an interface around the column descriptor types.

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -334,6 +334,11 @@ func newColumnCache(desc *descpb.TableDescriptor, mutations *mutationCache) *col
 	numMutations := len(mutations.columns)
 	numDeletable := numPublic + numMutations
 	for i := range colinfo.AllSystemColumnDescs {
+		if colinfo.AllSystemColumnDescs[i].ID == colinfo.TieringAttrColumnID && desc.PrimaryIndex.StorageTiering == nil {
+			// The tiering attribute column can only be used with table that use
+			// storage tiering.
+			continue
+		}
 		col := column{
 			desc:    &colinfo.AllSystemColumnDescs[i],
 			ordinal: numDeletable + i,

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -469,6 +469,16 @@ func (w index) IsTemporaryIndexForBackfill() bool {
 	return w.desc.UseDeletePreservingEncoding
 }
 
+// UsesStorageTiering implements the catalog.Index interface.
+func (w index) UsesStorageTiering() bool {
+	return w.desc.StorageTiering != nil
+}
+
+// StorageTieringColumnID implements the catalog.Index interface.
+func (w index) StorageTieringColumnID() descpb.ColumnID {
+	return w.desc.StorageTiering.TieringColumnID
+}
+
 // AsCheck implements the catalog.ConstraintProvider interface.
 func (w index) AsCheck() catalog.CheckConstraint {
 	return nil

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2303,6 +2303,22 @@ func NewTableDesc(
 		}
 	}
 
+	// Prototype hack.
+	if desc.Name == "tieredtable" {
+		col := catalog.FindColumnByName(&desc, "ts")
+		if col == nil {
+			return nil, errors.Errorf("tiering requires a \"timestamp\" column")
+		}
+		fmt.Printf("\n\ntimestamp column ID: %v\n\n", col.GetID())
+		threshold, _ := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+		desc.PrimaryIndex.StorageTiering = &descpb.StorageTieringDescriptor{
+			TieringColumnID: col.GetID(),
+			Threshold: &descpb.StorageTieringDescriptor_Fixed{
+				Fixed: threshold.Unix(),
+			},
+		}
+	}
+
 	// With all structural elements in place and IDs allocated, we can resolve the
 	// constraints and qualifications.
 	// FKs are resolved after the descriptor is otherwise complete and IDs have

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -213,6 +213,14 @@ type Index interface {
 	// IsTemporaryIndexForBackfill returns true iff the index is an index being
 	// used as the temporary index being used by an in-progress index backfill.
 	IsTemporaryIndexForBackfill() bool
+
+	// UsesStorageTiering returns true if the index is configured to use storage
+	// tiering.
+	UsesStorageTiering() bool
+
+	// StorageTieringColumn returns the column that is used for storage tiering;
+	// panics if the index does not use storage tiering.
+	StorageTieringColumn() IndexColumn
 }
 
 // IndexColumn describes a single column that is part of an index definition.

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -814,4 +814,12 @@ func (u *unknownIndex) IsTemporaryIndexForBackfill() bool {
 	return false
 }
 
+func (u *unknownIndex) UsesStorageTiering() bool {
+	return false
+}
+
+func (u *unknownIndex) StorageTieringColumn() cat.IndexColumn {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
 var _ cat.Index = &unknownIndex{}

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -255,6 +255,16 @@ func (hi *hypotheticalIndex) IsTemporaryIndexForBackfill() bool {
 	return false
 }
 
+// UsesStorageTiering is part of the cat.Index interface.
+func (hi *hypotheticalIndex) UsesStorageTiering() bool {
+	return false
+}
+
+// StorageTieringColumn is part of the cat.Index interface.
+func (hi *hypotheticalIndex) StorageTieringColumn() cat.IndexColumn {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
 // hasSameExplicitCols checks whether the given existing index has identical
 // explicit columns as the hypothetical index. To be identical, they need to
 // have the exact same list, length, and order. If the index is inverted, it

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -618,7 +618,7 @@ func FetchSpecRequiresRawMVCCValues(spec fetchpb.IndexFetchSpec) bool {
 		colID := spec.FetchedColumns[idx].ColumnID
 		if colinfo.IsColIDSystemColumn(colID) {
 			switch colinfo.GetSystemColumnKindFromColumnID(colID) {
-			case catpb.SystemColumnKind_ORIGINID, catpb.SystemColumnKind_ORIGINTIMESTAMP:
+			case catpb.SystemColumnKind_ORIGINID, catpb.SystemColumnKind_ORIGINTIMESTAMP, catpb.SystemColumnKind_TIERINGATTR:
 				return true
 			}
 		}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -739,9 +739,18 @@ func (t *tieringPolicyAndExtractor) ExtractAttribute(
 	userKey []byte, value []byte,
 ) (pebble.TieringAttribute, error) {
 	a, err := DecodeTieringAttributeFromMVCCValue(value)
+	if debugSpanPolicy {
+		k, _ := DecodeEngineKey(userKey)
+		if err != nil {
+			fmt.Printf("ExtractAttribute %s error: %v", k, err)
+		} else {
+			fmt.Printf("ExtractAttribute %s -> %d\n", k, a)
+		}
+	}
 	if err != nil {
 		return 0, err
 	}
+
 	return pebble.TieringAttribute(a), err
 }
 

--- a/pkg/storage/tiering_test.go
+++ b/pkg/storage/tiering_test.go
@@ -41,14 +41,18 @@ func TestTieringPolicy(t *testing.T) {
 	runner.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'`)
 
 	fmt.Printf("\n\ncreating table\n")
-	runner.Exec(t, "CREATE TABLE tieredtable (k INT PRIMARY KEY, v STRING, tierval INTEGER)")
+	runner.Exec(t, "CREATE TABLE tieredtable (k INT PRIMARY KEY, v STRING, ts TIMESTAMPTZ)")
 
 	// Wait for the span config to be applied.
 	fmt.Printf("\n\nsleeping\n")
 	time.Sleep(2 * time.Second)
 
 	fmt.Printf("\n\ninserting\n")
-	runner.Exec(t, "INSERT INTO tieredtable VALUES (1, 'foo', 10), (2, 'bar', 200), (3, 'baz', 300), (4, 'qux', 50)")
+	runner.Exec(t, `INSERT INTO tieredtable VALUES
+		(1, 'foo', '1970-01-01 00:10:00'),
+		(2, 'bar', '1970-01-01 00:00:01'),
+		(3, 'baz', '1970-01-01 00:11:00'),
+		(4, 'qux', '1970-01-01 00:00:02')`)
 
 	fmt.Printf("\n\nrunning compaction\n")
 	runner.Exec(t, `SELECT crdb_internal.compact_engine_span(1, 1,

--- a/pkg/storage/tiering_test.go
+++ b/pkg/storage/tiering_test.go
@@ -54,6 +54,14 @@ func TestTieringPolicy(t *testing.T) {
 		(3, 'baz', '1970-01-01 00:11:00'),
 		(4, 'qux', '1970-01-01 00:00:02')`)
 
+	fmt.Printf("\n\nquerying:\n")
+	runner.CheckQueryResults(t, `SELECT k, ts, crdb_internal_tiering_attr FROM tieredtable`, [][]string{
+		{"1", "1970-01-01 00:10:00 +0000 UTC", "600"},
+		{"2", "1970-01-01 00:00:01 +0000 UTC", "1"},
+		{"3", "1970-01-01 00:11:00 +0000 UTC", "660"},
+		{"4", "1970-01-01 00:00:02 +0000 UTC", "2"},
+	})
+
 	fmt.Printf("\n\nrunning compaction\n")
 	runner.Exec(t, `SELECT crdb_internal.compact_engine_span(1, 1,
 		(SELECT raw_start_key FROM [SHOW RANGES FROM TABLE tieredtable WITH KEYS] ORDER BY start_key LIMIT 1),


### PR DESCRIPTION
#### [tiering prototype] descpb: add storage tiering to index descriptor

Add storage tiering information in the index descriptor, and do the
necessary plumbing to populate the TieringAttribute. We currently only
support deriving it from a `TIMESTAMP` or `TIMESTAMPTZ` column.

#### [tiering prototype] colinfo: add tiering attribute system column

This allows us to query the tiering attribute, to verify that it is
populated correctly.