### PR TITLE
sql: add txn diagnostics collection to instrumentation helper

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1171,6 +1171,7 @@ func (s *Server) newConnExecutor(
 			connCtx:                      ctx,
 			testingForceRealTracingSpans: s.cfg.TestingKnobs.ForceRealTracingSpans,
 			execType:                     executorType,
+			txnInstrumentationHelper:     txnInstrumentationHelper{TxnDiagnosticsRecorder: s.cfg.TxnDiagnosticsRecorder},
 		},
 		transitionCtx: transitionCtx{
 			db:           s.cfg.DB,
@@ -1195,6 +1196,7 @@ func (s *Server) newConnExecutor(
 		executorType:              executorType,
 		hasCreatedTemporarySchema: false,
 		stmtDiagnosticsRecorder:   s.cfg.StmtDiagnosticsRecorder,
+		txnDiagnosticsRecorder:    s.cfg.TxnDiagnosticsRecorder,
 		indexUsageStats:           s.indexUsageStats,
 		txnIDCacheWriter:          s.txnIDCache,
 		totalActiveTimeStopWatch:  timeutil.NewStopWatch(),
@@ -1871,6 +1873,7 @@ type connExecutor struct {
 	// stmtDiagnosticsRecorder is used to track which queries need to have
 	// information collected.
 	stmtDiagnosticsRecorder *stmtdiagnostics.Registry
+	txnDiagnosticsRecorder  *stmtdiagnostics.TxnRegistry
 
 	// indexUsageStats is used to track index usage stats.
 	indexUsageStats *idxusage.LocalIndexUsageStats

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -293,6 +294,7 @@ func startConnExecutor(
 	// This pool should never be Stop()ed because, if the test is failing, memory
 	// is not properly released.
 	collectionFactory := descs.NewBareBonesCollectionFactory(st, keys.SystemSQLCodec)
+	registry := stmtdiagnostics.NewRegistry(nil, st)
 	cfg := &ExecutorConfig{
 		AmbientCtx: ambientCtx,
 		Settings:   st,
@@ -339,7 +341,8 @@ func startConnExecutor(
 		),
 		QueryCache:              querycache.New(0),
 		TestingKnobs:            ExecutorTestingKnobs{},
-		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, st),
+		StmtDiagnosticsRecorder: registry,
+		TxnDiagnosticsRecorder:  stmtdiagnostics.NewTxnRegistry(nil, st, registry, timeutil.DefaultTimeSource{}),
 		HistogramWindowInterval: base.DefaultHistogramWindowInterval(),
 		CollectionFactory:       collectionFactory,
 		LicenseEnforcer:         license.NewEnforcer(nil),

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -191,8 +191,7 @@ func (ex *connExecutor) recordStatementSummary(
 	}
 	startTime := phaseTimes.GetSessionPhaseTime(sessionphase.PlannerStartExecStmt).ToUTC()
 	implicitTxn := flags.IsSet(planFlagImplicitTxn)
-	stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
-		stmt.StmtNoConstants, implicitTxn, planner.SessionData().Database)
+	stmtFingerprintID := planner.instrumentation.fingerprintId
 	autoRetryReason := ex.state.mu.autoRetryReason
 	if automaticRetryStmtCount > 0 {
 		autoRetryReason = planner.autoRetryStmtReason

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -28,7 +28,7 @@ go_library(
 
 go_test(
     name = "stmtdiagnostics_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "main_test.go",
         "statement_diagnostics_helpers_test.go",
@@ -37,6 +37,7 @@ go_test(
         "txn_diagnostics_test.go",
     ],
     embed = [":stmtdiagnostics"],
+    exec_properties = {"test.Pool": "large"},
     tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
@@ -53,6 +54,7 @@ go_test(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/isql",
         "//pkg/sql/sqlerrors",
+        "//pkg/sql/sqlstats",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -8,7 +8,9 @@ package stmtdiagnostics_test
 import (
 	"context"
 	gosql "database/sql"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -23,11 +25,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -767,6 +771,271 @@ func TestTxnRegistry_InsertTxnRequest_Polling(t *testing.T) {
 		}
 		if _, ok = registry3.GetRequest(id); ok {
 			return errors.New("request still found on server 3")
+		}
+		return nil
+	})
+}
+
+func TestTxnBundleCollection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t)
+
+	txnStatements := []string{"SELECT 'aaaaaa', 'bbbbbb'",
+		"SELECT 'aaaaaa', 'bbbbbb', 'ccccc' UNION select 'ddddd', 'eeeee', 'fffff'"}
+
+	ctx := context.Background()
+	settings := cluster.MakeTestingClusterSettings()
+	// Set to 1s so that we can quickly pick up the request.
+	stmtdiagnostics.PollingInterval.Override(ctx, &settings.SV, time.Second)
+
+	knobs := sqlstats.CreateTestingKnobs()
+	knobs.SynchronousSQLStats = true
+	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Settings: settings,
+			Knobs: base.TestingKnobs{
+				SQLStatsKnobs: knobs,
+			},
+		},
+	})
+
+	defer tc.Stopper().Stop(ctx)
+
+	// SETUP
+	sqlConn := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	// Execute to transaction so that it is in transaction_statistics
+	executeTransactions(t, sqlConn, txnStatements)
+
+	// Get the fingerprint id and statement fingerprint ids for the transaction
+	// to make the txn diagnostics request
+	row := sqlConn.QueryRow(t,
+		`
+SELECT
+  ts.fingerprint_id AS fingerprint_id,
+  ts.metadata->'stmtFingerprintIDs' as fingerprint_ids
+FROM crdb_internal.transaction_statistics ts
+JOIN crdb_internal.statement_statistics ss on ss.transaction_fingerprint_id = ts.fingerprint_id
+WHERE ss.metadata->>'query' LIKE 'SELECT _, _'
+LIMIT 1`)
+	var fingerprintId []byte
+	var fingerprintIdsBytes []byte
+
+	row.Scan(&fingerprintId, &fingerprintIdsBytes)
+	_, txnFingerprintId, err := encoding.DecodeUint64Ascending(fingerprintId)
+	require.NoError(t, err)
+
+	var statementFingerprintStrs []string
+
+	err = json.Unmarshal(fingerprintIdsBytes, &statementFingerprintStrs)
+	require.NoError(t, err)
+
+	var statementFingerprintIds []uint64
+	for _, s := range statementFingerprintStrs {
+		value, err := strconv.ParseUint(s, 16, 64)
+		require.NoError(t, err)
+		statementFingerprintIds = append(statementFingerprintIds, value)
+	}
+
+	registry := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).TxnDiagnosticsRecorder
+
+	t.Run("txn diagnostic request", func(t *testing.T) {
+		// Insert a request for the transaction fingerprint
+		reqId, err := registry.InsertTxnRequestInternal(
+			ctx,
+			txnFingerprintId,
+			statementFingerprintIds,
+			"testuser",
+			0,
+			0,
+			0,
+			false,
+		)
+		require.NoError(t, err)
+
+		// Ensure that the request shows up in the system.transaction_diagnostics_requests table
+		var count int
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.transaction_diagnostics_requests WHERE completed=false and id=$1", reqId).Scan(&count)
+		require.Equal(t, 1, count)
+
+		// Execute the transaction until the request is marked as complete.
+		// We use a connection to a different server than the diagnostics request
+		// was made on to ensure that the request is properly gossiped.
+		runTxnUntilDiagnosticsCollected(t, tc, sqlutils.MakeSQLRunner(tc.ServerConn(1)), txnStatements, reqId)
+
+	})
+
+	t.Run("txn diagnostic with statement diagnostic request", func(t *testing.T) {
+
+		stmtReqId, err := registry.StmtRegistry.InsertRequestInternal(
+			ctx,
+			"SELECT _, _",
+			"", false, 0, 0, 0,
+		)
+		require.NoError(t, err)
+		var stmtcount int
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics_requests WHERE completed=false and id=$1", stmtReqId).Scan(&stmtcount)
+		require.Equal(t, 1, stmtcount)
+
+		// execute the statement to ensure that the correct statement diagnostics
+		// request is actually being created.
+		sqlConn.Exec(t, txnStatements[0])
+		// should be complete now
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics_requests WHERE completed=true and id=$1", stmtReqId).Scan(&stmtcount)
+		require.Equal(t, 1, stmtcount)
+		testutils.SucceedsSoon(t, func() error {
+			// wait for the statement diagnostics request to be removed from all
+			// server registries
+			for i := range tc.NumServers() {
+				stmtReg := tc.Server(i).ExecutorConfig().(sql.ExecutorConfig).StmtDiagnosticsRecorder
+				if found := stmtReg.TestingFindRequest(stmtReqId); found {
+					return errors.Newf("stmt request %d still in registry", stmtReqId)
+				}
+			}
+			return nil
+		})
+		// Make a new request for the same statement
+		stmtReqId, err = registry.StmtRegistry.InsertRequestInternal(
+			ctx,
+			"SELECT _, _",
+			"", false, 0, 0, 0,
+		)
+		require.NoError(t, err)
+		// make sure the statement diagnostics request is also marked as
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics_requests WHERE completed=false and id=$1", stmtReqId).Scan(&stmtcount)
+		require.Equal(t, 1, stmtcount)
+
+		// Insert a request for the transaction fingerprint
+		reqId, err := registry.InsertTxnRequestInternal(
+			ctx,
+			txnFingerprintId,
+			statementFingerprintIds,
+			"testuser",
+			0,
+			0,
+			0,
+			false,
+		)
+		require.NoError(t, err)
+
+		// Ensure that the request shows up in the system.transaction_diagnostics_requests table
+		var count int
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.transaction_diagnostics_requests WHERE completed=false and id=$1", reqId).Scan(&count)
+		require.Equal(t, 1, count)
+		runTxnUntilDiagnosticsCollected(t, tc, sqlConn, txnStatements, reqId)
+		// Ensure there are no more active transaction diagnostics requests
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.transaction_diagnostics_requests WHERE completed=false and id=$1", reqId).Scan(&count)
+		require.Equal(t, 0, count)
+		// make sure the statement diagnostics request is still incomplete
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics_requests WHERE completed=false and id=$1", stmtReqId).Scan(&stmtcount)
+		require.Equal(t, 1, stmtcount)
+
+		executeTransactions(t, sqlConn, txnStatements)
+		// should be complete now that there is no transaction diagnostics request
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.statement_diagnostics_requests WHERE completed=true and id=$1", stmtReqId).Scan(&stmtcount)
+		require.Equal(t, 1, stmtcount)
+	})
+
+	t.Run("multiple txn executions", func(t *testing.T) {
+		// Insert a request for the transaction fingerprint
+		reqId, err := registry.InsertTxnRequestInternal(
+			ctx,
+			txnFingerprintId,
+			statementFingerprintIds,
+			"testuser",
+			1,
+			1,
+			0,
+			false,
+		)
+		require.NoError(t, err)
+
+		// Ensure that the request shows up in the system.transaction_diagnostics_requests table
+		var count int
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.transaction_diagnostics_requests WHERE completed=false and id=$1", reqId).Scan(&count)
+		require.Equal(t, 1, count)
+
+		conn2 := sqlutils.MakeSQLRunner(tc.ServerConn(1))
+		conn3 := sqlutils.MakeSQLRunner(tc.ServerConn(2))
+
+		// Wait for the request to be in all node registries
+		testutils.SucceedsSoon(t, func() error {
+			for i := range tc.NumServers() {
+				innerRegistry := tc.Server(i).ExecutorConfig().(sql.ExecutorConfig).TxnDiagnosticsRecorder
+				_, ok := innerRegistry.GetRequest(reqId)
+				if !ok {
+					return errors.New("expected request to be in registry")
+				}
+			}
+			return nil
+		})
+
+		conn2.Exec(t, "BEGIN")
+		conn3.Exec(t, "BEGIN")
+
+		conn2.Exec(t, txnStatements[0])
+		conn2.Exec(t, txnStatements[1])
+
+		conn3.Exec(t, txnStatements[0])
+		conn3.Exec(t, txnStatements[1])
+		conn3.Exec(t, "COMMIT")
+		conn2.Exec(t, "COMMIT")
+
+		sqlConn.QueryRow(t, "SELECT count(*) FROM system.transaction_diagnostics_requests WHERE completed=true and id=$1", reqId).Scan(&count)
+		require.Equal(t, 1, count)
+
+		sqlConn.QueryRow(t, ""+
+			"SELECT count(*) FROM system.statement_diagnostics sd "+
+			"JOIN system.transaction_diagnostics_requests tdr on tdr.transaction_diagnostics_id = sd.transaction_diagnostics_id "+
+			"WHERE tdr.id=$1", reqId).Scan(&count)
+
+		require.Equal(t, 3, count)
+	})
+
+}
+
+func executeTransactions(t *testing.T, runner *sqlutils.SQLRunner, statements []string) {
+	t.Helper()
+	runner.Exec(t, "BEGIN")
+	for _, stmt := range statements {
+		runner.Exec(t, stmt)
+	}
+	runner.Exec(t, "COMMIT")
+}
+
+func runTxnUntilDiagnosticsCollected(
+	t *testing.T,
+	tc serverutils.TestClusterInterface,
+	sqlConn *sqlutils.SQLRunner,
+	statements []string,
+	reqId stmtdiagnostics.RequestID,
+) {
+	t.Helper()
+	testutils.SucceedsSoon(t, func() error {
+		executeTransactions(t, sqlConn, statements)
+		r := tc.ServerConn(0).QueryRow("SELECT count(*) FROM system.transaction_diagnostics_requests WHERE completed=true and id=$1", reqId)
+		if r.Err() != nil {
+			return r.Err()
+		}
+		var count int
+		err := r.Scan(&count)
+		if err != nil {
+			return err
+		}
+		if count != 1 {
+			return errors.Newf("expected 1 completed bundle, got %d", count)
+		}
+		return nil
+	})
+
+	testutils.SucceedsSoon(t, func() error {
+		for i := range tc.NumServers() {
+			registry := tc.Server(i).ExecutorConfig().(sql.ExecutorConfig).TxnDiagnosticsRecorder
+			_, ok := registry.GetRequest(reqId)
+			if ok {
+				return errors.Newf("expected request to be removed from registry. Still exits in registry %d", i)
+			}
 		}
 		return nil
 	})

--- a/pkg/sql/txn_instrumentation_test.go
+++ b/pkg/sql/txn_instrumentation_test.go
@@ -9,15 +9,20 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +35,7 @@ func TestTxnDiagnosticsCollector_AddStatementBundle_NoMoreFps(t *testing.T) {
 		func(t *testing.T, stmt tree.Statement) {
 			request := stmtdiagnostics.TxnRequest{}
 			requestID := stmtdiagnostics.RequestID(42)
-			collector := newTxnDiagnosticsCollector(request, requestID)
+			collector := newTxnDiagnosticsCollector(request, requestID, nil)
 
 			// Since stmtsFpsToCapture is empty, only commit/rollback should be accepted
 			bundle := stmtdiagnostics.StmtDiagnostic{}
@@ -48,7 +53,7 @@ func TestTxnDiagnosticsCollector_AddStatementBundle_ExpectedCommitOrRollback(t *
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	collector := newTxnDiagnosticsCollector(request, requestID)
+	collector := newTxnDiagnosticsCollector(request, requestID, nil)
 
 	stmt := &tree.Select{
 		Select: &tree.SelectClause{},
@@ -66,7 +71,7 @@ func TestTxnDiagnosticsCollector_AddStatementBundle_AlreadyFinalized(t *testing.
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	collector := newTxnDiagnosticsCollector(request, requestID)
+	collector := newTxnDiagnosticsCollector(request, requestID, nil)
 	collector.readyToFinalize = true
 
 	stmt := &tree.Select{
@@ -85,7 +90,7 @@ func TestTxnDiagnosticsCollector_AddStatementBundle_WithStmtsToCapture(t *testin
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	collector := newTxnDiagnosticsCollector(request, requestID)
+	collector := newTxnDiagnosticsCollector(request, requestID, nil)
 	collector.stmtsFpsToCapture = []uint64{123, 456}
 
 	stmt1 := &tree.Select{
@@ -117,7 +122,7 @@ func TestTxnDiagnosticsCollector_AddStatementBundle_WrongFingerprint(t *testing.
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	collector := newTxnDiagnosticsCollector(request, requestID)
+	collector := newTxnDiagnosticsCollector(request, requestID, nil)
 
 	collector.stmtsFpsToCapture = []uint64{123, 456}
 
@@ -141,10 +146,12 @@ func TestTxnInstrumentationHelper_StartDiagnostics(t *testing.T) {
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
 
-	helper.StartDiagnostics(request, requestID)
+	span := &tracing.Span{}
+	helper.StartDiagnostics(request, requestID, span)
 
 	require.Equal(t, request, helper.diagnosticsCollector.request)
 	require.Equal(t, requestID, helper.diagnosticsCollector.requestId)
+	require.Equal(t, span, helper.diagnosticsCollector.span)
 	require.True(t, helper.DiagnosticsInProgress())
 }
 
@@ -152,12 +159,42 @@ func TestTxnInstrumentationHelper_DiagnosticsInProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	helper := &txnInstrumentationHelper{}
+	for _, tc := range []struct {
+		name               string
+		requestId          stmtdiagnostics.RequestID
+		stmtsFpsToCapture  []uint64
+		stmtBundles        []stmtdiagnostics.StmtDiagnostic
+		expectedInProgress bool
+	}{
+		{
+			name:               "not in progress",
+			expectedInProgress: false,
+		}, {
+			name:               "with requestId",
+			requestId:          stmtdiagnostics.RequestID(42),
+			stmtsFpsToCapture:  nil,
+			stmtBundles:        nil,
+			expectedInProgress: true,
+		}, {
+			name:               "with stmtFpsToCapture",
+			stmtsFpsToCapture:  []uint64{123, 456},
+			expectedInProgress: true,
+		}, {
+			name:               "with stmtBundles",
+			stmtsFpsToCapture:  nil,
+			stmtBundles:        []stmtdiagnostics.StmtDiagnostic{{}},
+			expectedInProgress: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 
-	require.False(t, helper.DiagnosticsInProgress())
-
-	helper.diagnosticsCollector.requestId = stmtdiagnostics.RequestID(42)
-	require.True(t, helper.DiagnosticsInProgress())
+			helper := &txnInstrumentationHelper{}
+			helper.diagnosticsCollector.requestId = tc.requestId
+			helper.diagnosticsCollector.stmtsFpsToCapture = tc.stmtsFpsToCapture
+			helper.diagnosticsCollector.stmtBundles = tc.stmtBundles
+			require.Equal(t, tc.expectedInProgress, helper.DiagnosticsInProgress())
+		})
+	}
 }
 
 func TestTxnInstrumentationHelper_AddStatementBundle_Success(t *testing.T) {
@@ -168,7 +205,7 @@ func TestTxnInstrumentationHelper_AddStatementBundle_Success(t *testing.T) {
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	helper.StartDiagnostics(request, requestID)
+	helper.StartDiagnostics(request, requestID, nil)
 
 	ctx := context.Background()
 	stmt := &tree.CommitTransaction{} // Use commit since we have no expected statements
@@ -191,7 +228,7 @@ func TestTxnInstrumentationHelper_AddStatementBundle_Error(t *testing.T) {
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	helper.StartDiagnostics(request, requestID)
+	helper.StartDiagnostics(request, requestID, nil)
 
 	// Set collector to already finalized to trigger error
 	helper.diagnosticsCollector.readyToFinalize = true
@@ -217,7 +254,7 @@ func TestTxnInstrumentationHelper_AddStatementBundle_NoSuccess(t *testing.T) {
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	helper.StartDiagnostics(request, requestID)
+	helper.StartDiagnostics(request, requestID, nil)
 
 	// Set up expected fingerprints so we can trigger no-success case
 	helper.diagnosticsCollector.stmtsFpsToCapture = []uint64{123}
@@ -238,6 +275,7 @@ func TestTxnInstrumentationHelper_ShouldContinueDiagnostics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	ctx := context.Background()
 	type statement struct {
 		stmt tree.Statement
 		fpId uint64
@@ -299,13 +337,20 @@ func TestTxnInstrumentationHelper_ShouldContinueDiagnostics(t *testing.T) {
 			0,
 		)
 		requestID := stmtdiagnostics.RequestID(42)
-		helper.StartDiagnostics(request, requestID)
-		actual := helper.ShouldContinueDiagnostics(tc.stmt.stmt, tc.stmt.fpId)
+		tracer := tracing.NewTracer()
+		sp := tracer.StartSpan("parent-span", tracing.WithRecording(tracingpb.RecordingVerbose))
+		helper.StartDiagnostics(request, requestID, sp)
+		newCtx, actual := helper.ShouldContinueDiagnostics(ctx, tc.stmt.stmt, tc.stmt.fpId)
 		require.Equal(t, tc.shouldContinue, actual)
 
 		if !tc.shouldContinue {
 			require.Zero(t, helper.diagnosticsCollector)
 			require.False(t, helper.DiagnosticsInProgress())
+			require.Equal(t, ctx, newCtx)
+		} else {
+			require.NotEqual(t, ctx, newCtx)
+			returnedSpan := tracing.SpanFromContext(newCtx)
+			require.Equal(t, sp, returnedSpan)
 		}
 	}
 }
@@ -319,7 +364,7 @@ func TestTxnInstrumentationHelper_ShouldRedact(t *testing.T) {
 
 		request := stmtdiagnostics.NewTxnRequest(0, nil, shouldRedact, "", time.Time{}, 0, 0)
 		requestID := stmtdiagnostics.RequestID(42)
-		helper.StartDiagnostics(request, requestID)
+		helper.StartDiagnostics(request, requestID, nil)
 
 		require.Equal(t, shouldRedact, helper.ShouldRedact())
 	})
@@ -334,7 +379,7 @@ func TestTxnInstrumentationHelper_collectionFlow(t *testing.T) {
 
 	request := stmtdiagnostics.TxnRequest{}
 	requestID := stmtdiagnostics.RequestID(42)
-	helper.StartDiagnostics(request, requestID)
+	helper.StartDiagnostics(request, requestID, nil)
 
 	// Simulate a TxnRequest with multiple statement fingerprints
 	expectedFingerprints := []uint64{100, 200, 300}
@@ -344,7 +389,8 @@ func TestTxnInstrumentationHelper_collectionFlow(t *testing.T) {
 
 	// Process first statement
 	stmt1 := &tree.Select{Select: &tree.SelectClause{}}
-	require.True(t, helper.ShouldContinueDiagnostics(stmt1, 100))
+	_, shouldContinue := helper.ShouldContinueDiagnostics(ctx, stmt1, 100)
+	require.True(t, shouldContinue)
 
 	bundle1 := diagnosticsBundle{zip: []byte("stmt1-zip")}
 	helper.AddStatementBundle(ctx, stmt1, uint64(100), "SELECT * FROM table1", bundle1)
@@ -355,7 +401,8 @@ func TestTxnInstrumentationHelper_collectionFlow(t *testing.T) {
 
 	// Process second statement
 	stmt2 := &tree.Select{Select: &tree.SelectClause{}}
-	require.True(t, helper.ShouldContinueDiagnostics(stmt2, 200))
+	_, shouldContinue = helper.ShouldContinueDiagnostics(ctx, stmt2, 200)
+	require.True(t, shouldContinue)
 
 	bundle2 := diagnosticsBundle{zip: []byte("stmt2-zip")}
 	helper.AddStatementBundle(ctx, stmt2, uint64(200), "SELECT * FROM table2", bundle2)
@@ -366,7 +413,8 @@ func TestTxnInstrumentationHelper_collectionFlow(t *testing.T) {
 
 	// Process third statement
 	stmt3 := &tree.Select{Select: &tree.SelectClause{}}
-	require.True(t, helper.ShouldContinueDiagnostics(stmt3, 300))
+	_, shouldContinue = helper.ShouldContinueDiagnostics(ctx, stmt2, 300)
+	require.True(t, shouldContinue)
 
 	bundle3 := diagnosticsBundle{zip: []byte("stmt3-zip")}
 	helper.AddStatementBundle(ctx, stmt3, uint64(300), "SELECT * FROM table3", bundle3)
@@ -377,7 +425,8 @@ func TestTxnInstrumentationHelper_collectionFlow(t *testing.T) {
 
 	// Process commit statement
 	commit := &tree.CommitTransaction{}
-	require.True(t, helper.ShouldContinueDiagnostics(commit, 0))
+	_, shouldContinue = helper.ShouldContinueDiagnostics(ctx, commit, 0)
+	require.True(t, shouldContinue)
 
 	bundleCommit := diagnosticsBundle{zip: []byte("commit-zip")}
 	helper.AddStatementBundle(ctx, commit, uint64(0), "COMMIT", bundleCommit)
@@ -386,7 +435,7 @@ func TestTxnInstrumentationHelper_collectionFlow(t *testing.T) {
 	require.True(t, helper.diagnosticsCollector.readyToFinalize)
 }
 
-func TestTxnDiagnosticsCollector_AddTrace_RedactedRequest(t *testing.T) {
+func TestTxnDiagnosticsCollector_collectTrace_RedactedRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -400,31 +449,28 @@ func TestTxnDiagnosticsCollector_AddTrace_RedactedRequest(t *testing.T) {
 		0,
 		0,
 	)
-	collector := newTxnDiagnosticsCollector(request, stmtdiagnostics.RequestID(42))
+	collector := newTxnDiagnosticsCollector(request, stmtdiagnostics.RequestID(42), nil)
+	collector.collectTrace()
 
-	// Create a mock trace
-	trace := tracingpb.Recording{
-		{
-			TraceID:   1,
-			SpanID:    1,
-			Operation: "test-operation",
-		},
-	}
-
-	// Add trace - should be a no-op for redacted requests
-	collector.AddTrace(trace)
-
-	// Verify no files were added by finalizing and checking if zip is empty
 	buf, err := collector.z.Finalize()
 	require.NoError(t, err)
 
 	// Read the zip to check if it's empty
 	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	require.NoError(t, err)
-	require.Len(t, reader.File, 0, "No files should be added for redacted requests")
+	require.Len(t, reader.File, 1)
+
+	// Check that the file contains the expected message
+	rc, err := reader.File[0].Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	content, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, "trace not collected due to redacted request", string(content))
 }
 
-func TestTxnDiagnosticsCollector_AddTrace(t *testing.T) {
+func TestTxnDiagnosticsCollector_collectTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -438,21 +484,14 @@ func TestTxnDiagnosticsCollector_AddTrace(t *testing.T) {
 		0,
 		0,
 	)
-	collector := newTxnDiagnosticsCollector(request, stmtdiagnostics.RequestID(42))
 
-	// Create a valid trace with proper span
-	trace := tracingpb.Recording{
-		{
-			TraceID:   1,
-			SpanID:    1,
-			Operation: "test-operation",
-			StartTime: timeutil.Now(),
-			Duration:  time.Millisecond,
-		},
-	}
+	tracer := tracing.NewTracer()
+	span := tracer.StartSpan("test-tracer", tracing.WithRecording(tracingpb.RecordingVerbose))
+	span.Record("test msg")
+	collector := newTxnDiagnosticsCollector(request, stmtdiagnostics.RequestID(42), span)
 
 	// Add trace
-	collector.AddTrace(trace)
+	collector.collectTrace()
 
 	// Verify files were added
 	buf, err := collector.z.Finalize()
@@ -471,7 +510,7 @@ func TestTxnDiagnosticsCollector_AddTrace(t *testing.T) {
 	require.True(t, fileNames["trace-jaeger.json"])
 }
 
-func TestTxnDiagnosticsCollector_AddTrace_notrace(t *testing.T) {
+func TestTxnDiagnosticsCollector_collectTrace_emptyRecordings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -485,16 +524,77 @@ func TestTxnDiagnosticsCollector_AddTrace_notrace(t *testing.T) {
 		0,
 		0,
 	)
-	collector := newTxnDiagnosticsCollector(request, stmtdiagnostics.RequestID(42))
 
-	// Add trace
-	collector.AddTrace(nil)
+	collector := newTxnDiagnosticsCollector(request, stmtdiagnostics.RequestID(42), &tracing.Span{})
+	collector.collectTrace()
 
-	// Verify files were added
 	buf, err := collector.z.Finalize()
 	require.NoError(t, err)
 
+	// Read the zip to check if it's empty
 	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	require.NoError(t, err)
-	require.Len(t, reader.File, 0, "No files should be added for empty trace")
+	require.Len(t, reader.File, 1)
+
+	// Check that the file contains the expected message
+	rc, err := reader.File[0].Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	content, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, "trace empty", string(content))
+}
+
+func TestTxnDiagnosticsCollector_MaybeStartDiagnostics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	baseHelper := txnInstrumentationHelper{
+		TxnDiagnosticsRecorder: stmtdiagnostics.NewTxnRegistry(nil, nil, nil, timeutil.DefaultTimeSource{}),
+	}
+
+	t.Run("already in progress", func(t *testing.T) {
+		ctx := context.Background()
+		helper := baseHelper
+		helper.diagnosticsCollector.requestId = stmtdiagnostics.RequestID(42)
+		newCtx, started := helper.MaybeStartDiagnostics(ctx, 123, nil)
+		require.False(t, started)
+		require.Equal(t, ctx, newCtx)
+
+	})
+
+	t.Run("not started", func(t *testing.T) {
+		ctx := context.Background()
+		helper := baseHelper
+		newCtx, started := helper.MaybeStartDiagnostics(ctx, 123, nil)
+		require.False(t, started)
+		require.Equal(t, ctx, newCtx)
+	})
+	t.Run("started", func(t *testing.T) {
+		testutils.RunTrueAndFalse(t, "redacted", func(t *testing.T, redacted bool) {
+
+			ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
+			ctx := context.Background()
+			defer ts.Stopper().Stop(ctx)
+
+			helper := baseHelper
+			helper.TxnDiagnosticsRecorder = stmtdiagnostics.NewTxnRegistry(ts.InternalDB().(isql.DB), nil, nil, timeutil.DefaultTimeSource{})
+
+			err := helper.TxnDiagnosticsRecorder.InsertTxnRequest(ctx, 1, []uint64{123}, "testuser", 0, 0, 0, redacted)
+			require.NoError(t, err)
+
+			newCtx, started := helper.MaybeStartDiagnostics(ctx, 123, ts.Tracer())
+			require.True(t, started)
+			require.True(t, helper.DiagnosticsInProgress())
+			if redacted {
+				require.Equal(t, ctx, newCtx)
+				require.Nil(t, helper.diagnosticsCollector.span)
+			} else {
+				require.NotEqual(t, ctx, newCtx)
+				require.NotNil(t, helper.diagnosticsCollector.span)
+				require.Equal(t, tracing.SpanFromContext(newCtx), helper.diagnosticsCollector.span)
+			}
+		})
+	})
 }


### PR DESCRIPTION
commit 1/2:

When calling the setup method on instrumentationhelper (ih), ih will
now check if transaction diagnostics should should be collected. Transaction
diagnostics collection uses a prefix based matching system to determine
whether or not transaction diagnostics collection should start, continue,
or stop. This works by creating a list of statement fingerprint ids, that make
up a transaction fingerprint, and comparing the currently executing statement
fingerprint id against this list. If at any point the expected statement fingerprint
id doesn't match, diagnostics collection is short circuited and no longer
collected.

This change also causes transaction diagnostics collection to take precedence
over statement transaction diagnostics, meaning if a transaction diagnostics request
exists that contains a statement that also has a statement diagnostics request,
the transaction diagnostic request gets priority over collecting the bundle.

When a transaction diagnostics request is being fulfilled, statement bundles for
every statement in the transaction are built and collected in memory. Only after
a transaction is finalized and it is determined that the request is fulfilled are all
the statement bundles and the transaction trace stored in the corresponding
system tables.

Resolves: [CRDB-54321](https://cockroachlabs.atlassian.net/browse/CRDB-54321)
Epic: [CRDB-53541](https://cockroachlabs.atlassian.net/browse/CRDB-53541)
Release note: None

----

commit 2/2:
sql: replace statement fingerprint id construction with fingerprint id from instrumentation helper

The instrumentation helper now generates a statement fingerprint id in its
setup function and stores it in its state. Now, when fingerprint ids
are needed for sql stats collection or telemetry logging, the fingerprint
id from the instrumentation helper is used.

Epic: None
Release note: None