### PR TITLE
roachtest/mixedversion: ensure WaitForSQLReady for every node

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2199,7 +2199,7 @@ func (c *clusterImpl) StartE(
 	if !startOpts.RoachprodOpts.SkipInit && !startOpts.RoachprodOpts.SkipWaitForSQL {
 		// Wait for SQL to be ready on all nodes, for 'system' tenant, only.
 		for _, n := range nodes {
-			conn, err := c.ConnE(ctx, l, nodes[0], option.VirtualClusterName(install.SystemInterfaceName))
+			conn, err := c.ConnE(ctx, l, n, option.VirtualClusterName(install.SystemInterfaceName))
 			if err != nil {
 				return errors.Wrapf(err, "failed to connect to n%d", n)
 			}


### PR DESCRIPTION
A typo in [1] resulted in `WaitForSQLReady` being
checked for only one node, instead of every.

[1] https://github.com/cockroachdb/cockroach/pull/138109

Epic: none
Release note: None