### PR TITLE
workload: set allow_unsafe_internals for workload commands

### DIFF
--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -118,6 +118,7 @@ func SanitizeUrls(gen Generator, connFlags *ConnFlags, urls []string) (string, e
 func SetUrlConnVars(gen Generator, connFlags *ConnFlags, urls []string) error {
 	vars := make(map[string]string)
 	vars["application_name"] = gen.Meta().Name
+	vars["allow_unsafe_internals"] = "true"
 	if connFlags != nil {
 		if connFlags.IsoLevel != "" {
 			// As a convenience, replace underscores with spaces. This allows users of


### PR DESCRIPTION
Previously some workload `run` and `init` commands would fail if and when they try to access crdb_internal or system tables (if the `allow_unsafe_internals` session var is globally defaulted to false - which will be the case in 26.1)

This commit modifies all connections that workload commands use to have the `allow_unsafe_internals` session variable set to on.

Fixes: #152755
Release note: None