### PR TITLE
cdcprogresspb: delete unused field on ResolvedTables

### DIFF
--- a/pkg/ccl/changefeedccl/cdcprogresspb/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/BUILD.bazel
@@ -8,7 +8,6 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/jobs/jobspb:jobspb_proto",
         "//pkg/util/hlc:hlc_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
@@ -21,7 +20,6 @@ go_proto_library(
     proto = ":cdcprogresspb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/jobs/jobspb",
         "//pkg/util/hlc",
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
@@ -8,7 +8,6 @@ package cockroach.ccl.changefeedccl.cdcprogresspb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb";
 
 import "gogoproto/gogo.proto";
-import "jobs/jobspb/jobs.proto";
 import "util/hlc/timestamp.proto";
 
 // ResolvedTables contains per-table resolved timestamp information.
@@ -18,8 +17,9 @@ message ResolvedTables {
     (gogoproto.nullable) = false
   ];
 
-  // TODO(#148124): Write to this field for aggregator-to-frontier messages.
-  cockroach.sql.jobs.jobspb.ResolvedSpan.BoundaryType boundary_type = 2;
+  // TODO(#148124): Add a field notating resolved boundaries for
+  // aggregator-to-frontier messages. Maybe a map from timestamps
+  // to boundaries?
 }
 
 // ProtectedTimestampRecords is a map from table descriptor IDs to protected timestamp record IDs.


### PR DESCRIPTION
This patch deletes the currently unused `BoundaryType` field on the
`ResolvedTables` protobuf so that if we decide we don't need it or
choose a different type later, we aren't saddled with an extra field
that needs to be deprecated.

Informs #148124

Release note: None