### PR TITLE
roachprod: fix potential null pointer dereference

### DIFF
--- a/pkg/roachprod/cloud/gc_aws.go
+++ b/pkg/roachprod/cloud/gc_aws.go
@@ -360,6 +360,8 @@ func assumeRole(roleArn, roleSessionName, region string) (*types.Credentials, er
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to assume role %s", roleArn)
+	} else if tmpCredentials == nil {
+		return nil, errors.Errorf("failed to assume role %s, received nil credentials", roleArn)
 	}
 
 	return tmpCredentials.Credentials, nil
@@ -380,6 +382,8 @@ func stsCredentials(roleArn, roleSessionName, region string) (func(), error) {
 	tmpCredentials, err := assumeRole(roleArn, roleSessionName, region)
 	if err != nil {
 		return unset, err
+	} else if tmpCredentials == nil {
+		return unset, errors.Errorf("failed to assume role %s, received nil temperory credentials", roleArn)
 	}
 
 	_ = os.Setenv(amazon.AWSAccessKeyParam, *tmpCredentials.AccessKeyId)


### PR DESCRIPTION
This PR adds a safety check before dereferencing credentials received from aws in function `stsCredentials`.

Epic: none

Release note: None