### PR TITLE
xform: add a session variable to ignore row width

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4029,6 +4029,10 @@ func (m *sessionDataMutator) SetCostScansWithDefaultColSize(val bool) {
 	m.data.CostScansWithDefaultColSize = val
 }
 
+func (m *sessionDataMutator) SetOptimizerIgnoreRowWidth(val bool) {
+	m.data.OptimizerIgnoreRowWidth = val
+}
+
 func (m *sessionDataMutator) SetEnableImplicitTransactionForBatchStatements(val bool) {
 	m.data.EnableImplicitTransactionForBatchStatements = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4095,6 +4095,7 @@ optimizer_check_input_min_row_count                              1
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
+optimizer_ignore_row_width                                       off
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3090,6 +3090,7 @@ optimizer_check_input_min_row_count                              1              
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
+optimizer_ignore_row_width                                       off                 NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
@@ -3335,6 +3336,7 @@ optimizer_check_input_min_row_count                              1              
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
+optimizer_ignore_row_width                                       off                 NULL  user     NULL      off                 off
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on
@@ -3571,6 +3573,7 @@ optimizer_check_input_min_row_count                              NULL    NULL   
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  NULL    NULL     NULL     NULL        NULL
 optimizer_enable_lock_elision                                    NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries                 NULL    NULL     NULL     NULL        NULL
+optimizer_ignore_row_width                                       NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                                    NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                          NULL    NULL     NULL     NULL        NULL
 optimizer_plan_lookup_joins_with_reverse_scans                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -158,6 +158,7 @@ optimizer_check_input_min_row_count                              1
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
+optimizer_ignore_row_width                                       off
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -164,6 +164,7 @@ type Memo struct {
 	txnRowsReadErr                             int64
 	nullOrderedLast                            bool
 	costScansWithDefaultColSize                bool
+	ignoreRowWidth                             bool
 	allowUnconstrainedNonCoveringIndexScan     bool
 	testingOptimizerRandomSeed                 int64
 	testingOptimizerCostPerturbation           float64
@@ -271,6 +272,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		txnRowsReadErr:                             evalCtx.SessionData().TxnRowsReadErr,
 		nullOrderedLast:                            evalCtx.SessionData().NullOrderedLast,
 		costScansWithDefaultColSize:                evalCtx.SessionData().CostScansWithDefaultColSize,
+		ignoreRowWidth:                             evalCtx.SessionData().OptimizerIgnoreRowWidth,
 		allowUnconstrainedNonCoveringIndexScan:     evalCtx.SessionData().UnconstrainedNonCoveringIndexScanEnabled,
 		testingOptimizerRandomSeed:                 evalCtx.SessionData().TestingOptimizerRandomSeed,
 		testingOptimizerCostPerturbation:           evalCtx.SessionData().TestingOptimizerCostPerturbation,
@@ -446,6 +448,7 @@ func (m *Memo) IsStale(
 		m.txnRowsReadErr != evalCtx.SessionData().TxnRowsReadErr ||
 		m.nullOrderedLast != evalCtx.SessionData().NullOrderedLast ||
 		m.costScansWithDefaultColSize != evalCtx.SessionData().CostScansWithDefaultColSize ||
+		m.ignoreRowWidth != evalCtx.SessionData().OptimizerIgnoreRowWidth ||
 		m.allowUnconstrainedNonCoveringIndexScan != evalCtx.SessionData().UnconstrainedNonCoveringIndexScanEnabled ||
 		m.testingOptimizerRandomSeed != evalCtx.SessionData().TestingOptimizerRandomSeed ||
 		m.testingOptimizerCostPerturbation != evalCtx.SessionData().TestingOptimizerCostPerturbation ||

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -325,6 +325,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().CostScansWithDefaultColSize = false
 	notStale()
 
+	// Stale optimizer ignore row width.
+	evalCtx.SessionData().OptimizerIgnoreRowWidth = true
+	stale()
+	evalCtx.SessionData().OptimizerIgnoreRowWidth = false
+	notStale()
+
 	// Stale unconstrained non-covering index scan enabled.
 	evalCtx.SessionData().UnconstrainedNonCoveringIndexScanEnabled = true
 	stale()

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1654,6 +1654,12 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, scannedCols opt.ColS
 		costFactor += latencyCostFactor * adjustment
 	}
 
+	// If the optimizer is ignoring row width, then we don't need to consider
+	// the number of columns or the average size of the columns.
+	if c.evalCtx != nil && c.evalCtx.SessionData().OptimizerIgnoreRowWidth {
+		return memo.Cost{C: costFactor}
+	}
+
 	// The number of the columns in the index matter because more columns means
 	// more data to scan. The number of columns we actually return also matters
 	// because that is the amount of data that we could potentially transfer over

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -741,6 +741,9 @@ message LocalOnlySessionData {
   bool optimizer_use_improved_hoist_join_project = 186;
   // EnableInspectCommand controls use of the INSPECT command.
   bool enable_inspect_command = 187;
+  // OptimizerIgnoreRowWidth controls whether to include number of columns and
+  // bytes per column when costing plans.
+  bool optimizer_ignore_row_width = 188;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2565,6 +2565,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_ignore_row_width`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_ignore_row_width`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`optimizer_ignore_row_width`, s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerIgnoreRowWidth(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerIgnoreRowWidth), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`default_transaction_quality_of_service`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`default_transaction_quality_of_service`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2578,7 +2578,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerIgnoreRowWidth), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 
 	// CockroachDB extension.


### PR DESCRIPTION
In 2021 we added row width, in terms of bytes and number of columns, as a factor in the cost of a scan. The theory at the time was that the network overhead of transferring large rows vs. small rows was significant and needed to be accounted for in the costing of plans.

Recently, there have been some escalations where stale statistics make row width the dominant factor in plan selection. In these cases, an obvious plan using a tightly constrained index was bypassed because either the index column was too wide or, paradoxically, because there were more constrained columns in the scan.

These instances have us reconsidering whether incorporating row width in plan cost is something we need to be doing at all. It's likely that there is some benefit to picking narrower rows when possible, but this seems to be completely overshadowed by instances where we end up scanning, sometimes drastically, more rows.

Fixes: #153207
Release note (ops change): A new session variable, 'optimizer_ignore_row_width' setting has been added, which causes the optimizer to not factor in number of columns or width of columns when costing plans. While this setting is enabled, the value of 'cost_scans_with_default_col_size` is ignored because column size is not included in plan cost estimates.