### PR TITLE
jobs: skip TestRegistryLifecycle

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -393,6 +393,8 @@ func TestRegistryLifecycle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 152542)
+
 	t.Run("normal success", func(t *testing.T) {
 		rts := registryTestSuite{}
 		defer rts.setUp(t)()


### PR DESCRIPTION
several flakes a day is too much; skipping until we figure out what to do

Release note: none.
Epic: none.