### PR TITLE
changefeedccl: implement db-level changefeed EXCLUDE TABLES syntax

### DIFF
--- a/docs/generated/sql/bnf/create_changefeed_stmt.bnf
+++ b/docs/generated/sql/bnf/create_changefeed_stmt.bnf
@@ -4,11 +4,11 @@ create_changefeed_stmt ::=
 	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_table_target ( ( ',' changefeed_table_target ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
 	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_table_target ( ( ',' changefeed_table_target ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
 	| 'CREATE' 'CHANGEFEED' 'FOR' changefeed_table_target ( ( ',' changefeed_table_target ) )* 'INTO' sink 
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option 'INTO' sink 
+	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
+	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 
 	| 'CREATE' 'CHANGEFEED' 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )* 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause
 	| 'CREATE' 'CHANGEFEED' 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )* 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause
 	| 'CREATE' 'CHANGEFEED' 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )* 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -643,7 +643,7 @@ create_stats_stmt ::=
 
 create_changefeed_stmt ::=
 	'CREATE' 'CHANGEFEED' 'FOR' changefeed_table_targets opt_changefeed_sink opt_with_options
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_name opt_changefeed_sink opt_with_options
+	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_name db_level_changefeed_filter_option opt_changefeed_sink opt_with_options
 	| 'CREATE' 'CHANGEFEED' opt_changefeed_sink opt_with_options 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause
 
 create_extension_stmt ::=
@@ -1951,6 +1951,10 @@ changefeed_table_targets ::=
 opt_changefeed_sink ::=
 	'INTO' string_or_placeholder
 
+db_level_changefeed_filter_option ::=
+	'EXCLUDE' 'TABLES' table_name_list
+	| 
+
 target_list ::=
 	( target_elem ) ( ( ',' target_elem ) )*
 
@@ -2856,6 +2860,9 @@ create_stats_option_list ::=
 changefeed_table_target ::=
 	opt_table_prefix table_name opt_changefeed_family
 
+table_name_list ::=
+	db_object_name_list
+
 target_elem ::=
 	a_expr 'AS' target_name
 	| a_expr bare_col_label
@@ -2939,9 +2946,6 @@ row_or_rows ::=
 
 table_index_name_list ::=
 	( table_index_name ) ( ( ',' table_index_name ) )*
-
-table_name_list ::=
-	db_object_name_list
 
 view_name_list ::=
 	db_object_name_list
@@ -3533,6 +3537,9 @@ opt_changefeed_family ::=
 	'FAMILY' family_name
 	| 
 
+db_object_name_list ::=
+	( db_object_name ) ( ( ',' db_object_name ) )*
+
 target_name ::=
 	unrestricted_name
 
@@ -3605,9 +3612,6 @@ sortby_index ::=
 only_signed_fconst ::=
 	'+' 'FCONST'
 	| '-' 'FCONST'
-
-db_object_name_list ::=
-	( db_object_name ) ( ( ',' db_object_name ) )*
 
 inspect_option ::=
 	'INDEX' 'ALL'

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -224,6 +224,35 @@ func TestDatabaseLevelChangefeedBasics(t *testing.T) {
 	cdcTest(t, testFn)
 }
 
+func TestDatabaseLevelChangefeedWithFilter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		expectSuccess := func(stmt string) {
+			successfulFeed := feed(t, f, stmt)
+			defer closeFeed(t, successfulFeed)
+			_, err := successfulFeed.Next()
+			require.NoError(t, err)
+		}
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
+		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
+		sqlDB.Exec(t, `CREATE TABLE foo2 (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO foo2 VALUES (0, 'initial')`)
+		sqlDB.Exec(t, `UPSERT INTO foo2 VALUES (0, 'updated')`)
+
+		expectSuccess(`CREATE CHANGEFEED FOR DATABASE d EXCLUDE TABLES foo`)
+		expectSuccess(`CREATE CHANGEFEED FOR DATABASE d EXCLUDE TABLES foo,foo2`)
+		expectSuccess(`CREATE CHANGEFEED FOR DATABASE d EXCLUDE TABLES foo.bar.fizz, foo.foo2, foo`)
+		expectErrCreatingFeed(t, f, `CREATE CHANGEFEED FOR DATABASE d EXCLUDE TABLES foo.*`,
+			`at or near "*": syntax error`)
+		// TODO(#147421): Assert payload once the filter works
+	}
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
 func TestChangefeedBasicQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/parser/testdata/changefeed
+++ b/pkg/sql/parser/testdata/changefeed
@@ -178,3 +178,21 @@ at or near "into": syntax error
 DETAIL: source SQL:
 CREATE CHANGEFEED FOR database INTO 'foo'
                                ^
+
+parse
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES bar INTO 'foo'
+----
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES bar INTO '*****' -- normalized!
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES bar INTO ('*****') -- fully parenthesized
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES bar INTO '_' -- literals removed
+CREATE CHANGEFEED FOR DATABASE _ EXCLUDE TABLES _ INTO '*****' -- identifiers removed
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES bar INTO 'foo' -- passwords exposed
+
+parse
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES foo,bar INTO 'foo'
+----
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES foo, bar INTO '*****' -- normalized!
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES foo, bar INTO ('*****') -- fully parenthesized
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES foo, bar INTO '_' -- literals removed
+CREATE CHANGEFEED FOR DATABASE _ EXCLUDE TABLES _, _ INTO '*****' -- identifiers removed
+CREATE CHANGEFEED FOR DATABASE d1 EXCLUDE TABLES foo, bar INTO 'foo' -- passwords exposed


### PR DESCRIPTION
The syntax for EXCLUDE TABLES will be
CREATE CHANGEFEED FOR DATABASE FOO EXCLUDE TABLES fizz,buzz;

Resolves: #147423
Release note: none