### PR TITLE
kvserver: return error properly for GetAggregatedStoreStats

### DIFF
--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1089,7 +1089,7 @@ func (s *state) applyLoad(rng *rng, le workload.LoadEvent) {
 func (s *state) RangeUsageInfo(rangeID RangeID, storeID StoreID) allocator.RangeUsageInfo {
 	r, ok := s.Range(rangeID)
 	if !ok {
-		panic(fmt.Sprintf("no leaseholder store found for range %d", storeID))
+		panic(fmt.Sprintf("no leaseholder store found for range %d", rangeID))
 	}
 
 	if _, ok = r.Replica(storeID); !ok {

--- a/pkg/kv/kvserver/load/node_capacity_provider_test.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider_test.go
@@ -25,8 +25,8 @@ type mockStoresStatsAggregator struct {
 
 func (m *mockStoresStatsAggregator) GetAggregatedStoreStats(
 	_ bool,
-) (totalCPUUsage int64, totalStoreCount int32) {
-	return m.cpuUsage, m.storeCount
+) (totalCPUUsage int64, totalStoreCount int32, _ error) {
+	return m.cpuUsage, m.storeCount, nil
 }
 
 // TestNodeCapacityProvider tests the basic functionality of the
@@ -51,7 +51,8 @@ func TestNodeCapacityProvider(t *testing.T) {
 
 	// Provider should have valid stats.
 	testutils.SucceedsSoon(t, func() error {
-		nc := provider.GetNodeCapacity(false)
+		nc, err := provider.GetNodeCapacity(false)
+		require.NoError(t, err)
 		if nc.NodeCPURateUsage == 0 || nc.NodeCPURateCapacity == 0 || nc.StoresCPURate == 0 {
 			return errors.Newf(
 				"CPU usage or capacity is 0: node cpu rate usage %v, node cpu rate capacity %v, stores cpu rate %v",
@@ -62,7 +63,8 @@ func TestNodeCapacityProvider(t *testing.T) {
 
 	cancel()
 	// GetNodeCapacity should still return valid stats after cancellation.
-	nc := provider.GetNodeCapacity(false)
+	nc, err := provider.GetNodeCapacity(false)
+	require.NoError(t, err)
 	require.Greater(t, nc.NodeCPURateCapacity, int64(0))
 	require.Greater(t, nc.NodeCPURateUsage, int64(0))
 }

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1095,7 +1095,7 @@ func (rq *replicateQueue) TransferLease(
 	rangeUsageInfo allocator.RangeUsageInfo,
 ) error {
 	rq.metrics.TransferLeaseCount.Inc(1)
-	log.KvDistribution.Infof(ctx, "transferring lease to s%d", target)
+	log.KvDistribution.Infof(ctx, "transferring lease to %v", target)
 	// Inform allocator sync that the change has been applied which applies
 	// changes to store pool and inform mma.
 	changeID := rq.as.NonMMAPreTransferLease(
@@ -1109,7 +1109,7 @@ func (rq *replicateQueue) TransferLease(
 	rq.as.PostApply(changeID, err == nil /*success*/)
 
 	if err != nil {
-		return errors.Wrapf(err, "%s: unable to transfer lease to s%d", rlm, target)
+		return errors.Wrapf(err, "%s: unable to transfer lease to %v", rlm, target)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3295,6 +3295,11 @@ func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreD
 		return nil, err
 	}
 
+	nc, err := s.nodeCapacityProvider.GetNodeCapacity(useCached)
+	if err != nil {
+		return nil, err
+	}
+
 	// Initialize the store descriptor.
 	return &roachpb.StoreDescriptor{
 		StoreID:      s.Ident.StoreID,
@@ -3302,7 +3307,7 @@ func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreD
 		Node:         *s.nodeDesc,
 		Capacity:     capacity,
 		Properties:   s.Properties(),
-		NodeCapacity: s.nodeCapacityProvider.GetNodeCapacity(useCached),
+		NodeCapacity: nc,
 	}, nil
 }
 


### PR DESCRIPTION
Epic: none
Release note: none

---
**kvserver: pass replication target rq.TransferLease**

Previously, rq.TransferLease was updated to take in replication target (node ID
and store ID) instead of just a store ID, but the log line formatting wasn’t
updated accordingly. This commit fixes the log formatting.

---
**kvserver: return error properly for GetAggregatedStoreStats**

Previously, GetAggregatedStoreStats would panic on error for store.Capacity
instead of returning it. This commit fixes the issue by properly returning the
error back to store.Descriptor.

---
**asim: correctly output rangeID**

Previously, the log labeled a value as a range but printed the storeID. This
commit fixes it to correctly print the rangeID.