### PR TITLE
roachtest: disable use_soft_limit_for_distribute_scan in bulk ingest test

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -433,6 +433,13 @@ func makeSchemaChangeBulkIngestTest(
 				db := c.Conn(ctx, t.L(), 1)
 				defer db.Close()
 
+				// TODO(152859): Temporarily disable soft limit for distribute scan to
+				// test performance regression fix (see #152295).
+				t.L().Printf("Setting use_soft_limit_for_distribute_scan = false")
+				if _, err := db.Exec("SET use_soft_limit_for_distribute_scan = false"); err != nil {
+					t.Fatal(err)
+				}
+
 				t.L().Printf("Computing table statistics manually")
 				if _, err := db.Exec("CREATE STATISTICS stats from bulkingest.bulkingest"); err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
Temporarily disable use_soft_limit_for_distribute_scan in the schema change bulk ingest test to validate that this setting is the root cause of the performance regression observed in issue #152859. It is suspected that the regression occurred due to commit dd57482c4d5, which change the default value of use_soft_limit_for_distribute_scan. This just changes the setting back to its original default to verify.

Informs #152859

Release note: None