### PR TITLE
vecbench: show p50/p95/p99 vector search latencies

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -106,6 +106,7 @@ var buildTargetMapping = map[string]string{
 	"sql-bootstrap-data":   "//pkg/cmd/sql-bootstrap-data:sql-bootstrap-data",
 	"staticcheck":          "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
 	"tests":                "//pkg:all_tests",
+	"vecbench":             "//pkg/cmd/vecbench:vecbench",
 	"whoownsit":            "//pkg/cmd/whoownsit:whoownsit",
 	"workload":             "//pkg/cmd/workload:workload",
 }


### PR DESCRIPTION
Calculate the p50/p95/p99 latencies for vector search in the vecbench tool. Print the latencies as part of output.

Epic: CRDB-42943
Release note: None