### PR TITLE
cloud: fix usage of CombineErrors

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -84,7 +84,7 @@ func (l localWriter) Close() error {
 
 	syncErr := l.f.Sync()
 	closeErr := l.f.Close()
-	if err := errors.CombineErrors(closeErr, syncErr); err != nil {
+	if err := errors.CombineErrors(syncErr, closeErr); err != nil {
 		return err
 	}
 	// Finally put the file to its final location.

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -454,7 +454,7 @@ func WriteFile(ctx context.Context, dest ExternalStorage, basename string, src i
 	_, err = io.Copy(w, src)
 	if err != nil {
 		cancel()
-		return errors.CombineErrors(w.Close(), err)
+		return errors.CombineErrors(err, w.Close())
 	}
 	return errors.Wrap(w.Close(), "closing object")
 }


### PR DESCRIPTION
Previously, nodelocal and cloud contained CombineErrors calls that were passing the secondary error as the first argument. This is undesirable because only the first argument to CombineErrors is part of the causal error chain.

The instance of this in WriteFile was uncovered by a fault injection test. An injected error was being unexpectedly retried because Close was failing with a context cancelled error.

Release note: none
Epic: CRDB-53946