### PR TITLE
roachtest: Disable panic_node mutator for mixed-version-endpoints test

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -112,6 +112,8 @@ func runDBConsoleMixedVersion(ctx context.Context, t test.Test, c cluster.Cluste
 		c.CRDBNodes(),
 		// In 24.3 new endpoints were added to /api/v2 server.
 		mixedversion.MinimumSupportedVersion("v24.3.0"),
+		// Panics are problematic for the /logs endpoints, see https://github.com/cockroachdb/cockroach/issues/151493.
+		mixedversion.DisableMutators(mixedversion.PanicNode),
 	)
 
 	mvt.InMixedVersion("test db console endpoints", func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {


### PR DESCRIPTION
Previously many runs of the `db-console/mixed-version-endpoints` roachtest would run into a failure mode where accessing the logs endpoint on a node that had previously panic'ed would result in the endpoint returning a 500 (and the test subsequently failing). See #151493.

Any run that involves a panic_node mutator in the test plan is bound to run into this issue (since the fix is not backported).

This commit should reduce this failure mode significantly by disabling the panic_node mutator.

Fixes: #153087
Release note: None