### PR TITLE
server: remove panic

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -301,9 +301,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 
 	engines, err := cfg.CreateEngines(ctx)
 	if err != nil {
-		if true {
-			panic(err)
-		}
 		return nil, errors.Wrap(err, "failed to create engines")
 	}
 	stopper.AddCloser(&engines)


### PR DESCRIPTION
I don't know why this panic is here. If a reviewer happens to know, we can update this to a comment. But, we should be returning this error up the stack so that the user gets a clear error rather than a giant panic.

Epic: none
Release note: None