### PR TITLE
drtprod: set ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT to match ROACHPROD_GCE_DEFAULT_PROJECT

### DIFF
--- a/pkg/cmd/drtprod/cli/handlers.go
+++ b/pkg/cmd/drtprod/cli/handlers.go
@@ -29,6 +29,7 @@ func init() {
 	setEnvIfNotExists("ROACHPROD_GCE_DNS_DOMAIN", "drt.crdb.io")
 	setEnvIfNotExists("ROACHPROD_GCE_DNS_ZONE", "drt")
 	setEnvIfNotExists("ROACHPROD_GCE_DEFAULT_PROJECT", "cockroach-drt")
+	setEnvIfNotExists("ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT", "622274581499-compute@developer.gserviceaccount.com")
 
 	if _, exists := os.LookupEnv("DD_API_KEY"); !exists {
 		// set the DD_API_KEY if we are able to fetch it from the secrets.


### PR DESCRIPTION
Minor tweak to ensure the correct default
service account is set.

Epic: none
Release note: None