### PR TITLE
jsonpath/eval: graceful type unmatched handling

### DIFF
--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -274,7 +274,7 @@ func (ctx *jsonpathCtx) executeAnyItem(
 			}
 		}
 	default:
-		panic(errors.AssertionFailedf("executeAnyItem called with type: %s", jsonValue.Type()))
+		return nil, errors.AssertionFailedf("executeAnyItem called with type: %s", jsonValue.Type())
 	}
 	return agg, nil
 }

--- a/pkg/util/jsonpath/eval/method.go
+++ b/pkg/util/jsonpath/eval/method.go
@@ -83,7 +83,7 @@ func (ctx *jsonpathCtx) evalNumericMethod(
 			dec.Negative = false
 		}
 	default:
-		panic(errors.Newf("unimplemented method: %s", method.Type))
+		return nil, errors.Newf("unsupported jsonpath method type %d for numeric evaluation", method.Type)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -75,7 +75,7 @@ func (ctx *jsonpathCtx) evalOperation(
 	case jsonpath.OpPlus, jsonpath.OpMinus:
 		return ctx.evalUnaryArithmetic(op, jsonValue)
 	default:
-		panic(errors.AssertionFailedf("unhandled operation type"))
+		return nil, errors.AssertionFailedf("unhandled operation type")
 	}
 }
 
@@ -98,7 +98,7 @@ func (ctx *jsonpathCtx) evalBoolean(
 	case jsonpath.OpStartsWith:
 		return ctx.evalPredicate(op, jsonValue, evalStartsWithFunc, true /* evalRight */, false /* unwrapRight */)
 	default:
-		panic(errors.AssertionFailedf("unhandled operation type"))
+		return jsonpathBoolUnknown, errors.AssertionFailedf("unhandled operation type")
 	}
 }
 
@@ -224,7 +224,7 @@ func (ctx *jsonpathCtx) evalLogical(
 		}
 		return jsonpathBoolTrue, nil
 	default:
-		panic(errors.AssertionFailedf("unhandled logical operation type"))
+		return jsonpathBoolUnknown, errors.AssertionFailedf("unhandled logical operation type")
 	}
 
 	rightOp, ok := op.Right.(jsonpath.Operation)
@@ -247,7 +247,7 @@ func (ctx *jsonpathCtx) evalLogical(
 		}
 		return rightBool, nil
 	default:
-		panic(errors.AssertionFailedf("unhandled logical operation type"))
+		return jsonpathBoolUnknown, errors.AssertionFailedf("unhandled logical operation type")
 	}
 }
 
@@ -359,7 +359,7 @@ func evalComparisonFunc(operation jsonpath.Operation, l, r json.JSON) (jsonpathB
 		// Don't evaluate non-scalar types.
 		return jsonpathBoolUnknown, nil
 	default:
-		panic(errors.AssertionFailedf("unhandled json type"))
+		return jsonpathBoolUnknown, errors.AssertionFailedf("unhandled json type")
 	}
 
 	var res bool
@@ -377,7 +377,7 @@ func evalComparisonFunc(operation jsonpath.Operation, l, r json.JSON) (jsonpathB
 	case jsonpath.OpCompGreaterEqual:
 		res = cmp >= 0
 	default:
-		panic(errors.AssertionFailedf("unhandled jsonpath comparison type"))
+		return jsonpathBoolUnknown, errors.AssertionFailedf("unhandled jsonpath comparison type")
 	}
 	if res {
 		return jsonpathBoolTrue, nil
@@ -473,7 +473,7 @@ func performArithmetic(
 		}
 		_, err = tree.DecimalCtx.Rem(&res, leftNum, rightNum)
 	default:
-		panic(errors.AssertionFailedf("unhandled jsonpath arithmetic type"))
+		return nil, errors.AssertionFailedf("unhandled jsonpath arithmetic type")
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, if the type is not found in the switch case, we panic with a unhandled type error. Now we implement a more graceful way for erroring out.

Epic: none
Release note: None