### PR TITLE
sql: fix incorrect min timestamp error check

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3884,6 +3884,8 @@ func (ex *connExecutor) GetPCRReaderTimestamp() hlc.Timestamp {
 	return hlc.Timestamp{}
 }
 
+var minTSErr = kvpb.NewMinTimestampBoundUnsatisfiableError(hlc.Timestamp{}, hlc.Timestamp{})
+
 // resetEvalCtx initializes the fields of evalCtx that can change
 // during a session (i.e. the fields not set by initEvalCtx).
 //
@@ -3922,7 +3924,6 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 
 	// See resetPlanner for more context on setting the maximum timestamp for
 	// AOST read retries.
-	var minTSErr *kvpb.MinTimestampBoundUnsatisfiableError
 	if err := ex.state.mu.autoRetryReason; err != nil && errors.Is(err, minTSErr) {
 		evalCtx.AsOfSystemTime.MaxTimestampBound = ex.extraTxnState.descCollection.GetMaxTimestampBound()
 	} else if newTxn {


### PR DESCRIPTION
This commit fixes a check for a min timestamp error that would always
return false.

Release note: None
