### PR TITLE
sql: fix placeholder type checking

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1741,3 +1741,24 @@ statement ok
 EXECUTE p(120)
 
 subtest end
+
+# Regression test for #152664. Correctly type placeholders with UNKNOWN type
+# hints.
+statement ok
+PREPARE p152664 (BOOL, UNKNOWN, DECIMAL) AS SELECT IF($1, $2, $3) IS NOT NAN
+
+query B
+EXECUTE p152664(false, NULL, 4)
+----
+true
+
+statement ok
+DEALLOCATE p152664
+
+statement ok
+PREPARE p152664 (BOOL, DECIMAL, UNKNOWN) AS SELECT IF($1, $2, $3) IS NOT NAN
+
+query B
+EXECUTE p152664(true, 4, NULL)
+----
+true

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2991,7 +2991,9 @@ func typeCheckSameTypedPlaceholders(s typeCheckExprsState, typ *types.T) (*types
 			return nil, err
 		}
 		s.typedExprs[i] = typedExpr
-		typ = typedExpr.ResolvedType()
+		if t := typedExpr.ResolvedType(); !t.IsAmbiguous() {
+			typ = t
+		}
 	}
 	return typ, nil
 }


### PR DESCRIPTION
Previously, an binary expression with two placeholders could be
incorrectly typed in a prepared statement. The issue could occur when
one placeholder had an `UNKNOWN` type hint and one with a non-ambiguous
type hint, e.g., `INT`, `DECIMAL`, etc. The `UNKNOWN` type hint could
take precedence over the non-ambiguous type. This could cause incorrect
results in some cases.

The bug has been fixed by preferring non-ambiguous type hints over
ambiguous ones.

Fixes #152664

Release note (bug fix): A bug in type-checking placeholders with
`UNKNOWN` types has been fixed. It could cause incorrect results in some
cases.
