### PR TITLE
sql: fix single descriptor lookup

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -188,6 +188,10 @@ func (m *Manager) maybeGetDescriptorWithoutValidation(
 		return nil, err
 	}
 
+	if len(descArr) == 0 {
+		return nil, nil
+	}
+
 	return descArr[0], nil
 }
 


### PR DESCRIPTION
The LLM bug-finder found this bug introduced in #150188. This addresses
the issue.

Epic: none

Release note: None
