### PR TITLE
scripts: fix put command in gceworker.sh

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -243,14 +243,14 @@ put)
 		echo "or:    $0 put sourcepath"
 		exit 1
 	elif (($# == 1)); then
-		lpath="${1}"
+		lpaths=("${1}")
 		rpath="~"
 	else
-		lpath="${@:1:$#-1}"
+		lpaths=("${@:1:$#-1}")
 		rpath="${@: -1}"
 	fi
 	to="${NAME}:${rpath}"
-	gcloud compute scp --recurse ${lpath} "${to}"
+	gcloud compute scp --recurse "${lpaths[@]}" "${to}"
 	;;
 ip)
 	echo "$(get_ip)"


### PR DESCRIPTION
In #125154 we added a put command to send files to a gceworker via scp. The scp command allows for multiple source files, but it was using a scalar bash variable to hold the sourcepaths. This variable was not handling paths with spaces properly. For example:

```
% touch my\ file.txt
% scripts/gceworker.sh put 'my file.txt'
/usr/bin/scp: stat local "my": No such file or directory
ERROR: (gcloud.compute.scp) [/usr/bin/scp] exited with return code [255].
```

The fix is to use a bash array to hold the source paths, and to add quoting. With this fix it works correctly:

```
% touch my\ file.txt
% scripts/gceworker.sh put 'my file.txt'
my file.txt      100%    0     0.0KB/s   00:00
```

Epic: None
Release note: None