### PR TITLE
backup: fix show backup in collection root test

### DIFF
--- a/pkg/backup/backupdest/backup_index.go
+++ b/pkg/backup/backupdest/backup_index.go
@@ -440,7 +440,9 @@ func indexSubdir(subdir string) (string, error) {
 func flattenSubdirForIndex(subdir string) (string, error) {
 	subdirTime, err := time.Parse(backupbase.DateBasedIntoFolderName, subdir)
 	if err != nil {
-		return "", errors.Wrapf(err, "parsing subdir %q for flattening", subdir)
+		return "", errors.Wrapf(
+			err, "subdir does not match format '%s'", backupbase.DateBasedIntoFolderName,
+		)
 	}
 	return subdirTime.Format(backupbase.BackupIndexFlattenedSubdir), nil
 }
@@ -450,7 +452,9 @@ func flattenSubdirForIndex(subdir string) (string, error) {
 func unflattenIndexSubdir(flattened string) (string, error) {
 	subdirTime, err := time.Parse(backupbase.BackupIndexFlattenedSubdir, flattened)
 	if err != nil {
-		return "", errors.Wrapf(err, "parsing flattened index subdir %q for unflattening", flattened)
+		return "", errors.Wrapf(
+			err, "index subdir does not match format %s", backupbase.BackupIndexFlattenedSubdir,
+		)
 	}
 	unflattened := subdirTime.Format(backupbase.DateBasedIntoFolderName)
 	return unflattened, nil

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -713,12 +713,15 @@ func TestShowBackupPathIsCollectionRoot(t *testing.T) {
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
+	// Error output changes depending on whether or not the index is used. This
+	// deterministically enables the index to make the error output consistent.
+	sqlDB.Exec(t, "SET CLUSTER SETTING backup.index.read.enabled = true")
+
 	// Make an initial backup.
 	sqlDB.Exec(t, `BACKUP data.bank INTO $1`, localFoo)
 
 	// Ensure proper error gets returned from back SHOW BACKUP Path
-	sqlDB.ExpectErr(t, "The specified path is the root of a backup collection.",
-		"SHOW BACKUP '' IN $1", localFoo)
+	sqlDB.ExpectErr(t, "subdir does not match format", "SHOW BACKUP '' IN $1", localFoo)
 }
 
 // TestShowBackupCheckFiles verifies the check_files option catches a corrupt


### PR DESCRIPTION
#152142 changed the error that would be outputted when an empty subdir was passed to a `SHOW BACKUP` query. This patch updates the test that has begun failing because of it. It updates the error message to be more descriptive for the user and changes the test's expectations.

Epic: None

Fixes: #152935