### PR TITLE
testcluster: fix TestDRPCEnabledRandomly for cluster with multiple nodes

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -235,9 +235,12 @@ type SlimTestServerConfig struct {
 type DefaultTestDRPCOption uint8
 
 const (
+	// TestDRPCUnset represents an uninitialized or invalid DRPC option.
+	TestDRPCUnset DefaultTestDRPCOption = iota
+
 	// TestDRPCDisabled disables DRPC; all inter-node connectivity will use gRPC
 	// only.
-	TestDRPCDisabled DefaultTestDRPCOption = iota
+	TestDRPCDisabled
 
 	// TestDRPCEnabled enables DRPC. Some services may still use gRPC if they
 	// have not yet migrated to DRPC.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -333,6 +333,10 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		cfg.TestingKnobs.AdmissionControlOptions = &admission.Options{}
 	}
 
+	if params.DefaultDRPCOption == base.TestDRPCEnabled {
+		rpc.ExperimentalDRPCEnabled.Override(context.Background(), &st.SV, true)
+	}
+
 	return cfg
 }
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -546,8 +546,10 @@ func WaitForTenantCapabilities(
 // `TestServerArgs.Settings` based on that.
 func TryEnableDRPCSetting(ctx context.Context, t TestLogger, args *base.TestServerArgs) {
 	option := args.DefaultDRPCOption
-	if option == base.TestDRPCDisabled && globalDefaultDRPCOptionOverride.isSet {
+	var logSuffix string
+	if option == base.TestDRPCUnset && globalDefaultDRPCOptionOverride.isSet {
 		option = globalDefaultDRPCOptionOverride.value
+		logSuffix = " (override by TestingGlobalDRPCOption)"
 	}
 	enableDRPC := false
 	switch option {
@@ -561,6 +563,7 @@ func TryEnableDRPCSetting(ctx context.Context, t TestLogger, args *base.TestServ
 		return
 	}
 
+	t.Log("DRPC is enabled" + logSuffix)
 	if args.Settings == nil {
 		args.Settings = cluster.MakeClusterSettings()
 	}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -79,6 +79,7 @@ type TestCluster struct {
 	clusterArgs base.TestClusterArgs
 
 	defaultTestTenantOptions base.DefaultTestTenantOptions
+	defaultDRPCOption        base.DefaultTestDRPCOption
 
 	t serverutils.TestFataler
 }
@@ -260,6 +261,40 @@ func PrintTimings(testMain time.Duration) {
 	}
 }
 
+// validateDefaultTestTenant checks that per-server args don't override
+// the top-level DefaultTestTenant setting inconsistently.
+func (tc *TestCluster) validateDefaultTestTenant(
+	t serverutils.TestFataler, nodes int, defaultTestTenantOptions base.DefaultTestTenantOptions,
+) {
+	for i := range nodes {
+		if args, ok := tc.clusterArgs.ServerArgsPerNode[i]; ok &&
+			args.DefaultTestTenant != (base.DefaultTestTenantOptions{}) &&
+			args.DefaultTestTenant != defaultTestTenantOptions {
+			tc.Stopper().Stop(context.Background())
+			t.Fatalf("improper use of DefaultTestTenantOptions in per-server args: %v vs %v\n"+
+				"Tip: use the top-level ServerArgs to set the default test tenant options.",
+				args.DefaultTestTenant, defaultTestTenantOptions)
+		}
+	}
+}
+
+// validateDefaultDRPCOption checks that per-server args don't override
+// the top-level DefaultDRPCOption setting inconsistently.
+func (tc *TestCluster) validateDefaultDRPCOption(
+	t serverutils.TestFataler, nodes int, defaultDRPCOption base.DefaultTestDRPCOption,
+) {
+	for i := range nodes {
+		if args, ok := tc.clusterArgs.ServerArgsPerNode[i]; ok &&
+			args.DefaultDRPCOption != base.TestDRPCUnset &&
+			args.DefaultDRPCOption != defaultDRPCOption {
+			tc.Stopper().Stop(context.Background())
+			t.Fatalf("improper use of DefaultDRPCOption in per-server args: %v vs %v\n"+
+				"Tip: use the top-level ServerArgs to set the default DRPC option.",
+				args.DefaultDRPCOption, defaultDRPCOption)
+		}
+	}
+}
+
 // StartTestCluster creates and starts up a TestCluster made up of `nodes`
 // in-memory testing servers.
 // The cluster should be stopped using TestCluster.Stopper().Stop().
@@ -314,22 +349,17 @@ func NewTestCluster(
 		noLocalities = false
 	}
 
-	// Find out how to do the default test tenant.
-	// The choice should be made by the top-level ServerArgs.
+	// Resolve the test tenant configuration for the cluster. The choice should
+	// be made by the top-level ServerArgs.
 	defaultTestTenantOptions := tc.clusterArgs.ServerArgs.DefaultTestTenant
-	// API check: verify that no non-default choice was made via per-server args,
-	// and inform the user otherwise.
-	for i := 0; i < nodes; i++ {
-		if args, ok := tc.clusterArgs.ServerArgsPerNode[i]; ok &&
-			args.DefaultTestTenant != (base.DefaultTestTenantOptions{}) &&
-			args.DefaultTestTenant != defaultTestTenantOptions {
-			tc.Stopper().Stop(context.Background())
-			t.Fatalf("improper use of DefaultTestTenantOptions in per-server args: %v vs %v\n"+
-				"Tip: use the top-level ServerArgs to set the default test tenant options.",
-				args.DefaultTestTenant, defaultTestTenantOptions)
-		}
-	}
+	tc.validateDefaultTestTenant(t, nodes, defaultTestTenantOptions)
 	tc.defaultTestTenantOptions = serverutils.ShouldStartDefaultTestTenant(t, defaultTestTenantOptions)
+
+	// Resolve the DRPC configuration for the cluster. The choice should be made
+	// by the top-level ServerArgs.
+	defaultDRPCOption := tc.clusterArgs.ServerArgs.DefaultDRPCOption
+	tc.validateDefaultDRPCOption(t, nodes, defaultDRPCOption)
+	tc.defaultDRPCOption = serverutils.ShouldEnableDRPC(context.Background(), t, defaultDRPCOption)
 
 	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {
@@ -345,8 +375,6 @@ func NewTestCluster(
 		if serverArgs.Settings != nil && nodes > 1 {
 			serverArgs.Settings = cluster.TestingCloneClusterSettings(serverArgs.Settings)
 		}
-
-		serverutils.TryEnableDRPCSetting(context.Background(), t, &serverArgs)
 
 		// If a reusable listener registry is provided, create reusable listeners
 		// for every server that doesn't have a custom listener provided. (Only
@@ -650,9 +678,10 @@ func (tc *TestCluster) AddServer(
 		serverArgs.Addr = serverArgs.Listener.Addr().String()
 	}
 
-	// Inject the decision that was made about whether or not to start a
-	// test tenant server, into this new server's configuration.
+	// Inject the decisions that were made about test configuration
+	// into this new server's configuration.
 	serverArgs.DefaultTestTenant = tc.defaultTestTenantOptions
+	serverArgs.DefaultDRPCOption = tc.defaultDRPCOption
 
 	s, err := serverutils.NewServer(serverArgs)
 	if err != nil {


### PR DESCRIPTION
`` testcluster: fix TestDRPCEnabledRandomly for cluster with multiple nodes ``

This change fixes the behavior where it was deciding the DRPC enablement
for each node independently for TestDRPCEnabledRandomly option, leading to
a cluster startup with some nodes with DRPC enabled, and others not.

Now the DRPC option is resolved once at the cluster level and applied
consistently to all nodes, ensuring uniform DRPC configuration across
the entire test cluster.

`` server: fix DRPC option precedence for test-specific settings ``

Previously, when a test explicitly set TestDRPCDisabled but a global
DRPC override was configured, the global override would incorrectly
take precedence. This meant tests that explicitly disabled DRPC could
still end up running with DRPC enabled.

The fix also adds better logging to indicate when a global override
is being applied, making test behavior more transparent.

Epic: CRDB-48935
Release notes: none