### PR TITLE
server,sql: use generic dialers to create RPC clients

### DIFF
--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -866,7 +867,12 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
-		&execinfra.FlowCtx{Gateway: false},
+		&execinfra.FlowCtx{
+			Gateway: false,
+			Cfg: &execinfra.ServerConfig{
+				Settings: cluster.MakeTestingClusterSettings(),
+			},
+		},
 		0, /* processorID */
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -180,7 +180,7 @@ func (o *Outbox) Run(
 
 	var stream execinfrapb.RPCDistSQL_FlowStreamClient
 	if err := func() error {
-		client, err := execinfra.GetDistSQLClientForOutbox(ctx, dialer, sqlInstanceID, connectionTimeout)
+		client, err := execinfra.GetDistSQLClientForOutbox(ctx, dialer, o.flowCtx.Cfg.Settings, sqlInstanceID, connectionTimeout)
 		if err != nil {
 			log.Dev.VWarningf(ctx, 1, "Outbox Dial connection error, distributed query will fail: %+v", err)
 			return err

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -136,7 +136,9 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				flowCtx := &execinfra.FlowCtx{
 					EvalCtx: &evalCtx,
 					Mon:     evalCtx.TestingMon,
-					Cfg:     &execinfra.ServerConfig{Settings: st},
+					Cfg: &execinfra.ServerConfig{
+						Settings: st,
+					},
 				}
 				rng, _ := randutil.NewTestRand()
 				var (
@@ -194,7 +196,12 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					toDrain[i] = createMetadataSourceForID(i)
 				}
 				hashRouter, hashRouterOutputs := colflow.NewHashRouter(
-					&execinfra.FlowCtx{Gateway: false},
+					&execinfra.FlowCtx{
+						Gateway: false,
+						Cfg: &execinfra.ServerConfig{
+							Settings: st,
+						},
+					},
 					0, /* processorID */
 					allocators,
 					colexecargs.OpWithMetaInfo{
@@ -238,7 +245,12 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					outboxMetadataSources []colexecop.MetadataSource,
 				) {
 					outbox, err := colrpc.NewOutbox(
-						&execinfra.FlowCtx{Gateway: false},
+						&execinfra.FlowCtx{
+							Gateway: false,
+							Cfg: &execinfra.ServerConfig{
+								Settings: st,
+							},
+						},
 						0, /* processorID */
 						colmem.NewAllocator(outboxCtx, outboxMemAcc, testColumnFactory),
 						outboxConverterMemAcc,

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -30,12 +31,13 @@ import (
 func GetDistSQLClientForOutbox(
 	ctx context.Context,
 	dialer rpcbase.NodeDialerNoBreaker,
+	cs *cluster.Settings,
 	sqlInstanceID base.SQLInstanceID,
 	timeout time.Duration,
 ) (client execinfrapb.RPCDistSQLClient, err error) {
 	firstConnectionAttempt := timeutil.Now()
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
-		client, err = execinfrapb.DialDistSQLClientNoBreaker(dialer, ctx, roachpb.NodeID(sqlInstanceID), rpcbase.DefaultClass)
+		client, err = execinfrapb.DialDistSQLClientNoBreaker(dialer, ctx, roachpb.NodeID(sqlInstanceID), rpcbase.DefaultClass, cs)
 		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
 			break
 		}

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -20,8 +20,10 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/roachpb",
+        "//pkg/rpc/nodedialer",
         "//pkg/rpc/rpcbase",
         "//pkg/security/username",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -232,7 +232,7 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 
 	if err := func() error {
 		client, err := execinfra.GetDistSQLClientForOutbox(
-			ctx, m.flowCtx.Cfg.SQLInstanceDialer, m.sqlInstanceID, SettingFlowStreamTimeout.Get(&m.flowCtx.Cfg.Settings.SV),
+			ctx, m.flowCtx.Cfg.SQLInstanceDialer, m.flowCtx.Cfg.Settings, m.sqlInstanceID, SettingFlowStreamTimeout.Get(&m.flowCtx.Cfg.Settings.SV),
 		)
 		if err != nil {
 			log.Dev.VWarningf(ctx, 1, "Outbox Dial connection error, distributed query will fail: %+v", err)


### PR DESCRIPTION
Changes in this PR are a followup to #152948.

Epic: CRDB-48935
Fixes: #153034 
Release note: None