### PR TITLE
IMPORT: trigger async INSPECT job for validation

### DIFF
--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -477,7 +477,25 @@ func (n *scrubNode) runScrubTableJob(
 	ctx context.Context, p *planner, tableDesc catalog.TableDescriptor, asOf hlc.Timestamp,
 ) error {
 	// Consistency check is done async via a job.
-	jobID := p.ExecCfg().JobRegistry.MakeJobID()
+	jobID, err := TriggerInspectJob(ctx, tree.Serialize(n.n), p.ExecCfg(), tableDesc, asOf)
+	if err != nil {
+		return err
+	}
+	// Let the eval context track this job ID for status and error reporting.
+	p.extendedEvalCtx.jobs.addCreatedJobID(jobID)
+	return nil
+}
+
+// TriggerInspectJob starts an inspect job for the snapshot.
+func TriggerInspectJob(
+	ctx context.Context,
+	jobRecordDescription string,
+	execCfg *ExecutorConfig,
+	tableDesc catalog.TableDescriptor,
+	asOf hlc.Timestamp,
+) (jobspb.JobID, error) {
+	// Consistency check is done async via a job.
+	jobID := execCfg.JobRegistry.MakeJobID()
 
 	// TODO(148300): just grab the first secondary index and use that for the
 	// consistency check.
@@ -485,11 +503,12 @@ func (n *scrubNode) runScrubTableJob(
 	// and return a NOTICE.
 	secIndexes := tableDesc.PublicNonPrimaryIndexes()
 	if len(secIndexes) == 0 {
-		return errors.AssertionFailedf("must have at least one secondary index")
+		return jobID, errors.AssertionFailedf("must have at least one secondary index")
 	}
 
+	// TODO(sql-queries): add row count check when that is implemented.
 	jr := jobs.Record{
-		Description: tree.Serialize(n.n),
+		Description: jobRecordDescription,
 		Details: jobspb.InspectDetails{
 			Checks: []*jobspb.InspectDetails_Check{
 				{
@@ -507,22 +526,19 @@ func (n *scrubNode) runScrubTableJob(
 	}
 
 	var sj *jobs.StartableJob
-	if err := p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
-		return p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, txn, jr)
+	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
+		return execCfg.JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, txn, jr)
 	}); err != nil {
 		if sj != nil {
 			if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
 				log.Dev.Warningf(ctx, "failed to cleanup StartableJob: %v", cleanupErr)
 			}
 		}
-		return err
+		return jobID, err
 	}
-
-	log.Dev.Infof(ctx, "created and started inspect job %d (no-op)", jobID)
+	log.Dev.Infof(ctx, "created and started inspect job %d", jobID)
 	if err := sj.Start(ctx); err != nil {
-		return err
+		return jobID, err
 	}
-	// Let the eval context track this job ID for status and error reporting.
-	p.extendedEvalCtx.jobs.addCreatedJobID(jobID)
-	return nil
+	return jobID, nil
 }


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/146327

We found a bug that async flush can cause silent data corruption for IMPORT, and this commit is to trigger a validation step to alert if similar data corruption happens again. To avoid increasing the latency for IMPORT we trigger an INSPECT job that runs the validation asynchronously right after the table is set to public at the end of an import. We use the commit timestamp of the internal txn which update the table state to public, so that we can ensure the INSPECT focus on the snapshot at the end of the IMPORT job.

This behavior is gated by cluster settings `bulkio.import.row_count_validation.unsafe.enabled`, which is default to false.

See more internal discussion [here](https://cockroachlabs.slack.com/archives/C02DSDS9TM1/p1757439225277989?thread_ts=1756991224.633879&cid=C02DSDS9TM1).

Release note: Added `bulkio.import.row_count_validation.unsafe.enabled` (default false) that will trigger asynchronous INSPECT job at the end of an IMPORT execution.