### PR TITLE
cursor: add user-level CLAUDE.md to rule

### DIFF
--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -6,6 +6,5 @@ globs:
 alwaysApply: true
 ---
 
-- **ALWAYS** read and cache [`CLAUDE.md`](../../CLAUDE.md) (and [`CLAUDE.local.md`](../../CLAUDE.local.md), if present) at conversation start, **without exception**.
-- Enforce [`CLAUDE.md`](../../CLAUDE.md) for all messages in the session.
-- Enforce [`CLAUDE.local.md`](../../CLAUDE.local.md) additively; on conflict, prefer [`CLAUDE.md`](../../CLAUDE.md).
+- **ALWAYS** read and cache [`CLAUDE.md`](../../CLAUDE.md) at conversation start, **without exception**. If present, **always** read and cache `$HOME/CLAUDE.md` and [`CLAUDE.local.md`](../../CLAUDE.local.md), also **without exception**.
+- Enforce [`CLAUDE.local.md`](../../CLAUDE.local.md), `$HOME/CLAUDE.md`, and [`CLAUDE.md`](../../CLAUDE.md) for all messages in the session. On conflict, prefer [`CLAUDE.local.md`](../../CLAUDE.local.md), then `$HOME/CLAUDE.md`, then [`CLAUDE.md`](../../CLAUDE.md).


### PR DESCRIPTION
Useful for user-level preferences like gh to access Github, etc.

Epic: none
Release note: None