### PR TITLE
jobfrontier: add GetResolvedSpans/GetAllResolvedSpans

### DIFF
--- a/pkg/jobs/jobfrontier/BUILD.bazel
+++ b/pkg/jobs/jobfrontier/BUILD.bazel
@@ -8,9 +8,7 @@ go_library(
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
-        "//pkg/roachpb",
         "//pkg/sql/isql",
-        "//pkg/util/hlc",
         "//pkg/util/protoutil",
         "//pkg/util/span",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
Fixes #153074

---

**jobfrontier: add GetResolvedSpans helper function** 

This patch adds the helper function `GetResolvedSpans`, which is like
`Get` except it returns the resolved spans directly so that callers
can decide what to do with them.

Release note: None

---

**jobfrontier: add GetAllResolvedSpans helper function** 

This patch adds the helper function `GetResolvedSpans`, which is like
`GetResolvedSpans` except it collects and returns the resolved spans
for all frontiers associated with a job ID.

Release note: None
