### PR TITLE
sql/inspect: convert internal errors to inspect issues

### DIFF
--- a/pkg/sql/inspect/issue.go
+++ b/pkg/sql/inspect/issue.go
@@ -97,4 +97,9 @@ const (
 	// DanglingSecondaryIndexEntry occurs when a secondary index entry exists
 	// but the corresponding row in the primary index is missing.
 	DanglingSecondaryIndexEntry inspectErrorType = "dangling_secondary_index_entry"
+
+	// InternalError occurs when an internal error (e.g., data corruption, encoding
+	// issues) prevents the check from completing normally. These errors indicate
+	// potential data corruption or other serious issues that require investigation.
+	InternalError inspectErrorType = "internal_error"
 )


### PR DESCRIPTION
Previously, internal errors during index consistency checks would fail the entire job. Now these errors are converted to structured inspect issues with detailed context.

Closes #148299

Release Notes: None

Epic: None