### PR TITLE
release-25.2: kvserver: reset lb splitter on all queue splits

### DIFF
--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -302,6 +302,9 @@ func (sq *splitQueue) processAttempt(
 			return false, errors.Wrapf(err, "unable to split %s at key %q", r, splitKey)
 		}
 		sq.metrics.SpanConfigBasedSplitCount.Inc(1)
+
+		// Reset the splitter now that the bounds of the range changed.
+		r.loadBasedSplitter.Reset(sq.store.Clock().PhysicalTime())
 		return true, nil
 	}
 
@@ -327,6 +330,9 @@ func (sq *splitQueue) processAttempt(
 			return false, err
 		}
 		sq.metrics.SizeBasedSplitCount.Inc(1)
+
+		// Reset the splitter now that the bounds of the range changed.
+		r.loadBasedSplitter.Reset(sq.store.Clock().PhysicalTime())
 		return true, nil
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #145461.

/cc @cockroachdb/release

---

Previously, we'd only reset the load based splitter state when a load based split occurred. This was reasonable in most cases, as the odds of wanting to split for another reason in addition to load is rare but was nevertheless imperfect. As a result, samples could be left around in the load based splitter that didn't conform to the range boundaries post-split.

Informs: #144407
Release note: None

Release justification: low-risk escalation fixes
