### PR TITLE
sqlsmith: fix potential panic when creating stats on 0-column table

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1940,7 +1940,9 @@ func makeCreateStats(s *Smither) (tree.Statement, bool) {
 		s.rnd.Shuffle(len(columns), func(i, j int) {
 			columns[i], columns[j] = columns[j], columns[i]
 		})
-		columns = columns[0:s.rnd.Intn(len(columns))]
+		if len(columns) > 0 {
+			columns = columns[0 : s.rnd.Intn(len(columns))+1]
+		}
 	}
 
 	var options tree.CreateStatsOptions


### PR DESCRIPTION
This commit avoids a panic by adding a check for 0 columns before calling `rand.Intn(len(columns))`.

There is no release note since this is a test-only change.

Release note: None