### PR TITLE
[tiered prototype] roachpb: change encoding of TieringAttribute

### DIFF
--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -53,8 +53,15 @@ enum ValueType {
   // TUPLE represents a DTuple, encoded as repeated pairs of varint field number
   // followed by a value encoded Datum.
   TUPLE = 10;
+  // TUPLE_WITH_TIERING_ATTRIBUTE_4 is like TUPLE but the first four bytes
+  // are a 32-bit tiering attribute value (little endian).
+  TUPLE_WITH_TIERING_ATTRIBUTE_4 = 15;
+  // TUPLE_WITH_TIERING_ATTRIBUTE_8 is like TUPLE but the first eight bytes
+  // are a 64-bit tiering attribute value (little endian).
+  TUPLE_WITH_TIERING_ATTRIBUTE_8 = 16;
 
   BITARRAY = 11;
+
 
   // TIMESERIES is applied to values which contain InternalTimeSeriesData.
   TIMESERIES = 100;
@@ -87,12 +94,6 @@ message Value {
   bytes raw_bytes = 1;
   // Timestamp of value.
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
-
-  // Tiering attribute is used to populate the corresponding field in
-  // MVCCValueHeader.
-  // TODO(radu): prototype the alternative of encoding the tiering attribute
-  // directly into raw_bytes, as an optional header with a special tag.
-  uint64 tiering_attribute = 3;
 }
 
 // KeyValue is a pair of Key and Value for returned Key/Value pairs

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -618,7 +618,7 @@ func FetchSpecRequiresRawMVCCValues(spec fetchpb.IndexFetchSpec) bool {
 		colID := spec.FetchedColumns[idx].ColumnID
 		if colinfo.IsColIDSystemColumn(colID) {
 			switch colinfo.GetSystemColumnKindFromColumnID(colID) {
-			case catpb.SystemColumnKind_ORIGINID, catpb.SystemColumnKind_ORIGINTIMESTAMP, catpb.SystemColumnKind_TIERINGATTR:
+			case catpb.SystemColumnKind_ORIGINID, catpb.SystemColumnKind_ORIGINTIMESTAMP:
 				return true
 			}
 		}

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -217,12 +217,7 @@ message MVCCValueHeader {
     (gogoproto.omitempty) = true,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.Timestamp"];
 
-  // Tiering attribute is used when tiering is enabled at the storage layer. It
-  // associates each KV with a uint64 value (typically derived from a timestamp)
-  // in a way that is easily decodable from the storage layer.
-  uint64 tiering_attribute = 7;
-
-  // NextID = 8.
+  // NextID = 7.
 }
 
 // MVCCStatsDelta is convertible to MVCCStats, but uses signed variable width

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2706,7 +2706,6 @@ func mvccPutInternal(
 	versionValue.OmitInRangefeeds = opts.OmitInRangefeeds
 	versionValue.ImportEpoch = opts.ImportEpoch
 	versionValue.OriginID = opts.OriginID
-	versionValue.TieringAttribute = value.TieringAttribute
 	if opts.OriginTimestamp.IsSet() {
 		versionValue.OriginTimestamp = opts.OriginTimestamp
 	}

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -328,15 +328,9 @@ func DecodeMVCCValueAndErr(buf []byte, err error) (MVCCValue, error) {
 	return DecodeMVCCValue(buf)
 }
 
-func DecodeTieringAttributeFromMVCCValue(buf []byte) (uint64, error) {
-	if _, ok, err := tryDecodeSimpleMVCCValue(buf); ok || err != nil {
-		return 0, err
-	}
-	v, err := decodeExtendedMVCCValue(buf, true)
-	if err != nil {
-		return 0, err
-	}
-	return v.TieringAttribute, nil
+func DecodeTieringAttributeFromValue(buf []byte) (uint64, error) {
+	v := roachpb.Value{RawBytes: buf}
+	return v.GetTieringAttribute(), nil
 }
 
 // Static error definitions, to permit inlining.

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -291,15 +291,14 @@ func TestDecodeTieringAttributeFromMVCCValue(t *testing.T) {
 	var v MVCCValue
 	enc, err := EncodeMVCCValue(v)
 	require.NoError(t, err)
-	tieringAttr, err := DecodeTieringAttributeFromMVCCValue(enc)
+	tieringAttr, err := DecodeTieringAttributeFromValue(enc)
 	require.NoError(t, err)
 	assert.Equal(t, tieringAttr, uint64(0))
 
-	v.TieringAttribute = 123
-	v.Value.RawBytes = []byte{1, 2, 3}
+	v.Value.SetTupleAndTieringAttribute([]byte{1, 2, 3}, 123)
 	enc, err = EncodeMVCCValue(v)
 	require.NoError(t, err)
-	tieringAttr, err = DecodeTieringAttributeFromMVCCValue(enc)
+	tieringAttr, err = DecodeTieringAttributeFromValue(enc)
 	require.NoError(t, err)
 	assert.Equal(t, tieringAttr, uint64(123))
 }

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -738,7 +738,7 @@ func (t *tieringPolicyAndExtractor) Policy() pebble.TieringPolicy {
 func (t *tieringPolicyAndExtractor) ExtractAttribute(
 	userKey []byte, value []byte,
 ) (pebble.TieringAttribute, error) {
-	a, err := DecodeTieringAttributeFromMVCCValue(value)
+	a, err := DecodeTieringAttributeFromValue(value)
 	if debugSpanPolicy {
 		k, _ := DecodeEngineKey(userKey)
 		if err != nil {


### PR DESCRIPTION
Instead of plumbing the tiering attribute through the `roachpb.Value`
and `MVCCValueHeader` protos, we encode it directly in the value. We
do this by adding two variants of `ValueType_TUPLE` which encode a
4-byte or 8-byte tiering attribute. Note that the epoch timestamp in
seconds normally fits in 32 bits (about 1.8B seconds passed since
1970).

This is better because:
 - we don't pollute the protos that are used in very hot paths
 - we remove the awkwardness of populating the header and the
   duplication of the tiering attribute inside MVCCValue.
 - encoding and decoding is more efficient, especially in the common
   case when we don't need an `MVCCValueHeader` for other reasons.