### PR TITLE
workload/schemachanger: check for duplicate trigger functions

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -66,6 +66,17 @@ func (og *operationGenerator) columnExistsOnTable(
    )`, tableName.Schema(), tableName.Object(), columnName)
 }
 
+func (og *operationGenerator) fnExistsByName(
+	ctx context.Context, tx pgx.Tx, schemaName string, routineName string,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
+	SELECT routine_name
+    FROM information_schema.routines 
+   WHERE routine_schema = $1
+     AND routine_name = $2
+   )`, schemaName, routineName)
+}
+
 func (og *operationGenerator) tableHasRows(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
 ) (bool, error) {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5434,18 +5434,29 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 		return nil, err
 	}
 
+	schemaName, err := og.randSchema(ctx, tx, og.alwaysExisting())
+	if err != nil {
+		return nil, err
+	}
 	triggerFunctionName := fmt.Sprintf("trigger_function_%s", og.newUniqueSeqNumSuffix())
+	resolvedTriggerFunctionName := fmt.Sprintf("%s.%s", schemaName, triggerFunctionName)
 
-	// Try to generate a random SELECT statement for more complex dependencies
+	// Try to generate a random SELECT statement for more coamplex dependencies
 	selectStmt, err := og.selectStmt(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 	// Our trigger function will always return the original value to avoid
 	// breaking inserts.
-	triggerFunction := fmt.Sprintf(`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`, triggerFunctionName, selectStmt.sql)
+	triggerFunction := fmt.Sprintf(`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`, resolvedTriggerFunctionName, selectStmt.sql)
 
-	og.LogMessage(fmt.Sprintf("Created trigger function %s", triggerFunction))
+	// Check if the routine already exists.
+	routineAlreadyExists, err := og.fnExistsByName(ctx, tx, schemaName, triggerFunctionName)
+	if err != nil {
+		return nil, err
+	}
+
+	og.LogMessage(fmt.Sprintf("Created trigger function %s", resolvedTriggerFunctionName))
 
 	// Create TRIGGER statement components
 	triggerActionTime := "BEFORE"
@@ -5474,8 +5485,7 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 
 	// Build the SQL statement
 	sqlStatement := fmt.Sprintf("%s;CREATE TRIGGER %s %s %s ON %s FOR EACH ROW EXECUTE FUNCTION %s()",
-		triggerFunction, triggerName, triggerActionTime, eventClause, tableName, triggerFunctionName)
-
+		triggerFunction, triggerName, triggerActionTime, eventClause, tableName, resolvedTriggerFunctionName)
 	og.LogMessage(fmt.Sprintf("createTrigger: %s", sqlStatement))
 
 	opStmt := makeOpStmt(OpStmtDDL)
@@ -5487,6 +5497,7 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 		// It does not catch cases where the select statement in the trigger function
 		// has a select query on a table that doesn't exist.
 		{code: pgcode.UndefinedTable, condition: !triggerTableExists},
+		{code: pgcode.DuplicateFunction, condition: routineAlreadyExists},
 	})
 
 	opStmt.potentialExecErrors.addAll(codesWithConditions{


### PR DESCRIPTION
Previously, it was possible for trigger function names to collide if the workload was run mutliple times against a CRDB server. Certain tests like the mixed version tests will intentionally do this. So, before creating triggers or trigger functions we need to validate that function names do not collide.

Fixes: #152716

Release note: None