### PR TITLE
jsonpath: add err check for jsonValue Iterator retrieval

### DIFF
--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -267,7 +267,10 @@ func (ctx *jsonpathCtx) executeAnyItem(
 			}
 		}
 	case json.ObjectJSONType:
-		iter, _ := jsonValue.ObjectIter()
+		iter, err := jsonValue.ObjectIter()
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting iterator for json object")
+		}
 		for iter.Next() {
 			if err := processItem(iter.Value()); err != nil {
 				return nil, err


### PR DESCRIPTION
There are 2 types that can return `ObjectJSONType` as the type: `json.jsonObject` or `json.jsonEncoded`. The latter can return not-nil error in their implementation of `ObjectIter()`. This commit is to add error check for this case.

Epic: none
Release note (bug fix): adding error check for jsonValue Iterator when evaluating a jsonpath on a json value.