### PR TITLE
sql/inspect: skip flaky statement timeout test under race

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//pkg/sql/sessiondata",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",


### PR DESCRIPTION
The TestInspectJobImplicitTxnSemantics statement_timeout subtest was failing intermittently under race conditions. The test expects an INSPECT job to start and succeed even when the triggering EXPERIMENTAL SCRUB statement times out after 1 second, but on slow machines with race detection enabled, the job creation may not complete before the timeout.

Fixes #153164

Release note: None

Epic: None