### PR TITLE
kvserver: fix TestUpdateLastUpdateTimesUsingStoreLiveness

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -699,7 +699,7 @@ func (r *Replica) stepRaftGroupRaftMuLocked(req *kvserverpb.RaftMessageRequest) 
 			// Update the lastUpdateTimes map, unless configured not to by a testing
 			// knob.
 			disableUpdateLastUpdateTimesMapOnRaftGroupStep := false
-			if r.store.TestingKnobs() == nil &&
+			if r.store.TestingKnobs() != nil &&
 				r.store.TestingKnobs().DisableUpdateLastUpdateTimesMapOnRaftGroupStep != nil {
 				disableUpdateLastUpdateTimesMapOnRaftGroupStep = r.store.TestingKnobs().DisableUpdateLastUpdateTimesMapOnRaftGroupStep(r)
 			}


### PR DESCRIPTION
This test wasn't doing as advertised on the tin after I broke some testing knobs in 02fa61b3c8def5df47b7e70014d1c39457de8e79.

Epic: none

Release note: None