### PR TITLE
crosscluster: fix error handling in computeRangeStats

### DIFF
--- a/pkg/crosscluster/producer/range_stats.go
+++ b/pkg/crosscluster/producer/range_stats.go
@@ -108,7 +108,7 @@ func computeRangeStats(
 			}
 		}
 		if lazyIterator.Error() != nil {
-			return streampb.StreamEvent_RangeStats{}, err
+			return streampb.StreamEvent_RangeStats{}, lazyIterator.Error()
 		}
 	}
 	return stats, nil


### PR DESCRIPTION
`computeRangeStats` was returning `err` when it should have returned `lazyIterator.Error`. The code calling this is best effort, so returning success is not a critical bug. But it does mean we would miss a warning log.

Release note: none
Epic: none