### PR TITLE
opt: make outside-of-histogram estimates more pessimistic

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4438,6 +4438,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedHoistJoinProject(val bool) {
 	m.data.OptimizerUseImprovedHoistJoinProject = val
 }
 
+func (m *sessionDataMutator) SetOptimizerClampLowHistogramSelectivity(val bool) {
+	m.data.OptimizerClampLowHistogramSelectivity = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4442,6 +4442,10 @@ func (m *sessionDataMutator) SetOptimizerClampLowHistogramSelectivity(val bool) 
 	m.data.OptimizerClampLowHistogramSelectivity = val
 }
 
+func (m *sessionDataMutator) SetOptimizerClampInequalitySelectivity(val bool) {
+	m.data.OptimizerClampInequalitySelectivity = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4189,6 +4189,7 @@ opt_split_scan_limit                                             2048
 optimizer                                                        on
 optimizer_always_use_histograms                                  on
 optimizer_check_input_min_row_count                              1
+optimizer_clamp_inequality_selectivity                           off
 optimizer_clamp_low_histogram_selectivity                        off
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4189,6 +4189,7 @@ opt_split_scan_limit                                             2048
 optimizer                                                        on
 optimizer_always_use_histograms                                  on
 optimizer_check_input_min_row_count                              1
+optimizer_clamp_low_histogram_selectivity                        off
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3138,6 +3138,7 @@ on_update_rehome_row_enabled                                     on             
 opt_split_scan_limit                                             2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                                  on                  NULL      NULL        NULL        string
 optimizer_check_input_min_row_count                              1                   NULL      NULL        NULL        string
+optimizer_clamp_inequality_selectivity                           off                 NULL      NULL        NULL        string
 optimizer_clamp_low_histogram_selectivity                        off                 NULL      NULL        NULL        string
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
@@ -3384,6 +3385,7 @@ on_update_rehome_row_enabled                                     on             
 opt_split_scan_limit                                             2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                                  on                  NULL  user     NULL      on                  on
 optimizer_check_input_min_row_count                              1                   NULL  user     NULL      1                   1
+optimizer_clamp_inequality_selectivity                           off                 NULL  user     NULL      off                 off
 optimizer_clamp_low_histogram_selectivity                        off                 NULL  user     NULL      off                 off
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
@@ -3621,6 +3623,7 @@ opt_split_scan_limit                                             NULL    NULL   
 optimizer                                                        NULL    NULL     NULL     NULL        NULL
 optimizer_always_use_histograms                                  NULL    NULL     NULL     NULL        NULL
 optimizer_check_input_min_row_count                              NULL    NULL     NULL     NULL        NULL
+optimizer_clamp_inequality_selectivity                           NULL    NULL     NULL     NULL        NULL
 optimizer_clamp_low_histogram_selectivity                        NULL    NULL     NULL     NULL        NULL
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  NULL    NULL     NULL     NULL        NULL
 optimizer_enable_lock_elision                                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3138,6 +3138,7 @@ on_update_rehome_row_enabled                                     on             
 opt_split_scan_limit                                             2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                                  on                  NULL      NULL        NULL        string
 optimizer_check_input_min_row_count                              1                   NULL      NULL        NULL        string
+optimizer_clamp_low_histogram_selectivity                        off                 NULL      NULL        NULL        string
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
@@ -3383,6 +3384,7 @@ on_update_rehome_row_enabled                                     on             
 opt_split_scan_limit                                             2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                                  on                  NULL  user     NULL      on                  on
 optimizer_check_input_min_row_count                              1                   NULL  user     NULL      1                   1
+optimizer_clamp_low_histogram_selectivity                        off                 NULL  user     NULL      off                 off
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
@@ -3619,6 +3621,7 @@ opt_split_scan_limit                                             NULL    NULL   
 optimizer                                                        NULL    NULL     NULL     NULL        NULL
 optimizer_always_use_histograms                                  NULL    NULL     NULL     NULL        NULL
 optimizer_check_input_min_row_count                              NULL    NULL     NULL     NULL        NULL
+optimizer_clamp_low_histogram_selectivity                        NULL    NULL     NULL     NULL        NULL
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  NULL    NULL     NULL     NULL        NULL
 optimizer_enable_lock_elision                                    NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -155,6 +155,7 @@ on_update_rehome_row_enabled                                     on
 opt_split_scan_limit                                             2048
 optimizer_always_use_histograms                                  on
 optimizer_check_input_min_row_count                              1
+optimizer_clamp_inequality_selectivity                           off
 optimizer_clamp_low_histogram_selectivity                        off
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -155,6 +155,7 @@ on_update_rehome_row_enabled                                     on
 opt_split_scan_limit                                             2048
 optimizer_always_use_histograms                                  on
 optimizer_check_input_min_row_count                              1
+optimizer_clamp_low_histogram_selectivity                        off
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -213,6 +213,7 @@ type Memo struct {
 	useImprovedHoistJoinProject                bool
 	rowSecurity                                bool
 	clampLowHistogramSelectivity               bool
+	clampInequalitySelectivity                 bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -322,6 +323,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useImprovedHoistJoinProject:                evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
 		rowSecurity:                                evalCtx.SessionData().RowSecurity,
 		clampLowHistogramSelectivity:               evalCtx.SessionData().OptimizerClampLowHistogramSelectivity,
+		clampInequalitySelectivity:                 evalCtx.SessionData().OptimizerClampInequalitySelectivity,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -499,6 +501,7 @@ func (m *Memo) IsStale(
 		m.useImprovedHoistJoinProject != evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject ||
 		m.rowSecurity != evalCtx.SessionData().RowSecurity ||
 		m.clampLowHistogramSelectivity != evalCtx.SessionData().OptimizerClampLowHistogramSelectivity ||
+		m.clampInequalitySelectivity != evalCtx.SessionData().OptimizerClampInequalitySelectivity ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -212,6 +212,7 @@ type Memo struct {
 	disableSlowCascadeFastPathForRBRTables     bool
 	useImprovedHoistJoinProject                bool
 	rowSecurity                                bool
+	clampLowHistogramSelectivity               bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -320,6 +321,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		disableSlowCascadeFastPathForRBRTables:     evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables,
 		useImprovedHoistJoinProject:                evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
 		rowSecurity:                                evalCtx.SessionData().RowSecurity,
+		clampLowHistogramSelectivity:               evalCtx.SessionData().OptimizerClampLowHistogramSelectivity,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -496,6 +498,7 @@ func (m *Memo) IsStale(
 		m.disableSlowCascadeFastPathForRBRTables != evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables ||
 		m.useImprovedHoistJoinProject != evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject ||
 		m.rowSecurity != evalCtx.SessionData().RowSecurity ||
+		m.clampLowHistogramSelectivity != evalCtx.SessionData().OptimizerClampLowHistogramSelectivity ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -600,6 +600,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerClampLowHistogramSelectivity = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerClampInequalitySelectivity = true
+	stale()
+	evalCtx.SessionData().OptimizerClampInequalitySelectivity = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -595,6 +595,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerClampLowHistogramSelectivity = true
+	stale()
+	evalCtx.SessionData().OptimizerClampLowHistogramSelectivity = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -90,6 +90,16 @@ const (
 	// values from the spans a check constraint is allowed to have in order to build
 	// a histogram from it.
 	maxValuesForFullHistogramFromCheckConstraint = tabledesc.MaxBucketAllowed
+
+	// histogramPessimisticThreshold determines the cutoff point below which the
+	// selectivity estimate of a histogram is overridden with a more pessimistic
+	// estimate. This is to avoid over-fitting to a stale or inaccurate histogram.
+	//
+	// The value (1 in 10,000) was chosen because we choose sample sizes according
+	// to table size such that we expect to *nearly* always sample all values with
+	// multiplicity >= row_count/10000. Cardinality estimates below this threshold
+	// are increasingly likely to be inaccurate. See also computeNumberSamples.
+	histogramPessimisticThreshold = 1.0 / 10000.0
 )
 
 // statisticsBuilder is responsible for building the statistics that are
@@ -761,7 +771,10 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 					// is tracked here: https://github.com/cockroachdb/cockroach/issues/50655
 					col := cols.SingleColumn()
 					colStat.Histogram = &props.Histogram{}
-					colStat.Histogram.Init(sb.evalCtx, col, stat.Histogram())
+					// Track the minimum number of rows for which histogram selectivity
+					// estimates are trusted.
+					resolution := histogramPessimisticThreshold * stats.RowCount
+					colStat.Histogram.Init(sb.evalCtx, col, stat.Histogram(), resolution)
 				}
 
 				// Make sure the distinct count is at least 1, for the same reason as
@@ -786,7 +799,18 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 					invCols := opt.MakeColSet(invCol)
 					if invColStat, ok := stats.ColStats.Add(invCols); ok {
 						invColStat.Histogram = &props.Histogram{}
-						invColStat.Histogram.Init(sb.evalCtx, invCol, stat.Histogram())
+						// Track the minimum number of rows for which histogram selectivity
+						// estimates are trusted.
+						//
+						// NOTE: an inverted index can have multiple entries per table row.
+						// However, we still use the number of table rows here because the
+						// max multiplicity of a missed value is proportional to the number
+						// of table rows, not the number of inverted index entries. For
+						// example, the arrays [10, 20, 30] and [20, 40, 60] result in six
+						// inverted index entries, but only a maximum multiplicity of two
+						// for the value "20".
+						resolution := histogramPessimisticThreshold * stats.RowCount
+						invColStat.Histogram.Init(sb.evalCtx, invCol, stat.Histogram(), resolution)
 						// Set inverted entry counts from the histogram. Make sure the
 						// distinct count is at least 1, for the same reason as the row
 						// count above.
@@ -4558,9 +4582,14 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 		newCount := newHist.ValuesCount()
 		oldCount := oldHist.ValuesCount()
 
-		// Calculate the selectivity of the predicate. Nulls are already included
-		// in the histogram, so we do not need to account for them separately.
+		// Calculate the selectivity of the predicate using the histogram. Nulls
+		// are already included in the histogram, so we do not need to account for
+		// them separately.
 		predicateSelectivity := props.MakeSelectivityFromFraction(newCount, oldCount)
+
+		// Possibly clamp the selectivity to a higher value to avoid overly
+		// optimistic estimates.
+		predicateSelectivity = sb.clampSelForHistogram(inputColStat, colStat, s, predicateSelectivity)
 
 		// The maximum possible selectivity of the entire expression is the minimum
 		// selectivity of all individual predicates.
@@ -4570,6 +4599,34 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 	}
 
 	return selectivity, selectivityUpperBound
+}
+
+// clampSelForHistogram clamps the selectivity estimate derived from a histogram
+// to a minimum value. This accounts for the possibility that the histogram is
+// missing values due to sampling or staleness. See also
+// histogramPessimisticThreshold.
+func (sb *statisticsBuilder) clampSelForHistogram(
+	oldColStat, newColStat *props.ColumnStatistic, s *props.Statistics, originalSel props.Selectivity,
+) (clampedSel props.Selectivity) {
+	clampedSel = originalSel
+	oldHist, newHist := oldColStat.Histogram, newColStat.Histogram
+	if sb.evalCtx.SessionData().OptimizerClampLowHistogramSelectivity &&
+		newHist.ValuesCount() < oldHist.Resolution() {
+		// NOTE: columns with histograms are skipped when considering distinct
+		// counts in selectivityFromSingleColDistinctCounts, so this doesn't
+		// double count the effect of the predicate.
+		resClamp := props.MakeSelectivityFromFraction(newColStat.DistinctCount, oldColStat.DistinctCount)
+
+		// Cap the selectivity so that the row count estimate is no more than the
+		// pessimistic threshold. This can result in a lower estimate if the
+		// multiplicities of the filtered values really are low compared to the
+		// average multiplicity.
+		resClamp = props.MinSelectivity(resClamp,
+			props.MakeSelectivityFromFraction(oldHist.Resolution(), s.RowCount),
+		)
+		clampedSel = props.MaxSelectivity(clampedSel, resClamp)
+	}
+	return clampedSel
 }
 
 // selectivityFromMaxFrequencies calculates the selectivity of an equality
@@ -5332,7 +5389,10 @@ func (sb *statisticsBuilder) buildStatsFromCheckConstraints(
 			colStat.NullCount = nullCount
 			if useHistogram {
 				colStat.Histogram = &props.Histogram{}
-				colStat.Histogram.Init(sb.evalCtx, firstColID, histogram)
+				// Track the minimum number of rows for which histogram selectivity
+				// estimates are trusted.
+				resolution := histogramPessimisticThreshold * statistics.RowCount
+				colStat.Histogram.Init(sb.evalCtx, firstColID, histogram, resolution)
 			}
 			sb.finalizeFromRowCountAndDistinctCounts(colStat, statistics)
 			tabMeta.AddCheckConstraintsStats(firstColID, colStat)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -4637,6 +4637,9 @@ func (sb *statisticsBuilder) clampSelForHistogram(
 		resClamp = props.MinSelectivity(resClamp,
 			props.MakeSelectivityFromFraction(oldHist.Resolution(), s.RowCount),
 		)
+		if resClamp.AsFloat() > clampedSel.AsFloat() {
+			sb.mem.optimizationStats.ClampedHistogramSelectivity = true
+		}
 		clampedSel = props.MaxSelectivity(clampedSel, resClamp)
 	}
 
@@ -4647,6 +4650,9 @@ func (sb *statisticsBuilder) clampSelForHistogram(
 		// scan at least 1/10000th of the table. This accounts for the possibility
 		// that the histogram missed extreme values due to sampling or staleness.
 		inequalityClamp := props.MakeSelectivity(histogramUnboundedInequalityMinSelectivity)
+		if inequalityClamp.AsFloat() > clampedSel.AsFloat() {
+			sb.mem.optimizationStats.ClampedInequalitySelectivity = true
+		}
 		clampedSel = props.MaxSelectivity(clampedSel, inequalityClamp)
 	}
 	return clampedSel

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -38,6 +38,13 @@ type Histogram struct {
 	selectivity float64
 	buckets     []cat.HistogramBucket
 	col         opt.ColumnID
+	// resolution is the number of rows below which selectivity estimates based on
+	// this histogram should fall back to a more pessimistic distinct-count based
+	// estimate. This is used to avoid overfitting to histograms that may be
+	// missing values due to sampling or staleness. This number roughly
+	// corresponds to the highest expected multiplicity of any value missing from
+	// the histogram.
+	resolution float64
 }
 
 func (h *Histogram) String() string {
@@ -49,7 +56,9 @@ func (h *Histogram) String() string {
 }
 
 // Init initializes the histogram with data from the catalog.
-func (h *Histogram) Init(evalCtx *eval.Context, col opt.ColumnID, buckets []cat.HistogramBucket) {
+func (h *Histogram) Init(
+	evalCtx *eval.Context, col opt.ColumnID, buckets []cat.HistogramBucket, resolution float64,
+) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*h = Histogram{
@@ -57,6 +66,7 @@ func (h *Histogram) Init(evalCtx *eval.Context, col opt.ColumnID, buckets []cat.
 		col:         col,
 		selectivity: 1,
 		buckets:     buckets,
+		resolution:  resolution,
 	}
 }
 
@@ -132,6 +142,13 @@ func (h *Histogram) ValuesCount() float64 {
 		count += h.numEq(i)
 	}
 	return count
+}
+
+// Resolution returns the minimum row count for which selectivity estimates
+// based on this histogram should be trusted. See the resolution field comment
+// for details.
+func (h *Histogram) Resolution() float64 {
+	return h.resolution
 }
 
 // EqEstimate returns the estimated number of rows that equal the given
@@ -329,6 +346,7 @@ func (h *Histogram) filter(
 		evalCtx:     h.evalCtx,
 		col:         h.col,
 		selectivity: h.selectivity,
+		resolution:  h.resolution,
 	}
 	if bucketCount == 0 {
 		return filtered

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -45,6 +45,13 @@ type Histogram struct {
 	// corresponds to the highest expected multiplicity of any value missing from
 	// the histogram.
 	resolution float64
+	// hasTightUB and hasTightLB indicate whether there are guaranteed upper
+	// bounds on the range of values in the underlying dataset (possibly, though
+	// not necessarily, equal to the upper and lower bounds of the histogram).
+	// This is the case for a histogram derived after a filter that restricts the
+	// column's values to a finite range. Contrast this with the histogram derived
+	// from a table sample, which may miss extreme values or become stale.
+	hasTightUB, hasTightLB bool
 }
 
 func (h *Histogram) String() string {
@@ -70,21 +77,21 @@ func (h *Histogram) Init(
 	}
 }
 
-// bucketCount returns the number of buckets in the histogram.
-func (h *Histogram) bucketCount() int {
+// BucketCount returns the number of buckets in the histogram.
+func (h *Histogram) BucketCount() int {
 	return len(h.buckets)
 }
 
 // numEq returns NumEq for the ith histogram bucket, with the histogram's
 // selectivity applied. i must be greater than or equal to 0 and less than
-// bucketCount.
+// BucketCount.
 func (h *Histogram) numEq(i int) float64 {
 	return h.buckets[i].NumEq * h.selectivity
 }
 
 // numRange returns NumRange for the ith histogram bucket, with the histogram's
 // selectivity applied. i must be greater than or equal to 0 and less than
-// bucketCount.
+// BucketCount.
 func (h *Histogram) numRange(i int) float64 {
 	// The first bucket always has a zero value for NumRange, so the lower bound
 	// of the histogram is the upper bound of the first bucket. We only check this
@@ -100,7 +107,7 @@ func (h *Histogram) numRange(i int) float64 {
 
 // distinctRange returns DistinctRange for the ith histogram bucket, with the
 // histogram's selectivity applied. i must be greater than or equal to 0 and
-// less than bucketCount.
+// less than BucketCount.
 func (h *Histogram) distinctRange(i int) float64 {
 	n := h.buckets[i].NumRange
 	d := h.buckets[i].DistinctRange
@@ -127,7 +134,7 @@ func (h *Histogram) distinctRange(i int) float64 {
 }
 
 // upperBound returns UpperBound for the ith histogram bucket. i must be
-// greater than or equal to 0 and less than bucketCount.
+// greater than or equal to 0 and less than BucketCount.
 func (h *Histogram) upperBound(i int) tree.Datum {
 	return h.buckets[i].UpperBound
 }
@@ -149,6 +156,16 @@ func (h *Histogram) ValuesCount() float64 {
 // for details.
 func (h *Histogram) Resolution() float64 {
 	return h.resolution
+}
+
+// TightBounds returns whether the histogram has been constrained such that
+// there are guaranteed finite upper and lower bounds on the values in the
+// histogram column. Note that the guaranteed bounds may not match the
+// histogram's maximum and minimum values. This information can be used to
+// determine how to clamp row-count estimates for inequality filters to avoid
+// over-fitting on stale or inaccurate histograms.
+func (h *Histogram) TightBounds() (tightUpper, tightLower bool) {
+	return h.hasTightUB, h.hasTightLB
 }
 
 // EqEstimate returns the estimated number of rows that equal the given
@@ -332,6 +349,33 @@ func (h *Histogram) CanFilter(
 	return 0, exactPrefix, false
 }
 
+// checkSpanBounds determines whether the given spans bound the histogram column
+// above and below. This can be used to determine how to clamp row-count
+// estimates for inequality filters to avoid over-fitting on stale or inaccurate
+// histograms.
+func checkSpanBounds(
+	spanCount int, getSpan func(int) *constraint.Span, desc bool, colOffset int,
+) (hasUpperBound, hasLowerBound bool) {
+	if spanCount == 0 {
+		return false, false
+	}
+	firstSpan := getSpan(0)
+	lastSpan := getSpan(spanCount - 1)
+	hasBound := func(key constraint.Key) bool {
+		// A NULL value is not considered a bound in this context, since they order
+		// before (or after) all non-NULL values and are not included in histograms.
+		return key.Length() > colOffset && key.Value(colOffset) != tree.DNull
+	}
+	if desc {
+		hasUpperBound = hasBound(firstSpan.StartKey())
+		hasLowerBound = hasBound(lastSpan.EndKey())
+	} else {
+		hasLowerBound = hasBound(firstSpan.StartKey())
+		hasUpperBound = hasBound(lastSpan.EndKey())
+	}
+	return hasUpperBound, hasLowerBound
+}
+
 func (h *Histogram) filter(
 	ctx context.Context,
 	spanCount int,
@@ -341,12 +385,21 @@ func (h *Histogram) filter(
 	prefix []tree.Datum,
 	columns constraint.Columns,
 ) *Histogram {
-	bucketCount := h.bucketCount()
+	bucketCount := h.BucketCount()
 	filtered := &Histogram{
 		evalCtx:     h.evalCtx,
 		col:         h.col,
 		selectivity: h.selectivity,
 		resolution:  h.resolution,
+		hasTightLB:  h.hasTightLB,
+		hasTightUB:  h.hasTightUB,
+	}
+	spanUB, spanLB := checkSpanBounds(spanCount, getSpan, desc, colOffset)
+	if spanUB {
+		filtered.hasTightUB = true
+	}
+	if spanLB {
+		filtered.hasTightLB = true
 	}
 	if bucketCount == 0 {
 		return filtered
@@ -665,7 +718,7 @@ func (hi *histogramIter) init(h *Histogram, desc bool) {
 		desc: desc,
 	}
 	if desc {
-		hi.idx = h.bucketCount()
+		hi.idx = h.BucketCount()
 	}
 	hi.next()
 }
@@ -709,7 +762,7 @@ func (hi *histogramIter) next() (ok bool) {
 		hi.eub, hi.ub, hi.elb, hi.lb = getBounds()
 	} else {
 		hi.idx++
-		if hi.idx >= hi.h.bucketCount() {
+		if hi.idx >= hi.h.BucketCount() {
 			return false
 		}
 		// If iter.desc=false, the lower bounds are less than the upper bounds.

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -29,7 +29,7 @@ func TestEqEstimate(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	emptyHist := &Histogram{}
-	emptyHist.Init(&evalCtx, opt.ColumnID(1), []cat.HistogramBucket{})
+	emptyHist.Init(&evalCtx, opt.ColumnID(1), []cat.HistogramBucket{}, 0 /* resolution */)
 
 	if eq := emptyHist.EqEstimate(ctx, tree.NewDInt(0)); eq != 0 {
 		t.Errorf("expected %f but found %f", 0.0, eq)
@@ -45,7 +45,7 @@ func TestEqEstimate(t *testing.T) {
 		{NumRange: 40, DistinctRange: 7, NumEq: 35, UpperBound: tree.NewDInt(42)},
 	}
 	h := &Histogram{}
-	h.Init(&evalCtx, opt.ColumnID(1), histData)
+	h.Init(&evalCtx, opt.ColumnID(1), histData, 0 /* resolution */)
 
 	testData := []struct {
 		datum    tree.Datum
@@ -139,7 +139,7 @@ func TestCanFilter(t *testing.T) {
 	}
 
 	h := Histogram{}
-	h.Init(&evalCtx, opt.ColumnID(1), []cat.HistogramBucket{})
+	h.Init(&evalCtx, opt.ColumnID(1), []cat.HistogramBucket{}, 0 /* resolution */)
 	for _, tc := range testData {
 		c := constraint.ParseConstraint(&evalCtx, tc.constraint)
 		colIdx, _, ok := h.CanFilter(ctx, &c)
@@ -170,7 +170,7 @@ func TestHistogram(t *testing.T) {
 		{NumRange: 40, DistinctRange: 7, NumEq: 35, UpperBound: tree.NewDInt(42)},
 	}
 	h := &Histogram{}
-	h.Init(&evalCtx, opt.ColumnID(1), histData)
+	h.Init(&evalCtx, opt.ColumnID(1), histData, 0 /* resolution */)
 	count, expected := h.ValuesCount(), float64(91)
 	if count != expected {
 		t.Fatalf("expected %f but found %f", expected, count)
@@ -1212,7 +1212,7 @@ func BenchmarkHistogram(b *testing.B) {
 			for _, bucketCount := range bucketCounts {
 				b.Run(fmt.Sprintf("buckets=%v", bucketCount), func(b *testing.B) {
 					h := Histogram{}
-					h.Init(&evalCtx, opt.ColumnID(1), makeBuckets(typ, bucketCount))
+					h.Init(&evalCtx, opt.ColumnID(1), makeBuckets(typ, bucketCount), 0 /* resolution */)
 					c := makeConstraint(typ, bucketCount)
 					b.Run("DistinctValuesCount", func(b *testing.B) {
 						for i := 0; i < b.N; i++ {

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -283,7 +283,9 @@ func (c *ColumnStatistic) CopyFromOther(other *ColumnStatistic, evalCtx *eval.Co
 	c.NullCount = other.NullCount
 	if other.Histogram != nil && c.Cols.Len() == 1 {
 		c.Histogram = &Histogram{}
-		c.Histogram.Init(evalCtx, c.Cols.SingleColumn(), other.Histogram.buckets)
+		c.Histogram.Init(
+			evalCtx, c.Cols.SingleColumn(), other.Histogram.buckets, other.Histogram.resolution,
+		)
 	}
 }
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -568,6 +568,13 @@ func New(catalog cat.Catalog, sqlStr string) *OptTester {
 //   - max-stack: sets the maximum stack size for the goroutine that optimizes
 //     the query. See debug.SetMaxStack.
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
+	// Apply "session" defaults.
+	ot.catalog.(*testcat.Catalog).ForEachSessionVar(func(name string, value string) {
+		if err := sql.TestingSetSessionVariable(ot.ctx, ot.evalCtx, name, value); err != nil {
+			panic(err)
+		}
+	})
+
 	// Allow testcases to override the flags.
 	for _, a := range d.CmdArgs {
 		if err := ot.Flags.Set(a); err != nil {

--- a/pkg/sql/opt/testutils/testcat/set_var.go
+++ b/pkg/sql/opt/testutils/testcat/set_var.go
@@ -11,24 +11,32 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// SetVar implements the 'SET ...' SQL statement. Currently, it supports only
-// statements that set the current role (e.g., SET ROLE <user>).
+// SetVar implements the 'SET ...' SQL statement.
 func (tc *Catalog) SetVar(n *tree.SetVar) {
-	if n.Name != "role" {
-		panic(errors.Newf("SET only supports SET ROLE: %q", n.Name))
-	}
 	if len(n.Values) != 1 {
 		panic(errors.Newf("Only support 1 value with SET"))
 	}
 	if n.ResetAll {
 		panic(errors.Newf("RESET ALL is not supported with SET"))
 	}
-	newUser, err := username.MakeSQLUsernameFromUserInput(n.Values[0].String(), username.PurposeValidation)
-	if err != nil {
-		panic(err)
+	if n.Name == "role" {
+		newUser, err := username.MakeSQLUsernameFromUserInput(n.Values[0].String(), username.PurposeValidation)
+		if err != nil {
+			panic(err)
+		}
+		if _, found := tc.users[newUser]; !found {
+			panic(errors.Newf("User %q does not exist", newUser.Normalized()))
+		}
+		tc.currentUser = newUser
+	} else if _, isReset := n.Values[0].(tree.DefaultVal); isReset {
+		// "SET var = DEFAULT" means RESET.
+		if tc.sessionVars != nil {
+			delete(tc.sessionVars, n.Name)
+		}
+	} else {
+		if tc.sessionVars == nil {
+			tc.sessionVars = make(map[string]string)
+		}
+		tc.sessionVars[n.Name] = n.Values[0].String()
 	}
-	if _, found := tc.users[newUser]; !found {
-		panic(errors.Newf("User %q does not exist", newUser.Normalized()))
-	}
-	tc.currentUser = newUser
 }

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -60,6 +60,8 @@ type Catalog struct {
 
 	users       map[username.SQLUsername]roleMembership
 	currentUser username.SQLUsername
+
+	sessionVars map[string]string
 }
 
 type roleMembership struct {
@@ -531,6 +533,14 @@ func (tc *Catalog) GetDependencyDigest() cat.DependencyDigest {
 // LeaseByStableID does not do anything since no leasing is used here.
 func (tc *Catalog) LeaseByStableID(ctx context.Context, id cat.StableID) (uint64, error) {
 	return 1, nil
+}
+
+// ForEachSessionVar applies the given function to the session variable
+// name-value pairs determined by previous SET statements.
+func (tc *Catalog) ForEachSessionVar(fn func(name string, value string)) {
+	for k, v := range tc.sessionVars {
+		fn(k, v)
+	}
 }
 
 // ExecuteMultipleDDL parses the given semicolon-separated DDL SQL statements

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -26,9 +26,9 @@ ALTER TABLE t INJECT STATISTICS '[
     "histo_buckets": [
       {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
       {"num_eq": 1, "num_range": 99, "distinct_range": 99, "upper_bound": "100"},
-      {"num_eq": 1, "num_range": 199, "distinct_range": 199, "upper_bound": "200"},
-      {"num_eq": 1, "num_range": 299, "distinct_range": 299, "upper_bound": "300"},
-      {"num_eq": 1, "num_range": 399, "distinct_range": 399, "upper_bound": "400"}
+      {"num_eq": 1, "num_range": 199, "distinct_range": 199, "upper_bound": "300"},
+      {"num_eq": 1, "num_range": 299, "distinct_range": 299, "upper_bound": "600"},
+      {"num_eq": 1, "num_range": 399, "distinct_range": 399, "upper_bound": "1000"}
     ]
   },
   {
@@ -66,11 +66,26 @@ ALTER TABLE t INJECT STATISTICS '[
 ]'
 ----
 
-# --------------------------------------------------
+exec-ddl
+SET optimizer_prefer_bounded_cardinality = false;
+----
+
+exec-ddl
+SET optimizer_min_row_count = 0;
+----
+
+exec-ddl
+SET enable_zigzag_join = false;
+----
+
+# ------------------------------------------------------------------------------
 # Q1
-# --------------------------------------------------
+#
+# Choose between 4 single-row equality spans on "k" and a single unbounded
+# equality span on "i". The "i" span is outside the histogram range.
+# ------------------------------------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+opt
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
@@ -99,7 +114,7 @@ index-join t
       ├── key: (1)
       └── fd: ()-->(2)
 
-opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
+opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
@@ -128,7 +143,7 @@ index-join t
       ├── key: (1)
       └── fd: ()-->(2)
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 select
@@ -158,11 +173,14 @@ select
  └── filters
       └── i:2 = 500 [outer=(2), constraints=(/2: [/500 - /500]; tight), fd=()-->(2)]
 
-# --------------------------------------------------
+# ------------------------------------------------------------------------------
 # Q2
-# --------------------------------------------------
+#
+# Choose between 4 single-row equality spans on "k" and a single unbounded
+# inequality span on "i". The "i" span is outside the histogram range.
+# ------------------------------------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+opt
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 index-join t
@@ -189,7 +207,7 @@ index-join t
       │    ├── constraint: /2/1: [/501/100 - ]
       │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
       │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
-      │    │                <--- 0 ---------- 100 ---------- 200 ---------- 300 ---------- 400
+      │    │                <--- 0 ---------- 100 ---------- 300 ---------- 600 ---------- 1000
       │    │   histogram(2)=
       │    ├── cost: 18.0200002
       │    ├── key: (1)
@@ -197,7 +215,7 @@ index-join t
       └── filters
            └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
+opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
@@ -227,7 +245,7 @@ select
  └── filters
       └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
@@ -257,12 +275,15 @@ select
  └── filters
       └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
 
-# --------------------------------------------------
+# ------------------------------------------------------------------------------
 # Q3
-# --------------------------------------------------
+#
+# Choose between 3 single-row equality spans on "k" and a single unbounded
+# equality span on "i". The "i" and "k" spans are outside the histogram range.
+# ------------------------------------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
-SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
+opt
+SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 index-join t
  ├── columns: k:1!null i:2!null s:3
@@ -283,19 +304,19 @@ index-join t
       ├── fd: (1)-->(2)
       ├── scan t@t_i_idx
       │    ├── columns: k:1!null i:2!null
-      │    ├── constraint: /2/1: [/501/410 - ]
+      │    ├── constraint: /2/1: [/501/1010 - ]
       │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
       │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
-      │    │                <--- 0 ---------- 100 ---------- 200 ---------- 300 ---------- 400
+      │    │                <--- 0 ---------- 100 ---------- 300 ---------- 600 ---------- 1000
       │    │   histogram(2)=
       │    ├── cost: 18.0200002
       │    ├── key: (1)
       │    └── fd: (1)-->(2)
       └── filters
-           └── k:1 IN (410, 420, 430) [outer=(1), constraints=(/1: [/410 - /410] [/420 - /420] [/430 - /430]; tight)]
+           └── k:1 IN (1010, 1020, 1030) [outer=(1), constraints=(/1: [/1010 - /1010] [/1020 - /1020] [/1030 - /1030]; tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
-SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 select
  ├── columns: k:1!null i:2!null s:3
@@ -309,9 +330,9 @@ select
  ├── scan t
  │    ├── columns: k:1!null i:2 s:3
  │    ├── constraint: /1
- │    │    ├── [/410 - /410]
- │    │    ├── [/420 - /420]
- │    │    └── [/430 - /430]
+ │    │    ├── [/1010 - /1010]
+ │    │    ├── [/1020 - /1020]
+ │    │    └── [/1030 - /1030]
  │    ├── cardinality: [0 - 3]
  │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0]
  │    │   histogram(1)=
@@ -321,8 +342,8 @@ select
  └── filters
       └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
-SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
+opt set=optimizer_min_row_count=1
+SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 select
  ├── columns: k:1!null i:2!null s:3
@@ -336,9 +357,9 @@ select
  ├── scan t
  │    ├── columns: k:1!null i:2 s:3
  │    ├── constraint: /1
- │    │    ├── [/410 - /410]
- │    │    ├── [/420 - /420]
- │    │    └── [/430 - /430]
+ │    │    ├── [/1010 - /1010]
+ │    │    ├── [/1020 - /1020]
+ │    │    └── [/1030 - /1030]
  │    ├── cardinality: [0 - 3]
  │    ├── stats: [rows=6e-07, distinct(1)=6e-07, null(1)=0]
  │    │   histogram(1)=
@@ -348,11 +369,14 @@ select
  └── filters
       └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
 
-# --------------------------------------------------
+# ------------------------------------------------------------------------------
 # Q4
-# --------------------------------------------------
+#
+# Choose between equality spans on "k" and "i", all inside the histogram, vs an
+# inequality span on "s", which falls outside the histogram.
+# ------------------------------------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+opt
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
@@ -388,7 +412,7 @@ select
  │         │    ├── constraint: /3/1: (/NULL - /'apple')
  │         │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(3)=2e-07, null(3)=0]
  │         │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
- │         │    │                <--- 0 ---------- 100 ---------- 200 ---------- 300 ---------- 400
+ │         │    │                <--- 0 ---------- 100 ---------- 300 ---------- 600 ---------- 1000
  │         │    │   histogram(3)=
  │         │    ├── cost: 18.0200002
  │         │    ├── key: (1)
@@ -398,7 +422,7 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
+opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
@@ -431,7 +455,7 @@ select
       ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
       └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
@@ -464,11 +488,14 @@ select
       ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
       └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
 
-# --------------------------------------------------
+# ------------------------------------------------------------------------------
 # Q5
-# --------------------------------------------------
+#
+# Choose between an unbounded equality span on "i" inside the histogram vs an
+# inequality span on "s" outside its histogram.
+# ------------------------------------------------------------------------------
 
-opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+opt
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
@@ -497,7 +524,7 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
-opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
+opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
@@ -529,7 +556,7 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
-opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
@@ -558,11 +585,14 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
-# --------------------------------------------------
+# ------------------------------------------------------------------------------
 # Q6
-# --------------------------------------------------
+#
+# Choose between equality spans on "k", "i", and "s". The "k" span is inside the
+# histogram, while the "i" and "s" spans are outside their histograms.
+# ------------------------------------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+opt
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
@@ -597,7 +627,7 @@ select
  └── filters
       └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
+opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
@@ -632,7 +662,7 @@ select
  └── filters
       └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
 
-opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -124,6 +124,121 @@ ALTER TABLE t INJECT STATISTICS '[
 ----
 
 exec-ddl
+CREATE TABLE t_large (
+  k INT PRIMARY KEY,
+  u INT,
+  d INT,
+  i INT,
+  s STRING,
+  e status_enum,
+  UNIQUE INDEX (u),
+  INDEX (d),
+  INDEX (i),
+  INDEX (s),
+  INDEX (i) WHERE e = 'PENDING'
+)
+----
+
+exec-ddl
+ALTER TABLE t_large INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 1000000000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99999999, "distinct_range": 99999999, "upper_bound": "100000000"},
+      {"num_eq": 1, "num_range": 199999999, "distinct_range": 199999999, "upper_bound": "300000000"},
+      {"num_eq": 1, "num_range": 299999999, "distinct_range": 299999999, "upper_bound": "600000000"},
+      {"num_eq": 1, "num_range": 399999999, "distinct_range": 399999999, "upper_bound": "1000000000"}
+    ]
+  },
+  {
+    "columns": ["u"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 1000000000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99999999, "distinct_range": 99999999, "upper_bound": "100000000"},
+      {"num_eq": 1, "num_range": 199999999, "distinct_range": 199999999, "upper_bound": "300000000"},
+      {"num_eq": 1, "num_range": 299999999, "distinct_range": 299999999, "upper_bound": "600000000"},
+      {"num_eq": 1, "num_range": 399999999, "distinct_range": 399999999, "upper_bound": "1000000000"}
+    ]
+  },
+  {
+    "columns": ["d"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 1000000000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99999999, "distinct_range": 99999999, "upper_bound": "100000000"},
+      {"num_eq": 1, "num_range": 199999999, "distinct_range": 199999999, "upper_bound": "300000000"},
+      {"num_eq": 1, "num_range": 299999999, "distinct_range": 299999999, "upper_bound": "600000000"},
+      {"num_eq": 1, "num_range": 399999999, "distinct_range": 399999999, "upper_bound": "1000000000"}
+    ]
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 44000000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10000000, "num_range": 90000000, "distinct_range": 10000000, "upper_bound": "100000000"},
+      {"num_eq": 10000000, "num_range": 190000000, "distinct_range": 10000000, "upper_bound": "200000000"},
+      {"num_eq": 20000000, "num_range": 280000000, "distinct_range": 10000000, "upper_bound": "300000000"},
+      {"num_eq": 30000000, "num_range": 370000000, "distinct_range": 10000000, "upper_bound": "400000000"}
+    ]
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 400000000,
+    "null_count": 0,
+    "avg_size": 3,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "banana"},
+      {"num_eq": 100000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "cherry"},
+      {"num_eq": 200000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "mango"},
+      {"num_eq": 200000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "pineapple"}
+    ]
+  },
+  {
+    "columns": ["e"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 4,
+    "null_count": 0,
+    "avg_size": 1,
+    "histo_col_type": "status_enum",
+    "histo_buckets": [
+      {"num_eq": 1000000, "num_range": 0, "distinct_range": 0, "upper_bound": "ACKNOWLEDGED"},
+      {"num_eq": 99000000, "num_range": 0, "distinct_range": 0, "upper_bound": "DROPPED"},
+      {"num_eq": 900000000, "num_range": 0, "distinct_range": 0, "upper_bound": "SUCCEEDED"}
+    ]
+  }
+]'
+----
+
+exec-ddl
 SET optimizer_prefer_bounded_cardinality = false;
 ----
 
@@ -231,6 +346,100 @@ select
       └── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
 
 # ------------------------------------------------------------------------------
+# Q1 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE k IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    ├── [/130000000 - /130000000]
+ │    │    └── [/140000000 - /140000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE k IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    ├── [/130000000 - /130000000]
+ │    │    └── [/140000000 - /140000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE k IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
+ │   histogram(1)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    ├── [/130000000 - /130000000]
+ │    │    └── [/140000000 - /140000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+# ------------------------------------------------------------------------------
 # Q2
 #
 # Choose between 4 single-row equality spans on "k" and a single unbounded
@@ -333,6 +542,105 @@ select
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
 # ------------------------------------------------------------------------------
+# Q2 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
+----
+index-join t_large
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=
+ ├── cost: 18.668
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── select
+      ├── columns: k:1!null i:4!null
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=8.2e-10, distinct(1)=8e-10, null(1)=0]
+      │   histogram(1)=  0    2e-10    0    2e-10    0    2e-10    0    2e-10
+      │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+      ├── cost: 18.246
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan t_large@t_large_i_idx
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/500000001/100000000 - ]
+      │    ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0]
+      │    │   histogram(1)=  0  0  0.02    2e-10    0.04    2e-10    0.06    2e-10    0.08    2e-10
+      │    │                <--- 0 ------ 100000000 ------ 300000000 ------ 600000000 ------ 1000000000
+      │    │   histogram(4)=
+      │    ├── cost: 18.224
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── k:1 IN (100000000, 110000000, 120000000, 130000000) [outer=(1), constraints=(/1: [/100000000 - /100000000] [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
+ │   histogram(1)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+# ------------------------------------------------------------------------------
 # Q3
 #
 # Choose between 3 single-row equality spans on "k" and a single unbounded
@@ -425,6 +733,103 @@ select
  │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q3 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE k IN (410000000, 420000000, 430000000) AND i > 500000000
+----
+index-join t_large
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0  0.066667   0  0.066667   0  0.066667
+ │                <--- 410000000 --- 420000000 --- 430000000
+ │   histogram(4)=
+ ├── cost: 18.668
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── select
+      ├── columns: k:1!null i:4!null
+      ├── cardinality: [0 - 3]
+      ├── stats: [rows=6.2e-10, distinct(1)=6e-10, null(1)=0]
+      │   histogram(1)=  0    2e-10    0    2e-10    0    2e-10
+      │                <--- 410000000 --- 420000000 --- 430000000
+      ├── cost: 18.246
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan t_large@t_large_i_idx
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/500000001/410000000 - ]
+      │    ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0]
+      │    │   histogram(1)=  0  0  0.02    2e-10    0.04    2e-10    0.06    2e-10    0.08    2e-10
+      │    │                <--- 0 ------ 100000000 ------ 300000000 ------ 600000000 ------ 1000000000
+      │    │   histogram(4)=
+      │    ├── cost: 18.224
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── k:1 IN (410000000, 420000000, 430000000) [outer=(1), constraints=(/1: [/410000000 - /410000000] [/420000000 - /420000000] [/430000000 - /430000000]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE k IN (410000000, 420000000, 430000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0  0.066667   0  0.066667   0  0.066667
+ │                <--- 410000000 --- 420000000 --- 430000000
+ │   histogram(4)=
+ ├── cost: 19.24
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/410000000 - /410000000]
+ │    │    ├── [/420000000 - /420000000]
+ │    │    └── [/430000000 - /430000000]
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=3, distinct(1)=3, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1
+ │    │                <--- 410000000 --- 420000000 --- 430000000
+ │    ├── cost: 19.19
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE k IN (410000000, 420000000, 430000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
+ │   histogram(1)=  0   0.33333   0   0.33333   0   0.33333
+ │                <--- 410000000 --- 420000000 --- 430000000
+ │   histogram(4)=
+ ├── cost: 19.24
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/410000000 - /410000000]
+ │    │    ├── [/420000000 - /420000000]
+ │    │    └── [/430000000 - /430000000]
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=3, distinct(1)=3, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1
+ │    │                <--- 410000000 --- 420000000 --- 430000000
+ │    ├── cost: 19.19
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
 
 # ------------------------------------------------------------------------------
 # Q4
@@ -546,6 +951,122 @@ select
       └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
 
 # ------------------------------------------------------------------------------
+# Q4 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i = 400000000 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0, distinct(1,4,5)=0.2, null(1,4,5)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 18.277
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=8.2e-10]
+ │    ├── cost: 18.257
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── select
+ │         ├── columns: k:1!null s:5!null
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=8.2e-10, distinct(1)=8e-10, null(1)=0]
+ │         │   histogram(1)=  0    2e-10    0    2e-10    0    2e-10    0    2e-10
+ │         │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │         ├── cost: 18.247
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(5)
+ │         ├── scan t_large@t_large_s_idx
+ │         │    ├── columns: k:1!null s:5!null
+ │         │    ├── constraint: /5/1: (/NULL - /'apple')
+ │         │    ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(5)=0.2, null(5)=0]
+ │         │    │   histogram(1)=  0  0  0.02    2e-10    0.04    2e-10    0.06    2e-10    0.08    2e-10
+ │         │    │                <--- 0 ------ 100000000 ------ 300000000 ------ 600000000 ------ 1000000000
+ │         │    │   histogram(5)=
+ │         │    ├── cost: 18.225
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(5)
+ │         └── filters
+ │              └── k:1 IN (100000000, 110000000, 120000000, 130000000) [outer=(1), constraints=(/1: [/100000000 - /100000000] [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000]; tight)]
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i = 400000000 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0, distinct(1,4,5)=0.2, null(1,4,5)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 24.32
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      ├── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+      └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i = 400000000 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0, distinct(1,4,5)=1, null(1,4,5)=0]
+ │   histogram(1)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=  0      1
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 24.32
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      ├── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+      └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
+
+# ------------------------------------------------------------------------------
 # Q5
 #
 # Choose between an unbounded equality span on "i" inside the histogram vs an
@@ -641,6 +1162,100 @@ select
  │         └── fd: (1)-->(5)
  └── filters
       └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+
+# ------------------------------------------------------------------------------
+# Q5 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE i = 400000000 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0]
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 19.4885
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.4565
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=0.2, distinct(5)=0.2, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 18.225
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE i = 400000000 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0]
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 19.4885
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.4565
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=0.2, distinct(5)=0.2, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 18.225
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE i = 400000000 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0]
+ │   histogram(4)=  0      1
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 25.1625
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.1225
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=1, distinct(5)=1, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 19.045
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
 
 # ------------------------------------------------------------------------------
 # Q6
@@ -745,6 +1360,94 @@ select
  │    └── fd: ()-->(1-6)
  └── filters
       ├── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
+# ------------------------------------------------------------------------------
+# Q6 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE k = 100000000 AND i = 500000000 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0]
+ │   histogram(1)=  0     0.2
+ │                <--- 100000000
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.11
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1: [/100000000 - /100000000]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=  0      1
+ │    │                <--- 100000000
+ │    ├── cost: 9.07
+ │    ├── key: ()
+ │    └── fd: ()-->(1-6)
+ └── filters
+      ├── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE k = 100000000 AND i = 500000000 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0]
+ │   histogram(1)=  0     0.2
+ │                <--- 100000000
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.11
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1: [/100000000 - /100000000]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=  0      1
+ │    │                <--- 100000000
+ │    ├── cost: 9.07
+ │    ├── key: ()
+ │    └── fd: ()-->(1-6)
+ └── filters
+      ├── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE k = 100000000 AND i = 500000000 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0]
+ │   histogram(1)=  0      1
+ │                <--- 100000000
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.11
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1: [/100000000 - /100000000]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=  0      1
+ │    │                <--- 100000000
+ │    ├── cost: 9.07
+ │    ├── key: ()
+ │    └── fd: ()-->(1-6)
+ └── filters
+      ├── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
       └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
 
 # ------------------------------------------------------------------------------
@@ -853,7 +1556,108 @@ select
       └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
 # ------------------------------------------------------------------------------
-# Q7
+# Q7 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE u IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(4)=0.2, null(4)=0, distinct(2,4)=0.2, null(2,4)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 19.478
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE u IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(4)=0.2, null(4)=0, distinct(2,4)=0.2, null(2,4)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 48.4
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4]
+ │    ├── cost: 48.34
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)-->(1), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_u_key
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2
+ │         │    ├── [/110000000 - /110000000]
+ │         │    ├── [/120000000 - /120000000]
+ │         │    ├── [/130000000 - /130000000]
+ │         │    └── [/140000000 - /140000000]
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=4, distinct(2)=4, null(2)=0]
+ │         │   histogram(2)=  0      1      0      1      0      1      0      1
+ │         │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │         ├── cost: 24.09
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2), (2)-->(1)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE u IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(4)=1, null(4)=0, distinct(2,4)=1, null(2,4)=0]
+ │   histogram(2)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 25.15
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.12
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=1, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q8
 #
 # Choose between 4 equality spans on "d" and a single unbounded equality span
 # on "i". The "i" span is outside the histogram range. Note that an index join
@@ -950,6 +1754,100 @@ select
  │         └── fd: ()-->(4)
  └── filters
       └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q8 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE d IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(4)=0.2, null(4)=0, distinct(3,4)=0.2, null(3,4)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 19.488
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE d IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(4)=0.2, null(4)=0, distinct(3,4)=0.2, null(3,4)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 19.488
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.224
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE d IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(3,4)=1, null(3,4)=0]
+ │   histogram(3)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 25.16
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.12
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=1, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
 
 # ------------------------------------------------------------------------------
 # Q9
@@ -1063,6 +1961,113 @@ select
       └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
 # ------------------------------------------------------------------------------
+# Q9 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE e = 'PENDING' AND u IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(6)=0.2, null(6)=0, distinct(2,6)=0.2, null(2,6)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 19.478
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.2, distinct(6)=0.2, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE e = 'PENDING' AND u IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(6)=0.2, null(6)=0, distinct(2,6)=0.2, null(2,6)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 48.4
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4]
+ │    ├── cost: 48.34
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)-->(1), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_u_key
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2
+ │         │    ├── [/110000000 - /110000000]
+ │         │    ├── [/120000000 - /120000000]
+ │         │    ├── [/130000000 - /130000000]
+ │         │    └── [/140000000 - /140000000]
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=4, distinct(2)=4, null(2)=0]
+ │         │   histogram(2)=  0      1      0      1      0      1      0      1
+ │         │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │         ├── cost: 24.09
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2), (2)-->(1)
+ └── filters
+      └── e:6 = 'PENDING' [outer=(6), immutable, constraints=(/6: [/'PENDING' - /'PENDING']; tight), fd=()-->(6)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE e = 'PENDING' AND u IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(6)=1, null(6)=0, distinct(2,6)=1, null(2,6)=0]
+ │   histogram(2)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 25.15
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.12
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+# ------------------------------------------------------------------------------
 # Q10
 #
 # Choose between 4 equality spans on "d" and a partial index scan for a value of
@@ -1166,3 +2171,103 @@ select
  │         └── fd: (1)-->(4)
  └── filters
       └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q10 (large)
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t_large WHERE e = 'PENDING' AND d IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(6)=0.2, null(6)=0, distinct(3,6)=0.2, null(3,6)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 19.488
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.2, distinct(6)=0.2, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t_large WHERE e = 'PENDING' AND d IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(6)=0.2, null(6)=0, distinct(3,6)=0.2, null(3,6)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 19.488
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.2, distinct(6)=0.2, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.224
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t_large WHERE e = 'PENDING' AND d IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0, distinct(3,6)=1, null(3,6)=0]
+ │   histogram(3)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 25.16
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.12
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -254,6 +254,10 @@ exec-ddl
 SET optimizer_clamp_low_histogram_selectivity = false;
 ----
 
+exec-ddl
+SET optimizer_clamp_inequality_selectivity = false;
+----
+
 # ------------------------------------------------------------------------------
 # Q1
 #
@@ -378,6 +382,35 @@ index-join t
       ├── key: (1)
       └── fd: ()-->(4)
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
+----
+index-join t
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 24.0200012
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ └── scan t@t_i_idx
+      ├── columns: k:1!null i:4!null
+      ├── constraint: /4/1
+      │    ├── [/500/110 - /500/110]
+      │    ├── [/500/120 - /500/120]
+      │    ├── [/500/130 - /500/130]
+      │    └── [/500/140 - /500/140]
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
+      │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+      │                <--- 110 --- 120 --- 130 --- 140
+      │   histogram(4)=
+      ├── cost: 24.01
+      ├── key: (1)
+      └── fd: ()-->(4)
+
 # ------------------------------------------------------------------------------
 # Q1 (large)
 # ------------------------------------------------------------------------------
@@ -473,6 +506,36 @@ select
       └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
 
 opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    ├── [/130000000 - /130000000]
+ │    │    └── [/140000000 - /140000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
 SELECT * FROM t_large WHERE k IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
 ----
 select
@@ -639,6 +702,41 @@ index-join t
       └── filters
            └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
+----
+index-join t
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.0004001, distinct(1)=0.0004001, null(1)=0, distinct(4)=0.0004001, null(4)=0, distinct(1,4)=0.0004001, null(1,4)=0]
+ │   histogram(1)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 100 -------- 110 -------- 120 -------- 130 ---
+ │   histogram(4)=
+ ├── cost: 18.1554243
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── select
+      ├── columns: k:1!null i:4!null
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=0.0004, distinct(1)=0.0004, null(1)=0]
+      │   histogram(1)=  0 0.0001 0 0.0001 0 0.0001 0 0.0001
+      │                <--- 100 ---- 110 ---- 120 ---- 130 -
+      ├── cost: 18.1430001
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan t@t_i_idx
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/501/100 - ]
+      │    ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(4)=0.1, null(4)=0]
+      │    │   histogram(1)=  0  0  0.0099 0.0001 0.0199 0.0001 0.0299 0.0001 0.0399 0.0001
+      │    │                <--- 0 -------- 100 --------- 300 --------- 600 --------- 1000
+      │    │   histogram(4)=
+      │    ├── cost: 18.1220001
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q2 (large)
 # ------------------------------------------------------------------------------
@@ -739,6 +837,36 @@ select
       └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
 
 opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
 SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
 ----
 select
@@ -895,6 +1023,39 @@ index-join t
       └── filters
            └── k:1 IN (1010, 1020, 1030) [outer=(1), constraints=(/1: [/1010 - /1010] [/1020 - /1020] [/1030 - /1030]; tight)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
+----
+index-join t
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
+ │   histogram(1)=
+ │   histogram(4)=
+ ├── cost: 18.1530005
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── select
+      ├── columns: k:1!null i:4!null
+      ├── cardinality: [0 - 3]
+      ├── stats: [rows=2e-11, distinct(1)=2e-11, null(1)=0]
+      │   histogram(1)=
+      ├── cost: 18.1430001
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan t@t_i_idx
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/501/1010 - ]
+      │    ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(4)=0.1, null(4)=0]
+      │    │   histogram(1)=  0  0  0.0099 0.0001 0.0199 0.0001 0.0299 0.0001 0.0399 0.0001
+      │    │                <--- 0 -------- 100 --------- 300 --------- 600 --------- 1000
+      │    │   histogram(4)=
+      │    ├── cost: 18.1220001
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── k:1 IN (1010, 1020, 1030) [outer=(1), constraints=(/1: [/1010 - /1010] [/1020 - /1020] [/1030 - /1030]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q3 (large)
 # ------------------------------------------------------------------------------
@@ -1014,6 +1175,33 @@ select
  │    ├── stats: [rows=1.1, distinct(1)=1, null(1)=0]
  │    │   histogram(1)=
  │    ├── cost: 19.076
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE k IN (1010000000, 1020000000, 1030000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0]
+ │   histogram(1)=
+ │   histogram(4)=
+ ├── cost: 19.044
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/1010000000 - /1010000000]
+ │    │    ├── [/1020000000 - /1020000000]
+ │    │    └── [/1030000000 - /1030000000]
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0]
+ │    │   histogram(1)=
+ │    ├── cost: 19.022
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
@@ -1139,6 +1327,52 @@ select
       └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
 
 opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1.21e-05, distinct(1)=1.21e-05, null(1)=0, distinct(4)=1.21e-05, null(4)=0, distinct(5)=1.21e-05, null(5)=0, distinct(4,5)=1.21e-05, null(4,5)=0, distinct(1,4,5)=1.21e-05, null(1,4,5)=0]
+ │   histogram(1)=  0 3.025e-06 0 3.025e-06 0 3.025e-06 0 3.025e-06
+ │                <----- 100 ------- 110 ------- 120 ------- 130 --
+ │   histogram(4)=  0 1.21e-05
+ │                <---- 400 --
+ │   histogram(5)=
+ ├── cost: 18.1759271
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=0.0004]
+ │    ├── cost: 18.1559231
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── select
+ │         ├── columns: k:1!null s:5!null
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=0.0004, distinct(1)=0.0004, null(1)=0]
+ │         │   histogram(1)=  0 0.0001 0 0.0001 0 0.0001 0 0.0001
+ │         │                <--- 100 ---- 110 ---- 120 ---- 130 -
+ │         ├── cost: 18.1435001
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(5)
+ │         ├── scan t@t_s_idx
+ │         │    ├── columns: k:1!null s:5!null
+ │         │    ├── constraint: /5/1: (/NULL - /'apple')
+ │         │    ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(5)=0.1, null(5)=0]
+ │         │    │   histogram(1)=  0  0  0.0099 0.0001 0.0199 0.0001 0.0299 0.0001 0.0399 0.0001
+ │         │    │                <--- 0 -------- 100 --------- 300 --------- 600 --------- 1000
+ │         │    │   histogram(5)=
+ │         │    ├── cost: 18.1225001
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(5)
+ │         └── filters
+ │              └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
+ └── filters
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
@@ -1346,6 +1580,39 @@ select
  └── filters
       └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i = 400000000 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0, distinct(1,4,5)=0.2, null(1,4,5)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 24.32
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      ├── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+      └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
+
 # ------------------------------------------------------------------------------
 # Q5
 #
@@ -1444,6 +1711,35 @@ select
       └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
 
 opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE i = 400 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=0.0030001, distinct(4)=0.0030001, null(4)=0, distinct(5)=0.0030001, null(5)=0, distinct(4,5)=0.0030001, null(4,5)=0]
+ │   histogram(4)=  0 0.0030001
+ │                <----- 400 --
+ │   histogram(5)=
+ ├── cost: 18.7792507
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.1]
+ │    ├── cost: 18.7482507
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=0.1, distinct(5)=0.1, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 18.1225001
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
@@ -1595,6 +1891,35 @@ select
  └── filters
       └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE i = 400000000 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=3000.1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0]
+ │   histogram(4)=  0   3000.1
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 709268.779
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=100000]
+ │    ├── cost: 708268.748
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=100000, distinct(5)=1, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 102518.122
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+
 # ------------------------------------------------------------------------------
 # Q6
 #
@@ -1735,6 +2060,41 @@ select
  └── filters
       └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0]
+ │   histogram(1)=  0 2e-07
+ │                <--- 100
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.04000122
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 9.02000122
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-6)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500/100 - /500/100]
+ │         ├── cardinality: [0 - 1]
+ │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
+ │         │   histogram(1)=  0 2e-07
+ │         │                <--- 100
+ │         │   histogram(4)=
+ │         ├── cost: 9.01
+ │         ├── key: ()
+ │         └── fd: ()-->(1,4)
+ └── filters
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
 # ------------------------------------------------------------------------------
 # Q6 (large)
 # ------------------------------------------------------------------------------
@@ -1824,6 +2184,34 @@ select
       └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
 
 opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k = 100000000 AND i = 500000000 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0]
+ │   histogram(1)=  0     0.2
+ │                <--- 100000000
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.11
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1: [/100000000 - /100000000]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=  0      1
+ │    │                <--- 100000000
+ │    ├── cost: 9.07
+ │    ├── key: ()
+ │    └── fd: ()-->(1-6)
+ └── filters
+      ├── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
 SELECT * FROM t_large WHERE k = 100000000 AND i = 500000000 AND s = 'zzz'
 ----
 select
@@ -1986,6 +2374,36 @@ select
  └── filters
       └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(4)=2e-07, null(4)=0, distinct(2,4)=2e-07, null(2,4)=0]
+ │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 18.0600014
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.0200002
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q7 (large)
 # ------------------------------------------------------------------------------
@@ -2124,6 +2542,36 @@ select
  └── filters
       └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE u IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(4)=0.2, null(4)=0, distinct(2,4)=0.2, null(2,4)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 19.478
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q8
 #
@@ -2247,6 +2695,35 @@ select
  │         ├── stats: [rows=0.1, distinct(4)=0.1, null(4)=0]
  │         │   histogram(4)=
  │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(4)=2e-07, null(4)=0, distinct(3,4)=2e-07, null(3,4)=0]
+ │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 18.0700014
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.0200002
  │         ├── key: (1)
  │         └── fd: ()-->(4)
  └── filters
@@ -2379,6 +2856,35 @@ select
  │         └── fd: (1)-->(3)
  └── filters
       └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE d IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(4)=0.2, null(4)=0, distinct(3,4)=0.2, null(3,4)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 19.488
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t_large@t_large_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500000000 - /500000000]
+ │         ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
 
 # ------------------------------------------------------------------------------
 # Q9
@@ -2518,6 +3024,38 @@ select
  │         │   histogram(6)=  0      0
  │         │                <--- 'PENDING'
  │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE e = 'PENDING' AND u IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(6)=2e-07, null(6)=0, distinct(2,6)=2e-07, null(2,6)=0]
+ │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.0600014
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=2e-07, distinct(6)=2e-07, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.0200002
  │         ├── key: (1)
  │         └── fd: (1)-->(4)
  └── filters
@@ -2669,6 +3207,38 @@ select
  └── filters
       └── e:6 = 'PENDING' [outer=(6), immutable, constraints=(/6: [/'PENDING' - /'PENDING']; tight), fd=()-->(6)]
 
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE e = 'PENDING' AND u IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(6)=0.2, null(6)=0, distinct(2,6)=0.2, null(2,6)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 19.478
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.2, distinct(6)=0.2, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q10
 #
@@ -2800,6 +3370,37 @@ select
  │         │   histogram(6)=  0      0
  │         │                <--- 'PENDING'
  │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t WHERE e = 'PENDING' AND d IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(6)=2e-07, null(6)=0, distinct(3,6)=2e-07, null(3,6)=0]
+ │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.0700014
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=2e-07, distinct(6)=2e-07, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.0200002
  │         ├── key: (1)
  │         └── fd: (1)-->(4)
  └── filters
@@ -2940,3 +3541,34 @@ select
  │         └── fd: (1)-->(3)
  └── filters
       └── e:6 = 'PENDING' [outer=(6), immutable, constraints=(/6: [/'PENDING' - /'PENDING']; tight), fd=()-->(6)]
+
+opt set=optimizer_clamp_inequality_selectivity=true
+SELECT * FROM t_large WHERE e = 'PENDING' AND d IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(6)=0.2, null(6)=0, distinct(3,6)=0.2, null(3,6)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 19.488
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.2]
+ │    ├── cost: 19.456
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.2, distinct(6)=0.2, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.224
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -6,6 +6,8 @@
 exec-ddl
 CREATE TABLE t (
   k INT PRIMARY KEY,
+  u INT UNIQUE,
+  d INT,
   i INT,
   s STRING,
   INDEX (i),
@@ -17,6 +19,38 @@ exec-ddl
 ALTER TABLE t INJECT STATISTICS '[
   {
     "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99, "distinct_range": 99, "upper_bound": "100"},
+      {"num_eq": 1, "num_range": 199, "distinct_range": 199, "upper_bound": "300"},
+      {"num_eq": 1, "num_range": 299, "distinct_range": 299, "upper_bound": "600"},
+      {"num_eq": 1, "num_range": 399, "distinct_range": 399, "upper_bound": "1000"}
+    ]
+  },
+  {
+    "columns": ["u"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99, "distinct_range": 99, "upper_bound": "100"},
+      {"num_eq": 1, "num_range": 199, "distinct_range": 199, "upper_bound": "300"},
+      {"num_eq": 1, "num_range": 299, "distinct_range": 299, "upper_bound": "600"},
+      {"num_eq": 1, "num_range": 399, "distinct_range": 399, "upper_bound": "1000"}
+    ]
+  },
+  {
+    "columns": ["d"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
     "row_count": 1000,
     "distinct_count": 1000,
@@ -89,75 +123,75 @@ opt
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 4]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 110 --- 120 --- 130 --- 140
- │   histogram(2)=
+ │   histogram(4)=
  ├── cost: 24.0200012
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  └── scan t@t_i_idx
-      ├── columns: k:1!null i:2!null
-      ├── constraint: /2/1
+      ├── columns: k:1!null i:4!null
+      ├── constraint: /4/1
       │    ├── [/500/110 - /500/110]
       │    ├── [/500/120 - /500/120]
       │    ├── [/500/130 - /500/130]
       │    └── [/500/140 - /500/140]
       ├── cardinality: [0 - 4]
-      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
       │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
       │                <--- 110 --- 120 --- 130 --- 140
-      │   histogram(2)=
+      │   histogram(4)=
       ├── cost: 24.01
       ├── key: (1)
-      └── fd: ()-->(2)
+      └── fd: ()-->(4)
 
 opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 4]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 110 --- 120 --- 130 --- 140
- │   histogram(2)=
+ │   histogram(4)=
  ├── cost: 24.0200012
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  └── scan t@t_i_idx
-      ├── columns: k:1!null i:2!null
-      ├── constraint: /2/1
+      ├── columns: k:1!null i:4!null
+      ├── constraint: /4/1
       │    ├── [/500/110 - /500/110]
       │    ├── [/500/120 - /500/120]
       │    ├── [/500/130 - /500/130]
       │    └── [/500/140 - /500/140]
       ├── cardinality: [0 - 4]
-      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
       │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
       │                <--- 110 --- 120 --- 130 --- 140
-      │   histogram(2)=
+      │   histogram(4)=
       ├── cost: 24.01
       ├── key: (1)
-      └── fd: ()-->(2)
+      └── fd: ()-->(4)
 
 opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 4]
- ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
  │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 110 --- 120 --- 130 --- 140
- │   histogram(2)=
- ├── cost: 24.21
+ │   histogram(4)=
+ ├── cost: 24.29
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/110 - /110]
  │    │    ├── [/120 - /120]
@@ -167,11 +201,11 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 110 --- 120 --- 130 --- 140
- │    ├── cost: 24.15
+ │    ├── cost: 24.23
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      └── i:2 = 500 [outer=(2), constraints=(/2: [/500 - /500]; tight), fd=()-->(2)]
+      └── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
 
 # ------------------------------------------------------------------------------
 # Q2
@@ -184,34 +218,34 @@ opt
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 index-join t
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 4]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 100 --- 110 --- 120 --- 130
- │   histogram(2)=
+ │   histogram(4)=
  ├── cost: 18.0500006
  ├── key: (1)
- ├── fd: (1)-->(2,3)
+ ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── select
-      ├── columns: k:1!null i:2!null
+      ├── columns: k:1!null i:4!null
       ├── cardinality: [0 - 4]
       ├── stats: [rows=8e-10, distinct(1)=8e-10, null(1)=0]
       │   histogram(1)=  0 2e-10 0 2e-10 0 2e-10 0 2e-10
       │                <--- 100 --- 110 --- 120 --- 130
       ├── cost: 18.0400002
       ├── key: (1)
-      ├── fd: (1)-->(2)
+      ├── fd: (1)-->(4)
       ├── scan t@t_i_idx
-      │    ├── columns: k:1!null i:2!null
-      │    ├── constraint: /2/1: [/501/100 - ]
-      │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/501/100 - ]
+      │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
       │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
       │    │                <--- 0 ---------- 100 ---------- 300 ---------- 600 ---------- 1000
-      │    │   histogram(2)=
+      │    │   histogram(4)=
       │    ├── cost: 18.0200002
       │    ├── key: (1)
-      │    └── fd: (1)-->(2)
+      │    └── fd: (1)-->(4)
       └── filters
            └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
 
@@ -219,17 +253,17 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 4]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 100 --- 110 --- 120 --- 130
- │   histogram(2)=
- ├── cost: 24.21
+ │   histogram(4)=
+ ├── cost: 24.29
  ├── key: (1)
- ├── fd: (1)-->(2,3)
+ ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -239,27 +273,27 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.15
+ │    ├── cost: 24.23
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+      └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
 opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 4]
- ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
  │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 100 --- 110 --- 120 --- 130
- │   histogram(2)=
- ├── cost: 24.21
+ │   histogram(4)=
+ ├── cost: 24.29
  ├── key: (1)
- ├── fd: (1)-->(2,3)
+ ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -269,11 +303,11 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.15
+ │    ├── cost: 24.23
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+      └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
 # ------------------------------------------------------------------------------
 # Q3
@@ -286,32 +320,32 @@ opt
 SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 index-join t
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 3]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
  │   histogram(1)=
- │   histogram(2)=
+ │   histogram(4)=
  ├── cost: 18.0500006
  ├── key: (1)
- ├── fd: (1)-->(2,3)
+ ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── select
-      ├── columns: k:1!null i:2!null
+      ├── columns: k:1!null i:4!null
       ├── cardinality: [0 - 3]
       ├── stats: [rows=4e-17, distinct(1)=4e-17, null(1)=0]
       │   histogram(1)=
       ├── cost: 18.0400002
       ├── key: (1)
-      ├── fd: (1)-->(2)
+      ├── fd: (1)-->(4)
       ├── scan t@t_i_idx
-      │    ├── columns: k:1!null i:2!null
-      │    ├── constraint: /2/1: [/501/1010 - ]
-      │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/501/1010 - ]
+      │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
       │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
       │    │                <--- 0 ---------- 100 ---------- 300 ---------- 600 ---------- 1000
-      │    │   histogram(2)=
+      │    │   histogram(4)=
       │    ├── cost: 18.0200002
       │    ├── key: (1)
-      │    └── fd: (1)-->(2)
+      │    └── fd: (1)-->(4)
       └── filters
            └── k:1 IN (1010, 1020, 1030) [outer=(1), constraints=(/1: [/1010 - /1010] [/1020 - /1020] [/1030 - /1030]; tight)]
 
@@ -319,16 +353,16 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 select
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 3]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
  │   histogram(1)=
- │   histogram(2)=
+ │   histogram(4)=
  ├── cost: 19.03
  ├── key: (1)
- ├── fd: (1)-->(2,3)
+ ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/1010 - /1010]
  │    │    ├── [/1020 - /1020]
@@ -338,24 +372,24 @@ select
  │    │   histogram(1)=
  │    ├── cost: 19.01
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+      └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
 opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 select
- ├── columns: k:1!null i:2!null s:3
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5
  ├── cardinality: [0 - 3]
- ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0]
  │   histogram(1)=
- │   histogram(2)=
+ │   histogram(4)=
  ├── cost: 19.03
  ├── key: (1)
- ├── fd: (1)-->(2,3)
+ ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/1010 - /1010]
  │    │    ├── [/1020 - /1020]
@@ -365,9 +399,9 @@ select
  │    │   histogram(1)=
  │    ├── cost: 19.01
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+      └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
 # ------------------------------------------------------------------------------
 # Q4
@@ -380,65 +414,65 @@ opt
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
  ├── cardinality: [0 - 4]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0, distinct(1-3)=2e-07, null(1-3)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0, distinct(1,4,5)=2e-07, null(1,4,5)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 100 --- 110 --- 120 --- 130
- │   histogram(2)=  0 2e-07
+ │   histogram(4)=  0 2e-07
  │                <--- 400
- │   histogram(3)=
+ │   histogram(5)=
  ├── cost: 18.0700002
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── index-join t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── cardinality: [0 - 4]
  │    ├── stats: [rows=8e-10]
  │    ├── cost: 18.0500002
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
+ │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  │    └── select
- │         ├── columns: k:1!null s:3!null
+ │         ├── columns: k:1!null s:5!null
  │         ├── cardinality: [0 - 4]
  │         ├── stats: [rows=8e-10, distinct(1)=8e-10, null(1)=0]
  │         │   histogram(1)=  0 2e-10 0 2e-10 0 2e-10 0 2e-10
  │         │                <--- 100 --- 110 --- 120 --- 130
  │         ├── cost: 18.0400002
  │         ├── key: (1)
- │         ├── fd: (1)-->(3)
+ │         ├── fd: (1)-->(5)
  │         ├── scan t@t_s_idx
- │         │    ├── columns: k:1!null s:3!null
- │         │    ├── constraint: /3/1: (/NULL - /'apple')
- │         │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(3)=2e-07, null(3)=0]
+ │         │    ├── columns: k:1!null s:5!null
+ │         │    ├── constraint: /5/1: (/NULL - /'apple')
+ │         │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(5)=2e-07, null(5)=0]
  │         │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
  │         │    │                <--- 0 ---------- 100 ---------- 300 ---------- 600 ---------- 1000
- │         │    │   histogram(3)=
+ │         │    │   histogram(5)=
  │         │    ├── cost: 18.0200002
  │         │    ├── key: (1)
- │         │    └── fd: (1)-->(3)
+ │         │    └── fd: (1)-->(5)
  │         └── filters
  │              └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
  └── filters
-      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
 
 opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
  ├── cardinality: [0 - 4]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0, distinct(1-3)=2e-07, null(1-3)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0, distinct(1,4,5)=2e-07, null(1,4,5)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 100 --- 110 --- 120 --- 130
- │   histogram(2)=  0 2e-07
+ │   histogram(4)=  0 2e-07
  │                <--- 400
- │   histogram(3)=
- ├── cost: 24.22
+ │   histogram(5)=
+ ├── cost: 24.3
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -448,30 +482,30 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.15
+ │    ├── cost: 24.23
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
-      └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
+      ├── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+      └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
 
 opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
  ├── cardinality: [0 - 4]
- ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1, null(2,3)=0, distinct(1-3)=1, null(1-3)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0, distinct(1,4,5)=1, null(1,4,5)=0]
  │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 100 --- 110 --- 120 --- 130
- │   histogram(2)=  0   1
+ │   histogram(4)=  0   1
  │                <--- 400
- │   histogram(3)=
- ├── cost: 24.22
+ │   histogram(5)=
+ ├── cost: 24.3
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -481,12 +515,12 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.15
+ │    ├── cost: 24.23
  │    ├── key: (1)
- │    └── fd: (1)-->(2,3)
+ │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
  └── filters
-      ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
-      └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
+      ├── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+      └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
 
 # ------------------------------------------------------------------------------
 # Q5
@@ -499,91 +533,91 @@ opt
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
- ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0]
- │   histogram(2)=  0 2e-07
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0]
+ │   histogram(4)=  0 2e-07
  │                <--- 400
- │   histogram(3)=
+ │   histogram(5)=
  ├── cost: 18.0700014
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── index-join t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
+ │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  │    └── scan t@t_s_idx
- │         ├── columns: k:1!null s:3!null
- │         ├── constraint: /3/1: [/e'z\x00' - ]
- │         ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0]
- │         │   histogram(3)=
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=2e-07, distinct(5)=2e-07, null(5)=0]
+ │         │   histogram(5)=
  │         ├── cost: 18.0200002
  │         ├── key: (1)
- │         └── fd: (1)-->(3)
+ │         └── fd: (1)-->(5)
  └── filters
-      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
 
 opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
- ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0]
- │   histogram(2)=  0 2e-07
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0]
+ │   histogram(4)=  0 2e-07
  │                <--- 400
- │   histogram(3)=
+ │   histogram(5)=
  ├── cost: 18.0700014
  ├── cost-flags: unbounded-cardinality
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── index-join t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── cost-flags: unbounded-cardinality
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
+ │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  │    └── scan t@t_s_idx
- │         ├── columns: k:1!null s:3!null
- │         ├── constraint: /3/1: [/e'z\x00' - ]
- │         ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0]
- │         │   histogram(3)=
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=2e-07, distinct(5)=2e-07, null(5)=0]
+ │         │   histogram(5)=
  │         ├── cost: 18.0200002
  │         ├── cost-flags: unbounded-cardinality
  │         ├── key: (1)
- │         └── fd: (1)-->(3)
+ │         └── fd: (1)-->(5)
  └── filters
-      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
 
 opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
- ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1, null(2,3)=0]
- │   histogram(2)=  0   1
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0]
+ │   histogram(4)=  0   1
  │                <--- 400
- │   histogram(3)=
- ├── cost: 25.1375
+ │   histogram(5)=
+ ├── cost: 25.1575
  ├── key: (1)
- ├── fd: ()-->(2), (1)-->(3)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
  ├── index-join t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── stats: [rows=1]
- │    ├── cost: 25.0975
+ │    ├── cost: 25.1175
  │    ├── key: (1)
- │    ├── fd: (1)-->(2,3)
+ │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
  │    └── scan t@t_s_idx
- │         ├── columns: k:1!null s:3!null
- │         ├── constraint: /3/1: [/e'z\x00' - ]
- │         ├── stats: [rows=1, distinct(3)=1, null(3)=0]
- │         │   histogram(3)=
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=1, distinct(5)=1, null(5)=0]
+ │         │   histogram(5)=
  │         ├── cost: 19.045
  │         ├── key: (1)
- │         └── fd: (1)-->(3)
+ │         └── fd: (1)-->(5)
  └── filters
-      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
 
 # ------------------------------------------------------------------------------
 # Q6
@@ -596,96 +630,300 @@ opt
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
  ├── cardinality: [0 - 1]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0]
  │   histogram(1)=  0 2e-07
  │                <--- 100
- │   histogram(2)=
- │   histogram(3)=
- ├── cost: 9.04000121
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.04000122
  ├── key: ()
- ├── fd: ()-->(1-3)
+ ├── fd: ()-->(1-5)
  ├── index-join t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=2e-07]
- │    ├── cost: 9.02000121
+ │    ├── cost: 9.02000122
  │    ├── key: ()
- │    ├── fd: ()-->(1-3)
+ │    ├── fd: ()-->(1-5)
  │    └── scan t@t_i_idx
- │         ├── columns: k:1!null i:2!null
- │         ├── constraint: /2/1: [/500/100 - /500/100]
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500/100 - /500/100]
  │         ├── cardinality: [0 - 1]
- │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │         │   histogram(1)=  0 2e-07
  │         │                <--- 100
- │         │   histogram(2)=
+ │         │   histogram(4)=
  │         ├── cost: 9.01
  │         ├── key: ()
- │         └── fd: ()-->(1,2)
+ │         └── fd: ()-->(1,4)
  └── filters
-      └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
 
 opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
  ├── cardinality: [0 - 1]
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0]
  │   histogram(1)=  0 2e-07
  │                <--- 100
- │   histogram(2)=
- │   histogram(3)=
- ├── cost: 9.04000121
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.04000122
  ├── key: ()
- ├── fd: ()-->(1-3)
+ ├── fd: ()-->(1-5)
  ├── index-join t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=2e-07]
- │    ├── cost: 9.02000121
+ │    ├── cost: 9.02000122
  │    ├── key: ()
- │    ├── fd: ()-->(1-3)
+ │    ├── fd: ()-->(1-5)
  │    └── scan t@t_i_idx
- │         ├── columns: k:1!null i:2!null
- │         ├── constraint: /2/1: [/500/100 - /500/100]
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500/100 - /500/100]
  │         ├── cardinality: [0 - 1]
- │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │         │   histogram(1)=  0 2e-07
  │         │                <--- 100
- │         │   histogram(2)=
+ │         │   histogram(4)=
  │         ├── cost: 9.01
  │         ├── key: ()
- │         └── fd: ()-->(1,2)
+ │         └── fd: ()-->(1,4)
  └── filters
-      └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
 
 opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
- ├── columns: k:1!null i:2!null s:3!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0]
  │   histogram(1)=  0   1
  │                <--- 100
- │   histogram(2)=
- │   histogram(3)=
- ├── cost: 9.085
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.105
  ├── key: ()
- ├── fd: ()-->(1-3)
+ ├── fd: ()-->(1-5)
  ├── scan t
- │    ├── columns: k:1!null i:2 s:3
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
  │    ├── constraint: /1: [/100 - /100]
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  │    │   histogram(1)=  0   1
  │    │                <--- 100
- │    ├── cost: 9.045
+ │    ├── cost: 9.065
  │    ├── key: ()
- │    └── fd: ()-->(1-3)
+ │    └── fd: ()-->(1-5)
  └── filters
-      ├── i:2 = 500 [outer=(2), constraints=(/2: [/500 - /500]; tight), fd=()-->(2)]
-      └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
+      ├── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
+# ------------------------------------------------------------------------------
+# Q7
+#
+# Choose between 4 single-row equality spans on "u" and a single unbounded
+# equality span on "i". The "i" span is outside the histogram range. Note that
+# an index join is required for both possible plans.
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(4)=2e-07, null(4)=0, distinct(2,4)=2e-07, null(2,4)=0]
+ │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 18.0600014
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)-->(1,3,5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.0200002
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(4)=2e-07, null(4)=0, distinct(2,4)=2e-07, null(2,4)=0]
+ │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 48.38
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)-->(1,3,5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4]
+ │    ├── cost: 48.32
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5), (2)-->(1), (2)~~>(1,3-5)
+ │    └── scan t@t_u_key
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2
+ │         │    ├── [/110 - /110]
+ │         │    ├── [/120 - /120]
+ │         │    ├── [/130 - /130]
+ │         │    └── [/140 - /140]
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=4, distinct(2)=4, null(2)=0]
+ │         │   histogram(2)=  0   1   0   1   0   1   0   1
+ │         │                <--- 110 --- 120 --- 130 --- 140
+ │         ├── cost: 24.09
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2), (2)-->(1)
+ └── filters
+      └── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(4)=1, null(4)=0, distinct(2,4)=1, null(2,4)=0]
+ │   histogram(2)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 25.145
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)-->(1,3,5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.115
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=1, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q7
+#
+# Choose between 4 equality spans on "d" and a single unbounded equality span
+# on "i". The "i" span is outside the histogram range. Note that an index join
+# is required for both possible plans, and "d" has no uniqueness guarantee, but
+# has the same histogram as "k".
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5
+ ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(4)=2e-07, null(4)=0, distinct(3,4)=2e-07, null(3,4)=0]
+ │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 18.0700014
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.0200002
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5
+ ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(4)=2e-07, null(4)=0, distinct(3,4)=2e-07, null(3,4)=0]
+ │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 18.0700014
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.0200002
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5
+ ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(3,4)=1, null(3,4)=0]
+ │   histogram(3)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(4)=
+ ├── cost: 25.155
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.115
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=1, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -250,6 +250,10 @@ exec-ddl
 SET enable_zigzag_join = false;
 ----
 
+exec-ddl
+SET optimizer_clamp_low_histogram_selectivity = false;
+----
+
 # ------------------------------------------------------------------------------
 # Q1
 #
@@ -345,6 +349,35 @@ select
  └── filters
       └── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
+----
+index-join t
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.0004001, distinct(1)=0.0004001, null(1)=0, distinct(4)=0.0004001, null(4)=0, distinct(1,4)=0.0004001, null(1,4)=0]
+ │   histogram(1)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 110 -------- 120 -------- 130 -------- 140 ---
+ │   histogram(4)=
+ ├── cost: 24.0224326
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ └── scan t@t_i_idx
+      ├── columns: k:1!null i:4!null
+      ├── constraint: /4/1
+      │    ├── [/500/110 - /500/110]
+      │    ├── [/500/120 - /500/120]
+      │    ├── [/500/130 - /500/130]
+      │    └── [/500/140 - /500/140]
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=0.0004001, distinct(1)=0.0004001, null(1)=0, distinct(4)=0.0004001, null(4)=0, distinct(1,4)=0.0004001, null(1,4)=0]
+      │   histogram(1)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+      │                <----- 110 -------- 120 -------- 130 -------- 140 ---
+      │   histogram(4)=
+      ├── cost: 24.010008
+      ├── key: (1)
+      └── fd: ()-->(4)
+
 # ------------------------------------------------------------------------------
 # Q1 (large)
 # ------------------------------------------------------------------------------
@@ -417,6 +450,36 @@ select
  ├── cardinality: [0 - 4]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
  │   histogram(1)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    ├── [/130000000 - /130000000]
+ │    │    └── [/140000000 - /140000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
  │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
  │   histogram(4)=
  ├── cost: 24.31
@@ -541,6 +604,41 @@ select
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
+----
+index-join t
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.0004001, distinct(1)=0.0004001, null(1)=0, distinct(4)=0.0004001, null(4)=0, distinct(1,4)=0.0004001, null(1,4)=0]
+ │   histogram(1)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 100 -------- 110 -------- 120 -------- 130 ---
+ │   histogram(4)=
+ ├── cost: 18.1554243
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── select
+      ├── columns: k:1!null i:4!null
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=0.0004, distinct(1)=0.0004, null(1)=0]
+      │   histogram(1)=  0 0.0001 0 0.0001 0 0.0001 0 0.0001
+      │                <--- 100 ---- 110 ---- 120 ---- 130 -
+      ├── cost: 18.1430001
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan t@t_i_idx
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/501/100 - ]
+      │    ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(4)=0.1, null(4)=0]
+      │    │   histogram(1)=  0  0  0.0099 0.0001 0.0199 0.0001 0.0299 0.0001 0.0399 0.0001
+      │    │                <--- 0 -------- 100 --------- 300 --------- 600 --------- 1000
+      │    │   histogram(4)=
+      │    ├── cost: 18.1220001
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q2 (large)
 # ------------------------------------------------------------------------------
@@ -618,6 +716,36 @@ select
  ├── cardinality: [0 - 4]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
  │   histogram(1)=  0    0.25     0    0.25     0    0.25     0    0.25
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=
+ ├── cost: 24.31
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/100000000 - /100000000]
+ │    │    ├── [/110000000 - /110000000]
+ │    │    ├── [/120000000 - /120000000]
+ │    │    └── [/130000000 - /130000000]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0      1      0      1      0      1      0      1
+ │    │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │    ├── cost: 24.25
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(1,4)=0.2, null(1,4)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
  │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
  │   histogram(4)=
  ├── cost: 24.31
@@ -734,6 +862,39 @@ select
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
+----
+index-join t
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=1.01e-05, distinct(1)=1.01e-05, null(1)=0, distinct(4)=1.01e-05, null(4)=0]
+ │   histogram(1)=
+ │   histogram(4)=
+ ├── cost: 18.5530209
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── select
+      ├── columns: k:1!null i:4!null
+      ├── cardinality: [0 - 3]
+      ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0]
+      │   histogram(1)=
+      ├── cost: 18.1430001
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan t@t_i_idx
+      │    ├── columns: k:1!null i:4!null
+      │    ├── constraint: /4/1: [/501/1010 - ]
+      │    ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(4)=0.1, null(4)=0]
+      │    │   histogram(1)=  0  0  0.0099 0.0001 0.0199 0.0001 0.0299 0.0001 0.0399 0.0001
+      │    │                <--- 0 -------- 100 --------- 300 --------- 600 --------- 1000
+      │    │   histogram(4)=
+      │    ├── cost: 18.1220001
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── k:1 IN (1010, 1020, 1030) [outer=(1), constraints=(/1: [/1010 - /1010] [/1020 - /1020] [/1030 - /1030]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q3 (large)
 # ------------------------------------------------------------------------------
@@ -826,6 +987,33 @@ select
  │    │   histogram(1)=  0      1      0      1      0      1
  │    │                <--- 410000000 --- 420000000 --- 430000000
  │    ├── cost: 19.19
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ └── filters
+      └── i:4 > 500000000 [outer=(4), constraints=(/4: [/500000001 - ]; tight)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k IN (1010000000, 1020000000, 1030000000) AND i > 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0]
+ │   histogram(1)=
+ │   histogram(4)=
+ ├── cost: 19.107
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1
+ │    │    ├── [/1010000000 - /1010000000]
+ │    │    ├── [/1020000000 - /1020000000]
+ │    │    └── [/1030000000 - /1030000000]
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=1.1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=
+ │    ├── cost: 19.076
  │    ├── key: (1)
  │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
@@ -950,6 +1138,52 @@ select
       ├── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
       └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1.21e-05, distinct(1)=1.21e-05, null(1)=0, distinct(4)=1.21e-05, null(4)=0, distinct(5)=1.21e-05, null(5)=0, distinct(4,5)=1.21e-05, null(4,5)=0, distinct(1,4,5)=1.21e-05, null(1,4,5)=0]
+ │   histogram(1)=  0 3.025e-06 0 3.025e-06 0 3.025e-06 0 3.025e-06
+ │                <----- 100 ------- 110 ------- 120 ------- 130 --
+ │   histogram(4)=  0 1.21e-05
+ │                <---- 400 --
+ │   histogram(5)=
+ ├── cost: 18.1759271
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=0.0004]
+ │    ├── cost: 18.1559231
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── select
+ │         ├── columns: k:1!null s:5!null
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=0.0004, distinct(1)=0.0004, null(1)=0]
+ │         │   histogram(1)=  0 0.0001 0 0.0001 0 0.0001 0 0.0001
+ │         │                <--- 100 ---- 110 ---- 120 ---- 130 -
+ │         ├── cost: 18.1435001
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(5)
+ │         ├── scan t@t_s_idx
+ │         │    ├── columns: k:1!null s:5!null
+ │         │    ├── constraint: /5/1: (/NULL - /'apple')
+ │         │    ├── stats: [rows=0.1, distinct(1)=0.1, null(1)=0, distinct(5)=0.1, null(5)=0]
+ │         │    │   histogram(1)=  0  0  0.0099 0.0001 0.0199 0.0001 0.0299 0.0001 0.0399 0.0001
+ │         │    │                <--- 0 -------- 100 --------- 300 --------- 600 --------- 1000
+ │         │    │   histogram(5)=
+ │         │    ├── cost: 18.1225001
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(5)
+ │         └── filters
+ │              └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
+ └── filters
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+
 # ------------------------------------------------------------------------------
 # Q4 (large)
 # ------------------------------------------------------------------------------
@@ -1066,6 +1300,52 @@ select
       ├── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
       └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i = 400000000 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0, distinct(1,4,5)=0.2, null(1,4,5)=0]
+ │   histogram(1)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 20.7610001
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=1.066e-08]
+ │    ├── cost: 20.7410001
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── select
+ │         ├── columns: k:1!null s:5!null
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=1.066e-08, distinct(1)=1.04e-08, null(1)=0]
+ │         │   histogram(1)=  0   2.6e-09   0   2.6e-09   0   2.6e-09   0   2.6e-09
+ │         │                <--- 100000000 --- 110000000 --- 120000000 --- 130000000
+ │         ├── cost: 20.731
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(5)
+ │         ├── scan t_large@t_large_s_idx
+ │         │    ├── columns: k:1!null s:5!null
+ │         │    ├── constraint: /5/1: (/NULL - /'apple')
+ │         │    ├── stats: [rows=2.6, distinct(1)=2.6, null(1)=0, distinct(5)=1, null(5)=0]
+ │         │    │   histogram(1)=  0  0  0.26   2.6e-09   0.52   2.6e-09   0.78   2.6e-09   1.04   2.6e-09
+ │         │    │                <--- 0 ------ 100000000 ------ 300000000 ------ 600000000 ------ 1000000000
+ │         │    │   histogram(5)=
+ │         │    ├── cost: 20.685
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(5)
+ │         └── filters
+ │              └── k:1 IN (100000000, 110000000, 120000000, 130000000) [outer=(1), constraints=(/1: [/100000000 - /100000000] [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000]; tight)]
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+
 # ------------------------------------------------------------------------------
 # Q5
 #
@@ -1163,6 +1443,35 @@ select
  └── filters
       └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE i = 400 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=0.0030001, distinct(4)=0.0030001, null(4)=0, distinct(5)=0.0030001, null(5)=0, distinct(4,5)=0.0030001, null(4,5)=0]
+ │   histogram(4)=  0 0.0030001
+ │                <----- 400 --
+ │   histogram(5)=
+ ├── cost: 18.7792507
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.1]
+ │    ├── cost: 18.7482507
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=0.1, distinct(5)=0.1, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 18.1225001
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
+
 # ------------------------------------------------------------------------------
 # Q5 (large)
 # ------------------------------------------------------------------------------
@@ -1252,6 +1561,35 @@ select
  │         ├── stats: [rows=1, distinct(5)=1, null(5)=0]
  │         │   histogram(5)=
  │         ├── cost: 19.045
+ │         ├── key: (1)
+ │         └── fd: (1)-->(5)
+ └── filters
+      └── i:4 = 400000000 [outer=(4), constraints=(/4: [/400000000 - /400000000]; tight), fd=()-->(4)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE i = 400000000 AND s > 'z'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── stats: [rows=0.2, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0, distinct(4,5)=0.2, null(4,5)=0]
+ │   histogram(4)=  0     0.2
+ │                <--- 400000000
+ │   histogram(5)=
+ ├── cost: 36.5105
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2.6]
+ │    ├── cost: 36.4545
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_s_idx
+ │         ├── columns: k:1!null s:5!null
+ │         ├── constraint: /5/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=2.6, distinct(5)=1, null(5)=0]
+ │         │   histogram(5)=
+ │         ├── cost: 20.685
  │         ├── key: (1)
  │         └── fd: (1)-->(5)
  └── filters
@@ -1362,6 +1700,41 @@ select
       ├── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
       └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0]
+ │   histogram(1)=  0 2e-07
+ │                <--- 100
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.04060961
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=0.0001001]
+ │    ├── cost: 9.02060861
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-6)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500/100 - /500/100]
+ │         ├── cardinality: [0 - 1]
+ │         ├── stats: [rows=0.0001001, distinct(1)=0.0001001, null(1)=0, distinct(4)=0.0001001, null(4)=0, distinct(1,4)=0.0001001, null(1,4)=0]
+ │         │   histogram(1)=  0 0.0001001
+ │         │                <----- 100 --
+ │         │   histogram(4)=
+ │         ├── cost: 9.010002
+ │         ├── key: ()
+ │         └── fd: ()-->(1,4)
+ └── filters
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
 # ------------------------------------------------------------------------------
 # Q6 (large)
 # ------------------------------------------------------------------------------
@@ -1430,6 +1803,34 @@ select
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0]
  │   histogram(1)=  0      1
+ │                <--- 100000000
+ │   histogram(4)=
+ │   histogram(5)=
+ ├── cost: 9.11
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── scan t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── constraint: /1: [/100000000 - /100000000]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=  0      1
+ │    │                <--- 100000000
+ │    ├── cost: 9.07
+ │    ├── key: ()
+ │    └── fd: ()-->(1-6)
+ └── filters
+      ├── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+      └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE k = 100000000 AND i = 500000000 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.2, distinct(1)=0.2, null(1)=0, distinct(4)=0.2, null(4)=0, distinct(5)=0.2, null(5)=0]
+ │   histogram(1)=  0     0.2
  │                <--- 100000000
  │   histogram(4)=
  │   histogram(5)=
@@ -1555,6 +1956,36 @@ select
  └── filters
       └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.0004001, distinct(2)=0.0004001, null(2)=0, distinct(4)=0.0004001, null(4)=0, distinct(2,4)=0.0004001, null(2,4)=0]
+ │   histogram(2)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 110 -------- 120 -------- 130 -------- 140 ---
+ │   histogram(4)=
+ ├── cost: 18.7690007
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.1]
+ │    ├── cost: 18.7480007
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=0.1, distinct(4)=0.1, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q7 (large)
 # ------------------------------------------------------------------------------
@@ -1656,6 +2087,43 @@ select
  └── filters
       └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE u IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(4)=0.2, null(4)=0, distinct(2,4)=0.2, null(2,4)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 48.4
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4]
+ │    ├── cost: 48.34
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)-->(1), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_u_key
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2
+ │         │    ├── [/110000000 - /110000000]
+ │         │    ├── [/120000000 - /120000000]
+ │         │    ├── [/130000000 - /130000000]
+ │         │    └── [/140000000 - /140000000]
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=4, distinct(2)=4, null(2)=0]
+ │         │   histogram(2)=  0      1      0      1      0      1      0      1
+ │         │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │         ├── cost: 24.09
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2), (2)-->(1)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
+
 # ------------------------------------------------------------------------------
 # Q8
 #
@@ -1755,6 +2223,35 @@ select
  └── filters
       └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=0.0004001, distinct(3)=0.0004001, null(3)=0, distinct(4)=0.0004001, null(4)=0, distinct(3,4)=0.0004001, null(3,4)=0]
+ │   histogram(3)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 110 -------- 120 -------- 130 -------- 140 ---
+ │   histogram(4)=
+ ├── cost: 18.7790007
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.1]
+ │    ├── cost: 18.7480007
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:4!null
+ │         ├── constraint: /4/1: [/500 - /500]
+ │         ├── stats: [rows=0.1, distinct(4)=0.1, null(4)=0]
+ │         │   histogram(4)=
+ │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q8 (large)
 # ------------------------------------------------------------------------------
@@ -1848,6 +2345,40 @@ select
  │         └── fd: ()-->(4)
  └── filters
       └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE d IN (110000000, 120000000, 130000000, 140000000) AND i = 500000000
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(4)=0.2, null(4)=0, distinct(3,4)=0.2, null(3,4)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(4)=
+ ├── cost: 59.139
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=4.1]
+ │    ├── cost: 59.068
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_d_idx
+ │         ├── columns: k:1!null d:3!null
+ │         ├── constraint: /3/1
+ │         │    ├── [/110000000 - /110000000]
+ │         │    ├── [/120000000 - /120000000]
+ │         │    ├── [/130000000 - /130000000]
+ │         │    └── [/140000000 - /140000000]
+ │         ├── stats: [rows=4.1, distinct(3)=4, null(3)=0]
+ │         │   histogram(3)=  0      1      0      1      0      1      0      1
+ │         │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │         ├── cost: 34.202
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── i:4 = 500000000 [outer=(4), constraints=(/4: [/500000000 - /500000000]; tight), fd=()-->(4)]
 
 # ------------------------------------------------------------------------------
 # Q9
@@ -1960,6 +2491,38 @@ select
  └── filters
       └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE e = 'PENDING' AND u IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=0.0004001, distinct(2)=0.0004001, null(2)=0, distinct(6)=0.0004001, null(6)=0, distinct(2,6)=0.0004001, null(2,6)=0]
+ │   histogram(2)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 110 -------- 120 -------- 130 -------- 140 ---
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.7690007
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.1]
+ │    ├── cost: 18.7480007
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.1, distinct(6)=0.1, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q9 (large)
 # ------------------------------------------------------------------------------
@@ -2067,6 +2630,45 @@ select
  └── filters
       └── u:2 IN (110000000, 120000000, 130000000, 140000000) [outer=(2), constraints=(/2: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE e = 'PENDING' AND u IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(2)=0.2, null(2)=0, distinct(6)=0.2, null(6)=0, distinct(2,6)=0.2, null(2,6)=0]
+ │   histogram(2)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 48.4
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4]
+ │    ├── cost: 48.34
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)-->(1), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_u_key
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2
+ │         │    ├── [/110000000 - /110000000]
+ │         │    ├── [/120000000 - /120000000]
+ │         │    ├── [/130000000 - /130000000]
+ │         │    └── [/140000000 - /140000000]
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=4, distinct(2)=4, null(2)=0]
+ │         │   histogram(2)=  0      1      0      1      0      1      0      1
+ │         │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │         ├── cost: 24.09
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2), (2)-->(1)
+ └── filters
+      └── e:6 = 'PENDING' [outer=(6), immutable, constraints=(/6: [/'PENDING' - /'PENDING']; tight), fd=()-->(6)]
+
 # ------------------------------------------------------------------------------
 # Q10
 #
@@ -2172,6 +2774,37 @@ select
  └── filters
       └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
 
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t WHERE e = 'PENDING' AND d IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=0.0004001, distinct(3)=0.0004001, null(3)=0, distinct(6)=0.0004001, null(6)=0, distinct(3,6)=0.0004001, null(3,6)=0]
+ │   histogram(3)=  0 0.00010003 0 0.00010003 0 0.00010003 0 0.00010003
+ │                <----- 110 -------- 120 -------- 130 -------- 140 ---
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.7790007
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=0.1]
+ │    ├── cost: 18.7480007
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=0.1, distinct(6)=0.1, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.1220001
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
 # ------------------------------------------------------------------------------
 # Q10 (large)
 # ------------------------------------------------------------------------------
@@ -2271,3 +2904,39 @@ select
  │         └── fd: (1)-->(4)
  └── filters
       └── d:3 IN (110000000, 120000000, 130000000, 140000000) [outer=(3), constraints=(/3: [/110000000 - /110000000] [/120000000 - /120000000] [/130000000 - /130000000] [/140000000 - /140000000]; tight)]
+
+opt set=optimizer_clamp_low_histogram_selectivity=true
+SELECT * FROM t_large WHERE e = 'PENDING' AND d IN (110000000, 120000000, 130000000, 140000000)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=0.2, distinct(3)=0.2, null(3)=0, distinct(6)=0.2, null(6)=0, distinct(3,6)=0.2, null(3,6)=0]
+ │   histogram(3)=  0    0.05     0    0.05     0    0.05     0    0.05
+ │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 59.139
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t_large
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=4.1]
+ │    ├── cost: 59.068
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t_large@t_large_d_idx
+ │         ├── columns: k:1!null d:3!null
+ │         ├── constraint: /3/1
+ │         │    ├── [/110000000 - /110000000]
+ │         │    ├── [/120000000 - /120000000]
+ │         │    ├── [/130000000 - /130000000]
+ │         │    └── [/140000000 - /140000000]
+ │         ├── stats: [rows=4.1, distinct(3)=4, null(3)=0]
+ │         │   histogram(3)=  0      1      0      1      0      1      0      1
+ │         │                <--- 110000000 --- 120000000 --- 130000000 --- 140000000
+ │         ├── cost: 34.202
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── e:6 = 'PENDING' [outer=(6), immutable, constraints=(/6: [/'PENDING' - /'PENDING']; tight), fd=()-->(6)]

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -3,15 +3,24 @@
 # settings to show the effect those settings have on the plan.
 #
 
+# Simulate a status column that happened not to sample one of the enum values.
+exec-ddl
+CREATE TYPE status_enum AS ENUM ('ACKNOWLEDGED', 'DROPPED', 'PENDING', 'SUCCEEDED');
+----
+
 exec-ddl
 CREATE TABLE t (
   k INT PRIMARY KEY,
-  u INT UNIQUE,
+  u INT,
   d INT,
   i INT,
   s STRING,
+  e status_enum,
+  UNIQUE INDEX (u),
+  INDEX (d),
   INDEX (i),
-  INDEX (s)
+  INDEX (s),
+  INDEX (i) WHERE e = 'PENDING'
 )
 ----
 
@@ -96,6 +105,20 @@ ALTER TABLE t INJECT STATISTICS '[
       {"num_eq": 200, "num_range": 100, "distinct_range": 10, "upper_bound": "mango"},
       {"num_eq": 200, "num_range": 100, "distinct_range": 10, "upper_bound": "pineapple"}
     ]
+  },
+  {
+    "columns": ["e"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 4,
+    "null_count": 0,
+    "avg_size": 1,
+    "histo_col_type": "status_enum",
+    "histo_buckets": [
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "ACKNOWLEDGED"},
+      {"num_eq": 99, "num_range": 0, "distinct_range": 0, "upper_bound": "DROPPED"},
+      {"num_eq": 900, "num_range": 0, "distinct_range": 0, "upper_bound": "SUCCEEDED"}
+    ]
   }
 ]'
 ----
@@ -123,7 +146,7 @@ opt
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
@@ -131,7 +154,7 @@ index-join t
  │   histogram(4)=
  ├── cost: 24.0200012
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  └── scan t@t_i_idx
       ├── columns: k:1!null i:4!null
       ├── constraint: /4/1
@@ -152,7 +175,7 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
@@ -160,7 +183,7 @@ index-join t
  │   histogram(4)=
  ├── cost: 24.0200012
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  └── scan t@t_i_idx
       ├── columns: k:1!null i:4!null
       ├── constraint: /4/1
@@ -181,17 +204,17 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
  │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 110 --- 120 --- 130 --- 140
  │   histogram(4)=
- ├── cost: 24.29
+ ├── cost: 24.31
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/110 - /110]
  │    │    ├── [/120 - /120]
@@ -201,9 +224,9 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 110 --- 120 --- 130 --- 140
- │    ├── cost: 24.23
+ │    ├── cost: 24.25
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       └── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
 
@@ -218,7 +241,7 @@ opt
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 index-join t
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
@@ -226,7 +249,7 @@ index-join t
  │   histogram(4)=
  ├── cost: 18.0500006
  ├── key: (1)
- ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── select
       ├── columns: k:1!null i:4!null
       ├── cardinality: [0 - 4]
@@ -253,17 +276,17 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(1,4)=2e-07, null(1,4)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 100 --- 110 --- 120 --- 130
  │   histogram(4)=
- ├── cost: 24.29
+ ├── cost: 24.31
  ├── key: (1)
- ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -273,9 +296,9 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.23
+ │    ├── cost: 24.25
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
@@ -283,17 +306,17 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(1,4)=1, null(1,4)=0]
  │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 100 --- 110 --- 120 --- 130
  │   histogram(4)=
- ├── cost: 24.29
+ ├── cost: 24.31
  ├── key: (1)
- ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -303,9 +326,9 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.23
+ │    ├── cost: 24.25
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
@@ -320,14 +343,14 @@ opt
 SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 index-join t
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 3]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
  │   histogram(1)=
  │   histogram(4)=
  ├── cost: 18.0500006
  ├── key: (1)
- ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── select
       ├── columns: k:1!null i:4!null
       ├── cardinality: [0 - 3]
@@ -353,16 +376,16 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 3]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0]
  │   histogram(1)=
  │   histogram(4)=
  ├── cost: 19.03
  ├── key: (1)
- ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/1010 - /1010]
  │    │    ├── [/1020 - /1020]
@@ -372,7 +395,7 @@ select
  │    │   histogram(1)=
  │    ├── cost: 19.01
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
@@ -380,16 +403,16 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (1010, 1020, 1030) AND i > 500
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 3]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0]
  │   histogram(1)=
  │   histogram(4)=
  ├── cost: 19.03
  ├── key: (1)
- ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/1010 - /1010]
  │    │    ├── [/1020 - /1020]
@@ -399,7 +422,7 @@ select
  │    │   histogram(1)=
  │    ├── cost: 19.01
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       └── i:4 > 500 [outer=(4), constraints=(/4: [/501 - ]; tight)]
 
@@ -414,7 +437,7 @@ opt
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0, distinct(1,4,5)=2e-07, null(1,4,5)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
@@ -424,14 +447,14 @@ select
  │   histogram(5)=
  ├── cost: 18.0700002
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── cardinality: [0 - 4]
  │    ├── stats: [rows=8e-10]
  │    ├── cost: 18.0500002
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  │    └── select
  │         ├── columns: k:1!null s:5!null
  │         ├── cardinality: [0 - 4]
@@ -460,7 +483,7 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0, distinct(1,4,5)=2e-07, null(1,4,5)=0]
  │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
@@ -468,11 +491,11 @@ select
  │   histogram(4)=  0 2e-07
  │                <--- 400
  │   histogram(5)=
- ├── cost: 24.3
+ ├── cost: 24.32
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -482,9 +505,9 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.23
+ │    ├── cost: 24.25
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       ├── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
       └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
@@ -493,7 +516,7 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0, distinct(1,4,5)=1, null(1,4,5)=0]
  │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
@@ -501,11 +524,11 @@ select
  │   histogram(4)=  0   1
  │                <--- 400
  │   histogram(5)=
- ├── cost: 24.3
+ ├── cost: 24.32
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1
  │    │    ├── [/100 - /100]
  │    │    ├── [/110 - /110]
@@ -515,9 +538,9 @@ select
  │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
  │    │   histogram(1)=  0   1   0   1   0   1   0   1
  │    │                <--- 100 --- 110 --- 120 --- 130
- │    ├── cost: 24.23
+ │    ├── cost: 24.25
  │    ├── key: (1)
- │    └── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    └── fd: (1)-->(2-6), (2)~~>(1,3-6)
  └── filters
       ├── i:4 = 400 [outer=(4), constraints=(/4: [/400 - /400]; tight), fd=()-->(4)]
       └── s:5 < 'apple' [outer=(5), constraints=(/5: (/NULL - /'apple'); tight)]
@@ -533,20 +556,20 @@ opt
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0]
  │   histogram(4)=  0 2e-07
  │                <--- 400
  │   histogram(5)=
  ├── cost: 18.0700014
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  │    └── scan t@t_s_idx
  │         ├── columns: k:1!null s:5!null
  │         ├── constraint: /5/1: [/e'z\x00' - ]
@@ -562,7 +585,7 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── stats: [rows=2e-07, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0, distinct(4,5)=2e-07, null(4,5)=0]
  │   histogram(4)=  0 2e-07
  │                <--- 400
@@ -570,14 +593,14 @@ select
  ├── cost: 18.0700014
  ├── cost-flags: unbounded-cardinality
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── cost-flags: unbounded-cardinality
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  │    └── scan t@t_s_idx
  │         ├── columns: k:1!null s:5!null
  │         ├── constraint: /5/1: [/e'z\x00' - ]
@@ -594,20 +617,20 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── stats: [rows=1, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0, distinct(4,5)=1, null(4,5)=0]
  │   histogram(4)=  0   1
  │                <--- 400
  │   histogram(5)=
- ├── cost: 25.1575
+ ├── cost: 25.1625
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=1]
- │    ├── cost: 25.1175
+ │    ├── cost: 25.1225
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5), (2)~~>(1,3-5)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
  │    └── scan t@t_s_idx
  │         ├── columns: k:1!null s:5!null
  │         ├── constraint: /5/1: [/e'z\x00' - ]
@@ -630,7 +653,7 @@ opt
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── cardinality: [0 - 1]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0]
  │   histogram(1)=  0 2e-07
@@ -639,14 +662,14 @@ select
  │   histogram(5)=
  ├── cost: 9.04000122
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 9.02000122
  │    ├── key: ()
- │    ├── fd: ()-->(1-5)
+ │    ├── fd: ()-->(1-6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500/100 - /500/100]
@@ -665,7 +688,7 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── cardinality: [0 - 1]
  ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(4)=2e-07, null(4)=0, distinct(5)=2e-07, null(5)=0]
  │   histogram(1)=  0 2e-07
@@ -674,14 +697,14 @@ select
  │   histogram(5)=
  ├── cost: 9.04000122
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 9.02000122
  │    ├── key: ()
- │    ├── fd: ()-->(1-5)
+ │    ├── fd: ()-->(1-6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500/100 - /500/100]
@@ -700,26 +723,26 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
- ├── columns: k:1!null u:2 d:3 i:4!null s:5!null
+ ├── columns: k:1!null u:2 d:3 i:4!null s:5!null e:6
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0, distinct(5)=1, null(5)=0]
  │   histogram(1)=  0   1
  │                <--- 100
  │   histogram(4)=
  │   histogram(5)=
- ├── cost: 9.105
+ ├── cost: 9.11
  ├── key: ()
- ├── fd: ()-->(1-5)
+ ├── fd: ()-->(1-6)
  ├── scan t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── constraint: /1: [/100 - /100]
  │    ├── cardinality: [0 - 1]
  │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  │    │   histogram(1)=  0   1
  │    │                <--- 100
- │    ├── cost: 9.065
+ │    ├── cost: 9.07
  │    ├── key: ()
- │    └── fd: ()-->(1-5)
+ │    └── fd: ()-->(1-6)
  └── filters
       ├── i:4 = 500 [outer=(4), constraints=(/4: [/500 - /500]; tight), fd=()-->(4)]
       └── s:5 = 'zzz' [outer=(5), constraints=(/5: [/'zzz' - /'zzz']; tight), fd=()-->(5)]
@@ -736,7 +759,7 @@ opt
 SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2!null d:3 i:4!null s:5
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(4)=2e-07, null(4)=0, distinct(2,4)=2e-07, null(2,4)=0]
  │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
@@ -744,13 +767,13 @@ select
  │   histogram(4)=
  ├── cost: 18.0600014
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)-->(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500 - /500]
@@ -766,22 +789,22 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2!null d:3 i:4!null s:5
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(4)=2e-07, null(4)=0, distinct(2,4)=2e-07, null(2,4)=0]
  │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 110 --- 120 --- 130 --- 140
  │   histogram(4)=
- ├── cost: 48.38
+ ├── cost: 48.4
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)-->(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── cardinality: [0 - 4]
  │    ├── stats: [rows=4]
- │    ├── cost: 48.32
+ │    ├── cost: 48.34
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-5), (2)-->(1), (2)~~>(1,3-5)
+ │    ├── fd: (1)-->(2-6), (2)-->(1), (2)~~>(1,3-6)
  │    └── scan t@t_u_key
  │         ├── columns: k:1!null u:2!null
  │         ├── constraint: /2
@@ -803,21 +826,21 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE u IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2!null d:3 i:4!null s:5
+ ├── columns: k:1!null u:2!null d:3 i:4!null s:5 e:6
  ├── cardinality: [0 - 4]
  ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(4)=1, null(4)=0, distinct(2,4)=1, null(2,4)=0]
  │   histogram(2)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 110 --- 120 --- 130 --- 140
  │   histogram(4)=
- ├── cost: 25.145
+ ├── cost: 25.15
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)-->(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)-->(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=1]
- │    ├── cost: 25.115
+ │    ├── cost: 25.12
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500 - /500]
@@ -842,20 +865,20 @@ opt
 SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2 d:3!null i:4!null s:5
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
  ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(4)=2e-07, null(4)=0, distinct(3,4)=2e-07, null(3,4)=0]
  │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 110 --- 120 --- 130 --- 140
  │   histogram(4)=
  ├── cost: 18.0700014
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500 - /500]
@@ -871,7 +894,7 @@ opt set=optimizer_prefer_bounded_cardinality=true
 SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2 d:3!null i:4!null s:5
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
  ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(4)=2e-07, null(4)=0, distinct(3,4)=2e-07, null(3,4)=0]
  │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
  │                <--- 110 --- 120 --- 130 --- 140
@@ -879,14 +902,14 @@ select
  ├── cost: 18.0700014
  ├── cost-flags: unbounded-cardinality
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=2e-07]
  │    ├── cost: 18.0400014
  │    ├── cost-flags: unbounded-cardinality
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500 - /500]
@@ -903,20 +926,20 @@ opt set=optimizer_min_row_count=1
 SELECT * FROM t WHERE d IN (110, 120, 130, 140) AND i = 500
 ----
 select
- ├── columns: k:1!null u:2 d:3!null i:4!null s:5
+ ├── columns: k:1!null u:2 d:3!null i:4!null s:5 e:6
  ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(3,4)=1, null(3,4)=0]
  │   histogram(3)=  0 0.25  0 0.25  0 0.25  0 0.25
  │                <--- 110 --- 120 --- 130 --- 140
  │   histogram(4)=
- ├── cost: 25.155
+ ├── cost: 25.16
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  ├── index-join t
- │    ├── columns: k:1!null u:2 d:3 i:4 s:5
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
  │    ├── stats: [rows=1]
- │    ├── cost: 25.115
+ │    ├── cost: 25.12
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2,3,5), (2)~~>(1,3,5)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5,6), (2)~~>(1,3,5,6)
  │    └── scan t@t_i_idx
  │         ├── columns: k:1!null i:4!null
  │         ├── constraint: /4/1: [/500 - /500]
@@ -925,5 +948,221 @@ select
  │         ├── cost: 19.04
  │         ├── key: (1)
  │         └── fd: ()-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q9
+#
+# Choose between 4 equality spans on "u" and a partial index scan for a value of
+# "e" that is not in the histogram. Scanning either index requires an index
+# join.
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t WHERE e = 'PENDING' AND u IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(6)=2e-07, null(6)=0, distinct(2,6)=2e-07, null(2,6)=0]
+ │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.0600014
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=2e-07, distinct(6)=2e-07, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.0200002
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t WHERE e = 'PENDING' AND u IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(6)=2e-07, null(6)=0, distinct(2,6)=2e-07, null(2,6)=0]
+ │   histogram(2)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 48.4
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4]
+ │    ├── cost: 48.34
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)-->(1), (2)~~>(1,3-6)
+ │    └── scan t@t_u_key
+ │         ├── columns: k:1!null u:2!null
+ │         ├── constraint: /2
+ │         │    ├── [/110 - /110]
+ │         │    ├── [/120 - /120]
+ │         │    ├── [/130 - /130]
+ │         │    └── [/140 - /140]
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=4, distinct(2)=4, null(2)=0]
+ │         │   histogram(2)=  0   1   0   1   0   1   0   1
+ │         │                <--- 110 --- 120 --- 130 --- 140
+ │         ├── cost: 24.09
+ │         ├── key: (1)
+ │         └── fd: (1)-->(2), (2)-->(1)
+ └── filters
+      └── e:6 = 'PENDING' [outer=(6), immutable, constraints=(/6: [/'PENDING' - /'PENDING']; tight), fd=()-->(6)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t WHERE e = 'PENDING' AND u IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2!null d:3 i:4 s:5 e:6!null
+ ├── cardinality: [0 - 4]
+ ├── immutable
+ ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(6)=1, null(6)=0, distinct(2,6)=1, null(2,6)=0]
+ │   histogram(2)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 25.15
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)-->(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.12
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── u:2 IN (110, 120, 130, 140) [outer=(2), constraints=(/2: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+# ------------------------------------------------------------------------------
+# Q10
+#
+# Choose between 4 equality spans on "d" and a partial index scan for a value of
+# "e" that is not in the histogram. Scanning either index requires an index
+# join, and there is no unique constraint on "d" (though it has the same
+# histogram as "k").
+# ------------------------------------------------------------------------------
+
+opt
+SELECT * FROM t WHERE e = 'PENDING' AND d IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(6)=2e-07, null(6)=0, distinct(3,6)=2e-07, null(3,6)=0]
+ │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.0700014
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=2e-07, distinct(6)=2e-07, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.0200002
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_prefer_bounded_cardinality=true
+SELECT * FROM t WHERE e = 'PENDING' AND d IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0, distinct(6)=2e-07, null(6)=0, distinct(3,6)=2e-07, null(3,6)=0]
+ │   histogram(3)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 18.0700014
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=2e-07, distinct(6)=2e-07, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 18.0200002
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
+ └── filters
+      └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]
+
+opt set=optimizer_min_row_count=1
+SELECT * FROM t WHERE e = 'PENDING' AND d IN (110, 120, 130, 140)
+----
+select
+ ├── columns: k:1!null u:2 d:3!null i:4 s:5 e:6!null
+ ├── immutable
+ ├── stats: [rows=1, distinct(3)=1, null(3)=0, distinct(6)=1, null(6)=0, distinct(3,6)=1, null(3,6)=0]
+ │   histogram(3)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(6)=  0      0
+ │                <--- 'PENDING'
+ ├── cost: 25.16
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5), (2)~~>(1,3-5)
+ ├── index-join t
+ │    ├── columns: k:1!null u:2 d:3 i:4 s:5 e:6
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.12
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-6), (2)~~>(1,3-6)
+ │    └── scan t@t_i_idx1,partial
+ │         ├── columns: k:1!null i:4
+ │         ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+ │         │   histogram(6)=  0      0
+ │         │                <--- 'PENDING'
+ │         ├── cost: 19.04
+ │         ├── key: (1)
+ │         └── fd: (1)-->(4)
  └── filters
       └── d:3 IN (110, 120, 130, 140) [outer=(3), constraints=(/3: [/110 - /110] [/120 - /120] [/130 - /130] [/140 - /140]; tight)]

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -263,6 +263,18 @@ func (p *planner) makeOptimizerPlan(ctx context.Context) error {
 		return err
 	}
 
+	// Log and increment telemetry counters for interesting decisions made during
+	// optimization.
+	optStats := execMemo.GetOptimizationStats()
+	if optStats.ClampedHistogramSelectivity {
+		log.VEventf(ctx, 2, "clamped histogram selectivity during optimization")
+		telemetry.Inc(sqltelemetry.PlanClampedHistogramSelectivityCounter)
+	}
+	if optStats.ClampedInequalitySelectivity {
+		log.VEventf(ctx, 2, "clamped inequality selectivity during optimization")
+		telemetry.Inc(sqltelemetry.PlanClampedInequalitySelectivityCounter)
+	}
+
 	// Build the plan tree.
 	const disableTelemetryAndPlanGists = false
 	return p.runExecBuild(ctx, execMemo, disableTelemetryAndPlanGists)

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -743,6 +743,10 @@ message LocalOnlySessionData {
   bool enable_inspect_command = 187;
   // RowSecurity controls whether row-level security is enabled.
   bool row_security = 188;
+  // OptimizerClampLowHistogramSelectivity, when true, causes the optimizer to
+  // fall back to more pessimistic distinct-count-based estimates when the
+  // histogram-based estimate is smaller than a certain threshold.
+  bool optimizer_clamp_low_histogram_selectivity = 189;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -747,6 +747,10 @@ message LocalOnlySessionData {
   // fall back to more pessimistic distinct-count-based estimates when the
   // histogram-based estimate is smaller than a certain threshold.
   bool optimizer_clamp_low_histogram_selectivity = 189;
+  // OptimizerClampInequalitySelectivity, when true, causes the optimizer to
+  // clamp the selectivity of open-ended inequality filters (e.g. <, >, !=)
+  // but not (=, BETWEEN etc.) to a minimum threshold.
+  bool optimizer_clamp_inequality_selectivity = 190;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -220,6 +220,16 @@ var PlanTypeAutoCustomCounter = telemetry.GetCounterOnce("sql.plan.type.auto-cus
 // used when plan_cache_mode=auto.
 var PlanTypeAutoGenericCounter = telemetry.GetCounterOnce("sql.plan.type.auto-generic")
 
+// PlanClampedHistogramSelectivityCounter is to be incremented whenever a plan
+// is used that clamped the selectivity estimate derived from a histogram to a
+// minimum value.
+var PlanClampedHistogramSelectivityCounter = telemetry.GetCounterOnce("sql.plan.clamped-histogram-selectivity")
+
+// PlanClampedInequalitySelectivityCounter is to be incremented whenever a plan
+// is used that clamped the selectivity estimate derived from an inequality over
+// a histogram to a minimum value.
+var PlanClampedInequalitySelectivityCounter = telemetry.GetCounterOnce("sql.plan.clamped-inequality-selectivity")
+
 // We can't parameterize these telemetry counters, so just make a bunch of
 // buckets for setting the join reorder limit since the range of reasonable
 // values for the join reorder limit is quite small.

--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -321,3 +321,119 @@ sql.plan.opt.order-by-nulls-non-standard
 feature-usage
 SELECT a FROM x ORDER BY b DESC NULLS LAST
 ----
+
+# Test for clamped histogram selectivity.
+
+feature-list
+sql.plan.clamped-histogram-selectivity
+sql.plan.clamped-inequality-selectivity
+----
+
+exec
+SET optimizer_clamp_low_histogram_selectivity = true;
+----
+
+exec
+SET optimizer_clamp_inequality_selectivity = true;
+----
+
+exec
+CREATE TYPE status_enum AS ENUM ('ACKNOWLEDGED', 'DROPPED', 'PENDING', 'SUCCEEDED');
+----
+
+exec
+CREATE TABLE t_large (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING,
+  e status_enum,
+  INDEX (i),
+  INDEX (s),
+  INDEX (i) WHERE e = 'PENDING'
+)
+----
+
+exec
+ALTER TABLE t_large INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 1000000000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99000000, "distinct_range": 99000000, "upper_bound": "100000000"},
+      {"num_eq": 1, "num_range": 199000000, "distinct_range": 199000000, "upper_bound": "300000000"},
+      {"num_eq": 1, "num_range": 299000000, "distinct_range": 299000000, "upper_bound": "600000000"},
+      {"num_eq": 1, "num_range": 399000000, "distinct_range": 399000000, "upper_bound": "1000000000"}
+    ]
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 44000000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10000000, "num_range": 90000000, "distinct_range": 10000000, "upper_bound": "100000000"},
+      {"num_eq": 10000000, "num_range": 190000000, "distinct_range": 10000000, "upper_bound": "200000000"},
+      {"num_eq": 20000000, "num_range": 280000000, "distinct_range": 10000000, "upper_bound": "300000000"},
+      {"num_eq": 30000000, "num_range": 370000000, "distinct_range": 10000000, "upper_bound": "400000000"}
+    ]
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 400000000,
+    "null_count": 0,
+    "avg_size": 3,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "banana"},
+      {"num_eq": 100000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "cherry"},
+      {"num_eq": 200000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "mango"},
+      {"num_eq": 200000000, "num_range": 100000000, "distinct_range": 10000000, "upper_bound": "pineapple"}
+    ]
+  },
+  {
+    "columns": ["e"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000,
+    "distinct_count": 4,
+    "null_count": 0,
+    "avg_size": 1,
+    "histo_col_type": "status_enum",
+    "histo_buckets": [
+      {"num_eq": 1000000, "num_range": 0, "distinct_range": 0, "upper_bound": "ACKNOWLEDGED"},
+      {"num_eq": 99000000, "num_range": 0, "distinct_range": 0, "upper_bound": "DROPPED"},
+      {"num_eq": 900000000, "num_range": 0, "distinct_range": 0, "upper_bound": "SUCCEEDED"}
+    ]
+  }
+]'
+----
+
+feature-usage
+SELECT * FROM t_large WHERE e = 'PENDING' AND k IN (110000000, 120000000, 130000000, 140000000)
+----
+sql.plan.clamped-histogram-selectivity
+
+feature-usage
+SELECT * FROM t_large WHERE k IN (100000000, 110000000, 120000000, 130000000) AND i > 500000000
+----
+sql.plan.clamped-histogram-selectivity
+sql.plan.clamped-inequality-selectivity
+
+# Cases where the selectivity clamps do not apply.
+feature-usage
+SELECT * FROM t_large WHERE e = 'SUCCEEDED';
+SELECT * FROM t_large;
+SELECT 1;
+----

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4426,6 +4426,24 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	`optimizer_clamp_inequality_selectivity`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_clamp_inequality_selectivity`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_clamp_inequality_selectivity", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerClampInequalitySelectivity(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerClampInequalitySelectivity,
+			), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4408,6 +4408,24 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	`optimizer_clamp_low_histogram_selectivity`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_clamp_low_histogram_selectivity`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_clamp_low_histogram_selectivity", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerClampLowHistogramSelectivity(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerClampLowHistogramSelectivity,
+			), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### opt: improve outside-histogram optimizer tests

This commit makes the following improvements to the `outside-histogram`
optimizer test:
* Fixes a minor mistake in the test, where the upper bounds on a histogram
  for a unique column were incorrect.
* Simplifies the test code for setting session variable defaults.
* Adds comments explaining each test case.

Epic: None

Release note: None

#### opt: add unique and distinct column to outside-histogram test

This commit adds a column `u` with a unique index, and a column `d`
with a non-unique index to the outside-histogram test table. Both
columns use the same histogram as the primary key `k` (and therefore
have no duplicate values).

This commit also adds tests that are similar to `Q1`, but using the
new columns instead of `k`. This shows the optimizer's behavior when
the "good" plan requires an index join, and when filtering on `d`,
shows how the optimizer behaves when no plan limits the max cardinality
of the query.

Epic: None

Release note: None

#### opt: add outside-histogram test for missing enum value

This commit adds a pair of `outside-histogram` optimizer test cases that
simulate a query against an enum column for which one of the values was not
sampled.

Epic: None

Release note: None

#### opt: add outside-histogram tests with large table

This commit adds to the existing optimizer tests for filters that select
values outside of histograms. The new tests are against a large table
to show how the optimizer's trust of low-selectivity estimates varies
with table size.

Epic: None

Release note: None

#### opt: make outside-of-histogram estimates more pessimistic

This commit makes rowcount estimation fall back on distinct count estimates
when a constraint includes zero histogram values. This biases the optimizer
toward less risky plans when less information is known about the filtered
values.

The pessimistic logic is triggered when the estimate derived from a histogram
is smaller than `table_row_count / 10,000`. This threshold is chosen because
we choose samples such that we expect to sample *nearly* every value with
multiplicity down to `table_row_count / 10,000` (see computeNumberSamples).
Selecivity estimates from a histogram below this resolution are suspect,
since there is increasing likelihood that a value was missed either due
to being omitted from the sample, or due to staleness.

Informs #130201

Release note (sql change): Added a clamp for row-count estimates over very
large tables so that the optimizer assumes that at least one distinct value
will be scanned. This reduces the chances of a catastrophic underestimate.
The new logic is off by default, gated by a session setting
`optimizer_clamp_low_histogram_selectivity`.

#### opt: use pessimistic estimates for inequality filters

This commit changes row count estimates for inequality filters, so that
we expect at least `rowCount / (bucketCount * 100)` rows to "survive" the
filter. This is in line with Postgres, which clamps inequality rowcount
estimates in a similar fashion.

Informs #130201

Release note (sql change): Added a clamp for the estimated selectivity of
inequality predicates that are unbounded on one or both sides (ex: `x > 5`).
This reduces the chances of a catastrophic understimate causing the optimizer
to choose a poorly-constrained scan. The new logic is off by default, gated by
the session setting `optimizer_clamp_inequality_selectivity`.

#### sql/opt: add telemetry counters for selectivity clamping

This commit adds telemetry counters for the new histogram selectivity
clamping behavior, as well as log messages to indicate when the new
behavior applies in a query's trace.

Epic: None

Release note: None