### PR TITLE
vecstore: when reusing memory, set length to the desired length

### DIFF
--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -384,7 +384,7 @@ func (d *PKDecoder) Init(fetchSpec *fetchpb.IndexFetchSpec) {
 	if cap(d.output) < len(fetchSpec.FetchedColumns) {
 		d.output = make(rowenc.EncDatumRow, len(fetchSpec.FetchedColumns))
 	} else {
-		d.output = d.output[:0]
+		d.output = d.output[:len(fetchSpec.FetchedColumns)]
 	}
 	for i, col := range fetchSpec.FetchedColumns {
 		d.colOrdMap.Set(col.ColumnID, i)


### PR DESCRIPTION
Previously, when reusing memory for the output field, PKDecoder.Init() would truncate the output field instead of setting it to the desired length. This could lead to a runtime out of bounds memory reference.

Epic: none
Release note (bug fix): An issue that could cause vector index uses to throw an out of bounds access exception has been fixed.