### PR TITLE
[WIP] sql: fix transaction idle latency tracking 

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3005,6 +3005,7 @@ func (ex *connExecutor) execCopyOut(
 	}()
 
 	stmtTS := ex.server.cfg.Clock.PhysicalTime()
+	ex.extraTxnState.idleLatency += ex.statsCollector.PhaseTimes().GetIdleLatency(ex.statsCollector.PreviousPhaseTimes())
 	ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 	ex.resetPlanner(ctx, &ex.planner, ex.state.mu.txn, stmtTS)
 	ex.setCopyLoggingFields(cmd.ParsedStmt)
@@ -3219,6 +3220,7 @@ func (ex *connExecutor) execCopyIn(
 		stmtTimestamp: ex.server.cfg.Clock.PhysicalTime(),
 		initPlanner:   ex.initPlanner,
 		resetPlanner: func(ctx context.Context, p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time) {
+			ex.extraTxnState.idleLatency += ex.statsCollector.PhaseTimes().GetIdleLatency(ex.statsCollector.PreviousPhaseTimes())
 			ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 			ex.resetPlanner(ctx, p, txn, stmtTS)
 			ex.setCopyLoggingFields(cmd.ParsedStmt)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -195,6 +195,7 @@ func (ex *connExecutor) prepare(
 			// beginning of the execution (in execStmtInOpenState). We might have also
 			// instrumented the planner to collect execution statistics, and resetting
 			// the planner here would break the assumptions of the instrumentation.
+			ex.extraTxnState.idleLatency += ex.statsCollector.PhaseTimes().GetIdleLatency(ex.statsCollector.PreviousPhaseTimes())
 			ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime())
 		}
@@ -435,6 +436,7 @@ func (ex *connExecutor) execBind(
 		}
 
 		resolve := func(ctx context.Context, txn *kv.Txn) (err error) {
+			ex.extraTxnState.idleLatency += ex.statsCollector.PhaseTimes().GetIdleLatency(ex.statsCollector.PreviousPhaseTimes())
 			ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 			p := &ex.planner
 			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -290,7 +290,7 @@ func (ex *connExecutor) recordStatementSummary(
 		ex.extraTxnState.transactionStatementsHash.Add(uint64(stmtFingerprintID))
 	}
 	ex.extraTxnState.numRows += rowsAffected
-	ex.extraTxnState.idleLatency += idleLatRaw
+	// NB: idleLatency is accumulated at statsCollector.Reset() time
 
 	if log.V(2) {
 		// ages since significant epochs


### PR DESCRIPTION
This isn't ready for a merge because when I pushed the unit test behind this PR, I couldn't get it to fail...which is confusing. Needs a bit more investigation because clearly our existing implementation measures idle latency correctly *sometimes*, but unclear where that breaks down.

----

Previously, we were not accumulating idle latency from each
statement's `phaseTimes` into the `ex.extraTxnState.idleLatency`
variable. This would result in severely undercounted idle latencies
for transactions that would be smaller than the sum of individual
statement idle latencies.

This change adds an accumulation of idle latency from the current
statement's current and "previous" `phaseTimes` every time we
`Reset()` the `statsCollector`. Resets are triggered when we're about
to execute a new statement, so it is the natural spot to record the
accumulated idle latency.

Resolves: https://github.com/cockroachdb/cockroach/issues/146116
Epic: None

Release note (bug fix): transaction idle latency will now be more
accurate when reported in SQL Activity in DB Console and in sql stats
system tables.