### PR TITLE
kvcoord: correctly initialize txnWriteBuffer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -281,9 +281,6 @@ func newRootTxnCoordSender(
 		timeSource: timeutil.DefaultTimeSource{},
 		txn:        &tcs.mu.txn,
 	}
-	tcs.interceptorAlloc.txnWriteBuffer.init(
-		&tcs.interceptorAlloc.txnPipeliner,
-	)
 
 	tcs.initCommonInterceptors(tcf, txn, kv.RootTxn)
 
@@ -363,6 +360,7 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 		allowConcurrentRequests: typ == kv.LeafTxn,
 	}
 	tc.interceptorAlloc.txnSeqNumAllocator.writeSeq = txn.Sequence
+	tc.interceptorAlloc.txnWriteBuffer.init(&tc.interceptorAlloc.txnPipeliner)
 }
 
 func (tc *TxnCoordSender) connectInterceptors() {

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -398,6 +398,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
+  AND message NOT LIKE '%QueryIntent%'
 ----
 dist sender send  r77: sending batch 6 CPut to (n1,s1):1
 dist sender send  r77: sending batch 6 CPut to (n1,s1):1


### PR DESCRIPTION
Previously we were initializing the pipelineEnabler on a copy of the txnWriteBuffer that would later be overwritten. As a result, we were never re-enabling pipelining after a mid-transaction flush. This is OK from a correctness perspective since this was only intended as a potential performance improvement for some workloads under buffered writes.

There is a potentially strong argument that we shouldn't do this at all and that if someone sees a regression of their workload under buffered writes they should turn it off rather than relying on this fallback.

Epic: None
Release note: None