### PR TITLE
roachtest: deflake malformed subdir error in roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -41,6 +41,10 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()
 
+			if _, err := db.Exec(`SET CLUSTER SETTING backup.index.read.enabled = false`); err != nil {
+				t.Fatal(err)
+			}
+
 			m := c.NewDeprecatedMonitor(ctx, c.All())
 			m.Go(func(ctx context.Context) error {
 				t.Status("loading fixture")

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -116,6 +116,9 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			allConns = append(allConns, c.Conn(ctx, t.L(), node))
 		}
 		conn := allConns[0]
+		if _, err := conn.Exec(`SET CLUSTER SETTING backup.index.read.enabled = false`); err != nil {
+			t.Fatal(err)
+		}
 		t.Status("executing setup")
 		t.L().Printf("setup:\n%s", strings.Join(setup, "\n"))
 		for _, stmt := range setup {

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -41,6 +41,9 @@ func loadTPCHDataset(
 	if err != nil {
 		return err
 	}
+	if _, err := db.Exec(`SET CLUSTER SETTING backup.index.read.enabled = false`); err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		if retErr == nil {
 			if _, err = db.Exec("USE tpch"); err != nil {

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -65,6 +65,9 @@ func registerTPCDSVec(r registry.Registry) {
 		); err != nil {
 			t.Fatal(err)
 		}
+		if _, err := clusterConn.Exec(`SET CLUSTER SETTING backup.index.read.enabled = false`); err != nil {
+			t.Fatal(err)
+		}
 		t.Status("restoring TPCDS dataset for Scale Factor 1")
 		if _, err := clusterConn.Exec(
 			`


### PR DESCRIPTION
#152937 forced the `subdir` provided in `RESTORE`/`SHOW BACKUP(S)` commands to match the expected format `YYYY/MM/DD-HHMMSS.SS` and fast fails if the subdir is not formatted correctly. Several of our roachtests are depending on older fixtures and therefore do not provide a valid subdir. This patch deflakes those failing tests by enforcing that `backup.index.read.enabled = false` before attempting to read from those older fixtures.

The long term solution is to update these fixtures and ensure a properly formatted subdir is used.

Fixes: #153267
Fixes: #153272
Fixes: #153268
Fixes: #153264
Fixes: #153240
Fixes: #153230
Fixes: #153237
Fixes: #153235
Fixes: #153234
Fixes: #153233
Fixes: #153232
Fixes: #153231
Fixes: #153230
Fixes: #153228
Fixes: #153320

Release note: None