### PR TITLE
jobfrontier: change Get to accept read-only frontier

### DIFF
--- a/pkg/jobs/jobfrontier/frontier.go
+++ b/pkg/jobs/jobfrontier/frontier.go
@@ -82,7 +82,11 @@ func Get(
 // InfoStorage keys are prefixed with "frontier/", the passed name, and then a
 // chunk identifier.
 func Store(
-	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, name string, frontier span.Frontier,
+	ctx context.Context,
+	txn isql.Txn,
+	jobID jobspb.JobID,
+	name string,
+	frontier span.ReadOnlyFrontier,
 ) error {
 	return storeChunked(ctx, txn, jobID, name, frontier, 2<<20 /* 2mb */)
 }
@@ -92,7 +96,7 @@ func storeChunked(
 	txn isql.Txn,
 	jobID jobspb.JobID,
 	name string,
-	frontier span.Frontier,
+	frontier span.ReadOnlyFrontier,
 	chunkSize int,
 ) error {
 	infoStorage := jobs.InfoStorageForJob(txn, jobID)

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -27,17 +27,13 @@ import (
 // Frontier is not safe for concurrent modification, but MakeConcurrentFrontier
 // can be used to make thread safe frontier.
 type Frontier interface {
+	ReadOnlyFrontier
+
 	// AddSpansAt adds the provided spans to the frontier at the provided timestamp.
 	// If the span overlaps any spans already tracked by the frontier, the tree is adjusted
 	// to hold union of the span and the overlaps, with all entries assigned startAt starting
 	// timestamp.
 	AddSpansAt(startAt hlc.Timestamp, spans ...roachpb.Span) error
-
-	// Frontier returns the minimum timestamp being tracked.
-	Frontier() hlc.Timestamp
-
-	// PeekFrontierSpan returns one of the spans at the Frontier.
-	PeekFrontierSpan() roachpb.Span
 
 	// Forward advances the timestamp for a span. Any part of the span that doesn't
 	// overlap the tracked span set will be ignored. True is returned if the
@@ -49,6 +45,16 @@ type Frontier interface {
 	// letting a frontier be GCed is safe in that it won't cause a memory leak,
 	// but it will prevent frontier nodes from being efficiently re-used.
 	Release()
+}
+
+// ReadOnlyFrontier is a subset of Frontier with only the methods
+// that are read-only.
+type ReadOnlyFrontier interface {
+	// Frontier returns the minimum timestamp being tracked.
+	Frontier() hlc.Timestamp
+
+	// PeekFrontierSpan returns one of the spans at the Frontier.
+	PeekFrontierSpan() roachpb.Span
 
 	// Entries returns an iterator over the entries in the frontier.
 	// Updates to the frontier are restricted until iteration is stopped.

--- a/pkg/util/span/multi_frontier.go
+++ b/pkg/util/span/multi_frontier.go
@@ -241,19 +241,6 @@ func (f *MultiFrontier[P]) String() string {
 	return buf.String()
 }
 
-// ReadOnlyFrontier is a subset of Frontier with only the methods
-// that are read-only.
-type ReadOnlyFrontier interface {
-	Frontier() hlc.Timestamp
-	PeekFrontierSpan() roachpb.Span
-	Entries() iter.Seq2[roachpb.Span, hlc.Timestamp]
-	SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Span, hlc.Timestamp]
-	Len() int
-	String() string
-}
-
-var _ ReadOnlyFrontier = Frontier(nil)
-
 // Frontiers returns an iterator over the sub-frontiers (with read-only access).
 func (f *MultiFrontier[P]) Frontiers() iter.Seq2[P, ReadOnlyFrontier] {
 	return func(yield func(P, ReadOnlyFrontier) bool) {


### PR DESCRIPTION
**span: redefine Frontier in terms of ReadOnlyFrontier**

The `ReadOnlyFrontier` interface is a strict subset of `Frontier`
and to reduce duplicate code, this commit redefines `Frontier`
in terms of `ReadOnlyFrontier`.

Release note: None

---

**jobfrontier: change Get to accept read-only frontier**

This patch changes `Get` to accept a read-only frontier to prevent
any accidental modification of the passed-in frontier.

Release note: None

---

Epic: None