### PR TITLE
kv: use generic dialer to create RPC client

### DIFF
--- a/pkg/kv/kvserver/closedts/ctpb/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/ctpb/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
+        "//pkg/settings/cluster",
         "//pkg/util/timeutil",
     ],
 )

--- a/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
+++ b/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
@@ -10,24 +10,18 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 )
 
 // DialSideTransportClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
 // RPCSideTransportClient.
 func DialSideTransportClient(
-	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+	nd rpcbase.NodeDialer,
+	ctx context.Context,
+	nodeID roachpb.NodeID,
+	class rpcbase.ConnectionClass,
+	cs *cluster.Settings,
 ) (RPCSideTransportClient, error) {
-	if !rpcbase.TODODRPC {
-		conn, err := nd.Dial(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCSideTransportClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCSideTransportClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, class, NewGRPCSideTransportClientAdapter, NewDRPCSideTransportClientAdapter, cs)
 }

--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -30,8 +30,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@io_storj_drpc//:drpc",
-        "@org_golang_google_grpc//:grpc",
     ],
 )
 


### PR DESCRIPTION
Changes in this PR are a followup to #152948.

Epic: CRDB-48935
Informs: #153921 
Release note: None