### PR TITLE
pkg/*: introduce cloudScope field to metric metadata

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -13,6 +13,7 @@ layers:
       derivative: NONE
       how_to_use: This metric provides a useful context when assessing the state of changefeeds. This metric characterizes the end-to-end lag between a committed change and that change applied at the destination.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.emitted_bytes
       exported_name: changefeed_emitted_bytes
       description: Bytes emitted by all feeds
@@ -33,6 +34,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric provides a useful context when assessing the state of changefeeds. This metric characterizes the rate of changes being streamed from the CockroachDB cluster.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.error_retries
       exported_name: changefeed_error_retries
       description: Total retryable errors encountered by all changefeeds
@@ -43,6 +45,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric tracks transient changefeed errors. Alert on "too many" errors, such as 50 retries in 15 minutes. For example, during a rolling upgrade this counter will increase because the changefeed jobs will restart following node restarts. There is an exponential backoff, up to 10 minutes. But if there is no rolling upgrade in process or other cluster maintenance, and the error rate is high, investigate the changefeed job.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.failures
       exported_name: changefeed_failures
       description: Total number of changefeed jobs which have failed
@@ -53,6 +56,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric tracks the permanent changefeed job failures that the jobs system will not try to restart. Any increase in this counter should be investigated. An alert on this metric is recommended.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.running
       exported_name: changefeed_running
       description: Number of currently running changefeeds, including sinkless
@@ -63,6 +67,7 @@ layers:
       derivative: NONE
       how_to_use: This metric tracks the total number of all running changefeeds.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: jobs.changefeed.currently_paused
       exported_name: jobs_changefeed_currently_paused
       labeled_name: 'jobs{name: changefeed, status: currently_paused}'
@@ -119,6 +124,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: Errors of this type are normal during elastic cluster topology changes when leaseholders are actively rebalancing. They are automatically retried. However they may create occasional response time spikes. In that case, this metric may provide the explanation of the cause.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: distsender.rpc.sent.nextreplicaerror
       exported_name: distsender_rpc_sent_nextreplicaerror
       description: Number of replica-addressed RPCs sent due to per-replica errors
@@ -129,6 +135,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: RPC errors do not necessarily indicate a problem. This metric tracks remote procedure calls that return a status value other than "success". A non-success status of an RPC should not be misconstrued as a network transport issue. It is database code logic executed on another cluster node. The non-success status is a result of an orderly execution of an RPC that reports a specific logical condition.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
   - name: LOGICAL_DATA_REPLICATION
     metrics:
     - name: logical_replication.commit_latency
@@ -193,6 +200,7 @@ layers:
       derivative: NONE
       how_to_use: This metric gives the node's clock skew. In a well-configured environment, the actual clock skew would be in the sub-millisecond range. A skew exceeding 5 ms is likely due to a NTP service mis-configuration. Reducing the actual clock skew reduces the probability of uncertainty related conflicts and corresponding retires which has a positive impact on workload performance. Conversely, a larger actual clock skew increases the probability of retries due to uncertainty conflicts, with potentially measurable adverse effects on workload performance.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: rpc.connection.avg_round_trip_latency
       exported_name: rpc_connection_avg_round_trip_latency
       description: |
@@ -440,6 +448,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: Monitor this metric and investigate backup job failures.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: schedules.BACKUP.last-completed-time
       exported_name: schedules_BACKUP_last_completed_time
       description: The unix timestamp of the most recently completed backup by a schedule specified as maintaining this metric
@@ -450,6 +459,7 @@ layers:
       derivative: NONE
       how_to_use: "Monitor this metric to ensure that backups are\n\t\t\t\t\t\tmeeting the recovery point objective (RPO). Each node\n\t\t\t\t\t\texports the time that it last completed a backup on behalf\n\t\t\t\t\t\tof the schedule. If a node is restarted, it will report 0\n\t\t\t\t\t\tuntil it completes a backup. If all nodes are restarted,\n\t\t\t\t\t\tmax() is 0 until a node completes a backup.\n\n\t\t\t\t\t\tTo make use of this metric, first, from each node, take the maximum\n\t\t\t\t\t\tover a rolling window equal to or greater than the backup frequency,\n\t\t\t\t\t\tand then take the maximum of those values across nodes. For example\n\t\t\t\t\t\twith a backup frequency of 60 minutes, monitor time() -\n\t\t\t\t\t\tmax_across_nodes(max_over_time(schedules_BACKUP_last_completed_time,\n\t\t\t\t\t\t60min))."
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.conn.failures
       exported_name: sql_conn_failures
       description: Number of SQL connection failures
@@ -470,6 +480,7 @@ layers:
       derivative: NONE
       how_to_use: These metrics characterize the database connection latency which can affect the application performance, for example, by having slow startup times. Connection failures are not recorded in these metrics.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.conns
       exported_name: sql_conns
       description: Number of open SQL connections
@@ -480,6 +491,7 @@ layers:
       derivative: NONE
       how_to_use: This metric shows the number of connections as well as the distribution, or balancing, of connections across cluster nodes. An imbalance can lead to nodes becoming overloaded. Review Connection Pooling.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.ddl.count
       exported_name: sql_ddl_count
       description: Number of SQL DDL statements successfully executed
@@ -490,6 +502,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.ddl.count.internal
       exported_name: sql_ddl_count_internal
       description: Number of SQL DDL statements successfully executed (internal queries)
@@ -498,6 +511,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.delete.count
       exported_name: sql_delete_count
       labeled_name: 'sql.count{query_type: delete}'
@@ -509,6 +523,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.delete.count.internal
       exported_name: sql_delete_count_internal
       labeled_name: 'sql.count{query_type: delete, query_internal: true}'
@@ -518,6 +533,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.contended_queries.count
       exported_name: sql_distsql_contended_queries_count
       description: Number of SQL queries that experienced contention
@@ -528,6 +544,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric is incremented whenever there is a non-trivial amount of contention experienced by a statement whether read-write or write-write conflicts. Monitor this metric to correlate possible workload performance issues to contention conflicts.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.failure.count
       exported_name: sql_failure_count
       description: Number of statements resulting in a planning or runtime error
@@ -538,6 +555,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric is a high-level indicator of workload and application degradation with query failures. Use the Insights page to find failed executions with their error code to troubleshoot or use application-level logs, if instrumented, to determine the cause of error.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.failure.count.internal
       exported_name: sql_failure_count_internal
       description: Number of statements resulting in a planning or runtime error (internal queries)
@@ -546,6 +564,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.full.scan.count
       exported_name: sql_full_scan_count
       description: Number of full table or index scans
@@ -556,6 +575,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric is a high-level indicator of potentially suboptimal query plans in the workload that may require index tuning and maintenance. To identify the statements with a full table scan, use SHOW FULL TABLE SCAN or the SQL Activity Statements page with the corresponding metric time frame. The Statements page also includes explain plans and index recommendations. Not all full scans are necessarily bad especially over smaller tables.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.full.scan.count.internal
       exported_name: sql_full_scan_count_internal
       description: Number of full table or index scans (internal queries)
@@ -564,6 +584,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.insert.count
       exported_name: sql_insert_count
       labeled_name: 'sql.count{query_type: insert}'
@@ -575,6 +596,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.insert.count.internal
       exported_name: sql_insert_count_internal
       labeled_name: 'sql.count{query_type: insert, query_internal: true}'
@@ -584,6 +606,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.root.current
       exported_name: sql_mem_root_current
       description: Current sql statement memory usage for root
@@ -594,6 +617,7 @@ layers:
       derivative: NONE
       how_to_use: This metric shows how memory set aside for temporary materializations, such as hash tables and intermediary result sets, is utilized. Use this metric to optimize memory allocations based on long term observations. The maximum amount is set with --max_sql_memory. If the utilization of sql memory is persistently low, perhaps some portion of this memory allocation can be shifted to --cache.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.new_conns
       exported_name: sql_new_conns
       description: Number of SQL connections created
@@ -604,6 +628,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: The rate of this metric shows how frequently new connections are being established. This can be useful in determining if a high rate of incoming new connections is causing additional load on the server due to a misconfigured application.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.routine.delete.count
       exported_name: sql_routine_delete_count
       labeled_name: 'sql.count{query_type: routine-delete}'
@@ -771,6 +796,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.select.count.internal
       exported_name: sql_select_count_internal
       labeled_name: 'sql.count{query_type: select, query_internal: true}'
@@ -780,6 +806,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.service.latency
       exported_name: sql_service_latency
       description: Latency of SQL request execution
@@ -790,6 +817,7 @@ layers:
       derivative: NONE
       how_to_use: These high-level metrics reflect workload performance. Monitor these metrics to understand latency over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. The Statements page has P90 Latency and P99 latency columns to enable correlation with this metric.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.service.latency.internal
       exported_name: sql_service_latency_internal
       description: Latency of SQL request execution (internal queries)
@@ -798,6 +826,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.statements.active
       exported_name: sql_statements_active
       description: Number of currently active user SQL statements
@@ -808,6 +837,7 @@ layers:
       derivative: NONE
       how_to_use: This high-level metric reflects workload volume.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.statements.active.internal
       exported_name: sql_statements_active_internal
       description: Number of currently active user SQL statements (internal queries)
@@ -816,6 +846,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.abort.count
       exported_name: sql_txn_abort_count
       description: Number of SQL transaction abort errors
@@ -826,6 +857,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This high-level metric reflects workload performance. A persistently high number of SQL transaction abort errors may negatively impact the workload performance and needs to be investigated.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.abort.count.internal
       exported_name: sql_txn_abort_count_internal
       description: Number of SQL transaction abort errors (internal queries)
@@ -834,6 +866,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.begin.count
       exported_name: sql_txn_begin_count
       description: Number of SQL transaction BEGIN statements successfully executed
@@ -844,6 +877,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric reflects workload volume by counting explicit transactions. Use this metric to determine whether explicit transactions can be refactored as implicit transactions (individual statements).
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.begin.count.internal
       exported_name: sql_txn_begin_count_internal
       description: Number of SQL transaction BEGIN statements successfully executed (internal queries)
@@ -852,6 +886,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.commit.count
       exported_name: sql_txn_commit_count
       description: Number of SQL transaction COMMIT statements successfully executed
@@ -862,6 +897,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric shows the number of transactions that completed successfully. This metric can be used as a proxy to measure the number of successful explicit transactions.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.commit.count.internal
       exported_name: sql_txn_commit_count_internal
       description: Number of SQL transaction COMMIT statements successfully executed (internal queries)
@@ -870,6 +906,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.latency
       exported_name: sql_txn_latency
       description: Latency of SQL transactions
@@ -880,6 +917,7 @@ layers:
       derivative: NONE
       how_to_use: These high-level metrics provide a latency histogram of all executed SQL transactions. These metrics provide an overview of the current SQL workload.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.latency.internal
       exported_name: sql_txn_latency_internal
       description: Latency of SQL transactions (internal queries)
@@ -888,6 +926,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.rollback.count
       exported_name: sql_txn_rollback_count
       description: Number of SQL transaction ROLLBACK statements successfully executed
@@ -898,6 +937,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric shows the number of orderly transaction rollbacks. A persistently high number of rollbacks may negatively impact the workload performance and needs to be investigated.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txn.rollback.count.internal
       exported_name: sql_txn_rollback_count_internal
       description: Number of SQL transaction ROLLBACK statements successfully executed (internal queries)
@@ -906,6 +946,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txns.open
       exported_name: sql_txns_open
       description: Number of currently open user SQL transactions
@@ -916,6 +957,7 @@ layers:
       derivative: NONE
       how_to_use: This metric should roughly correspond to the number of cores * 4. If this metric is consistently larger, scale out the cluster.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.txns.open.internal
       exported_name: sql_txns_open_internal
       description: Number of currently open user SQL transactions (internal queries)
@@ -924,6 +966,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.update.count
       exported_name: sql_update_count
       labeled_name: 'sql.count{query_type: update}'
@@ -935,6 +978,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.update.count.internal
       exported_name: sql_update_count_internal
       labeled_name: 'sql.count{query_type: update, query_internal: true}'
@@ -944,6 +988,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.restarts.serializable
       exported_name: txn_restarts_serializable
       description: Number of restarts due to a forwarded commit timestamp and isolation=SERIALIZABLE
@@ -954,6 +999,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric is one measure of the impact of contention conflicts on workload performance. For guidance on contention conflicts, review transaction contention best practices and performance tuning recipes. Tens of restarts per minute may be a high value, a signal of an elevated degree of contention in the workload, which should be investigated.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.restarts.txnaborted
       exported_name: txn_restarts_txnaborted
       description: Number of restarts due to an abort by a concurrent transaction (usually due to deadlock)
@@ -994,6 +1040,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric is one measure of the impact of contention conflicts on workload performance. For guidance on contention conflicts, review transaction contention best practices and performance tuning recipes. Tens of restarts per minute may be a high value, a signal of an elevated degree of contention in the workload, which should be investigated.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
   - name: TTL
     metrics:
     - name: jobs.row_level_ttl.currently_paused
@@ -1221,6 +1268,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.backfill_pending_ranges
       exported_name: changefeed_backfill_pending_ranges
       description: Number of ranges in an ongoing backfill that are yet to be fully emitted
@@ -1229,6 +1277,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.batch_reduction_count
       exported_name: changefeed_batch_reduction_count
       description: Number of times a changefeed aggregator node attempted to reduce the size of message batches it emitted to the sink
@@ -1637,6 +1686,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.message_size_hist
       exported_name: changefeed_message_size_hist
       description: Message size histogram
@@ -1645,6 +1695,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: changefeed.messages.messages_pushback_nanos
       exported_name: changefeed_messages_messages_pushback_nanos
       description: Total time spent throttled for messages quota
@@ -1957,6 +2008,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: cloud.conns_opened
       exported_name: cloud_conns_opened
       description: HTTP connections opened by cloud operations
@@ -2109,6 +2161,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: distsender.batches.async.in_progress
       exported_name: distsender_batches_async_in_progress
       description: Number of partial batches currently being executed asynchronously
@@ -2149,6 +2202,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: distsender.circuit_breaker.replicas.count
       exported_name: distsender_circuit_breaker_replicas_count
       description: Number of replicas currently tracked by DistSender circuit breakers
@@ -3681,6 +3735,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: distsender.rpc.sent.local
       exported_name: distsender_rpc_sent_local
       description: Number of replica-addressed RPCs sent through the local-server optimization
@@ -3689,6 +3744,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: distsender.rpc.subsume.sent
       exported_name: distsender_rpc_subsume_sent
       description: |-
@@ -4704,6 +4760,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: jobs.claimed_jobs
       exported_name: jobs_claimed_jobs
       description: number of jobs claimed in job-adopt iterations
@@ -7180,6 +7237,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: round-trip-default-class-latency
       exported_name: round_trip_default_class_latency
       description: |
@@ -7208,6 +7266,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: round-trip-raft-class-latency
       exported_name: round_trip_raft_class_latency
       description: |
@@ -7321,6 +7380,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: schedules.BACKUP.succeeded
       exported_name: schedules_BACKUP_succeeded
       labeled_name: 'schedules{name: BACKUP, status: succeeded}'
@@ -7330,6 +7390,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: schedules.CHANGEFEED.failed
       exported_name: schedules_CHANGEFEED_failed
       labeled_name: 'schedules{name: CHANGEFEED, status: failed}'
@@ -7485,6 +7546,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.bytesout
       exported_name: sql_bytesout
       description: Number of SQL bytes sent
@@ -7493,6 +7555,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.call_stored_proc.count
       exported_name: sql_call_stored_proc_count
       description: Number of successfully executed stored procedure calls
@@ -7773,6 +7836,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.exec.latency.internal
       exported_name: sql_distsql_exec_latency_internal
       description: Latency of DistSQL statement execution (internal queries)
@@ -7781,6 +7845,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.flows.active
       exported_name: sql_distsql_flows_active
       description: Number of distributed SQL flows currently active
@@ -7789,6 +7854,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.flows.total
       exported_name: sql_distsql_flows_total
       description: Number of distributed SQL flows executed
@@ -7797,6 +7863,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.queries.active
       exported_name: sql_distsql_queries_active
       description: Number of invocations of the execution engine currently active (multiple of which may occur for a single SQL statement)
@@ -7805,6 +7872,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.queries.spilled
       exported_name: sql_distsql_queries_spilled
       description: Number of queries that have spilled to disk
@@ -7821,6 +7889,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.select.count
       exported_name: sql_distsql_select_count
       description: Number of SELECT statements planned to be distributed
@@ -7829,6 +7898,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.select.count.internal
       exported_name: sql_distsql_select_count_internal
       description: Number of SELECT statements planned to be distributed (internal queries)
@@ -7837,6 +7907,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.select.distributed_exec.count
       exported_name: sql_distsql_select_distributed_exec_count
       description: Number of SELECT statements that were distributed
@@ -7861,6 +7932,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.service.latency.internal
       exported_name: sql_distsql_service_latency_internal
       description: Latency of DistSQL request execution (internal queries)
@@ -7869,6 +7941,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.distsql.vec.openfds
       exported_name: sql_distsql_vec_openfds
       description: Current number of open file descriptors used by vectorized external storage
@@ -7885,6 +7958,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.exec.latency.consistent
       exported_name: sql_exec_latency_consistent
       description: Latency of SQL statement execution of non-historical queries
@@ -7941,6 +8015,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.feature_flag_denial
       exported_name: sql_feature_flag_denial
       description: Counter of the number of statements denied by a feature flag
@@ -8261,6 +8336,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.distsql.max
       exported_name: sql_mem_distsql_max
       description: Memory usage per sql statement for distsql
@@ -8269,6 +8345,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.internal.current
       exported_name: sql_mem_internal_current
       description: Current sql statement memory usage for internal
@@ -8293,6 +8370,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.internal.session.max
       exported_name: sql_mem_internal_session_max
       description: Memory usage per sql session for internal
@@ -8301,6 +8379,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.internal.session.prepared.current
       exported_name: sql_mem_internal_session_prepared_current
       description: Current sql session memory usage by prepared statements for internal
@@ -8325,6 +8404,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.internal.txn.max
       exported_name: sql_mem_internal_txn_max
       description: Memory usage per sql transaction for internal
@@ -8333,6 +8413,7 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.mem.root.max
       exported_name: sql_mem_root_max
       description: Memory usage per sql statement for root
@@ -8413,6 +8494,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.misc.count.internal
       exported_name: sql_misc_count_internal
       description: Number of other SQL statements successfully executed (internal queries)
@@ -8421,6 +8503,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.misc.started.count
       exported_name: sql_misc_started_count
       description: Number of other SQL statements started
@@ -8557,6 +8640,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.query.count.internal
       exported_name: sql_query_count_internal
       description: Number of SQL operations started including queries, and transaction control statements (internal queries)
@@ -8565,6 +8649,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: sql.query.started.count
       exported_name: sql_query_started_count
       description: Number of SQL operations started including queries, and transaction control statements
@@ -9493,6 +9578,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.commit_waits
       exported_name: txn_commit_waits
       description: Number of KV transactions that had to commit-wait on commit in order to ensure linearizability. This generally happens to transactions writing to global ranges.
@@ -9509,6 +9595,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.commits1PC
       exported_name: txn_commits1PC
       description: Number of KV transaction one-phase commits
@@ -9517,6 +9604,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.commits_read_only
       exported_name: txn_commits_read_only
       description: Number of read only KV transaction commits
@@ -9573,6 +9661,7 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.inflight_locks_over_tracking_budget
       exported_name: txn_inflight_locks_over_tracking_budget
       description: KV transactions whose in-flight writes and locking reads have exceeded the intent tracking memory budget (kv.transaction.max_intents_bytes).
@@ -9661,6 +9750,7 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+      cloud_scope: ESSENTIAL_SHARED
     - name: txn.restarts.asyncwritefailure
       exported_name: txn_restarts_asyncwritefailure
       description: Number of restarts due to async consensus writes that failed to leave intents
@@ -9885,6 +9975,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric measures the length of time, in seconds, that the CockroachDB process has been running. Monitor this metric to detect events such as node restarts, which may require investigation or intervention.
       essential: true
+      cloud_scope: ESSENTIAL_SHARED
   - name: NETWORKING
     metrics:
     - name: sys.host.net.send.tcp.fast_retrans_segs

--- a/pkg/backup/schedule_exec.go
+++ b/pkg/backup/schedule_exec.go
@@ -600,6 +600,7 @@ func init() {
 						with a backup frequency of 60 minutes, monitor time() -
 						max_across_nodes(max_over_time(schedules_BACKUP_last_completed_time,
 						60min)).`,
+						CloudScope: metric.Metadata_ESSENTIAL_SHARED,
 					}),
 					RpoTenantMetric: metric.NewExportedGaugeVec(metric.Metadata{
 						Name:        "schedules.BACKUP.last-completed-time-by-virtual_cluster",

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -726,6 +726,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_CHANGEFEEDS,
 		HowToUse:    `This metric tracks transient changefeed errors. Alert on "too many" errors, such as 50 retries in 15 minutes. For example, during a rolling upgrade this counter will increase because the changefeed jobs will restart following node restarts. There is an exponential backoff, up to 10 minutes. But if there is no rolling upgrade in process or other cluster maintenance, and the error rate is high, investigate the changefeed job.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaChangefeedFailures = metric.Metadata{
 		Name:        "changefeed.failures",
@@ -735,6 +736,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_CHANGEFEEDS,
 		HowToUse:    `This metric tracks the permanent changefeed job failures that the jobs system will not try to restart. Any increase in this counter should be investigated. An alert on this metric is recommended.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 
 	metaEventQueueTime = metric.Metadata{
@@ -816,6 +818,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Essential:   true,
 		Category:    metric.Metadata_CHANGEFEEDS,
 		HowToUse:    `This metric provides a useful context when assessing the state of changefeeds. This metric characterizes the rate of changes being streamed from the CockroachDB cluster.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaChangefeedEmittedBatchSizes := metric.Metadata{
 		Name:        "changefeed.emitted_batch_sizes",
@@ -881,6 +884,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Essential:   true,
 		Category:    metric.Metadata_CHANGEFEEDS,
 		HowToUse:    `This metric provides a useful context when assessing the state of changefeeds. This metric characterizes the end-to-end lag between a committed change and that change applied at the destination.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaAdmitLatency := metric.Metadata{
 		Name: "changefeed.admit_latency",
@@ -897,12 +901,14 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Help:        "Number of changefeeds currently executing backfill",
 		Measurement: "Count",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaChangefeedBackfillPendingRanges := metric.Metadata{
 		Name:        "changefeed.backfill_pending_ranges",
 		Help:        "Number of ranges in an ongoing backfill that are yet to be fully emitted",
 		Measurement: "Count",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaChangefeedRunning := metric.Metadata{
 		Name:        "changefeed.running",
@@ -912,12 +918,14 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Essential:   true,
 		Category:    metric.Metadata_CHANGEFEEDS,
 		HowToUse:    `This metric tracks the total number of all running changefeeds.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaMessageSize := metric.Metadata{
 		Name:        "changefeed.message_size_hist",
 		Help:        "Message size histogram",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaBatchReductionCount := metric.Metadata{
 		Name:        "changefeed.batch_reduction_count",
@@ -1034,6 +1042,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Help:        "The most any changefeed's persisted checkpoint is behind the present",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 
 	functionalGaugeMinFn := func(childValues []int64) int64 {

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -48,6 +48,7 @@ type MetricInfo struct {
 	Derivative   string `yaml:"derivative"`
 	HowToUse     string `yaml:"how_to_use,omitempty"`
 	Essential    bool   `yaml:"essential,omitempty"`
+	CloudScope   string `yaml:"cloud_scope,omitempty"`
 }
 
 type Category struct {
@@ -477,6 +478,11 @@ func generateMetricList(ctx context.Context, skipFiltering bool) (map[string]*La
 
 		for _, chart := range section.Charts {
 			// There are many charts, but only 1 metric per chart.
+			var cloudScopeStr string
+			if chart.Metrics[0].CloudScope.String() != "CLOUD_SCOPE_UNSET" {
+				cloudScopeStr = chart.Metrics[0].CloudScope.String()
+			}
+
 			metric := MetricInfo{
 				Name:         chart.Metrics[0].Name,
 				ExportedName: chart.Metrics[0].ExportedName,
@@ -489,6 +495,7 @@ func generateMetricList(ctx context.Context, skipFiltering bool) (map[string]*La
 				Derivative:   chart.Derivative.String(),
 				HowToUse:     chart.Metrics[0].HowToUse,
 				Essential:    chart.Metrics[0].Essential,
+				CloudScope:   cloudScopeStr,
 			}
 			category.Metrics = append(category.Metrics, metric)
 		}

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -211,7 +211,7 @@ func makeMetaResumeCompeted(jt jobspb.Type) metric.Metadata {
 
 func makeMetaResumeRetryError(jt jobspb.Type) metric.Metadata {
 	typeStr := typeToString(jt)
-	return metric.Metadata{
+	m := metric.Metadata{
 		Name: fmt.Sprintf("jobs.%s.resume_retry_error", typeStr),
 		Help: fmt.Sprintf("Number of %s jobs which failed with a retriable error",
 			typeStr),
@@ -224,6 +224,13 @@ func makeMetaResumeRetryError(jt jobspb.Type) metric.Metadata {
 			metric.LabelStatus, "retry_error",
 		),
 	}
+
+	// Add shared scope for changefeed jobs
+	if jt == jobspb.TypeChangefeed {
+		m.CloudScope = metric.Metadata_ESSENTIAL_SHARED
+	}
+
+	return m
 }
 
 func makeMetaResumeFailed(jt jobspb.Type) metric.Metadata {

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -51,12 +51,14 @@ var (
 		Help:        "Number of batches processed",
 		Measurement: "Batches",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaDistSenderPartialBatchCount = metric.Metadata{
 		Name:        "distsender.batches.partial",
 		Help:        "Number of partial batches processed after being divided on range boundaries",
 		Measurement: "Partial Batches",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaDistSenderReplicaAddressedBatchRequestBytes = metric.Metadata{
 		Name:        "distsender.batch_requests.replica_addressed.bytes",
@@ -133,12 +135,14 @@ var (
 		Help:        "Number of replica-addressed RPCs sent",
 		Measurement: "RPCs",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaTransportLocalSentCount = metric.Metadata{
 		Name:        "distsender.rpc.sent.local",
 		Help:        "Number of replica-addressed RPCs sent through the local-server optimization",
 		Measurement: "RPCs",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaTransportSenderNextReplicaErrCount = metric.Metadata{
 		Name:        "distsender.rpc.sent.nextreplicaerror",
@@ -148,6 +152,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_DISTRIBUTED,
 		HowToUse:    `RPC errors do not necessarily indicate a problem. This metric tracks remote procedure calls that return a status value other than "success". A non-success status of an RPC should not be misconstrued as a network transport issue. It is database code logic executed on another cluster node. The non-success status is a result of an orderly execution of an RPC that reports a specific logical condition.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaDistSenderNotLeaseHolderErrCount = metric.Metadata{
 		Name:        "distsender.errors.notleaseholder",
@@ -157,6 +162,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_DISTRIBUTED,
 		HowToUse:    `Errors of this type are normal during elastic cluster topology changes when leaseholders are actively rebalancing. They are automatically retried. However they may create occasional response time spikes. In that case, this metric may provide the explanation of the cause.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaDistSenderInLeaseTransferBackoffsCount = metric.Metadata{
 		Name:        "distsender.errors.inleasetransferbackoffs",
@@ -180,6 +186,7 @@ cause values for this metric to be emitted by leaving a transaction open
 for a long time and contending with it using a second transaction.`,
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaDistSenderSlowReplicaRPCs = metric.Metadata{
 		Name: "distsender.slow.replicarpcs",

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -70,18 +70,21 @@ var (
 		Help:        "Number of aborted KV transactions",
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaCommitsRates = metric.Metadata{
 		Name:        "txn.commits",
 		Help:        "Number of committed KV transactions (including 1PC)",
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaCommits1PCRates = metric.Metadata{
 		Name:        "txn.commits1PC",
 		Help:        "Number of KV transaction one-phase commits",
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaCommitsReadOnly = metric.Metadata{
 		Name:        "txn.commits_read_only",
@@ -165,6 +168,7 @@ var (
 		Help:        "KV transaction durations",
 		Measurement: "KV Txn Duration",
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaTxnsWithCondensedIntentSpans = metric.Metadata{
 		Name: "txn.condensed_intent_spans",
@@ -215,6 +219,7 @@ var (
 		Help:        "Number of restarted KV transactions",
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	// There are two ways we can get "write too old" restarts. In both cases, a
 	// WriteTooOldError is generated in the MVCC layer. This is intercepted on
@@ -231,6 +236,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This metric is one measure of the impact of contention conflicts on workload performance. For guidance on contention conflicts, review transaction contention best practices and performance tuning recipes. Tens of restarts per minute may be a high value, a signal of an elevated degree of contention in the workload, which should be investigated.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaRestartsSerializable = metric.Metadata{
 		Name:        "txn.restarts.serializable",
@@ -240,6 +246,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This metric is one measure of the impact of contention conflicts on workload performance. For guidance on contention conflicts, review transaction contention best practices and performance tuning recipes. Tens of restarts per minute may be a high value, a signal of an elevated degree of contention in the workload, which should be investigated.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaRestartsAsyncWriteFailure = metric.Metadata{
 		Name:        "txn.restarts.asyncwritefailure",

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -52,12 +52,14 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_NETWORKING,
 		HowToUse:    "This metric gives the node's clock skew. In a well-configured environment, the actual clock skew would be in the sub-millisecond range. A skew exceeding 5 ms is likely due to a NTP service mis-configuration. Reducing the actual clock skew reduces the probability of uncertainty related conflicts and corresponding retires which has a positive impact on workload performance. Conversely, a larger actual clock skew increases the probability of retries due to uncertainty conflicts, with potentially measurable adverse effects on workload performance.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaClockOffsetStdDevNanos = metric.Metadata{
 		Name:        "clock-offset.stddevnanos",
 		Help:        "Stddev clock offset with other nodes",
 		Measurement: "Clock Offset",
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaClockOffsetMedianNanos = metric.Metadata{
 		// An outlier resistant measure of centrality, useful for
@@ -93,6 +95,7 @@ rare or short-lived degradations.
 `,
 		Measurement: "Round-trip time",
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 
 	metaDefaultConnectionRoundTripLatency = metric.Metadata{

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -275,9 +275,10 @@ var (
 		Measurement: "Uptime",
 		Unit:        metric.Unit_SECONDS,
 
-		Essential: true,
-		Category:  metric.Metadata_HARDWARE,
-		HowToUse:  `This metric measures the length of time, in seconds, that the CockroachDB process has been running. Monitor this metric to detect events such as node restarts, which may require investigation or intervention.`,
+		Essential:  true,
+		Category:   metric.Metadata_HARDWARE,
+		HowToUse:   `This metric measures the length of time, in seconds, that the CockroachDB process has been running. Monitor this metric to detect events such as node restarts, which may require investigation or intervention.`,
+		CloudScope: metric.Metadata_ESSENTIAL_SHARED,
 	}
 
 	// These disk and network stats are counters of the number of operations, packets, bytes, and

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -820,6 +820,7 @@ var (
 		Help:        "Latency of SQL statement execution",
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaSQLExecLatencyConsistent = metric.Metadata{
 		Name:        "sql.exec.latency.consistent",
@@ -848,6 +849,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "These high-level metrics reflect workload performance. Monitor these metrics to understand latency over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. The Statements page has P90 Latency and P99 latency columns to enable correlation with this metric.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaSQLServiceLatencyConsistent = metric.Metadata{
 		Name:        "sql.service.latency.consistent",
@@ -878,6 +880,7 @@ var (
 		Help:        "Number of SELECT statements planned to be distributed",
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaDistSQLSelectDistributed = metric.Metadata{
 		Name:        "sql.distsql.select.distributed_exec.count",
@@ -891,6 +894,7 @@ var (
 		Measurement: "Latency",
 		MetricType:  io_prometheus_client.MetricType_HISTOGRAM,
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaDistSQLServiceLatency = metric.Metadata{
 		Name:        "sql.distsql.service.latency",
@@ -898,6 +902,7 @@ var (
 		Measurement: "Latency",
 		MetricType:  io_prometheus_client.MetricType_HISTOGRAM,
 		Unit:        metric.Unit_NANOSECONDS,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaUniqueStatementCount = metric.Metadata{
 		Name:        "sql.query.unique.count",
@@ -913,6 +918,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This high-level metric reflects workload performance. A persistently high number of SQL transaction abort errors may negatively impact the workload performance and needs to be investigated.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaFailure = metric.Metadata{
 		Name:        "sql.failure.count",
@@ -922,6 +928,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This metric is a high-level indicator of workload and application degradation with query failures. Use the Insights page to find failed executions with their error code to troubleshoot or use application-level logs, if instrumented, to determine the cause of error.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaStatementTimeout = metric.Metadata{
 		Name:        "sql.statement_timeout.count",
@@ -943,6 +950,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `These high-level metrics provide a latency histogram of all executed SQL transactions. These metrics provide an overview of the current SQL workload.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaSQLTxnsOpen = metric.Metadata{
 		Name:        "sql.txns.open",
@@ -952,6 +960,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This metric should roughly correspond to the number of cores * 4. If this metric is consistently larger, scale out the cluster.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaSQLActiveQueries = metric.Metadata{
 		Name:        "sql.statements.active",
@@ -961,6 +970,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This high-level metric reflects workload volume.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaFullTableOrIndexScan = metric.Metadata{
 		Name:        "sql.full.scan.count",
@@ -970,6 +980,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This metric is a high-level indicator of potentially suboptimal query plans in the workload that may require index tuning and maintenance. To identify the statements with a full table scan, use SHOW FULL TABLE SCAN or the SQL Activity Statements page with the corresponding metric time frame. The Statements page also includes explain plans and index recommendations. Not all full scans are necessarily bad especially over smaller tables.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 
 	// Below are the metadata for the statement started counters.
@@ -1158,6 +1169,7 @@ var (
 		Help:        "Number of SQL operations started including queries, and transaction control statements",
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaTxnBeginExecuted = metric.Metadata{
 		Name:        "sql.txn.begin.count",
@@ -1167,6 +1179,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This metric reflects workload volume by counting explicit transactions. Use this metric to determine whether explicit transactions can be refactored as implicit transactions (individual statements).",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaTxnCommitExecuted = metric.Metadata{
 		Name:        "sql.txn.commit.count",
@@ -1176,6 +1189,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This metric shows the number of transactions that completed successfully. This metric can be used as a proxy to measure the number of successful explicit transactions.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaTxnRollbackExecuted = metric.Metadata{
 		Name:        "sql.txn.rollback.count",
@@ -1185,6 +1199,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This metric shows the number of orderly transaction rollbacks. A persistently high number of rollbacks may negatively impact the workload performance and needs to be investigated.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaTxnPrepareExecuted = metric.Metadata{
 		Name:        "sql.txn.prepare.count",
@@ -1214,6 +1229,7 @@ var (
 		Essential:    true,
 		Category:     metric.Metadata_SQL,
 		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+		CloudScope:   metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaUpdateExecuted = metric.Metadata{
 		Name:         "sql.update.count",
@@ -1225,6 +1241,7 @@ var (
 		Essential:    true,
 		Category:     metric.Metadata_SQL,
 		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+		CloudScope:   metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaInsertExecuted = metric.Metadata{
 		Name:         "sql.insert.count",
@@ -1236,6 +1253,7 @@ var (
 		Essential:    true,
 		Category:     metric.Metadata_SQL,
 		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+		CloudScope:   metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaDeleteExecuted = metric.Metadata{
 		Name:         "sql.delete.count",
@@ -1247,6 +1265,7 @@ var (
 		Essential:    true,
 		Category:     metric.Metadata_SQL,
 		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+		CloudScope:   metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaCRUDExecuted = metric.Metadata{
 		Name:        "sql.crud_query.count",
@@ -1298,6 +1317,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaCopyExecuted = metric.Metadata{
 		Name:        "sql.copy.count",
@@ -1322,6 +1342,7 @@ var (
 		Help:        "Number of other SQL statements successfully executed",
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaRoutineSelectExecuted = metric.Metadata{
 		Name:         "sql.routine.select.count",

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -45,12 +45,14 @@ var (
 		Help:        "Number of invocations of the execution engine currently active (multiple of which may occur for a single SQL statement)",
 		Measurement: "DistSQL runs",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaQueriesTotal = metric.Metadata{
 		Name:        "sql.distsql.queries.total",
 		Help:        "Number of invocations of the execution engine executed (multiple of which may occur for a single SQL statement)",
 		Measurement: "DistSQL runs",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaDistributedCount = metric.Metadata{
 		Name:        "sql.distsql.distributed_exec.count",
@@ -66,6 +68,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This metric is incremented whenever there is a non-trivial amount of contention experienced by a statement whether read-write or write-write conflicts. Monitor this metric to correlate possible workload performance issues to contention conflicts.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaCumulativeContentionNanos = metric.Metadata{
 		Name:        "sql.distsql.cumulative_contention_nanos",
@@ -78,24 +81,28 @@ var (
 		Help:        "Number of distributed SQL flows currently active",
 		Measurement: "Flows",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaFlowsTotal = metric.Metadata{
 		Name:        "sql.distsql.flows.total",
 		Help:        "Number of distributed SQL flows executed",
 		Measurement: "Flows",
 		Unit:        metric.Unit_COUNT,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaMemMaxBytes = metric.Metadata{
 		Name:        "sql.mem.distsql.max",
 		Help:        "Memory usage per sql statement for distsql",
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaMemCurBytes = metric.Metadata{
 		Name:        "sql.mem.distsql.current",
 		Help:        "Current sql statement memory usage for distsql",
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	metaVecOpenFDs = metric.Metadata{
 		Name:        "sql.distsql.vec.openfds",

--- a/pkg/sql/mem_metrics.go
+++ b/pkg/sql/mem_metrics.go
@@ -60,12 +60,22 @@ var _ metric.Struct = MemoryMetrics{}
 const log10int64times1000 = 19 * 1000
 
 func makeMemMetricMetadata(name, help string) metric.Metadata {
-	return metric.Metadata{
+	m := metric.Metadata{
 		Name:        name,
 		Help:        help,
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
 	}
+
+	// Add shared scope for specific memory metrics in the cloud shared list
+	switch name {
+	case "sql.mem.internal.session.current", "sql.mem.internal.session.max",
+		"sql.mem.internal.txn.current", "sql.mem.internal.txn.max",
+		"sql.mem.root.current":
+		m.CloudScope = metric.Metadata_ESSENTIAL_SHARED
+	}
+
+	return m
 }
 
 func makeMemMetricHistogram(

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -117,6 +117,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `This metric shows the number of connections as well as the distribution, or balancing, of connections across cluster nodes. An imbalance can lead to nodes becoming overloaded. Review Connection Pooling.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaNewConns = metric.Metadata{
 		Name:        "sql.new_conns",
@@ -126,6 +127,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    `The rate of this metric shows how frequently new connections are being established. This can be useful in determining if a high rate of incoming new connections is causing additional load on the server due to a misconfigured application.`,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaConnsWaitingToHash = metric.Metadata{
 		Name:        "sql.conns_waiting_to_hash",
@@ -138,12 +140,14 @@ var (
 		Help:        "Number of SQL bytes received",
 		Measurement: "SQL Bytes",
 		Unit:        metric.Unit_BYTES,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaBytesOut = metric.Metadata{
 		Name:        "sql.bytesout",
 		Help:        "Number of SQL bytes sent",
 		Measurement: "SQL Bytes",
 		Unit:        metric.Unit_BYTES,
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaConnLatency = metric.Metadata{
 		Name:        "sql.conn.latency",
@@ -153,6 +157,7 @@ var (
 		Essential:   true,
 		Category:    metric.Metadata_SQL,
 		HowToUse:    "These metrics characterize the database connection latency which can affect the application performance, for example, by having slow startup times. Connection failures are not recorded in these metrics.",
+		CloudScope:  metric.Metadata_ESSENTIAL_SHARED,
 	}
 	MetaConnFailures = metric.Metadata{
 		Name:        "sql.conn.failures",

--- a/pkg/ts/catalog/BUILD.bazel
+++ b/pkg/ts/catalog/BUILD.bazel
@@ -22,6 +22,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ts/tspb:tspb_proto",
+        "//pkg/util/metric:metric_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_github_prometheus_client_model//io/prometheus/client:io_prometheus_client_proto",
     ],
@@ -35,6 +36,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ts/tspb",
+        "//pkg/util/metric",
         "@com_github_gogo_protobuf//gogoproto",
         "@com_github_prometheus_client_model//go",
     ],

--- a/pkg/ts/catalog/catalog_generator.go
+++ b/pkg/ts/catalog/catalog_generator.go
@@ -101,6 +101,7 @@ func generateInternal(
 					Essential:      meta.Essential,
 					HowToUse:       meta.HowToUse,
 					LabeledName:    formatLabeledName(meta),
+					CloudScope:     meta.CloudScope,
 				},
 			},
 		})

--- a/pkg/ts/catalog/chart_catalog.proto
+++ b/pkg/ts/catalog/chart_catalog.proto
@@ -8,6 +8,7 @@ package cockroach.ts.catalog;
 option go_package = "github.com/cockroachdb/cockroach/pkg/ts/catalog";
 
 import "ts/tspb/timeseries.proto";
+import "util/metric/metric.proto";
 
 import "gogoproto/gogo.proto";
 import "io/prometheus/client/metrics.proto";
@@ -96,6 +97,8 @@ message ChartMetric {
   optional string howToUse = 8 [(gogoproto.nullable) = false];
   // labeledName is the name of the metric with its labels, formatted as name{label1: value1, ...}.
   optional string labeledName = 9 [(gogoproto.nullable) = false];
+  // cloudScope specifies where a metric is exported across CockroachDB Cloud offerings.
+  required cockroach.util.metric.Metadata.CloudScope cloudScope = 10 [(gogoproto.nullable) = false];
 }
 
 // IndividualChart describes both the properties necessary to display

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -90,6 +90,19 @@ message Metadata {
     EXPIRATIONS = 16;
   }
 
+  // CloudScope specifies where a metric is exposed across CockroachDB Cloud offerings.
+  // “Essential” indicates the metric is exported via the customer metrics integration.
+  enum CloudScope {
+    // CLOUD_SCOPE_UNSET: metric is not exported to customer metrics integration.
+    CLOUD_SCOPE_UNSET = 0;
+    // ESSENTIAL_ADVANCED: exported only in the Advanced (CRDB) deployment offering.
+    ESSENTIAL_ADVANCED = 1;
+    // ESSENTIAL_TENANT: exported only in the Serverless/Tenant deployment offering.
+    ESSENTIAL_TENANT = 2;
+    // ESSENTIAL_SHARED: exported in both Advanced and Serverless/Tenant offerings.
+    ESSENTIAL_SHARED = 3;
+  }
+
   // if essential is true, the metric is required to be included in
   // a DB Console dashboard, in our public docs, and in all tsdump
   // exports.
@@ -104,6 +117,8 @@ message Metadata {
   // how_to_use is an extended description of how to use this metric
   // with a running cluster. This is required if `essential` is true.
   required string how_to_use = 12 [(gogoproto.nullable) = false];
+  // cloud_scope specifies where a metric is exposed across CockroachDB Cloud offerings.
+  required CloudScope cloud_scope = 10 [(gogoproto.nullable) = false];
 
-  // Next ID: 10 (then 13).
+  // Next ID: 14
 }


### PR DESCRIPTION
This commit adds cloudScope field to metric metadata to indicate where a metric is 
exported in CockroachDB Cloud (Advanced, Tenant/Serverless, or Shared). Moreover, 
tagged few metrics that are shared across offerings as `ESSENTIAL_SHARED`.

This change aims to standardize the metric visibility and enhance monitoring 
capabilities in cloud deployments.

Part of: CC-33737
Epic: CC-33357
Release note: None