### PR TITLE
workload/schemachange: expect DatatypeMismatch errors for NULL defaults

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2520,7 +2520,7 @@ func (og *operationGenerator) setColumnDefault(ctx context.Context, tx pgx.Tx) (
 
 	defaultDatum := randgen.RandDatum(og.params.rng, datumTyp, columnForDefault.nullable)
 	stmt := makeOpStmt(OpStmtDDL)
-	if (!datumTyp.Equivalent(columnForDefault.typ)) && defaultDatum != tree.DNull {
+	if !datumTyp.Equivalent(columnForDefault.typ) {
 		stmt.expectedExecErrors.add(pgcode.DatatypeMismatch)
 	}
 	// Generated columns cannot have default values.


### PR DESCRIPTION
Previously, the workload only expected DatatypeMismatch errors when setting default values that were non-NULL. However, after fixing the type casting syntax in SET DEFAULT operations, NULL values with explicit type casts (e.g., NULL::enum_type) now properly reach the type checker and correctly produce DatatypeMismatch errors when the cast type doesn't match the column type.

Fixes #152957

Release note: none

Epic: None