### PR TITLE
sqlsmith: fix random CREATE STATISTICS for tables with 0 columns

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1937,10 +1937,12 @@ func makeCreateStats(s *Smither) (tree.Statement, bool) {
 				columns = append(columns, col.Name)
 			}
 		}
-		s.rnd.Shuffle(len(columns), func(i, j int) {
-			columns[i], columns[j] = columns[j], columns[i]
-		})
-		columns = columns[0:s.rnd.Intn(len(columns))]
+		if len(columns) > 0 {
+			s.rnd.Shuffle(len(columns), func(i, j int) {
+				columns[i], columns[j] = columns[j], columns[i]
+			})
+			columns = columns[0:s.rnd.Intn(len(columns))]
+		}
 	}
 
 	var options tree.CreateStatsOptions


### PR DESCRIPTION
In #125267 we added random CREATE STATISTICS statements to SQL Smith.

If a table has zero columns, we should skip choosing a column for the random CREATE STATISTICS command.

Release note: None