### PR TITLE
changefeedccl: revert to single PTS if per-table PTS is disabled

### DIFF
--- a/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
@@ -22,10 +22,14 @@ message ResolvedTables {
   cockroach.sql.jobs.jobspb.ResolvedSpan.BoundaryType boundary_type = 2;
 }
 
-// ProtectedTimestampRecords is a map from table descriptor IDs to protected timestamp record IDs.
+// ProtectedTimestampRecords contains the IDs of protected timestamps records
+// for the changefeed.
 message ProtectedTimestampRecords {
-  map<uint32, bytes> protected_timestamp_records = 1 [
+  // PerTableRecords maps the ID of a lagging table to a protected timestamp
+  // record that protects it.
+  map<uint32, bytes> per_table_records = 2 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID",
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
+    (gogoproto.nullable) = false
   ];
 }

--- a/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
@@ -23,7 +23,7 @@ message ResolvedTables {
 }
 
 // ProtectedTimestampRecords contains the IDs of protected timestamps records
-// for the changefeed.
+// for a changefeed.
 message ProtectedTimestampRecords {
   // SystemTablesRecord protects all system tables back to the highwater.
   bytes system_tables_record = 1 [

--- a/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
@@ -25,6 +25,12 @@ message ResolvedTables {
 // ProtectedTimestampRecords contains the IDs of protected timestamps records
 // for the changefeed.
 message ProtectedTimestampRecords {
+  // SystemTablesRecord protects all system tables back to the highwater.
+  bytes system_tables_record = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "SystemTablesRecord",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
+  ];
   // PerTableRecords maps the ID of a lagging table to a protected timestamp
   // record that protects it.
   map<uint32, bytes> per_table_records = 2 [

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -2207,6 +2207,7 @@ func (cf *changeFrontier) advancePrimaryProtectedTimestamp(
 	if err := pts.UpdateTimestamp(ctx, progress.ProtectedTimestampRecord, timestamp); err != nil {
 		return false, err
 	}
+
 	return true, nil
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -2003,13 +2003,13 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 		}
 
 		if !isLagging {
-			if ptsEntries.ProtectedTimestampRecords[tableID] != nil {
+			if ptsEntries.PerTableRecords[tableID] != uuid.Nil {
 				tableIDsToRelease = append(tableIDsToRelease, tableID)
 			}
 			continue
 		}
 
-		if ptsEntries.ProtectedTimestampRecords[tableID] != nil {
+		if ptsEntries.PerTableRecords[tableID] != uuid.Nil {
 			if updated, err := cf.advancePerTableProtectedTimestampRecord(ctx, ptsEntries, tableID, tableHighWater, pts); err != nil {
 				return hlc.Timestamp{}, false, err
 			} else if updated {
@@ -2046,10 +2046,10 @@ func (cf *changeFrontier) releasePerTableProtectedTimestampRecords(
 	pts protectedts.Storage,
 ) error {
 	for _, tableID := range tableIDs {
-		if err := pts.Release(ctx, *ptsEntries.ProtectedTimestampRecords[tableID]); err != nil {
+		if err := pts.Release(ctx, ptsEntries.PerTableRecords[tableID]); err != nil {
 			return err
 		}
-		delete(ptsEntries.ProtectedTimestampRecords, tableID)
+		delete(ptsEntries.PerTableRecords, tableID)
 	}
 	return writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, ptsEntries, txn, cf.spec.JobID)
 }
@@ -2061,7 +2061,7 @@ func (cf *changeFrontier) advancePerTableProtectedTimestampRecord(
 	tableHighWater hlc.Timestamp,
 	pts protectedts.Storage,
 ) (updated bool, err error) {
-	rec, err := pts.GetRecord(ctx, *ptsEntries.ProtectedTimestampRecords[tableID])
+	rec, err := pts.GetRecord(ctx, ptsEntries.PerTableRecords[tableID])
 	if err != nil {
 		return false, err
 	}
@@ -2071,7 +2071,7 @@ func (cf *changeFrontier) advancePerTableProtectedTimestampRecord(
 		return false, nil
 	}
 
-	if err := pts.UpdateTimestamp(ctx, *ptsEntries.ProtectedTimestampRecords[tableID], tableHighWater); err != nil {
+	if err := pts.UpdateTimestamp(ctx, ptsEntries.PerTableRecords[tableID], tableHighWater); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -2084,9 +2084,6 @@ func (cf *changeFrontier) createPerTableProtectedTimestampRecords(
 	tableIDsToCreate map[descpb.ID]hlc.Timestamp,
 	pts protectedts.Storage,
 ) error {
-	if ptsEntries.ProtectedTimestampRecords == nil {
-		ptsEntries.ProtectedTimestampRecords = make(map[descpb.ID]*uuid.UUID)
-	}
 	for tableID, tableHighWater := range tableIDsToCreate {
 		targets, err := cf.createPerTablePTSTarget(tableID)
 		if err != nil {
@@ -2096,7 +2093,7 @@ func (cf *changeFrontier) createPerTableProtectedTimestampRecords(
 			ctx, cf.FlowCtx.Codec(), cf.spec.JobID, targets, tableHighWater,
 		)
 		uuid := ptr.ID.GetUUID()
-		ptsEntries.ProtectedTimestampRecords[tableID] = &uuid
+		ptsEntries.PerTableRecords[tableID] = uuid
 		if err := pts.Protect(ctx, ptr); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1425,6 +1425,33 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 			initialHighwater = *ts
 		}
 
+		var perTableProtectedTimestamps bool
+		if cf.spec.ProgressConfig != nil {
+			perTableProtectedTimestamps = cf.spec.ProgressConfig.PerTableProtectedTimestamps
+		}
+
+		if !perTableProtectedTimestamps {
+			if err := cf.js.job.DebugNameNoTxn(changefeedJobProgressTxnName).Update(cf.Ctx(), func(
+				txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+			) error {
+				progress := md.Progress
+				changefeedProgress := progress.Details.(*jobspb.Progress_Changefeed).Changefeed
+				if err := cf.revertPerTableProtectedTimestampRecords(ctx, txn, changefeedProgress); err != nil {
+					return err
+				}
+				ju.UpdateProgress(progress)
+				return nil
+			}); err != nil {
+				log.Changefeed.Warningf(
+					cf.Ctx(),
+					"moving to draining due to error reverting per-table protected ts records: %v",
+					err,
+				)
+				cf.MoveToDraining(err)
+				return
+			}
+		}
+
 		// latestResolvedKV timestamp is set to the current time to make
 		// sure that even if the target table does not have any
 		// KV events coming in, the changefeed will remain
@@ -1455,6 +1482,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	if cf.spec.ProgressConfig != nil {
 		perTableTracking = cf.spec.ProgressConfig.PerTableTracking
 	}
+
 	cf.frontier, err = resolvedspan.NewCoordinatorFrontier(
 		cf.spec.Feed.StatementTime, initialHighwater, cf.FlowCtx.Codec(),
 		perTableTracking,
@@ -1959,6 +1987,43 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		}
 		return updatedMainPTS || updatedPerTablePTS || updatedSystemTablesPTS, nil
 	}
+	if len(ptsEntries.PerTableRecords) > 0 {
+		// In this case, we should have tried to revert the per-table protected timestamp records,
+		// but we didn't because there were still lagging tables.
+		// We now try to advance the protected timestamp for the lagging tables unless
+		// there are no lagging tables and all can be protected with the primary PTS record.
+		updatedPerTablePTS, err :=
+			cf.advanceLaggingPerTableProtectedTimestamps(ctx, txn, progress, &ptsEntries, highwater)
+		if err != nil {
+			return false, err
+		}
+
+		// Check if the call to advanceLaggingPerTableProtectedTimestamps resulted in
+		// all lagging tables catching up.
+		if len(ptsEntries.PerTableRecords) == 0 {
+			// If no tables are lagging, we can revert the new per-table style PTS records.
+			if err := cf.revertPerTableProtectedTimestampRecords(ctx, txn, progress); err != nil {
+				return false, err
+			}
+			_, err := cf.advanceProtectedTimestamp(ctx, progress, pts, highwater)
+			if err != nil {
+				return false, err
+			}
+			// Since we went from having lagging tables to not having any lagging
+			// tables, we have advanced the primary PTS record even if we don't
+			// end up advancing it in advanceProtectedTimestamp.
+			return true, err
+		}
+
+		// We always advance the system tables PTS record to the highwater.
+		updatedSystemTablesPTS, err :=
+			cf.advanceSystemTablesProtectedTimestamp(ctx, txn, &ptsEntries, highwater, pts)
+		if err != nil {
+			return false, err
+		}
+
+		return updatedPerTablePTS || updatedSystemTablesPTS, nil
+	}
 
 	return cf.advanceProtectedTimestamp(ctx, progress, pts, highwater)
 }
@@ -2040,6 +2105,84 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 	}
 
 	return newPTS, updatedPerTablePTS, nil
+}
+
+func (cf *changeFrontier) advanceLaggingPerTableProtectedTimestamps(
+	ctx context.Context,
+	txn isql.Txn,
+	progress *jobspb.ChangefeedProgress,
+	ptsEntries *cdcprogresspb.ProtectedTimestampRecords,
+	highwater hlc.Timestamp,
+) (updatedPerTablePTS bool, err error) {
+	pts := cf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
+
+	primaryPTS, err := pts.GetRecord(ctx, progress.ProtectedTimestampRecord)
+	if err != nil {
+		return false, err
+	}
+	primaryPTSTimestamp := primaryPTS.Timestamp
+	isLagging := highwater.Less(primaryPTSTimestamp)
+	if cf.knobs.IsPTSReversionLagging != nil {
+		isLagging = cf.knobs.IsPTSReversionLagging()
+	}
+
+	// If the highwater has caught up to the primary PTS timestamp,
+	// we should release all per-table PTS records. Otherwise, we should
+	// advance them with the highwater.
+	if !isLagging {
+		allLaggingTableIDs := make([]descpb.ID, 0)
+		for tableID := range ptsEntries.PerTableRecords {
+			allLaggingTableIDs = append(allLaggingTableIDs, tableID)
+		}
+		if err := cf.releasePerTableProtectedTimestampRecords(ctx, txn, ptsEntries, allLaggingTableIDs, pts); err != nil {
+			return false, err
+		}
+		ptsEntries.PerTableRecords = nil
+		if err := writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, ptsEntries, txn, cf.spec.JobID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	for tableID := range ptsEntries.PerTableRecords {
+		if updated, err := cf.advancePerTableProtectedTimestampRecord(ctx, ptsEntries, tableID, highwater, pts); err != nil {
+			return false, err
+		} else if updated {
+			updatedPerTablePTS = true
+		}
+	}
+
+	return updatedPerTablePTS, nil
+}
+
+func (cf *changeFrontier) revertPerTableProtectedTimestampRecords(
+	ctx context.Context, txn isql.Txn, progress *jobspb.ChangefeedProgress,
+) error {
+	pts := cf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
+
+	var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+	if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, cf.spec.JobID); err != nil {
+		return err
+	}
+
+	if len(ptsEntries.PerTableRecords) > 0 {
+		// If there are any lagging tables records, we don't revert until these
+		// lagging tables have caught up to the highwater.
+		return nil
+	}
+	ptsEntries.PerTableRecords = nil
+
+	if ptsEntries.SystemTablesRecord != uuid.Nil {
+		if err := pts.Release(ctx, ptsEntries.SystemTablesRecord); err != nil {
+			return err
+		}
+		ptsEntries.SystemTablesRecord = uuid.Nil
+	}
+
+	if err := writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, cf.spec.JobID); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (cf *changeFrontier) releasePerTableProtectedTimestampRecords(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1832,12 +1832,29 @@ func (b *changefeedResumer) OnFailOrCancel(
 	exec := jobExec.(sql.JobExecContext)
 	execCfg := exec.ExecCfg()
 	progress := b.job.Progress()
-	b.maybeCleanUpProtectedTimestamp(
-		ctx,
-		execCfg.InternalDB,
-		execCfg.ProtectedTimestampProvider,
-		progress.GetChangefeed().ProtectedTimestampRecord,
-	)
+
+	maybeCleanUpProtectedTimestamp := func(ptsID uuid.UUID) {
+		b.maybeCleanUpProtectedTimestamp(
+			ctx,
+			execCfg.InternalDB,
+			execCfg.ProtectedTimestampProvider,
+			ptsID,
+		)
+	}
+	maybeCleanUpProtectedTimestamp(progress.GetChangefeed().ProtectedTimestampRecord)
+	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		ptsEntries := cdcprogresspb.ProtectedTimestampRecords{}
+		if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, b.job.ID()); err != nil {
+			return err
+		}
+		maybeCleanUpProtectedTimestamp(ptsEntries.SystemTablesRecord)
+		for _, perTableRecord := range ptsEntries.PerTableRecords {
+			maybeCleanUpProtectedTimestamp(perTableRecord)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
 
 	var numTargets uint
 	if b.job != nil {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -12026,6 +12026,13 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Hour)
 
+		// The pts query in this test assumes that the pts record is stored
+		// in the job progress table. This assumption is only true when
+		// PerTableProtectedTimestamps is disabled. We will add test coverage
+		// for when it is enabled in the following commit.
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+
 		sqlDB.Exec(t, `CREATE TABLE foo (id INT)`)
 
 		registry := s.Server.JobRegistry().(*jobs.Registry)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/checkpoint"
@@ -12008,6 +12009,9 @@ func TestChangefeedAvroDecimalColumnWithDiff(t *testing.T) {
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
 }
 
+// TestChangefeedProtectedTimestampUpdate tests that a changefeed will update
+// its protected timestamp record when the high watermark advances and update
+// the related metrics.
 func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -12026,10 +12030,8 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Hour)
 
-		// The pts query in this test assumes that the pts record is stored
-		// in the job progress table. This assumption is only true when
-		// PerTableProtectedTimestamps is disabled. We will add test coverage
-		// for when it is enabled in the following commit.
+		// This test only tests the non-per-table PTS behavior. We test the
+		// per-table PTS behavior in TestChangefeedProtectedTimestampUpdatePerTablePTS.
 		changefeedbase.PerTableProtectedTimestamps.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, false)
 
@@ -12073,8 +12075,25 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		ptsQry := fmt.Sprintf(`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`, p.ProtectedTimestampRecord)
+		// When PerTableProtectedTimestamps is disabled, expect record in ProtectedTimestampRecord
+		// but not in ProtectedTimestampRecords
+		require.NotEqual(t, uuid.Nil, p.ProtectedTimestampRecord)
+
 		var ts, ts2 string
 		sqlDB.QueryRow(t, ptsQry).Scan(&ts)
+
+		// Verify that per-table records don't exist
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+		err = execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID()); err != nil {
+				return err
+			}
+
+			// If the file exists, the records should be nil
+			require.Equal(t, uuid.Nil, ptsEntries.SystemTablesRecord)
+			return nil
+		})
 		require.NoError(t, err)
 
 		// Force the changefeed to restart.
@@ -12086,7 +12105,6 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 
 		// Check that the PTS was not updated after the resume.
 		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)
-		require.NoError(t, err)
 		require.Equal(t, ts, ts2)
 
 		// Lower the PTS lag and check that it has been updated.
@@ -12099,7 +12117,6 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		testutils.SucceedsSoon(t, checkHWM)
 
 		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)
-		require.NoError(t, err)
 		require.Less(t, ts, ts2)
 
 		managePTSCount, _ = metrics.AggMetrics.Timers.PTSManage.WindowedSnapshot().Total()
@@ -12116,7 +12133,161 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		verifyFunc = vf
 	})
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"), withTxnRetries)
+	cdcTest(t, testFn, feedTestEnterpriseSinks, withTxnRetries)
+}
+
+// TestChangefeedProtectedTimestampUpdatePerTablePTS tests that a
+// changefeed will update its per-table protected timestamp records when the
+// high watermark advances and update the related metrics when the
+// per-table protected timestamp records are enabled.
+func TestChangefeedProtectedTimestampUpdatePerTablePTS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	verifyFunc := func() {}
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		defer verifyFunc()
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		// Checkpoint and trigger potential protected timestamp updates frequently.
+		// Make the protected timestamp lag long enough that it shouldn't be
+		// immediately updated after a restart.
+		changefeedbase.SpanCheckpointInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Hour)
+
+		// Enable per-table protected timestamps and progress tracking.
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
+		sqlDB.Exec(t, `CREATE TABLE foo (id INT)`)
+
+		registry := s.Server.JobRegistry().(*jobs.Registry)
+		metrics := registry.MetricsStruct().Changefeed.(*Metrics)
+		createPTSCount, _ := metrics.AggMetrics.Timers.PTSCreate.WindowedSnapshot().Total()
+		managePTSCount, _ := metrics.AggMetrics.Timers.PTSManage.WindowedSnapshot().Total()
+		managePTSErrorCount, _ := metrics.AggMetrics.Timers.PTSManageError.WindowedSnapshot().Total()
+		require.Equal(t, int64(0), createPTSCount)
+		require.Equal(t, int64(0), managePTSCount)
+		require.Equal(t, int64(0), managePTSErrorCount)
+
+		createStmt := `CREATE CHANGEFEED FOR foo WITH resolved='10ms', no_initial_scan`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		createPTSCount, _ = metrics.AggMetrics.Timers.PTSCreate.WindowedSnapshot().Total()
+		managePTSCount, _ = metrics.AggMetrics.Timers.PTSManage.WindowedSnapshot().Total()
+		require.Equal(t, int64(1), createPTSCount)
+		require.Equal(t, int64(0), managePTSCount)
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		// Wait for the changefeed to checkpoint and update PTS at least once.
+		var lastHWM hlc.Timestamp
+		checkHWM := func() error {
+			hwm, err := eFeed.HighWaterMark()
+			if err == nil && !hwm.IsEmpty() && lastHWM.Less(hwm) {
+				lastHWM = hwm
+				return nil
+			}
+			return errors.New("waiting for high watermark to advance")
+		}
+		testutils.SucceedsSoon(t, checkHWM)
+
+		p, err := eFeed.Progress()
+		require.NoError(t, err)
+
+		// When PerTablePTS is enabled, expect records in ProtectedTimestampRecords
+		// but not in the changefeed progress ProtectedTimestampRecord
+		require.NotEqual(t, uuid.Nil, p.ProtectedTimestampRecord)
+
+		var initialPrimaryPTS, initialSystemPTS string
+
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+		getPTSByID := func(id uuid.UUID) string {
+			var ts string
+			query := fmt.Sprintf(`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`, id)
+			sqlDB.QueryRow(t, query).Scan(&ts)
+			return ts
+		}
+		err = execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID()); err != nil {
+				return err
+			}
+
+			require.NotEqual(t, uuid.Nil, ptsEntries.SystemTablesRecord)
+
+			initialPrimaryPTS = getPTSByID(p.ProtectedTimestampRecord)
+			initialSystemPTS = getPTSByID(ptsEntries.SystemTablesRecord)
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Force the changefeed to restart.
+		require.NoError(t, eFeed.Pause())
+		require.NoError(t, eFeed.Resume())
+
+		// Wait for a new checkpoint.
+		testutils.SucceedsSoon(t, checkHWM)
+
+		// Check that the primary and system tables PTS records were not updated.
+		err = execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID()); err != nil {
+				return err
+			}
+			newPrimaryPTS := getPTSByID(p.ProtectedTimestampRecord)
+			require.Equal(t, initialPrimaryPTS, newPrimaryPTS)
+			newSystemPTS := getPTSByID(ptsEntries.SystemTablesRecord)
+			require.Equal(t, initialSystemPTS, newSystemPTS)
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Lower the PTS lag and check that it has been updated.
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+
+		// Ensure that the resolved timestamp advances at least once
+		// since the PTS lag override.
+		testutils.SucceedsSoon(t, checkHWM)
+		testutils.SucceedsSoon(t, checkHWM)
+
+		// Check that the primary and system tables PTS records were updated.
+		err = execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID()); err != nil {
+				return err
+			}
+			newPrimaryPTS := getPTSByID(p.ProtectedTimestampRecord)
+			require.Less(t, initialPrimaryPTS, newPrimaryPTS)
+			newSystemPTS := getPTSByID(ptsEntries.SystemTablesRecord)
+			require.Less(t, initialSystemPTS, newSystemPTS)
+			return nil
+		})
+		require.NoError(t, err)
+
+		managePTSCount, _ = metrics.AggMetrics.Timers.PTSManage.WindowedSnapshot().Total()
+		managePTSErrorCount, _ = metrics.AggMetrics.Timers.PTSManageError.WindowedSnapshot().Total()
+		require.GreaterOrEqual(t, managePTSCount, int64(2))
+		require.Equal(t, int64(0), managePTSErrorCount)
+	}
+
+	withTxnRetries := withArgsFn(func(args *base.TestServerArgs) {
+		requestFilter, vf := testutils.TestingRequestFilterRetryTxnWithPrefix(t, changefeedJobProgressTxnName, 1)
+		args.Knobs.Store = &kvserver.StoreTestingKnobs{
+			TestingRequestFilter: requestFilter,
+		}
+		verifyFunc = vf
+	})
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks, withTxnRetries)
 }
 
 // TestChangefeedProtectedTimestampUpdateError tests that a changefeed that

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -1039,7 +1039,7 @@ func TestChangefeedProtectedTimestampUpdateForMultipleTables(t *testing.T) {
 				return err
 			}
 
-			require.Equal(t, 0, ptsEntries.Size())
+			require.Equal(t, 0, len(ptsEntries.PerTableRecords))
 			return nil
 		})
 
@@ -1137,12 +1137,16 @@ func TestChangefeedPerTableProtectedTimestampProgression(t *testing.T) {
 						return err
 					}
 
-					if len(ptsEntries.ProtectedTimestampRecords) != len(expectedTables) {
-						return errors.Newf("expected %d per-table PTS records, got %d", len(expectedTables), len(ptsEntries.ProtectedTimestampRecords))
+					if len(ptsEntries.PerTableRecords) != len(expectedTables) {
+						return errors.Newf(
+							"expected %d per-table PTS records, got %d",
+							len(expectedTables),
+							len(ptsEntries.PerTableRecords),
+						)
 					}
 
 					for tableID := range expectedTables {
-						if ptsEntries.ProtectedTimestampRecords[tableID] == nil {
+						if ptsEntries.PerTableRecords[tableID] == uuid.Nil {
 							return errors.Newf("expected PTS record for table %d", tableID)
 						}
 					}

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -249,13 +249,6 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
-		// This test verifies that we ensure that the protected timestamp is
-		// removed when the job is canceled which isn't true when per-table PTS
-		// records are enabled. We will add that functionality in the following
-		// commit and remove this override.
-		changefeedbase.PerTableProtectedTimestamps.Override(
-			context.Background(), &s.Server.ClusterSettings().SV, false)
-
 		sysDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'`)
 		sysDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 100`)
@@ -386,10 +379,10 @@ func TestChangefeedAlterPTS(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `CREATE TABLE foo2 (a INT PRIMARY KEY, b STRING)`)
-		// We need to disable per-table PTS records for this test so that we can
-		// make assertions about the PTS records.
-		changefeedbase.PerTableProtectedTimestamps.Override(
-			context.Background(), &s.Server.ClusterSettings().SV, false)
+
+		perTablePTSEnabled :=
+			changefeedbase.PerTableProtectedTimestamps.Get(&s.Server.ClusterSettings().SV) &&
+				changefeedbase.TrackPerTableProgress.Get(&s.Server.ClusterSettings().SV)
 
 		f2 := feed(t, f, `CREATE CHANGEFEED FOR table foo with protect_data_from_gc_on_pause,
 			resolved='1s', min_checkpoint_frequency='1s'`)
@@ -408,7 +401,13 @@ func TestChangefeedAlterPTS(t *testing.T) {
 
 		_, _ = expectResolvedTimestamp(t, f2)
 
-		require.Equal(t, 1, getNumPTSRecords())
+		expectedNumPTSRecords := func() int {
+			if perTablePTSEnabled {
+				return 2
+			}
+			return 1
+		}()
+		require.Equal(t, expectedNumPTSRecords, getNumPTSRecords())
 
 		require.NoError(t, jobFeed.Pause())
 		sqlDB.Exec(t, fmt.Sprintf("ALTER CHANGEFEED %d ADD TABLE foo2 with initial_scan='yes'", jobFeed.JobID()))
@@ -416,7 +415,7 @@ func TestChangefeedAlterPTS(t *testing.T) {
 
 		_, _ = expectResolvedTimestamp(t, f2)
 
-		require.Equal(t, 1, getNumPTSRecords())
+		require.Equal(t, expectedNumPTSRecords, getNumPTSRecords())
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
@@ -1075,7 +1074,7 @@ func TestChangefeedProtectedTimestampUpdateForMultipleTables(t *testing.T) {
 		verifyFunc = vf
 	})
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"), withTxnRetries)
+	cdcTest(t, testFn, feedTestEnterpriseSinks, withTxnRetries)
 }
 
 // TestChangefeedPerTableProtectedTimestampProgression tests that
@@ -1173,13 +1172,12 @@ func TestChangefeedPerTableProtectedTimestampProgression(t *testing.T) {
 							return errors.Newf("expected PTS record for table %d", tableID)
 						}
 					}
-
 					return nil
 				})
 			})
 		}
 
-		// Assert that feed-level PTS record exists.
+		// Assert that the feed-level PTS record exists.
 		assertFeedLevelPTS := func() {
 			testutils.SucceedsSoon(t, func() error {
 				hwm, err := eFeed.HighWaterMark()
@@ -1195,7 +1193,7 @@ func TestChangefeedPerTableProtectedTimestampProgression(t *testing.T) {
 						return err
 					}
 					if progress.ProtectedTimestampRecord.Equal(uuid.UUID{}) {
-						return errors.New("expected feed-level PTS record not to be set")
+						return errors.New("expected feed-level PTS record to be set")
 					}
 					return nil
 				})

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -1234,6 +1234,454 @@ func TestChangefeedPerTableProtectedTimestampProgression(t *testing.T) {
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
 
+// TestChangefeedPerTableProtectedTimestampsRevert tests that a changefeed
+// can be toggled between per-table and single protected timestamp modes
+// by changing the cluster setting and restarting the changefeed.
+func TestChangefeedPerTableProtectedTimestampsRevert(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		changefeedbase.SpanCheckpointInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 50*time.Millisecond)
+
+		sqlDB.Exec(t, `CREATE TABLE table1 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table2 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (1, 'data1'), (2, 'data2')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (1, 'data1'), (2, 'data2')`)
+
+		var table1ID, table2ID descpb.ID
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table1' AND database_name = current_database()`).Scan(&table1ID)
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table2' AND database_name = current_database()`).Scan(&table2ID)
+
+		getPTSRecords := func() []map[string]string {
+			rows := sqlDB.Query(t, "SELECT id, ts, target FROM system.protected_ts_records")
+			r, err := sqlutils.RowsToStrMatrix(rows)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			var records []map[string]string
+			for _, row := range r {
+				record := make(map[string]string)
+				record["id"] = row[0]
+				record["ts"] = row[1]
+				record["target"] = row[2]
+				records = append(records, record)
+			}
+			return records
+		}
+
+		// Enable per-table protected timestamps and progress tracking
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
+		createStmt := `CREATE CHANGEFEED FOR table1, table2 WITH resolved='100ms'`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`table1: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table1: [2]->{"after": {"id": 2, "s": "data2"}}`,
+			`table2: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table2: [2]->{"after": {"id": 2, "s": "data2"}}`,
+		})
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		// Wait for a new checkpoint.
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		recordsWithPerTable := getPTSRecords()
+		require.Greater(t, len(recordsWithPerTable), 1, "Expected multiple PTS records with per-table enabled")
+
+		require.NoError(t, eFeed.Pause())
+
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+
+		require.NoError(t, eFeed.Resume())
+		// Wait for a new checkpoint.
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		// Verify that with per-table PTS disabled, we now have a single PTS record
+		// in the old style with one record for all tables.
+		recordsWithSinglePTS := getPTSRecords()
+		require.Equal(t, 1, len(recordsWithSinglePTS), "Expected single PTS record with per-table disabled")
+
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (3, 'data3')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (3, 'data3')`)
+		assertPayloads(t, testFeed, []string{
+			`table1: [3]->{"after": {"id": 3, "s": "data3"}}`,
+			`table2: [3]->{"after": {"id": 3, "s": "data3"}}`,
+		})
+
+		finalRecords := getPTSRecords()
+		require.Equal(t, 1, len(finalRecords), "Expected single PTS record to persist after processing new data")
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
+// TestChangefeedPerTableProtectedTimestampsRevertWithLaggingTables tests that a
+// changefeed created with per-table protected timestamps enabled is not reverted
+// while there are still lagging tables.
+func TestChangefeedPerTableProtectedTimestampsRevertWithLaggingTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Configure frequent checkpointing and PTS updates for faster testing
+		changefeedbase.SpanCheckpointInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 50*time.Millisecond)
+
+		// Enable per-table protected timestamps and progress tracking
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
+		sqlDB.Exec(t, `CREATE TABLE table1 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table2 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table3 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (1, 'data1'), (2, 'data2')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (1, 'data1'), (2, 'data2')`)
+		sqlDB.Exec(t, `INSERT INTO table3 VALUES (1, 'data1'), (2, 'data2')`)
+
+		// Get table ID for controlling lagging behavior
+		var table1ID descpb.ID
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table1' AND database_name = current_database()`).Scan(&table1ID)
+
+		knobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		var table1Lagging atomic.Bool
+		knobs.IsTableLagging = func(tableID descpb.ID) bool {
+			switch tableID {
+			case table1ID:
+				return table1Lagging.Load()
+			default:
+				return false
+			}
+		}
+
+		createStmt := `CREATE CHANGEFEED FOR table1, table2, table3 WITH resolved='100ms'`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`table1: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table1: [2]->{"after": {"id": 2, "s": "data2"}}`,
+			`table2: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table2: [2]->{"after": {"id": 2, "s": "data2"}}`,
+			`table3: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table3: [2]->{"after": {"id": 2, "s": "data2"}}`,
+		})
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+
+		getPTSEntries := func() cdcprogresspb.ProtectedTimestampRecords {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				return readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID())
+			}))
+			return ptsEntries
+		}
+
+		assertPTSRecords := func(expectedLaggingTables map[descpb.ID]struct{}) {
+			testutils.SucceedsSoon(t, func() error {
+				ptsEntries := getPTSEntries()
+
+				if ptsEntries.SystemTablesRecord.Equal(uuid.Nil) {
+					return errors.New("expected system tables PTS record to exist")
+				}
+				if len(ptsEntries.PerTableRecords) != len(expectedLaggingTables) {
+					return errors.Newf("expected %d per-table PTS records, got %d", len(expectedLaggingTables), len(ptsEntries.PerTableRecords))
+				}
+				for tableID := range expectedLaggingTables {
+					if ptsEntries.PerTableRecords[tableID] == uuid.Nil {
+						return errors.Newf("expected PTS record for table %d", tableID)
+					}
+				}
+
+				progress, err := eFeed.Progress()
+				if err != nil {
+					return err
+				}
+				if !progress.ProtectedTimestampRecord.Equal(uuid.Nil) {
+					return errors.New("expected old-style PTS record to not exist")
+				}
+				return nil
+			})
+		}
+
+		assertOldStylePTS := func() {
+			testutils.SucceedsSoon(t, func() error {
+				progress, err := eFeed.Progress()
+				if err != nil {
+					return err
+				}
+				if progress.ProtectedTimestampRecord.Equal(uuid.Nil) {
+					return errors.New("expected old-style PTS record to exist")
+				}
+
+				ptsEntries := getPTSEntries()
+				if !ptsEntries.SystemTablesRecord.Equal(uuid.Nil) {
+					return errors.New("expected system tables PTS record not to exist")
+				}
+				return nil
+			})
+		}
+
+		table1Lagging.Store(true)
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+		assertPTSRecords(map[descpb.ID]struct{}{table1ID: {}})
+
+		// We are going to turn off per-table protected timestamps. Once we do,
+		// we will use only the changefeed's highwater to determine if per table
+		// protected timestamps have caught up to the primary PTS record, because
+		// we no longer have access to per-table highwaters.
+		knobs.IsPTSReversionLagging = func() bool {
+			return table1Lagging.Load()
+		}
+
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+
+		require.NoError(t, eFeed.Pause())
+		require.NoError(t, eFeed.Resume())
+
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		assertPTSRecords(map[descpb.ID]struct{}{table1ID: {}})
+
+		getSystemTablesPTS := func() hlc.Timestamp {
+			ptsEntries := getPTSEntries()
+			require.NotEqual(t, uuid.Nil, ptsEntries.SystemTablesRecord)
+			var ts hlc.Timestamp
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				ptp := s.Server.DistSQLServer().(*distsql.ServerImpl).ServerConfig.ProtectedTimestampProvider
+				rec, err := ptp.WithTxn(txn).GetRecord(ctx, ptsEntries.SystemTablesRecord)
+				if err != nil {
+					return err
+				}
+				ts = rec.Timestamp
+				return nil
+			}))
+			return ts
+		}
+
+		getTable1PTS := func() hlc.Timestamp {
+			ptsEntries := getPTSEntries()
+			require.NotEqual(t, uuid.Nil, ptsEntries.PerTableRecords[table1ID])
+			var ts hlc.Timestamp
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				ptp := s.Server.DistSQLServer().(*distsql.ServerImpl).ServerConfig.ProtectedTimestampProvider
+				rec, err := ptp.WithTxn(txn).GetRecord(ctx, ptsEntries.PerTableRecords[table1ID])
+				if err != nil {
+					return err
+				}
+				ts = rec.Timestamp
+				return nil
+			}))
+			return ts
+		}
+
+		systemTablesPTSBefore := getSystemTablesPTS()
+		table1PTSBefore := getTable1PTS()
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+		testutils.SucceedsSoon(t, func() error {
+			systemTablesPTSAfter := getSystemTablesPTS()
+			table1PTSAfter := getTable1PTS()
+			if !systemTablesPTSBefore.Less(systemTablesPTSAfter) {
+				return errors.Newf("expected system tables PTS to advance from %v, got %v", systemTablesPTSBefore, systemTablesPTSAfter)
+			}
+			if !table1PTSBefore.Less(table1PTSAfter) {
+				return errors.Newf("expected table 1 PTS to advance from %v, got %v", table1PTSBefore, table1PTSAfter)
+			}
+			return nil
+		})
+
+		// Once the changefeed's highwater has caught up to the primary PTS record,
+		// we should revert the per-table protected timestamp records as soon as
+		// the highwater has caught up to the primary PTS record.
+		table1Lagging.Store(false)
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+		assertOldStylePTS()
+
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (3, 'data3')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (3, 'data3')`)
+		sqlDB.Exec(t, `INSERT INTO table3 VALUES (3, 'data3')`)
+		assertPayloads(t, testFeed, []string{
+			`table1: [3]->{"after": {"id": 3, "s": "data3"}}`,
+			`table2: [3]->{"after": {"id": 3, "s": "data3"}}`,
+			`table3: [3]->{"after": {"id": 3, "s": "data3"}}`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
+// TestChangefeedPerTablePTSReleaseWithDisabledTracking tests that per-table PTS
+// records cannot be released when per-table tracking is disabled, even after
+// tables stop lagging.
+func TestChangefeedPerTablePTSReleaseWithDisabledTracking(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Configure frequent checkpointing and PTS updates for faster testing
+		changefeedbase.SpanCheckpointInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 50*time.Millisecond)
+
+		// Enable per-table protected timestamps and progress tracking
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
+		sqlDB.Exec(t, `CREATE TABLE table1 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table2 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (1, 'data1')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (1, 'data1')`)
+
+		var table1ID, table2ID descpb.ID
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table1' AND database_name = current_database()`).Scan(&table1ID)
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table2' AND database_name = current_database()`).Scan(&table2ID)
+
+		knobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		var table1Lagging, table2Lagging atomic.Bool
+		knobs.IsTableLagging = func(tableID descpb.ID) bool {
+			switch tableID {
+			case table1ID:
+				return table1Lagging.Load()
+			case table2ID:
+				return table2Lagging.Load()
+			default:
+				return false
+			}
+		}
+
+		createStmt := `CREATE CHANGEFEED FOR table1, table2 WITH resolved='100ms'`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`table1: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table2: [1]->{"after": {"id": 1, "s": "data1"}}`,
+		})
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+
+		getPTSEntries := func() cdcprogresspb.ProtectedTimestampRecords {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				return readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID())
+			}))
+			return ptsEntries
+		}
+
+		assertPerTablePTSExist := func(expectedTables map[descpb.ID]struct{}) {
+			testutils.SucceedsSoon(t, func() error {
+				ptsEntries := getPTSEntries()
+				if len(ptsEntries.PerTableRecords) != len(expectedTables) {
+					return errors.Newf("expected %d per-table PTS records, got %d", len(expectedTables), len(ptsEntries.PerTableRecords))
+				}
+				for tableID := range expectedTables {
+					if ptsEntries.PerTableRecords[tableID] == uuid.Nil {
+						return errors.Newf("expected PTS record for table %d", tableID)
+					}
+				}
+				return nil
+			})
+		}
+
+		table1Lagging.Store(true)
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		assertPerTablePTSExist(map[descpb.ID]struct{}{table1ID: {}})
+
+		require.NoError(t, eFeed.Pause())
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+
+		table1Lagging.Store(false)
+		require.NoError(t, eFeed.Resume())
+
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		assertPerTablePTSExist(map[descpb.ID]struct{}{})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
 func fetchRoleMembers(
 	ctx context.Context, execCfg *sql.ExecutorConfig, ts hlc.Timestamp,
 ) ([][]string, error) {

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -98,6 +98,11 @@ type TestingKnobs struct {
 	// to check if the table is lagging.
 	IsTableLagging func(tableID descpb.ID) bool
 
+	// IsPTSReversionLagging is a callback that's invoked by manage protected timestamp
+	// to check if the changefeed's highwater has caught up to the primary PTS record
+	// when reverting per-table protected timestamps.
+	IsPTSReversionLagging func() bool
+
 	// PulsarClientSkipCreation skips creating the sink client when
 	// dialing.
 	PulsarClientSkipCreation bool


### PR DESCRIPTION
When per-table protected timestamp records are disabled via the
cluster setting, a restarted changefeed should eventually fall
back to the legacy single-record format. However, if any tables
are still lagging, we retain their individual PTS records and
continue attempting to advance them using the highwater timestamp
on each management cycle. Once all lagging tables have caught up,
the changefeed cleans up the per-table records and reverts fully
to a single protected timestamp record.

Fixes: https://github.com/cockroachdb/cockroach/issues/147790
Epic: [CRDB-1421](https://cockroachlabs.atlassian.net/browse/CRDB-1421)
Release note: None