### PR TITLE
changefeedccl: migrate CDC logs from DEV to CHANGEFEED logging channel

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -258,7 +258,7 @@ func (e *familyEvaluator) planAndRun(ctx context.Context) (err error) {
 	if log.V(1) {
 		start := timeutil.Now()
 		defer func() {
-			log.Dev.Infof(ctx, "Planning for CDC expression %s (v=%d) took %s (err=%v)",
+			log.Changefeed.Infof(ctx, "Planning for CDC expression %s (v=%d) took %s (err=%v)",
 				tree.AsString(e.norm), e.norm.desc.Version, timeutil.Since(start), err)
 		}()
 	}

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -612,7 +612,7 @@ func (d *eventDecoder) DecodeKV(
 	err = changefeedbase.WithTerminalError(errors.Wrapf(err,
 		"error decoding key %s@%s (hex_kv: %x)",
 		keys.PrettyPrint(nil, kv.Key), kv.Value.Timestamp, kvBytes))
-	log.Dev.Errorf(ctx, "terminal error decoding KV: %v", err)
+	log.Changefeed.Errorf(ctx, "terminal error decoding KV: %v", err)
 	return Row{}, err
 }
 
@@ -844,7 +844,7 @@ func MakeRowFromTuple(ctx context.Context, evalCtx *eval.Context, t *tree.DTuple
 		r.AddValueColumn(name, d.ResolvedType())
 		if err := r.SetValueDatumAt(i, d); err != nil {
 			if build.IsRelease() {
-				log.Dev.Warningf(ctx, "failed to set row value from tuple due to error %v", err)
+				log.Changefeed.Warningf(ctx, "failed to set row value from tuple due to error %v", err)
 				_ = r.SetValueDatumAt(i, tree.DNull)
 			} else {
 				panic(err)

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -784,10 +784,10 @@ func TestEventColumnOrderingWithSchemaChanges(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedEvents := len(tc.expectMainFamily) + len(tc.expectECFamily)
-			log.Dev.Infof(ctx, "expectedEvents: %d\n", expectedEvents)
+			log.Changefeed.Infof(ctx, "expectedEvents: %d\n", expectedEvents)
 			for i := 0; i < expectedEvents; i++ {
 				v, deleteRange := popRow(t)
-				log.Dev.Infof(ctx, "event[%d]: v=%+v, deleteRange=%+v", i, v, deleteRange)
+				log.Changefeed.Infof(ctx, "event[%d]: v=%+v, deleteRange=%+v", i, v, deleteRange)
 
 				if deleteRange != nil {
 					// Should not see a RangeFeedValue and a RangeFeedDeleteRange

--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -423,16 +423,16 @@ func RunNemesis(
 		time := timeutil.Now()
 		for i := 0; i < numInserts; i++ {
 			query := queryGen.Generate()
-			log.Dev.Infof(ctx, "Executing query: %s", query)
+			log.Changefeed.Infof(ctx, "Executing query: %s", query)
 			err := timeutil.RunWithTimeout(ctx, "nemeses populate table",
 				insertTimeout, func(ctx context.Context) error {
 					_, err := db.ExecContext(ctx, query)
 					return err
 				})
-			log.Dev.Infof(ctx, "Time taken to execute last query: %s", timeutil.Since(time))
+			log.Changefeed.Infof(ctx, "Time taken to execute last query: %s", timeutil.Since(time))
 			time = timeutil.Now()
 			if err != nil {
-				log.Dev.Infof(ctx, "Skipping query %s because error %s", query, err)
+				log.Changefeed.Infof(ctx, "Skipping query %s because error %s", query, err)
 				continue
 			}
 		}
@@ -454,10 +454,10 @@ func RunNemesis(
 		var id int
 		var ts string
 		if err := rows.Scan(&id, &ts); err != nil {
-			log.Dev.Infof(ctx, "# skipping row because error: %s", err)
+			log.Changefeed.Infof(ctx, "# skipping row because error: %s", err)
 			continue
 		}
-		log.Dev.Infof(ctx, "INSERT INTO foo (id,ts) VALUES (%d, %s);", id, ts)
+		log.Changefeed.Infof(ctx, "INSERT INTO foo (id,ts) VALUES (%d, %s);", id, ts)
 	}
 
 	cfo := newChangefeedOption(testName)
@@ -465,7 +465,7 @@ func RunNemesis(
 		`CREATE CHANGEFEED FOR foo %s`,
 		cfo.OptionString(),
 	)
-	log.Dev.Infof(ctx, "Using changefeed options: %s", changefeedStatement)
+	log.Changefeed.Infof(ctx, "Using changefeed options: %s", changefeedStatement)
 	foo, err := f.Feed(changefeedStatement)
 	if err != nil {
 		return nil, err
@@ -922,7 +922,7 @@ var compiledStateTransitions = fsm.Compile(stateTransitions)
 
 func logEvent(fn func(fsm.Args) error) func(fsm.Args) error {
 	return func(a fsm.Args) error {
-		log.Dev.Infof(a.Ctx, "Event: %#v, Payload: %#v\n", a.Event, a.Payload)
+		log.Changefeed.Infof(a.Ctx, "Event: %#v, Payload: %#v\n", a.Event, a.Payload)
 		return fn(a)
 	}
 }
@@ -1084,7 +1084,7 @@ func noteFeedMessage(a fsm.Args) error {
 			if err != nil {
 				return err
 			}
-			log.Dev.Infof(a.Ctx, "%v", string(m.Resolved))
+			log.Changefeed.Infof(a.Ctx, "%v", string(m.Resolved))
 			err = ns.v.NoteResolved(m.Partition, ts)
 			if err != nil {
 				return err
@@ -1096,7 +1096,7 @@ func noteFeedMessage(a fsm.Args) error {
 				return err
 			}
 			ns.availableRows--
-			log.Dev.Infof(a.Ctx, "%s->%s", m.Key, m.Value)
+			log.Changefeed.Infof(a.Ctx, "%s->%s", m.Key, m.Value)
 			return ns.v.NoteRow(m.Partition, string(m.Key), string(m.Value), ts, m.Topic)
 		}
 	}

--- a/pkg/ccl/changefeedccl/cdctest/row.go
+++ b/pkg/ccl/changefeedccl/cdctest/row.go
@@ -95,10 +95,10 @@ func MakeRangeFeedValueReaderExtended(
 			case r := <-rows:
 				rowKey := r.Key.String() + r.Value.String()
 				if _, isDup := dups[rowKey]; isDup {
-					log.Dev.Infof(context.Background(), "Skip duplicate %s", roachpb.PrettyPrintKey(nil, r.Key))
+					log.Changefeed.Infof(context.Background(), "Skip duplicate %s", roachpb.PrettyPrintKey(nil, r.Key))
 					continue
 				}
-				log.Dev.Infof(context.Background(), "Read row %s", roachpb.PrettyPrintKey(nil, r.Key))
+				log.Changefeed.Infof(context.Background(), "Read row %s", roachpb.PrettyPrintKey(nil, r.Key))
 				dups[rowKey] = struct{}{}
 				return r, nil
 			case d := <-deleteRangeC:

--- a/pkg/ccl/changefeedccl/cdcutils/throttle.go
+++ b/pkg/ccl/changefeedccl/cdcutils/throttle.go
@@ -113,7 +113,7 @@ func NodeLevelThrottler(sv *settings.Values, metrics *Metrics) *Throttler {
 		configStr := changefeedbase.NodeSinkThrottleConfig.Get(sv)
 		if configStr != "" {
 			if err := json.Unmarshal([]byte(configStr), &config); err != nil {
-				log.Dev.Errorf(context.Background(),
+				log.Changefeed.Errorf(context.Background(),
 					"failed to parse node throttle config %q: err=%v; throttling disabled", configStr, err)
 			}
 		}

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -164,7 +164,7 @@ func emitResolvedTimestamp(
 		return err
 	}
 	if log.V(2) {
-		log.Dev.Infof(ctx, `resolved %s`, resolved)
+		log.Changefeed.Infof(ctx, `resolved %s`, resolved)
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -252,7 +252,7 @@ func startDistChangefeed(
 		return err
 	}
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.Dev.Infof(ctx, "tracked spans: %s", trackedSpans)
+		log.Changefeed.Infof(ctx, "tracked spans: %s", trackedSpans)
 	}
 	localState.trackedSpans = trackedSpans
 
@@ -265,7 +265,7 @@ func startDistChangefeed(
 	if progress := localState.progress.GetChangefeed(); progress != nil && progress.SpanLevelCheckpoint != nil {
 		spanLevelCheckpoint = progress.SpanLevelCheckpoint
 		if log.V(2) {
-			log.Dev.Infof(ctx, "span-level checkpoint: %s", spanLevelCheckpoint)
+			log.Changefeed.Infof(ctx, "span-level checkpoint: %s", spanLevelCheckpoint)
 		}
 	}
 	p, planCtx, err := makePlan(execCtx, jobID, details, description, initialHighWater,
@@ -413,7 +413,7 @@ func makePlan(
 		evalCtx := execCtx.ExtendedEvalContext()
 		oracle := replicaoracle.NewOracle(replicaOracleChoice, dsp.ReplicaOracleConfig(locFilter))
 		if useBulkOracle.Get(&evalCtx.Settings.SV) {
-			log.Dev.Infof(ctx, "using bulk oracle for DistSQL planning")
+			log.Changefeed.Infof(ctx, "using bulk oracle for DistSQL planning")
 			oracle = kvfollowerreadsccl.NewBulkOracle(dsp.ReplicaOracleConfig(evalCtx.Locality), locFilter, kvfollowerreadsccl.StreakConfig{})
 		}
 		planCtx := dsp.NewPlanningCtxWithOracle(ctx, execCtx.ExtendedEvalContext(), nil, /* planner */
@@ -423,12 +423,12 @@ func makePlan(
 			return nil, nil, err
 		}
 		if log.ExpensiveLogEnabled(ctx, 2) {
-			log.Dev.Infof(ctx, "spans returned by DistSQL: %v", spanPartitions)
+			log.Changefeed.Infof(ctx, "spans returned by DistSQL: %v", spanPartitions)
 		}
 		switch {
 		case distMode == sql.LocalDistribution || rangeDistribution == defaultDistribution:
 		case rangeDistribution == balancedSimpleDistribution:
-			log.Dev.Infof(ctx, "rebalancing ranges using balanced simple distribution")
+			log.Changefeed.Infof(ctx, "rebalancing ranges using balanced simple distribution")
 			sender := execCtx.ExecCfg().DB.NonTransactionalSender()
 			distSender := sender.(*kv.CrossRangeTxnWrapperSender).Wrapped().(*kvcoord.DistSender)
 			ri := kvcoord.MakeRangeIterator(distSender)
@@ -438,7 +438,7 @@ func makePlan(
 				return nil, nil, err
 			}
 			if log.ExpensiveLogEnabled(ctx, 2) {
-				log.Dev.Infof(ctx, "spans after balanced simple distribution rebalancing: %v", spanPartitions)
+				log.Changefeed.Infof(ctx, "spans after balanced simple distribution rebalancing: %v", spanPartitions)
 			}
 		default:
 			return nil, nil, errors.AssertionFailedf("unsupported dist strategy %d and dist mode %d",
@@ -473,7 +473,7 @@ func makePlan(
 		aggregatorSpecs := make([]*execinfrapb.ChangeAggregatorSpec, len(spanPartitions))
 		for i, sp := range spanPartitions {
 			if log.ExpensiveLogEnabled(ctx, 2) {
-				log.Dev.Infof(ctx, "watched spans for node %d: %v", sp.SQLInstanceID, sp)
+				log.Changefeed.Infof(ctx, "watched spans for node %d: %v", sp.SQLInstanceID, sp)
 			}
 
 			watches := make([]execinfrapb.ChangeAggregatorSpec_Watch, len(sp.Spans))
@@ -543,11 +543,11 @@ func makePlan(
 			flowSpecs,
 			execinfrapb.DiagramFlags{},
 		); err != nil {
-			log.Dev.Warningf(ctx, "failed to generate changefeed plan diagram: %s", err)
+			log.Changefeed.Warningf(ctx, "failed to generate changefeed plan diagram: %s", err)
 		} else if diagURL := diagURL.String(); len(diagURL) > maxLenDiagURL {
-			log.Dev.Warningf(ctx, "changefeed plan diagram length is too large to be logged: %d", len(diagURL))
+			log.Changefeed.Warningf(ctx, "changefeed plan diagram length is too large to be logged: %d", len(diagURL))
 		} else {
-			log.Dev.Infof(ctx, "changefeed plan diagram: %s", diagURL)
+			log.Changefeed.Infof(ctx, "changefeed plan diagram: %s", diagURL)
 		}
 
 		return p, planCtx, nil
@@ -656,7 +656,7 @@ func rebalanceSpanPartitions(
 		nRanges, ok := p.NumRanges()
 		// We cannot rebalance if we're missing range information.
 		if !ok {
-			log.Dev.Warning(ctx, "skipping rebalance due to missing range info")
+			log.Changefeed.Warning(ctx, "skipping rebalance due to missing range info")
 			return partitions, nil
 		}
 		builders[i].numRanges = nRanges

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5537,7 +5537,7 @@ func requireTerminalErrorSoon(
 					assert.Regexp(t, errRegex, err)
 					return nil
 				}
-				log.Dev.Infof(ctx, "waiting for error; skipping test feed message: %s", m.String())
+				log.Changefeed.Infof(ctx, "waiting for error; skipping test feed message: %s", m.String())
 			}
 		}
 	})
@@ -5862,7 +5862,7 @@ func TestChangefeedStopOnSchemaChange(t *testing.T) {
 		t.Helper()
 		for {
 			if ev, err := f.Next(); err != nil {
-				log.Dev.Infof(context.Background(), "got event %v %v", ev, err)
+				log.Changefeed.Infof(context.Background(), "got event %v %v", ev, err)
 				tsStr = timestampStrFromError(t, err)
 				_ = f.Close()
 				return tsStr
@@ -8620,7 +8620,7 @@ func TestChangefeedPropagatesTerminalError(t *testing.T) {
 								errors.Newf("synthetic fatal error from node %d", nodeToFail),
 								pgcode.Io, "something happened with IO")),
 						"while doing something")
-					log.Dev.Errorf(ctx, "BeforeEmitRow returning error %s", err)
+					log.Changefeed.Errorf(ctx, "BeforeEmitRow returning error %s", err)
 					return err
 				}
 				return nil
@@ -8646,7 +8646,7 @@ func TestChangefeedPropagatesTerminalError(t *testing.T) {
 		for feedErr == nil {
 			_, feedErr = feed.Next()
 		}
-		log.Dev.Errorf(context.Background(), "feedErr=%s", feedErr)
+		log.Changefeed.Errorf(context.Background(), "feedErr=%s", feedErr)
 		require.Regexp(t, "synthetic fatal error", feedErr)
 
 		// enterprise feeds should also have the job marked failed.

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -387,7 +387,7 @@ func (e *versionEncoder) datumToJSON(ctx context.Context, d tree.Datum) (json.JS
 				return nil, err
 			}
 			if collides && jsonNullObjectCollisionLogLim.ShouldLog() {
-				log.Dev.Warningf(ctx, "JSON value collides with reserved null object: %q", j.String())
+				log.Changefeed.Warningf(ctx, "JSON value collides with reserved null object: %q", j.String())
 			}
 		}
 	}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -301,7 +301,7 @@ func newEvaluator(
 				"error upgrading changefeed expression.  Please recreate changefeed manually"))
 		}
 		if newExpr != sc {
-			log.Dev.Warningf(ctx,
+			log.Changefeed.Warningf(ctx,
 				"changefeed expression %s (job %d) created prior to 22.2-30 rewritten as %s",
 				tree.AsString(sc), spec.JobID,
 				tree.AsString(newExpr))
@@ -479,13 +479,13 @@ func (c *kvEventToRowConsumer) encodeAndEmit(
 	})
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
-			log.Dev.Warningf(ctx, `sink failed to emit row: %v`, err)
+			log.Changefeed.Warningf(ctx, `sink failed to emit row: %v`, err)
 			c.metrics.SinkErrors.Inc(1)
 		}
 		return err
 	}
 	if log.V(3) {
-		log.Dev.Infof(ctx, `r %s: %s(%+v) -> %s`, updatedRow.TableName, keyCopy, headers, valueCopy)
+		log.Changefeed.Infof(ctx, `r %s: %s(%+v) -> %s`, updatedRow.TableName, keyCopy, headers, valueCopy)
 	}
 	return nil
 }
@@ -518,7 +518,7 @@ func (c *kvEventToRowConsumer) makeRowHeaders(
 	}
 	if objIt == nil {
 		if jsonHeaderWrongTypeLogLim.ShouldLog() || log.V(2) {
-			log.Dev.Warningf(ctx, "headers column %s must be a JSON object, was %s, in: %s", c.encodingOpts.HeadersJSONColName, redact.SafeString(headersJSON.Type().String()), updatedRow.DebugString())
+			log.Changefeed.Warningf(ctx, "headers column %s must be a JSON object, was %s, in: %s", c.encodingOpts.HeadersJSONColName, redact.SafeString(headersJSON.Type().String()), updatedRow.DebugString())
 		}
 		return nil, nil
 	}
@@ -536,7 +536,7 @@ func (c *kvEventToRowConsumer) makeRowHeaders(
 			headers[objIt.Key()] = []byte(objIt.Value().String())
 		default:
 			if jsonHeaderWrongValTypeLogLim.ShouldLog() || log.V(2) {
-				log.Dev.Warningf(ctx, "headers column %s must be a JSON object with primitive values, got %s - %s, in: %s",
+				log.Changefeed.Warningf(ctx, "headers column %s must be a JSON object with primitive values, got %s - %s, in: %s",
 					c.encodingOpts.HeadersJSONColName, redact.SafeString(objIt.Value().Type().String()), objIt.Value(), updatedRow.DebugString())
 			}
 		}
@@ -702,7 +702,7 @@ func (c *parallelEventConsumer) workerLoop(
 	defer func() {
 		err := consumer.Close()
 		if err != nil {
-			log.Dev.Errorf(ctx, "closing consumer: %v", err)
+			log.Changefeed.Errorf(ctx, "closing consumer: %v", err)
 		}
 	}()
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -117,15 +117,15 @@ func readNextMessages(
 			return nil, ctx.Err()
 		}
 		if log.V(1) {
-			log.Dev.Infof(context.Background(), "about to read a message (%d out of %d)", len(actual), numMessages)
+			log.Changefeed.Infof(context.Background(), "about to read a message (%d out of %d)", len(actual), numMessages)
 		}
 		m, err := f.Next()
 		if log.V(1) {
 			if m != nil {
-				log.Dev.Infof(context.Background(), `msg %s: %s->%s (%s) (%s)`,
+				log.Changefeed.Infof(context.Background(), `msg %s: %s->%s (%s) (%s)`,
 					m.Topic, m.Key, m.Value, m.Resolved, timeutil.Since(lastMessage))
 			} else {
-				log.Dev.Infof(context.Background(), `err %v`, err)
+				log.Changefeed.Infof(context.Background(), `err %v`, err)
 			}
 		}
 		lastMessage = timeutil.Now()
@@ -359,7 +359,7 @@ func assertPayloadsBaseErr(
 	}()
 
 	if log.V(1) {
-		log.Dev.Infof(ctx, "expected messages: \n%s", strings.Join(expected, "\n"))
+		log.Changefeed.Infof(ctx, "expected messages: \n%s", strings.Join(expected, "\n"))
 	}
 
 	actual, err := readNextMessages(ctx, f, len(expected))

--- a/pkg/ccl/changefeedccl/kvevent/bench_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/bench_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func BenchmarkMemBuffer(b *testing.B) {
-	log.Dev.Infof(context.Background(), "b.N=%d", b.N)
+	log.Changefeed.Infof(context.Background(), "b.N=%d", b.N)
 
 	eventPool := func() []kvevent.Event {
 		const valSize = 16 << 10

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -283,7 +283,7 @@ func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
 	}
 
 	if log.V(2) {
-		log.Dev.Infof(ctx, "Add event: %s", e.String())
+		log.Changefeed.Infof(ctx, "Add event: %s", e.String())
 	}
 
 	// Immediately enqueue event if it already has allocation,
@@ -522,13 +522,13 @@ func logSlowAcquisition(
 	return func(ctx context.Context, poolName string, r quotapool.Request, start time.Time) func() {
 		shouldLog := logSlowAcquire.ShouldLog()
 		if shouldLog {
-			log.Dev.Warningf(ctx, "have been waiting %s attempting to acquire changefeed quota (buffer=%s)", redact.SafeString(bufType),
+			log.Changefeed.Warningf(ctx, "have been waiting %s attempting to acquire changefeed quota (buffer=%s)", redact.SafeString(bufType),
 				timeutil.Since(start))
 		}
 
 		return func() {
 			if shouldLog {
-				log.Dev.Infof(ctx, "acquired changefeed quota after %s (buffer=%s)", timeutil.Since(start), redact.SafeString(bufType))
+				log.Changefeed.Infof(ctx, "acquired changefeed quota after %s (buffer=%s)", timeutil.Since(start), redact.SafeString(bufType))
 			}
 		}
 	}

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -127,7 +127,7 @@ func (t Type) Index() int {
 	case TypeResolved, resolvedBackfill, resolvedRestart, resolvedExit:
 		return int(TypeResolved)
 	default:
-		log.Dev.Warningf(context.TODO(),
+		log.Changefeed.Warningf(context.TODO(),
 			"returning TypeFlush boundary type for unknown event type %d", t)
 		return int(TypeFlush)
 	}
@@ -171,7 +171,7 @@ func (e *Event) boundaryType() jobspb.ResolvedSpan_BoundaryType {
 	case resolvedExit:
 		return jobspb.ResolvedSpan_EXIT
 	default:
-		log.Dev.Warningf(context.TODO(),
+		log.Changefeed.Warningf(context.TODO(),
 			"returning jobspb.ResolvedSpan_EXIT boundary type for unknown boundary")
 		return jobspb.ResolvedSpan_EXIT
 	}
@@ -229,7 +229,7 @@ func (e *Event) getTimestamp(backfillTS hlc.Timestamp) hlc.Timestamp {
 	case TypeFlush:
 		return hlc.Timestamp{}
 	default:
-		log.Dev.Warningf(context.TODO(),
+		log.Changefeed.Warningf(context.TODO(),
 			"setting empty timestamp for unknown event type")
 		return hlc.Timestamp{}
 	}

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -65,7 +65,7 @@ func (p *scanRequestScanner) Scan(ctx context.Context, sink kvevent.Writer, cfg 
 
 	if log.V(2) {
 		var sp roachpb.Spans = cfg.Spans
-		log.Dev.Infof(ctx, "performing scan on %s at %v withDiff %v",
+		log.Changefeed.Infof(ctx, "performing scan on %s at %v withDiff %v",
 			sp, cfg.Timestamp, cfg.WithDiff)
 	}
 
@@ -119,7 +119,7 @@ func (p *scanRequestScanner) Scan(ctx context.Context, sink kvevent.Writer, cfg 
 				backfillDec()
 			}
 			if log.V(2) {
-				log.Dev.Infof(ctx, `exported %d of %d: %v`, finished, len(spans), err)
+				log.Changefeed.Infof(ctx, `exported %d of %d: %v`, finished, len(spans), err)
 			}
 			return err
 		})
@@ -156,7 +156,7 @@ func (p *scanRequestScanner) tryAcquireMemory(
 		// Sink implements memory allocator interface, so acquire
 		// memory needed to hold scan reply.
 		if logMemAcquireEvery.ShouldLog() {
-			log.Dev.Errorf(ctx, "Failed to acquire memory for export span: %s (attempt %d)",
+			log.Changefeed.Errorf(ctx, "Failed to acquire memory for export span: %s (attempt %d)",
 				err, attempt.CurrentAttempt()+1)
 		}
 		alloc, err = allocator.AcquireMemory(ctx, changefeedbase.ScanRequestSize.Get(&p.settings.SV))
@@ -182,7 +182,7 @@ func (p *scanRequestScanner) exportSpan(
 
 	txn := p.db.NewTxn(ctx, "changefeed backfill")
 	if log.V(2) {
-		log.Dev.Infof(ctx, `sending ScanRequest %s at %s`, span, ts)
+		log.Changefeed.Infof(ctx, `sending ScanRequest %s at %s`, span, ts)
 	}
 	if err := txn.SetFixedTimestamp(ctx, ts); err != nil {
 		return err
@@ -248,7 +248,7 @@ func (p *scanRequestScanner) exportSpan(
 		return err
 	}
 	if log.V(2) {
-		log.Dev.Infof(ctx, `finished Scan of %s at %s took %s`,
+		log.Changefeed.Infof(ctx, `finished Scan of %s at %s took %s`,
 			span, ts.AsOfSystemTime(), timeutil.Since(stopwatchStart))
 	}
 	return nil
@@ -319,7 +319,7 @@ func slurpScanResponse(
 				return errors.Wrapf(err, `decoding changes for %s`, span)
 			}
 			if log.V(3) {
-				log.Dev.Infof(ctx, "scanResponse: %s@%s", keys.PrettyPrint(nil, keyBytes), ts)
+				log.Changefeed.Infof(ctx, "scanResponse: %s@%s", keys.PrettyPrint(nil, keyBytes), ts)
 			}
 			if err = sink.Add(ctx, kvevent.NewBackfillKVEvent(keyBytes, ts, valBytes, withDiff, backfillTS)); err != nil {
 				return errors.Wrapf(err, `buffering changes for %s`, span)

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -165,7 +165,7 @@ func (parquetSink *parquetCloudStorageSink) EmitResolvedTimestamp(
 	part := resolved.GoTime().Format(parquetSink.wrapped.partitionFormat)
 	filename := fmt.Sprintf(`%s.RESOLVED`, cloudStorageFormatTime(resolved))
 	if log.V(1) {
-		log.Dev.Infof(ctx, "writing file %s %s", filename, resolved.AsOfSystemTime())
+		log.Changefeed.Infof(ctx, "writing file %s %s", filename, resolved.AsOfSystemTime())
 	}
 	return cloud.WriteFile(ctx, parquetSink.wrapped.es, filepath.Join(part, filename), &buf)
 }
@@ -232,7 +232,7 @@ func (parquetSink *parquetCloudStorageSink) EncodeAndEmitRow(
 	file.adjustBytesToTarget(ctx, newAllocSize)
 
 	if log.V(1) && parquetSink.everyN.ShouldLog() {
-		log.Dev.Infof(ctx, "topic: %d/%d, written: %d, buffered %d, new alloc: %d, old alloc: %d",
+		log.Changefeed.Infof(ctx, "topic: %d/%d, written: %d, buffered %d, new alloc: %d, old alloc: %d",
 			topic.GetTopicIdentifier().TableID, topic.GetTopicIdentifier().FamilyID, int64(file.buf.Len()),
 			bufferedBytesEstimate, prevAllocSize, newAllocSize)
 	}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -97,7 +97,7 @@ func (s *scheduledChangefeedExecutor) NotifyJobTermination(
 ) error {
 	if jobState == jobs.StateSucceeded {
 		s.metrics.NumSucceeded.Inc(1)
-		log.Dev.Infof(ctx, "changefeed job %d scheduled by %d succeeded", jobID, schedule.ScheduleID())
+		log.Changefeed.Infof(ctx, "changefeed job %d scheduled by %d succeeded", jobID, schedule.ScheduleID())
 		return nil
 	}
 
@@ -105,7 +105,7 @@ func (s *scheduledChangefeedExecutor) NotifyJobTermination(
 	err := errors.Errorf(
 		"changefeed job %d scheduled by %d failed with status %s",
 		jobID, schedule.ScheduleID(), jobState)
-	log.Dev.Errorf(ctx, "changefeed error: %v	", err)
+	log.Changefeed.Errorf(ctx, "changefeed error: %v	", err)
 	jobs.DefaultHandleFailedRun(schedule, "changefeed job %d failed with err=%v", jobID, err)
 	return nil
 }
@@ -195,7 +195,7 @@ func (s *scheduledChangefeedExecutor) executeChangefeed(
 	// pause the schedule. To maintain backward compatability with schedules
 	// without a clusterID, don't pause schedules without a clusterID.
 	if !currentDetails.ClusterID.Equal(uuid.Nil) && currentClusterID != currentDetails.ClusterID {
-		log.Dev.Infof(ctx, "scheduled changedfeed %d last run by different cluster %s, pausing until manually resumed",
+		log.Changefeed.Infof(ctx, "scheduled changedfeed %d last run by different cluster %s, pausing until manually resumed",
 			sj.ScheduleID(),
 			currentDetails.ClusterID)
 		currentDetails.ClusterID = currentClusterID
@@ -204,7 +204,7 @@ func (s *scheduledChangefeedExecutor) executeChangefeed(
 		return nil
 	}
 
-	log.Dev.Infof(ctx, "Starting scheduled changefeed %d: %s",
+	log.Changefeed.Infof(ctx, "Starting scheduled changefeed %d: %s",
 		sj.ScheduleID(), tree.AsString(changefeedStmt))
 	changefeedFn, err := planCreateChangefeed(ctx, planner, changefeedStmt)
 	if err != nil {
@@ -596,7 +596,7 @@ func doCreateChangefeedSchedule(
 	createChangefeedopts := changefeedbase.MakeStatementOptions(spec.createChangefeedOptions)
 	initialScanSpecifiedByUser := createChangefeedopts.IsInitialScanSpecified()
 	if !initialScanSpecifiedByUser {
-		log.Dev.Infof(ctx, "Initial scan type not specified, forcing %s option", changefeedbase.OptInitialScanOnly)
+		log.Changefeed.Infof(ctx, "Initial scan type not specified, forcing %s option", changefeedbase.OptInitialScanOnly)
 		spec.Options = append(spec.Options, tree.KVOption{
 			Key:   changefeedbase.OptInitialScan,
 			Value: tree.NewStrVal("only"),

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -190,7 +190,7 @@ func setupHTTPClient(baseURL *url.URL, s *schemaRegistryParams) (*httputil.Clien
 	httpClient.Timeout = s.timeout
 
 	if baseURL.Scheme == "http" {
-		log.Dev.Warningf(context.Background(), "TLS configuration provided but schema registry %s uses HTTP", baseURL)
+		log.Changefeed.Warningf(context.Background(), "TLS configuration provided but schema registry %s uses HTTP", baseURL)
 	}
 	return httpClient, nil
 }
@@ -228,7 +228,7 @@ func (r *confluentSchemaRegistry) RegisterSchemaForSubject(
 ) (int32, error) {
 	u := r.urlForPath(fmt.Sprintf("subjects/%s/versions", subject))
 	if log.V(1) {
-		log.Dev.Infof(ctx, "registering avro schema %s %s", u, schema)
+		log.Changefeed.Infof(ctx, "registering avro schema %s %s", u, schema)
 	}
 
 	req := confluentSchemaVersionRequest{Schema: schema}
@@ -285,7 +285,7 @@ func (r *confluentSchemaRegistry) doWithRetry(ctx context.Context, fn func() err
 		if r.sliMetrics != nil {
 			r.sliMetrics.SchemaRegistryRetries.Inc(1)
 		}
-		log.Dev.VInfof(ctx, 1, "retrying schema registry operation: %s", err.Error())
+		log.Changefeed.VInfof(ctx, 1, "retrying schema registry operation: %s", err.Error())
 	}
 	return changefeedbase.MarkRetryableError(err)
 }
@@ -302,7 +302,7 @@ func gracefulClose(ctx context.Context, toClose io.ReadCloser) {
 	const respExtraReadLimit = 4096
 	_, _ = io.CopyN(io.Discard, toClose, respExtraReadLimit)
 	if err := toClose.Close(); err != nil {
-		log.Dev.VInfof(ctx, 2, "failure to close schema registry connection", err)
+		log.Changefeed.VInfof(ctx, 2, "failure to close schema registry connection", err)
 	}
 }
 

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -512,7 +512,7 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 		desc1 := ld1.Underlying().(catalog.TableDescriptor)
 		if !desc1.IsSchemaLocked() {
 			if log.V(2) {
-				log.Dev.Infof(ctx, "desc %d not schema-locked at frontier %s", desc1.GetID(), frontier)
+				log.Changefeed.Infof(ctx, "desc %d not schema-locked at frontier %s", desc1.GetID(), frontier)
 			}
 			return false, nil
 		}
@@ -530,7 +530,7 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 		desc2 := ld2.Underlying().(catalog.TableDescriptor)
 		if desc1.GetVersion() != desc2.GetVersion() {
 			if log.V(1) {
-				log.Dev.Infof(ctx,
+				log.Changefeed.Infof(ctx,
 					"desc %d version changed from version %d to %d between frontier %s and atOrBefore %s",
 					desc1.GetID(), desc1.GetVersion(), desc2.GetVersion(), frontier, atOrBefore)
 			}
@@ -547,7 +547,7 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 		// We swallow any non-terminal errors so that the slow path can be tried
 		// after we resume polling.
 		if log.V(1) {
-			log.Dev.Infof(ctx, "got a non-terminal error while checking if polling can be paused: %s", err)
+			log.Changefeed.Infof(ctx, "got a non-terminal error while checking if polling can be paused: %s", err)
 		}
 		return nil
 	}
@@ -570,7 +570,7 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 // transactionally).
 func (tf *schemaFeed) waitForTS(ctx context.Context, ts hlc.Timestamp) error {
 	if log.V(1) {
-		log.Dev.Infof(ctx, "waiting for frontier to reach %s", ts)
+		log.Changefeed.Infof(ctx, "waiting for frontier to reach %s", ts)
 	}
 
 	waitCh, needToWait := func() (<-chan error, bool) {
@@ -587,14 +587,14 @@ func (tf *schemaFeed) waitForTS(ctx context.Context, ts hlc.Timestamp) error {
 		if needToWait {
 			waited := timeutil.Since(start)
 			if log.V(1) {
-				log.Dev.Infof(ctx, "waited %s for frontier to reach %s: err=%v", waited, ts, err)
+				log.Changefeed.Infof(ctx, "waited %s for frontier to reach %s: err=%v", waited, ts, err)
 			}
 			if tf.metrics != nil {
 				tf.metrics.TableMetadataNanos.Inc(waited.Nanoseconds())
 			}
 		} else {
 			if log.V(1) {
-				log.Dev.Infof(ctx, "fastpath taken when waiting for %s", ts)
+				log.Changefeed.Infof(ctx, "fastpath taken when waiting for %s", ts)
 			}
 		}
 		return err
@@ -826,7 +826,7 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 	ctx context.Context, startTS, endTS hlc.Timestamp,
 ) ([]catalog.Descriptor, error) {
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.Dev.Infof(ctx, `fetching table descs (%s,%s]`, startTS, endTS)
+		log.Changefeed.Infof(ctx, `fetching table descs (%s,%s]`, startTS, endTS)
 	}
 	codec := tf.leaseMgr.Codec()
 	start := timeutil.Now()
@@ -841,7 +841,7 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 		res, err := sendExportRequestWithPriorityOverride(
 			ctx, tf.settings, tf.db.KV().NonTransactionalSender(), span, startTS, endTS)
 		if log.ExpensiveLogEnabled(ctx, 2) {
-			log.Dev.Infof(ctx, `fetched table descs (%s,%s] took %s err=%s`, startTS, endTS, timeutil.Since(start), err)
+			log.Changefeed.Infof(ctx, `fetched table descs (%s,%s] took %s err=%s`, startTS, endTS, timeutil.Since(start), err)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
@@ -128,9 +128,9 @@ func (filter tableEventFilter) shouldFilter(
 	et := classifyTableEvent(e)
 
 	if log.V(2) {
-		log.Dev.Infof(ctx, "table event %v classified as %v", e, et)
+		log.Changefeed.Infof(ctx, "table event %v classified as %v", e, et)
 		defer func() {
-			log.Dev.Infof(ctx, "should filter table event %v: %t", e, ok)
+			log.Changefeed.Infof(ctx, "should filter table event %v: %t", e, ok)
 		}()
 	}
 

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -594,7 +594,7 @@ func (n *nullSink) EmitRow(
 		return err
 	}
 	if log.V(2) {
-		log.Dev.Infof(ctx, "emitting row %s@%s", key, updated.String())
+		log.Changefeed.Infof(ctx, "emitting row %s@%s", key, updated.String())
 	}
 	return nil
 }
@@ -608,7 +608,7 @@ func (n *nullSink) EmitResolvedTimestamp(
 		return err
 	}
 	if log.V(2) {
-		log.Dev.Infof(ctx, "emitting resolved %s", resolved.String())
+		log.Changefeed.Infof(ctx, "emitting resolved %s", resolved.String())
 	}
 
 	return nil
@@ -618,7 +618,7 @@ func (n *nullSink) EmitResolvedTimestamp(
 func (n *nullSink) Flush(ctx context.Context) error {
 	defer n.metrics.recordFlushRequestCallback()()
 	if log.V(2) {
-		log.Dev.Info(ctx, "flushing")
+		log.Changefeed.Info(ctx, "flushing")
 	}
 
 	return nil

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -644,7 +644,7 @@ func (s *cloudStorageSink) EmitResolvedTimestamp(
 	part := resolved.GoTime().Format(s.partitionFormat)
 	filename := fmt.Sprintf(`%s.RESOLVED`, cloudStorageFormatTime(resolved))
 	if log.V(1) {
-		log.Dev.Infof(ctx, "writing file %s %s", filename, resolved.AsOfSystemTime())
+		log.Changefeed.Infof(ctx, "writing file %s %s", filename, resolved.AsOfSystemTime())
 	}
 	return cloud.WriteFile(ctx, s.es, filepath.Join(part, filename), bytes.NewReader(payload))
 }
@@ -833,7 +833,7 @@ func (s *cloudStorageSink) flushFile(ctx context.Context, file *cloudStorageSink
 		return nil
 	default:
 		if logQueueDepth.ShouldLog() {
-			log.Dev.Infof(ctx, "changefeed flush queue is full; ~%d bytes to flush",
+			log.Changefeed.Infof(ctx, "changefeed flush queue is full; ~%d bytes to flush",
 				flushQueueDepth*s.targetMaxFileSize)
 		}
 	}
@@ -879,7 +879,7 @@ func (s *cloudStorageSink) asyncFlusher(ctx context.Context) error {
 			flushDone()
 
 			if err != nil {
-				log.Dev.Errorf(ctx, "error flushing file to storage: %s", err)
+				log.Changefeed.Errorf(ctx, "error flushing file to storage: %s", err)
 				s.asyncFlushErr = err
 				return err
 			}

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -93,7 +93,7 @@ func newKafkaSinkClientV2(
 		// This detects unavoidable data loss due to kafka cluster issues, and we may as well log it if it happens.
 		// See #127246 for further work we can do here.
 		kgo.ProducerOnDataLossDetected(func(topic string, part int32) {
-			log.Dev.Errorf(ctx, `kafka sink detected data loss for topic %s partition %d`, redact.SafeString(topic), redact.SafeInt(part))
+			log.Changefeed.Errorf(ctx, `kafka sink detected data loss for topic %s partition %d`, redact.SafeString(topic), redact.SafeInt(part))
 		}),
 	}
 
@@ -214,7 +214,7 @@ func (k *kafkaSinkClientV2) FlushResolvedPayload(
 			msgs = make([]*kgo.Record, 0, len(k.metadataMu.allTopicPartitions))
 			return forEachTopic(func(topic string) error {
 				if _, ok := k.metadataMu.allTopicPartitions[topic]; !ok {
-					log.Dev.Warningf(ctx, `cannot flush resolved timestamp for unknown topic %s`, topic)
+					log.Changefeed.Warningf(ctx, `cannot flush resolved timestamp for unknown topic %s`, topic)
 				}
 				for _, partition := range k.metadataMu.allTopicPartitions[topic] {
 					msgs = append(msgs, &kgo.Record{
@@ -266,7 +266,7 @@ func (k *kafkaSinkClientV2) maybeUpdateTopicPartitions(
 		return nil
 	}
 
-	log.Dev.Infof(ctx, `updating kafka metadata for topics: %+v`, topics)
+	log.Changefeed.Infof(ctx, `updating kafka metadata for topics: %+v`, topics)
 
 	topicDetails, err := k.adminClient.ListTopics(ctx, topics...)
 	if err != nil {
@@ -481,7 +481,7 @@ func buildKgoConfig(
 			return nil, err
 		}
 		opts = append(opts, authOpts...)
-		log.Dev.VInfof(ctx, 2, "applied kafka auth mechanism: %+#v\n", dialConfig.authMechanism)
+		log.Changefeed.VInfof(ctx, 2, "applied kafka auth mechanism: %+#v\n", dialConfig.authMechanism)
 	}
 
 	// Apply some statement level overrides. The flush related ones (Messages, MaxMessages, Bytes) are not applied here, but on the sinkBatchConfig instead.
@@ -604,7 +604,7 @@ func (k kgoLogAdapter) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 	for i := 0; i < len(keyvals); i += 2 {
 		format += ` %s=%v`
 	}
-	log.Dev.InfofDepth(k.ctx, 1, format, append([]any{redact.SafeString(level.String()), redact.SafeString(msg)}, keyvals...)...) //nolint:fmtsafe
+	log.Changefeed.InfofDepth(k.ctx, 1, format, append([]any{redact.SafeString(level.String()), redact.SafeString(msg)}, keyvals...)...) //nolint:fmtsafe
 }
 
 var _ kgo.Logger = kgoLogAdapter{}

--- a/pkg/ccl/changefeedccl/sink_pubsub_v2.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub_v2.go
@@ -338,7 +338,7 @@ func makePublisherClient(
 
 	// See https://pkg.go.dev/cloud.google.com/go/pubsub#hdr-Emulator for emulator information.
 	if addr, _ := envutil.ExternalEnvString("PUBSUB_EMULATOR_HOST", 1); addr != "" {
-		log.Dev.Infof(ctx, "Establishing connection to pubsub emulator at %s", addr)
+		log.Changefeed.Infof(ctx, "Establishing connection to pubsub emulator at %s", addr)
 		conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, errors.Newf("grpc.Dial: %w", err)

--- a/pkg/ccl/changefeedccl/tableset/watcher.go
+++ b/pkg/ccl/changefeedccl/tableset/watcher.go
@@ -149,7 +149,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
-	log.Dev.Infof(ctx, "starting watcher with filter=%s, initialTS=%s", w.filter, initialTS)
+	log.Changefeed.Infof(ctx, "starting watcher with filter=%s, initialTS=%s", w.filter, initialTS)
 
 	w.acc = w.mon.MakeBoundAccount()
 	defer w.acc.Close(ctx)
@@ -198,7 +198,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 				}
 				if diff.AsOf.Less(initialTS) {
 					if log.V(2) {
-						log.Dev.Infof(ctx, "diff %s is before initialTS %s; skipping", diff, initialTS)
+						log.Changefeed.Infof(ctx, "diff %s is before initialTS %s; skipping", diff, initialTS)
 					}
 					continue
 				}
@@ -216,7 +216,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 			// Flush buffered tables when we receive a resolved message.
 			case resolved := <-incomingResolveds:
 				if log.V(2) {
-					log.Dev.Infof(ctx, "resolved: %s; %d tables buffered", resolved, len(bufferedTableDiffs[curResolved]))
+					log.Changefeed.Infof(ctx, "resolved: %s; %d tables buffered", resolved, len(bufferedTableDiffs[curResolved]))
 				}
 
 				if resolved.Less(curResolved) {
@@ -271,7 +271,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 			}
 
 			if log.V(2) {
-				log.Dev.Infof(ctx, "onValue: %s; prev: %s", table, prevTable)
+				log.Changefeed.Infof(ctx, "onValue: %s; prev: %s", table, prevTable)
 			}
 
 			tableIncluded := w.filter.includes(table)
@@ -291,7 +291,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 			} else if dropped {
 				diff = TableDiff{Dropped: prevTable, AsOf: kv.Value.Timestamp}
 			} else {
-				log.Dev.Warningf(ctx, "onValue: unexpected table state: table=%s, prev=%s", table, prevTable)
+				log.Changefeed.Warningf(ctx, "onValue: unexpected table state: table=%s, prev=%s", table, prevTable)
 				return nil
 			}
 			select {
@@ -308,7 +308,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 		rangefeed.WithMemoryMonitor(w.mon),
 		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
 			if log.V(2) {
-				log.Dev.Infof(ctx, "onCheckpoint: chk=%s", checkpoint)
+				log.Changefeed.Infof(ctx, "onCheckpoint: chk=%s", checkpoint)
 			}
 			// This can happen when done catching up; ignore it.
 			if checkpoint.ResolvedTS.IsEmpty() {
@@ -351,18 +351,18 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 		return err
 	}
 
-	log.Dev.Infof(ctx, "rangefeed started")
+	log.Changefeed.Infof(ctx, "rangefeed started")
 
 	// Wait for shutdown due to error or context cancellation.
 	select {
 	case err := <-errCh:
 		cancel(err)
 		err = errors.Join(err, eg.Wait())
-		log.Dev.Warningf(ctx, "watcher %d shutting down due to error: %v (%s)", w.id, err, context.Cause(ctx))
+		log.Changefeed.Warningf(ctx, "watcher %d shutting down due to error: %v (%s)", w.id, err, context.Cause(ctx))
 		return err
 	case <-ctx.Done():
 		err = errors.Join(ctx.Err(), eg.Wait())
-		log.Dev.Warningf(ctx, "watcher %d shutting down due to context cancellation: %v (%s)", w.id, err, context.Cause(ctx))
+		log.Changefeed.Warningf(ctx, "watcher %d shutting down due to context cancellation: %v (%s)", w.id, err, context.Cause(ctx))
 		return err
 	}
 }
@@ -428,7 +428,7 @@ func (w *Watcher) popDiffsUpTo(ctx context.Context, upTo hlc.Timestamp) ([]Table
 func (w *Watcher) maybeWaitForResolved(ctx context.Context, ts hlc.Timestamp) error {
 	start := timeutil.Now()
 	if log.V(2) {
-		log.Dev.Infof(ctx, "maybeWaitForResolved(%s) start", ts)
+		log.Changefeed.Infof(ctx, "maybeWaitForResolved(%s) start", ts)
 	}
 
 	maybeWaiter := func() chan struct{} {
@@ -437,7 +437,7 @@ func (w *Watcher) maybeWaitForResolved(ctx context.Context, ts hlc.Timestamp) er
 
 		if w.mu.resolved.Compare(ts) >= 0 {
 			if log.V(2) {
-				log.Dev.Infof(ctx, "maybeWaitForResolved(%s) already resolved", ts)
+				log.Changefeed.Infof(ctx, "maybeWaitForResolved(%s) already resolved", ts)
 			}
 			return nil
 		}
@@ -451,7 +451,7 @@ func (w *Watcher) maybeWaitForResolved(ctx context.Context, ts hlc.Timestamp) er
 	select {
 	case <-maybeWaiter:
 		if log.V(2) {
-			log.Dev.Infof(ctx, "maybeWaitForResolved(%s) done waiting in %s", ts, timeutil.Since(start))
+			log.Changefeed.Infof(ctx, "maybeWaitForResolved(%s) done waiting in %s", ts, timeutil.Since(start))
 		}
 		return nil
 	case <-ctx.Done():
@@ -467,7 +467,7 @@ func (w *Watcher) updateResolvedLocked(ctx context.Context, ts hlc.Timestamp) er
 	// the lag seems to be about 3s, coinciding with the default value of kv.closed_timestamp.target_duration.
 	// this is probably fine since the changefeed data will have the same lag anyway.
 	if log.V(2) {
-		log.Dev.Infof(ctx, "updateResolved@%d %s -> %s", timeutil.Now().Unix(), w.mu.resolved, ts)
+		log.Changefeed.Infof(ctx, "updateResolved@%d %s -> %s", timeutil.Now().Unix(), w.mu.resolved, ts)
 	}
 	w.mu.resolved = ts
 	for wts, waiter := range w.mu.resolvedWaiters {
@@ -489,7 +489,7 @@ func (w *Watcher) kvToTable(
 	ctx context.Context, kv roachpb.KeyValue, dec cdcevent.Decoder,
 ) (Table, error) {
 	if log.V(2) {
-		log.Dev.Infof(ctx, "kvToTable: %s, %s", kv.Key, kv.Value.Timestamp)
+		log.Changefeed.Infof(ctx, "kvToTable: %s, %s", kv.Key, kv.Value.Timestamp)
 	}
 
 	row, err := dec.DecodeKV(ctx, kv, cdcevent.CurrentRow, kv.Value.Timestamp, false)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -186,7 +186,7 @@ func (t seenTrackerMap) markSeen(m *cdctest.TestFeedMessage) (isNew bool) {
 		if marshalledValue, err := gojson.Marshal(valueMap); err == nil {
 			normalizedValue = marshalledValue
 		} else {
-			log.Dev.Infof(context.Background(), "could not marshal test feed message %v", err)
+			log.Changefeed.Infof(context.Background(), "could not marshal test feed message %v", err)
 		}
 	} else {
 		// JSON unmarshal failed, try Protobuf
@@ -199,12 +199,12 @@ func (t seenTrackerMap) markSeen(m *cdctest.TestFeedMessage) (isNew bool) {
 			}
 			marshalledValue, err := protoutil.Marshal(&msg)
 			if err != nil {
-				log.Dev.Infof(context.Background(), "could not re-marshal normalized Protobuf: %v", err)
+				log.Changefeed.Infof(context.Background(), "could not re-marshal normalized Protobuf: %v", err)
 			} else {
 				normalizedValue = marshalledValue
 			}
 		} else {
-			log.Dev.Infof(context.Background(), "could not decode test feed message as JSON or Protobuf: %v, %v", err, m.Value)
+			log.Changefeed.Infof(context.Background(), "could not decode test feed message as JSON or Protobuf: %v, %v", err, m.Value)
 		}
 	}
 
@@ -216,7 +216,7 @@ func (t seenTrackerMap) markSeen(m *cdctest.TestFeedMessage) (isNew bool) {
 	seenKey := m.Topic + m.Partition + string(m.Key) + string(normalizedValue)
 	if _, ok := t[seenKey]; ok {
 		if log.V(1) {
-			log.Dev.Infof(context.Background(), "skip dup %s", seenKey)
+			log.Changefeed.Infof(context.Background(), "skip dup %s", seenKey)
 		}
 		return false
 	}
@@ -651,7 +651,7 @@ func (f *jobFeed) Close() error {
 			return nil
 		}
 		if _, err := f.db.Exec(`CANCEL JOB $1`, f.jobID); err != nil {
-			log.Dev.Infof(context.Background(), `could not cancel feed %d: %v`, f.jobID, err)
+			log.Changefeed.Infof(context.Background(), `could not cancel feed %d: %v`, f.jobID, err)
 		} else {
 			return f.WaitForState(func(s jobs.State) bool { return s == jobs.StateCanceled })
 		}
@@ -878,7 +878,7 @@ func (e *enterpriseFeedFactory) AsUser(user string, fn func(*sqlutils.SQLRunner)
 }
 
 func (e enterpriseFeedFactory) startFeedJob(f *jobFeed, create string, args ...interface{}) error {
-	log.Dev.Infof(context.Background(), "Starting feed job: %q", create)
+	log.Changefeed.Infof(context.Background(), "Starting feed job: %q", create)
 	e.di.prepareJob(f)
 	if err := e.db.QueryRow(create, args...).Scan(&f.jobID); err != nil {
 		e.di.pendingJob = nil
@@ -1604,7 +1604,7 @@ func (c *cloudFeed) walkDir(path string, d fs.DirEntry, err error) error {
 		c.seenFiles = make(map[string]struct{})
 	}
 	if _, seen := c.seenFiles[path]; seen {
-		log.Dev.Infof(context.Background(), "Skip file %s", path)
+		log.Changefeed.Infof(context.Background(), "Skip file %s", path)
 		return nil
 	}
 	c.seenFiles[path] = struct{}{}


### PR DESCRIPTION
Replace all instances of log.Dev with log.Changefeed in the changefeedccl directory.

Resolves: #153046
Release note: None