### PR TITLE
release-25.3: rttanalysisccl: wait for replication before starting test

### DIFF
--- a/pkg/ccl/benchccl/rttanalysisccl/multi_region_bench_test.go
+++ b/pkg/ccl/benchccl/rttanalysisccl/multi_region_bench_test.go
@@ -28,6 +28,9 @@ var reg = rttanalysis.NewRegistry(numNodes, rttanalysis.MakeClusterConstructor(f
 	cluster, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		tb, numNodes, knobs,
 	)
+	if err := cluster.WaitForFullReplication(); err != nil {
+		tb.Fatal(err)
+	}
 	db := cluster.ServerConn(0)
 	// Eventlog is async, and introduces jitter in the benchmark.
 	if _, err := db.Exec("SET CLUSTER SETTING server.eventlog.enabled = false"); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #152871 on behalf of @rafiss.

----

This should help prevent a timeout that has occurred while setting the cluster setting and waiting for the new value to be present.

fixes https://github.com/cockroachdb/cockroach/issues/152612
Release note: None

----

Release justification: test only change