### PR TITLE
backup: add generics to ValidateEndTimeAndTruncate

### DIFF
--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -688,12 +688,18 @@ func ResolveBackupManifests(
 
 	totalMemSize := ownedMemSize
 	ownedMemSize = 0
-	validatedDefaultURIs, validatedMainBackupManifests, validatedLocalityInfo, err := backupinfo.ValidateEndTimeAndTruncate(
-		defaultURIs, mainBackupManifests, localityInfo, endTime, includeSkipped, includeCompacted,
+	manifestEntries, err := backupinfo.ZipBackupTreeEntries(
+		defaultURIs, mainBackupManifests, localityInfo,
 	)
-
 	if err != nil {
 		return nil, nil, nil, 0, err
 	}
-	return validatedDefaultURIs, validatedMainBackupManifests, validatedLocalityInfo, totalMemSize, nil
+	validatedEntries, err := backupinfo.ValidateEndTimeAndTruncate(
+		manifestEntries, endTime, includeSkipped, includeCompacted,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+	uris, manifests, localityInfo := backupinfo.UnzipBackupTreeEntries(validatedEntries)
+	return uris, manifests, localityInfo, totalMemSize, nil
 }

--- a/pkg/backup/backupinfo/manifest_handling_test.go
+++ b/pkg/backup/backupinfo/manifest_handling_test.go
@@ -576,8 +576,10 @@ func TestValidateEndTimeAndTruncate(t *testing.T) {
 				inputLocs[i].URIsByOriginalLocalityKV[index] = index
 			}
 
-			uris, res, locs, err := backupinfo.ValidateEndTimeAndTruncate(
-				inputURIs, tc.manifests, inputLocs,
+			manifestEntries, err := backupinfo.ZipBackupTreeEntries(inputURIs, tc.manifests, inputLocs)
+			require.NoError(t, err)
+			manifestEntries, err = backupinfo.ValidateEndTimeAndTruncate(
+				manifestEntries,
 				hlc.Timestamp{WallTime: int64(tc.endTime)},
 				false, /* includeSkipped */
 				tc.includeCompacted,
@@ -586,6 +588,7 @@ func TestValidateEndTimeAndTruncate(t *testing.T) {
 				require.ErrorContains(t, err, tc.err)
 				return
 			}
+			uris, res, locs := backupinfo.UnzipBackupTreeEntries(manifestEntries)
 			require.Equal(t, len(tc.expected), len(res))
 			require.Equal(t, expectedOrder, uris)
 			require.Len(t, locs, len(tc.expected))


### PR DESCRIPTION
This patch updates ValidateEndTimeAndTruncate to use generics instead of the zipped BackupEntry. This allows us to pass in anything that conforms to the `ManifestLike` interface, i.e. `BackupIndexMetadata` so that we can run the validation and truncation logic on other types.

Epic: CRDB-47942

Release note: None