### PR TITLE
workload: use IMPORT by default, but warn against uniqueness violations

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -309,6 +310,12 @@ func (l ImportDataLoader) InitialDataLoad(
 ) (int64, error) {
 	if l.FilesPerNode == 0 {
 		l.FilesPerNode = 1
+	}
+	mayContainDuplicates := slices.ContainsFunc(gen.Tables(), func(tbl workload.Table) bool {
+		return tbl.InitialRows.MayContainDuplicates
+	})
+	if mayContainDuplicates {
+		log.Dev.Warningf(ctx, "importing fixture using a key generator that may contain duplicates; IMPORT may abort with a key uniqueness violation at higher row counts")
 	}
 
 	log.Dev.Infof(ctx, "starting import of %d tables", len(gen.Tables()))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -46,7 +46,7 @@ type Generator interface {
 func SupportsFixtures(gen Generator) bool {
 	tt := gen.Tables()
 	for _, t := range tt {
-		if t.InitialRows.FillBatch == nil || t.InitialRows.MayContainDuplicates {
+		if t.InitialRows.FillBatch == nil {
 			return false
 		}
 	}


### PR DESCRIPTION
In 1041bf06 (#152979), we converted ycsb and kv workloads to use INSERT statements for initial data loading when hashing keys.

Hashing keys can cause key collisions. At higher row counts, these collisions are inevitable. Since IMPORTs require imported data to be unique, an IMPORT with colliding keys would fail. Before #152979, only the ycsb workload was susceptible to this failure mode, because the kv workload did not use the same key generator for data loaded through --insert-count (#107874). Fixing #107874 made the kv workload susceptible to this type of failure.

The change to use INSERTs instead of IMPORTs ran afoul of KV message size limits (see #153086). For now we revert the change to automatically use IMPORTs and instead warn about the possibility of collisions.

Epic: none
Release note: none