### PR TITLE
roachtest: deflake online restore recovery roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2673,7 +2673,13 @@ func (d BackupRestoreTestDriver) getORDownloadJobID(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand,
 ) (int, error) {
 	var downloadJobID int
-	if err := d.testUtils.QueryRow(ctx, rng, `SELECT job_id FROM [SHOW JOBS] WHERE description LIKE '%Background Data Download%' ORDER BY created DESC LIMIT 1`).Scan(&downloadJobID); err != nil {
+	if err := d.testUtils.QueryRow(
+		ctx,
+		rng,
+		`SELECT job_id FROM [SHOW JOBS]
+		WHERE description LIKE '%Background Data Download%' AND job_type = 'RESTORE'
+		ORDER BY created DESC LIMIT 1`,
+	).Scan(&downloadJobID); err != nil {
 		return 0, err
 	}
 	return downloadJobID, nil


### PR DESCRIPTION
The online restore recovery roachtest would very occasionally flake due to it detecting the download job having succeeded. It turns out that the download job was not succeeding, but to find the job, we match on the description containing "Background Data Download", which the GC job that runs to cleanup after download contains. So if the download job failed fast enough, the query to find the download job would match on the GC job instead. This patch updates the query to only look for restore jobs instead.

Fixes: #151973

Release note: None