### PR TITLE
import: fix bulk summary override bug when import with multiple files

### DIFF
--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -431,10 +431,10 @@ func ingestKvs(
 	pkIndexAdder.SetOnFlush(func(summary kvpb.BulkOpSummary) {
 		for i, emitted := range writtenRow {
 			atomic.StoreInt64(&pkFlushedRow[i], emitted)
-			bulkSummaryMu.Lock()
-			bulkSummaryMu.summary.Add(summary)
-			bulkSummaryMu.Unlock()
 		}
+		bulkSummaryMu.Lock()
+		bulkSummaryMu.summary.Add(summary)
+		bulkSummaryMu.Unlock()
 		if indexAdder.IsEmpty() {
 			for i, emitted := range writtenRow {
 				atomic.StoreInt64(&idxFlushedRow[i], emitted)
@@ -444,10 +444,10 @@ func ingestKvs(
 	indexAdder.SetOnFlush(func(summary kvpb.BulkOpSummary) {
 		for i, emitted := range writtenRow {
 			atomic.StoreInt64(&idxFlushedRow[i], emitted)
-			bulkSummaryMu.Lock()
-			bulkSummaryMu.summary.Add(summary)
-			bulkSummaryMu.Unlock()
 		}
+		bulkSummaryMu.Lock()
+		bulkSummaryMu.summary.Add(summary)
+		bulkSummaryMu.Unlock()
 	})
 
 	// offsets maps input file ID to a slot in our progress tracking slices.
@@ -473,12 +473,12 @@ func ingestKvs(
 				prog.ResumePos[file] = idx
 			}
 			prog.CompletedFraction[file] = math.Float32frombits(atomic.LoadUint32(&writtenFraction[offset]))
-			// Write down the summary of how much we've ingested since the last update.
-			bulkSummaryMu.Lock()
-			prog.BulkSummary = bulkSummaryMu.summary
-			bulkSummaryMu.summary.Reset()
-			bulkSummaryMu.Unlock()
 		}
+		// Write down the summary of how much we've ingested since the last update.
+		bulkSummaryMu.Lock()
+		prog.BulkSummary = bulkSummaryMu.summary
+		bulkSummaryMu.summary.Reset()
+		bulkSummaryMu.Unlock()
 		select {
 		case progCh <- prog:
 		case <-ctx.Done():


### PR DESCRIPTION
When the import source is more than 1 csv file, there is a risk that the bulk summary is incorrectly reset after the first csv file progress is processed, leading to the actual progress being overriden with a nil value. This commit is to fix it.

More internal discussion can be found [here](https://cockroachlabs.slack.com/archives/C02DSDS9TM1/p1756991625692929).

Epic: None
Release note (bug fix): Fix bulk summary override bug with IMPORT with multiple files. This bug is introduced from https://github.com/cockroachdb/cockroach/pull/68218 since v21.2.
