### PR TITLE
changefeedccl: fix unhandled error in enriched changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -7,7 +7,6 @@ package changefeedccl
 
 import (
 	"context"
-	"net"
 	"net/url"
 	"strings"
 
@@ -96,7 +95,7 @@ func newEnrichedSourceData(
 	sink sinkType,
 	schemaInfo map[descpb.ID]tableSchemaInfo,
 ) (enrichedSourceData, error) {
-	var sourceNodeLocality, nodeName, nodeID string
+	var sourceNodeLocality, nodeID string
 	tiers := cfg.Locality.Tiers
 
 	nodeLocalities := make([]string, 0, len(tiers))
@@ -115,10 +114,6 @@ func newEnrichedSourceData(
 	if err != nil {
 		return enrichedSourceData{}, err
 	}
-	host, _, err := net.SplitHostPort(parsedUrl.Host)
-	if err == nil {
-		nodeName = host
-	}
 
 	if optionalNodeID, ok := nodeInfo.NodeID.OptionalNodeID(); ok {
 		nodeID = optionalNodeID.String()
@@ -131,7 +126,7 @@ func newEnrichedSourceData(
 		clusterName:        cfg.ExecutorConfig.(*sql.ExecutorConfig).RPCContext.ClusterName(),
 		clusterID:          nodeInfo.LogicalClusterID().String(),
 		sourceNodeLocality: sourceNodeLocality,
-		nodeName:           nodeName,
+		nodeName:           parsedUrl.Hostname(),
 		nodeID:             nodeID,
 		tableSchemaInfo:    schemaInfo,
 	}, nil


### PR DESCRIPTION
Previously we would supress this error potentially resulting in the source field of enriched changefeed messages not having the proper data and failing silently.

Use a different function to avoid the error.

Epic: none

Release note: None