### PR TITLE
cloud: Skip checksums when not necessary

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -710,6 +710,11 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		if s.opts.usePathStyle {
 			options.UsePathStyle = true
 		}
+
+		if s.opts.skipChecksum {
+			// Try to skip checksums when it isn't required.
+			options.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		}
 	})
 	u := manager.NewUploader(c, func(uploader *manager.Uploader) {
 		uploader.PartSize = cloud.WriteChunkSize.Get(&s.settings.SV)


### PR DESCRIPTION
The Go S3 SDK made a change to defaults where the SDK will try to calculate full object checksums on multipart uploads. This checksum is then sent upon completing the multipart upload.

When the `AWS_SKIP_CHECKSUM` variable is set, the default behavior will end up trying to calculate the checksum.

This should fix issues with certain S3-compatible APIs that haven't built support for full object checksumming. This includes Backblaze B2 and Storj.

Fixes: #153195