### PR TITLE
roachtest: fix live migration error message

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1261,7 +1261,7 @@ func (r *testRunner) runTest(
 				if liveMigrationVMNames != "" {
 					failureMsg = fmt.Sprintf("VMs had live migrations during the test run: %s\n\n**Other Failures:**\n%s", liveMigrationVMNames, failureMsg)
 					t.resetFailures()
-					t.Error(liveMigrationError(hostErrorVMNames))
+					t.Error(liveMigrationError(liveMigrationVMNames))
 				}
 
 				output := fmt.Sprintf("%s\ntest artifacts and logs in: %s", failureMsg, t.ArtifactsDir())


### PR DESCRIPTION
Previously the error reporting would list host error vms, instead of live migration vms. This change fixes that.

Epic: none
Fixes: none
Release note: none