### PR TITLE
backupinfo: fix error handling in desciter

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -60,11 +60,12 @@ go_test(
     name = "backupinfo_test",
     srcs = [
         "backup_metadata_test.go",
+        "desc_sst_test.go",
         "main_test.go",
         "manifest_handling_test.go",
     ],
+    embed = [":backupinfo"],
     deps = [
-        ":backupinfo",
         "//pkg/base",
         "//pkg/blobs",
         "//pkg/ccl",
@@ -93,6 +94,7 @@ go_test(
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata.go
@@ -1244,6 +1244,11 @@ func (di *DescIterator) Next() {
 		}
 	}
 
+	if di.backing.iterError != nil {
+		di.err = di.backing.iterError
+		return
+	}
+
 	di.value = nextValue
 }
 

--- a/pkg/ccl/backupccl/backupinfo/desc_sst_test.go
+++ b/pkg/ccl/backupccl/backupinfo/desc_sst_test.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backupinfo
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescSSTError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	iter := &DescIterator{
+		backing: bytesIter{
+			iterError: errors.New("internal iterator error"),
+		},
+	}
+
+	iter.Next()
+
+	valid, err := iter.Valid()
+	require.False(t, valid)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Backport 1/1 commits from #151148.

/cc @cockroachdb/release

Release justification: Low risk bugfix that fixes an issue that could cause incomplete restores which is a serious correctness issue.

---

Previously, the DescIter.Valid would return (false, nil) if the underlying SST iterator was in an error state. This is an "empty" state when it needs to propagate the error.

Fixes: #151144
Release note: Fixes a rare bug in restore where an object storage on restore start could cause restore to report success without creating the restored tables or databases.