### PR TITLE
kvpb: always use t.ExpectExclusionSince in EarliestActiveTimestamp

### DIFF
--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -101,7 +101,7 @@ func (ba *BatchRequest) EarliestActiveTimestamp() hlc.Timestamp {
 			//
 			// See the example in RefreshRequest for more details.
 			if !t.ExpectExclusionSince.IsEmpty() {
-				ts.Backward(t.ExpectExclusionSince.Next())
+				ts.Backward(t.ExpectExclusionSince)
 			}
 		case *ExportRequest:
 			if !t.StartTime.IsEmpty() {
@@ -115,7 +115,7 @@ func (ba *BatchRequest) EarliestActiveTimestamp() hlc.Timestamp {
 			//
 			// See the example in RefreshRequest for more details.
 			if !t.ExpectExclusionSince.IsEmpty() {
-				ts.Backward(t.ExpectExclusionSince.Next())
+				ts.Backward(t.ExpectExclusionSince)
 			}
 		case *PutRequest:
 			// A PutRequest with ExpectExclusionSince set need to be able to observe MVCC


### PR DESCRIPTION
Previously, some cases used ExpectExclusionSince while others used ExpectExclusionSince.Next().

I think this was OK in practice because any write we needed to observe would need to be at ExpectExclusionSince.Next() since we set that field based on the ReadTimestamp of a locking Get. Such Get's scan with FailOnMoreRecent set which, despite the name, also fails if the current value equals the read timestamp. Thus, any new write violating our exclusion would have to be at .Next() or higher.

If the above analysis doesn't convince your or is wrong, also note that this is only required for weak isolation buffered writes which can only be enabled via a non-public cluster setting (SSI transactions refresh their reads).

In case the argument above is wrong, I've chosen to normalize these to the earlier timestamp.

I've forgone a release note given the above argument.

Epic: none
Release note: None