### PR TITLE
roachtest: fix `sumCounterIncreases`

### DIFF
--- a/pkg/cmd/roachtest/tests/ts_util.go
+++ b/pkg/cmd/roachtest/tests/ts_util.go
@@ -91,7 +91,7 @@ func sumCounterIncreases(dataPoints []tspb.TimeSeriesDatapoint) (sum float64) {
 			sum += dataPoints[i].Value
 			continue
 		}
-		sum += dataPoints[i].Value - dataPoints[0].Value
+		sum += dataPoints[i].Value - dataPoints[i-1].Value
 	}
 	return sum
 }


### PR DESCRIPTION
Fix a typo in `sumCounterIncreases`
which was previously overshooting, i.e.,
double counting.

Epic: none
Release note: None