### PR TITLE
roachtest: use LeaderLeases for schemachange/bulkingest tests

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -359,7 +359,7 @@ func makeSchemaChangeBulkIngestTest(
 		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.SSD(4)),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		Leases:           registry.MetamorphicLeases,
+		Leases:           registry.LeaderLeases,
 		Timeout:          length * 2,
 		PostProcessPerfMetrics: func(test string, histogram *roachtestutil.HistogramMetric) (roachtestutil.AggregatedPerfMetrics, error) {
 			// The histogram tracks the total elapsed time for the CREATE INDEX operation.


### PR DESCRIPTION
Changed from MetamorphicLeases to LeaderLeases in
makeSchemaChangeBulkIngestTest to address potential test stability issues identified in issue #152857.

Closes #152857

Release note: none

Epic: None