### PR TITLE
importer: simplify MakeTestingSimpleTableDescriptor

### DIFF
--- a/pkg/ccl/changefeedccl/avro/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro/avro_test.go
@@ -72,7 +72,8 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 	tableID := descpb.ID(bootstrap.TestingUserDescID(1))
 	semaCtx := makeTestSemaCtx()
 	mutDesc, err := importer.MakeTestingSimpleTableDescriptor(
-		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importer.NoFKs, timeutil.Now().UnixNano())
+		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, timeutil.Now().UnixNano(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/encoder_json_test.go
+++ b/pkg/ccl/changefeedccl/encoder_json_test.go
@@ -342,7 +342,8 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 	tableID := descpb.ID(bootstrap.TestingUserDescID(1))
 	semaCtx := makeTestSemaCtx()
 	mutDesc, err := importer.MakeTestingSimpleTableDescriptor(
-		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importer.NoFKs, timeutil.Now().UnixNano())
+		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, timeutil.Now().UnixNano(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/kcjsonschema/kafka_connect_json_schema_test.go
+++ b/pkg/ccl/changefeedccl/kcjsonschema/kafka_connect_json_schema_test.go
@@ -183,7 +183,8 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 	tableID := descpb.ID(bootstrap.TestingUserDescID(1))
 	semaCtx := makeTestSemaCtx()
 	mutDesc, err := importer.MakeTestingSimpleTableDescriptor(
-		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importer.NoFKs, timeutil.Now().UnixNano())
+		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, timeutil.Now().UnixNano(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -358,7 +358,8 @@ func (pt partitioningTest) parse() (parsed parsedPartitioningTest, _ error) {
 		st := cluster.MakeTestingClusterSettings()
 		parentID, tableID := descpb.ID(bootstrap.TestingUserDescID(0)), descpb.ID(bootstrap.TestingUserDescID(1))
 		mutDesc, err := importer.MakeTestingSimpleTableDescriptor(
-			ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importer.NoFKs, timeutil.Now().UnixNano())
+			ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, timeutil.Now().UnixNano(),
+		)
 		if err != nil {
 			return parsed, err
 		}

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -236,7 +236,8 @@ func parseSchemaDefinition(schemaPath string) (opts []sqlsmith.SmitherOption, _ 
 		case *tree.CreateTable:
 			tableID := descpb.ID(int(parentID) + i + 1)
 			desc, err := importer.MakeTestingSimpleTableDescriptor(
-				context.Background(), &semaCtx, st, t, parentID, keys.PublicSchemaID, tableID, importer.NoFKs, wall)
+				context.Background(), &semaCtx, st, t, parentID, keys.PublicSchemaID, tableID, wall,
+			)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to create table descriptor for statement %s", t)
 			}

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -100,7 +100,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
-        "@com_github_lib_pq//oid",
         "@com_github_linkedin_goavro_v2//:goavro",
     ],
 )
@@ -162,7 +161,6 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
-        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/importer/bench_test.go
+++ b/pkg/sql/importer/bench_test.go
@@ -63,7 +63,8 @@ func toTableDescriptor(
 	parentID := descpb.ID(keys.SystemDatabaseID)
 	testSettings := cluster.MakeTestingClusterSettings()
 	tableDesc, err := importer.MakeTestingSimpleTableDescriptor(
-		ctx, &semaCtx, testSettings, createTable, parentID, keys.PublicSchemaID, tableID, importer.NoFKs, ts.UnixNano())
+		ctx, &semaCtx, testSettings, createTable, parentID, keys.PublicSchemaID, tableID, ts.UnixNano(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/importer/csv_internal_test.go
+++ b/pkg/sql/importer/csv_internal_test.go
@@ -30,27 +30,27 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 	}{
 		{
 			stmt:  "create table if not exists a (i int)",
-			error: "unsupported IF NOT EXISTS",
+			error: "IF NOT EXISTS is not supported",
 		},
 		{
 			stmt:  "create table a as select 1",
-			error: "CREATE AS not supported",
+			error: "CREATE AS is not supported",
 		},
 		{
 			stmt:  "create table a (i int references b (id))",
-			error: `this IMPORT format does not support foreign keys`,
+			error: `foreign keys are not supported`,
 		},
 		{
 			stmt:  "create table a (i int, constraint a foreign key (i) references c (id))",
-			error: `this IMPORT format does not support foreign keys`,
+			error: `foreign keys are not supported`,
 		},
 		{
 			stmt:  "create table a (i int, j int as (i + 10) virtual)",
-			error: `to import into a table with virtual computed columns, use IMPORT INTO`,
+			error: `virtual computed columns are not supported`,
 		},
 		{
 			stmt:  "create table a (i int, index ((i + 1)))",
-			error: `to import into a table with expression indexes, use IMPORT INTO`,
+			error: `expression indexes are not supported`,
 		},
 		{
 			stmt: `create table a (
@@ -81,7 +81,7 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			if !ok {
 				t.Fatal("expected CREATE TABLE statement in table file")
 			}
-			_, err = MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, parentID, keys.PublicSchemaID, tableID, NoFKs, 0)
+			_, err = MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, parentID, keys.PublicSchemaID, tableID, 0)
 			if !testutils.IsError(err, tc.error) {
 				t.Fatalf("expected %v, got %+v", tc.error, err)
 			}

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -933,14 +933,12 @@ func newTestSpec(
 	var descr *tabledesc.Mutable
 	switch format.Format {
 	case roachpb.IOFileFormat_CSV:
-		descr = descForTable(ctx, t,
-			"CREATE TABLE simple (i INT PRIMARY KEY, s text )", 100, 150, 200, NoFKs)
+		descr = descForTable(ctx, t, "CREATE TABLE simple (i INT PRIMARY KEY, s text )", 100, 150, 200)
 	case
 		roachpb.IOFileFormat_MysqlOutfile,
 		roachpb.IOFileFormat_PgCopy,
 		roachpb.IOFileFormat_Avro:
-		descr = descForTable(ctx, t,
-			"CREATE TABLE simple (i INT PRIMARY KEY, s text, b bytea default null)", 100, 150, 200, NoFKs)
+		descr = descForTable(ctx, t, "CREATE TABLE simple (i INT PRIMARY KEY, s text, b bytea default null)", 100, 150, 200)
 	default:
 		t.Fatalf("Unsupported input format: %v", format)
 	}

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -3235,7 +3235,7 @@ func BenchmarkCSVConvertRecord(b *testing.B) {
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 
-	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), NoFKs, 1)
+	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), 1)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -4191,7 +4191,7 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 
-	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), NoFKs, 1)
+	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), 1)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -4294,8 +4294,7 @@ func BenchmarkPgCopyConvertRecord(b *testing.B) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
 
-	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup,
-		descpb.ID(100), NoFKs, 1)
+	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), 1)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -7,17 +7,13 @@ package importer
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
@@ -25,24 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	"github.com/lib/pq/oid"
 )
-
-type fkHandler struct {
-	allowed  bool
-	skip     bool
-	resolver fkResolver
-}
-
-// NoFKs is used by formats that do not support FKs.
-var NoFKs = fkHandler{resolver: fkResolver{
-	tableNameToDesc: make(map[string]*tabledesc.Mutable),
-}}
 
 // MakeTestingSimpleTableDescriptor creates a tabledesc.Mutable from a
 // CreateTable parse node without the full machinery. Many parts of the syntax
@@ -62,7 +44,6 @@ func MakeTestingSimpleTableDescriptor(
 	st *cluster.Settings,
 	create *tree.CreateTable,
 	parentID, parentSchemaID, tableID descpb.ID,
-	fks fkHandler,
 	walltime int64,
 ) (*tabledesc.Mutable, error) {
 	db := dbdesc.NewInitial(parentID, "foo", username.RootUserName())
@@ -80,10 +61,10 @@ func MakeTestingSimpleTableDescriptor(
 	}).BuildCreatedMutableSchema()
 	create.HoistConstraints()
 	if create.IfNotExists {
-		return nil, unimplemented.NewWithIssueDetailf(42846, "import.if-no-exists", "unsupported IF NOT EXISTS")
+		return nil, errors.Newf("IF NOT EXISTS is not supported")
 	}
 	if create.AsSource != nil {
-		return nil, unimplemented.NewWithIssueDetailf(42846, "import.create-as", "CREATE AS not supported")
+		return nil, errors.Newf("CREATE AS is not supported")
 	}
 
 	filteredDefs := create.Defs[:0]
@@ -96,34 +77,21 @@ func MakeTestingSimpleTableDescriptor(
 		case *tree.IndexTableDef:
 			for i := range def.Columns {
 				if def.Columns[i].Expr != nil {
-					return nil, unimplemented.NewWithIssueDetail(56002, "import.expression-index",
-						"to import into a table with expression indexes, use IMPORT INTO")
+					return nil, errors.Newf("expression indexes are not supported")
 				}
 			}
-
 		case *tree.ColumnTableDef:
 			if def.IsComputed() && def.IsVirtual() {
-				return nil, unimplemented.NewWithIssueDetail(56002, "import.computed",
-					"to import into a table with virtual computed columns, use IMPORT INTO")
+				return nil, errors.Newf("virtual computed columns are not supported")
 			}
 
 			if err := sql.SimplifySerialInColumnDefWithRowID(ctx, def, &create.Table); err != nil {
 				return nil, err
 			}
-
 		case *tree.ForeignKeyConstraintTableDef:
-			if !fks.allowed {
-				return nil, unimplemented.NewWithIssueDetailf(42846, "import.fk",
-					"this IMPORT format does not support foreign keys")
-			}
-			if fks.skip {
-				continue
-			}
-			// Strip the schema/db prefix.
-			def.Table = tree.MakeUnqualifiedTableName(def.Table.ObjectName)
-
+			return nil, errors.Newf("foreign keys are not supported")
 		default:
-			return nil, unimplemented.Newf(fmt.Sprintf("import.%T", def), "unsupported table definition: %s", tree.AsString(def))
+			return nil, errors.Newf("unsupported table definition: %s", tree.AsString(def))
 		}
 		// only append this def after we make it past the error checks and continues
 		filteredDefs = append(filteredDefs, create.Defs[i])
@@ -143,7 +111,7 @@ func MakeTestingSimpleTableDescriptor(
 	tableDesc, err := sql.NewTableDesc(
 		ctx,
 		nil, /* txn */
-		&fks.resolver,
+		nil, /* vt */
 		st,
 		create,
 		db,
@@ -168,29 +136,14 @@ func MakeTestingSimpleTableDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	if err := fixDescriptorFKState(tableDesc); err != nil {
-		return nil, err
-	}
+	tableDesc.SetPublic()
 
 	return tableDesc, nil
-}
-
-// fixDescriptorFKState repairs validity and table states set during descriptor
-// creation. sql.NewTableDesc and ResolveFK set the table to the ADD state
-// and mark references an validated. This function sets the table to PUBLIC
-// and the FKs to unvalidated.
-func fixDescriptorFKState(tableDesc *tabledesc.Mutable) error {
-	tableDesc.SetPublic()
-	for i := range tableDesc.OutboundFKs {
-		tableDesc.OutboundFKs[i].Validity = descpb.ConstraintValidity_Unvalidated
-	}
-	return nil
 }
 
 var (
 	errSequenceOperators = errors.New("sequence operations unsupported")
 	errRegionOperator    = errors.New("region operations unsupported")
-	errSchemaResolver    = errors.New("schema resolver unsupported")
 )
 
 // Implements the tree.RegionOperator interface.
@@ -311,102 +264,4 @@ func (so *importSequenceOperators) SetSequenceValueByID(
 	ctx context.Context, seqID uint32, newVal int64, isCalled bool,
 ) error {
 	return errSequenceOperators
-}
-
-type fkResolver struct {
-	tableNameToDesc map[string]*tabledesc.Mutable
-}
-
-var _ resolver.SchemaResolver = &fkResolver{}
-
-// GetObjectNamesAndIDs implements the resolver.SchemaResolver interface.
-func (r *fkResolver) GetObjectNamesAndIDs(
-	ctx context.Context, db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor,
-) (tree.TableNames, descpb.IDs, error) {
-	return nil, nil, errors.AssertionFailedf("GetObjectNamesAndIDs is not implemented by fkResolver")
-}
-
-// MustGetCurrentSessionDatabase implements the resolver.SchemaResolver interface.
-func (r *fkResolver) MustGetCurrentSessionDatabase(
-	ctx context.Context,
-) (catalog.DatabaseDescriptor, error) {
-	return nil, errors.AssertionFailedf("MustGetCurrentSessionDatabase is not implemented by fkResolver")
-}
-
-// CurrentDatabase implements the resolver.SchemaResolver interface.
-func (r *fkResolver) CurrentDatabase() string {
-	return ""
-}
-
-// CurrentSearchPath implements the resolver.SchemaResolver interface.
-func (r *fkResolver) CurrentSearchPath() sessiondata.SearchPath {
-	return sessiondata.SearchPath{}
-}
-
-// LookupObject implements the tree.ObjectNameExistingResolver interface.
-func (r *fkResolver) LookupObject(
-	ctx context.Context, flags tree.ObjectLookupFlags, dbName, scName, obName string,
-) (found bool, prefix catalog.ResolvedObjectPrefix, objMeta catalog.Descriptor, err error) {
-	var lookupName string
-	if scName != "" {
-		lookupName = strings.TrimPrefix(obName, scName+".")
-	}
-	tbl, ok := r.tableNameToDesc[lookupName]
-	if ok {
-		return true, prefix, tbl, nil
-	}
-	names := make([]string, 0, len(r.tableNameToDesc))
-	for k := range r.tableNameToDesc {
-		names = append(names, k)
-	}
-	suggestions := strings.Join(names, ",")
-	return false, prefix, nil, errors.Errorf("referenced table %q not found in tables being imported (%s)",
-		lookupName, suggestions)
-}
-
-// LookupSchema implements the resolver.ObjectNameTargetResolver interface.
-func (r fkResolver) LookupSchema(
-	ctx context.Context, dbName, scName string,
-) (found bool, scMeta catalog.ResolvedObjectPrefix, err error) {
-	return false, scMeta, errSchemaResolver
-}
-
-// ResolveTypeByOID implements the resolver.SchemaResolver interface.
-func (r fkResolver) ResolveTypeByOID(ctx context.Context, oid oid.Oid) (*types.T, error) {
-	return nil, errSchemaResolver
-}
-
-// ResolveType implements the resolver.SchemaResolver interface.
-func (r fkResolver) ResolveType(
-	ctx context.Context, name *tree.UnresolvedObjectName,
-) (*types.T, error) {
-	return nil, errSchemaResolver
-}
-
-// GetQualifiedTableNameByID implements the resolver.SchemaResolver interface.
-func (r fkResolver) GetQualifiedTableNameByID(
-	ctx context.Context, id int64, requiredType tree.RequiredTableKind,
-) (*tree.TableName, error) {
-	return nil, errSchemaResolver
-}
-
-// GetQualifiedFunctionNameByID implements the resolver.SchemaResolver interface.
-func (r fkResolver) GetQualifiedFunctionNameByID(
-	ctx context.Context, id int64,
-) (*tree.RoutineName, error) {
-	return nil, errSchemaResolver
-}
-
-// ResolveFunction implements the resolver.SchemaResolver interface.
-func (r fkResolver) ResolveFunction(
-	ctx context.Context, name tree.UnresolvedRoutineName, path tree.SearchPath,
-) (*tree.ResolvedFunctionDefinition, error) {
-	return nil, errSchemaResolver
-}
-
-// ResolveFunctionByOID implements the resolver.SchemaResolver interface.
-func (r fkResolver) ResolveFunctionByOID(
-	ctx context.Context, oid oid.Oid,
-) (*tree.RoutineName, *tree.Overload, error) {
-	return nil, nil, errSchemaResolver
 }

--- a/pkg/sql/importer/read_import_avro_test.go
+++ b/pkg/sql/importer/read_import_avro_test.go
@@ -199,13 +199,12 @@ func newTestHelper(ctx context.Context, t *testing.T, gens ...avroGen) *testHelp
 	evalCtx := eval.MakeTestingEvalContext(st)
 
 	return &testHelper{
-		schemaJSON: string(schemaJSON),
-		schemaTable: descForTable(ctx, t, createStmt, 100, 150, 200, NoFKs).
-			ImmutableCopy().(catalog.TableDescriptor),
-		codec:    codec,
-		gens:     gens,
-		settings: st,
-		evalCtx:  evalCtx,
+		schemaJSON:  string(schemaJSON),
+		schemaTable: descForTable(ctx, t, createStmt, 100, 150, 200).ImmutableCopy().(catalog.TableDescriptor),
+		codec:       codec,
+		gens:        gens,
+		settings:    st,
+		evalCtx:     evalCtx,
 	}
 }
 
@@ -588,7 +587,7 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 
-	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaID, descpb.ID(100), NoFKs, 1)
+	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaID, descpb.ID(100), 1)
 	require.NoError(b, err)
 
 	kvCh := make(chan row.KVBatch)


### PR DESCRIPTION
We no longer need any FK handling in this function, which allows us to remove some dead code. Also update error messages to not reference no longer open issues.

Epic: None
Release note: None