### PR TITLE
sql: enforce schema_locked for TRUNCATE

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -3603,9 +3603,11 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 	sqlDB.Exec(t, `ALTER TABLE data.bank ADD COLUMN points_balance INT DEFAULT 50`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[5])
 
+	sqlDB.Exec(t, "ALTER TABLE data.bank SET (schema_locked=false)")
 	sqlDB.Exec(t, `TRUNCATE TABLE data.bank`)
 	sqlDB.Exec(t, `TRUNCATE TABLE data.bank`)
 	sqlDB.Exec(t, `TRUNCATE TABLE data.bank`)
+	sqlDB.Exec(t, "ALTER TABLE data.bank SET (schema_locked=true)")
 	sqlDB.Exec(t, `CREATE TABLE other.sometable AS SELECT * FROM data.sometable`)
 	sqlDB.Exec(t, `DROP TABLE data.sometable`)
 	sqlDB.Exec(t, `CREATE INDEX ON data.teller (name)`)
@@ -3613,7 +3615,9 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO data.teller VALUES (2, 'craig')`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[6])
 
+	sqlDB.Exec(t, "ALTER TABLE data.bank SET (schema_locked=false)")
 	sqlDB.Exec(t, `TRUNCATE TABLE data.bank`)
+	sqlDB.Exec(t, "ALTER TABLE data.bank SET (schema_locked=true)")
 	sqlDB.Exec(t, `INSERT INTO data.bank VALUES (2, 2), (4, 4)`)
 	sqlDB.Exec(t, `DROP TABLE other.sometable`)
 	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts[7])
@@ -5037,7 +5041,9 @@ func TestBackupRestoreIncrementalTruncateTable(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO data.t VALUES ('before')`)
 	sqlDB.Exec(t, `BACKUP DATABASE data INTO $1`, full)
 	sqlDB.Exec(t, `UPDATE data.t SET s = 'after'`)
+	sqlDB.Exec(t, "ALTER TABLE data.t SET (schema_locked=false)")
 	sqlDB.Exec(t, `TRUNCATE data.t`)
+	sqlDB.Exec(t, "ALTER TABLE data.t SET (schema_locked=true)")
 
 	sqlDB.Exec(t, "BACKUP DATABASE data INTO $1", full)
 }

--- a/pkg/bench/rttanalysis/truncate_bench_test.go
+++ b/pkg/bench/rttanalysis/truncate_bench_test.go
@@ -12,36 +12,36 @@ func init() {
 	reg.Register("Truncate", []RoundTripBenchTestCase{
 		{
 			Name:  "truncate 1 column 0 rows",
-			Setup: "CREATE TABLE t(x INT);",
+			Setup: "CREATE TABLE t(x INT) WITH (schema_locked=false);",
 			Stmt:  "TRUNCATE t",
 		},
 		{
 			Name: "truncate 1 column 1 row",
-			Setup: `CREATE TABLE t(x INT); 
+			Setup: `CREATE TABLE t(x INT) WITH (schema_locked=false); 
 INSERT INTO t (x) VALUES (1);`,
 			Stmt: "TRUNCATE t",
 		},
 		{
 			Name: "truncate 1 column 2 rows",
-			Setup: `CREATE TABLE t(x INT); 
+			Setup: `CREATE TABLE t(x INT) WITH (schema_locked=false);
 INSERT INTO t (x) VALUES (1);
 INSERT INTO t (x) VALUES (2);`,
 			Stmt: "TRUNCATE t",
 		},
 		{
 			Name:  "truncate 2 column 0 rows",
-			Setup: `CREATE TABLE t(x INT, y INT);`,
+			Setup: `CREATE TABLE t(x INT, y INT) WITH (schema_locked=false);`,
 			Stmt:  "TRUNCATE t",
 		},
 		{
 			Name: "truncate 2 column 1 rows",
-			Setup: `CREATE TABLE t(x INT, y INT); 
+			Setup: `CREATE TABLE t(x INT, y INT) WITH (schema_locked=false); 
 INSERT INTO t (x, y) VALUES (1, 1);`,
 			Stmt: "TRUNCATE t",
 		},
 		{
 			Name: "truncate 2 column 2 rows",
-			Setup: `CREATE TABLE t(x INT, y INT); 
+			Setup: `CREATE TABLE t(x INT, y INT) WITH (schema_locked=false);
 INSERT INTO t (x, y) VALUES (1, 1);
 INSERT INTO t (x,y) VALUES (2, 2);`,
 			Stmt: "TRUNCATE t",

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -520,7 +520,9 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.CheckQueryResults(t, `SELECT key, value FROM sink ORDER BY PRIMARY KEY sink`,
 		[][]string{{`k1`, `v0`}},
 	)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=false)`)
 	sqlDB.Exec(t, `TRUNCATE sink`)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=true)`)
 
 	// Verify the implicit flushing
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`0`}})
@@ -532,7 +534,9 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`3`}})
 	require.NoError(t, sink.Flush(ctx))
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM sink`, [][]string{{`4`}})
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=false)`)
 	sqlDB.Exec(t, `TRUNCATE sink`)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=true)`)
 
 	// Two tables interleaved in time
 	var pool testAllocPool
@@ -544,7 +548,9 @@ func TestSQLSink(t *testing.T) {
 	sqlDB.CheckQueryResults(t, `SELECT topic, key, value FROM sink ORDER BY PRIMARY KEY sink`,
 		[][]string{{`bar`, `kbar`, `v0`}, {`foo`, `kfoo`, `v0`}, {`foo`, `kfoo`, `v1`}},
 	)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=false)`)
 	sqlDB.Exec(t, `TRUNCATE sink`)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=true)`)
 
 	// Multiple keys interleaved in time. Use sqlSinkNumPartitions+1 keys to
 	// guarantee that at lease two of them end up in the same partition.
@@ -569,7 +575,9 @@ func TestSQLSink(t *testing.T) {
 			{`2`, `v0`, `v1`},
 		},
 	)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=false)`)
 	sqlDB.Exec(t, `TRUNCATE sink`)
+	sqlDB.Exec(t, `ALTER TABLE sink SET (schema_locked=true)`)
 
 	// Emit resolved
 	var e testEncoder

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1518,7 +1518,13 @@ bar  CREATE TABLE public.bar (
 
 
 statement ok
+ALTER TABLE bar SET (schema_locked=false)
+
+statement ok
 TRUNCATE bar;
+
+statement ok
+ALTER TABLE bar RESET (schema_locked)
 
 query TT
 SHOW CREATE TABLE bar;

--- a/pkg/ccl/multiregionccl/unique_test.go
+++ b/pkg/ccl/multiregionccl/unique_test.go
@@ -150,8 +150,10 @@ CREATE TABLE u (
 		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
 
 		// Clean up.
-		_, err = db.Exec(`TRUNCATE test.t`)
-		require.NoError(t, err)
+		r.Exec(t, `ALTER TABLE test.t SET (schema_locked=false)`)
+		r.Exec(t, `TRUNCATE test.t`)
+		r.Exec(t, `ALTER TABLE test.t SET (schema_locked=true)`)
+
 	})
 
 	t.Run("validate_implicitly_partitioned_primary_index", func(t *testing.T) {
@@ -192,8 +194,9 @@ CREATE TABLE u (
 		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
 
 		// Clean up.
-		_, err = db.Exec(`TRUNCATE test.u`)
-		require.NoError(t, err)
+		r.Exec(t, `ALTER TABLE test.u SET (schema_locked=false)`)
+		r.Exec(t, `TRUNCATE test.u`)
+		r.Exec(t, `ALTER TABLE test.u SET (schema_locked=true)`)
 	})
 
 	t.Run("validate_implicitly_partitioned_secondary_index", func(t *testing.T) {
@@ -234,8 +237,9 @@ CREATE TABLE u (
 		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
 
 		// Clean up.
-		_, err = db.Exec(`TRUNCATE test.u`)
-		require.NoError(t, err)
+		r.Exec(t, `ALTER TABLE test.u SET (schema_locked=false)`)
+		r.Exec(t, `TRUNCATE test.u`)
+		r.Exec(t, `ALTER TABLE test.u SET (schema_locked=true)`)
 	})
 
 }

--- a/pkg/cli/interactive_tests/test_copy.tcl
+++ b/pkg/cli/interactive_tests/test_copy.tcl
@@ -10,7 +10,7 @@ eexpect root@
 send "drop table if exists t;\r"
 eexpect "DROP TABLE"
 eexpect root@
-send "create table t (id INT PRIMARY KEY, t TEXT);\r"
+send "create table t (id INT PRIMARY KEY, t TEXT) WITH (schema_locked=false);\r"
 eexpect "CREATE TABLE"
 eexpect root@
 

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -797,15 +797,16 @@ func TestLogicalReplicationWithPhantomDelete(t *testing.T) {
 	skip.UnderDeadlock(t)
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
-	tc, s, serverASQL, serverBSQL := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
-	defer tc.Stopper().Stop(ctx)
-
-	serverAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
-
 	for _, mode := range []string{"validated", "immediate"} {
 		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			tc, s, serverASQL, serverBSQL := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
+			defer tc.Stopper().Stop(ctx)
+
+			serverAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+			serverASQL.Exec(t, "ALTER TABLE tab SET (schema_locked = false)")
+			serverBSQL.Exec(t, "ALTER TABLE tab SET (schema_locked = false)")
+
 			serverASQL.Exec(t, "TRUNCATE tab")
 			serverBSQL.Exec(t, "TRUNCATE tab")
 			var jobBID jobspb.JobID

--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -338,7 +338,7 @@ func TestStoreProcedureCallStatementMetrics(t *testing.T) {
 	)
 
 	_, err := db.Exec(`		
-		CREATE TABLE tbl (id SERIAL PRIMARY KEY, t text UNIQUE);
+		CREATE TABLE tbl (id SERIAL PRIMARY KEY, t text UNIQUE) WITH (schema_locked=false);
 		INSERT INTO tbl (t) VALUES ('d');`)
 	require.NoError(t, err)
 
@@ -529,7 +529,7 @@ func TestUDFStatementMetrics(t *testing.T) {
 	)
 
 	_, err := db.Exec(`		
-		CREATE TABLE tbl (id SERIAL PRIMARY KEY, t text UNIQUE);
+		CREATE TABLE tbl (id SERIAL PRIMARY KEY, t text UNIQUE) WITH (schema_locked=false);
 		INSERT INTO tbl (t) VALUES ('d');`)
 	require.NoError(t, err)
 

--- a/pkg/sql/comment_on_column_test.go
+++ b/pkg/sql/comment_on_column_test.go
@@ -26,7 +26,7 @@ func TestCommentOnColumn(t *testing.T) {
 		if _, err := db.Exec(`
 		CREATE DATABASE d;
 		SET DATABASE = d;
-		CREATE TABLE t (c1 INT, c2 INT, c3 INT);
+		CREATE TABLE t (c1 INT, c2 INT, c3 INT) WITH (schema_locked=false);
 	`); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/comment_on_index_test.go
+++ b/pkg/sql/comment_on_index_test.go
@@ -22,7 +22,7 @@ func TestCommentOnIndex(t *testing.T) {
 		if _, err := db.Exec(`
 		CREATE DATABASE d;
 		SET DATABASE = d;
-		CREATE TABLE t (c INT, INDEX t_c_idx (c));
+		CREATE TABLE t (c INT, INDEX t_c_idx (c)) WITH (schema_locked=false);
 	`); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/comment_on_table_test.go
+++ b/pkg/sql/comment_on_table_test.go
@@ -22,7 +22,7 @@ func TestCommentOnTable(t *testing.T) {
 		if _, err := db.Exec(`
 		CREATE DATABASE d;
 		SET DATABASE = d;
-		CREATE TABLE t (i INT );
+		CREATE TABLE t (i INT ) WITH (schema_locked=false);
 	`); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -376,7 +376,11 @@ func TestCopyFromTransaction(t *testing.T) {
 						lastts = vals[0]
 					}
 				})
-				err := tconn.Exec(ctx, "TRUNCATE TABLE lineitem")
+				err := tconn.Exec(ctx, "ALTER TABLE lineitem SET (schema_locked=false)")
+				require.NoError(t, err)
+				err = tconn.Exec(ctx, "TRUNCATE TABLE lineitem")
+				require.NoError(t, err)
+				err = tconn.Exec(ctx, "ALTER TABLE lineitem SET (schema_locked=true)")
 				require.NoError(t, err)
 			})
 		}

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -503,7 +503,7 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	defer lease.TestingDisableTableLeases()()
 
 	sqlRunner.Exec(t, `CREATE DATABASE t;`)
-	sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));`)
+	sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v)) WITH (schema_locked=false);`)
 
 	// read table descriptor
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
@@ -525,7 +525,7 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 				// Init table with some entries.
 				sqlRunner.Exec(t, `TRUNCATE TABLE t.test`)
 				sqlRunner.Exec(t, `DROP TABLE t.test;`)
-				sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));`)
+				sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v)) WITH (schema_locked=false);`)
 				// read table descriptor
 				mTest.tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 					kvDB, server.Codec(), "t", "test")
@@ -705,7 +705,7 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 				}
 				// Init table to start state.
 				sqlRunner.Exec(t, `DROP TABLE t.test;`)
-				sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR, INDEX foo (i, v), FAMILY (k),FAMILY (v), FAMILY (i));`)
+				sqlRunner.Exec(t, `CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR, INDEX foo (i, v), FAMILY (k),FAMILY (v), FAMILY (i)) WITH (schema_locked=false);`)
 				sqlRunner.Exec(t, `CREATE INDEX allidx ON t.test (k, v);`)
 				if _, err := sqlDB.Exec(`TRUNCATE TABLE t.test`); err != nil {
 					t.Fatal(err)

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1445,7 +1445,7 @@ CREATE TABLE statistics_agg_test (
   int_x int,
   dy decimal,
   dx decimal
-)
+) WITH (schema_locked=false);
 
 statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
@@ -2585,7 +2585,7 @@ CREATE TABLE string_agg_test (
   id INT PRIMARY KEY,
   company_id INT,
   employee STRING
-)
+) WITH (schema_locked=false);
 
 query IT colnames
 SELECT company_id, string_agg(employee, ',')
@@ -3176,7 +3176,7 @@ SELECT x, SUM (y) FROM t GROUP BY (x) ORDER BY SUM (y)
 subtest every
 
 statement ok
-CREATE TABLE t_every (x BOOL)
+CREATE TABLE t_every (x BOOL) WITH (schema_locked=false)
 
 query B
 SELECT every (x) FROM t_every

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -373,8 +373,15 @@ INSERT INTO uses_alphabets_2 VALUES(1);
 statement error pq: could not remove enum value "e" as it is being used in a default expresion of "uses_alphabets_2"
 ALTER TYPE alphabets DROP VALUE 'e'
 
+
+statement ok
+ALTER TABLE uses_alphabets_2 SET (schema_locked=false)
+
 statement ok
 TRUNCATE uses_alphabets_2
+
+statement ok
+ALTER TABLE uses_alphabets_2 RESET (schema_locked)
 
 statement error pq: could not remove enum value "e" as it is being used in a default expresion of "uses_alphabets_2"
 ALTER TYPE alphabets DROP VALUE 'e'
@@ -551,7 +558,14 @@ statement error could not remove enum value "b" as it is being used by table "te
 ALTER TYPE alphabets_60004 DROP VALUE 'b'
 
 statement ok
+ALTER TABLE using_alphabets_60004 SET (schema_locked=false);
+
+statement ok
 TRUNCATE using_alphabets_60004
+
+statement ok
+ALTER TABLE using_alphabets_60004 RESET (schema_locked);
+
 
 statement ok
 ALTER TYPE alphabets_60004 DROP VALUE 'c'
@@ -563,7 +577,15 @@ statement error could not remove enum value "b" as it is being used by table "te
 ALTER TYPE alphabets_60004 DROP VALUE 'b'
 
 statement ok
+ALTER TABLE using_alphabets2_60004 SET (schema_locked=false);
+
+
+statement ok
 TRUNCATE using_alphabets2_60004
+
+statement ok
+ALTER TABLE using_alphabets2_60004 RESET (schema_locked);
+
 
 statement ok
 ALTER TYPE alphabets_60004 DROP VALUE 'a'
@@ -740,7 +762,13 @@ statement error pgcode 2BP01 could not remove enum value "a" as it is being used
 ALTER TYPE typ_127147 DROP VALUE 'a';
 
 statement ok
+ALTER TABLE t SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t;
+
+statement ok
+ALTER TABLE t RESET (schema_locked);
 
 statement ok
 ALTER TYPE typ_127147 DROP VALUE 'a';

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -2195,7 +2195,43 @@ c3-pk3-b2-pk2  NULL
 c3-pk4-b2-pk2  NULL
 
 statement ok
+ALTER TABLE c3 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE c2 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE c1 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE b2 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE b1 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE a SET (schema_locked=false)
+
+statement ok
 TRUNCATE c3, c2, c1, b2, b1, a;
+
+statement ok
+ALTER TABLE c3 RESET (schema_locked)
+
+statement ok
+ALTER TABLE c2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE c1 RESET (schema_locked)
+
+statement ok
+ALTER TABLE b2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE b1 RESET (schema_locked)
+
+statement ok
+ALTER TABLE a RESET (schema_locked)
 
 # Clean up after the test.
 statement ok
@@ -2742,7 +2778,45 @@ c3-pk3-b2-pk2  b2-default
 c3-pk4-b2-pk2  b2-default
 
 statement ok
+
+statement ok
+ALTER TABLE c3 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE c2 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE c1 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE b2 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE b1 SET (schema_locked=false)
+
+statement ok
+ALTER TABLE a SET (schema_locked=false)
+
+statement ok
 TRUNCATE c3, c2, c1, b2, b1, a;
+
+statement ok
+ALTER TABLE c3 RESET (schema_locked)
+
+statement ok
+ALTER TABLE c2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE c1 RESET (schema_locked)
+
+statement ok
+ALTER TABLE b2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE b1 RESET (schema_locked)
+
+statement ok
+ALTER TABLE a RESET (schema_locked)
 
 # Clean up after the test.
 statement ok
@@ -3454,11 +3528,23 @@ SELECT * FROM a ORDER BY x;
 ----
 x    y
 
+statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
+ALTER TABLE a SET (schema_locked=false);
+
 # Now try the same with inserts
 statement ok
 TRUNCATE b, a;
 INSERT INTO a VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
 INSERT INTO b VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
+
+statement ok
+ALTER TABLE a RESET (schema_locked);
 
 # For this, only x=6,y=6 should cascade.
 statement ok
@@ -3525,11 +3611,23 @@ SELECT * FROM a ORDER BY x;
 ----
 x    y
 
+statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
+ALTER TABLE a SET (schema_locked=false);
+
 # Now try the same with updates.
 statement ok
 TRUNCATE b, a;
 INSERT INTO a VALUES (NULL, NULL), (NULL, 4), (5, NULL), (6, 6);
 INSERT INTO b VALUES (NULL, NULL), (6, 6);
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
+
+statement ok
+ALTER TABLE a RESET (schema_locked);
 
 # For this test, only x=6,y=6 should cascade.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -22,7 +22,7 @@ SHOW TABLES FROM "E"
 # When non-quoted, table names are normalized during creation.
 
 statement ok
-CREATE TABLE A(x INT)
+CREATE TABLE A(x INT) WITH (schema_locked=false)
 
 statement error pgcode 42P01 relation "A" does not exist
 SHOW COLUMNS FROM "A"
@@ -94,7 +94,7 @@ DROP TABLE a
 # must be thus quoted during use.
 
 statement ok
-CREATE TABLE "B"(x INT)
+CREATE TABLE "B"(x INT) WITH (schema_locked=false)
 
 statement error pgcode 42P01 relation "b" does not exist
 SHOW COLUMNS FROM B

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -280,7 +280,13 @@ SELECT a, b, c, d FROM x
 1 2 3 1
 
 statement ok
+ALTER TABLE x SET (schema_locked=false)
+
+statement ok
 TRUNCATE x
+
+statement ok
+ALTER TABLE x RESET (schema_locked)
 
 # statement ok
 # INSERT INTO x VALUES (2, 3) ON CONFLICT (a) DO UPDATE SET a = 2, b = 3
@@ -294,7 +300,13 @@ SELECT a, b, c, d FROM x
 2 3 4 2
 
 statement ok
+ALTER TABLE x SET (schema_locked=false)
+
+statement ok
 TRUNCATE x
+
+statement ok
+ALTER TABLE x RESET (schema_locked)
 
 statement error cannot write directly to computed column "c"
 UPSERT INTO x VALUES (2, 3, 12)
@@ -771,7 +783,13 @@ SELECT d FROM x
 {1,2,3}
 
 statement ok
+ALTER TABLE x SET (schema_locked=false)
+
+statement ok
 TRUNCATE x
+
+statement ok
+ALTER TABLE x RESET (schema_locked)
 
 # Make sure we get the permutation on the inserts correct.
 
@@ -1005,7 +1023,7 @@ ALTER TABLE x
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE x SET (schema_locked=true);
+ALTER TABLE x RESET (schema_locked);
 
 # Verify a bad statement fails.
 statement error pq: could not parse "a" as type int

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -848,8 +848,15 @@ start_pretty    end_pretty
 statement ok
 SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'
 
+
+statement ok
+ALTER TABLE foo SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE foo
+
+statement ok
+ALTER TABLE foo RESET (schema_locked)
 
 # Ensure that there are no longer any splits left over on the original indexes.
 # TRUNCATE will have created equivalent splits points on the new indexes, so

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -56,8 +56,15 @@ SELECT a, b <= now(), c >= 0.0, d <= now() FROM t
 ----
 42 true true true
 
+
+statement ok
+ALTER TABLE t SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE t
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement ok
 INSERT INTO t DEFAULT VALUES

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -457,8 +457,15 @@ a  b  c   a  b  c
 4  d  40  4  d  40
 
 # Clean u_a to input a new set of data, and to improve test readability.
+
+statement ok
+ALTER TABLE u_a SET (schema_locked=false)
+
 statement ok
 TRUNCATE u_a
+
+statement ok
+ALTER TABLE u_a RESET (schema_locked)
 
 statement ok
 INSERT INTO u_a VALUES (1, 'a', 5), (2, 'b', 10), (3, 'c', 15), (4, 'd', 20), (5, 'd', 25), (6, 'd', 30), (7, 'd', 35), (8, 'd', 40), (9, 'd', 45)

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -273,7 +273,7 @@ RESET autocommit_before_ddl
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE expr SET (schema_locked=true)
+ALTER TABLE expr RESET (schema_locked)
 
 # Now add all of the schema elements.
 statement ok
@@ -336,7 +336,13 @@ statement ok
 INSERT INTO tab VALUES ('hello');
 
 statement ok
+ALTER TABLE tab SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE tab
+
+statement ok
+ALTER TABLE tab RESET (schema_locked);
 
 statement error pq: cannot drop type "ty" because other objects \(\[test.public.tab\]\) still depend on it
 DROP TYPE ty

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -245,8 +245,15 @@ ORDER BY "timestamp", info
 # Truncate a table
 ##################
 
+
+statement ok
+ALTER TABLE a SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE a
+
+statement ok
+ALTER TABLE a RESET (schema_locked)
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -246,8 +246,15 @@ ORDER BY "timestamp", info
 # Truncate a table
 ##################
 
+
+statement ok
+ALTER TABLE a SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE a
+
+statement ok
+ALTER TABLE a RESET (schema_locked)
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -312,7 +312,7 @@ CREATE INDEX err ON t (a) WHERE crdb_internal_idx_expr_2 > 0
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE t SET (schema_locked=true);
+ALTER TABLE t RESET (schema_locked);
 
 # Referencing an inaccessible column in a FK is not allowed.
 statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced by a foreign key
@@ -437,7 +437,7 @@ CREATE INDEX t_cast_idx ON t (a, (NULL::TEXT), b)
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE t SET (schema_locked=true);
+ALTER TABLE t RESET (schema_locked);
 
 statement ok
 CREATE INDEX err ON t (a, (j->'a'));
@@ -1111,7 +1111,13 @@ statement ok
 INSERT INTO l VALUES (1, 1), (6, 6)
 
 statement ok
+ALTER TABLE l SET (schema_locked=false);
+
+statement ok
 TRUNCATE l
+
+statement ok
+ALTER TABLE l RESET (schema_locked);
 
 query II rowsort
 SELECT * FROM l@a_plus_b

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -159,8 +159,15 @@ INSERT INTO child VALUES (1, 10) ON CONFLICT (c) DO UPDATE SET p = 1
 statement error foreign key
 INSERT INTO child VALUES (1, 10) ON CONFLICT (c) DO UPDATE SET p = 10
 
+
+statement ok
+ALTER TABLE child SET (schema_locked=false)
+
 statement ok
 TRUNCATE child
+
+statement ok
+ALTER TABLE child RESET (schema_locked)
 
 statement ok
 INSERT INTO child VALUES (1, 1)
@@ -614,11 +621,11 @@ ALTER TABLE "user content"."customer reviews"
 # Cross database references are used below
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE "user content"."customer reviews" SET (schema_locked=true);
+ALTER TABLE "user content"."customer reviews" RESET (schema_locked);
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE orders SET (schema_locked=true);
+ALTER TABLE orders RESET (schema_locked);
 
 # This is allowed because we match using MATCH SIMPLE.
 statement ok
@@ -638,8 +645,21 @@ INSERT INTO "user content"."customer reviews" (id, product, body, shipment, "ord
 statement ok
 ALTER TABLE delivery DROP CONSTRAINT delivery_order_shipment_fkey
 
+
+statement ok
+ALTER TABLE orders SET (schema_locked=false);
+
+statement ok
+ALTER TABLE "user content"."customer reviews" SET (schema_locked=false);
+
 statement ok
 TRUNCATE orders, "user content"."customer reviews"
+
+statement ok
+ALTER TABLE orders RESET (schema_locked)
+
+statement ok
+ALTER TABLE "user content"."customer reviews" RESET (schema_locked)
 
 # Changing now non-referenced and secondary field is fine.
 statement ok
@@ -652,24 +672,78 @@ UPDATE products SET sku = '780', upc = 'blah' WHERE sku = '750'
 statement error pgcode 23503 delete on table "products" violates foreign key constraint "delivery_item_fkey" on table "delivery"\nDETAIL: Key \(upc\)=\('885155001450'\) is still referenced from table "delivery"\.
 DELETE FROM products WHERE sku = '750'
 
+statement ok
+ALTER TABLE products SET (schema_locked=false);
+
 statement error "products" is referenced by foreign key from table "orders"
 TRUNCATE products
+
+statement ok
+ALTER TABLE products RESET (schema_locked)
 
 query I
 SELECT count(*) FROM delivery
 ----
 4
 
+
+statement ok
+ALTER TABLE products SET (schema_locked=false);
+
+statement ok
+ALTER TABLE "user content"."customer reviews" SET (schema_locked=false);
+
+statement ok
+ALTER TABLE orders SET (schema_locked=false);
+
+statement ok
+ALTER TABLE delivery SET (schema_locked=false);
+
 statement ok
 TRUNCATE products CASCADE
+
+statement ok
+ALTER TABLE products RESET (schema_locked)
+
+statement ok
+ALTER TABLE "user content"."customer reviews" RESET (schema_locked)
+
+statement ok
+ALTER TABLE orders RESET (schema_locked)
+
+statement ok
+ALTER TABLE delivery RESET (schema_locked)
 
 query I
 SELECT count(*) FROM delivery
 ----
 0
 
+
+statement ok
+ALTER TABLE delivery SET (schema_locked=false);
+
+statement ok
+ALTER TABLE products SET (schema_locked=false);
+
+statement ok
+ALTER TABLE orders SET (schema_locked=false);
+
+statement ok
+ALTER TABLE "user content"."customer reviews" SET (schema_locked=false);
+
 statement ok
 TRUNCATE delivery, products, orders, "user content"."customer reviews"
+
+statement ok
+ALTER TABLE delivery RESET (schema_locked)
+
+
+statement ok
+ALTER TABLE orders RESET (schema_locked)
+
+statement ok
+ALTER TABLE "user content"."customer reviews" RESET (schema_locked)
 
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM orders] ORDER BY constraint_name
@@ -1979,7 +2053,13 @@ statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', row
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
@@ -1988,7 +2068,13 @@ statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', row
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x)
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
@@ -2350,7 +2436,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', NULL)
@@ -2359,7 +2451,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, NULL, 'z1')
@@ -2368,7 +2466,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', 'y1', NULL)
@@ -2377,7 +2481,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x1', NULL, 'z1')
@@ -2386,7 +2496,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES (NULL, 'y1', 'z1')
@@ -2395,7 +2511,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y1', 'z1')
@@ -2404,7 +2526,13 @@ statement error foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2', row
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z1')
@@ -2413,7 +2541,13 @@ statement error foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2', row
 ALTER TABLE b ADD CONSTRAINT fk_ref FOREIGN KEY (a_z, a_y, a_x) REFERENCES a (z, y, x) MATCH FULL
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 INSERT INTO b (a_x, a_y, a_z) VALUES ('x2', 'y2', 'z2')
@@ -2591,7 +2725,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2606,7 +2746,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2621,7 +2767,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2636,7 +2788,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2651,7 +2809,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2666,7 +2830,13 @@ statement error foreign key violation: MATCH FULL does not allow mixing of null 
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2681,7 +2851,13 @@ statement error pq: foreign key violation: "b" row a_z='z1', a_y='y1', a_x='x2',
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2696,7 +2872,13 @@ statement error pq: foreign key violation: "b" row a_z='z1', a_y='y2', a_x='x2',
 ALTER TABLE b VALIDATE CONSTRAINT fk_ref
 
 statement ok
+ALTER TABLE b SET (schema_locked=false);
+
+statement ok
 TRUNCATE b
+
+statement ok
+ALTER TABLE b RESET (schema_locked);
 
 statement ok
 ALTER TABLE b DROP CONSTRAINT fk_ref
@@ -2817,11 +2999,11 @@ INSERT INTO parentid (k, v) VALUES (0, 1); INSERT INTO childid (id) VALUES (2);
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE parentid SET (schema_locked=false)
+ALTER TABLE parentid SET (schema_locked=false);
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE childid SET (schema_locked=false)
+ALTER TABLE childid SET (schema_locked=false);
 
 statement error column \"id\" does not exist
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -2835,11 +3017,11 @@ ROLLBACK;
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE parentid SET (schema_locked=true)
+ALTER TABLE parentid RESET (schema_locked)
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE childid SET (schema_locked=true)
+ALTER TABLE childid RESET (schema_locked)
 
 subtest dont_check_nulls
 # Make sure that nulls are never checked while executing FK constraints.
@@ -2977,7 +3159,13 @@ statement error update on table "self" violates foreign key constraint "self_y_f
 UPDATE self SET x = 5 WHERE y = 1
 
 statement ok
+ALTER TABLE self SET (schema_locked=false);
+
+statement ok
 TRUNCATE self
+
+statement ok
+ALTER TABLE self RESET (schema_locked);
 
 statement ok
 INSERT INTO self VALUES (1, 1)
@@ -3291,10 +3479,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE NO ACTION', followed by 'ON DELETE CASCADE'
 statement ok
@@ -3320,10 +3520,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE RESTRICT', followed by 'ON DELETE SET NULL'
 statement ok
@@ -3350,10 +3562,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE RESTRICT', followed by 'ON DELETE CASCADE'
 statement ok
@@ -3379,10 +3603,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE CASCADE', followed by 'ON DELETE SET DEFAULT'
 statement ok
@@ -3408,10 +3644,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE CASCADE', followed by 'ON DELETE SET NULL'
 statement ok
@@ -3437,10 +3685,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE SET DEFAULT', followed by 'ON DELETE CASCADE'
 statement ok
@@ -3466,10 +3726,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE SET DEFAULT', followed by 'ON DELETE SET NULL'
 statement ok
@@ -3495,10 +3767,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON DELETE SET NULL', followed by 'ON DELETE SET DEFAULT'
 statement ok
@@ -3525,10 +3809,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 statement ok
 DROP TABLE t2 CASCADE;
@@ -3574,10 +3870,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE NO ACTION', followed by 'ON UPDATE CASCADE'
 statement ok
@@ -3604,10 +3912,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE RESTRICT', followed by 'ON UPDATE SET NULL'
 statement ok
@@ -3634,10 +3954,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE RESTRICT', followed by 'ON UPDATE CASCADE'
 statement ok
@@ -3664,10 +3996,22 @@ statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
 statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
+statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE CASCADE', followed by 'ON UPDATE SET DEFAULT'
 statement ok
@@ -3693,11 +4037,24 @@ ALTER TABLE t2 DROP CONSTRAINT fk1;
 statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
+
+statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
 statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE CASCADE', followed by 'ON UPDATE SET NULL'
 statement ok
@@ -3723,11 +4080,24 @@ ALTER TABLE t2 DROP CONSTRAINT fk1;
 statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
+
+statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
 statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE SET DEFAULT', followed by 'ON UPDATE CASCADE'
 statement ok
@@ -3753,11 +4123,24 @@ ALTER TABLE t2 DROP CONSTRAINT fk1;
 statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
+
+statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
 statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE SET DEFAULT', followed by 'ON UPDATE SET NULL'
 statement ok
@@ -3783,11 +4166,24 @@ ALTER TABLE t2 DROP CONSTRAINT fk1;
 statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
+
+statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
 statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 # 'ON UPDATE SET NULL', followed by 'ON UPDATE SET DEFAULT'
 statement ok
@@ -3813,11 +4209,24 @@ ALTER TABLE t2 DROP CONSTRAINT fk1;
 statement ok
 ALTER TABLE t2 DROP CONSTRAINT fk2;
 
+
+statement ok
+ALTER TABLE t2 SET (schema_locked=false);
+
+statement ok
+ALTER TABLE t1 SET (schema_locked=false);
+
 statement ok
 TRUNCATE TABLE t2;
 
 statement ok
 TRUNCATE TABLE t1
+
+statement ok
+ALTER TABLE t2 RESET (schema_locked)
+
+statement ok
+ALTER TABLE t1 RESET (schema_locked)
 
 statement ok
 DROP TABLE t2 CASCADE;

--- a/pkg/sql/logictest/testdata/logic_test/inner-join
+++ b/pkg/sql/logictest/testdata/logic_test/inner-join
@@ -56,8 +56,24 @@ SELECT c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 # A semi-join emits exactly one row for every matching row in the LHS.
 # The following test ensures that the SemiJoin doesn't commute into an
 # InnerJoin as that guarantee would be lost.
+
 statement ok
-TRUNCATE TABLE abc; TRUNCATE TABLE def;
+ALTER TABLE abc SET (schema_locked=false)
+
+statement ok
+TRUNCATE TABLE abc;
+
+statement ok
+ALTER TABLE abc RESET (schema_locked)
+
+statement ok
+ALTER TABLE def SET (schema_locked=false)
+
+statement ok
+TRUNCATE TABLE def;
+
+statement ok
+ALTER TABLE def RESET (schema_locked)
 
 statement ok
 INSERT INTO abc VALUES (1, 1, 1)

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -397,7 +397,13 @@ INSERT INTO insert_t TABLE select_t ORDER BY v DESC LIMIT 3 RETURNING x, v
 # Check that INSERT supports LIMIT (MySQL extension)
 
 statement ok
+ALTER TABLE insert_t SET (schema_locked=false)
+
+statement ok
 TRUNCATE TABLE insert_t
+
+statement ok
+ALTER TABLE insert_t RESET (schema_locked)
 
 statement ok
 INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
@@ -408,7 +414,13 @@ SELECT * FROM insert_t
 1  9
 
 statement ok
+ALTER TABLE insert_t SET (schema_locked=false)
+
+statement ok
 TRUNCATE TABLE insert_t
+
+statement ok
+ALTER TABLE insert_t RESET (schema_locked)
 
 statement ok
 INSERT INTO insert_t (SELECT * FROM select_t LIMIT 1)

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -757,8 +757,15 @@ CREATE TABLE l (
 statement ok
 INSERT INTO l VALUES (1, 1), (6, 6)
 
+
+statement ok
+ALTER TABLE l SET (schema_locked=false)
+
 statement ok
 TRUNCATE l
+
+statement ok
+ALTER TABLE l RESET (schema_locked)
 
 query II rowsort
 SELECT * FROM l@a_b_gt_5 WHERE b > 5

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1694,8 +1694,15 @@ statement ok
 PREPARE s_114867 AS INSERT INTO test_114867(colors) VALUES (ARRAY[$1::text]::color[]);
 EXECUTE s_114867('red')
 
+
+statement ok
+ALTER TABLE test_114867 SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE test_114867 CASCADE
+
+statement ok
+ALTER TABLE test_114867 RESET (schema_locked)
 
 statement ok
 EXECUTE s_114867('red')

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -46,7 +46,13 @@ statement ok
 UPDATE t SET v = 2 WHERE k = 2
 
 statement ok
+ALTER TABLE t SET (schema_locked=false)
+
+statement ok
 TRUNCATE t
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement ok
 DROP TABLE t
@@ -204,7 +210,13 @@ statement error user testuser does not have SELECT privilege on relation t
 UPDATE t SET v = 2 WHERE k = 2
 
 statement ok
+ALTER TABLE t SET (schema_locked=false)
+
+statement ok
 TRUNCATE t
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement ok
 DROP TABLE t
@@ -248,7 +260,13 @@ statement ok
 UPDATE t SET v = 2 WHERE k = 2
 
 statement ok
+ALTER TABLE t SET (schema_locked=false)
+
+statement ok
 TRUNCATE t
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement ok
 DROP TABLE t

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -649,7 +649,7 @@ ALTER TABLE colref DROP COLUMN c1;
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE colref SET (schema_locked=true)
+ALTER TABLE colref RESET (schema_locked)
 
 statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
@@ -685,7 +685,7 @@ ALTER TABLE colref DROP COLUMN c2;
 
 skipif config schema-locked-disabled
 statement ok
-ALTER TABLE colref SET (schema_locked=true)
+ALTER TABLE colref RESET (schema_locked)
 
 statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
@@ -962,7 +962,7 @@ statement error pq: ALTER TABLE ... ROW LEVEL SECURITY is only implemented in th
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 
 statement ok
-ALTER TABLE roaches SET (schema_locked=true);
+ALTER TABLE roaches RESET (schema_locked);
 
 statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
@@ -2495,7 +2495,13 @@ trunc  CREATE TABLE public.trunc (
 
 # Truncate should be allowed, despite the policy to prevent deletes.
 statement ok
+ALTER TABLE trunc SET (schema_locked=false)
+
+statement ok
 TRUNCATE TABLE trunc;
+
+statement ok
+ALTER TABLE trunc RESET (schema_locked)
 
 query IT
 SELECT a, b FROM trunc ORDER BY a;
@@ -3225,9 +3231,15 @@ select * from multip ORDER BY key, value;
 statement ok
 SET ROLE root;
 
+statement ok
+ALTER TABLE multip SET (schema_locked=false);
+
 # Setup to verify the write policies.
 statement ok
 TRUNCATE TABLE multip;
+
+statement ok
+ALTER TABLE multip RESET (schema_locked);
 
 statement ok
 CREATE POLICY or1 ON multip AS PERMISSIVE USING (key = 1);

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -39,7 +39,13 @@ SELECT * FROM kview
 7 8
 
 statement ok
+ALTER TABLE kv SET (schema_locked=false)
+
+statement ok
 TRUNCATE TABLE kv
+
+statement ok
+ALTER TABLE kv RESET (schema_locked)
 
 query II
 SELECT * FROM kv
@@ -62,7 +68,13 @@ CREATE TABLE selfref (
 )
 
 statement ok
+ALTER TABLE selfref SET (schema_locked=false)
+
+statement ok
 TRUNCATE table selfref
+
+statement ok
+ALTER TABLE selfref RESET (schema_locked)
 
 statement ok
 INSERT INTO selfref VALUES (1, NULL);
@@ -84,7 +96,13 @@ CREATE TABLE bar (
 );
 
 statement ok
+ALTER TABLE bar SET (schema_locked=false)
+
+statement ok
 TRUNCATE bar
+
+statement ok
+ALTER TABLE bar RESET (schema_locked)
 
 statement ok
 DROP TABLE bar;
@@ -118,7 +136,13 @@ SELECT get_min_t0();
 0
 
 statement ok
+ALTER TABLE t0 SET (schema_locked=false)
+
+statement ok
 TRUNCATE TABLE t0;
+
+statement ok
+ALTER TABLE t0 RESET (schema_locked)
 
 query I
 SELECT * FROM v0 ORDER BY c0;
@@ -187,7 +211,15 @@ CREATE TABLE t (
 COMMENT ON COLUMN t.x IS '''hi''); DROP TABLE t;';
 COMMENT ON COLUMN t.z IS 'comm"en"t2';
 COMMENT ON INDEX t@i2 IS 'comm''ent3';
+
+statement ok
+ALTER TABLE t SET (schema_locked=false)
+
+statement ok
 TRUNCATE t
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 query TT
 SELECT column_name, comment FROM [SHOW COLUMNS FROM t WITH COMMENT] ORDER BY column_name

--- a/pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation
+++ b/pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation
@@ -7,7 +7,7 @@ SET CLUSTER SETTING jobs.registry.interval.cancel = '50ms'
 # Make sure that table cannot be truncated if an index is being dropped
 # concurrently.
 statement ok
-CREATE TABLE t1(a int primary key, b int);
+CREATE TABLE t1(a int primary key, b int) WITH (schema_locked=false);
 
 statement ok
 CREATE INDEX idx_b ON t1(b);
@@ -28,7 +28,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = '';
 # dropped concurrently.
 statement ok
 CREATE TYPE e AS ENUM ('v1', 'v2');
-CREATE TABLE t2(a int primary key, b e);
+CREATE TABLE t2(a int primary key, b e) WITH (schema_locked = false);
 
 statement ok
 SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
@@ -45,7 +45,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = '';
 # Make sure that table cannot be truncated when a constraint without index is
 # being added concurrently.
 statement ok
-CREATE TABLE t3(a INT PRIMARY KEY, b INT);
+CREATE TABLE t3(a INT PRIMARY KEY, b INT) WITH (schema_locked = false);
 
 statement ok
 SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
@@ -61,7 +61,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = '';
 
 # Make sure table cannot be truncated if there is concurrent primary key change.
 statement ok
-CREATE TABLE t4(a INT PRIMARY KEY, b INT NOT NULL);
+CREATE TABLE t4(a INT PRIMARY KEY, b INT NOT NULL) WITH (schema_locked=false);
 
 statement ok
 SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1753,8 +1753,15 @@ SHOW intervalstyle
 ----
 iso_8601
 
+
+statement ok
+ALTER TABLE rewind_session_test SET (schema_locked=false)
+
 statement ok
 TRUNCATE rewind_session_test
+
+statement ok
+ALTER TABLE rewind_session_test RESET (schema_locked)
 
 statement ok
 SET intervalstyle = 'postgres'

--- a/pkg/sql/logictest/testdata/logic_test/udf_fk
+++ b/pkg/sql/logictest/testdata/logic_test/udf_fk
@@ -56,7 +56,19 @@ WITH x AS (INSERT INTO parent VALUES (2) RETURNING p) SELECT f_fk_c(101, 2);
 (101,2)
 
 statement ok
+ALTER TABLE parent SET (schema_locked=false)
+
+statement ok
+ALTER TABLE child SET (schema_locked=false)
+
+statement ok
 TRUNCATE parent CASCADE
+
+statement ok
+ALTER TABLE parent RESET (schema_locked)
+
+statement ok
+ALTER TABLE child RESET (schema_locked)
 
 statement ok
 INSERT INTO parent (p) VALUES (1);
@@ -114,8 +126,21 @@ subtest end
 
 subtest delete
 
+
+statement ok
+ALTER TABLE parent SET (schema_locked=false)
+
+statement ok
+ALTER TABLE child SET (schema_locked=false)
+
 statement ok
 TRUNCATE parent CASCADE
+
+statement ok
+ALTER TABLE parent RESET (schema_locked)
+
+statement ok
+ALTER TABLE child RESET (schema_locked)
 
 statement ok
 INSERT INTO parent (p) VALUES (1), (2), (3), (4);
@@ -204,7 +229,19 @@ subtest end
 subtest upsert
 
 statement ok
+ALTER TABLE child SET (schema_locked=false)
+
+statement ok
+ALTER TABLE parent SET (schema_locked=false)
+
+statement ok
 TRUNCATE parent CASCADE
+
+statement ok
+ALTER TABLE child RESET (schema_locked)
+
+statement ok
+ALTER TABLE parent RESET (schema_locked)
 
 statement ok
 CREATE FUNCTION f_fk_c_ocdu(k INT, r INT) RETURNS RECORD AS $$
@@ -667,8 +704,15 @@ SELECT i, j FROM child@child_j_idx;
 statement ok
 DROP TABLE IF EXISTS child CASCADE;
 
+
+statement ok
+ALTER TABLE parent SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE parent;
+
+statement ok
+ALTER TABLE parent RESET (schema_locked)
 
 statement ok
 CREATE TABLE child (i INT PRIMARY KEY, j INT UNIQUE REFERENCES parent (j) ON UPDATE CASCADE ON DELETE CASCADE, INDEX (j));

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -564,9 +564,24 @@ SELECT a FROM ab UNION ALL SELECT x AS a FROM xy
 
 # If the ordering is only required on a subset of the columns, ensure that we
 # still produce the correct ordering.
+
+statement ok
+ALTER TABLE ab SET (schema_locked=false)
+
 statement ok
 TRUNCATE ab;
+
+statement ok
+ALTER TABLE ab RESET (schema_locked)
+
+statement ok
+ALTER TABLE xy SET (schema_locked=false)
+
+statement ok
 TRUNCATE xy;
+
+statement ok
+ALTER TABLE xy RESET (schema_locked)
 
 statement ok
 INSERT INTO ab VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -372,8 +372,14 @@ SELECT * FROM pks
 
 # Check that UPDATE properly supports ORDER BY (MySQL extension)
 
+statement ok
+ALTER TABLE kv SET (schema_locked=false)
+
 statement count 0
 TRUNCATE kv
+
+statement ok
+ALTER TABLE kv RESET (schema_locked)
 
 statement count 4
 INSERT INTO kv VALUES (1, 9), (8, 2), (3, 7), (6, 4)
@@ -387,8 +393,15 @@ UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 3 RETURNING k,v
 
 # Check that UPDATE properly supports LIMIT (MySQL extension)
 
+
+statement ok
+ALTER TABLE kv SET (schema_locked=false)
+
 statement ok
 TRUNCATE kv;
+
+statement ok
+ALTER TABLE kv RESET (schema_locked)
 
 statement count 3
 INSERT INTO kv VALUES (1, 2), (2, 3), (3, 4)

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -934,7 +934,7 @@ subtest end
 subtest import_into
 
 statement ok
-CREATE TABLE import_test (a INT PRIMARY KEY, v VECTOR(3))
+CREATE TABLE import_test (a INT PRIMARY KEY, v VECTOR(3)) WITH (schema_locked=false)
 
 statement ok
 INSERT INTO import_test VALUES (1, '[1, 2, 3]')

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -264,8 +264,15 @@ UPDATE t_idx SET b=b+1 RETURNING w
 
 # Upsert tests on t.
 
+
+statement ok
+ALTER TABLE t SET (schema_locked=false)
+
 statement ok
 TRUNCATE t
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement error cannot write directly to computed column
 UPSERT INTO t(a,b,v) VALUES (1, 1, 1)
@@ -342,8 +349,15 @@ a  b    v
 
 # Upsert tests on t_idx.
 
+
+statement ok
+ALTER TABLE t_idx SET (schema_locked=false)
+
 statement ok
 TRUNCATE t_idx
+
+statement ok
+ALTER TABLE t_idx RESET (schema_locked)
 
 statement error cannot write directly to computed column
 UPSERT INTO t_idx(a,b,v) VALUES (1, 1, 1)

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -678,6 +678,8 @@ func TestTruncateTable(t *testing.T) {
 			_, err := db.ExecContext(ctx, createTable)
 			message := fmt.Sprintf("tenant=%s", tenant)
 			require.NoErrorf(t, err, message)
+			_, err = db.ExecContext(ctx, "ALTER TABLE t SET (schema_locked=false)")
+			require.NoErrorf(t, err, message)
 			_, err = db.ExecContext(ctx, "ALTER TABLE t SPLIT AT VALUES (1);")
 			require.NoErrorf(t, err, message)
 

--- a/pkg/sql/mutation_test.go
+++ b/pkg/sql/mutation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
 )
 
 // Regression tests for #22304.
@@ -271,8 +272,12 @@ PARTITION ALL BY LIST (r) (
 		}
 		rows.Close()
 
+		_, err = db.Exec(`ALTER TABLE d.upsert SET (schema_locked=false)`)
+		require.NoError(t, err)
 		if _, err := db.Exec(`TRUNCATE TABLE d.upsert`); err != nil {
 			t.Fatal(err)
 		}
+		_, err = db.Exec(`ALTER TABLE d.upsert SET (schema_locked=true)`)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -24,8 +24,15 @@ SELECT crdb_internal.execute_internally('SELECT k FROM t;', true);
 3
 5
 
+
+statement ok
+ALTER TABLE t SET (schema_locked=false)
+
 statement ok
 SELECT crdb_internal.execute_internally('TRUNCATE t;', true);
+
+statement ok
+ALTER TABLE t SET (schema_locked=true)
 
 query empty
 SELECT crdb_internal.execute_internally('SELECT k FROM t;', true);

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -233,8 +233,15 @@ vectorized: true
               table: t@bc
               spans: /"3"-/"3"/PrefixEnd
 
+
+statement ok
+ALTER TABLE t SET (schema_locked=false)
+
 statement ok
 TRUNCATE TABLE t
+
+statement ok
+ALTER TABLE t SET (schema_locked=true)
 
 statement ok
 INSERT INTO t VALUES

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -904,7 +904,7 @@ INSERT INTO d.t VALUES (10),(11);
 CREATE TABLE d.ts (a TIMESTAMP, b DATE);
 CREATE TABLE d.two (a INT, b INT);
 CREATE TABLE d.intStr (a INT, s STRING);
-CREATE TABLE d.str (s STRING, b BYTES);
+CREATE TABLE d.str (s STRING, b BYTES) WITH (schema_locked=false);
 CREATE TABLE d.arr (a INT[], b TEXT[]);
 CREATE TABLE d.emptynorows (); -- zero columns, zero rows
 CREATE TABLE d.emptyrows (x INT);

--- a/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
+++ b/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
@@ -1455,7 +1455,7 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Query {"String": "CREATE TABLE IF NOT EXISTS tbl (x timestamp, y int);"}
+Query {"String": "CREATE TABLE IF NOT EXISTS tbl (x timestamp, y int) WITH (schema_locked=false);"}
 Query {"String": "TRUNCATE tbl;"}
 Query {"String": "CREATE OR REPLACE PROCEDURE insert_one() LANGUAGE PLpgSQL AS $$ BEGIN INSERT INTO tbl (x, y) VALUES (now(), 1); END; $$;"}
 ----
@@ -1532,10 +1532,10 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Query {"String": "CREATE TABLE IF NOT EXISTS sensors (id TEXT NOT NULL, ts TIMESTAMPTZ NOT NULL, val FLOAT8 NULL, CONSTRAINT s_pk PRIMARY KEY (id, ts));"}
+Query {"String": "CREATE TABLE IF NOT EXISTS sensors (id TEXT NOT NULL, ts TIMESTAMPTZ NOT NULL, val FLOAT8 NULL, CONSTRAINT s_pk PRIMARY KEY (id, ts)) WITH (schema_locked=false);"}
 Query {"String": "TRUNCATE sensors;"}
 Query {"String": "INSERT INTO sensors values ('a', now(), 0.1);"}
-Query {"String": "CREATE TABLE IF NOT EXISTS sensors_summary (id TEXT NOT NULL, val FLOAT8 NULL, CONSTRAINT ss_pk PRIMARY KEY (id));"}
+Query {"String": "CREATE TABLE IF NOT EXISTS sensors_summary (id TEXT NOT NULL, val FLOAT8 NULL, CONSTRAINT ss_pk PRIMARY KEY (id)) WITH (schema_locked=false);"}
 Query {"String": "TRUNCATE sensors_summary;"}
 Query {"String": "CREATE TYPE IF NOT EXISTS k AS (x TEXT, y FLOAT8);"}
 ----

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3885,7 +3885,7 @@ func TestTruncateInternals(t *testing.T) {
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'));
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14')) WITH (schema_locked=false);
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -3981,7 +3981,7 @@ func TestTruncateCompletion(t *testing.T) {
 	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
 	sqlRunner.Exec(t, `CREATE DATABASE t;`)
 	sqlRunner.Exec(t, `CREATE TABLE t.pi (d DECIMAL PRIMARY KEY);`)
-	sqlRunner.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DEFAULT (DECIMAL '3.14'));`)
+	sqlRunner.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DEFAULT (DECIMAL '3.14')) WITH (schema_locked=false);`)
 
 	sqlRunner.Exec(t, `INSERT INTO t.pi VALUES (3.14)`)
 

--- a/pkg/sql/show_fingerprints_test.go
+++ b/pkg/sql/show_fingerprints_test.go
@@ -81,7 +81,7 @@ func TestShowFingerprintsColumnNames(t *testing.T) {
 		"cApiTaLByTEs" BYTES,
 		INDEX capital_int_idx ("cApiTaLInT"),
 		INDEX capital_bytes_idx ("cApiTaLByTEs")
-	)`)
+	) WITH (schema_locked=false)`)
 
 	sqlDB.Exec(t, `INSERT INTO d.t VALUES (1, 2, 'a')`)
 	fprint1 := sqlDB.QueryStr(t, `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE d.t`)

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -88,7 +88,7 @@ func TestTelemetryLogging(t *testing.T) {
 	db.QueryRow(t, `SHOW database`).Scan(&databaseName)
 	db.Exec(t, `SET application_name = 'telemetry-logging-test'`)
 	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
-	db.Exec(t, "CREATE TABLE t();")
+	db.Exec(t, "CREATE TABLE t() WITH (schema_locked=false);")
 	db.Exec(t, "CREATE TABLE u(x int);")
 	db.Exec(t, "INSERT INTO u SELECT generate_series(1, 100);")
 	// Use INJECT STATISTICS instead of ANALYZE to avoid test flakes.

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -19,7 +19,7 @@ SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;
 ----
 
 exec-sql
-CREATE TABLE t()
+CREATE TABLE t() WITH (schema_locked=false)
 ----
 
 spy-sql unixSecs=0.1

--- a/pkg/sql/tests/truncate_test.go
+++ b/pkg/sql/tests/truncate_test.go
@@ -400,7 +400,7 @@ func TestTruncatePreservesSplitPoints(t *testing.T) {
 
 			var err error
 			_, err = conn.ExecContext(ctx, `
-CREATE TABLE a(a INT PRIMARY KEY, b INT, INDEX(b));
+CREATE TABLE a(a INT PRIMARY KEY, b INT, INDEX(b)) WITH (schema_locked=false);
 INSERT INTO a SELECT g,g FROM generate_series(1,10000) g(g);
 ALTER TABLE a SPLIT AT VALUES(1000), (2000), (3000), (4000), (5000), (6000), (7000), (8000), (9000);
 ALTER INDEX a_b_idx SPLIT AT VALUES(1000), (2000), (3000), (4000), (5000), (6000), (7000), (8000), (9000);

--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -290,6 +291,8 @@ func TestUnsplitRanges(t *testing.T) {
 		defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 
 		require.NoError(t, tests.CreateKVTable(sqlDB, tableName, numRows))
+		_, err := sqlDB.Exec(fmt.Sprintf(`ALTER TABLE t.%s SET (schema_locked=false)`, tableName))
+		require.NoError(t, err)
 
 		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", tableName)
 		tableSpan := tableDesc.TableSpan(keys.SystemSQLCodec)

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -191,7 +191,7 @@ func TestGetZoneConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlDB.Exec(`CREATE TABLE db2.tb2 (k INT PRIMARY KEY, v INT)`); err != nil {
+	if _, err := sqlDB.Exec(`CREATE TABLE db2.tb2 (k INT PRIMARY KEY, v INT) WITH (schema_locked=false)`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -430,7 +430,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := sqlDB.Exec(`CREATE TABLE db2.tb2 (k INT PRIMARY KEY, v INT)`); err != nil {
+	if _, err := sqlDB.Exec(`CREATE TABLE db2.tb2 (k INT PRIMARY KEY, v INT) WITH (schema_locked=false)`); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Previously, we were completely ignoring schema_locked for the TRUNCATE command, which could changefeeds to break. To address this, this patch blocks TRUNCATE on schema_locked tables.

Fixes: #151941

Release note (bug fix): schema_locked was not enforced on the TRUNCATE command, which could cause changefeed jobs to fail.