### PR TITLE
sql/opt: decompile plan gists into PlanGrams

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "explain",
     srcs = [
+        "decompile.go",
         "emit.go",
         "explain_factory.go",
         "flags.go",
@@ -29,6 +30,7 @@ go_library(
         "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/exec",
         "//pkg/sql/opt/invertedexpr",  # keep
+        "//pkg/sql/opt/props/physical",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catid",
@@ -57,6 +59,7 @@ go_test(
     name = "explain_test",
     size = "medium",
     srcs = [
+        "decompile_test.go",
         "explain_factory_test.go",
         "main_test.go",
         "output_test.go",
@@ -74,8 +77,11 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/exec",
+        "//pkg/sql/opt/props/physical",
         "//pkg/sql/opt/testutils/opttester",
         "//pkg/sql/opt/testutils/testcat",
         "//pkg/sql/sem/eval",

--- a/pkg/sql/opt/exec/explain/decompile.go
+++ b/pkg/sql/opt/exec/explain/decompile.go
@@ -1,0 +1,573 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package explain
+
+import (
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/errors"
+)
+
+// DecompileToPlanGram converts a plan gist's explain.Node tree into a
+// PlanGram describing the optimizer plans that match the gist. Exec nodes
+// that could map to multiple optimizer operators produce an alternation.
+//
+// The decompiler always emits a structurally-valid PlanGram, so an error
+// indicates a bug. The error is returned rather than panicked so callers can
+// skip the pinned plan rather than fail the query; a caller may choose to
+// panic on it in test builds.
+//
+// TODO(drewk): the current decompiler only varies the operator across
+// alternates — children, tables, and indexes are shared. PlanGram itself
+// supports per-alternate children/fields, recursion, and shared nodes, so
+// future refinements could exploit those (e.g., PlaceholderScan without an
+// Index field, or a single shared production for a sub-plan referenced from
+// multiple places).
+func DecompileToPlanGram(node *Node) (physical.PlanGram, error) {
+	d := &decompiler{b: &physical.PlanGramBuilder{}}
+	g, err := d.build(node)
+	if err != nil {
+		return physical.PlanGram{}, err
+	}
+	return g, nil
+}
+
+// decompiler emits PlanGramBuilder calls for a node tree. Each node is
+// visited exactly once; alternation children are promoted to their own
+// productions so the alternate rules share them by reference.
+type decompiler struct {
+	b       *physical.PlanGramBuilder
+	counter int
+}
+
+// freshName allocates a unique production name.
+func (d *decompiler) freshName() string {
+	name := "n" + strconv.Itoa(d.counter)
+	d.counter++
+	return name
+}
+
+// build wraps the root production and finalizes the grammar.
+func (d *decompiler) build(node *Node) (physical.PlanGram, error) {
+	if err := d.b.EnterProduction("root"); err != nil {
+		return physical.PlanGram{}, err
+	}
+	// emit (not emitInProduction): root must have exactly one rule, so an
+	// alternation root needs to be a ref to a sibling production.
+	if err := d.emit(node); err != nil {
+		return physical.PlanGram{}, err
+	}
+	if err := d.b.LeaveProduction(); err != nil {
+		return physical.PlanGram{}, err
+	}
+	return d.b.Build()
+}
+
+// emit emits a node inside an expression context (i.e., as a child of an
+// expression). Single-op nodes inline as an expression; alternation nodes
+// ref a freshly-named production at this position and declare it via
+// emitAltRules.
+func (d *decompiler) emit(node *Node) error {
+	if wrappedOp, ok := node.wrapperOp(); ok {
+		// Wrap the alternation in its own production so both alternates
+		// (with and without the wrappedOp) sit at the current child slot.
+		if len(node.children) != 1 {
+			return errors.AssertionFailedf("wrapper op has %d children, want 1", len(node.children))
+		}
+		return d.inFreshProduction(func() error {
+			return d.emitWrappedAlt(wrappedOp, node.children[0])
+		})
+	}
+	if node.isTransparent() {
+		// The node's sole child is emitted in its place.
+		if len(node.children) != 1 {
+			return errors.AssertionFailedf("transparent op has %d children, want 1", len(node.children))
+		}
+		return d.emit(node.children[0])
+	}
+	ops, fields := node.decompile()
+	if ops == nil {
+		return errors.AssertionFailedf(
+			"decompile: no case for execOperator %d; add an explicit case "+
+				"(use opt.UnknownOp if no constraint applies)", node.op)
+	}
+	children, err := node.decompileChildren()
+	if err != nil {
+		return err
+	}
+	if len(ops) == 1 {
+		return d.emitExpr(ops[0], fields, children)
+	}
+	return d.inFreshProduction(func() error {
+		return d.emitAltRules(ops, fields, children)
+	})
+}
+
+// emitInProduction emits a node directly as the rule(s) of the enclosing
+// production: single-op contributes one rule; alternation contributes one
+// rule per alternate.
+func (d *decompiler) emitInProduction(node *Node) error {
+	if wrappedOp, ok := node.wrapperOp(); ok {
+		if len(node.children) != 1 {
+			return errors.AssertionFailedf("wrapper op has %d children, want 1", len(node.children))
+		}
+		return d.emitWrappedAlt(wrappedOp, node.children[0])
+	}
+	if node.isTransparent() {
+		if len(node.children) != 1 {
+			return errors.AssertionFailedf("transparent op has %d children, want 1", len(node.children))
+		}
+		return d.emitInProduction(node.children[0])
+	}
+	ops, fields := node.decompile()
+	if ops == nil {
+		return errors.AssertionFailedf(
+			"decompile: no case for execOperator %d; add an explicit case "+
+				"(use opt.UnknownOp if no constraint applies)", node.op)
+	}
+	children, err := node.decompileChildren()
+	if err != nil {
+		return err
+	}
+	if len(ops) == 1 {
+		return d.emitExpr(ops[0], fields, children)
+	}
+	return d.emitAltRules(ops, fields, children)
+}
+
+// inFreshProduction runs emitRules in a freshly-named production, referenced
+// at the current builder position.
+func (d *decompiler) inFreshProduction(emitRules func() error) error {
+	name := d.freshName()
+	if err := d.b.RefProduction(name); err != nil {
+		return err
+	}
+	if err := d.b.EnterProduction(name); err != nil {
+		return err
+	}
+	if err := emitRules(); err != nil {
+		return err
+	}
+	return d.b.LeaveProduction()
+}
+
+// emitWrappedAlt emits the two rules
+//
+//	(wrappedOp childRef) | childRef
+//
+// into the current production, followed by the declaration of childRef. See
+// wrapperOp for when this alternation is needed.
+func (d *decompiler) emitWrappedAlt(wrappedOp opt.Operator, child *Node) error {
+	childName := d.freshName()
+	// Rule 1: (wrappedOp childRef).
+	if err := d.b.EnterExpr(wrappedOp); err != nil {
+		return err
+	}
+	if err := d.b.RefProduction(childName); err != nil {
+		return err
+	}
+	if err := d.b.LeaveExpr(); err != nil {
+		return err
+	}
+	// Rule 2: childRef (unwrapped).
+	if err := d.b.RefProduction(childName); err != nil {
+		return err
+	}
+	// Declare childRef as its own production.
+	if err := d.b.EnterProduction(childName); err != nil {
+		return err
+	}
+	if err := d.emitInProduction(child); err != nil {
+		return err
+	}
+	return d.b.LeaveProduction()
+}
+
+// emitAltRules emits one expression rule per alternate op into the current
+// production. The alternation's children are promoted to their own
+// productions and referenced by name from each rule so the children are
+// described exactly once.
+func (d *decompiler) emitAltRules(
+	ops []opt.Operator, fields []physical.PlanGramField, children []*Node,
+) error {
+	childNames := make([]string, len(children))
+	for i := range children {
+		childNames[i] = d.freshName()
+	}
+	for _, op := range ops {
+		if err := d.b.EnterExpr(op); err != nil {
+			return err
+		}
+		for _, f := range fields {
+			if err := d.b.AddField(f); err != nil {
+				return err
+			}
+		}
+		for _, cn := range childNames {
+			if err := d.b.RefProduction(cn); err != nil {
+				return err
+			}
+		}
+		if err := d.b.LeaveExpr(); err != nil {
+			return err
+		}
+	}
+	for i, child := range children {
+		if err := d.b.EnterProduction(childNames[i]); err != nil {
+			return err
+		}
+		if err := d.emitInProduction(child); err != nil {
+			return err
+		}
+		if err := d.b.LeaveProduction(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitExpr emits a single inline expression at the current builder position.
+func (d *decompiler) emitExpr(
+	op opt.Operator, fields []physical.PlanGramField, children []*Node,
+) error {
+	if err := d.b.EnterExpr(op); err != nil {
+		return err
+	}
+	for _, f := range fields {
+		if err := d.b.AddField(f); err != nil {
+			return err
+		}
+	}
+	for _, c := range children {
+		if err := d.emit(c); err != nil {
+			return err
+		}
+	}
+	return d.b.LeaveExpr()
+}
+
+// decompileChildren returns n.children, swapping the inputs of hash and
+// merge joins back to optimizer order when execbuild commuted them
+// (RightSemi/RightAnti — see execbuilder.buildHashJoin).
+func (n *Node) decompileChildren() ([]*Node, error) {
+	var jt descpb.JoinType
+	switch n.op {
+	case hashJoinOp:
+		args, ok := n.args.(*hashJoinArgs)
+		if !ok {
+			return nil, errors.AssertionFailedf("hashJoinOp node has args of type %T", n.args)
+		}
+		jt = args.JoinType
+	case mergeJoinOp:
+		args, ok := n.args.(*mergeJoinArgs)
+		if !ok {
+			return nil, errors.AssertionFailedf("mergeJoinOp node has args of type %T", n.args)
+		}
+		jt = args.JoinType
+	default:
+		return n.children, nil
+	}
+	if jt == descpb.RightSemiJoin || jt == descpb.RightAntiJoin {
+		if len(n.children) != 2 {
+			return nil, errors.AssertionFailedf("join has %d children, want 2", len(n.children))
+		}
+		return []*Node{n.children[1], n.children[0]}, nil
+	}
+	return n.children, nil
+}
+
+// wrapperOp reports whether n is an execbuilder-side wrapper that may or may
+// not correspond to an optimizer-side wrappedOp at the same position. If
+// true, the decompiler emits "(wrappedOp child) | child" so the matcher can
+// try both shapes. Today only simpleProjectOp qualifies: execbuilder uses it
+// for both real memo.ProjectExprs and for wrappers (applyPresentation,
+// buildGroupBy), and the gist can't tell them apart.
+func (n *Node) wrapperOp() (wrappedOp opt.Operator, ok bool) {
+	if n.op == simpleProjectOp {
+		return opt.ProjectOp, true
+	}
+	return opt.UnknownOp, false
+}
+
+// isTransparent reports whether n has no optimizer-side counterpart and should
+// be replaced by its sole child during decompilation. serializingProjectOp is
+// an execbuilder wrapper (applyPresentation) with no opt op; simpleProjectOp is
+// handled by wrapperOp instead.
+func (n *Node) isTransparent() bool {
+	return n.op == serializingProjectOp
+}
+
+// decompile returns the optimizer operator(s) this exec node could represent
+// and any associated field constraints (e.g., table and index names). Multiple
+// operators indicate alternation (e.g., a scan could be either ScanOp or
+// PlaceholderScanOp).
+//
+// A nil ops slice means the execOperator has no explicit case, which the caller
+// turns into an assertion failure: a new op was added to factory.opt without
+// being mapped here (see TestDecompileCoversAllOps). Wrapper and transparent
+// ops must not reach decompile — emit/emitInProduction check wrapperOp and
+// isTransparent first.
+func (n *Node) decompile() (ops []opt.Operator, fields []physical.PlanGramField) {
+	switch n.op {
+	case scanOp:
+		// TODO(drewk): consider encoding ScanParams (constrained columns,
+		// hard limit, locking) as fields so the PlanGram can distinguish a
+		// constrained scan from a full scan.
+		args := n.args.(*scanArgs)
+		return []opt.Operator{opt.ScanOp, opt.PlaceholderScanOp},
+			tableIndexFields(args.Table, args.Index)
+
+	case indexJoinOp:
+		return []opt.Operator{opt.IndexJoinOp},
+			tableIndexFields(n.args.(*indexJoinArgs).Table, nil /* index */)
+
+	case lookupJoinOp:
+		args := n.args.(*lookupJoinArgs)
+		return []opt.Operator{opt.LookupJoinOp, opt.LockOp},
+			tableIndexFields(args.Table, args.Index)
+
+	case invertedJoinOp:
+		args := n.args.(*invertedJoinArgs)
+		return []opt.Operator{opt.InvertedJoinOp},
+			tableIndexFields(args.Table, args.Index)
+
+	case hashJoinOp:
+		joinOp := joinTypeToOp(n.args.(*hashJoinArgs).JoinType)
+		return []opt.Operator{joinOp}, nil
+
+	case mergeJoinOp:
+		// TODO(drewk): consider specifying the ordering.
+		return []opt.Operator{opt.MergeJoinOp}, nil
+
+	case applyJoinOp:
+		joinOp := applyJoinTypeToOp(n.args.(*applyJoinArgs).JoinType)
+		return []opt.Operator{joinOp}, nil
+
+	case sortOp:
+		// TODO(drewk): consider specifying the ordering.
+		return []opt.Operator{opt.SortOp}, nil
+	case topKOp:
+		return []opt.Operator{opt.TopKOp}, nil
+	case filterOp:
+		return []opt.Operator{opt.SelectOp}, nil
+	case invertedFilterOp:
+		return []opt.Operator{opt.InvertedFilterOp}, nil
+	case valuesOp, literalValuesOp:
+		return []opt.Operator{opt.ValuesOp}, nil
+	case groupByOp:
+		// TODO(drewk): consider specifying the ordering.
+		return []opt.Operator{opt.GroupByOp}, nil
+	case scalarGroupByOp:
+		return []opt.Operator{opt.ScalarGroupByOp}, nil
+	case distinctOp:
+		return []opt.Operator{opt.DistinctOnOp}, nil
+	case limitOp:
+		return []opt.Operator{opt.LimitOp}, nil
+	case max1RowOp:
+		return []opt.Operator{opt.Max1RowOp}, nil
+	case ordinalityOp:
+		return []opt.Operator{opt.OrdinalityOp}, nil
+	case windowOp:
+		return []opt.Operator{opt.WindowOp}, nil
+	case projectSetOp:
+		return []opt.Operator{opt.ProjectSetOp}, nil
+	case zigzagJoinOp:
+		args := n.args.(*zigzagJoinArgs)
+		return []opt.Operator{opt.ZigzagJoinOp}, zigzagFields(args)
+	case recursiveCTEOp:
+		return []opt.Operator{opt.RecursiveCTEOp}, nil
+	case unionAllOp:
+		// UnionAllOp and LocalityOptimizedSearchOp both lower to
+		// ConstructUnionAll in execbuilder (see buildSetOp), so the gist
+		// alone cannot distinguish them.
+		return []opt.Operator{opt.UnionAllOp, opt.LocalityOptimizedSearchOp}, nil
+
+	// Set ops: the gist preserves the ALL bit but drops the set operation type
+	// (UNION/INTERSECT/EXCEPT). UnionAll/LocalityOptimizedSearch always lower
+	// to unionAllOp, so they don't appear here.
+	case hashSetOpOp:
+		return setOpAlternates(n.args.(*hashSetOpArgs).All), nil
+	case streamingSetOpOp:
+		return setOpAlternates(n.args.(*streamingSetOpArgs).All), nil
+
+	// DML operators.
+	case insertOp, insertFastPathOp:
+		return []opt.Operator{opt.InsertOp}, nil
+	case updateOp, updateSwapOp:
+		return []opt.Operator{opt.UpdateOp}, nil
+	case upsertOp:
+		return []opt.Operator{opt.UpsertOp}, nil
+	case deleteOp, deleteRangeOp, deleteSwapOp:
+		return []opt.Operator{opt.DeleteOp}, nil
+
+	// DDL and misc operators.
+	case createTableOp, createTableAsOp:
+		return []opt.Operator{opt.CreateTableOp}, nil
+	case createViewOp:
+		return []opt.Operator{opt.CreateViewOp}, nil
+	case sequenceSelectOp:
+		return []opt.Operator{opt.SequenceSelectOp}, nil
+	case exportOp:
+		return []opt.Operator{opt.ExportOp}, nil
+	case createStatisticsOp:
+		return []opt.Operator{opt.CreateStatisticsOp}, nil
+	case showTraceOp:
+		return []opt.Operator{opt.ShowTraceForSessionOp}, nil
+	case showCompletionsOp:
+		return []opt.Operator{opt.ShowCompletionsOp}, nil
+	case opaqueOp:
+		return []opt.Operator{opt.OpaqueRelOp}, nil
+	case callOp:
+		return []opt.Operator{opt.CallOp}, nil
+	case vectorSearchOp:
+		return []opt.Operator{opt.VectorSearchOp}, nil
+	case vectorMutationSearchOp:
+		return []opt.Operator{opt.VectorMutationSearchOp}, nil
+	case createFunctionOp:
+		return []opt.Operator{opt.CreateFunctionOp}, nil
+	case createTriggerOp:
+		return []opt.Operator{opt.CreateTriggerOp}, nil
+	case controlJobsOp:
+		return []opt.Operator{opt.ControlJobsOp}, nil
+	case controlSchedulesOp:
+		return []opt.Operator{opt.ControlSchedulesOp}, nil
+	case cancelQueriesOp:
+		return []opt.Operator{opt.CancelQueriesOp}, nil
+	case cancelSessionsOp:
+		return []opt.Operator{opt.CancelSessionsOp}, nil
+	case alterTableSplitOp:
+		return []opt.Operator{opt.AlterTableSplitOp}, nil
+	case alterTableUnsplitOp, alterTableUnsplitAllOp:
+		return []opt.Operator{opt.AlterTableUnsplitOp}, nil
+	case alterTableRelocateOp:
+		return []opt.Operator{opt.AlterTableRelocateOp}, nil
+	case alterRangeRelocateOp:
+		return []opt.Operator{opt.AlterRangeRelocateOp}, nil
+
+	case renderOp:
+		// renderOp is always produced from a memo.ProjectExpr (see
+		// execbuilder.buildProject), so the optimizer plan always has a
+		// ProjectExpr at this position.
+		return []opt.Operator{opt.ProjectOp}, nil
+
+	case bufferOp:
+		// TODO(drewk): buffer also appears when the execbuilder wraps a
+		// mutation for cascade fan-out (mutation.go ConstructBuffer), which
+		// has no dedicated opt op. That case will mismatch WithOp.
+		return []opt.Operator{opt.WithOp}, nil
+	case scanBufferOp:
+		// scanBufferOp comes from WithScanExpr and from the recursive
+		// function's reference to the working buffer in a RecursiveCTE; both
+		// are WithScanOp at the optimizer level.
+		//
+		// TODO(drewk): the optimizer plan wraps the buffered subtree in a With
+		// whose WithScans reference it by label. The decompiler doesn't follow
+		// buffer labels yet, so the emitted grammar is missing the (With)
+		// parent. Track labels to reconstruct it.
+		return []opt.Operator{opt.WithScanOp}, nil
+
+	// Execution-only ops: saveTable is a testing artifact; errorIfRows is
+	// pulled into plan.Checks by the gist decoder before the decompiler runs.
+	case saveTableOp, errorIfRowsOp:
+		return []opt.Operator{opt.UnknownOp}, nil
+
+	// Explain is invisible to PlanGram matching.
+	case explainOp, explainOptOp:
+		return []opt.Operator{opt.UnknownOp}, nil
+
+	default:
+		// A missing case means a new execOperator was added without being
+		// mapped here. Returning nil ops signals this to the caller, which
+		// turns it into an assertion failure so the pinned plan is skipped
+		// rather than silently dropping the operator constraint.
+		return nil, nil
+	}
+}
+
+// tableIndexFields returns PlanGramFields for a table and index.
+func tableIndexFields(table cat.Table, index cat.Index) []physical.PlanGramField {
+	var fields []physical.PlanGramField
+	if table != nil {
+		fields = append(fields, physical.PlanGramField{Key: "Table", Val: string(table.Name())})
+	}
+	if index != nil {
+		fields = append(fields, physical.PlanGramField{Key: "Index", Val: string(index.Name())})
+	}
+	return fields
+}
+
+// zigzagFields returns PlanGramFields for a zigzag join's left and right
+// tables and indexes, matching memo.ZigzagJoinExpr.PlanGramMatchableFields.
+func zigzagFields(args *zigzagJoinArgs) []physical.PlanGramField {
+	var fields []physical.PlanGramField
+	if args.LeftTable != nil {
+		fields = append(fields, physical.PlanGramField{Key: "LeftTable", Val: string(args.LeftTable.Name())})
+	}
+	if args.RightTable != nil {
+		fields = append(fields, physical.PlanGramField{Key: "RightTable", Val: string(args.RightTable.Name())})
+	}
+	if args.LeftIndex != nil {
+		fields = append(fields, physical.PlanGramField{Key: "LeftIndex", Val: string(args.LeftIndex.Name())})
+	}
+	if args.RightIndex != nil {
+		fields = append(fields, physical.PlanGramField{Key: "RightIndex", Val: string(args.RightIndex.Name())})
+	}
+	return fields
+}
+
+// setOpAlternates returns the optimizer set-op operators that could have
+// produced a hashSetOp / streamingSetOp gist node with the given ALL bit.
+// UnionAllOp and LocalityOptimizedSearchOp are excluded: both lower to
+// unionAllOp in the gist.
+func setOpAlternates(all bool) []opt.Operator {
+	if all {
+		return []opt.Operator{opt.IntersectAllOp, opt.ExceptAllOp}
+	}
+	return []opt.Operator{opt.UnionOp, opt.IntersectOp, opt.ExceptOp}
+}
+
+// joinTypeToOp maps a descpb.JoinType to its optimizer operator. RIGHT_SEMI
+// and RIGHT_ANTI map to SemiJoinOp/AntiJoinOp: the execbuilder produces the
+// right variants by swapping inputs (see execbuilder.buildHashJoin).
+func joinTypeToOp(jt descpb.JoinType) opt.Operator {
+	switch jt {
+	case descpb.InnerJoin:
+		return opt.InnerJoinOp
+	case descpb.LeftOuterJoin:
+		return opt.LeftJoinOp
+	case descpb.RightOuterJoin:
+		return opt.RightJoinOp
+	case descpb.FullOuterJoin:
+		return opt.FullJoinOp
+	case descpb.LeftSemiJoin, descpb.RightSemiJoin:
+		return opt.SemiJoinOp
+	case descpb.LeftAntiJoin, descpb.RightAntiJoin:
+		return opt.AntiJoinOp
+	default:
+		return opt.UnknownOp
+	}
+}
+
+// applyJoinTypeToOp maps a descpb.JoinType to the corresponding apply join
+// optimizer operator.
+func applyJoinTypeToOp(jt descpb.JoinType) opt.Operator {
+	switch jt {
+	case descpb.InnerJoin:
+		return opt.InnerJoinApplyOp
+	case descpb.LeftOuterJoin:
+		return opt.LeftJoinApplyOp
+	case descpb.LeftSemiJoin:
+		return opt.SemiJoinApplyOp
+	case descpb.LeftAntiJoin:
+		return opt.AntiJoinApplyOp
+	default:
+		return opt.UnknownOp
+	}
+}

--- a/pkg/sql/opt/exec/explain/decompile_test.go
+++ b/pkg/sql/opt/exec/explain/decompile_test.go
@@ -1,0 +1,365 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package explain
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecompileCoversAllOps verifies that every execOperator is handled, by one
+// of node.wrapperOp, node.isTransparent, or an explicit node.decompile case.
+// A new op added to factory.opt that nobody remembered to wire up here
+// would otherwise hit decompile's default branch, which returns nil ops;
+// emit/emitInProduction turn that into an assertion failure in production,
+// discarding the pinned plan.
+//
+// When a case runs to completion, the returned ops slice is also checked:
+// nil means the op is unhandled (a wiring bug); a non-nil slice must be
+// non-empty, since an empty slice would silently drop the operator constraint.
+func TestDecompileCoversAllOps(t *testing.T) {
+	for op := execOperator(1); op < numOperators; op++ {
+		t.Run(fmt.Sprintf("op%d", op), func(t *testing.T) {
+			n := &Node{op: op}
+			// These short-circuits run before decompile in emit/emitInProduction,
+			// so the op is covered without reaching a decompile case.
+			if _, ok := n.wrapperOp(); ok {
+				return
+			}
+			if n.isTransparent() {
+				return
+			}
+			var ops []opt.Operator
+			panicked := false
+			func() {
+				defer func() {
+					// A handled case with a nil n.args panics on a type assertion
+					// when it tries to read its arguments, which still counts as
+					// covered.
+					if recover() != nil {
+						panicked = true
+					}
+				}()
+				ops, _ = n.decompile()
+			}()
+			if panicked {
+				return
+			}
+			if ops == nil {
+				t.Fatalf("execOperator %d has no decompile case; add one "+
+					"(use opt.UnknownOp if no constraint applies)", op)
+			}
+			if len(ops) == 0 {
+				t.Fatalf("case for op %d returned empty ops slice; "+
+					"include at least one op", op)
+			}
+		})
+	}
+}
+
+func TestJoinTypeToOp(t *testing.T) {
+	tests := []struct {
+		joinType   descpb.JoinType
+		expectedOp opt.Operator
+	}{
+		{joinType: descpb.InnerJoin, expectedOp: opt.InnerJoinOp},
+		{joinType: descpb.LeftOuterJoin, expectedOp: opt.LeftJoinOp},
+		{joinType: descpb.RightOuterJoin, expectedOp: opt.RightJoinOp},
+		{joinType: descpb.FullOuterJoin, expectedOp: opt.FullJoinOp},
+		{joinType: descpb.LeftSemiJoin, expectedOp: opt.SemiJoinOp},
+		{joinType: descpb.LeftAntiJoin, expectedOp: opt.AntiJoinOp},
+		// RIGHT_SEMI and RIGHT_ANTI are produced by the execbuilder when it
+		// swaps hash join inputs based on row count estimates. They map to the
+		// same optimizer operators as their LEFT counterparts.
+		{joinType: descpb.RightSemiJoin, expectedOp: opt.SemiJoinOp},
+		{joinType: descpb.RightAntiJoin, expectedOp: opt.AntiJoinOp},
+		// Set-op join types (used by the lower-level execution layers for
+		// INTERSECT/EXCEPT) never appear in plan-gist hash joins, so they fall
+		// through to UnknownOp.
+		{joinType: descpb.IntersectAllJoin, expectedOp: opt.UnknownOp},
+		{joinType: descpb.ExceptAllJoin, expectedOp: opt.UnknownOp},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.joinType.String(), func(t *testing.T) {
+			require.Equal(t, tc.expectedOp, joinTypeToOp(tc.joinType))
+		})
+	}
+}
+
+// TestDecompileChildrenCommutesJoins verifies that hash and merge joins
+// whose joinType is RightSemi or RightAnti have their inputs swapped back to
+// optimizer order during decompile. The execbuilder commutes these joins to
+// keep the smaller side on the right at execution time (see buildHashJoin
+// and buildMergeJoin in execbuilder), but the optimizer plan we're trying
+// to match has the original left/right order with SemiJoinOp/AntiJoinOp.
+func TestDecompileChildrenCommutesJoins(t *testing.T) {
+	left := &Node{op: scanOp}
+	right := &Node{op: scanOp}
+
+	tests := []struct {
+		name       string
+		node       *Node
+		expectSwap bool
+	}{
+		{
+			name: "hash inner join not swapped",
+			node: &Node{
+				op:       hashJoinOp,
+				args:     &hashJoinArgs{JoinType: descpb.InnerJoin},
+				children: []*Node{left, right},
+			},
+		},
+		{
+			name: "hash left semi join not swapped",
+			node: &Node{
+				op:       hashJoinOp,
+				args:     &hashJoinArgs{JoinType: descpb.LeftSemiJoin},
+				children: []*Node{left, right},
+			},
+		},
+		{
+			name: "hash right semi join swapped",
+			node: &Node{
+				op:       hashJoinOp,
+				args:     &hashJoinArgs{JoinType: descpb.RightSemiJoin},
+				children: []*Node{left, right},
+			},
+			expectSwap: true,
+		},
+		{
+			name: "hash right anti join swapped",
+			node: &Node{
+				op:       hashJoinOp,
+				args:     &hashJoinArgs{JoinType: descpb.RightAntiJoin},
+				children: []*Node{left, right},
+			},
+			expectSwap: true,
+		},
+		{
+			name: "merge inner join not swapped",
+			node: &Node{
+				op:       mergeJoinOp,
+				args:     &mergeJoinArgs{JoinType: descpb.InnerJoin},
+				children: []*Node{left, right},
+			},
+		},
+		{
+			name: "merge right semi join swapped",
+			node: &Node{
+				op:       mergeJoinOp,
+				args:     &mergeJoinArgs{JoinType: descpb.RightSemiJoin},
+				children: []*Node{left, right},
+			},
+			expectSwap: true,
+		},
+		{
+			name: "merge right anti join swapped",
+			node: &Node{
+				op:       mergeJoinOp,
+				args:     &mergeJoinArgs{JoinType: descpb.RightAntiJoin},
+				children: []*Node{left, right},
+			},
+			expectSwap: true,
+		},
+		{
+			// Apply joins are left-driven and don't get commuted by
+			// execbuild, so RightSemi/RightAnti shouldn't arise — but if one
+			// somehow appears, decompileChildren should not swap.
+			name: "apply join not swapped",
+			node: &Node{
+				op:       applyJoinOp,
+				args:     &applyJoinArgs{JoinType: descpb.LeftSemiJoin},
+				children: []*Node{left, right},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.node.decompileChildren()
+			require.NoError(t, err)
+			require.Len(t, got, 2)
+			if tc.expectSwap {
+				require.Same(t, right, got[0], "expected swap: got[0] should be the original right")
+				require.Same(t, left, got[1], "expected swap: got[1] should be the original left")
+			} else {
+				require.Same(t, left, got[0], "expected no swap: got[0] should be the original left")
+				require.Same(t, right, got[1], "expected no swap: got[1] should be the original right")
+			}
+		})
+	}
+}
+
+func TestApplyJoinTypeToOp(t *testing.T) {
+	tests := []struct {
+		joinType   descpb.JoinType
+		expectedOp opt.Operator
+	}{
+		{joinType: descpb.InnerJoin, expectedOp: opt.InnerJoinApplyOp},
+		{joinType: descpb.LeftOuterJoin, expectedOp: opt.LeftJoinApplyOp},
+		{joinType: descpb.LeftSemiJoin, expectedOp: opt.SemiJoinApplyOp},
+		{joinType: descpb.LeftAntiJoin, expectedOp: opt.AntiJoinApplyOp},
+		// Apply joins don't have right/full/outer variants in the optimizer.
+		{joinType: descpb.RightOuterJoin, expectedOp: opt.UnknownOp},
+		{joinType: descpb.FullOuterJoin, expectedOp: opt.UnknownOp},
+		{joinType: descpb.RightSemiJoin, expectedOp: opt.UnknownOp},
+		{joinType: descpb.RightAntiJoin, expectedOp: opt.UnknownOp},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.joinType.String(), func(t *testing.T) {
+			require.Equal(t, tc.expectedOp, applyJoinTypeToOp(tc.joinType))
+		})
+	}
+}
+
+// TestDecompileSetOpAlternates verifies the optimizer-operator alternation
+// each set-op gist node decompiles to. The gist preserves the ALL bit but
+// drops the set operation type (UNION/INTERSECT/EXCEPT). UnionAll and
+// LocalityOptimizedSearch both lower to unionAllOp in the gist, so neither
+// can appear in the hash/streaming alternates.
+func TestDecompileSetOpAlternates(t *testing.T) {
+	tests := []struct {
+		name        string
+		node        *Node
+		expectedOps []opt.Operator
+	}{
+		{
+			name:        "hash set op (distinct)",
+			node:        &Node{op: hashSetOpOp, args: &hashSetOpArgs{All: false}},
+			expectedOps: []opt.Operator{opt.UnionOp, opt.IntersectOp, opt.ExceptOp},
+		},
+		{
+			name:        "hash set op (all)",
+			node:        &Node{op: hashSetOpOp, args: &hashSetOpArgs{All: true}},
+			expectedOps: []opt.Operator{opt.IntersectAllOp, opt.ExceptAllOp},
+		},
+		{
+			name:        "streaming set op (distinct)",
+			node:        &Node{op: streamingSetOpOp, args: &streamingSetOpArgs{All: false}},
+			expectedOps: []opt.Operator{opt.UnionOp, opt.IntersectOp, opt.ExceptOp},
+		},
+		{
+			name:        "streaming set op (all)",
+			node:        &Node{op: streamingSetOpOp, args: &streamingSetOpArgs{All: true}},
+			expectedOps: []opt.Operator{opt.IntersectAllOp, opt.ExceptAllOp},
+		},
+		{
+			name:        "union all covers UnionAll and LocalityOptimizedSearch",
+			node:        &Node{op: unionAllOp, args: &unionAllArgs{}},
+			expectedOps: []opt.Operator{opt.UnionAllOp, opt.LocalityOptimizedSearchOp},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ops, _ := tc.node.decompile()
+			require.Equal(t, tc.expectedOps, ops)
+		})
+	}
+}
+
+// TestDecompileMatchesLocalityOptimizedSearch verifies that the decompiled
+// grammar for a unionAllOp gist node matches both UnionAllOp and
+// LocalityOptimizedSearchOp at the root, since execbuilder lowers both to
+// ConstructUnionAll and the gist alone cannot distinguish them.
+func TestDecompileMatchesLocalityOptimizedSearch(t *testing.T) {
+	left := &Node{op: scanOp, args: &scanArgs{}}
+	right := &Node{op: scanOp, args: &scanArgs{}}
+	root := &Node{
+		op:       unionAllOp,
+		args:     &unionAllArgs{},
+		children: []*Node{left, right},
+	}
+
+	pg, err := DecompileToPlanGram(root)
+	require.NoError(t, err)
+
+	visited := alternates(t, pg)
+	require.True(t, anyMatches(visited, &mockExpr{op: opt.UnionAllOp, children: 2}),
+		"expected UnionAllOp match; alternates: %v", grammarsToStrings(visited))
+	require.True(t, anyMatches(visited, &mockExpr{op: opt.LocalityOptimizedSearchOp, children: 2}),
+		"expected LocalityOptimizedSearchOp match; alternates: %v", grammarsToStrings(visited))
+}
+
+// TestDecompileWrapsSimpleProject verifies that a simpleProjectOp node in a
+// gist tree decompiles to a "(Project child) | child" alternation, so the
+// resulting PlanGram matches both shapes the gist could have come from:
+//
+//   - the optimizer plan with a real ProjectExpr wrapping the input
+//     (e.g. SELECT col FROM ...);
+//   - the optimizer plan with no Project at this position, where the
+//     simpleProject was added by an execbuilder wrapper such as
+//     applyPresentation.
+//
+// The grammar's behavior is asserted by enumerating its root-level alternates
+// and checking that each shape (Project wrapping a Scan, and a bare Scan)
+// matches at least one of them.
+func TestDecompileWrapsSimpleProject(t *testing.T) {
+	// Build a gist node tree: simpleProject -> scan.
+	scan := &Node{op: scanOp, args: &scanArgs{}}
+	root := &Node{op: simpleProjectOp, children: []*Node{scan}}
+
+	pg, err := DecompileToPlanGram(root)
+	require.NoError(t, err)
+
+	t.Run("matches Project wrapping Scan", func(t *testing.T) {
+		visited := alternates(t, pg)
+		require.True(t, anyMatches(visited, &mockExpr{op: opt.ProjectOp, children: 1}),
+			"alternates: %v", grammarsToStrings(visited))
+	})
+	t.Run("matches bare Scan", func(t *testing.T) {
+		visited := alternates(t, pg)
+		require.True(t, anyMatches(visited, &mockExpr{op: opt.ScanOp, children: 0}),
+			"alternates: %v", grammarsToStrings(visited))
+	})
+}
+
+// alternates returns the expanded concrete-expression alternates reachable
+// from the root of pg, mirroring how enforceProps expands a production with
+// multiple rules during optimization.
+func alternates(t *testing.T, pg physical.PlanGram) []physical.PlanGram {
+	t.Helper()
+	var out []physical.PlanGram
+	pg.VisitAlternates(func(alt physical.PlanGram) {
+		out = append(out, alt)
+	})
+	return out
+}
+
+func anyMatches(alts []physical.PlanGram, e *mockExpr) bool {
+	for _, a := range alts {
+		if a.Matches(e, nil /* md */) {
+			return true
+		}
+	}
+	return false
+}
+
+func grammarsToStrings(alts []physical.PlanGram) []string {
+	out := make([]string, len(alts))
+	for i, a := range alts {
+		out[i] = a.String()
+	}
+	return out
+}
+
+// mockExpr is a minimal opt.Expr used to drive PlanGram.Matches in tests.
+type mockExpr struct {
+	op       opt.Operator
+	children int
+}
+
+func (m *mockExpr) Op() opt.Operator   { return m.op }
+func (m *mockExpr) ChildCount() int    { return m.children }
+func (m *mockExpr) Child(int) opt.Expr { return nil }
+func (m *mockExpr) Private() any       { return nil }

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -6,6 +6,7 @@
 package explain_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -49,7 +50,7 @@ func explainGist(gist string, catalog cat.Catalog) string {
 	return ob.BuildString()
 }
 
-func plan(ot *opttester.OptTester, t *testing.T) string {
+func planNode(ot *opttester.OptTester, t *testing.T) *explain.Plan {
 	f := explain.NewFactory(exec.StubFactory{}, &tree.SemaContext{}, &eval.Context{})
 	expr, err := ot.Optimize()
 	if err != nil {
@@ -65,15 +66,53 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	if explainPlan == nil {
 		t.Fatal("Couldn't ExecBuild memo, use a logictest instead?")
 	}
+	return explainPlan.(*explain.Plan)
+}
+
+func planString(plan *explain.Plan, t *testing.T) string {
 	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true, ShowPolicyInfo: true}
 	ob := explain.NewOutputBuilder(flags)
-	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" }, false /* createPostQueryPlanIfMissing */)
+	err := explain.Emit(context.Background(), &eval.Context{}, plan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" }, false /* createPostQueryPlanIfMissing */)
 	if err != nil {
 		t.Error(err)
 	}
 	str := ob.BuildString()
 	fmt.Printf("%s\n", str)
 	return str
+}
+
+func plan(ot *opttester.OptTester, t *testing.T) string {
+	explainPlan := planNode(ot, t)
+	return planString(explainPlan, t)
+}
+
+func decompile(ot *opttester.OptTester, catalog cat.Catalog, t *testing.T) string {
+	explainPlan := planNode(ot, t)
+	ogPlanGram, err := explain.DecompileToPlanGram(explainPlan.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	explainShape := planString(explainPlan, t)
+
+	gist := makeGist(ot, t)
+	gistExplainPlan, err := explain.DecodePlanGistToPlan(gist.String(), catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gistPlanGram, err := explain.DecompileToPlanGram(gistExplainPlan.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ogPlanGram.String() != gistPlanGram.String() {
+		t.Fatalf(
+			"PlanGrams from original explain tree and plan gist do not match:\n  original: %s\n  gist:     %s",
+			ogPlanGram, gistPlanGram,
+		)
+	}
+	var pg bytes.Buffer
+	gistPlanGram.FormatPretty(&pg, true /* newlines */)
+	return fmt.Sprintf("explain(shape):\n%splangram:\n%s", explainShape, pg.String())
 }
 
 func TestExplainBuilder(t *testing.T) {
@@ -102,12 +141,13 @@ func TestExplainBuilder(t *testing.T) {
 			return plan(ot, t)
 		case "hash":
 			return fmt.Sprintf("%d\n", makeGist(ot, t).Hash())
+		case "decompile":
+			return decompile(ot, catalog, t)
 		default:
 			return ot.RunCommand(t, d)
 		}
 	}
-	// RFC: should I move this to opt_tester?
-	for _, testfile := range []string{"gists", "gists_tpce", "row_level_security"} {
+	for _, testfile := range []string{"gists", "gists_tpce", "plangram", "row_level_security"} {
 		t.Run(testfile, func(t *testing.T) {
 			datadriven.RunTest(t, datapathutils.TestDataPath(t, testfile), testGists)
 			// Reset the catalog for the next test.

--- a/pkg/sql/opt/exec/explain/testdata/plangram
+++ b/pkg/sql/opt/exec/explain/testdata/plangram
@@ -1,0 +1,1044 @@
+import file=tpce_schema
+----
+
+exec-ddl
+CREATE TABLE foo (a INT PRIMARY KEY, b INT[], c STRING, INVERTED INDEX b_inverted_index(b), UNIQUE INDEX c_idx(c))
+----
+
+exec-ddl
+CREATE TABLE bar (ba INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), INDEX(c))
+----
+
+exec-ddl
+CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT)
+----
+
+# ConstructScan/ConstructSerializingProject
+decompile
+SELECT * from foo LIMIT 10
+----
+explain(shape):
+• scan
+  table: foo@foo_pkey
+  spans: LIMITED SCAN
+  limit: 10
+plangram:
+root: n0;
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# ConstructFilter
+decompile
+SELECT * from foo WHERE a = 1
+----
+explain(shape):
+• scan
+  table: foo@foo_pkey
+  spans: 1+ spans
+plangram:
+root: n0;
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+decompile
+SELECT * from foo WHERE a IN (1, 3, 5)
+----
+explain(shape):
+• scan
+  table: foo@foo_pkey
+  spans: 1+ spans
+plangram:
+root: n0;
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# ConstructInvertedFilter/ConstructIndexJoin
+decompile
+SELECT * from foo WHERE b @> ARRAY[1]
+----
+explain(shape):
+• index join
+│ table: foo@foo_pkey
+│
+└── • scan
+      table: foo@b_inverted_index
+      spans: 1+ spans
+plangram:
+root: (IndexJoin Table="foo" n0);
+n0:
+  (Scan Table="foo" Index="b_inverted_index")
+  | (PlaceholderScan Table="foo" Index="b_inverted_index");
+
+# ConstructSimpleProjectOp
+decompile
+select a,b from foo@c_idx where c = 'bar'
+----
+explain(shape):
+• index join
+│ table: foo@foo_pkey
+│
+└── • scan
+      table: foo@c_idx
+      spans: 1+ spans
+plangram:
+root: n0;
+n0:
+  (Project n1)
+  | n1;
+n1: (IndexJoin Table="foo" n2);
+n2:
+  (Scan Table="foo" Index="c_idx")
+  | (PlaceholderScan Table="foo" Index="c_idx");
+
+# ConstructRender
+decompile
+select a + 1 from foo
+----
+explain(shape):
+• render
+│
+└── • scan
+      table: foo@c_idx
+      spans: FULL SCAN
+plangram:
+root: (Project n0);
+n0:
+  (Scan Table="foo" Index="c_idx")
+  | (PlaceholderScan Table="foo" Index="c_idx");
+
+# ConstructApplyJoin
+decompile
+SELECT * FROM abc WHERE EXISTS(SELECT * FROM (VALUES (a), (b)) WHERE column1=a)
+----
+explain(shape):
+• apply join (semi)
+│ pred: column1 = a
+│
+├── • scan
+│     table: abc@abc_pkey
+│     spans: FULL SCAN
+│
+└── • inner loop (unoptimized)
+    │
+    └── • values
+           ├── (a,)
+           └── (b,)
+plangram:
+root: (SemiJoinApply n0);
+n0:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructHashJoin
+decompile
+SELECT * FROM foo INNER HASH JOIN bar ON a = ba
+----
+explain(shape):
+• hash join
+│ equality: (a) = (ba)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     table: foo@foo_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      table: bar@bar_pkey
+      spans: FULL SCAN
+plangram:
+root: (InnerJoin n0 n1);
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+n1:
+  (Scan Table="bar" Index="bar_pkey")
+  | (PlaceholderScan Table="bar" Index="bar_pkey");
+
+# ConstructMergeJoin
+decompile
+SELECT * FROM foo JOIN bar ON a = ba
+----
+explain(shape):
+• merge join
+│ equality: (a) = (ba)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     table: foo@foo_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      table: bar@bar_pkey
+      spans: FULL SCAN
+plangram:
+root: (MergeJoin n0 n1);
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+n1:
+  (Scan Table="bar" Index="bar_pkey")
+  | (PlaceholderScan Table="bar" Index="bar_pkey");
+
+# ConstructGroupBy
+decompile
+SELECT c, count(*) FROM foo, bar WHERE a = 1 GROUP BY c
+----
+explain(shape):
+• group (streaming)
+│
+└── • cross join
+    │
+    ├── • scan
+    │     table: bar@bar_pkey
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          table: foo@foo_pkey
+          spans: 1+ spans
+plangram:
+root: (GroupBy n0);
+n0:
+  (Project n1)
+  | n1;
+n1: (InnerJoin n2 n3);
+n2:
+  (Scan Table="bar" Index="bar_pkey")
+  | (PlaceholderScan Table="bar" Index="bar_pkey");
+n3:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# ConstructScalarGroupBy
+decompile
+SELECT sum(a),max(c) FROM foo
+----
+explain(shape):
+• group (scalar)
+│
+└── • scan
+      table: foo@c_idx
+      spans: FULL SCAN
+plangram:
+root: (ScalarGroupBy n0);
+n0:
+  (Scan Table="foo" Index="c_idx")
+  | (PlaceholderScan Table="foo" Index="c_idx");
+
+# ConstructInsert
+decompile
+INSERT INTO foo VALUES (1,ARRAY[1,2],'str')
+----
+explain(shape):
+• insert fast path
+  into: foo(a, b, c)
+  auto commit
+  size: 3 columns, 1 row
+plangram:
+root: (Insert);
+
+# ConstructDistinct
+decompile
+SELECT DISTINCT ON (b,c) b,c from abc
+----
+explain(shape):
+• distinct
+│ distinct on: b, c
+│
+└── • scan
+      table: abc@abc_pkey
+      spans: FULL SCAN
+plangram:
+root: (DistinctOn n0);
+n0:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructHashSetOpOp
+decompile
+SELECT * FROM abc INTERSECT ALL SELECT * FROM abc
+----
+explain(shape):
+• intersect all
+│
+├── • scan
+│     table: abc@abc_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      table: abc@abc_pkey
+      spans: FULL SCAN
+plangram:
+root: n0;
+n0:
+  (IntersectAll n1 n2)
+  | (ExceptAll n1 n2);
+n1:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+n2:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructStreamingSetOpOp
+decompile
+SELECT * FROM abc UNION SELECT * FROM abc ORDER BY b,a
+----
+explain(shape):
+• distinct
+│ distinct on: a
+│
+└── • union all
+    │
+    ├── • sort
+    │   │ order: +b,+a
+    │   │
+    │   └── • scan
+    │         table: abc@abc_pkey
+    │         spans: FULL SCAN
+    │
+    └── • sort
+        │ order: +b,+a
+        │
+        └── • scan
+              table: abc@abc_pkey
+              spans: FULL SCAN
+plangram:
+root: (DistinctOn n0);
+n0:
+  (UnionAll n1 n2)
+  | (LocalityOptimizedSearch n1 n2);
+n1: (Sort n3);
+n3:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+n2: (Sort n4);
+n4:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructUnionAllOp
+decompile
+SELECT * FROM abc UNION ALL SELECT * FROM abc
+----
+explain(shape):
+• union all
+│
+├── • scan
+│     table: abc@abc_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      table: abc@abc_pkey
+      spans: FULL SCAN
+plangram:
+root: n0;
+n0:
+  (UnionAll n1 n2)
+  | (LocalityOptimizedSearch n1 n2);
+n1:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+n2:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructOrdinality
+decompile
+SELECT * FROM abc WITH ORDINALITY
+----
+explain(shape):
+• ordinality
+│
+└── • scan
+      table: abc@abc_pkey
+      spans: FULL SCAN
+plangram:
+root: (Ordinality n0);
+n0:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructLookupJoin
+decompile
+SELECT * FROM foo INNER LOOKUP JOIN bar ON a = ba
+----
+explain(shape):
+• lookup join
+│ table: bar@bar_pkey
+│ equality: (a) = (ba)
+│ equality cols are key
+│
+└── • scan
+      table: foo@foo_pkey
+      spans: FULL SCAN
+plangram:
+root: n0;
+n0:
+  (LookupJoin Table="bar" Index="bar_pkey" n1)
+  | (Lock Table="bar" Index="bar_pkey" n1);
+n1:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# ConstructInvertedJoin
+decompile
+SELECT * FROM foo JOIN bar ON b @> ARRAY[1,2]
+----
+explain(shape):
+• cross join
+│
+├── • scan
+│     table: bar@bar_pkey
+│     spans: FULL SCAN
+│
+└── • lookup join
+    │ table: foo@foo_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │
+    └── • zigzag join
+          left table: foo@b_inverted_index
+          left columns: (a, b_inverted_key)
+          left fixed values: 1 column
+          right table: foo@b_inverted_index
+          right columns: (a, b_inverted_key)
+          right fixed values: 1 column
+plangram:
+root: (InnerJoin n0 n1);
+n0:
+  (Scan Table="bar" Index="bar_pkey")
+  | (PlaceholderScan Table="bar" Index="bar_pkey");
+n1:
+  (LookupJoin Table="foo" Index="foo_pkey" n2)
+  | (Lock Table="foo" Index="foo_pkey" n2);
+n2:
+  (Project n3)
+  | n3;
+n3: (ZigzagJoin LeftTable="foo" RightTable="foo" LeftIndex="b_inverted_index" RightIndex="b_inverted_index");
+
+# ConstructZigzagJoin
+decompile
+SELECT * FROM abc WHERE b = 2 AND c = 3
+----
+explain(shape):
+• zigzag join
+  pred: (b = _) AND (c = _)
+  left table: abc@abc_b_idx
+  left columns: (a, b)
+  left fixed values: 1 column
+  right table: abc@abc_c_idx
+  right columns: (a, c)
+  right fixed values: 1 column
+plangram:
+root: n0;
+n0:
+  (Project n1)
+  | n1;
+n1: (ZigzagJoin LeftTable="abc" RightTable="abc" LeftIndex="abc_b_idx" RightIndex="abc_c_idx");
+
+# ConstructMax1Row
+decompile
+SELECT (SELECT a FROM abc FOR UPDATE)
+----
+explain(shape):
+• root
+│
+├── • values
+│     size: 1 column, 1 row
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT a FROM abc FOR UPDATE)
+    │ exec mode: one row
+    │
+    └── • max1row
+        │
+        └── • scan
+              table: abc@abc_b_idx
+              spans: FULL SCAN
+              locking strength: for update
+plangram:
+root: (Values);
+
+# ConstructProjectSet
+decompile
+SELECT * FROM generate_series(1, 3)
+----
+explain(shape):
+• project set
+│
+└── • emptyrow
+plangram:
+root:
+  (ProjectSet
+    (Values));
+
+# ConstructWindow
+decompile
+SELECT * FROM (SELECT avg(a) OVER () FROM abc)
+----
+explain(shape):
+• window
+│
+└── • scan
+      table: abc@abc_b_idx
+      spans: FULL SCAN
+plangram:
+root: n0;
+n0:
+  (Project n1)
+  | n1;
+n1: (Window n2);
+n2:
+  (Scan Table="abc" Index="abc_b_idx")
+  | (PlaceholderScan Table="abc" Index="abc_b_idx");
+
+# ConstructExplainOpt
+decompile
+EXPLAIN (OPT) SELECT 1
+----
+explain(shape):
+• explain
+plangram:
+root: (_);
+
+# ConstructExplain
+decompile
+EXPLAIN SELECT 1
+----
+explain(shape):
+• explain
+plangram:
+root: (_);
+
+# ConstructShowTrace
+decompile
+SHOW TRACE FOR SESSION
+----
+explain(shape):
+• show trace
+plangram:
+root: (ShowTraceForSession);
+
+# ConstructInsert
+decompile
+INSERT INTO abc SELECT * from abc
+----
+explain(shape):
+• insert
+│ into: abc(a, b, c)
+│ auto commit
+│
+└── • scan
+      table: abc@abc_pkey
+      spans: FULL SCAN
+plangram:
+root: (Insert n0);
+n0:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructUpdate
+decompile
+UPDATE abc SET b = 2 WHERE a = 1
+----
+explain(shape):
+• update
+│ table: abc
+│ set: b
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          table: abc@abc_pkey
+          spans: 1+ spans
+          locking strength: for update
+plangram:
+root: (Update n0);
+n0:
+  (Project n1)
+  | n1;
+n1: (Project n2);
+n2:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructUpsert
+decompile
+UPSERT INTO abc (a,b,c) VALUES (1,2,3)
+----
+explain(shape):
+• upsert
+│ into: abc(a, b, c)
+│ auto commit
+│ arbiter indexes: abc_pkey
+│
+└── • cross join (left outer)
+    │
+    ├── • values
+    │     size: 3 columns, 1 row
+    │
+    └── • scan
+          table: abc@abc_pkey
+          spans: 1+ spans
+          locking strength: for update
+plangram:
+root: (Upsert n0);
+n0:
+  (Project n1)
+  | n1;
+n1:
+  (LeftJoin
+    (Values)
+    n2);
+n2:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# ConstructDeleteRange
+decompile
+DELETE FROM foo
+----
+explain(shape):
+• delete
+│ from: foo
+│ auto commit
+│
+└── • scan
+      table: foo@foo_pkey
+      spans: FULL SCAN
+      locking strength: for update
+plangram:
+root: (Delete n0);
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# ConstructDelete
+decompile
+DELETE FROM foo WHERE a = 1
+----
+explain(shape):
+• delete
+│ from: foo
+│ auto commit
+│
+└── • scan
+      table: foo@foo_pkey
+      spans: 1+ spans
+      locking strength: for update
+plangram:
+root: (Delete n0);
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# createTableOp
+decompile
+CREATE TABLE t1 (x int)
+----
+explain(shape):
+• create table
+plangram:
+root: (CreateTable);
+
+# createTableAsOp
+decompile
+CREATE TABLE t2 AS SELECT * FROM abc
+----
+explain(shape):
+• create table as
+│
+└── • render
+    │
+    └── • scan
+          table: abc@abc_pkey
+          spans: FULL SCAN
+plangram:
+root:
+  (CreateTable
+    (Project n0));
+n0:
+  (Scan Table="abc" Index="abc_pkey")
+  | (PlaceholderScan Table="abc" Index="abc_pkey");
+
+# createViewOp
+decompile
+CREATE VIEW v AS SELECT 1
+----
+explain(shape):
+• create view
+plangram:
+root: (CreateView);
+
+exec-ddl
+CREATE SEQUENCE select_test
+----
+
+# ConstructTopK
+decompile
+SELECT * FROM xyz ORDER BY y LIMIT 10
+----
+explain(shape):
+• top-k
+│ order: +y
+│ k: 10
+│
+└── • scan
+      table: xyz@xyz_pkey
+      spans: FULL SCAN
+plangram:
+root: (TopK n0);
+n0:
+  (Scan Table="xyz" Index="xyz_pkey")
+  | (PlaceholderScan Table="xyz" Index="xyz_pkey");
+
+
+# ConstructSequenceSelect
+decompile
+SELECT * FROM select_test
+----
+explain(shape):
+• sequence select
+plangram:
+root: (SequenceSelect);
+
+
+# alterTableSplitOp
+decompile
+ALTER TABLE foo SPLIT AT VALUES(1)
+----
+explain(shape):
+• split
+│ index: foo@foo_pkey
+│ expiry: CAST(_ AS STRING)
+│
+└── • values
+      size: 1 column, 1 row
+plangram:
+root:
+  (AlterTableSplit
+    (Values));
+
+# alterTableUnsplitOp
+decompile
+ALTER TABLE foo UNSPLIT AT VALUES(1)
+----
+explain(shape):
+• unsplit
+│ index: foo@foo_pkey
+│
+└── • values
+      size: 1 column, 1 row
+plangram:
+root:
+  (AlterTableUnsplit
+    (Values));
+
+
+# alterTableUnsplitAllOp
+decompile
+ALTER TABLE foo UNSPLIT ALL
+----
+explain(shape):
+• unsplit all
+  index: foo@foo_pkey
+plangram:
+root: (AlterTableUnsplit);
+
+# alterTableRelocateOp
+decompile
+ALTER TABLE abc EXPERIMENTAL_RELOCATE VALUES (ARRAY[1],1)
+----
+explain(shape):
+• relocate table
+│ index: abc@abc_pkey
+│
+└── • values
+      size: 2 columns, 1 row
+plangram:
+root:
+  (AlterTableRelocate
+    (Values));
+
+# ConstructBuffer/ConstructScanBuffer
+decompile
+SELECT * FROM [INSERT INTO abc SELECT a, b, c FROM abc RETURNING a] ORDER BY a
+----
+explain(shape):
+• root
+│
+├── • sort
+│   │ order: +a
+│   │
+│   └── • scan buffer
+│         label: buffer 1
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: INSERT INTO abc SELECT a, b, c FROM abc RETURNING a
+    │ exec mode: discard all rows
+    │
+    └── • buffer
+        │ label: buffer 1
+        │
+        └── • insert
+            │ into: abc(a, b, c)
+            │
+            └── • scan
+                  table: abc@abc_pkey
+                  spans: FULL SCAN
+plangram:
+root:
+  (Sort
+    (WithScan));
+
+# ConstructRecursiveCTE/recursiveCTEOp
+decompile
+WITH RECURSIVE cte(x) AS (VALUES (1) UNION ALL SELECT x+1 FROM cte WHERE x < 10) SELECT * FROM cte
+----
+explain(shape):
+• render
+│
+└── • recursive cte
+    │
+    └── • values
+          size: 1 column, 1 row
+plangram:
+root:
+  (Project
+    (RecursiveCTE
+      (Values)));
+
+# controlSchedulesOp
+decompile
+PAUSE SCHEDULE 123
+----
+explain(shape):
+• control schedules
+│
+└── • values
+      size: 1 column, 1 row
+plangram:
+root:
+  (ControlSchedules
+    (Values));
+
+# controlJobsOp
+decompile
+CANCEL JOBS SELECT 1
+----
+explain(shape):
+• control jobs
+│
+└── • values
+      size: 1 column, 1 row
+plangram:
+root:
+  (ControlJobs
+    (Values));
+
+# cancelQueriesOp
+decompile
+CANCEL QUERIES SELECT '1'
+----
+explain(shape):
+• cancel queries
+│
+└── • values
+      size: 1 column, 1 row
+plangram:
+root:
+  (CancelQueries
+    (Values));
+
+# cancelSessionsOp
+decompile
+CANCEL SESSIONS SELECT '1'
+----
+explain(shape):
+• cancel sessions
+│
+└── • values
+      size: 1 column, 1 row
+plangram:
+root:
+  (CancelSessions
+    (Values));
+
+# ConstructCreateStatistics
+decompile
+CREATE STATISTICS s1 FROM foo
+----
+explain(shape):
+• create statistics
+plangram:
+root: (CreateStatistics);
+
+# ConstructExport
+decompile
+EXPORT INTO CSV "tmp" FROM SELECT * FROM foo
+----
+explain(shape):
+• export
+│
+└── • scan
+      table: foo@foo_pkey
+      spans: FULL SCAN
+plangram:
+root: (Export n0);
+n0:
+  (Scan Table="foo" Index="foo_pkey")
+  | (PlaceholderScan Table="foo" Index="foo_pkey");
+
+# ConstructValues
+decompile
+SELECT 1
+----
+explain(shape):
+• values
+  size: 1 column, 1 row
+plangram:
+root: (Values);
+
+
+# See what gist does on an explain query
+decompile
+EXPLAIN SELECT * from foo LIMIT 1
+----
+explain(shape):
+• explain
+plangram:
+root: (_);
+
+# ConstructShowCompletions
+decompile
+SHOW COMPLETIONS AT OFFSET 10 FOR 'select 123'
+----
+explain(shape):
+• show completions
+  offset: 10
+  syntax: "select 123"
+plangram:
+root: (ShowCompletions);
+
+exec-ddl
+CREATE TABLE ts (a int, b STRING)
+----
+
+decompile
+SELECT max(a), b FROM ts WHERE a = 1 AND b LIKE '$ internal%' GROUP BY b
+----
+explain(shape):
+• group (hash)
+│ group by: b
+│
+└── • filter
+    │ filter: (a = _) AND (b LIKE _)
+    │
+    └── • scan
+          table: ts@ts_pkey
+          spans: FULL SCAN
+plangram:
+root:
+  (GroupBy
+    (Select n0));
+n0:
+  (Scan Table="ts" Index="ts_pkey")
+  | (PlaceholderScan Table="ts" Index="ts_pkey");
+
+decompile
+SELECT b_name, sum(tr_qty * tr_bid_price)::FLOAT8
+FROM sector, industry, company, security, trade_request, broker
+WHERE tr_b_id = b_id
+  AND s_symb = tr_s_symb
+  AND co_id = s_co_id
+  AND in_id = co_in_id
+  AND sc_id = in_sc_id
+  AND b_name = ANY ARRAY[
+                     'Broker1', 'Broker2', 'Broker3', 'Broker4', 'Broker5',
+                     'Broker6', 'Broker7', 'Broker8', 'Broker9', 'Broker10',
+                     'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15',
+                     'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker20',
+                     'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25',
+                     'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker30'
+                   ]
+  AND sc_name = 'Energy'
+GROUP BY b_name
+ORDER BY 2 DESC
+----
+explain(shape):
+• sort
+│ order: -sum
+│
+└── • render
+    │
+    └── • group (hash)
+        │ group by: b_name
+        │
+        └── • render
+            │
+            └── • lookup join
+                │ table: broker@broker_pkey
+                │ equality: (tr_b_id) = (b_id)
+                │ equality cols are key
+                │ pred: b_name IN _
+                │
+                └── • hash join
+                    │ equality: (tr_s_symb) = (s_symb)
+                    │ right cols are key
+                    │
+                    ├── • scan
+                    │     table: trade_request@trade_request_tr_b_id_tr_s_symb_idx
+                    │     spans: FULL SCAN
+                    │
+                    └── • lookup join
+                        │ table: security@security_s_co_id_s_issue_key
+                        │ equality: (co_id) = (s_co_id)
+                        │
+                        └── • lookup join
+                            │ table: company@company_co_in_id_idx
+                            │ equality: (in_id) = (co_in_id)
+                            │
+                            └── • lookup join
+                                │ table: industry@industry_in_sc_id_idx
+                                │ equality: (sc_id) = (in_sc_id)
+                                │
+                                └── • scan
+                                      table: sector@sector_sc_name_key
+                                      spans: 1+ spans
+plangram:
+root:
+  (Sort
+    (Project
+      (GroupBy
+        (Project n0))));
+n0:
+  (LookupJoin Table="broker" Index="broker_pkey" n1)
+  | (Lock Table="broker" Index="broker_pkey" n1);
+n1: (InnerJoin n2 n3);
+n2:
+  (Scan Table="trade_request" Index="trade_request_tr_b_id_tr_s_symb_idx")
+  | (PlaceholderScan Table="trade_request" Index="trade_request_tr_b_id_tr_s_symb_idx");
+n3:
+  (LookupJoin Table="security" Index="security_s_co_id_s_issue_key" n4)
+  | (Lock Table="security" Index="security_s_co_id_s_issue_key" n4);
+n4:
+  (LookupJoin Table="company" Index="company_co_in_id_idx" n5)
+  | (Lock Table="company" Index="company_co_in_id_idx" n5);
+n5:
+  (LookupJoin Table="industry" Index="industry_in_sc_id_idx" n6)
+  | (Lock Table="industry" Index="industry_in_sc_id_idx" n6);
+n6:
+  (Scan Table="sector" Index="sector_sc_name_key")
+  | (PlaceholderScan Table="sector" Index="sector_sc_name_key");

--- a/pkg/sql/opt/plangram/plangram.go
+++ b/pkg/sql/opt/plangram/plangram.go
@@ -11,27 +11,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
 
-// VisibleToPlanGram returns false if expr is invisible to PlanGram
-// matching. Invisible expressions (e.g. Distribute, Barrier, Explain, etc) are
-// ignored during PlanGram matching.
-func VisibleToPlanGram(expr memo.RelExpr) bool {
-	switch expr.(type) {
-	// Invisible expressions must be unary so that the required PlanGram term can
-	// be passed down to the child group.
-	case *memo.NormCycleTestRelExpr, *memo.MemoCycleTestRelExpr, *memo.BarrierExpr,
-		*memo.DistributeExpr, *memo.ExplainExpr:
-		return false
-	default:
-		return true
-	}
-}
-
 // BuildChildRequired returns the PlanGram term for the nth child of
 // the parent expression.
 func BuildChildRequired(
 	parent memo.RelExpr, required physical.PlanGram, childIdx int, md *opt.Metadata,
 ) physical.PlanGram {
-	if !VisibleToPlanGram(parent) {
+	if !physical.VisibleToPlanGram(parent.Op()) {
 		// For expressions not visible to PlanGrams, the current term is simply
 		// passed down.
 		return required

--- a/pkg/sql/opt/plangram/plangram_test.go
+++ b/pkg/sql/opt/plangram/plangram_test.go
@@ -42,7 +42,7 @@ func TestVisibleToPlanGram(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, plangram.VisibleToPlanGram(tc.expr))
+			require.Equal(t, tc.expected, physical.VisibleToPlanGram(tc.expr.Op()))
 		})
 	}
 }

--- a/pkg/sql/opt/props/physical/BUILD.bazel
+++ b/pkg/sql/opt/props/physical/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sqlerrors",
-        "//pkg/util/buildutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -16,7 +16,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -208,7 +207,9 @@ func (p PlanGram) WithNoneFallback() PlanGram {
 }
 
 // FormatPretty writes the full PlanGram grammar to the buffer, starting with
-// the root, optionally with multiple lines.
+// the root. If newlines is true, each production is on its own line and
+// nested parenthesized expressions are indented to their paren depth. If
+// newlines is false, the entire grammar is written on a single line.
 func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 	if newlines {
 		defer b.WriteRune('\n')
@@ -222,9 +223,33 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 		return
 	}
 
-	// formatTerm writes a RHS term to the buffer.
-	var formatTerm func(planGramTerm)
-	formatTerm = func(term planGramTerm) {
+	// hasNestedExpr reports whether term is an expression with at least one
+	// nested expression child. Such terms are broken across multiple lines
+	// in the indented form; expressions whose children are all refs/any/none
+	// stay on a single line.
+	hasNestedExpr := func(term planGramTerm) bool {
+		expr, ok := term.(*planGramExpr)
+		if !ok {
+			return false
+		}
+		for _, child := range expr.children {
+			if _, isExpr := child.(*planGramExpr); isExpr {
+				return true
+			}
+		}
+		return false
+	}
+
+	writeIndent := func(depth int) {
+		for i := 0; i < depth*2; i++ {
+			b.WriteRune(' ')
+		}
+	}
+
+	// formatTerm writes a RHS term to the buffer. depth is the current paren
+	// depth, used to indent broken expressions when newlines is true.
+	var formatTerm func(term planGramTerm, depth int)
+	formatTerm = func(term planGramTerm, depth int) {
 		if term == nil {
 			b.WriteString("any")
 			return
@@ -251,24 +276,50 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 				b.WriteRune('=')
 				b.WriteString(strconv.Quote(field.Val))
 			}
+			breakChildren := newlines && hasNestedExpr(t)
 			for _, child := range t.children {
-				b.WriteRune(' ')
-				formatTerm(child)
+				if breakChildren {
+					b.WriteRune('\n')
+					writeIndent(depth + 1)
+				} else {
+					b.WriteRune(' ')
+				}
+				formatTerm(child, depth+1)
 			}
 			b.WriteRune(')')
 		default:
-			if buildutil.CrdbTestBuild {
-				panic(errors.AssertionFailedf("unexpected planGramTerm type %T", t))
-			}
+			panic(errors.AssertionFailedf("unexpected planGramTerm type %T", t))
 		}
 	}
 
-	b.WriteString("root: ")
-	formatTerm(p.root)
-	b.WriteRune(';')
+	// formatProduction emits a production. If newlines is true and the
+	// production has multiple rules or a single rule that needs breaking,
+	// the rules go on their own indented lines (with `|` prefixing alts);
+	// otherwise the production stays on a single line.
+	formatProduction := func(name string, rules []planGramTerm) {
+		b.WriteString(name)
+		b.WriteRune(':')
+		breakLines := newlines && (len(rules) > 1 || hasNestedExpr(rules[0]))
+		for i, rule := range rules {
+			if breakLines {
+				b.WriteRune('\n')
+				writeIndent(1)
+				if i > 0 {
+					b.WriteString("| ")
+				}
+			} else if i == 0 {
+				b.WriteRune(' ')
+			} else {
+				b.WriteString(" | ")
+			}
+			formatTerm(rule, 1)
+		}
+		b.WriteRune(';')
+	}
 
-	// Visit each LHS nonterminal reachable from the root, and for each, write all
-	// the production rules to the buffer.
+	formatProduction("root", []planGramTerm{p.root})
+
+	// Write each production reachable from the root.
 	visited := make(map[*planGramProduction]struct{})
 	p.root.visitProductions(visited, func(pp *planGramProduction) {
 		if newlines {
@@ -276,16 +327,7 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 		} else {
 			b.WriteRune(' ')
 		}
-		b.WriteString(pp.name)
-		for i, rule := range pp.rules {
-			if i == 0 {
-				b.WriteString(": ")
-			} else {
-				b.WriteString(" | ")
-			}
-			formatTerm(rule)
-		}
-		b.WriteRune(';')
+		formatProduction(pp.name, pp.rules)
 	})
 }
 

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"io"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -59,6 +60,10 @@ import (
 // PlanGrams are equivalent to top-down non-deterministic finite tree
 // automatons. We could compile the PlanGram into a state-table-based NFTA, but
 // for now we simply walk and interpret it during planning.
+//
+// PlanGrams are constructed via PlanGramBuilder or ParsePlanGram. The internal
+// term representation is hidden so that the package retains freedom to change
+// it (e.g., to intern shared subtrees or compile to an NFTA).
 //
 // For some background see https://en.wikipedia.org/wiki/Regular_tree_grammar
 // and https://en.wikipedia.org/wiki/Tree_automaton.
@@ -344,18 +349,316 @@ func (p PlanGram) String() string {
 	return b.String()
 }
 
-// ParsePlanGram parses a PlanGram grammar from the given io.Reader, or returns
-// an error if it cannot.
+// PlanGramBuilder builds a PlanGram via a stateful nested-context API,
+// modeled on explain.OutputBuilder. The builder maintains an implicit
+// "current position" stack: Enter* pushes a new context, Leave* pops it.
+// AddField and the Ref* methods apply to whatever's on top.
+//
+// Production references are by name. Forward references are permitted: a
+// production may be referenced before EnterProduction has declared it; the
+// reference is resolved at Build time. The same idiom supports cycles —
+// reference a production from within its own rules.
+//
+// Nested EnterProduction (declaring a sub-production while another context is
+// open) is allowed; the inner production is not connected to the outer
+// context except via explicit RefProduction calls. This matches the
+// requirement of decompile, where an alternation production is declared
+// inline at the spot where it is referenced.
+//
+// The zero value is ready to use. Build does not mutate state, so it may be
+// called multiple times (returning equivalent PlanGrams) or interleaved with
+// further construction calls. To construct a new grammar, call Reset —
+// following the strings.Builder convention.
+//
+// A PlanGramBuilder is not safe for concurrent use.
+type PlanGramBuilder struct {
+	// productions tracks all named productions, including forward-reference
+	// stubs (which have empty rules until their EnterProduction call
+	// completes). Lazily allocated on first use; cleared by Reset.
+	productions map[string]*planGramProduction
+	// stack is the nested context stack. Each frame is the in-progress
+	// production or expression at that nesting depth. Cleared by Reset.
+	stack []planGramTerm
+}
+
+// EnterProduction starts a new named production. Subsequent EnterExpr / Ref*
+// calls add rules to this production until the matching LeaveProduction. The
+// "root" production is required and must contain exactly one rule.
+//
+// See planGramProduction.name for the constraints on name. Calling
+// EnterProduction with a name that already has rules (i.e., was previously
+// completed via LeaveProduction) is a duplicate error.
+func (b *PlanGramBuilder) EnterProduction(name string) error {
+	if name == "any" || name == "none" {
+		return errors.Newf("%q cannot be used as a production name", name)
+	}
+	pp, err := b.getOrCreateProduction(name)
+	if err != nil {
+		return err
+	}
+	if len(pp.rules) > 0 {
+		return errors.Newf("duplicate production %q", name)
+	}
+	// Disallow re-entering an already-in-progress production.
+	for _, frame := range b.stack {
+		if frame == pp {
+			return errors.Newf("production %q already in progress", name)
+		}
+	}
+	b.stack = append(b.stack, pp)
+	return nil
+}
+
+// LeaveProduction pops the current production. The production must have at
+// least one rule. Pairs with EnterProduction.
+func (b *PlanGramBuilder) LeaveProduction() error {
+	if len(b.stack) == 0 {
+		return errors.New("LeaveProduction without matching EnterProduction")
+	}
+	top, ok := b.stack[len(b.stack)-1].(*planGramProduction)
+	if !ok {
+		return errors.New("LeaveProduction called with expression on top")
+	}
+	if len(top.rules) == 0 {
+		return errors.Newf("production %q has no rules", top.name)
+	}
+	b.stack = b.stack[:len(b.stack)-1]
+	return nil
+}
+
+// EnterExpr starts a new expression with the given op. Subsequent AddField,
+// EnterExpr, and Ref* calls add fields and children. On LeaveExpr, the
+// completed expression becomes either a child of the enclosing expression or
+// a rule of the enclosing production, depending on context.
+func (b *PlanGramBuilder) EnterExpr(op opt.Operator) error {
+	if len(b.stack) == 0 {
+		return errors.New("EnterExpr on empty builder")
+	}
+	if !VisibleToPlanGram(op) {
+		return errors.AssertionFailedf("op %s is invisible to PlanGram matching", op)
+	}
+	b.stack = append(b.stack, &planGramExpr{op: op})
+	return nil
+}
+
+// VisibleToPlanGram reports whether op participates in PlanGram matching.
+// Invisible operators (e.g. Explain, Barrier, Distribute) are optimizer-internal
+// or are dropped before a plan is costed; the matcher skips them, so a PlanGram
+// must never contain one. Invisible operators must be unary so that the required
+// PlanGram term can be passed down to the child group during matching.
+func VisibleToPlanGram(op opt.Operator) bool {
+	switch op {
+	case opt.ExplainOp, opt.BarrierOp, opt.DistributeOp,
+		opt.NormCycleTestRelOp, opt.MemoCycleTestRelOp:
+		return false
+	default:
+		return true
+	}
+}
+
+// LeaveExpr pops the current expression and appends it to the now-current
+// frame. Pairs with EnterExpr.
+func (b *PlanGramBuilder) LeaveExpr() error {
+	if len(b.stack) == 0 {
+		return errors.New("LeaveExpr without matching EnterExpr")
+	}
+	top, ok := b.stack[len(b.stack)-1].(*planGramExpr)
+	if !ok {
+		return errors.New("LeaveExpr called with production on top")
+	}
+	b.stack = b.stack[:len(b.stack)-1]
+	return b.appendTerm(top)
+}
+
+// AddField adds a field constraint to the current expression. Must precede
+// any child added via EnterExpr or Ref*.
+func (b *PlanGramBuilder) AddField(field PlanGramField) error {
+	if len(b.stack) == 0 {
+		return errors.New("AddField outside expression")
+	}
+	top, ok := b.stack[len(b.stack)-1].(*planGramExpr)
+	if !ok {
+		return errors.New("AddField called with production on top")
+	}
+	if len(top.children) > 0 {
+		return errors.New("fields must come before children in expression")
+	}
+	if err := validateFieldKey(field.Key); err != nil {
+		return err
+	}
+	top.fields = append(top.fields, field)
+	return nil
+}
+
+// RefProduction appends a reference to a named production at the current
+// position. Forward references are permitted; the named production is
+// resolved at Build. The names "any" and "none" resolve to anyPlanGramTerm
+// and nonePlanGramTerm respectively (callers may also use RefAny / RefNone
+// for clarity).
+func (b *PlanGramBuilder) RefProduction(name string) error {
+	if len(b.stack) == 0 {
+		return errors.New("RefProduction on empty builder")
+	}
+	switch name {
+	case "any":
+		return b.appendTerm(anyPlanGramTerm)
+	case "none":
+		return b.appendTerm(nonePlanGramTerm)
+	case "root":
+		return errors.New(`"root" cannot be used as a nonterminal reference`)
+	}
+	pp, err := b.getOrCreateProduction(name)
+	if err != nil {
+		return err
+	}
+	return b.appendTerm(pp)
+}
+
+// RefAny appends anyPlanGramTerm at the current position.
+func (b *PlanGramBuilder) RefAny() error {
+	if len(b.stack) == 0 {
+		return errors.New("RefAny on empty builder")
+	}
+	return b.appendTerm(anyPlanGramTerm)
+}
+
+// RefNone appends nonePlanGramTerm at the current position.
+func (b *PlanGramBuilder) RefNone() error {
+	if len(b.stack) == 0 {
+		return errors.New("RefNone on empty builder")
+	}
+	return b.appendTerm(nonePlanGramTerm)
+}
+
+// Build validates and returns the PlanGram for the grammar constructed so
+// far. It does not mutate the builder, so it may be called multiple times
+// (returning equivalent PlanGrams) or interleaved with further construction
+// calls (e.g., to inspect the in-progress grammar). To construct a new
+// grammar, call Reset.
+//
+// PlanGrams previously returned by Build remain valid across further
+// construction and across Reset: the builder API prevents re-entering a
+// completed production (so no production reachable from a returned root can
+// gain rules), and Reset only clears the builder's references to the
+// underlying production nodes.
+func (b *PlanGramBuilder) Build() (PlanGram, error) {
+	if len(b.stack) != 0 {
+		return PlanGram{}, errors.Newf("unmatched Enter without Leave (%d open)", len(b.stack))
+	}
+	root, ok := b.productions["root"]
+	if !ok {
+		return PlanGram{}, errors.New(`missing "root" production`)
+	}
+	if len(root.rules) != 1 {
+		return PlanGram{}, errors.New("root must have exactly one term, not alternates")
+	}
+	// Report any undefined nonterminals deterministically. Allocation is
+	// confined to the error path: a nil slice with no appends costs nothing.
+	var undefined []string
+	for name, pp := range b.productions {
+		if len(pp.rules) == 0 {
+			undefined = append(undefined, name)
+		}
+	}
+	if len(undefined) > 0 {
+		slices.Sort(undefined)
+		return PlanGram{}, errors.Newf("undefined nonterminal(s): %s", strings.Join(undefined, ", "))
+	}
+	return PlanGram{root: root.rules[0]}, nil
+}
+
+// Reset clears the builder so it can be used to construct another grammar.
+// The underlying map and slice memory are retained. PlanGrams previously
+// returned by Build are unaffected — they hold their own references to the
+// production nodes.
+func (b *PlanGramBuilder) Reset() {
+	clear(b.productions)
+	// Nil stack entries before reslicing so the builder doesn't retain
+	// references to popped frames.
+	clear(b.stack)
+	b.stack = b.stack[:0]
+}
+
+// appendTerm appends a term as a child of the top expression or as a rule of
+// the top production. Returns an error if the stack is empty.
+func (b *PlanGramBuilder) appendTerm(term planGramTerm) error {
+	if len(b.stack) == 0 {
+		return errors.New("term added outside production or expression")
+	}
+	switch top := b.stack[len(b.stack)-1].(type) {
+	case *planGramExpr:
+		top.children = append(top.children, term)
+	case *planGramProduction:
+		top.rules = append(top.rules, term)
+	default:
+		return errors.AssertionFailedf("unexpected stack frame type %T", top)
+	}
+	return nil
+}
+
+// getOrCreateProduction returns the production for the given name, creating
+// a forward-reference stub if one does not yet exist. Validates the name and
+// lazily allocates the productions map on first use.
+func (b *PlanGramBuilder) getOrCreateProduction(name string) (*planGramProduction, error) {
+	if err := validateNonterminalName(name); err != nil {
+		return nil, err
+	}
+	if pp, ok := b.productions[name]; ok {
+		return pp, nil
+	}
+	if b.productions == nil {
+		b.productions = make(map[string]*planGramProduction)
+	}
+	pp := &planGramProduction{name: name}
+	b.productions[name] = pp
+	return pp, nil
+}
+
+// validateNonterminalName checks the syntactic constraints on production /
+// reference names.
+func validateNonterminalName(name string) error {
+	if len(name) == 0 {
+		return errors.New("name cannot be empty")
+	}
+	if name[0] >= '0' && name[0] <= '9' {
+		return errors.Newf("name %q must not start with a digit", name)
+	}
+	return validateNameChars(name)
+}
+
+// validateFieldKey checks the syntactic constraints on a field key. Field keys
+// share the same character restrictions as nonterminal names so that the
+// grammar remains tokenizable.
+func validateFieldKey(key string) error {
+	if len(key) == 0 {
+		return errors.New("field key cannot be empty")
+	}
+	return validateNameChars(key)
+}
+
+// validateNameChars rejects strings containing characters that would break
+// tokenization: the reserved punctuation `"'\,():;=|` and any whitespace.
+func validateNameChars(s string) error {
+	if strings.ContainsAny(s, `"'\,():;=|`) {
+		return errors.Newf("%q contains invalid character", s)
+	}
+	if strings.IndexFunc(s, unicode.IsSpace) >= 0 {
+		return errors.Newf("%q contains whitespace", s)
+	}
+	return nil
+}
+
+// ParsePlanGram parses a PlanGram grammar from the given io.Reader, or
+// returns an error if it cannot.
 func ParsePlanGram(r io.Reader) (PlanGram, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Split(tokenizePlanGram)
 
 	p := planGramParser{
-		scanner:     scanner,
-		productions: make(map[string]*planGramProduction),
+		scanner: scanner,
+		builder: &PlanGramBuilder{},
 	}
 
-	// Parse all productions, including "root".
 	for {
 		if _, ok := p.peek(); !ok {
 			break
@@ -369,33 +672,17 @@ func ParsePlanGram(r io.Reader) (PlanGram, error) {
 		return PlanGram{}, err
 	}
 
-	// Validate that root exists and has exactly one term (no alternates).
-	root, ok := p.productions["root"]
-	if !ok {
-		return PlanGram{}, errors.New("missing \"root\" production")
-	}
-	if len(root.rules) != 1 {
-		return PlanGram{}, errors.New("root must have exactly one term, not alternates")
-	}
-
-	// Validate all forward references were resolved (i.e. every production has
-	// at least one rule).
-	for name, pp := range p.productions {
-		if len(pp.rules) == 0 {
-			return PlanGram{}, errors.Newf("undefined nonterminal %q", name)
-		}
-	}
-
-	return PlanGram{root: root.rules[0]}, nil
+	return p.builder.Build()
 }
 
 // planGramParser is a recursive-descent parser for plangram grammars with
-// 1-token lookahead.
+// 1-token lookahead. It drives a PlanGramBuilder for construction and
+// validation.
 type planGramParser struct {
-	scanner     *bufio.Scanner
-	tok         string
-	hasTok      bool
-	productions map[string]*planGramProduction
+	scanner *bufio.Scanner
+	tok     string
+	hasTok  bool
+	builder *PlanGramBuilder
 }
 
 // next consumes and returns the next token.
@@ -438,72 +725,22 @@ func (p *planGramParser) expect(want string) error {
 	return nil
 }
 
-// getOrCreateProduction returns the production for the given name, creating a
-// forward-reference stub if one does not yet exist. The name must not be empty,
-// punctuation, or a quoted string.
-func (p *planGramParser) getOrCreateProduction(name string) (*planGramProduction, error) {
-	if len(name) == 0 {
-		return nil, errors.New("name cannot be empty")
-	}
-	if name[0] >= '0' && name[0] <= '9' {
-		return nil, errors.Newf("name %q must not start with a digit", name)
-	}
-	if strings.ContainsAny(name, `"'\,():;=|`) {
-		return nil, errors.Newf("name %q contains invalid character", name)
-	}
-	pp, ok := p.productions[name]
-	if !ok {
-		pp = &planGramProduction{name: name}
-		p.productions[name] = pp
-	}
-	return pp, nil
-}
-
-// resolveNonterminal maps a nonterminal name to its term. "any" and "none" are
-// resolved to their special terms; "root" is an error (root cannot be
-// referenced from other productions).
-func (p *planGramParser) resolveNonterminal(name string) (planGramTerm, error) {
-	switch name {
-	case "any":
-		return anyPlanGramTerm, nil
-	case "none":
-		return nonePlanGramTerm, nil
-	case "root":
-		return nil, errors.New("\"root\" cannot be used as a nonterminal reference")
-	default:
-		pp, err := p.getOrCreateProduction(name)
-		if err != nil {
-			return nil, err
-		}
-		return pp, nil
-	}
-}
-
 // parseProduction parses: NAME ":" term { "|" term } ";".
 func (p *planGramParser) parseProduction() error {
 	name, err := p.next()
 	if err != nil {
 		return err
 	}
-	if name == "any" || name == "none" {
-		return errors.Newf("%q cannot be used as a production name", name)
-	}
-	pp, err := p.getOrCreateProduction(name)
-	if err != nil {
+	if err := p.builder.EnterProduction(name); err != nil {
 		return err
-	}
-	if len(pp.rules) > 0 {
-		return errors.Newf("duplicate production %q", name)
 	}
 	if err := p.expect(":"); err != nil {
 		return err
 	}
 	for {
-		term, err := p.parseTerm()
-		if err != nil {
+		if err := p.parseTerm(); err != nil {
 			return err
 		}
-		pp.rules = append(pp.rules, term)
 		tok, ok := p.peek()
 		if !ok || tok != "|" {
 			break
@@ -512,18 +749,21 @@ func (p *planGramParser) parseProduction() error {
 			return err
 		}
 	}
-	return p.expect(";")
+	if err := p.expect(";"); err != nil {
+		return err
+	}
+	return p.builder.LeaveProduction()
 }
 
 // parseTerm parses a single term: either an expression (starting with "(") or
-// a nonterminal name.
-func (p *planGramParser) parseTerm() (planGramTerm, error) {
+// a nonterminal reference.
+func (p *planGramParser) parseTerm() error {
 	tok, ok := p.peek()
 	if !ok {
 		if err := p.scanner.Err(); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, errors.New("unexpected end of input: expected term")
+		return errors.New("unexpected end of input: expected term")
 	}
 	if tok == "(" {
 		return p.parseExpr()
@@ -531,19 +771,19 @@ func (p *planGramParser) parseTerm() (planGramTerm, error) {
 	// Must be a nonterminal name.
 	name, err := p.next()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return p.resolveNonterminal(name)
+	return p.builder.RefProduction(name)
 }
 
 // parseExpr parses: "(" OP_NAME { field } { child } ")".
-func (p *planGramParser) parseExpr() (planGramTerm, error) {
+func (p *planGramParser) parseExpr() error {
 	if err := p.expect("("); err != nil {
-		return nil, err
+		return err
 	}
 	opName, err := p.next()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	var op opt.Operator
 	if opName == "_" {
@@ -552,74 +792,71 @@ func (p *planGramParser) parseExpr() (planGramTerm, error) {
 		var ok bool
 		op, ok = opt.OperatorByCamelCase(opName)
 		if !ok {
-			return nil, errors.Newf("unknown operator %q", opName)
+			return errors.Newf("unknown operator %q", opName)
 		}
 	}
-	expr := &planGramExpr{op: op}
+	if err := p.builder.EnterExpr(op); err != nil {
+		return err
+	}
 
 	for {
 		tok, ok := p.peek()
 		if !ok {
 			if err := p.scanner.Err(); err != nil {
-				return nil, err
+				return err
 			}
-			return nil, errors.New("unexpected end of input: expected \")\"")
+			return errors.New("unexpected end of input: expected \")\"")
 		}
 		if tok == ")" {
 			if _, err := p.next(); err != nil { // consume ")"
-				return nil, err
+				return err
 			}
 			break
 		}
 		if tok == "(" {
 			// Inline child expression.
-			child, err := p.parseExpr()
-			if err != nil {
-				return nil, err
+			if err := p.parseExpr(); err != nil {
+				return err
 			}
-			expr.children = append(expr.children, child)
 			continue
 		}
 		if len(tok) == 1 && strings.IndexByte(`":;=|`, tok[0]) >= 0 {
-			return nil, errors.Newf("unexpected %q in expression", tok)
+			return errors.Newf("unexpected %q in expression", tok)
 		}
-		// Consume the name. Then peek to decide if it's a field (followed by "=")
-		// or a nonterminal child.
+		// Consume the name. Then peek to decide if it's a field (followed by
+		// "=") or a nonterminal child.
 		name, err := p.next()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if next, ok := p.peek(); !ok || next != "=" {
 			// Nonterminal child.
-			term, err := p.resolveNonterminal(name)
-			if err != nil {
-				return nil, err
+			if err := p.builder.RefProduction(name); err != nil {
+				return err
 			}
-			expr.children = append(expr.children, term)
 			continue
 		}
 		// Field: Name="value".
-		if len(expr.children) > 0 {
-			return nil, errors.New("fields must come before children in expression")
-		}
 		if _, err = p.next(); err != nil { // consume "="
-			return nil, err
+			return err
 		}
 		val, err := p.next()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if len(val) == 0 || val[0] != '"' {
-			return nil, errors.Newf("expected quoted string for field value, got %q", val)
+			return errors.Newf("expected quoted string for field value, got %q", val)
 		}
 		unquoted, err := strconv.Unquote(val)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid field value %s", val)
+			return errors.Wrapf(err, "invalid field value %s", val)
 		}
-		expr.fields = append(expr.fields, PlanGramField{Key: name, Val: unquoted})
+		if err := p.builder.AddField(PlanGramField{Key: name, Val: unquoted}); err != nil {
+			return err
+		}
 	}
 	// TODO(michae2): check for correct number of children.
-	return expr, nil
+	return p.builder.LeaveExpr()
 }
 
 // tokenizePlanGram is a bufio.SplitFunc that tokenizes a byte stream for

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -160,7 +160,7 @@ func TestPlanGramFormatPretty(t *testing.T) {
 				},
 			}},
 			expectedOneLine:  "root: (Select (Scan));",
-			expectedNewlines: "root: (Select (Scan));\n",
+			expectedNewlines: "root:\n  (Select\n    (Scan));\n",
 		},
 		{
 			name: "child referencing nil",
@@ -202,7 +202,7 @@ func TestPlanGramFormatPretty(t *testing.T) {
 				children: []planGramTerm{&planGramExpr{op: opt.UnknownOp}},
 			}},
 			expectedOneLine:  "root: (Select (_));",
-			expectedNewlines: "root: (Select (_));\n",
+			expectedNewlines: "root:\n  (Select\n    (_));\n",
 		},
 		{
 			name: "with nonterminal production",
@@ -216,8 +216,12 @@ func TestPlanGramFormatPretty(t *testing.T) {
 				},
 			}},
 			expectedOneLine: "root: (Select (IndexJoin scan)); scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");",
-			expectedNewlines: "root: (Select (IndexJoin scan));\n" +
-				"scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");\n",
+			expectedNewlines: "root:\n" +
+				"  (Select\n" +
+				"    (IndexJoin scan));\n" +
+				"scan:\n" +
+				"  (Scan Index=\"abc_b_idx\")\n" +
+				"  | (Scan Index=\"abc_c_idx\");\n",
 		},
 		{
 			name: "multiple fields",
@@ -243,10 +247,16 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			expectedNewlines: "root: (Scan Index=\"has \\\"quotes\\\" and spaces\");\n",
 		},
 		{
-			name:             "cyclical productions",
-			plangram:         PlanGram{root: cycle},
-			expectedOneLine:  "root: cycle; cycle: (InnerJoin cycle cycle) | scan; scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");",
-			expectedNewlines: "root: cycle;\ncycle: (InnerJoin cycle cycle) | scan;\nscan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");\n",
+			name:            "cyclical productions",
+			plangram:        PlanGram{root: cycle},
+			expectedOneLine: "root: cycle; cycle: (InnerJoin cycle cycle) | scan; scan: (Scan Index=\"abc_b_idx\") | (Scan Index=\"abc_c_idx\");",
+			expectedNewlines: "root: cycle;\n" +
+				"cycle:\n" +
+				"  (InnerJoin cycle cycle)\n" +
+				"  | scan;\n" +
+				"scan:\n" +
+				"  (Scan Index=\"abc_b_idx\")\n" +
+				"  | (Scan Index=\"abc_c_idx\");\n",
 		},
 	}
 

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -810,6 +810,371 @@ func TestPlanGramVisitAlternates(t *testing.T) {
 	}
 }
 
+func TestPlanGramBuilder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("simple terminal", func(t *testing.T) {
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.AddField(PlanGramField{Key: "Index", Val: "abc_a_idx"}))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t, `root: (Scan Index="abc_a_idx");`, pg.String())
+	})
+
+	t.Run("nested expressions", func(t *testing.T) {
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.SelectOp))
+		require.NoError(t, b.EnterExpr(opt.IndexJoinOp))
+		require.NoError(t, b.AddField(PlanGramField{Key: "Table", Val: "abc"}))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.AddField(PlanGramField{Key: "Index", Val: "abc_b_idx"}))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t, `root: (Select (IndexJoin Table="abc" (Scan Index="abc_b_idx")));`, pg.String())
+	})
+
+	t.Run("any and none refs", func(t *testing.T) {
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.SelectOp))
+		require.NoError(t, b.RefAny())
+		require.NoError(t, b.RefNone())
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t, "root: (Select any none);", pg.String())
+	})
+
+	t.Run("forward reference and alternates", func(t *testing.T) {
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.SelectOp))
+		require.NoError(t, b.EnterExpr(opt.IndexJoinOp))
+		require.NoError(t, b.RefProduction("scan"))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		require.NoError(t, b.EnterProduction("scan"))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.AddField(PlanGramField{Key: "Index", Val: "abc_b_idx"}))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.AddField(PlanGramField{Key: "Index", Val: "abc_c_idx"}))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t,
+			`root: (Select (IndexJoin scan)); scan: (Scan Index="abc_b_idx") | (Scan Index="abc_c_idx");`,
+			pg.String())
+	})
+
+	t.Run("self-referencing cycle", func(t *testing.T) {
+		// Nested EnterProduction: declare cycle inside the root expression at
+		// the spot where it's referenced. This mirrors what decompile.go does.
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.RefProduction("cycle"))
+		require.NoError(t, b.EnterProduction("cycle"))
+		require.NoError(t, b.EnterExpr(opt.InnerJoinOp))
+		require.NoError(t, b.RefProduction("cycle"))
+		require.NoError(t, b.RefProduction("cycle"))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.RefProduction("scan"))
+		require.NoError(t, b.LeaveProduction())
+		require.NoError(t, b.LeaveProduction())
+		require.NoError(t, b.EnterProduction("scan"))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.AddField(PlanGramField{Key: "Index", Val: "abc_b_idx"}))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t,
+			`root: cycle; cycle: (InnerJoin cycle cycle) | scan; scan: (Scan Index="abc_b_idx");`,
+			pg.String())
+	})
+
+	t.Run("reuse after Reset", func(t *testing.T) {
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg1, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t, "root: (Scan);", pg1.String())
+
+		b.Reset()
+
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.SelectOp))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg2, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t, "root: (Select);", pg2.String())
+
+		// The first grammar must not be affected by the reset.
+		require.Equal(t, "root: (Scan);", pg1.String())
+	})
+
+	t.Run("Build does not mutate", func(t *testing.T) {
+		// Build can be called repeatedly and interleaved with construction
+		// without disturbing the builder state, matching the strings.Builder
+		// convention.
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.SelectOp))
+		require.NoError(t, b.RefProduction("scan"))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+
+		// First Build: "scan" hasn't been defined yet.
+		_, err := b.Build()
+		require.ErrorContains(t, err, "undefined nonterminal(s): scan")
+
+		// Define it and try again. State from the failed Build persists.
+		require.NoError(t, b.EnterProduction("scan"))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+
+		pg1, err := b.Build()
+		require.NoError(t, err)
+		pg2, err := b.Build()
+		require.NoError(t, err)
+		require.Equal(t, pg1.String(), pg2.String())
+		require.Equal(t, "root: (Select scan); scan: (Scan);", pg1.String())
+	})
+
+	t.Run("Build result stable across further construction", func(t *testing.T) {
+		// PlanGrams returned by Build alias the builder's production
+		// pointers, but the API prevents mutation of any production
+		// reachable from a previously-returned root (re-entering a completed
+		// production is a duplicate error). Adding *new* productions after
+		// Build must therefore leave earlier PlanGrams unchanged.
+		var b PlanGramBuilder
+		require.NoError(t, b.EnterProduction("root"))
+		require.NoError(t, b.EnterExpr(opt.SelectOp))
+		require.NoError(t, b.RefProduction("scan"))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		require.NoError(t, b.EnterProduction("scan"))
+		require.NoError(t, b.EnterExpr(opt.ScanOp))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		pg1, err := b.Build()
+		require.NoError(t, err)
+
+		// Add an unrelated production that pg1 doesn't reference.
+		require.NoError(t, b.EnterProduction("unused"))
+		require.NoError(t, b.EnterExpr(opt.ValuesOp))
+		require.NoError(t, b.LeaveExpr())
+		require.NoError(t, b.LeaveProduction())
+		require.Equal(t, "root: (Select scan); scan: (Scan);", pg1.String())
+
+		// Reset must also leave pg1 alone.
+		b.Reset()
+		require.Equal(t, "root: (Select scan); scan: (Scan);", pg1.String())
+	})
+
+	// Error tests: setup returns the first non-nil error it encounters. If
+	// setup returns nil, Build's error is checked instead (covers errors that
+	// only surface at finalization, e.g. missing root or unmatched Enter).
+	errorTests := []struct {
+		name        string
+		setup       func(t *testing.T, b *PlanGramBuilder) error
+		expectedErr string
+	}{
+		{
+			name:        "missing root",
+			setup:       func(*testing.T, *PlanGramBuilder) error { return nil },
+			expectedErr: `missing "root" production`,
+		},
+		{
+			name: "fields after children",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.IndexJoinOp))
+				require.NoError(t, b.EnterExpr(opt.ScanOp))
+				require.NoError(t, b.LeaveExpr())
+				return b.AddField(PlanGramField{Key: "Table", Val: "abc"})
+			},
+			expectedErr: "fields must come before children",
+		},
+		{
+			name: "duplicate production",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.ScanOp))
+				require.NoError(t, b.LeaveExpr())
+				require.NoError(t, b.LeaveProduction())
+				return b.EnterProduction("root")
+			},
+			expectedErr: `duplicate production "root"`,
+		},
+		{
+			name: "any as production name",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.EnterProduction("any")
+			},
+			expectedErr: `"any" cannot be used as a production name`,
+		},
+		{
+			name: "root reference",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.SelectOp))
+				return b.RefProduction("root")
+			},
+			expectedErr: `"root" cannot be used as a nonterminal reference`,
+		},
+		{
+			name: "root with alternates",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.ScanOp))
+				require.NoError(t, b.LeaveExpr())
+				require.NoError(t, b.EnterExpr(opt.SelectOp))
+				require.NoError(t, b.LeaveExpr())
+				require.NoError(t, b.LeaveProduction())
+				return nil
+			},
+			expectedErr: "root must have exactly one term",
+		},
+		{
+			name: "undefined nonterminal",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.SelectOp))
+				require.NoError(t, b.RefProduction("missing"))
+				require.NoError(t, b.LeaveExpr())
+				require.NoError(t, b.LeaveProduction())
+				return nil
+			},
+			expectedErr: "undefined nonterminal(s): missing",
+		},
+		{
+			name: "unmatched enter at build",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.SelectOp))
+				require.NoError(t, b.LeaveExpr())
+				// LeaveProduction missing; surfaces at Build.
+				return nil
+			},
+			expectedErr: "unmatched Enter",
+		},
+		{
+			name: "production name with invalid character",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.EnterProduction("bad,name")
+			},
+			expectedErr: "contains invalid character",
+		},
+		{
+			name: "production name starting with digit",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.EnterProduction("9bad")
+			},
+			expectedErr: "must not start with a digit",
+		},
+		{
+			name: "empty production name",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.EnterProduction("")
+			},
+			expectedErr: "name cannot be empty",
+		},
+		{
+			name: "production name with whitespace",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.EnterProduction("bad name")
+			},
+			expectedErr: "contains whitespace",
+		},
+		{
+			name: "field key with invalid character",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.ScanOp))
+				return b.AddField(PlanGramField{Key: "bad:key", Val: "abc"})
+			},
+			expectedErr: "contains invalid character",
+		},
+		{
+			name: "field key with whitespace",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.ScanOp))
+				return b.AddField(PlanGramField{Key: "bad key", Val: "abc"})
+			},
+			expectedErr: "contains whitespace",
+		},
+		{
+			name: "empty field key",
+			setup: func(t *testing.T, b *PlanGramBuilder) error {
+				require.NoError(t, b.EnterProduction("root"))
+				require.NoError(t, b.EnterExpr(opt.ScanOp))
+				return b.AddField(PlanGramField{Key: "", Val: "abc"})
+			},
+			expectedErr: "field key cannot be empty",
+		},
+		{
+			name: "EnterExpr outside any context",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.EnterExpr(opt.ScanOp)
+			},
+			expectedErr: "EnterExpr on empty builder",
+		},
+		{
+			name: "RefProduction outside production",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.RefProduction("scan")
+			},
+			expectedErr: "RefProduction on empty builder",
+		},
+		{
+			name: "RefAny outside production",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.RefAny()
+			},
+			expectedErr: "RefAny on empty builder",
+		},
+		{
+			name: "RefNone outside production",
+			setup: func(_ *testing.T, b *PlanGramBuilder) error {
+				return b.RefNone()
+			},
+			expectedErr: "RefNone on empty builder",
+		},
+	}
+
+	for _, tc := range errorTests {
+		t.Run("error/"+tc.name, func(t *testing.T) {
+			var b PlanGramBuilder
+			err := tc.setup(t, &b)
+			if err == nil {
+				_, err = b.Build()
+			}
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
 func TestPlanGramWithNoneFallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1083,7 +1448,7 @@ func TestPlanGramParse(t *testing.T) {
 		{
 			name:        "undefined nonterminal",
 			input:       "root: (Select missing);",
-			expectedErr: `undefined nonterminal "missing"`,
+			expectedErr: "undefined nonterminal(s): missing",
 		},
 		{
 			name:        "duplicate production",

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/distribution"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/plangram"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -639,7 +638,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	}
 
 	// Penalize expressions that don't match the PlanGram.
-	if plangram.VisibleToPlanGram(candidate) && !required.PlanGram.Matches(candidate, c.mem.Metadata()) {
+	if physical.VisibleToPlanGram(candidate.Op()) && !required.PlanGram.Matches(candidate, c.mem.Metadata()) {
 		cost.Penalties |= memo.PlanGramMismatchPenalty
 	}
 


### PR DESCRIPTION
This branch adds a plan gist decompiler: given a CockroachDB plan gist
(a compact encoding of a query plan), produce a `physical.PlanGram`
(regular tree grammar) describing the set of optimizer plans whose
structure matches the gist. The decompiled grammar can then be used to
pin physical plans.

The branch is structured as three commits, each independently
reviewable:

1. **`sql/opt/props/physical: indent expressions in FormatPretty`** —
   cosmetic prerequisite. Adds a `newlines=true` mode for `FormatPretty`
   that indents nested expressions and breaks multi-rule productions
   onto their own lines, making the testdata in the third commit
   readable.

2. **`sql/opt/props/physical: add PlanGramBuilder`** — a stateful
   `Enter*`/`Leave*`/`AddField`/`Ref*`/`Build`/`Reset` API for
   constructing PlanGrams. `ParsePlanGram` is rewired onto it so all
   construction invariants are validated in one place.

3. **`sql/opt/exec/explain: decompile plan gists into PlanGrams`** —
   the decompiler itself, plus a `plangram` datadriven file that
   round-trips each test case (original explain tree vs gist-decoded
   explain tree) and asserts the two derived PlanGrams are equal.

To make the grammar match the optimizer plan, the decompiler reverses
two execbuilder transformations: hash/merge joins commuted to
`RightSemi`/`RightAnti` get their inputs swapped back, and
`simpleProject` wrappers are encoded as `(Project child) | child` so
the matcher can try both shapes. Other ambiguities the gist can't
resolve (e.g. `UnionAll` vs `LocalityOptimizedSearch`, set ops
constrained only by the ALL bit) are encoded as alternations across
the surviving optimizer operators.

Fixes #152061
Release note: None