### PR TITLE
sstbatcher: pass unix nanos when computing stats

### DIFF
--- a/pkg/kv/bulk/sst_adder.go
+++ b/pkg/kv/bulk/sst_adder.go
@@ -345,7 +345,7 @@ func addStatsToSplitTables(left, right, original *sstSpan, sendStartTimestamp ti
 		return err
 	}
 	statsIter.SeekGE(storage.MVCCKey{Key: right.start})
-	right.stats, err = storage.ComputeStatsForIter(statsIter, sendStartTimestamp.Unix())
+	right.stats, err = storage.ComputeStatsForIter(statsIter, sendStartTimestamp.UnixNano())
 	statsIter.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, when regenerating stats from a split, we passed unix seconds to the stats calculation routine instead of unix nanoseconds. This is incorrect, but doesn't seem to have any observable impact on behavior since the time is used to estimate the age of garbage. The SST batcher cannot calculate garbage age bytes since it is missing the previous value and therefore does not know the size of the value.

Epic: none
Release note: none