### PR TITLE
storage: use minimum supported version for TransportSSTWriter

### DIFF
--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -117,7 +117,13 @@ func makeSSTRewriteOptions(
 // scanned and their keys inserted into new sstables (NB: constructed using
 // MakeIngestionSSTWriter) that ultimately are uploaded to object storage.
 func MakeTransportSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer) SSTWriter {
-	format := minPebbleFormatVersionInCluster(cs.Version.ActiveVersion(ctx).Version).MaxTableFormat()
+	// MakeTransportSSTWriter is used to evaluate export requests. The export
+	// requests could be issued by a non-system tenant with an older binary, so we
+	// must emit at the minimum supported version.
+	//
+	// TODO(radu): ideally the tenant would be able to specify the desired format
+	// version (#153283).
+	format := MinimumSupportedFormatVersion.MaxTableFormat()
 
 	opts := DefaultPebbleOptions().MakeWriterOptions(0, format)
 


### PR DESCRIPTION
MakeTransportSSTWriter is used when evaluating export requests. These
requests can be issued by non-system tenants which can run older
binaries. Since we have currently have no way of knowing what binary
version that is, we must emit at the minimum supported version.

Fixes #152723

This reverts one aspect of #151176