### PR TITLE
opt: enable optimizer_ignore_wide_scans by default

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4412,6 +4412,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedHoistJoinProject(val bool) {
 	m.data.OptimizerUseImprovedHoistJoinProject = val
 }
 
+func (m *sessionDataMutator) SetOptimizerIgnoreWideScans(val bool) {
+	m.data.OptimizerIgnoreWideScans = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4067,6 +4067,7 @@ optimizer_check_input_min_row_count                              1
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
+optimizer_ignore_wide_scans                                      off
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4067,7 +4067,7 @@ optimizer_check_input_min_row_count                              1
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
-optimizer_ignore_wide_scans                                      off
+optimizer_ignore_wide_scans                                      on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3081,7 +3081,7 @@ optimizer_check_input_min_row_count                              1              
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
-optimizer_ignore_wide_scans                                      off                 NULL      NULL        NULL        string
+optimizer_ignore_wide_scans                                      on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
@@ -3327,7 +3327,7 @@ optimizer_check_input_min_row_count                              1              
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
-optimizer_ignore_wide_scans                                      off                 NULL  user     NULL      off                 off
+optimizer_ignore_wide_scans                                      on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3081,6 +3081,7 @@ optimizer_check_input_min_row_count                              1              
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
+optimizer_ignore_wide_scans                                      off                 NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
@@ -3326,6 +3327,7 @@ optimizer_check_input_min_row_count                              1              
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
+optimizer_ignore_wide_scans                                      off                 NULL  user     NULL      off                 off
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on
@@ -3562,6 +3564,7 @@ optimizer_check_input_min_row_count                              NULL    NULL   
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  NULL    NULL     NULL     NULL        NULL
 optimizer_enable_lock_elision                                    NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries                 NULL    NULL     NULL     NULL        NULL
+optimizer_ignore_wide_scans                                      NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                                    NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                          NULL    NULL     NULL     NULL        NULL
 optimizer_plan_lookup_joins_with_reverse_scans                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -158,6 +158,7 @@ optimizer_check_input_min_row_count                              1
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
+optimizer_ignore_wide_scans                                      off
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -158,7 +158,7 @@ optimizer_check_input_min_row_count                              1
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
-optimizer_ignore_wide_scans                                      off
+optimizer_ignore_wide_scans                                      on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -641,6 +641,19 @@ func (c *Constraint) ConstrainedColumnCount() int {
 	return count
 }
 
+// ConstrainedColumns returns the set of columns which are constrained by
+// the Constraint. For example, for the constraint:
+//
+//	/a/b/c: [/1/1 - /1] [/3 - /3]
+//
+// ConstrainedColumns would return (a,b).
+func (c *Constraint) ConstrainedColumns() (cols opt.ColSet) {
+	for i, n := 0, c.ConstrainedColumnCount(); i < n; i++ {
+		cols.Add(c.Columns.Get(i).ID())
+	}
+	return cols
+}
+
 // Prefix returns the length of the longest prefix of columns for which all the
 // spans have the same start and end values. For example:
 //

--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -618,14 +618,14 @@ func (c *Constraint) ExactPrefix(ctx context.Context, evalCtx *eval.Context) int
 	}
 }
 
-// ConstrainedColumns returns the number of columns which are constrained by
+// ConstrainedColumnCount returns the number of columns which are constrained by
 // the Constraint. For example:
 //
 //	/a/b/c: [/1/1 - /1] [/3 - /3]
 //
 // has 2 constrained columns. This may be less than the total number of columns
 // in the constraint, especially if it represents an index constraint.
-func (c *Constraint) ConstrainedColumns(evalCtx *eval.Context) int {
+func (c *Constraint) ConstrainedColumnCount() int {
 	count := 0
 	for i := 0; i < c.Spans.Count(); i++ {
 		sp := c.Spans.Get(i)
@@ -638,7 +638,6 @@ func (c *Constraint) ConstrainedColumns(evalCtx *eval.Context) int {
 			count = end.Length()
 		}
 	}
-
 	return count
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
@@ -18405,7 +18405,11 @@ vectorized: true
   table: t1401@t1401_c_idx
   spans: [/'2022-01-25 21:17:27.216095+00' - ]
 
-# Without forecasts, the bad plan uses t1401_c_idx.
+# Without forecasts (and with optimizer_ignore_wide_scans disabled) the bad plan
+# uses t1401_c_idx.
+
+statement ok
+SET optimizer_ignore_wide_scans=false
 
 query T
 EXPLAIN SELECT
@@ -18438,6 +18442,9 @@ vectorized: true
               estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
               table: t1401@t1401_c_idx
               spans: [/'2022-01-25 21:17:27.216095+00' - ]
+
+statement ok
+RESET optimizer_ignore_wide_scans
 
 statement ok
 RESET optimizer_use_forecasts

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -722,22 +722,17 @@ t1:
 index-recommendations
 SELECT * FROM t1 WHERE k = 1 AND f != 0
 ----
-creation: CREATE INDEX ON t.public.t1 (k) STORING (i, f, s);
+creation: CREATE INDEX ON t.public.t1 (k, f) STORING (i, s);
 --
 optimal plan:
-select
+scan t1@_hyp_3
  ├── columns: k:1!null i:2 f:3!null s:4
- ├── cost: 29.0500001
+ ├── constraint: /1/3/5
+ │    ├── (/1/NULL - /1/-5e-324]
+ │    └── [/1/5e-324 - /1]
+ ├── cost: 32.1933333
  ├── cost-flags: unbounded-cardinality
- ├── fd: ()-->(1)
- ├── scan t1@_hyp_1
- │    ├── columns: k:1!null i:2 f:3 s:4
- │    ├── constraint: /1/5: [/1 - /1]
- │    ├── cost: 28.9200001
- │    ├── cost-flags: unbounded-cardinality
- │    └── fd: ()-->(1)
- └── filters
-      └── f:3 != 0.0 [outer=(3), constraints=(/3: (/NULL - /-5e-324] [/5e-324 - ]; tight)]
+ └── fd: ()-->(1)
 
 # Multi-column combinations used: EQ, EQ + R.
 index-candidates
@@ -1195,7 +1190,7 @@ FROM (
 )
 ----
 creation: CREATE INDEX ON t.public.t1 (k);
-creation: CREATE INDEX ON t.public.t1 (s) STORING (f);
+creation: CREATE INDEX ON t.public.t1 (s, f);
 creation: CREATE INDEX ON t.public.t2 (k) STORING (i, s);
 --
 optimal plan:
@@ -1204,7 +1199,7 @@ union-all
  ├── left columns: count_rows:14
  ├── right columns: count_rows:22
  ├── cardinality: [1 - ]
- ├── cost: 2766.55828
+ ├── cost: 2769.71494
  ├── cost-flags: unbounded-cardinality
  ├── project
  │    ├── columns: count_rows:14!null
@@ -1239,23 +1234,18 @@ union-all
  └── scalar-group-by
       ├── columns: count_rows:22!null
       ├── cardinality: [1 - 1]
-      ├── cost: 28.9733334
+      ├── cost: 32.13
       ├── cost-flags: unbounded-cardinality
       ├── key: ()
       ├── fd: ()-->(22)
-      ├── select
+      ├── scan t1@_hyp_4
       │    ├── columns: f:17!null t1.s:18!null
-      │    ├── cost: 28.8500001
+      │    ├── constraint: /18/17/19
+      │    │    ├── (/'NG'/NULL - /'NG'/-5e-324]
+      │    │    └── [/'NG'/5e-324 - /'NG']
+      │    ├── cost: 32.0066667
       │    ├── cost-flags: unbounded-cardinality
-      │    ├── fd: ()-->(18)
-      │    ├── scan t1@_hyp_1
-      │    │    ├── columns: f:17 t1.s:18!null
-      │    │    ├── constraint: /18/19: [/'NG' - /'NG']
-      │    │    ├── cost: 28.7200001
-      │    │    ├── cost-flags: unbounded-cardinality
-      │    │    └── fd: ()-->(18)
-      │    └── filters
-      │         └── f:17 != 0.0 [outer=(17), constraints=(/17: (/NULL - /-5e-324] [/5e-324 - ]; tight)]
+      │    └── fd: ()-->(18)
       └── aggregations
            └── count-rows [as=count_rows:22]
 

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -211,6 +211,7 @@ type Memo struct {
 	useExistsFilterHoistRule                   bool
 	disableSlowCascadeFastPathForRBRTables     bool
 	useImprovedHoistJoinProject                bool
+	ignoreWideScans                            bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -318,6 +319,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useExistsFilterHoistRule:                   evalCtx.SessionData().OptimizerUseExistsFilterHoistRule,
 		disableSlowCascadeFastPathForRBRTables:     evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables,
 		useImprovedHoistJoinProject:                evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
+		ignoreWideScans:                            evalCtx.SessionData().OptimizerIgnoreWideScans,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -493,6 +495,7 @@ func (m *Memo) IsStale(
 		m.useExistsFilterHoistRule != evalCtx.SessionData().OptimizerUseExistsFilterHoistRule ||
 		m.disableSlowCascadeFastPathForRBRTables != evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables ||
 		m.useImprovedHoistJoinProject != evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject ||
+		m.ignoreWideScans != evalCtx.SessionData().OptimizerIgnoreWideScans ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -595,6 +595,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerIgnoreWideScans = true
+	stale()
+	evalCtx.SessionData().OptimizerIgnoreWideScans = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3749,7 +3749,7 @@ func (sb *statisticsBuilder) applyIndexConstraint(
 	//  "unapplied conjuncts" and account for their selectivity in
 	//  selectivityFromUnappliedConjuncts.
 	prefix := c.Prefix(sb.ctx, sb.evalCtx)
-	for i, n := 0, c.ConstrainedColumns(sb.evalCtx); i < n && i <= prefix; i++ {
+	for i, n := 0, c.ConstrainedColumnCount(); i < n && i <= prefix; i++ {
 		col := c.Columns.Get(i).ID()
 		constrainedCols.Add(col)
 		if i < applied {

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -3391,7 +3391,7 @@ ALTER TABLE stale INJECT STATISTICS '[
 # When optimizer_always_use_histograms and optimizer_prefer_bounded_cardinality
 # are disabled, and optimizer_min_row_count=0, we may choose the non-unique
 # index.
-opt set=(optimizer_always_use_histograms=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+opt set=(optimizer_always_use_histograms=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0,optimizer_ignore_wide_scans=false)
 SELECT * FROM stale WHERE x = 'bar1' AND (y = 'bar1000' OR y = 'bar1001') LIMIT 1
 ----
 limit
@@ -3464,5 +3464,26 @@ index-join stale
       │    └── [/'bar1'/'bar1001' - /'bar1'/'bar1001']
       ├── limit: 1
       ├── stats: [rows=4.4e-08]
+      ├── key: ()
+      └── fd: ()-->(1-3)
+
+# When optimizer_ignore_wide_scans is enabled, we should choose the unique
+# index.
+opt set=(optimizer_ignore_wide_scans=true,optimizer_always_use_histograms=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
+SELECT * FROM stale WHERE x = 'bar1' AND (y = 'bar1000' OR y = 'bar1001') LIMIT 1
+----
+index-join stale
+ ├── columns: w:1(string!null) x:2(string!null) y:3(string!null) z:4(string)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1-4)
+ └── scan stale@stale_x_y_key
+      ├── columns: w:1(string!null) x:2(string!null) y:3(string!null)
+      ├── constraint: /2/3
+      │    ├── [/'bar1'/'bar1000' - /'bar1'/'bar1000']
+      │    └── [/'bar1'/'bar1001' - /'bar1'/'bar1001']
+      ├── limit: 1
+      ├── stats: [rows=1]
       ├── key: ()
       └── fd: ()-->(1-3)

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -298,7 +298,7 @@ func (h *Histogram) CanFilter(
 	ctx context.Context, c *constraint.Constraint,
 ) (colOffset, exactPrefix int, ok bool) {
 	exactPrefix = c.ExactPrefix(ctx, h.evalCtx)
-	constrainedCols := c.ConstrainedColumns(h.evalCtx)
+	constrainedCols := c.ConstrainedColumnCount()
 	for i := 0; i < constrainedCols && i <= exactPrefix; i++ {
 		if c.Columns.Get(i).ID() == h.col {
 			return i, exactPrefix, true

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -973,15 +973,15 @@ sort
       │    │    │    └── fd: ()-->(28)
       │    │    ├── inner-join (lookup transactiondetails)
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
-      │    │    │    ├── key columns: [52 53 13] = [1 2 3]
+      │    │    │    ├── key columns: [49 50 13] = [1 2 3]
       │    │    │    ├── stats: [rows=12345.7, distinct(3)=12345.7, null(3)=0, distinct(4)=11100.2, null(4)=0, distinct(13)=12345.7, null(13)=0]
       │    │    │    ├── key: (4,5,13)
       │    │    │    ├── fd: ()-->(1,2,11,12), (3-5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: "lookup_join_const_col_@1":52!null "lookup_join_const_col_@2":53!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
-      │    │    │    │    ├── stats: [rows=12345.7, distinct(13)=12345.7, null(13)=0, distinct(52)=1, null(52)=0, distinct(53)=1, null(53)=0]
+      │    │    │    │    ├── columns: "lookup_join_const_col_@1":49!null "lookup_join_const_col_@2":50!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
+      │    │    │    │    ├── stats: [rows=12345.7, distinct(13)=12345.7, null(13)=0, distinct(49)=1, null(49)=0, distinct(50)=1, null(50)=0]
       │    │    │    │    ├── key: (13)
-      │    │    │    │    ├── fd: ()-->(11,12,52,53), (13)-->(14,15)
+      │    │    │    │    ├── fd: ()-->(11,12,49,50), (13)-->(14,15)
       │    │    │    │    ├── select
       │    │    │    │    │    ├── columns: transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
       │    │    │    │    │    ├── stats: [rows=12345.7, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=12345.7, null(13)=0, distinct(14)=12345.7, null(14)=0, distinct(15)=12345.7, null(15)=0, distinct(11,12)=1, null(11,12)=0, distinct(13-15)=12345.7, null(13-15)=0, distinct(11-15)=12345.7, null(11-15)=0]
@@ -997,8 +997,8 @@ sort
       │    │    │    │    │         ├── accountname:14 != 'someaccount' [outer=(14), constraints=(/14: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
       │    │    │    │    │         └── customername:15 != 'somecustomer' [outer=(15), constraints=(/15: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
       │    │    │    │    └── projections
-      │    │    │    │         ├── 1 [as="lookup_join_const_col_@1":52]
-      │    │    │    │         └── false [as="lookup_join_const_col_@2":53]
+      │    │    │    │         ├── 1 [as="lookup_join_const_col_@1":49]
+      │    │    │    │         └── false [as="lookup_join_const_col_@2":50]
       │    │    │    └── filters
       │    │    │         └── (transactiondate:3 >= '2020-02-23 00:00:00+00') AND (transactiondate:3 <= '2020-03-01 00:00:00+00') [outer=(3), constraints=(/3: [/'2020-02-23 00:00:00+00' - /'2020-03-01 00:00:00+00']; tight)]
       │    │    └── filters

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -977,15 +977,15 @@ sort
       │    │    │    └── fd: ()-->(32)
       │    │    ├── inner-join (lookup transactiondetails)
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
-      │    │    │    ├── key columns: [60 61 15] = [1 2 3]
+      │    │    │    ├── key columns: [57 58 15] = [1 2 3]
       │    │    │    ├── stats: [rows=12345.7, distinct(3)=12345.7, null(3)=0, distinct(4)=11100.2, null(4)=0, distinct(15)=12345.7, null(15)=0]
       │    │    │    ├── key: (4,5,15)
       │    │    │    ├── fd: ()-->(1,2,13,14), (3-5)-->(6,7), (15)-->(16,17), (3)==(15), (15)==(3)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: "lookup_join_const_col_@1":60!null "lookup_join_const_col_@2":61!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
-      │    │    │    │    ├── stats: [rows=12345.7, distinct(15)=12345.7, null(15)=0, distinct(60)=1, null(60)=0, distinct(61)=1, null(61)=0]
+      │    │    │    │    ├── columns: "lookup_join_const_col_@1":57!null "lookup_join_const_col_@2":58!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
+      │    │    │    │    ├── stats: [rows=12345.7, distinct(15)=12345.7, null(15)=0, distinct(57)=1, null(57)=0, distinct(58)=1, null(58)=0]
       │    │    │    │    ├── key: (15)
-      │    │    │    │    ├── fd: ()-->(13,14,60,61), (15)-->(16,17)
+      │    │    │    │    ├── fd: ()-->(13,14,57,58), (15)-->(16,17)
       │    │    │    │    ├── select
       │    │    │    │    │    ├── columns: transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
       │    │    │    │    │    ├── stats: [rows=12345.7, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0, distinct(15)=12345.7, null(15)=0, distinct(16)=12345.7, null(16)=0, distinct(17)=12345.7, null(17)=0, distinct(13,14)=1, null(13,14)=0, distinct(15-17)=12345.7, null(15-17)=0, distinct(13-17)=12345.7, null(13-17)=0]
@@ -1001,8 +1001,8 @@ sort
       │    │    │    │    │         ├── accountname:16 != 'someaccount' [outer=(16), constraints=(/16: (/NULL - /'someaccount') [/e'someaccount\x00' - ]; tight)]
       │    │    │    │    │         └── customername:17 != 'somecustomer' [outer=(17), constraints=(/17: (/NULL - /'somecustomer') [/e'somecustomer\x00' - ]; tight)]
       │    │    │    │    └── projections
-      │    │    │    │         ├── 1 [as="lookup_join_const_col_@1":60]
-      │    │    │    │         └── false [as="lookup_join_const_col_@2":61]
+      │    │    │    │         ├── 1 [as="lookup_join_const_col_@1":57]
+      │    │    │    │         └── false [as="lookup_join_const_col_@2":58]
       │    │    │    └── filters
       │    │    │         └── (transactiondate:3 >= '2020-02-23 00:00:00+00') AND (transactiondate:3 <= '2020-03-01 00:00:00+00') [outer=(3), constraints=(/3: [/'2020-02-23 00:00:00+00' - /'2020-03-01 00:00:00+00']; tight)]
       │    │    └── filters

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2893,6 +2893,251 @@ project
  └── projections
       └── mod(a, 16)
 
+
+# ----------------------------------------------------------
+# GenerateConstrainedScans with optimizer_ignore_wide_scans
+# ----------------------------------------------------------
+
+exec-ddl
+CREATE TABLE t_ignore_wide_scans (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  f INT,
+  INDEX a_b_idx (a, b) STORING (c),
+  INDEX a_c_idx (a, c) STORING (b),
+  INDEX a_d_idx (a, d) STORING (f, c)
+)
+----
+
+# Do not generate a constrained scan over a_b_idx nor a_d_idx because they
+# would only constrain a.
+# NOTE: GenerateIndexScans is disabled to avoid generating full scans over
+# secondary indexes which make the output bigger and more confusing to read.
+memo set=(optimizer_ignore_wide_scans=true) disable=GenerateIndexScans
+SELECT k FROM t_ignore_wide_scans WHERE a = 1 AND c = 2
+----
+memo (optimized, ~8KB, required=[presentation: k:1])
+ ├── G1: (project G2 G3 k)
+ │    └── [presentation: k:1]
+ │         ├── best: (project G2 G3 k)
+ │         └── cost: 19.12
+ ├── G2: (select G4 G5) (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │         └── cost: 19.09
+ ├── G3: (projections)
+ ├── G4: (scan t_ignore_wide_scans,cols=(1,2,4))
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans,cols=(1,2,4))
+ │         └── cost: 1129.02
+ ├── G5: (filters G6 G7)
+ ├── G6: (eq G8 G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (variable a)
+ ├── G9: (const 1)
+ ├── G10: (variable c)
+ └── G11: (const 2)
+
+# Similar case as above, but when all the indexes are non-covering.
+memo set=(optimizer_ignore_wide_scans=true) disable=GenerateIndexScans
+SELECT k, e FROM t_ignore_wide_scans WHERE a = 1 AND c = 2
+----
+memo (optimized, ~9KB, required=[presentation: k:1,e:6])
+ ├── G1: (project G2 G3 k e)
+ │    └── [presentation: k:1,e:6]
+ │         ├── best: (project G2 G3 k e)
+ │         └── cost: 25.23
+ ├── G2: (select G4 G5) (index-join G6 t_ignore_wide_scans,cols=(1,2,4,6))
+ │    └── []
+ │         ├── best: (index-join G6 t_ignore_wide_scans,cols=(1,2,4,6))
+ │         └── cost: 25.20
+ ├── G3: (projections)
+ ├── G4: (scan t_ignore_wide_scans,cols=(1,2,4,6))
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans,cols=(1,2,4,6))
+ │         └── cost: 1139.12
+ ├── G5: (filters G7 G8)
+ ├── G6: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │         └── cost: 19.09
+ ├── G7: (eq G9 G10)
+ ├── G8: (eq G11 G12)
+ ├── G9: (variable a)
+ ├── G10: (const 1)
+ ├── G11: (variable c)
+ └── G12: (const 2)
+
+# We should generate a wide constrained scan over a_d_idx because it is covering
+# and no narrower constraints are covering.
+memo set=(optimizer_ignore_wide_scans=true) disable=GenerateIndexScans
+SELECT k, f FROM t_ignore_wide_scans WHERE a = 1 AND c = 2
+----
+memo (optimized, ~11KB, required=[presentation: k:1,f:7])
+ ├── G1: (project G2 G3 k f)
+ │    └── [presentation: k:1,f:7]
+ │         ├── best: (project G2 G3 k f)
+ │         └── cost: 25.23
+ ├── G2: (select G4 G5) (index-join G6 t_ignore_wide_scans,cols=(1,2,4,7)) (select G7 G8)
+ │    └── []
+ │         ├── best: (index-join G6 t_ignore_wide_scans,cols=(1,2,4,7))
+ │         └── cost: 25.20
+ ├── G3: (projections)
+ ├── G4: (scan t_ignore_wide_scans,cols=(1,2,4,7))
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans,cols=(1,2,4,7))
+ │         └── cost: 1139.12
+ ├── G5: (filters G9 G10)
+ ├── G6: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │         └── cost: 19.09
+ ├── G7: (scan t_ignore_wide_scans@a_d_idx,cols=(1,2,4,7),constrained)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_d_idx,cols=(1,2,4,7),constrained)
+ │         └── cost: 28.92
+ ├── G8: (filters G10)
+ ├── G9: (eq G11 G12)
+ ├── G10: (eq G13 G14)
+ ├── G11: (variable a)
+ ├── G12: (const 1)
+ ├── G13: (variable c)
+ └── G14: (const 2)
+
+# We should generate a wide constrained scan over a_b_idx because it can provide
+# the required ordering.
+# TODO(mgartner): This is broken because it tries to use required orderings, but
+# that doesn't work.
+memo set=(optimizer_ignore_wide_scans=true) disable=GenerateIndexScans
+SELECT k FROM t_ignore_wide_scans WHERE a = 1 AND c = 2 ORDER BY b
+----
+memo (optimized, ~8KB, required=[presentation: k:1] [ordering: +3])
+ ├── G1: (project G2 G3 k b)
+ │    ├── [presentation: k:1] [ordering: +3]
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 19.19
+ │    └── []
+ │         ├── best: (project G2 G3 k b)
+ │         └── cost: 19.13
+ ├── G2: (select G4 G5) (scan t_ignore_wide_scans@a_c_idx,cols=(1-4),constrained)
+ │    ├── [ordering: +3 opt(2,4)]
+ │    │    ├── best: (sort G2)
+ │    │    └── cost: 19.18
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_idx,cols=(1-4),constrained)
+ │         └── cost: 19.10
+ ├── G3: (projections)
+ ├── G4: (scan t_ignore_wide_scans,cols=(1-4))
+ │    ├── [ordering: +2,+3]
+ │    │    ├── best: (sort G4)
+ │    │    └── cost: 1409.57
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans,cols=(1-4))
+ │         └── cost: 1139.12
+ ├── G5: (filters G6 G7)
+ ├── G6: (eq G8 G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (variable a)
+ ├── G9: (const 1)
+ ├── G10: (variable c)
+ └── G11: (const 2)
+
+# Hinted, wide constrained scans are not ignored.
+opt set=(optimizer_ignore_wide_scans=true) disable=GenerateIndexScans
+SELECT k FROM t_ignore_wide_scans@a_b_idx WHERE a = 1 AND c = 2
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2!null c:4!null
+      ├── key: (1)
+      ├── fd: ()-->(2,4)
+      ├── scan t_ignore_wide_scans@a_b_idx
+      │    ├── columns: k:1!null a:2!null c:4
+      │    ├── constraint: /2/3/1: [/1 - /1]
+      │    ├── flags: force-index=a_b_idx
+      │    ├── key: (1)
+      │    └── fd: ()-->(2), (1)-->(4)
+      └── filters
+           └── c:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+
+exec-ddl
+CREATE INDEX a_c_partial_idx ON t_ignore_wide_scans (a) WHERE c = 2
+----
+
+# Constrained partial index scans are considered even when wide scans are
+# ignored.
+memo set=(optimizer_ignore_wide_scans=true) disable=(GenerateIndexScans,GeneratePartialIndexScans)
+SELECT k FROM t_ignore_wide_scans WHERE a = 1 AND c = 2
+----
+memo (optimized, ~12KB, required=[presentation: k:1])
+ ├── G1: (project G2 G3 k)
+ │    └── [presentation: k:1]
+ │         ├── best: (project G2 G3 k)
+ │         └── cost: 19.12
+ ├── G2: (select G4 G5) (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained) (project G6 G7 k a)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │         └── cost: 19.09
+ ├── G3: (projections)
+ ├── G4: (scan t_ignore_wide_scans,cols=(1,2,4))
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans,cols=(1,2,4))
+ │         └── cost: 1129.02
+ ├── G5: (filters G8 G9)
+ ├── G6: (scan t_ignore_wide_scans@a_c_partial_idx,partial,cols=(1,2),constrained)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_partial_idx,partial,cols=(1,2),constrained)
+ │         └── cost: 19.06
+ ├── G7: (projections G10)
+ ├── G8: (eq G11 G12)
+ ├── G9: (eq G13 G10)
+ ├── G10: (const 2)
+ ├── G11: (variable a)
+ ├── G12: (const 1)
+ └── G13: (variable c)
+
+exec-ddl
+DROP INDEX a_c_partial_idx
+----
+
+exec-ddl
+CREATE INDEX a_c_partial_idx ON t_ignore_wide_scans (a) WHERE c > 0
+----
+
+# Constrained partial index scans are not considered if they don't eliminate the
+# same number of remaining filters as another constrained scan.
+memo set=(optimizer_ignore_wide_scans=true) disable=(GenerateIndexScans,GeneratePartialIndexScans)
+SELECT k FROM t_ignore_wide_scans WHERE a = 1 AND c = 2
+----
+memo (optimized, ~10KB, required=[presentation: k:1])
+ ├── G1: (project G2 G3 k)
+ │    └── [presentation: k:1]
+ │         ├── best: (project G2 G3 k)
+ │         └── cost: 19.12
+ ├── G2: (select G4 G5) (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans@a_c_idx,cols=(1,2,4),constrained)
+ │         └── cost: 19.09
+ ├── G3: (projections)
+ ├── G4: (scan t_ignore_wide_scans,cols=(1,2,4))
+ │    └── []
+ │         ├── best: (scan t_ignore_wide_scans,cols=(1,2,4))
+ │         └── cost: 1129.02
+ ├── G5: (filters G6 G7)
+ ├── G6: (eq G8 G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (variable a)
+ ├── G9: (const 1)
+ ├── G10: (variable c)
+ └── G11: (const 2)
+
+
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -677,12 +677,12 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~10KB, required=[presentation: k:1])
+memo (optimized, ~9KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
  │         └── cost: 9.08
- ├── G2: (select G4 G5) (select G6 G7) (scan a@u,cols=(1,2),constrained)
+ ├── G2: (select G4 G5) (scan a@u,cols=(1,2),constrained)
  │    └── []
  │         ├── best: (scan a@u,cols=(1,2),constrained)
  │         └── cost: 9.06
@@ -691,18 +691,13 @@ memo (optimized, ~10KB, required=[presentation: k:1])
  │    └── []
  │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1078.52
- ├── G5: (filters G8 G9)
- ├── G6: (scan a,cols=(1,2),constrained)
- │    └── []
- │         ├── best: (scan a,cols=(1,2),constrained)
- │         └── cost: 9.06
- ├── G7: (filters G8)
- ├── G8: (eq G10 G11)
- ├── G9: (eq G12 G13)
- ├── G10: (variable u)
- ├── G11: (const 1)
- ├── G12: (variable k)
- └── G13: (const 5)
+ ├── G5: (filters G6 G7)
+ ├── G6: (eq G8 G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (variable u)
+ ├── G9: (const 1)
+ ├── G10: (variable k)
+ └── G11: (const 5)
 
 # Constraint + remaining filter.
 opt
@@ -723,12 +718,12 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k+u = 1
 ----
-memo (optimized, ~11KB, required=[presentation: k:1])
+memo (optimized, ~9KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
  │         └── cost: 9.08
- ├── G2: (select G4 G5) (select G6 G7) (scan a@u,cols=(1,2),constrained)
+ ├── G2: (select G4 G5) (scan a@u,cols=(1,2),constrained)
  │    └── []
  │         ├── best: (scan a@u,cols=(1,2),constrained)
  │         └── cost: 9.06
@@ -737,18 +732,13 @@ memo (optimized, ~11KB, required=[presentation: k:1])
  │    └── []
  │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1078.52
- ├── G5: (filters G8 G9)
- ├── G6: (scan a,cols=(1,2),constrained)
- │    └── []
- │         ├── best: (scan a,cols=(1,2),constrained)
- │         └── cost: 9.06
- ├── G7: (filters G8)
- ├── G8: (eq G10 G11)
- ├── G9: (eq G12 G13)
- ├── G10: (variable u)
- ├── G11: (const 1)
- ├── G12: (variable k)
- └── G13: (const 0)
+ ├── G5: (filters G6 G7)
+ ├── G6: (eq G8 G9)
+ ├── G7: (eq G10 G11)
+ ├── G8: (variable u)
+ ├── G9: (const 1)
+ ├── G10: (variable k)
+ └── G11: (const 0)
 
 opt
 SELECT k FROM a WHERE u = 1 AND v = 5
@@ -10063,8 +10053,8 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~42KB, required=[presentation: p:1,q:2,r:3,s:4])
- ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
+memo (optimized, ~35KB, required=[presentation: p:1,q:2,r:3,s:4])
+ ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (lookup-join G8 G9 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G10 G7 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
  │         └── cost: 30.17
@@ -10072,65 +10062,43 @@ memo (optimized, ~42KB, required=[presentation: p:1,q:2,r:3,s:4])
  │    └── []
  │         ├── best: (scan pqr,cols=(1-4))
  │         └── cost: 11129.12
- ├── G3: (filters G14 G15 G16)
- ├── G4: (index-join G17 pqr,cols=(1-4))
+ ├── G3: (filters G11 G12 G13)
+ ├── G4: (index-join G14 pqr,cols=(1-4))
  │    └── []
- │         ├── best: (index-join G17 pqr,cols=(1-4))
+ │         ├── best: (index-join G14 pqr,cols=(1-4))
  │         └── cost: 88.80
- ├── G5: (filters G15 G16)
- ├── G6: (index-join G18 pqr,cols=(1-4))
+ ├── G5: (filters G12 G13)
+ ├── G6: (index-join G15 pqr,cols=(1-4))
  │    └── []
- │         ├── best: (index-join G18 pqr,cols=(1-4))
- │         └── cost: 732.04
- ├── G7: (filters G14 G16)
- ├── G8: (index-join G19 pqr,cols=(1-4))
- │    └── []
- │         ├── best: (index-join G19 pqr,cols=(1-4))
- │         └── cost: 1148.97
- ├── G9: (filters G14)
- ├── G10: (index-join G20 pqr,cols=(1-4))
- │    └── []
- │         ├── best: (index-join G20 pqr,cols=(1-4))
+ │         ├── best: (index-join G15 pqr,cols=(1-4))
  │         └── cost: 89.54
- ├── G11: (zigzag-join G21 pqr@q pqr@r)
+ ├── G7: (filters G11)
+ ├── G8: (zigzag-join G16 pqr@q pqr@r)
  │    └── []
- │         ├── best: (zigzag-join G21 pqr@q pqr@r)
+ │         ├── best: (zigzag-join G16 pqr@q pqr@r)
  │         └── cost: 30.14
- ├── G12: (filters G16)
- ├── G13: (zigzag-join G5 pqr@r pqr@s)
+ ├── G9: (filters G13)
+ ├── G10: (zigzag-join G5 pqr@r pqr@s)
  │    └── []
  │         ├── best: (zigzag-join G5 pqr@r pqr@s)
  │         └── cost: 139.14
- ├── G14: (eq G22 G23)
- ├── G15: (eq G24 G23)
- ├── G16: (eq G25 G26)
- ├── G17: (scan pqr@q,cols=(1,2),constrained)
+ ├── G11: (eq G17 G18)
+ ├── G12: (eq G19 G18)
+ ├── G13: (eq G20 G21)
+ ├── G14: (scan pqr@q,cols=(1,2),constrained)
  │    └── []
  │         ├── best: (scan pqr@q,cols=(1,2),constrained)
  │         └── cost: 28.33
- ├── G18: (scan pqr@r,cols=(1,3),constrained)
- │    └── []
- │         ├── best: (scan pqr@r,cols=(1,3),constrained)
- │         └── cost: 122.02
- ├── G19: (select G27 G28)
- │    └── []
- │         ├── best: (select G27 G28)
- │         └── cost: 1088.05
- ├── G20: (scan pqr@rs,cols=(1,3,4),constrained)
+ ├── G15: (scan pqr@rs,cols=(1,3,4),constrained)
  │    └── []
  │         ├── best: (scan pqr@rs,cols=(1,3,4),constrained)
  │         └── cost: 28.62
- ├── G21: (filters G14 G15)
- ├── G22: (variable q)
- ├── G23: (const 1)
- ├── G24: (variable r)
- ├── G25: (variable s)
- ├── G26: (const 'foo')
- ├── G27: (scan pqr@s,cols=(1,3,4),constrained)
- │    └── []
- │         ├── best: (scan pqr@s,cols=(1,3,4),constrained)
- │         └── cost: 1078.02
- └── G28: (filters G15)
+ ├── G16: (filters G11 G12)
+ ├── G17: (variable q)
+ ├── G18: (const 1)
+ ├── G19: (variable r)
+ ├── G20: (variable s)
+ └── G21: (const 'foo')
 
 # Zigzag joins cannot be planned for indexes where equality columns do not
 # immediately follow fixed columns. Here, the only index on t is (t,s,p) and

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -741,6 +741,10 @@ message LocalOnlySessionData {
   bool optimizer_use_improved_hoist_join_project = 186;
   // EnableInspectCommand controls use of the INSPECT command.
   bool enable_inspect_command = 187;
+  // OptimizerIgnoreWideScans controls whether the optimizer should only
+  // construct the constrained scans with the tightest spans within a single
+  // memo group. See GenerateConstrainedScans for more details.
+  bool optimizer_ignore_wide_scans = 188;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4418,7 +4418,7 @@ var varGen = map[string]sessionVar{
 				evalCtx.SessionData().OptimizerIgnoreWideScans,
 			), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4402,6 +4402,24 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	`optimizer_ignore_wide_scans`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_ignore_wide_scans`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_ignore_wide_scans", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerIgnoreWideScans(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerIgnoreWideScans,
+			), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Release note (sql change): The session setting
`optimizer_ignore_wide_scans` is now enabled by default.
