### PR TITLE
roachprod: potential shell syntax error in fips

### DIFF
--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -181,7 +181,8 @@ const startupScriptFIPS = `
 {{ if .EnableFIPS }}
 sudo apt-get install -yq ubuntu-advantage-tools jq
 # Enable FIPS (in practice, it's often already enabled at this point).
-if [ $(sudo pro status --format json | jq '.services[] | select(.name == "fips") | .status') != '"enabled"' ]; then
+fips_status=$(sudo pro status --format json | jq '.services[] | select(.name == "fips") | .status')
+if [ "$fips_status" != '"enabled"' ]; then
 	sudo ua enable fips --assume-yes
 fi
 {{ end }}`


### PR DESCRIPTION
Previous patch #137555 introduced a check on FIPS enablement in a FIPS environment.

To avoid a potential shell syntax error if this code was to be executed outside of a Ubuntu Pro FIPS environment, this patch adds quotes around the result of the `pro status` command result to avoid an `[: !=: unary operator expected` error.

Epic: none
Release note: None