### PR TITLE
release-25.3: roachtest: increase timeout for hibernate test

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -251,7 +251,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
-		Timeout:          5 * time.Hour,
+		Timeout:          6 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},


### PR DESCRIPTION
Backport 1/1 commits from #153288 on behalf of @spilchen.

----

We noticed that on s390x the hibernate test can timeout after 5 hours. There are also several runs that succeeded but came close to timing out. We are going to bump the timeout to give that platform more chance to finish the test.

Fixes #153029

Release note: none

Epic: none

----

Release justification: test only fix