### PR TITLE
sql: remove some EXPLAIN [ANALYZE] fields in non-VERBOSE mode

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_redact
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_redact
@@ -63,7 +63,6 @@ query T
 EXPLAIN (REDACT) INSERT INTO p VALUES (1, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: p(p, q)
@@ -177,7 +176,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM p WHERE p = 11
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -263,7 +261,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM q WHERE q > 2
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
@@ -48,7 +48,6 @@ FROM child
 INNER LOOKUP JOIN parent ON c_p_id = p_id
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent@parent_pkey
@@ -67,7 +66,6 @@ FROM child
 INNER LOOKUP JOIN parent ON p_data = c_data
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -126,7 +124,6 @@ FROM child_rbr
 INNER LOOKUP JOIN parent_rbr ON c_p_id = p_id
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
@@ -154,7 +151,6 @@ FROM child_rbr
 INNER JOIN parent_rbr ON c_p_id = p_id WHERE c_int = 1
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
@@ -184,7 +180,6 @@ FROM child_rbr
 INNER LOOKUP JOIN parent_rbr ON c_p_id = p_id AND c_int + c_int2 = p_int WHERE c_int2 > -1
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
@@ -219,7 +214,6 @@ FROM child_rbr
 INNER LOOKUP JOIN parent_rbr ON c_p_id = p_id WHERE child_rbr.crdb_region = 'ap-southeast-2'
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
@@ -62,7 +62,6 @@ WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
   AND address = '221B Baker Street';
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -79,7 +78,6 @@ WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
   AND address = '221B Baker Street' LIMIT 1;
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -106,7 +104,6 @@ WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
   AND address = '221B Baker Street' LIMIT 2;
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -128,7 +125,6 @@ WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
   AND address = '221B Baker Street';
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -39,7 +39,6 @@ query T retry
 EXPLAIN INSERT INTO child (id, p_id) VALUES (1, 10), (2, 150)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -266,7 +265,6 @@ VALUES
   (2057, 4, 3, 4, 3, 2100.9, '2021-04-15 15:22:14', '9    zmssaF9m')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -352,7 +350,6 @@ WHERE
     order_id = '94e4b847-8f2f-4ac5-83f1-641d6e3df727'
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -386,7 +383,6 @@ WHERE
     order_id = '94e4b847-8f2f-4ac5-83f1-641d6e3df727'
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -442,7 +438,6 @@ query T
 EXPLAIN UPDATE t85043 SET ts = '2022-08-01 18:07:07' WHERE id = 'ab020c49-ba5e-4800-8000-00000000014e'
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t85043

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -573,8 +573,11 @@ p.crdb_region = c.crdb_region LIMIT 1
 # Locality-optimized search of locality-optimized join and lookup join is
 # treated as having a home region.
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1] OFFSET 3
+SELECT * FROM [
+  EXPLAIN SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1
+] WHERE info !~ '(distribution|vectorized):.*'
 ----
+·
 • limit
 │ count: 1
 │
@@ -686,8 +689,11 @@ SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.acco
 ----
 
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1] OFFSET 3
+SELECT * FROM [
+  EXPLAIN SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1
+] WHERE info !~ '(distribution|vectorized):.*'
 ----
+·
 • limit
 │ count: 1
 │
@@ -704,9 +710,12 @@ SELECT * FROM [EXPLAIN SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rb
 
 # Lookup into a local RBT table is allowed.
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) rbr,
-               messages_rbt rbt WHERE rbr.account_id = rbt.account_id] OFFSET 3
+SELECT * FROM [
+  EXPLAIN SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) rbr,
+  messages_rbt rbt WHERE rbr.account_id = rbt.account_id
+] WHERE info !~ '(distribution|vectorized):.*'
 ----
+·
 • lookup join
 │ table: messages_rbt@messages_rbt_pkey
 │ equality: (account_id) = (account_id)

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1457,7 +1457,6 @@ WHERE
 ;
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -257,7 +257,6 @@ query T
 EXPLAIN INSERT INTO fk_using_implicit_columns_against_t VALUES (1, 1, 4)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -735,7 +734,6 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -805,7 +803,6 @@ query T
 EXPLAIN UPSERT INTO t VALUES (3, 3, 3, 3, 3, 3, 3)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
@@ -50,7 +50,7 @@ CREATE TABLE t (
   j JSON,
   UNIQUE INDEX (c),
   FAMILY (pk, a, b, c, d, j)
-) PARTITION ALL BY LIST(a) ( 
+) PARTITION ALL BY LIST(a) (
   PARTITION one VALUES IN ('one'),
   PARTITION two VALUES IN ('two'),
   PARTITION three VALUES IN ('three'),
@@ -194,7 +194,6 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, 'two', 3, 4, 5)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: t(pk, a, b, c, d, j)
@@ -229,7 +228,6 @@ query T
 EXPLAIN UPDATE t SET c = 4 WHERE pk = 2
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t
@@ -269,7 +267,6 @@ query T
 EXPLAIN UPSERT INTO t VALUES (1, 'five', 3, 4, 15)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t(pk, a, b, c, d, j)
@@ -313,7 +310,6 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, 'three', 3, 4, 15) ON CONFLICT DO NOTHING
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: t(pk, a, b, c, d, j)
@@ -347,7 +343,6 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, 'one', 3, 4, 5) ON CONFLICT (pk) DO UPDATE SET d = t.d + 10
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t(pk, a, b, c, d, j)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -343,7 +343,7 @@ query T retry
 SELECT * FROM [
   EXPLAIN INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
   VALUES ('ca-central-1', 7, 7, 8, 9) ON CONFLICT DO NOTHING
-] OFFSET 2
+] OFFSET 1
 ----
 ·
 • insert
@@ -413,7 +413,7 @@ SET locality_optimized_partitioned_index_scan = false
 
 # Query with locality optimized search disabled.
 query T
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 1
 ----
 ·
 • scan
@@ -421,7 +421,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 
   table: regional_by_row_table@regional_by_row_table_pkey
   spans: [/'ap-southeast-2'/1 - /'ap-southeast-2'/1] [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8klGrmzAUx9_3KcJ52kaKxu5hBAZ33Fom9LZ3VdjgViTVczunNVkS6S3F7z602-6tuLH2oXkQcnL8nf8vegDzowQOoT_zbyPylkyXizvy4H-9n30M5uT1JAij8PPsDTlt0LjJZSXKZL1PtNwlVqxLJF8--UufqIJ8ICwmi-k09CPiAYVKZjgXWzTAH4BBTEFpmaIxUrelQ9cQZE_AXQp5pWrblmMKqdQI_AA2tyUCh6ids0SRoXZcoJChFXnZYQcj3QxWE1XgHijcyrLeVoYTVVCiCo8SQcmaku9AIVSiPXFWcLMChzkuxA0FWdvncMaKDQJnL2yCCXC3oZcJsSsJrVZP790zpdilUt71pNJzpby_Sj271JXUGWrMTjziZkB7LkdSOeNe43AUrxdlfM79LtEoWRn8r0lub9KItdkx2-BR1Mhap3ivZdr1HreLDtQVMjT2eDo-boKqO2LtBI1i--eff0lil5JYn-RdSvL6pPE_Se9OSO6pXUzhsZS7JM-Ag_trjQYevxe0L4iNaT9b-E3uOmy0V-2lP4rSIIU7UeAELeptXuXG5ilwq2tsmlc_AwAA__9wGtJB
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8klGrmzAUx9_3KcJ52kaKxu5hBAZ33Fom9LZ3VdjgViTVczunNVkS6S3F7z602-6tuLH2oXkQcnL8nf8vegDzowQOoT_zbyPylkyXizvy4H-9n30M5uT1JAij8PPsDTlt0LjJZSXKZL1PtNwlVqxLJF8--UufqIJ8ICwmi-k09CPCgEIlM5yLLRrgD8AgpqC0TNEYqdvSoWsIsifgLoW8UrVtyzGFVGoEfgCb2xKBQ9TOWaLIUDsuUMjQirzssIORbgariSpwDxRuZVlvK8OJKihRhUeJoGRNyXegECrRnjgruFmBwxwX4oaCrO1zOGPFBoGzFzbBBLjb0MuE2JWEVqun9-6ZUuxSKe96Uum5Ut5fpZ5d6krqDDVmJx5xM6A9lyOpnHGvcTiK14syPud-l2iUrAz-1yS3N2nE2uyYbfAoamStU7zXMu16j9tFB-oKGRp7PB0fN0HVHbF2gkax_fPPvySxS0msT_IuJXl90vifpHcnJPfULqbwWMpdkmfAwf21RgOP3wvaF8TGtJ8t_CZ3HTbaq_bSH0VpkMKdKHCCFvU2r3Jj8xS41TU2zaufAQAA__9q59JA
 
 statement ok
 SET vectorize=on
@@ -465,7 +465,7 @@ statement ok
 SET vectorize=on
 
 query T retry
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 1
 ----
 ·
 • union all
@@ -481,7 +481,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 
       table: regional_by_row_table@regional_by_row_table_pkey
       spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8kmGL2jAYx9_vU4Tn1TYiNq2DERjcOCsTPL1ZYYOzSGyfc5m1yZIUT8TvPlq33bXU2-mLywshTx5_-f_ydA_2VwYconAUXs_IezKYTm7IXfj9dvR5OCZv-8NoFn0dvSP1BoMrqXKRLZa7hVHbhRPLDMm3L-E0JHpNPhEWk8lgEIUz4gOFXKU4Fhu0wO-AQUxBG5WgtcqUpX3VMEwfgHsUZK4LV5ZjCokyCHwPTroMgcOsvGeKIkXT9YBCik7IrMK2RrpqrS70GndA4VplxSa3nOg1JXrtUyIoWVLyEyhEWpQn3TlczaHLuh7EBwqqcI_hrBMrBM6e2Az7wL0DvUyIvZLQfP7w0fuPlN-QYpdK-a8nlZwr5Z-UenQpcmVSNJjWPOJDi_ZYdZTuBo3G9ihBI0rwgigWjRQZOTtRrz6CkdxIR9jJV-o1ovXOGf0UrVa5xRc9gte4qcNKCUxXeBS3qjAJ3hqVVL3H7aQCVYUUrTue9o6bYV4dsfIGg2Lzb8hPSexZUnCa5DVJ_qUk1iQFl9oFTVLvWdKHGsmr28UU7jO1XcgUOHh_Vqfl5--C8g9iZcsPIPqhthV2ttPl-O5FZpHCjVhjHx2ajcyldTIB7kyBh8Ob3wEAAP__tq0eJw==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8kmGL2jAYx9_vU4Tn1TYiNtbBCAxunJUJnt6ssMFZJLbPuczaZEmKJ9LvPlq33bXU2-mLywshTx5_-f_y9AD2VwocwmAcXM_JezKcTW_IXfD9dvx5NCFvB6NwHn4dvyP1BoNrqTKRLlf7pVG7pROrFMm3L8EsIHpDPhEWkelwGAZzwoBCphKciC1a4HfAIKKgjYrRWmXK0qFqGCUPwD0KMtO5K8sRhVgZBH4AJ12KwGFe3jNDkaDpekAhQSdkWmFbI121Vpd6g3ugcK3SfJtZTvSGEr3pUSIoWVHyEyiEWpQn3QVcLaDLuh5EBQWVu8dw1ok1AmdPbEYD4F5BLxNiryS0WDx89P4j1WtIsUuleq8nFZ8r1Tsp9eiSZ8okaDCpeURFi_ZEdZTu-o3G9ih-I4r_gigWjRQpOTtRvz6CsdxKR9jJV-o3ovXPGf0MrVaZxRc9gte4qcNKCUzWeBS3Kjcx3hoVV73H7bQCVYUErTue9o-bUVYdsfIGg2L7b8hPSexZkn-a5DVJvUtJrEnyL7Xzm6T-s6QPNZJXt4so3Kdqt5QJcPD-rE7Lz98F5R_E2pYfQPhD7SrsfK_L8d2L1CKFG7HBATo0W5lJ62QM3Jkci-LN7wAAAP__sJUeJg==
 
 query T
 EXPLAIN (VEC) SELECT * FROM regional_by_row_table WHERE pk = 1
@@ -567,7 +567,7 @@ RESET vectorize
 # scanned in the first child of the limited union all.
 query T nodeidx=3 retry
 USE multi_region_test_db; SET locality_optimized_partitioned_index_scan = true;
-SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 1
 ----
 ·
 • union all
@@ -586,7 +586,7 @@ SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 
 
 # Query with more than one key.
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk IN (1, 4)] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk IN (1, 4)] OFFSET 1
 ----
 ·
 • union all
@@ -661,7 +661,7 @@ SET locality_optimized_partitioned_index_scan = false
 
 # Anti join with locality optimized search disabled.
 query T
-SELECT * FROM [EXPLAIN SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 1
 ----
 ·
 • lookup join (anti)
@@ -691,7 +691,7 @@ fetched: /parent/parent_pkey/'ap-southeast-2'/10 -> <undecoded>
 
 # Semi join with locality optimized search disabled.
 query T
-SELECT * FROM [EXPLAIN SELECT * FROM child WHERE EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM child WHERE EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 1
 ----
 ·
 • lookup join (semi)
@@ -722,7 +722,7 @@ output row: [10 10]
 
 # Inner join with locality optimized search disabled.
 query T
-SELECT * FROM [EXPLAIN SELECT * FROM child INNER JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM child INNER JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 1
 ----
 ·
 • lookup join
@@ -753,7 +753,7 @@ output row: [10 10 10]
 
 # Left join with locality optimized search disabled.
 query T
-SELECT * FROM [EXPLAIN SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 1
 ----
 ·
 • lookup join (left outer)
@@ -787,7 +787,7 @@ SET locality_optimized_partitioned_index_scan = true
 
 # Anti join with locality optimized search enabled.
 query T retry
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 1
 ----
 ·
 • lookup join (anti)
@@ -813,7 +813,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * 
               table: child@child_pkey
               spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyslGFr8kgQx9_fpxjmjXqkuBstlIWCpUbOYmNPA1eoImkytXuN2Ty7CbUUv_vDJvapCbXQ0ryI7uzkN___7LCvaH4lKHDuTbzLAP6G0Wx6DXfe7c3kYuxDezieB_N_Jx2oJ0SPMonhv3-8mQdtfxqAd2sToV1Py0JNab7Py1YyhnOIVvZPpwMX_hDaURXkrLOE6Wg09wJw0cFUxeSHGzIo7pDj0sFMq4iMUdqGXsuEcbxFwRyUaVbkNrx0MFKaULxiLvOEUGAQ3ic0ozAm3WXoYEx5KJMSW3oYlO9V9kQv6OClSopNagRYWc5eKjo4z0Ib7S5wsMAuZ12Gy52DqsjfK5s8XBMKfiB1PETBds731PIfULtYbM_YXjGEaQwcVP5I-qh6t6GeH1X_LtqQlmECRap0TJrimu7l7gObvjpRWdetG5zIjcyBH5XWa0hzv9LYKyXTfV979bLBS0YCJt4ogAs_GMPVdOyjg9XkDqqft4ZPlHoqMvhfyRRUKqA96MM5bFt91hJCDDhjnJ3tB3vgwjkMep3Dc8qqc9Lx_UrTWqr0qNl-w2zvm2b7P2vW3gjb1tmhXQe2rajm_0cacNpoQP8rDZiRyVRqqDGJH1dijUon3I4sxWuqxtyoQkd0o1VU5lbLaQkqAzGZvNp1q8U4Lbe4raAp3Py5BQ5J_Lsk3iS5n5J6NRI7JLlNUu9TUv84qdck9T8lnR4nMdv7h0Q925tMINs_Jx-83h60H4RrYwdg_qieS6wddIPiIUwMOXgdPtGQctIbmUqTywhFrgva7f76HQAA__8pKDXV
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyslGFr8kgQx9_fpxjmjXqkuKsWykLBUiOXYmNPA1eoImkytXuN2Ty7CbUUv_vDJvapCbXQ0ryI7uzkN___7LCvaH4lKHDuTtzLAP6G8Wx6DXfu7c3kwvOhPfLmwfzfSQfqCdGjTGL47x935kLbnwbg3tpEaNfTslBTmu_zspWM4Ryilf3T6cCFP4J2VAU56yxhOh7P3QA4OpiqmPxwQwbFHXJcOphpFZExStvQa5ngxVsUzEGZZkVuw0sHI6UJxSvmMk8IBQbhfUIzCmPSXYYOxpSHMimxpYdh-V5lT_SCDl6qpNikRoCV5eylooPzLLTR7gKHC-xy1mW43Dmoivy9ssnDNaHgB1K9EQq2c76nlv-A2sVie8b2iiFMY-Cg8kfSR9X3Gur5UfXvog1pGSZQpErHpCmu6V7uPrDpqxOVdXt1gxO5kTnwo9L6DWm9rzT2Ssl039d-vWzwkpGAiTsO4MIPPLiaej46WE3usPp5a_hEqacig_-VTEGlAtrDAZzDtjVgLSHEkDPG2dl-sIc9OIdhv3N4Tll1Tjq-X2laS5UeNTtomO1_0-zgZ83aG2HbOju068C2FdX8_0gDThsNGHylATMymUoNNSbx40qsUemE25GleE3VmBtV6IhutIrK3Go5LUFlICaTV7u9auGl5Ra3FTSFmz-3wCGJf5fEm6Tep6R-jcQOSb0mqf8paXCc1G-SBp-STo-TmO39Q6Ke7U0mkO2fkw9ebw_aD8K1sQMwf1TPJdYOukHxECaGHLwOn2hEOemNTKXJZYQi1wXtdn_9DgAA__8ivDXU
 
 statement ok
 SET vectorize=on
@@ -868,7 +868,7 @@ fetched: /parent/parent_pkey/'ca-central-1'/20 -> <undecoded>
 
 # Semi join with locality optimized search enabled.
 query T retry
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 1
 ----
 ·
 • lookup join (semi)
@@ -890,7 +890,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE EXISTS (SELECT * FROM
           table: child@child_pkey
           spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1FrIjEQx9_vUwzzoh4pJqsPJVCw1JWzWO2pcIUqst2d2lzXzV4SqaX43Y_s2lY9LbRcHrKbyeQ_v8xMXtD-SVHiKOyFF2P4Dp3h4Apuw5vr3nm3D9V2dzQe_ezVYNchflBpAr9-hMMQwhvvA9VdjzwylLmNSz5TCZxBPPM_NTjvt6EalzbBa1MYdDqjcAwBMsx0Qv1oQRblLQqcMsyNjslabbzppXDoJiuUnKHK8qXz5inDWBtC-YJOuZRQ4ji6S2lIUUKmzpFhQi5SaSFb0LeKeZY_0jMyvNDpcpFZCR6LbUiR4SiPvLU-wdYE64LXOU7XDPXSvUe2LpoTSrGF2m2j5Gv2NVrxH2gnk9Up3xBDlCUgQLsHMkfpgz16cZT-HdqSUVEKy0ybhAwlO9zT9YFr9vWJzuvB7gV7aqEciKNojT204DOJvdQq2-S1sRt2_JyThF7YGcMovOrC5aDbR4Zl47bKz2vCe1o_LnP4rVUGOpNQbTXhDFaVJq9IKVuCc8FPN43dCuAMWo0aMhzSQjuC9MBp_7hWldPt8wxWlXhH8F_Ft8rnZeVNcjczNFc6O5q-5l76Gp9J35BsrjNLe6U9HInvRToRvgcomVPZN1YvTUzXRseFb7kcFEKFISHryt2gXHSzYkv4CIaixduz2lYSX1US-0rBh0qNHSW-rRTsKzU-VGoeV-I-Y_epfvIPWiLfjJMD0-tAfyCaW1-20YN-KmR9c1uU91FqieFV9EhtcmQWKlPWqRilM0tar7_9DQAA__-kMOJR
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1FrIjEQx9_vUwzzoh4pJupDCRQsdeUsVnsqXKGKbHenNtd1s5dEail-9yO7ttU9LbRcHrKbyeQ_v8xMXtD-SVDiOOgHFxP4Dt3R8Apug5vr_nlvANVObzwZ_-zXYN8helBJDL9-BKMAghvvA9V9jyw0lLqtSzZXMZxBNPc_NTgfdKAaFTbBazMYdrvjYAICGaY6pkG4JIvyFgXOGGZGR2StNt70kjv04jVKzlCl2cp584xhpA2hfEGnXEIocRLeJTSiMCZT58gwJheqJJfN6dv5PM8e6RkZXuhktUytBI_FtqTIcJyF3lqfYnuKdcHrHGcbhnrl3iNbFy4IpdhB7XVQ8g37Gq34D7TT6fqUb4khTGMQoN0DmaP0jRK9OEr_Dm3JqDCBVapNTIbiPe7Z5sA1B_pEZ_XG_gX7aqkciKNozRJa4zOJvdQq3ea1uR928pyRhH7QncA4uOrB5bA3QIZF47aLz2vC-1o_rjL4rVUKOpVQbbfgDNaVFq9IKduCc8FPt43dbsAZtJs1ZDiipXYEyYHT_nGtK6e75xmsK9Ge4L-Kb5XPisqb-G5uaKF0ejR9rVL6mp9J34hsplNLpdIejsRLkU6E7wGKF1T0jdUrE9G10VHuWyyHuVBuiMm6YrdRLHppviV8BEPh8u1Z7SqJryqJslLjQ6XmnhLfVWqUlZofKrWOK3GfsftEP_kHLZFvx8mB6XWgPxAurC_b-EE_5bK-uS3K-zCxxPAqfKQOOTJLlSrrVITSmRVtNt_-BgAA__-eveJQ
 
 statement ok
 SET vectorize=on
@@ -946,7 +946,7 @@ output row: [20 20]
 
 # Inner join with locality optimized search enabled.
 query T retry
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child INNER JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child INNER JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 1
 ----
 ·
 • lookup join
@@ -968,7 +968,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child INNER JOIN parent ON p_id =
           table: child@child_pkey
           spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk0FP4zwQhu_frxjNpfDJqHbaA7KEFESLNqikbFtpV6JVFZKheEnjrO2IItT_vkpSoM22SKD1wYnH9juP37Ff0P5OUeK4P-hfTOB_uBwNr-G2__NmcB6EcNQLxpPx98Ex7C6IH1SaQBCG_RFcDYMQ8shQ5mAYQj5XCZxBPK9-fnzrj_oQ1zHBZzC8vBz3J-Ahw0wnFEZLsihvUeCMYW50TNZqU4ZeqgVBskLJGaosL1wZnjGMtSGUL-iUSwklTqK7lEYUJWTaHBkm5CKVVrIVqF_18_yRnpHhhU6LZWZlRcU2oMhwnEdltD1Ff4ptwdscZ2uGunDvma2LFoRSbKEGPZR8zb5GK_4B7XS6OuUbYoiyBARo90DmIL3XoBcH6d-hLRkVpVBk2iRkKNnhnq33HDPUJzpve7sHHKilciAOonUaaN5njL3SKtv42tlNW99Ov_68OjvQ-rHI4ZdWGehMwpHfhTNYtbq8JaX0BeeCnx7DediDI9-DM_A7x8hwREvtCNI9u8sHs2qdbu9nsGrFO4J_K76VOK9LbJK7uaGF0hkyHBZOgi-Y7zG_c9C3bsO3zmd8G5HNdWapUdP9mXgj04koi0_JguoLY3VhYroxOq7W1sNhJVQFErKunvXqQZBVU6LMYChavr2nbSXxVSXRVPI-VOrsKPFtJa-p1PlQqXtYiZeO3af6qXzJEvmmnezpXhuWG6KFLcs2ftBPlezkOS9Nv49SSwyvo0fqkSOzVJmyTsUonSlovf7vTwAAAP__9TTaxw==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk0FP4zwQhu_frxjNpfDJqHbaA7KEFESLNqikbFtpV6JVFZKheEnjrO2IItT_vkpSoM22SKD1wYnH9juP37Ff0P5OUeK4P-hfTOB_uBwNr-G2__NmcB6EcNQLxpPx98Ex7C6IH1SaQBCG_RFcDYMQ8shQ5mAYQj5XCZxBPK9-fnzrj_oQ1zHBZzC8vBz3JyCQYaYTCqMlWZS3KHDGMDc6Jmu1KUMv1YIgWaHkDFWWF64MzxjG2hDKF3TKpYQSJ9FdSiOKEjJtjgwTcpFKK9kK1K_6ef5Iz8jwQqfFMrOyomIbUGQ4zqMy2p6iP8W24G2OszVDXbj3zNZFC0IptlCDHkq-Zl-jFf-AdjpdnfINMURZAgK0eyBzkN5r0IuD9O_QloyKUigybRIylOxwz9Z7jhnqE523vd0DDtRSORAH0ToNNO8zxl5plW187eymrW-nX39enR1o_Vjk8EurDHQm4cjvwhmsWl3eklL6gnPBT4_hPOzBke_BGfidY2Q4oqV2BOme3eWDWbVOt_czWLXiHcG_Fd9KnNclNsnd3NBC6QwZDgsnwRfM95jfOehbt-Fb5zO-jcjmOrPUqOn-TLyR6USUxadkQfWFsbowMd0YHVdr6-GwEqoCCVlXz3r1IMiqKVFmMBQt397TtpL4qpJoKnkfKnV2lPi2ktdU6nyo1D2sxEvH7lP9VL5kiXzTTvZ0rw3LDdHClmUbP-inSnbynJem30epJYbX0SP1yJFZqkxZp2KUzhS0Xv_3JwAA___vyNrG
 
 statement ok
 SET vectorize=on
@@ -1024,7 +1024,7 @@ output row: [20 20 20]
 
 # Left join with locality optimized search enabled.
 query T retry
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child LEFT JOIN parent ON p_id = c_p_id WHERE c_id = 10] OFFSET 1
 ----
 ·
 • lookup join (left outer)
@@ -1046,7 +1046,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child LEFT JOIN parent ON p_id = 
           table: child@child_pkey
           spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1Fv2jAQx9_3KU73Qju5wg48VJYqpSpBo6LQAdMmFYTS5Eq9hjizHZWq4rtPSWgLGVRqtTwYfLb_9_P_zs9o_yQocRz0g4sJfIXuaHgFN8Gv6_55bwBHnd54Mv7eP4bdDdG9SmLoB90JXA57A8hCQ6mD4QCyuYrhDKJ5-efnt2AUQFTFBJ_BsNsdBxPwkGGqYxqES7Iob1DgjGFmdETWalOEnssNvXiFkjNUaZa7IjxjGGlDKJ_RKZcQSpyEtwmNKIzJNDkyjMmFKillS06_HOfZAz0hwwud5MvUypKKbUCR4TgLi2hziv4Um4I3Oc7WDHXu3jJbFy4IpdhC7XVQ8jX7HK34D7TT6eqUb4ghTGMQoN09mYP0Xo1eHKR_g7ZkVJhAnmoTk6F4h3u23nPNgT7RWdPbvWBfLZUDcRCtVUPzPmLspVbpxtfWbtrJU0ay6tbhj0kwKnsWGVZd61c_L473tX7IM_itVQo6lXDkt-EMVo02b0gpfcG54KfHcD7owJHvwRn4rWNkOKKldgTJntPFO1o1TrfPM1g1oh3BfxVfS59VpTfx7dzQQukUGQ5zJ8EXzPeY3zroZ7vmZ-sjfo7IZjq1VKv1_ky8lulEFE1B8YKqRrI6NxFdGx2Ve6vpsBQqAzFZV6161aSXlkuiyGAoXL6-s20l8VklUVfy3lVq7SjxbSWvrtR6V6l9WIkXjt0l-rF44RL55jvZM7x8WBwIF7Yo2_heP5ayRbdblHdhYonhVfhAHXJklipV1qkIpTM5rddf_gYAAP__PpHhDA==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1Fv2jAQx9_3KU73Qju5wg48VJYqpSpBo6LQAdMmFYTS5Eq9hjizHZWq4rtPSWgLGVRqtTwYfLb_9_P_zs9o_yQocRz0g4sJfIXuaHgFN8Gv6_55bwBHnd54Mv7eP4bdDdG9SmLoB90JXA57A8hCQ6mD4QCyuYrhDKJ5-efnt2AUQFTFBJ_BsNsdBxMQyDDVMQ3CJVmUNyhwxjAzOiJrtSlCz-WGXrxCyRmqNMtdEZ4xjLQhlM_olEsIJU7C24RGFMZkmhwZxuRClZSyJadfjvPsgZ6Q4YVO8mVqZUnFNqDIcJyFRbQ5RX-KTcGbHGdrhjp3b5mtCxeEUmyh9joo-Zp9jlb8B9rpdHXKN8QQpjEI0O6ezEF6r0YvDtK_QVsyKkwgT7WJyVC8wz1b77nmQJ_orOntXrCvlsqBOIjWqqF5HzH2Uqt042trN-3kKSNZdevwxyQYlT2LDKuu9aufF8f7Wj_kGfzWKgWdSjjy23AGq0abN6SUvuBc8NNjOB904Mj34Az81jEyHNFSO4Jkz-niHa0ap9vnGawa0Y7gv4qvpc-q0pv4dm5ooXSKDIe5k-AL5nvMbx30s13zs_URP0dkM51aqtV6fyZey3QiiqageEFVI1mdm4iujY7KvdV0WAqVgZisq1a9atJLyyVRZDAULl_f2baS-KySqCt57yq1dpT4tpJXV2q9q9Q-rMQLx-4S_Vi8cIl8853sGV4-LA6EC1uUbXyvH0vZotstyrswscTwKnygDjkyS5Uq61SE0pmc1usvfwMAAP__OQ3hCw==
 
 statement ok
 SET vectorize=on
@@ -1101,7 +1101,7 @@ fetched: /parent/parent_pkey/'ca-central-1'/20 -> <undecoded>
 output row: [20 20 20]
 
 query T retry
-SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -1151,7 +1151,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 # Non-constant insert values cannot be inlined in uniqueness check, and all
 # regions must be searched for duplicates.
 query T retry
-SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 1
 ----
 ·
 • root
@@ -1199,7 +1199,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
                       label: buffer 1
 
 query T retry
-SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -1249,7 +1249,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
                       label: buffer 1
 
 query T
-SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 2
+SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 1
 ----
 ·
 • root
@@ -1530,7 +1530,7 @@ ALTER TABLE regional_by_row_table ADD CONSTRAINT unique_b_a UNIQUE(b, a)
 
 # The unique partial index disallows fast path insert.
 query T retry
-SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -1649,7 +1649,7 @@ INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-
 # to stats issues w/ empty stats, partial indexes and multicol stats its not.
 # Hopefully fixing #67583 (and possibly #67479) will resolve this.
 query T retry
-SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)] OFFSET 2
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)] OFFSET 1
 ----
 ·
 • root
@@ -1725,7 +1725,7 @@ SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, 
 # Hopefully fixing #67583 (and possibly #67479) will resolve this.
 query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
-VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
+VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 1
 ----
 ·
 • root
@@ -1896,7 +1896,7 @@ pk  a     b     crdb_region_col
 # We do not need uniqueness checks on pk since uniqueness can be inferred
 # through the functional dependency between pk and the computed region column.
 query T retry
-SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)] OFFSET 1
 ----
 ·
 • insert fast path
@@ -1916,7 +1916,7 @@ INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (2, 1, 1)
 
 # Verify that we plan single-region scans for REGIONAL BY ROW tables with a computed region.
 query T
-SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as WHERE pk = 10] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as WHERE pk = 10] OFFSET 1
 ----
 ·
 • scan
@@ -1939,7 +1939,7 @@ CREATE TABLE regional_by_row_table_virt (
 
 # Uniqueness checks for virtual columns should be efficient.
 query T retry
-SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -2015,7 +2015,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
                                   spans: [/'ap-southeast-2'/11 - /'ap-southeast-2'/11] [/'ca-central-1'/11 - /'ca-central-1'/11] [/'us-east-1'/11 - /'us-east-1'/11]
 
 query T retry
-SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt (pk, a, b) VALUES (1, 1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -2104,7 +2104,7 @@ CREATE TABLE regional_by_row_table_virt_partial (
 
 # Uniqueness checks for virtual columns should be efficient.
 query T retry
-SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -2197,7 +2197,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
                                   spans: FULL SCAN (SOFT LIMIT)
 
 query T retry
-SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 1
 ----
 ·
 • root
@@ -2340,7 +2340,7 @@ ALTER TABLE t65064 INJECT STATISTICS '[
 ]';
 
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM t65064 WHERE username = 'kharris'] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t65064 WHERE username = 'kharris'] OFFSET 1
 ----
 ·
 • union all
@@ -2393,7 +2393,6 @@ LIMIT
     1]
 ----
 distribution: local
-vectorized: true
 ·
 • union all
 │ limit: 1
@@ -2882,7 +2881,7 @@ INSERT INTO regional_by_row_table_as1 (pk) VALUES (1), (2), (3), (10), (20)
 
 # An extra crdb_region check constraint should still allow locality optimized scan.
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as1 LIMIT 3] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as1 LIMIT 3] OFFSET 1
 ----
 ·
 • render
@@ -2926,7 +2925,6 @@ EXPLAIN INSERT INTO users (name, email)
 VALUES ('Craig Roacher', 'craig@cockroachlabs.com')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: users(id, name, email, crdb_region)
@@ -2984,7 +2982,6 @@ EXPLAIN SELECT users.crdb_region AS user_region, user_settings.crdb_region AS us
   FROM users JOIN user_settings ON users.id = user_settings.user_id AND users.id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882';
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: user_settings@user_settings_pkey
@@ -3020,7 +3017,6 @@ EXPLAIN SELECT users_dt.crdb_region AS user_region, user_settings.crdb_region AS
   users_dt.crdb_region = user_settings.crdb_region
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: user_settings@user_settings_pkey
@@ -3063,7 +3059,6 @@ EXPLAIN SELECT users_dt.crdb_region AS user_region, user_settings.crdb_region AS
   FROM (SELECT crdb_region, * FROM users@id2_idx LIMIT 1) users_dt JOIN user_settings ON users_dt.id2+1 > user_settings.id2 AND users_dt.id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882' and users_dt.crdb_region = user_settings.crdb_region
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: user_settings@user_settings_pkey
@@ -3100,7 +3095,6 @@ EXPLAIN SELECT users.crdb_region AS user_region, user_settings.crdb_region AS us
   FROM users JOIN user_settings ON users.crdb_region = user_settings.crdb_region AND users.id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882';
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: user_settings@user_settings_pkey
@@ -3124,7 +3118,6 @@ query T
 EXPLAIN INSERT INTO user_settings (user_id, value) VALUES ('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: user_settings(id, id2, user_id, value, crdb_region)
@@ -3136,7 +3129,6 @@ query T
 EXPLAIN INSERT INTO user_settings_cascades (user_id, value) VALUES ('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: user_settings_cascades(id, user_id, value, crdb_region)
@@ -3148,7 +3140,6 @@ query T retry
 EXPLAIN DELETE FROM users WHERE id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882'
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3495,7 +3486,7 @@ output row: [20 20]
 
 # Left join with locality optimized search enabled.
 query T retry
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM t108206_c WHERE EXISTS (SELECT * FROM t108206_p WHERE p_id = c_p_id) AND c_id = 20] OFFSET 2
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM t108206_c WHERE EXISTS (SELECT * FROM t108206_p WHERE p_id = c_p_id) AND c_id = 20] OFFSET 1
 ----
 ·
 • lookup join (semi)
@@ -3516,7 +3507,7 @@ SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM t108206_c WHERE EXISTS (SELECT * 
           table: t108206_c@t108206_c_pkey
           spans: [/'ca-central-1'/20 - /'ca-central-1'/20] [/'us-east-1'/20 - /'us-east-1'/20]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1Fr4kAQx9_vUwzzoh5b3EQ5ZKFgqZGzWO2pcIUqkiZTu9eYze1uqKX43Y-NntWcFlouDyGZnf3Nf_47-4rmd4ICx0E_uJzAV-iOhtdwF9ze9C96A6h2euPJ-Ee_BocJ1uMtn3-bR_DzezAKILh1eVA9npVts7K5jOEcorn7qMHFoAPVaBPzeW0Gw253HEzAR4apimkQLsmguEMPZwwzrSIyRmkXei0SevEKBWco0yy3LjxjGClNKF7RSpsQCpyE9wmNKIxJ1zkyjMmGMimwuybau6959kQvyPBSJfkyNQKcPLZVjAzHWeii9Sm2p1j3eZ3jbM1Q5fZNgbHhglB4e5J7HRR8zT6n2vuPqqfTVYtvlUOYxuCBso-kT3bhl7rwTnbxJt6QlmECeap0TJriA_2z9ZF2B-pMZXX_sNG-XEoL3klpjZI0_yMGXymZbv1tHJadvGQkoB90JzAOrntwNewNkO1sz3a2Z4W9cxmvkGFfqac8g19KpqBSAdV2E85hVWnyihCi7XHu8dZ25Ns-nEO7UUOGI1oqS5Ac2e1u36rS2t_PYFWJDoD_EnczkG1mQMf3c00LqdKTRjZLRjY-YuSITKZSQ6VDPl6JlyqdeW4aKF7QZoKMynVEN1pFRe7md1iAikBMxm5W_c1PLy2WPFdBU7jcXbR9kvdZklcm-e-SGgckvk_yy6TGu6TmaRJ3jj0k6tldbYF8-5wdef190G0IF8Yd2_hRPRdYN-YGxUOYGGJ4HT5RhyzppUylsTJCYXVO6_WXPwEAAP__fkfliA==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJysk1FrIjEQx9_vUwzzoh4pJqscEihY6spZrPZUuEIV2e5Oba7rZi-J1FL87kdWz6qnhZbbh2V3MvnNf_6ZvKL9naLEYdgNL0fwFdqD_jXchbc33YtOD8qtznA0_NGtwH6CE7wR8G_TGH5-DwchhLc-D8rHs_JNVj5VCZxDPPUfFbjotaAcr2MBr0yg324PwxEIZJjphHrRnCzKOxQ4YZgbHZO12vjQa5HQSZYoOUOV5QvnwxOGsTaE8hWdcimhxFF0n9KAooRMlSPDhFyk0gK7baK5_ZrmT_SCDC91uphnVoKXxzaKkeEwj3y0OsbmGKsBr3KcrBjqhXtTYF00I5RiR3KnhZKv2OdUi_-oejxeNvhGOURZAgK0eyRzsovgoAtxsos38ZaMilJYZNokZCjZ0z9ZHWm3p890Xg32G-2quXIgTkqrHUgLPmLwlVbZxt_aftnRS04SumF7BMPwugNX_U4P2db2fGt7Xtg7VckSGXa1flrk8EurDHQmodyswzksS3VeklI2BeeCNzYj3wzgHJq1CjIc0Fw7gvTIbn_7lqXG7n4Gy1K8B_yXuJ2BfD0DJrmfGpopnZ00sn5gZO0jRg7I5jqzdHDIxyvxg0pnwk8DJTNaT5DVCxPTjdFxkbv-7RegIpCQdevVYP3TyYol4SsYiubbi7ZLEp8liUNS8C6ptkfiu6TgkFR7l1Q_TeLesYdUP_urLZFvnrMjr78P-g3RzPpjGz7q5wLrx9yifIhSSwyvoydqkSMzV5myTsUonVnQavXlTwAAAP__eLrlhw==
 
 statement ok
 SET vectorize=on
@@ -3727,7 +3718,6 @@ EXPLAIN INSERT INTO users2 (crdb_region, name, email)
 VALUES ('ap-southeast-2', 'Craig Roacher', 'craig@cockroachlabs.com')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: users2(id, name, email, crdb_region)
@@ -3741,7 +3731,6 @@ EXPLAIN INSERT INTO users2 (name, email)
 VALUES ('Bill Roacher', 'bill@cockroachlabs.com'), ('Jill Roacher', 'jill@cockroachlabs.com')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3779,7 +3768,6 @@ query T nosort
 EXECUTE e1 ('Bill Roacher', 'bill@cockroachlabs.com', 'Jo Roacher', 'jo@cockroachlabs.com')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3832,7 +3820,6 @@ EXPLAIN INSERT INTO users3 (crdb_region, name, email)
 VALUES ('ap-southeast-2', 'craig@cockroachlabs.com', 'craig@cockroachlabs.com')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3867,7 +3854,6 @@ EXPLAIN INSERT INTO multi_region_test_db.regional_by_row_table (pk, pk2, a, b) V
 (1, 1, 1, -5)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: regional_by_row_table(pk, pk2, a, b, j, crdb_region)
@@ -3891,7 +3877,6 @@ query T nosort
 EXECUTE s1 (1, 1, 1, -5)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: regional_by_row_table(pk, pk2, a, b, j, crdb_region)
@@ -3914,7 +3899,6 @@ query T nosort
 EXECUTE s3 (7, 7, 7, 7, 6, 7, 8, -5)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3991,7 +3975,6 @@ query T
 EXPLAIN INSERT INTO user_settings2 (id2, user_id, value) VALUES (2, '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: user_settings2(id, id2, user_id, value, crdb_region)
@@ -4009,7 +3992,6 @@ VALUES (2, '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo'),
        (2, '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo');
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4075,7 +4057,6 @@ VALUES
   ('east1234', gen_random_uuid(), gen_random_uuid(), 1, TIMESTAMP '2016-01-25 10:10:10.555555')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: hash_sharded_rbr_computed(region_id, my_uuid, my_uuid2, another_id, row_ts, crdb_region_col, crdb_internal_region_id_shard_16, crdb_internal_another_id_row_ts_shard_16)
@@ -4112,7 +4093,6 @@ VALUES
   ('east1234', 'east1234', gen_random_uuid(), gen_random_uuid(), 1, TIMESTAMP '2016-01-25 10:10:10.555555')
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: hash_sharded_rbr_computed_check(region_based_id, my_uuid, my_uuid2, another_id, row_ts, geo_zone, crdb_region_col, crdb_internal_region_based_id_shard_16, crdb_internal_another_id_row_ts_shard_16)
@@ -4132,7 +4112,6 @@ VALUES
   ('east1235', 'east1234', gen_random_uuid(), gen_random_uuid(), 1, TIMESTAMP '2016-01-25 10:10:10.555555')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4185,7 +4164,6 @@ query T
 EXPLAIN INSERT INTO user_settings3 (id2, user_id, value) VALUES (2, '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4234,7 +4212,7 @@ CREATE UNIQUE INDEX ON regional_by_row_table (b, a) USING HASH
 
 # After adding a hash sharded unique index, fast path is still legal.
 query T
-SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 1
 ----
 ·
 • insert fast path

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -28,7 +28,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -77,7 +76,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -126,7 +124,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -148,7 +145,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -194,7 +190,6 @@ query T retry,nosort
 EXECUTE p
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -211,7 +206,6 @@ query T retry,nosort
 EXECUTE p
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -238,7 +232,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -262,7 +255,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -321,7 +313,6 @@ query T retry
 EXPLAIN SELECT * FROM t WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -370,7 +361,6 @@ query T retry,nosort
 EXECUTE p
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -385,7 +375,6 @@ query T retry,nosort
 EXECUTE p
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -417,7 +406,6 @@ query T retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -434,7 +422,6 @@ query T retry
 EXPLAIN SELECT * FROM t36642 WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -494,7 +481,6 @@ query T retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -512,7 +498,6 @@ query T retry
 EXPLAIN SELECT * FROM t36644 WHERE k=10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/cli/clisqlshell/sql_test.go
+++ b/pkg/cli/clisqlshell/sql_test.go
@@ -218,7 +218,6 @@ func Example_misc_table() {
 	//            info
 	// --------------------------
 	//   distribution: local
-	//   vectorized: true
 	//
 	//   • render
 	//   │
@@ -226,7 +225,7 @@ func Example_misc_table() {
 	//         missing stats
 	//         table: t@t_pkey
 	//         spans: FULL SCAN
-	// (9 rows)
+	// (8 rows)
 }
 
 func Example_in_memory() {

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -625,7 +625,7 @@ ALTER TABLE t SPLIT AT SELECT generate_series(1, 30000, 3000);
 		for i := 0; i < 2; i++ {
 			gRPCCalls := -1
 			var err error
-			rows := runner.QueryStr(t, `EXPLAIN ANALYZE SELECT length(blob) FROM t@t_v_idx WHERE v = '1';`)
+			rows := runner.QueryStr(t, `EXPLAIN ANALYZE (VERBOSE) SELECT length(blob) FROM t@t_v_idx WHERE v = '1';`)
 			for _, row := range rows {
 				if matches := kvGRPCCallsRegex.FindStringSubmatch(row[0]); len(matches) > 0 {
 					gRPCCalls, err = strconv.Atoi(strings.ReplaceAll(matches[1], ",", ""))
@@ -693,7 +693,7 @@ ALTER TABLE t SPLIT AT SELECT i*2000 FROM generate_series(0, 2) AS g(i);
 			runner.Exec(t, `SET streamer_always_maintain_ordering = $1;`, inOrder)
 			gRPCCalls := -1
 			var err error
-			rows := runner.QueryStr(t, `EXPLAIN ANALYZE SELECT * FROM t@v_idx WHERE v > 0`)
+			rows := runner.QueryStr(t, `EXPLAIN ANALYZE (VERBOSE) SELECT * FROM t@v_idx WHERE v > 0`)
 			for _, row := range rows {
 				if matches := kvGRPCCallsRegex.FindStringSubmatch(row[0]); len(matches) > 0 {
 					gRPCCalls, err = strconv.Atoi(strings.ReplaceAll(matches[1], ",", ""))

--- a/pkg/sql/colfetcher/scan_limit_test.go
+++ b/pkg/sql/colfetcher/scan_limit_test.go
@@ -22,7 +22,7 @@ import (
 // TestScanLimitKVPairsRead is a regression test for fetching an extra KV batch
 // beyond the limit when the index has more than one column family and doesn't
 // include the max column family. It verifies that the correct number of KV
-// pairs are read as reported in EXPLAIN ANALYZE output.
+// pairs are read as reported in EXPLAIN ANALYZE (VERBOSE) output.
 func TestScanLimitKVPairsRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -61,11 +61,11 @@ func TestScanLimitKVPairsRead(t *testing.T) {
 
 	// Case with no NULL values.
 	sqlDB.Exec(t, `INSERT INTO t_multi_cf (SELECT t, t%19, t*7, t//3 FROM generate_series(1, 100) g(t))`)
-	rows := sqlDB.QueryStr(t, `EXPLAIN ANALYZE SELECT a, b FROM t_multi_cf LIMIT 5`)
+	rows := sqlDB.QueryStr(t, `EXPLAIN ANALYZE (VERBOSE) SELECT a, b FROM t_multi_cf LIMIT 5`)
 	checkRows(rows)
 
 	// Case with some NULL values in the stored columns.
 	sqlDB.Exec(t, `UPDATE t_multi_cf SET a = NULL WHERE k % 10 = 0`)
-	rows = sqlDB.QueryStr(t, `EXPLAIN ANALYZE SELECT a, b FROM t_multi_cf LIMIT 5`)
+	rows = sqlDB.QueryStr(t, `EXPLAIN ANALYZE (VERBOSE) SELECT a, b FROM t_multi_cf LIMIT 5`)
 	checkRows(rows)
 }

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -724,7 +724,7 @@ func TestExplainAnalyzeBufferedWrites(t *testing.T) {
 			_, err = conn.ExecContext(ctx, stmt)
 			require.NoError(t, err)
 		}
-		result, err := conn.QueryContext(ctx, "EXPLAIN ANALYZE "+tc.query)
+		result, err := conn.QueryContext(ctx, "EXPLAIN ANALYZE (VERBOSE) "+tc.query)
 		require.NoError(t, err)
 		rows, err := sqlutils.RowsToStrMatrix(result)
 		require.NoError(t, err)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -941,7 +941,7 @@ func (ih *instrumentationHelper) emitExplainAnalyzePlanToOutputBuilder(
 	ob.AddTxnInfo(iso, ih.txnPriority, qos, asOfSystemTime)
 	// Highlight that write buffering was enabled on the current txn, unless
 	// we're in "deterministic explain" mode.
-	if ih.txnBufferedWritesEnabled && !flags.Deflake.HasAny(explain.DeflakeAll) {
+	if flags.Verbose && ih.txnBufferedWritesEnabled && !flags.Deflake.HasAny(explain.DeflakeAll) {
 		// In order to not pollute the output, we don't include the write
 		// buffering info for read-only implicit txns. However, if we're in an
 		// explicit txn, even if the stmt is read-only, it might still be

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -338,7 +338,7 @@ SELECT index_id, index_name FROM crdb_internal.table_indexes WHERE descriptor_na
 # Make sure that each index can index join against the new primary key;
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT * FROM t@i1] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t@i1] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • index join
@@ -355,7 +355,7 @@ SELECT * FROM t@i1
 1 2 3 4 {}
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT * FROM t@i2] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t@i2] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • index join
@@ -372,7 +372,7 @@ SELECT * FROM t@i2
 1 2 3 4 {}
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT * FROM t@i3] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t@i3] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • index join
@@ -389,7 +389,7 @@ SELECT * FROM t@i3
 1 2 3 4 {}
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT * FROM t@i4] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t@i4] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • index join
@@ -406,7 +406,7 @@ SELECT * FROM t@i4
 1 2 3 4 {}
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT * FROM t@i5] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t@i5] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • index join
@@ -423,7 +423,7 @@ SELECT * FROM t@i5
 1 2 3 4 {}
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT * FROM t@i7] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM t@i7] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • index join
@@ -495,7 +495,7 @@ t  CREATE TABLE public.t (
    );
 
 query T nosort
-SELECT * FROM [EXPLAIN INSERT INTO t VALUES (4, 5, 6)] OFFSET 2
+SELECT * FROM [EXPLAIN INSERT INTO t VALUES (4, 5, 6)] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • insert fast path

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1998,7 +1998,7 @@ ANALYZE system.locations
 
 # EXPLAIN output should indicate stats collected on system.locations.
 query T retry
-SELECT * FROM [EXPLAIN SELECT * FROM system.locations] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT * FROM system.locations] OFFSET 1
 ----
 ·
 • scan
@@ -2969,7 +2969,6 @@ query T
 EXPLAIN SELECT * FROM t68254 WHERE e IN ('{"baz": 2}', '{"baz": 3}', '{"baz": 4}')
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -2986,7 +2985,6 @@ query T
 EXPLAIN SELECT * FROM t68254 WHERE f IN ('{"baz": 2}', '{"baz": 3}', '{"baz": 4}')
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -3003,7 +3001,6 @@ query T
 EXPLAIN SELECT * FROM t68254 WHERE c->'foo'->'bar' > '{"baz": 0}'
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │

--- a/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
+++ b/pkg/sql/logictest/testdata/logic_test/experimental_distsql_planning
@@ -144,7 +144,7 @@ SELECT n,a,b FROM a WHERE a = 5 AND b = 2
 5  5  2
 
 query T nosort
-SELECT * FROM [EXPLAIN SELECT n,a,b FROM a WHERE a = 5 AND b = 2] OFFSET 2
+SELECT * FROM [EXPLAIN SELECT n,a,b FROM a WHERE a = 5 AND b = 2] WHERE info !~ '(distribution|vectorized):.*'
 ----
 ·
 • zigzag join

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4491,8 +4491,11 @@ ALTER TABLE t65890_c ADD CONSTRAINT fk FOREIGN KEY (a, b) REFERENCES t65890_p(a,
 # Ensure that a fast path on ba_idx is used.
 skipif config weak-iso-level-configs
 query T
-SELECT * FROM [EXPLAIN INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)] OFFSET 3
+SELECT * FROM [
+  EXPLAIN INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)
+] WHERE info !~ '(distribution|vectorized):.*'
 ----
+·
 • insert fast path
   into: t65890_c(k, b, a)
   auto commit
@@ -4501,8 +4504,11 @@ SELECT * FROM [EXPLAIN INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)] OFFSET 3
 
 onlyif config weak-iso-level-configs
 query T
-SELECT * FROM [EXPLAIN INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)] OFFSET 3
+SELECT * FROM [
+  EXPLAIN INSERT INTO t65890_c (k, b, a) VALUES (1, 2, 3)
+] WHERE info !~ '(distribution|vectorized):.*'
 ----
+·
 • insert fast path
   into: t65890_c(k, b, a)
   auto commit

--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -515,25 +515,16 @@ EXPLAIN ANALYZE EXECUTE p (33, 44)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   KV time: 0µs
   KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
+  actual row count: 0
   missing stats
   table: t155159@t155159_a_b_idx
   spans: [/33/44 - /33]
@@ -575,32 +566,22 @@ EXPLAIN ANALYZE EXECUTE p (33, 44, 55, 66);
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • union
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 0
 │
 ├── • scan
 │     sql nodes: <hidden>
 │     kv nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 0
 │     KV time: 0µs
 │     KV rows decoded: 0
-│     KV bytes read: 0 B
-│     KV gRPC calls: 0
-│     estimated max memory allocated: 0 B
+│     actual row count: 0
 │     missing stats
 │     table: t155159@t155159_a_b_idx
 │     spans: [/33/44 - /33]
@@ -610,12 +591,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 0
       KV time: 0µs
       KV rows decoded: 0
-      KV bytes read: 0 B
-      KV gRPC calls: 0
-      estimated max memory allocated: 0 B
+      actual row count: 0
       missing stats
       table: t155159@t155159_a_b_idx
       spans: [/55/66 - /55]
@@ -649,20 +627,14 @@ EXPLAIN ANALYZE EXECUTE p158945a(NULL)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • norows
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   execution time: 0µs
+  actual row count: 0
 
 statement ok
 PREPARE p158945b AS SELECT k FROM t158945 WHERE a = $1
@@ -676,20 +648,14 @@ EXPLAIN ANALYZE EXECUTE p158945b(NULL)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • norows
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   execution time: 0µs
+  actual row count: 0
 
 # Regression test for #159124.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -124,7 +124,6 @@ query T
 EXPLAIN ALTER TABLE users RENAME COLUMN title TO woo
 ----
 distribution: local
-vectorized: true
 ·
 • alter table
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -190,7 +190,6 @@ query T
 EXPLAIN ALTER DATABASE v RENAME TO x
 ----
 distribution: local
-vectorized: true
 ·
 • alter database
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -153,7 +153,6 @@ query T
 EXPLAIN ALTER INDEX users@bar RENAME TO woo
 ----
 distribution: local
-vectorized: true
 ·
 • alter index
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -215,7 +215,6 @@ query T
 EXPLAIN ALTER TABLE kv RENAME TO kv2
 ----
 distribution: local
-vectorized: true
 ·
 • alter table
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -272,7 +272,6 @@ query T
 EXPLAIN (PLAN) select oid::INT, polname, polrelid::INT, polcmd, polpermissive, polroles::string, polqual, polwithcheck from pg_catalog.pg_policy WHERE polrelid = 'multi_pol_tab2'::regclass
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -5405,7 +5404,7 @@ statement ok
 CREATE ROLE can_bypassrls_global;
 
 statement ok
-GRANT SYSTEM BYPASSRLS TO can_bypassrls_global; 
+GRANT SYSTEM BYPASSRLS TO can_bypassrls_global;
 
 query B
 SELECT rolbypassrls FROM pg_authid WHERE rolname = 'can_bypassrls' OR rolname = 'can_bypassrls_global';
@@ -5449,7 +5448,7 @@ statement ok
 CREATE ROLE can_createrole_global;
 
 statement ok
-GRANT SYSTEM CREATEROLE TO can_createrole_global; 
+GRANT SYSTEM CREATEROLE TO can_createrole_global;
 
 query B
 SELECT rolcreaterole FROM pg_authid WHERE rolname = 'can_createrole' OR rolname = 'can_createrole_global';
@@ -5480,7 +5479,7 @@ statement ok
 DROP ROLE cannot_createrole;
 
 statement ok
-REVOKE SYSTEM CREATEROLE FROM can_createrole_global; 
+REVOKE SYSTEM CREATEROLE FROM can_createrole_global;
 
 statement ok
 DROP ROLE can_createrole_global;
@@ -5497,7 +5496,7 @@ statement ok
 CREATE ROLE can_createdb_global;
 
 statement ok
-GRANT SYSTEM CREATEDB TO can_createdb_global; 
+GRANT SYSTEM CREATEDB TO can_createdb_global;
 
 query B
 SELECT rolcreatedb FROM pg_authid WHERE rolname = 'can_createdb' OR rolname = 'can_createdb_global';
@@ -5528,7 +5527,7 @@ statement ok
 DROP ROLE cannot_createdb;
 
 statement ok
-REVOKE SYSTEM CREATEDB FROM can_createdb_global; 
+REVOKE SYSTEM CREATEDB FROM can_createdb_global;
 
 statement ok
 DROP ROLE can_createdb_global;

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -195,7 +195,6 @@ query T
 EXPLAIN SELECT a FROM abc WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -233,7 +232,6 @@ query T
 EXPLAIN SELECT a FROM abc WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • filter
@@ -251,7 +249,6 @@ query T
 EXPLAIN SELECT a, x FROM abc JOIN xy ON y = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: xy@xy_y_idx
@@ -293,7 +290,6 @@ query T
 EXPLAIN SELECT a, x FROM abc JOIN xy ON y = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • hash join
@@ -343,7 +339,6 @@ query T
 EXPLAIN SELECT a FROM abc@abc_pkey WHERE b = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • scan
@@ -386,7 +381,6 @@ query T
 EXPLAIN SELECT a + 1 FROM abc WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • render
@@ -431,7 +425,6 @@ query T
 EXPLAIN SELECT c FROM xy JOIN abc ON c = y WHERE x = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • hash join
@@ -774,7 +767,6 @@ query T
 EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: xy@xy_pkey
@@ -800,7 +792,6 @@ query T
 EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • hash join
@@ -832,7 +823,6 @@ query T
 EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • lookup join
@@ -884,7 +874,6 @@ query T
 EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • lookup join
@@ -926,7 +915,6 @@ query T
 EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • merge join

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -1,6 +1,20 @@
 # LogicTest: !local-prepared
 # cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
 
+# Speed up the rangefeed.
+user host-cluster-root
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '50ms';
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms';
+
+statement ok
+SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '50ms';
+
+user root
+
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT, INDEX (y));
 

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -166,7 +166,6 @@ query T
 EXPLAIN TRUNCATE TABLE tt
 ----
 distribution: local
-vectorized: true
 ·
 • truncate
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -110,7 +110,6 @@ query T
 EXPLAIN CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 ----
 distribution: local
-vectorized: true
 ·
 • create function
 

--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -180,7 +180,7 @@ func TestStreamerTightBudget(t *testing.T) {
 	sqlDB.Exec(t, fmt.Sprintf("SET distsql_workmem = '%dB'", blobSize))
 
 	// Perform an index join to read the blobs.
-	query := "EXPLAIN ANALYZE SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"
+	query := "EXPLAIN ANALYZE (VERBOSE) SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"
 	maximumMemoryUsageRegex := regexp.MustCompile(`maximum memory usage: (\d+\.\d+) MiB`)
 	rows := sqlDB.QueryStr(t, query)
 	// Build pretty output for an error message in case we need it.

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -505,7 +505,6 @@ query T
 EXPLAIN SELECT min(a), max(a) FROM abc
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -748,7 +747,6 @@ query T
 EXPLAIN SELECT min(x), max(z) FROM xyz
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -786,7 +784,6 @@ query T
 EXPLAIN SELECT min(x), max(z), sum(x) FROM xyz
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -801,7 +798,6 @@ query T
 EXPLAIN SELECT min(y), max(y) FROM xyz WHERE x in (0, 4, 7)
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -814,7 +810,6 @@ query T
 EXPLAIN SELECT min(x), max(x) FROM xyz WHERE x = 1
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -829,7 +824,6 @@ query T
 EXPLAIN SELECT min(z), max(y) FROM xyz WHERE z in (3.0, 6.0, 8.0)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -886,7 +880,6 @@ query T
 EXPLAIN SELECT min(z), max(y), count(x) FROM xyz WHERE z in (3.0, 6.0, 8.0)
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -900,7 +893,6 @@ query T
 EXPLAIN SELECT max(z), min(x) FROM (SELECT x,y,z FROM xyz a) dt WHERE dt.y > 0
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -948,7 +940,6 @@ query T
 EXPLAIN SELECT max(z), min(x) FROM xyz WHERE (z,x) = (SELECT max(z), min(x) FROM xyz)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2136,7 +2127,6 @@ query T
 EXPLAIN SELECT a, sum_int(c) AS s FROM t124101 GROUP BY a, c ORDER BY a, a, s, c LIMIT 2;
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -9,7 +9,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x = ARRAY[1,4,6]
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -20,7 +19,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -31,7 +29,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -42,7 +39,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -53,7 +49,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -72,7 +67,6 @@ query T
 EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -10,7 +10,6 @@ query T
 EXPLAIN CALL foo(0);
 ----
 distribution: local
-vectorized: true
 ·
 • call
   estimated row count: 0
@@ -122,7 +121,6 @@ query T
 EXPLAIN (DISTSQL) CALL foo(3);
 ----
 distribution: local
-vectorized: true
 ·
 • call
   estimated row count: 0
@@ -136,20 +134,14 @@ EXPLAIN ANALYZE CALL foo(3);
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • call
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   execution time: 0µs
+  actual row count: 0
   estimated row count: 0
   procedure: foo(3)
 
@@ -159,20 +151,14 @@ EXPLAIN ANALYZE (DISTSQL) CALL foo(3);
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • call
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   execution time: 0µs
+  actual row count: 0
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/call_plpgsql
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call_plpgsql
@@ -11,7 +11,6 @@ query T
 EXPLAIN CALL foo(0);
 ----
 distribution: local
-vectorized: true
 ·
 • call
   estimated row count: 0
@@ -128,7 +127,6 @@ query T
 EXPLAIN (DISTSQL) CALL foo(3);
 ----
 distribution: local
-vectorized: true
 ·
 • call
   estimated row count: 0
@@ -142,20 +140,14 @@ EXPLAIN ANALYZE CALL foo(3);
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • call
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   execution time: 0µs
+  actual row count: 0
   estimated row count: 0
   procedure: foo(3)
 
@@ -165,20 +157,14 @@ EXPLAIN ANALYZE (DISTSQL) CALL foo(3);
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • call
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   execution time: 0µs
+  actual row count: 0
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -848,7 +848,6 @@ query T
 EXPLAIN DELETE FROM delrng1 WHERE p = 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -906,7 +905,6 @@ query T
 EXPLAIN DELETE FROM self WHERE a = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -991,7 +989,6 @@ query T
 EXPLAIN DELETE FROM loop_a WHERE id = 'loop_a-pk1';
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1068,43 +1065,33 @@ EXPLAIN ANALYZE DELETE FROM loop_a WHERE id = 'loop_a-pk1';
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 9 (72 B, 18 KVs, 9 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • delete
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
 │   │ execution time: 0µs
+│   │ actual row count: 1
 │   │ from: loop_a
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 1
 │       │ execution time: 0µs
+│       │ actual row count: 1
 │       │ label: buffer 1
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
 │             kv nodes: <hidden>
 │             regions: <hidden>
-│             actual row count: 1
 │             KV time: 0µs
 │             KV rows decoded: 1
-│             KV pairs read: 2
-│             KV bytes read: 8 B
-│             KV gRPC calls: 1
-│             estimated max memory allocated: 0 B
+│             actual row count: 1
 │             missing stats
 │             table: loop_a@loop_a_pkey
 │             spans: [/'loop_a-pk1' - /'loop_a-pk1']
@@ -1118,36 +1105,31 @@ quality of service: regular
         ├── • delete
         │   │ sql nodes: <hidden>
         │   │ regions: <hidden>
-        │   │ actual row count: 1
         │   │ execution time: 0µs
+        │   │ actual row count: 1
         │   │ from: loop_b
         │   │
         │   └── • buffer
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
-        │       │ actual row count: 1
         │       │ execution time: 0µs
+        │       │ actual row count: 1
         │       │ label: buffer 1
         │       │
         │       └── • hash join (semi)
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
-        │           │ actual row count: 1
         │           │ execution time: 0µs
-        │           │ estimated max memory allocated: 0 B
+        │           │ actual row count: 1
         │           │ equality: (cascade_delete) = (id)
         │           │
         │           ├── • scan
         │           │     sql nodes: <hidden>
         │           │     kv nodes: <hidden>
         │           │     regions: <hidden>
-        │           │     actual row count: 3
         │           │     KV time: 0µs
         │           │     KV rows decoded: 3
-        │           │     KV pairs read: 6
-        │           │     KV bytes read: 24 B
-        │           │     KV gRPC calls: 3
-        │           │     estimated max memory allocated: 0 B
+        │           │     actual row count: 3
         │           │     missing stats
         │           │     table: loop_b@loop_b_pkey
         │           │     spans: FULL SCAN
@@ -1155,8 +1137,8 @@ quality of service: regular
         │           └── • scan buffer
         │                 sql nodes: <hidden>
         │                 regions: <hidden>
-        │                 actual row count: 1
         │                 execution time: 0µs
+        │                 actual row count: 1
         │                 estimated row count: 1
         │                 label: buffer 1000000
         │
@@ -1168,46 +1150,41 @@ quality of service: regular
                 ├── • delete
                 │   │ sql nodes: <hidden>
                 │   │ regions: <hidden>
-                │   │ actual row count: 1
                 │   │ execution time: 0µs
+                │   │ actual row count: 1
                 │   │ from: loop_a
                 │   │
                 │   └── • buffer
                 │       │ sql nodes: <hidden>
                 │       │ regions: <hidden>
-                │       │ actual row count: 1
                 │       │ execution time: 0µs
+                │       │ actual row count: 1
                 │       │ label: buffer 1
                 │       │
                 │       └── • lookup join
                 │           │ sql nodes: <hidden>
                 │           │ kv nodes: <hidden>
                 │           │ regions: <hidden>
-                │           │ actual row count: 1
                 │           │ KV time: 0µs
                 │           │ KV rows decoded: 1
-                │           │ KV pairs read: 2
-                │           │ KV bytes read: 8 B
-                │           │ KV gRPC calls: 1
                 │           │ execution time: 0µs
-                │           │ estimated max memory allocated: 0 B
+                │           │ actual row count: 1
                 │           │ table: loop_a@loop_a_cascade_delete_idx
                 │           │ equality: (id) = (cascade_delete)
                 │           │
                 │           └── • distinct
                 │               │ sql nodes: <hidden>
                 │               │ regions: <hidden>
-                │               │ actual row count: 1
                 │               │ execution time: 0µs
-                │               │ estimated max memory allocated: 0 B
+                │               │ actual row count: 1
                 │               │ estimated row count: 1
                 │               │ distinct on: id
                 │               │
                 │               └── • scan buffer
                 │                     sql nodes: <hidden>
                 │                     regions: <hidden>
-                │                     actual row count: 1
                 │                     execution time: 0µs
+                │                     actual row count: 1
                 │                     estimated row count: 1
                 │                     label: buffer 1000000
                 │
@@ -1250,7 +1227,6 @@ query T
 EXPLAIN DELETE FROM t3 WHERE id3 = 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1433,7 +1409,6 @@ query T
 EXPLAIN DELETE FROM p138974 WHERE v = 1;
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1481,48 +1456,39 @@ EXPLAIN ANALYZE DELETE FROM p138974 WHERE v = 1;
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • delete
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 0
 │   │ execution time: 0µs
+│   │ actual row count: 0
 │   │ from: p138974
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │ label: buffer 1
 │       │
 │       └── • filter
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 0
 │           │ execution time: 0µs
+│           │ actual row count: 0
 │           │ filter: v = 1
 │           │
 │           └── • scan
 │                 sql nodes: <hidden>
 │                 kv nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 0
 │                 KV time: 0µs
 │                 KV rows decoded: 0
-│                 KV bytes read: 0 B
-│                 KV gRPC calls: 0
-│                 estimated max memory allocated: 0 B
+│                 actual row count: 0
 │                 missing stats
 │                 table: p138974@p138974_pkey
 │                 spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -61,7 +61,6 @@ query T
 EXPLAIN DELETE FROM unindexed
 ----
 distribution: local
-vectorized: true
 ·
 • delete range
   from: unindexed
@@ -71,7 +70,6 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: unindexed
@@ -93,7 +91,6 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: unindexed
@@ -115,7 +112,6 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE k > 0
 ----
 distribution: local
-vectorized: true
 ·
 • delete range
   from: unindexed
@@ -130,7 +126,6 @@ query T
 EXPLAIN DELETE FROM unindexed WHERE k > 0 LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: unindexed
@@ -147,7 +142,6 @@ query T
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: indexed
@@ -164,7 +158,6 @@ query T
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: indexed
@@ -182,7 +175,6 @@ query T
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: indexed
@@ -483,20 +475,14 @@ EXPLAIN ANALYZE EXECUTE p(1)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • delete
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ execution time: 0µs
+│ actual row count: 0
 │ from: t137352
 │ auto commit
 │
@@ -504,12 +490,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 0
       KV time: 0µs
       KV rows decoded: 0
-      KV bytes read: 0 B
-      KV gRPC calls: 0
-      estimated max memory allocated: 0 B
+      actual row count: 0
       missing stats
       table: t137352@t137352_pkey
       spans: [/1 - /1]
@@ -538,33 +521,24 @@ EXPLAIN ANALYZE EXECUTE p(10)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • delete
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ execution time: 0µs
+│ actual row count: 0
 │ from: t137352
 │ auto commit
 │
 └── • lookup join
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 0
     │ KV time: 0µs
     │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
+    │ actual row count: 0
     │ table: t137352@t137352_pkey
     │ equality: (k) = (k)
     │ equality cols are key
@@ -574,13 +548,10 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ KV time: 0µs
         │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 0
         │ table: t137352@t137352_a_idx
         │ equality: ($1) = (a)
         │ locking strength: for update
@@ -588,8 +559,8 @@ quality of service: regular
         └── • values
               sql nodes: <hidden>
               regions: <hidden>
-              actual row count: 1
               execution time: 0µs
+              actual row count: 1
               size: 1 column, 1 row
 
 statement ok
@@ -625,7 +596,6 @@ query T
 EXPLAIN DELETE FROM t139160 WHERE k = 1
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t139160
@@ -653,7 +623,6 @@ query T
 EXPLAIN DELETE FROM t139160 WHERE i = 2
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t139160
@@ -681,7 +650,6 @@ query T
 EXPLAIN DELETE FROM t139160 WHERE i = 2 RETURNING v
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t139160
@@ -714,7 +682,6 @@ query T
 EXPLAIN DELETE FROM t139160 WHERE u = 3
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t139160
@@ -742,7 +709,6 @@ query T
 EXPLAIN DELETE FROM t139160 WHERE u = 3 RETURNING v
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t139160
@@ -775,7 +741,6 @@ query T
 EXPLAIN DELETE FROM t139160 WHERE v = 4
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t139160
@@ -804,7 +769,6 @@ query T
 EXPLAIN DELETE FROM t139105 WHERE k = 1
 ----
 distribution: local
-vectorized: true
 ·
 • delete range
   from: t139105
@@ -1005,7 +969,6 @@ DELETE FROM entity_address WHERE id IN (
 );
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/disable_optimizer_rules
+++ b/pkg/sql/opt/exec/execbuilder/testdata/disable_optimizer_rules
@@ -11,7 +11,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE b = 1
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: t@t_pkey
@@ -30,7 +29,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE b = 1
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: t@t_pkey
@@ -49,7 +47,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE b = 1
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 1
@@ -73,7 +70,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE b = 1
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 1
@@ -100,7 +96,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE b = 1
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 1
@@ -119,7 +114,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE b = 1
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: t@t_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -10,7 +10,6 @@ query T
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 distribution: local
-vectorized: true
 ·
 • union
 │
@@ -28,7 +27,6 @@ query T
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
 distribution: local
-vectorized: true
 ·
 • union all
 │
@@ -47,7 +45,6 @@ query T
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
 distribution: local
-vectorized: true
 ·
 • union
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -57,33 +57,24 @@ EXPLAIN ANALYZE (DISTSQL) SELECT count(*) FROM kv
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • group (scalar)
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
 │ execution time: 0µs
+│ actual row count: 1
 │
 └── • scan
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 5
       KV time: 0µs
       KV rows decoded: 5
-      KV pairs read: 10
-      KV bytes read: 40 B
-      KV gRPC calls: 5
-      estimated max memory allocated: 0 B
+      actual row count: 5
       missing stats
       table: kv@kv_pkey
       spans: FULL SCAN
@@ -99,23 +90,16 @@ EXPLAIN ANALYZE (DISTSQL) SELECT * FROM kv JOIN kw ON kv.k = kw.k
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • merge join
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
-│ estimated max sql temp disk usage: 0 B
+│ actual row count: 5
 │ equality: (k) = (k)
 │ left cols are key
 │ right cols are key
@@ -124,13 +108,9 @@ quality of service: regular
 │     sql nodes: <hidden>
 │     kv nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 5
 │     KV time: 0µs
 │     KV rows decoded: 5
-│     KV pairs read: 10
-│     KV bytes read: 40 B
-│     KV gRPC calls: 5
-│     estimated max memory allocated: 0 B
+│     actual row count: 5
 │     missing stats
 │     table: kv@kv_pkey
 │     spans: FULL SCAN
@@ -139,13 +119,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 5
       KV time: 0µs
       KV rows decoded: 5
-      KV pairs read: 10
-      KV bytes read: 40 B
-      KV gRPC calls: 5
-      estimated max memory allocated: 0 B
+      actual row count: 5
       missing stats
       table: kw@kw_pkey
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -12,7 +12,6 @@ query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: y, z
@@ -27,7 +26,6 @@ query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: y, z
@@ -42,7 +40,6 @@ query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -60,7 +57,6 @@ query T
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +y,+z
@@ -78,7 +74,6 @@ query T
 EXPLAIN SELECT DISTINCT y + z AS r FROM xyz ORDER BY y + z
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: r
@@ -98,7 +93,6 @@ query T
 EXPLAIN SELECT DISTINCT y AS w, z FROM xyz ORDER BY z
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: y, z
@@ -113,7 +107,6 @@ query T
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +y

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_agg
@@ -69,7 +69,6 @@ EXPLAIN (DISTSQL) SELECT
 FROM data GROUP BY b
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: b
@@ -99,7 +98,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -114,7 +112,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum((a-1)*1000 + (b-1)*100 + (c::INT-1)*10 + (d-1)) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -131,7 +128,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), count(a), max(a) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -146,7 +142,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a+b), count(a+b), max(a+b) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -163,7 +158,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum((a-1)*1000) + sum((b-1)*100) + sum((c::INT-1)*10) + sum(d-1) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -182,7 +176,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), min(b), max(c), count(d) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -199,7 +192,6 @@ query T
 EXPLAIN (DISTSQL) SELECT avg(a+b+c::INT+d) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -218,7 +210,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), round(stddev(b), 1) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -235,7 +226,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), round(variance(b), 1) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -252,7 +242,6 @@ query T
 EXPLAIN (DISTSQL) SELECT stddev(a+b+c::INT+d) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -269,7 +258,6 @@ query T
 EXPLAIN (DISTSQL) SELECT variance(a+b+c::INT+d) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -288,7 +276,6 @@ query T
 EXPLAIN (DISTSQL) SELECT covar_pop(a, c), regr_sxx(a, c), regr_sxy(a, c), regr_syy(a, c), regr_avgx(a, c), regr_avgy(a, c), regr_intercept(a, c), regr_r2(a, c), regr_slope(a, c), regr_count(a, c), covar_samp(a, c), corr(a, c), sqrdiff(a) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -306,7 +293,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), avg(b), sum(c), avg(d), stddev(a), stddev_samp(a), stddev_pop(a), variance(b), var_samp(b), var_pop(b), sum(a+b+c::INT+d), covar_pop(a, c), regr_sxx(a, c), regr_sxy(a, c), regr_syy(a, c), regr_avgx(a, c), regr_avgy(a, c), regr_intercept(a, c), regr_r2(a, c), regr_slope(a, c), regr_count(a, c), covar_samp(a, c), corr(a, c), sqrdiff(a)  FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -324,7 +310,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), min(b), max(c), count(d), avg(a+b+c::INT+d), stddev(a+b), variance(c::INT+d), covar_pop(b, d), regr_sxx(a, c), regr_sxy(a, c), regr_syy(a, c), regr_avgx(a, c), regr_avgy(b, c), regr_intercept(a, b), regr_r2(b, c), regr_slope(a, c), sqrdiff(a), regr_count(a, b), covar_samp(b, c), corr(a, c) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -343,7 +328,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), stddev(a), avg(a) FILTER (WHERE a > 5), count(b), avg(b), variance(b) FILTER (WHERE b < 8), sum(b) FILTER (WHERE b < 8), stddev(b) FILTER (WHERE b > 2) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -360,7 +344,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), avg(DISTINCT a), variance(a) FILTER (WHERE a > 0) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -377,7 +360,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), avg(a), count(a), stddev(a), variance(a) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -392,7 +374,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), avg(b), sum(a), sum(a), avg(b) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -407,7 +388,6 @@ query T
 EXPLAIN (DISTSQL) SELECT avg(c), sum(c), avg(d), sum(d) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -422,7 +402,6 @@ query T
 EXPLAIN (DISTSQL) SELECT max(a), min(b) FROM data HAVING min(b) > 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -463,7 +442,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT (a) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: a
@@ -480,7 +458,6 @@ query T
 EXPLAIN (DISTSQL) SELECT SUM (DISTINCT A) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -499,7 +476,6 @@ query T
 EXPLAIN (DISTSQL) SELECT SUM (DISTINCT A), SUM (DISTINCT B) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -514,7 +490,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT a, b FROM data WHERE (a + b + c::INT) = 27 ORDER BY a,b
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: a, b
@@ -534,7 +509,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT a, b FROM data WHERE (a + b + c::INT) = 27 ORDER BY b,a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +b,+a
@@ -557,7 +531,6 @@ query T
 EXPLAIN (DISTSQL) SELECT c, d, sum(a+c::INT) + avg(b+d) FROM data GROUP BY c, d
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -577,7 +550,6 @@ query T
 EXPLAIN (DISTSQL) SELECT c, d, sum(a+c::INT) + avg(b+d) FROM data GROUP BY c, d ORDER BY c, d
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -602,7 +574,6 @@ query T
 EXPLAIN (DISTSQL) SELECT c, d, sum(a+c::INT) + avg(b+d) FROM data WHERE a > 9 GROUP BY c, d
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -622,7 +593,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a), sum(b), sum(c) FROM data GROUP BY d HAVING sum(a+b) > 10
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ filter: sum > 10
@@ -643,7 +613,6 @@ query T
 EXPLAIN (DISTSQL) SELECT avg(a+b), c FROM data GROUP BY c, d HAVING c = d
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: d
@@ -664,7 +633,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum(a+b) FILTER (WHERE a = c) FROM data GROUP BY d
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: d
@@ -683,7 +651,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(a+b), sum(a+b) FILTER (WHERE a < d), sum(a+b) FILTER (WHERE a = c) FROM data WHERE a = 1 GROUP BY d
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: d
@@ -702,7 +669,6 @@ query T
 EXPLAIN (DISTSQL) SELECT xor_agg(to_hex(a)::bytes) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -720,7 +686,6 @@ query T
 EXPLAIN (DISTSQL) SELECT xor_agg(a) FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -735,7 +700,6 @@ query T
 EXPLAIN (DISTSQL) SELECT max(t.a), min(t.b), avg(t.c)  FROM (VALUES (1, 2, 3), (4, 5, 6), (7, 8, 0)) AS t(a, b, c) WHERE b > 3
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │ estimated row count: 1
@@ -753,7 +717,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, '222'), (2, '444')) t1(a,b) JOIN (VALUES (1, 100.0), (3, 32.0)) t2(a,b) ON t1.a = t2.a
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ estimated row count: 2
@@ -774,7 +737,6 @@ query T
 EXPLAIN (DISTSQL) SELECT array_agg(a) FROM (SELECT a FROM data WHERE b = 1 AND c = 1.0 AND d = 1.0 ORDER BY a)
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -792,7 +754,6 @@ query T
 EXPLAIN (DISTSQL) SELECT json_agg(a) FROM (SELECT a FROM data WHERE b = 1 AND c = 1.0 AND d = 1.0 ORDER BY a)
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -840,7 +801,6 @@ query T
 EXPLAIN (DISTSQL) SELECT a, max(b) FROM sorted_data GROUP BY a
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: a
@@ -856,7 +816,6 @@ query T
 EXPLAIN (DISTSQL) SELECT a, max(b) FROM sorted_data GROUP BY a ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: a
@@ -873,7 +832,6 @@ query T
 EXPLAIN (DISTSQL) SELECT c, min(b), a FROM sorted_data GROUP BY a, c
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: a
@@ -890,7 +848,6 @@ query T
 EXPLAIN (DISTSQL) SELECT c, min(b), a FROM sorted_data GROUP BY a, c ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: a
@@ -907,7 +864,6 @@ query T
 EXPLAIN (DISTSQL) SELECT b, max(c) FROM sorted_data@foo GROUP BY b
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: b
@@ -927,7 +883,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM (SELECT a, max(c) FROM sorted_data GROUP BY a) JOIN (SELECT b, min(c) FROM sorted_data@foo GROUP BY b) ON a = b
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (a) = (b)
@@ -962,7 +917,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(x) FROM (SELECT a, b::float + c AS x FROM data) GROUP BY a ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: a
@@ -981,7 +935,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(x) FROM (SELECT a, b::float + c AS x FROM data) WHERE a > x GROUP BY a ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: a
@@ -1081,7 +1034,6 @@ query T
 EXPLAIN (DISTSQL) SELECT b, count(*) FROM data2 WHERE a=1 GROUP BY b;
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: b
@@ -1103,7 +1055,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(v) FROM data INNER LOOKUP JOIN uv ON (a=u) GROUP BY u ORDER BY u
 ----
 distribution: full
-vectorized: true
 ·
 • group (streaming)
 │ group by: u
@@ -1126,7 +1077,6 @@ query T
 EXPLAIN (DISTSQL) SELECT array_agg((a, a)) FROM data
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -88,7 +88,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: x, y, z
@@ -127,7 +126,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -172,7 +170,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: y
@@ -205,7 +202,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats
@@ -242,7 +238,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: a, b

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_group_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_group_join
@@ -39,7 +39,6 @@ query T
 EXPLAIN (DISTSQL) SELECT data1.a, sum(data1.d) FROM data AS data1 INNER HASH JOIN data AS data2 ON data1.a = data2.c GROUP BY data1.a
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: a
@@ -67,7 +66,6 @@ query T
 EXPLAIN (DISTSQL) SELECT data1.a, sum(data1.d) FROM data AS data1 INNER HASH JOIN data AS data2 ON data1.a = data2.c GROUP BY data1.a
 ----
 distribution: full
-vectorized: true
 ·
 • group (hash)
 │ group by: a

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -27,7 +27,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 10 AND v < 50
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (v > 10) AND (v < 50)
@@ -43,7 +42,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 10 AND v < 50 ORDER BY v
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +v
@@ -63,7 +61,6 @@ query T
 EXPLAIN (DISTSQL) SELECT w FROM t WHERE v > 10 AND v < 50 ORDER BY v
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +v
@@ -83,7 +80,6 @@ query T
 EXPLAIN (DISTSQL) SELECT w FROM t WHERE v > 40 AND v < 50 ORDER BY v
 ----
 distribution: full
-vectorized: true
 ·
 • index join
 │ table: t@t_pkey
@@ -107,7 +103,6 @@ query T
 EXPLAIN SELECT * FROM abc WHERE b between 1 AND 3 ORDER BY c, b LIMIT 2;
 ----
 distribution: full
-vectorized: true
 ·
 • top-k
 │ order: +c,+b
@@ -129,7 +124,6 @@ query T
 EXPLAIN SELECT * FROM abc WHERE b between 1 AND 3 ORDER BY c, b LIMIT 2;
 ----
 distribution: full
-vectorized: true
 ·
 • limit
 │ count: 2

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_inverted_index
@@ -88,7 +88,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1, 2]' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ estimated row count: 1
@@ -108,7 +107,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1]' AND b @> '[2]' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ estimated row count: 1
@@ -128,7 +126,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[[1, 2]]' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ estimated row count: 1
@@ -194,7 +191,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM array_tab@foo_inv WHERE b @> '{1, 2}' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -85,12 +85,12 @@ vectorized: true
 #            └── scan  ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
 # ·                    table           data@primary       ·                               ·
 # ·                    spans           ALL                ·                               ·
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY c,d)
 # ----
 # https://cockroachdb.github.io/distsqlplan/decode.html#eJzElk9v2kwQxu_vp4jm9FbZCu_a_LNUiWsqNanS3ioODt6CJcKitZEaRXz3ChyEbMM-ni6yjwR-3tmZ3-TxO21Mqh-TV51T_IskCVIkKCRBEQka0lzQ1pqFznNjDz8pgYf0D8WBoGyz3RWHP88FLYzVFL9TkRVrTTH9TF7W-lknqbaDgASlukiy9fGYrc1eE_s2S5MiIUFPuyK-m0kxUzTfCzK74uOp54e9vN2tknxVfcwJmQvKi2SpKZZ78W8FDlsUGIpZVCvwfLLinPzD2ELbgQzq97kXM3Xv24TwainnRxmbaqvTq-e3_uWF233Tdqm_mmxzuGKtsWv9u_j_g_70xWbL1fljxQThbnfkf8cLlT-az2Y7UNWxXCthWClBtndN9rIMjAJHt10GcPJpGWQHyyD7XYZRF8ug2g9a9WIio8DxbU0EJ59MVB2YqPo1cdyFiWH7QYe9mMgocHJbE8HJJxPDDkwM-zVx0oWJUftBR72YyChwelsTwcknE6MOTIz6NXHa9avqhYKedb41m1y3egMNDlfS6VKXDcvNzi70d2sWx2PKj09H7vjmk-q8KL8Nyw8Pm_KrQ4Ht4YkPLJUXPfKhVeCmZZ0OKnQFDuqwYjRc8eCJD1xrOJce-dC1hjfo0NnwyD2tyD0t6R7X0Gc_3DDYDzeM9gPQYD_cNNqPkbPjY3fDxz774YbBfrhhtB-ABvvhptF-THz2Y-pjuBsGhrthZDiggeFuGiZAI0AqHZfgn4psJAhHckADywGNNEc48BzgSHTZyBGO6bKRIxzVAQ1cBzSSHeHAdoBD3d0ZKodAd06INmfOSVEuDXVn5SgXh7q7kxTpzolSLo10Z4UpG0e6s-K0ibvzVE6B7pxEbc6cE6lcGurOClUujnRX7lSt6z7f__c3AAD__68_ThQ=
-# 
+#
 # # ORDER BY on the columns equal to the mergeJoinOrder columns should not
 # # require a terminal SORT node.
 # query TTTTT
@@ -114,7 +114,7 @@ vectorized: true
 #            └── scan  ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
 # ·                    table           data@primary       ·                               ·
 # ·                    spans           ALL                ·                               ·
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY a,b)
 # ----
@@ -153,7 +153,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +b,+a
@@ -176,17 +175,17 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8l99v4kYQx9_7V
 # TODO(radu): rework these tests (the inner ORDER BY aren't useful anymore).
 #
 # # Merge joins should be planned for (FULL|LEFT|RIGHT) OUTER joins
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) FULL OUTER JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c and b=d ORDER BY a,b)
 # ----
 # https://cockroachdb.github.io/distsqlplan/decode.html#eJzEl0Fv2kAQhe_9FWhOrbJVvGNDwFIlLq2UKA1VmpwqDg7eEiTCorWRGkX57xUQhAxh3zqD8NHBb994Zj6_-IVmNjc32ZMpKP1DmhQxKYpJUUKK2jRUNHd2ZIrCuuUta8Fl_o_SSNFkNl-Uyz8PFY2sM5S-UDkpp4ZSussepubWZLlx5xEpyk2ZTaYrm7mbPGXuuZ9nZUaKBosybfW16jMNXxXZRfl26vawh-fWY1Y8Vo_ZSIaKijIbG0r1q_pYge2AAmPVT3YK3DpzHeff1pXGneto93nOVJ_PpE2ID5ayPcq63DiTH_QPvvOdp_tp3Nhc2cls-Yg7jb17npu09eP--ro1uL_7ftu6GlzekKKp-Vt-fjv1yzc3GT9uLysbovxjSD4wBg4aw9ajLe_vO8Xc2K92fs7Vfh0qoVMpQYfvuW4ExBoFdo4LInDegKhPAKJuFsROkyCGjYGDxnAIRA5fMm6EghoFXhyXAuC8oYBPQAE3S8FFkxSEjYGDxnCIgjh8yeJGKKhRYPe4FADnDQXxCSiIm6Wg2yQFYWPgoDEcoiAJX7KkEQpqFNg7LgXAeUNBcgIKkmYp6DVJQdgYOGgMIZ8m73jcmmJuZ4UJ-uKIlu00-dish1XYhRuZX86OVjbry8FKt_pvLzdFuf41Xl9cztY_LQsMF_ckYp2I1CJvBt56Vx1V1BVxtCvmGg3neuKeRLzT8LpqkTcD79jb8MTf8MQrbvtH3faPuuO37kjg8ovBgvvFCC6gFnkjuC68He_6G96VwOUXgwX3ixFcQC3yRnD1vA3Xkb_jeu9VWgcvvfcqrUMIUIM1BWrECJLL3GEE7b1Qq1OLwdT23qh1QAFqsK1AjVBBcpk7gkX700S3Qd_9eYJoEeUJUKN9lSUKksvcIS3-UNEgVbQoVoAa7assWJBc5g5p8WcLg2xhUbawKFuAGuwrUCNakFzmjmhhf7YwyBYWZQtQo88MWbYgucwd0cL-bGGQLVwvW4avn_4HAAD__9-kdhE=
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) LEFT OUTER JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c and b=d ORDER BY a,b)
 # ----
 # https://cockroachdb.github.io/distsqlplan/decode.html#eJzEl0Fv2k4Qxe__T4Hm9K-yVbxjQ8BSJS6plKgNVUpPFQcHbwkSYdHaSI2ifPcKCEKGsG-dQfjo4LdvPDM_v_iF5jY3d9mTKSj9TZoUMSmKSVFCito0UrRwdmyKwrrVLRvBTf6X0kjRdL5Ylqs_jxSNrTOUvlA5LWeGUhpmDzNzb7LcuMuIFOWmzKaztc3CTZ8y99zPszIjRYNlmbb6WvWZRq-K7LJ8O3V32MNz6zErHqvHbCUjRUWZTQyl-lV9rMB2QIGx6id7Be6cuY7zT-tK4y51tP88F6rPF9ImxEdL2R1lXW6cyY_6B9_5ztN9N25ibu10vnrEvcYOnxcmbX27_jpsDX4Nr-9bt4ObO1I0M3_K_99O_fTFTSePu8vKhij_GJIPjIGDxrDzaMv7-04xd_azXVxytV_HSuhUStDhe64bAbFGgZ3TggictyDqM4ComwWx0ySIYWPgoDEcA5HDl4wboaBGgVenpQA4byngM1DAzVJw1SQFYWPgoDEcoyAOX7K4EQpqFNg9LQXAeUtBfAYK4mYp6DZJQdgYOGgMxyhIwpcsaYSCGgX2TksBcN5SkJyBgqRZCnpNUhA2Bg4aQ8inyTse96ZY2Hlhgr44olU7TT4xm2EVdunG5oez47XN5nKw1q3_28tNUW5-jTcXN_PNT6sCw8U9iVgnIrXIm4G33ldHFXVFHO2LuUbDuZ64JxHvNbyuWuTNwDv2NjzxNzzxitv-Ubf9o-74rTsSuPxisOB-MYILqEXeCK4rb8e7_oZ3JXD5xWDB_WIEF1CLvBFcPW_DdeTvuD54ldbBSx-8SusQAtRgTYEaMYLkMncYQQcv1OrUYjC1gzdqHVCAGmwrUCNUkFzmjmDR_jTRbdB3f54gWkR5AtRoX2WJguQyd0iLP1Q0SBUtihWgRvsqCxYkl7lDWvzZwiBbWJQtLMoWoAb7CtSIFiSXuSNa2J8tDLKFRdkC1OgzQ5YtSC5zR7SwP1sYZAvXy5bR63__AgAA__86O3Xp
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) RIGHT OUTER JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c and b=d ORDER BY a,b)
 # ----
@@ -225,16 +224,16 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8l99v4kYQx9_7V
 #                      └── scan  ·               ·                                    (a[omitted], b[omitted], c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
 # ·                              table           data@primary                         ·                                                                               ·
 # ·                              spans           ALL                                  ·                                                                               ·
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d)))
 # ----
 # https://cockroachdb.github.io/distsqlplan/decode.html#eJzMmE1v2kwQx-_Pp4jm9FTZKt61eZUq-ZpKTaq0t4qDg7cEiWBkG6lRxHevgFBiL5m_xxY2R15-zOxk9-d_9pWWSWzvomeb0fgXaVJkSJFPigJS1KOJolWaTG2WJen2K3vgNv5DY0_RfLla59u3J4qmSWpp_Er5PF9YGtPP6HFhH2wU2_TGI0WxzaP5Yldmlc6fo_QljKM8oslGUbLO337oyD--XD1F2VORDLUKjQp9FQY02UwUZXk0szTWG1Wvsx7TmaL7dT6-2tWs0WahQVO3Qc3N7tDh2zzed3gs7UtK_0jSfFu1V17QtQrNddMpBB-2cvypJI1tauMP61f-5onVfbPpzH5N5kub3pjSYBf2d_7_G_3pSzqfPR1fFraCOjXumvu213AgKvSvVRgIBvOOQAPqfTygw6-UBvXvbe7sHFffr7D69fLUak42f5d8TlY3vlf65unag0JtLTiQ7bpM0Fm_E5dJRsfNrobLQOmDy_otuEx36zJ9cS6TD-SsLuu36zJT_VCYdn0i6GzQiU8EDWpudjV8AkoffDJowSemW5-Yi_OJfCBn9cmgXZ_41Q-F365PBJ0NO_GJoEHNza6GT0Dpg0-GLfjE79Yn_sX5RD6Qs_pk2K5PguqHImjXJ4LORp34RNCg5mZXwyeg9MEnoxZ8EnTrk-DifCIfyFl9Muru7uZEaw82WyXLzFa6mfG2i7PxzO5HmSXrdGq_p8l0V2b_8n7H7f7LjG2W7z_t7V_cLvcfbRusDmvTiB42oU3QhPY9ntYsDUrzsNaN6EET2viN6BFPmzLtFUZegL0y7AsmbmRwaeJSetCELk1cSo94OhCcbSFcOttSetiENuDPzdOls-3QPXab9vk93uf3uOY3-aCJi3kYuRjQwMU8jVzM08jFwyYu5mHkYkADF_M0cjGggYtH7D7VHr9PNf_0BMcT0EjHCAc-BjgSMsKBkTX_CAVKBjRyMsKBlAGOrAxwpGXNxwfgZc0_SIFaAY3cinAgV4AjuwIcRl3-aYqKgxyAwi7AUdoFOQLFXYADx2o-Seg-kKyTJUSS5WkoWYAjyfI4lCzAkWQlOUpKQ8mKkpQUh5IVZSkXd1KFSLJOqhBJlqehZAGOJMvjULI8jiRrJIFKSiPJIhxIFuBIsghHlwpOqijsWGN4yRonVUgkC2gkWYQDyQIcSRbhQLJGkqikNJIswoFkAY4kC3AkWePEColkjZMqJJIFNJIswoFkAY4kC3AoWUmgktJQsqJAJcWhZEWBysWdVFGU7BBIVnJF4x4X0R2NGEeSFd3SiHEkWUmiktJQsqJEJcWhZEWJyr04d2IFK9nJ5r-_AQAA__9IVxsL
-# 
-# 
+#
+#
 # statement ok
 # CREATE TABLE distsql_mj_test (k INT, v INT)
-# 
+#
 # query T
 # EXPLAIN (DISTSQL) (SELECT l.k, r.k FROM (SELECT * FROM distsql_mj_test ORDER BY k) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k) r ON l.k = r.k)
 # ----

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
@@ -139,7 +139,6 @@ query T
 EXPLAIN SELECT * FROM parent1 JOIN child1 USING(pid1)
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -191,7 +190,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -245,7 +243,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -299,7 +296,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -360,7 +356,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -416,7 +411,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -486,7 +480,6 @@ EXPLAIN (DISTSQL)
     OR pa1 > 0
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -557,7 +550,6 @@ EXPLAIN (DISTSQL)
     OR pa1 > 0
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -586,7 +578,6 @@ EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   OR pa1 > 0
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -620,7 +611,6 @@ EXPLAIN (DISTSQL)
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (pid1, cid2, cid3) = (pid1, cid2, cid3)
@@ -653,7 +643,6 @@ EXPLAIN
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (pid1, cid2, cid3) = (pid1, cid2, cid3)
@@ -679,7 +668,6 @@ EXPLAIN (DISTSQL)
     pid1 >= 10 AND pid1 <= 39
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -808,7 +796,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -868,7 +855,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -923,7 +909,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40
 ----
 distribution: full
-vectorized: true
 ·
 • merge join (left outer)
 │ equality: (pid1) = (pid1)
@@ -976,7 +961,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20
 ----
 distribution: full
-vectorized: true
 ·
 • merge join (left outer)
 │ equality: (pid1) = (pid1)
@@ -998,7 +982,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid1)
@@ -1019,7 +1002,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (pid1) = (pid2)
@@ -1043,7 +1025,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (pa1) = (ca1)
@@ -1064,7 +1045,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (pid1, cid2) = (pid1, cid2)
@@ -1086,7 +1066,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)
 ----
 distribution: full
-vectorized: true
 ·
 • hash join
 │ equality: (pid1, cid3) = (pid1, cid3)
@@ -1113,7 +1092,6 @@ EXPLAIN (DISTSQL)
 ORDER BY pid1
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent1@parent1_pkey
@@ -1145,7 +1123,6 @@ EXPLAIN (DISTSQL)
   JOIN grandchild1 USING (pid1, cid1)
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: parent1@parent1_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -112,12 +112,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -168,12 +164,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -188,12 +180,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -208,12 +196,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -231,12 +215,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -263,12 +243,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -287,12 +263,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -314,12 +286,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·
@@ -341,12 +309,8 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • create statistics
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -52,7 +52,6 @@ query T
 EXPLAIN (DISTSQL) SELECT 5, 2+y, * FROM NumToStr WHERE y <= 10 ORDER BY str
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -71,7 +70,6 @@ query T
 EXPLAIN (DISTSQL) SELECT 5, 2 + y, * FROM NumToStr WHERE y % 1000 = 0 ORDER BY str
 ----
 distribution: full
-vectorized: true
 ·
 • render
 │
@@ -93,7 +91,6 @@ query T
 EXPLAIN (DISTSQL) SELECT str FROM NumToStr WHERE y < 10 AND str LIKE '%e%' ORDER BY y
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: str LIKE '%e%'
@@ -110,7 +107,6 @@ query T
 EXPLAIN (DISTSQL) SELECT str FROM NumToStr WHERE y % 1000 = 0 AND str LIKE '%i%' ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ filter: ((y % 1000) = 0) AND (str LIKE '%i%')
@@ -130,7 +126,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared
 ----
 distribution: full
-vectorized: true
 ·
 • hash join
 │ equality: (xsquared) = (y)
@@ -195,7 +190,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ equality: (x) = (y)
@@ -229,7 +223,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(y) FROM NumToStr
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -245,7 +238,6 @@ query T
 EXPLAIN (DISTSQL) SELECT count(*) FROM NumToStr
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -261,7 +253,6 @@ query T
 EXPLAIN (DISTSQL) SELECT count(*) FROM NumToStr WHERE str LIKE '%five%'
 ----
 distribution: full
-vectorized: true
 ·
 • group (scalar)
 │
@@ -283,7 +274,6 @@ query T
 EXPLAIN (DISTSQL) SELECT y FROM NumToStr LIMIT 5
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -297,7 +287,6 @@ query T
 EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y LIMIT 5
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -312,7 +301,6 @@ query T
 EXPLAIN (DISTSQL) SELECT y FROM NumToStr WHERE y < 1000 OR y > 9000 ORDER BY y DESC LIMIT 5
 ----
 distribution: full
-vectorized: true
 ·
 • revscan
   missing stats
@@ -340,7 +328,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -401,7 +388,6 @@ query T
 EXPLAIN (DISTSQL) SELECT count(*) FROM (SELECT 1 AS one FROM NumToSquare WHERE x > 10 ORDER BY xsquared LIMIT 10)
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_ordinality
@@ -52,7 +52,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, y, z, ordinality FROM xyz WITH ORDINALITY
 ----
 distribution: local
-vectorized: true
 ·
 • ordinality
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_single_flow
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_single_flow
@@ -32,7 +32,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t1, t2 WHERE t1.a = t2.b
 ----
 distribution: full
-vectorized: true
 ·
 • hash join
 │ equality: (a) = (b)
@@ -110,7 +109,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t1, t2 WHERE t1.a = t2.b
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ estimated row count: 10,000
@@ -145,7 +143,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t1, t2 WHERE t1.b = 1 AND t1.a = t2.a
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ estimated row count: 3,333
@@ -187,7 +184,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t1 INNER MERGE JOIN t2 ON t1.a = t2.a WHERE t1.c = 1
 ----
 distribution: full
-vectorized: true
 ·
 • merge join
 │ estimated row count: 100

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant
@@ -7,7 +7,6 @@ query T
 EXPLAIN SELECT * FROM tbl1 WHERE a < 3 OR (a > 7 AND a < 9) OR a > 14
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats
@@ -32,7 +31,6 @@ query T
 EXPLAIN SELECT v, w FROM tbl2 WHERE k <= 3
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -66,7 +66,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE k IN (1, 3, 5)
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats
@@ -82,7 +81,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE k >= 3 AND k < 5
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats
@@ -98,7 +96,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE k >= 1 LIMIT 10
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats
@@ -130,7 +127,6 @@ query T retry
 EXPLAIN SELECT * FROM t93887 WHERE y = 1
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: y = 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_union
@@ -37,7 +37,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM xyz UNION ALL SELECT x FROM xyz ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • union all
 │
@@ -63,7 +62,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM xyz UNION SELECT x FROM xyz ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -87,7 +85,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM xyz WHERE x < 3 UNION SELECT x FROM xyz WHERE x >= 3 ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -117,7 +114,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM xyz WHERE x <= 4 UNION SELECT x FROM xyz WHERE x > 1 ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -147,7 +143,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, y FROM xyz UNION ALL SELECT y, x from xyz
 ----
 distribution: full
-vectorized: true
 ·
 • union all
 │
@@ -168,7 +163,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) UNION ALL (SELECT x FROM xyz ORDER BY z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • union all
 │
@@ -194,7 +188,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) UNION (SELECT x FROM xyz ORDER BY z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -218,7 +211,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) UNION ALL (SELECT x FROM xyz ORDER BY y, z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • union all
 │
@@ -245,7 +237,6 @@ query T
 EXPLAIN (DISTSQL) VALUES (1), (2) UNION VALUES (2), (3)
 ----
 distribution: local
-vectorized: true
 ·
 • union
 │ estimated row count: 4
@@ -265,7 +256,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz) INTERSECT ALL (SELECT y FROM xyz) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -288,7 +278,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz) INTERSECT (SELECT y FROM xyz) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -312,7 +301,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY y) INTERSECT ALL (SELECT y FROM xyz ORDER BY y)
 ----
 distribution: full
-vectorized: true
 ·
 • intersect all
 │
@@ -332,7 +320,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY y) INTERSECT (SELECT y FROM xyz ORDER BY y)
 ----
 distribution: full
-vectorized: true
 ·
 • intersect
 │
@@ -353,7 +340,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz WHERE x < 2) INTERSECT ALL (SELECT x FROM xyz WHERE x >= 2) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -382,7 +368,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz WHERE x < 2) INTERSECT (SELECT x FROM xyz WHERE x >= 2) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -412,7 +397,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz WHERE x < 3) INTERSECT ALL (SELECT y FROM xyz WHERE x >= 1) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -441,7 +425,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz WHERE x < 3) INTERSECT (SELECT y FROM xyz WHERE x >= 1) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -471,7 +454,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, y FROM xyz INTERSECT ALL SELECT y, x from xyz
 ----
 distribution: full
-vectorized: true
 ·
 • intersect all
 │
@@ -491,7 +473,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, y FROM xyz INTERSECT SELECT y, x from xyz
 ----
 distribution: full
-vectorized: true
 ·
 • intersect
 │
@@ -512,7 +493,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) INTERSECT ALL (SELECT x FROM xyz ORDER BY z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -535,7 +515,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) INTERSECT (SELECT x FROM xyz ORDER BY z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -559,7 +538,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) INTERSECT ALL (SELECT x FROM xyz ORDER BY y, z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -582,7 +560,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) INTERSECT (SELECT x FROM xyz ORDER BY y, z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -606,7 +583,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY z) INTERSECT ALL (SELECT y FROM xyz ORDER BY z)
 ----
 distribution: full
-vectorized: true
 ·
 • intersect all
 │
@@ -626,7 +602,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY z) INTERSECT ALL (SELECT y FROM xyz ORDER BY z)
 ----
 distribution: full
-vectorized: true
 ·
 • intersect all
 │
@@ -647,7 +622,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM ((SELECT x, y FROM xyz) INTERSECT ALL (SELECT x, y FROM xyz))
 ----
 distribution: full
-vectorized: true
 ·
 • intersect all
 │
@@ -667,7 +641,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM ((SELECT x, y FROM xyz) INTERSECT (SELECT x, y FROM xyz))
 ----
 distribution: full
-vectorized: true
 ·
 • intersect
 │
@@ -690,7 +663,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz) EXCEPT ALL (SELECT x AS y FROM xyz) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -713,7 +685,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz) EXCEPT (SELECT x AS y FROM xyz) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -737,7 +708,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY y) EXCEPT ALL (SELECT y FROM xyz ORDER BY y)
 ----
 distribution: full
-vectorized: true
 ·
 • except all
 │
@@ -757,7 +727,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY y) EXCEPT (SELECT y FROM xyz ORDER BY y)
 ----
 distribution: full
-vectorized: true
 ·
 • except
 │
@@ -778,7 +747,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz WHERE x < 2) EXCEPT ALL (SELECT x FROM xyz WHERE x >= 2) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -807,7 +775,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz WHERE x < 2) EXCEPT (SELECT x FROM xyz WHERE x >= 2) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -837,7 +804,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz WHERE x >= 1) EXCEPT ALL (SELECT y FROM xyz WHERE x < 3) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -866,7 +832,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz WHERE x >= 1) EXCEPT (SELECT y FROM xyz WHERE x < 3) ORDER BY y
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +y
@@ -896,7 +861,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, y FROM xyz EXCEPT ALL SELECT y, x from xyz
 ----
 distribution: full
-vectorized: true
 ·
 • except all
 │
@@ -916,7 +880,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x, y FROM xyz EXCEPT SELECT y, x from xyz
 ----
 distribution: full
-vectorized: true
 ·
 • except
 │
@@ -937,7 +900,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) EXCEPT ALL (SELECT y AS x FROM xyz ORDER BY z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -960,7 +922,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) EXCEPT (SELECT y AS x FROM xyz ORDER BY z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -984,7 +945,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) EXCEPT ALL (SELECT x FROM xyz ORDER BY y, z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -1007,7 +967,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT x FROM xyz ORDER BY y) EXCEPT (SELECT x FROM xyz ORDER BY y, z) ORDER BY x
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +x
@@ -1031,7 +990,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY z) EXCEPT ALL (SELECT y FROM xyz ORDER BY z)
 ----
 distribution: full
-vectorized: true
 ·
 • except all
 │
@@ -1051,7 +1009,6 @@ query T
 EXPLAIN (DISTSQL) (SELECT y FROM xyz ORDER BY z) EXCEPT (SELECT y FROM xyz ORDER BY z)
 ----
 distribution: full
-vectorized: true
 ·
 • except
 │
@@ -1072,7 +1029,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM ((SELECT x, y FROM xyz) EXCEPT ALL (SELECT x, y FROM xyz))
 ----
 distribution: full
-vectorized: true
 ·
 • except all
 │
@@ -1092,7 +1048,6 @@ query T
 EXPLAIN (DISTSQL) SELECT x FROM ((SELECT x, y FROM xyz) EXCEPT (SELECT x, y FROM xyz))
 ----
 distribution: full
-vectorized: true
 ·
 • except
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_window
@@ -42,7 +42,6 @@ EXPLAIN (DISTSQL) SELECT
 FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • window
 │
@@ -69,7 +68,6 @@ EXPLAIN (DISTSQL) SELECT
 FROM data
 ----
 distribution: full
-vectorized: true
 ·
 • window
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -42,7 +42,6 @@ query T rowsort
 SELECT crdb_internal.execute_internally('EXPLAIN SELECT k FROM t;', 'Database=test');
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/experimental_distsql_planning_5node
+++ b/pkg/sql/opt/exec/execbuilder/testdata/experimental_distsql_planning_5node
@@ -55,7 +55,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM kv
 ----
 distribution: full
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -4,7 +4,6 @@ query T
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -12,7 +11,6 @@ query T
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -77,7 +75,6 @@ query T
 EXPLAIN CREATE DATABASE foo
 ----
 distribution: local
-vectorized: true
 ·
 • create database
 
@@ -85,7 +82,6 @@ query T
 EXPLAIN CREATE TABLE foo (x INT)
 ----
 distribution: local
-vectorized: true
 ·
 • create table
 
@@ -96,7 +92,6 @@ query T
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
 distribution: local
-vectorized: true
 ·
 • create index
 
@@ -107,7 +102,6 @@ query T
 EXPLAIN DROP DATABASE foo
 ----
 distribution: local
-vectorized: true
 ·
 • drop database
 
@@ -118,7 +112,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW JOBS] WHERE info NOT LIKE '%size%' AND info NOT LIKE '%filter%'
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: -column71,-created
@@ -168,7 +161,6 @@ query T
 EXPLAIN DROP INDEX foo@a
 ----
 distribution: local
-vectorized: true
 ·
 • drop index
 
@@ -176,7 +168,6 @@ query T
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
 distribution: local
-vectorized: true
 ·
 • alter table
 
@@ -218,7 +209,6 @@ query T
 EXPLAIN ALTER TABLE foo RELOCATE VALUES (ARRAY[1], 1)
 ----
 distribution: local
-vectorized: true
 ·
 • relocate table
 │ index: foo@foo_pkey
@@ -247,7 +237,6 @@ query T
 EXPLAIN ALTER INDEX foo@a RELOCATE VALUES (ARRAY[1], 1)
 ----
 distribution: local
-vectorized: true
 ·
 • relocate table
 │ index: foo@a
@@ -276,7 +265,6 @@ query T
 EXPLAIN DROP TABLE foo
 ----
 distribution: local
-vectorized: true
 ·
 • drop table
 
@@ -284,7 +272,6 @@ query T
 EXPLAIN ALTER RANGE 20+2 RELOCATE FROM 30+3 TO 40+4
 ----
 distribution: local
-vectorized: true
 ·
 • relocate range
 │ replicas: VOTERS
@@ -333,7 +320,6 @@ query T
 EXPLAIN ALTER RANGE RELOCATE FROM 30+3 TO 40+4 FOR SELECT 20+2
 ----
 distribution: local
-vectorized: true
 ·
 • relocate range
 │ replicas: VOTERS
@@ -365,7 +351,6 @@ query T
 EXPLAIN SHOW DATABASES
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +name
@@ -377,7 +362,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW TABLES] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +nspname,+relname
@@ -432,7 +416,6 @@ SELECT regexp_replace(info, 'classoid = [0-9]+', 'classoid = <oid>') AS info
 FROM [EXPLAIN SHOW TABLES WITH COMMENT] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +nspname,+relname
@@ -502,7 +485,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW DATABASE] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: variable = 'database'
@@ -514,7 +496,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW SCHEMAS] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +nspname
@@ -541,7 +522,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW TIME ZONE] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • show
 
@@ -549,7 +529,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • show
 
@@ -557,7 +536,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_PRIORITY] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • show
 
@@ -565,7 +543,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW DEFAULT_TRANSACTION_USE_FOLLOWER_READS] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • show
 
@@ -573,7 +550,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW TRANSACTION ISOLATION LEVEL] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • show
 
@@ -581,7 +557,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW TRANSACTION PRIORITY] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • show
 
@@ -589,7 +564,6 @@ query T
 EXPLAIN SHOW COLUMNS FROM foo
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +ordinal_position,+column_name,+crdb_sql_type,+is_nullable,+column_default,+generation_expression,+indices,+is_hidden
@@ -621,7 +595,6 @@ query T
 SELECT * FROM [EXPLAIN SHOW GRANTS ON foo] WHERE info NOT LIKE '%size%'
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -676,7 +649,6 @@ query T
 EXPLAIN SHOW INDEX FROM foo
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +index_name,+seq_in_index
@@ -719,7 +691,6 @@ query T
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +conname,+constraint_type,+condef,+convalidated
@@ -758,7 +729,6 @@ query T retry
 EXPLAIN SHOW USERS
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 3
@@ -849,7 +819,6 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: t(k, v)
@@ -863,7 +832,6 @@ query T
 EXPLAIN SELECT * FROM t
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -886,7 +854,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -900,7 +867,6 @@ query T
 EXPLAIN (PLAN) SELECT * FROM t INNER LOOKUP JOIN t2 ON t.k = t2.x
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: t2@t2_pkey
@@ -933,7 +899,6 @@ query T
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
 distribution: local
-vectorized: true
 ·
 • values
   size: 3 columns, 2 rows
@@ -942,7 +907,6 @@ query T
 EXPLAIN VALUES (1)
 ----
 distribution: local
-vectorized: true
 ·
 • values
   size: 1 column, 1 row
@@ -972,7 +936,6 @@ query T
 EXPLAIN SELECT DISTINCT v FROM t
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: v
@@ -1073,7 +1036,6 @@ query T
 EXPLAIN SELECT * FROM system.table_statistics WHERE name = 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: name = 'foo'
@@ -1353,7 +1315,6 @@ query T
 EXPLAIN SELECT * FROM another_db.sc.t WHERE a = 1
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: a = 1
@@ -2053,7 +2014,6 @@ query T
 EXPLAIN SELECT string_agg(x, y) FROM (VALUES ('foo', 'foo'), ('bar', 'bar')) t(x, y)
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │ estimated row count: 1
@@ -2065,7 +2025,6 @@ query T
 EXPLAIN SELECT corr(a, b) FROM tc;
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -2083,7 +2042,6 @@ WITH
 SELECT * FROM a, b
 ----
 NULL  distribution: local
-NULL  vectorized: true
 NULL  ·
 NULL  • scan
 NULL    missing stats
@@ -2095,7 +2053,6 @@ query T
 EXPLAIN EXPLAIN SELECT 1
 ----
 distribution: local
-vectorized: true
 ·
 • explain
 
@@ -2107,7 +2064,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE k IN (10, 20, 30, 40, 50, 60, 70, 80)
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -2129,7 +2085,6 @@ query T
 EXPLAIN UPSERT INTO u VALUES (1, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: u(k, v)
@@ -2151,7 +2106,6 @@ query T
 EXPLAIN INSERT INTO u VALUES (1, 1) ON CONFLICT DO NOTHING
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: u(k, v)
@@ -2218,7 +2172,6 @@ query T
 EXPLAIN SELECT * FROM percent
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1,000,000 (100% of the table; stats collected <hidden> ago)
@@ -2229,7 +2182,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 150000
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 150,000 (15% of the table; stats collected <hidden> ago)
@@ -2240,7 +2192,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 20000
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 20,000 (2.0% of the table; stats collected <hidden> ago)
@@ -2251,7 +2202,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 1234
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1,234 (0.12% of the table; stats collected <hidden> ago)
@@ -2262,7 +2212,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 980
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 980 (0.10% of the table; stats collected <hidden> ago)
@@ -2273,7 +2222,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 and 100
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 100 (0.01% of the table; stats collected <hidden> ago)
@@ -2284,7 +2232,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 and 99
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 99 (<0.01% of the table; stats collected <hidden> ago)
@@ -2295,7 +2242,6 @@ query T
 EXPLAIN SELECT * FROM percent WHERE a = 1
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
@@ -2307,7 +2253,6 @@ query T
 EXPLAIN INSERT INTO t2 SELECT x FROM t2 WHERE false
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: t2(x)
@@ -2328,20 +2273,14 @@ EXPLAIN ANALYZE EXECUTE prep(1)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • values
   sql nodes: <hidden>
   regions: <hidden>
-  actual row count: 1
   execution time: 0µs
+  actual row count: 1
   size: 1 column, 1 row
 
 # Tests for EXPLAIN (OPT, MEMO).
@@ -2529,7 +2468,6 @@ query T
 EXPLAIN SELECT t1.k FROM very_large_table AS t1, very_large_table AS t2;
 ----
 distribution: local
-vectorized: true
 ·
 • cross join
 │ estimated row count: 9,223,372,036,854,775,807
@@ -2592,7 +2530,6 @@ query T
 EXPLAIN SELECT k FROM t_hints WHERE k >= 100
 ----
 distribution: local
-vectorized: true
 statement hints count: 1
 ·
 • filter

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -9,25 +9,16 @@ EXPLAIN ANALYZE (PLAN) SELECT k FROM kv WHERE k >= 2
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   KV time: 0µs
   KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
+  actual row count: 0
   missing stats
   table: kv@kv_pkey
   spans: [/2 - ]
@@ -41,27 +32,17 @@ EXPLAIN ANALYZE (PLAN) SELECT * FROM kv WHERE k >= 2
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 3
   KV time: 0µs
   KV rows decoded: 3
-  KV pairs read: 6
-  KV bytes read: 24 B
-  KV gRPC calls: 3
-  estimated max memory allocated: 0 B
+  actual row count: 3
   missing stats
   table: kv@kv_pkey
   spans: [/2 - ]
@@ -90,20 +71,13 @@ EXPLAIN ANALYZE SHOW TABLES
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • sort
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
 │ order: +nspname,+relname
 │
 └── • render
@@ -112,7 +86,6 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
         │ equality: (column80) = (table_id)
         │
         ├── • render
@@ -121,7 +94,6 @@ quality of service: regular
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
         │       │ execution time: 0µs
-        │       │ estimated max memory allocated: 0 B
         │       │ equality: (column62) = (table_id)
         │       │ right cols are key
         │       │
@@ -131,7 +103,6 @@ quality of service: regular
         │       │       │ sql nodes: <hidden>
         │       │       │ regions: <hidden>
         │       │       │ execution time: 0µs
-        │       │       │ estimated max memory allocated: 0 B
         │       │       │ equality: (oid) = (relowner)
         │       │       │
         │       │       ├── • virtual table
@@ -144,7 +115,6 @@ quality of service: regular
         │       │           │ sql nodes: <hidden>
         │       │           │ regions: <hidden>
         │       │           │ execution time: 0µs
-        │       │           │ estimated max memory allocated: 0 B
         │       │           │ equality: (oid) = (relnamespace)
         │       │           │
         │       │           ├── • filter
@@ -175,7 +145,6 @@ quality of service: regular
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
         │           │ execution time: 0µs
-        │           │ estimated max memory allocated: 0 B
         │           │ distinct on: table_id
         │           │
         │           └── • virtual table
@@ -199,21 +168,15 @@ EXPLAIN ANALYZE DELETE FROM kv WHERE true RETURNING *;
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • delete
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 4
 │ execution time: 0µs
+│ actual row count: 4
 │ from: kv
 │ auto commit
 │
@@ -221,13 +184,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 4
       KV time: 0µs
       KV rows decoded: 4
-      KV pairs read: 8
-      KV bytes read: 32 B
-      KV gRPC calls: 4
-      estimated max memory allocated: 0 B
+      actual row count: 4
       missing stats
       table: kv@kv_pkey
       spans: FULL SCAN
@@ -239,30 +198,24 @@ EXPLAIN ANALYZE INSERT INTO kv VALUES (1, 10) RETURNING k + v;
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • render
 │
 └── • insert
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 1
     │ execution time: 0µs
+    │ actual row count: 1
     │ estimated row count: 1
     │ into: kv(k, v)
     │
     └── • values
           sql nodes: <hidden>
           regions: <hidden>
-          actual row count: 1
           execution time: 0µs
+          actual row count: 1
           size: 2 columns, 1 row
 
 # Verify that the number of applied statement hints is displayed.
@@ -281,26 +234,17 @@ EXPLAIN ANALYZE SELECT k FROM kv WHERE k >= 100
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 statement hints count: 1
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   KV time: 0µs
   KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
+  actual row count: 0
   missing stats
   table: kv@kv_pkey
   spans: [/100 - ]

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -70,31 +70,24 @@ EXPLAIN ANALYZE (DISTSQL) SELECT kv.k, avg(kw.k) FROM kv JOIN kw ON kv.k=kw.k GR
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • group (streaming)
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
+│ actual row count: 5
 │ group by: k
 │ ordered: +k
 │
 └── • merge join
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 5
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
+    │ actual row count: 5
     │ equality: (k) = (k)
     │ left cols are key
     │ right cols are key
@@ -103,13 +96,9 @@ quality of service: regular
     │     sql nodes: <hidden>
     │     kv nodes: <hidden>
     │     regions: <hidden>
-    │     actual row count: 5
     │     KV time: 0µs
     │     KV rows decoded: 5
-    │     KV pairs read: 10
-    │     KV bytes read: 40 B
-    │     KV gRPC calls: 5
-    │     estimated max memory allocated: 0 B
+    │     actual row count: 5
     │     missing stats
     │     table: kv@kv_pkey
     │     spans: FULL SCAN
@@ -118,13 +107,9 @@ quality of service: regular
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 5
           KV time: 0µs
           KV rows decoded: 5
-          KV pairs read: 10
-          KV bytes read: 40 B
-          KV gRPC calls: 5
-          estimated max memory allocated: 0 B
+          actual row count: 5
           missing stats
           table: kw@kw_pkey
           spans: FULL SCAN
@@ -208,38 +193,30 @@ EXPLAIN ANALYZE (DISTSQL) SELECT DISTINCT(kw.w) FROM kv JOIN kw ON kv.k = kw.w O
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • sort
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 5
 │ order: +w
 │
 └── • distinct
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 5
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
+    │ actual row count: 5
     │ distinct on: w
     │
     └── • hash join
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 5
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 5
         │ equality: (k) = (w)
         │ left cols are key
         │
@@ -247,13 +224,9 @@ quality of service: regular
         │     sql nodes: <hidden>
         │     kv nodes: <hidden>
         │     regions: <hidden>
-        │     actual row count: 5
         │     KV time: 0µs
         │     KV rows decoded: 5
-        │     KV pairs read: 10
-        │     KV bytes read: 40 B
-        │     KV gRPC calls: 5
-        │     estimated max memory allocated: 0 B
+        │     actual row count: 5
         │     missing stats
         │     table: kv@kv_pkey
         │     spans: FULL SCAN
@@ -262,13 +235,9 @@ quality of service: regular
               sql nodes: <hidden>
               kv nodes: <hidden>
               regions: <hidden>
-              actual row count: 5
               KV time: 0µs
               KV rows decoded: 5
-              KV pairs read: 10
-              KV bytes read: 40 B
-              KV gRPC calls: 5
-              estimated max memory allocated: 0 B
+              actual row count: 5
               missing stats
               table: kw@kw_pkey
               spans: FULL SCAN
@@ -356,41 +325,29 @@ EXPLAIN ANALYZE (DISTSQL) SELECT * FROM kv WITH ORDINALITY AS a, kv WITH ORDINAL
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • cross join
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 25
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
-│ estimated max sql temp disk usage: 0 B
+│ actual row count: 25
 │
 ├── • ordinality
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 5
 │   │ execution time: 0µs
+│   │ actual row count: 5
 │   │
 │   └── • scan
 │         sql nodes: <hidden>
 │         kv nodes: <hidden>
 │         regions: <hidden>
-│         actual row count: 5
 │         KV time: 0µs
 │         KV rows decoded: 5
-│         KV pairs read: 10
-│         KV bytes read: 40 B
-│         KV gRPC calls: 5
-│         estimated max memory allocated: 0 B
+│         actual row count: 5
 │         missing stats
 │         table: kv@kv_pkey
 │         spans: FULL SCAN
@@ -398,20 +355,16 @@ quality of service: regular
 └── • ordinality
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 5
     │ execution time: 0µs
+    │ actual row count: 5
     │
     └── • scan
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 5
           KV time: 0µs
           KV rows decoded: 5
-          KV pairs read: 10
-          KV bytes read: 40 B
-          KV gRPC calls: 5
-          estimated max memory allocated: 0 B
+          actual row count: 5
           missing stats
           table: kv@kv_pkey
           spans: FULL SCAN
@@ -430,7 +383,6 @@ query T
 EXPLAIN (DISTSQL) SELECT sum(k) FROM kv WHERE FALSE
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │ estimated row count: 1
@@ -446,35 +398,24 @@ EXPLAIN ANALYZE (DISTSQL) SELECT avg(k) OVER () FROM kv
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • window
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 5
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
-│ estimated max sql temp disk usage: 0 B
+│ actual row count: 5
 │
 └── • scan
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 5
       KV time: 0µs
       KV rows decoded: 5
-      KV pairs read: 10
-      KV bytes read: 40 B
-      KV gRPC calls: 5
-      estimated max memory allocated: 0 B
+      actual row count: 5
       missing stats
       table: kv@kv_pkey
       spans: FULL SCAN
@@ -489,25 +430,16 @@ EXPLAIN ANALYZE (DISTSQL) SELECT k FROM kv WHERE k = 0
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   KV time: 0µs
   KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
+  actual row count: 0
   missing stats
   table: kv@kv_pkey
   spans: [/0 - /0]
@@ -526,37 +458,32 @@ EXPLAIN ANALYZE (DISTSQL) INSERT INTO child VALUES (1, (SELECT min(p) FROM paren
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
-maximum memory usage: <hidden>
 DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • insert
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
 │   │ execution time: 0µs
+│   │ actual row count: 1
 │   │ into: child(c, p)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 1
 │       │ execution time: 0µs
+│       │ actual row count: 1
 │       │ label: buffer 1
 │       │
 │       └── • values
 │             sql nodes: <hidden>
 │             regions: <hidden>
-│             actual row count: 1
 │             execution time: 0µs
+│             actual row count: 1
 │             size: 2 columns, 1 row
 │
 ├── • subquery
@@ -567,20 +494,16 @@ quality of service: regular
 │   └── • group (scalar)
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 1
 │       │ execution time: 0µs
+│       │ actual row count: 1
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
 │             kv nodes: <hidden>
 │             regions: <hidden>
-│             actual row count: 1
 │             KV time: 0µs
 │             KV rows decoded: 1
-│             KV pairs read: 2
-│             KV bytes read: 8 B
-│             KV gRPC calls: 1
-│             estimated max memory allocated: 0 B
+│             actual row count: 1
 │             missing stats
 │             table: parent@parent_pkey
 │             spans: LIMITED SCAN
@@ -591,21 +514,17 @@ quality of service: regular
     └── • error if rows
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ execution time: 0µs
+        │ actual row count: 0
         │
         └── • lookup join (anti)
             │ sql nodes: <hidden>
             │ kv nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 0
             │ KV time: 0µs
             │ KV rows decoded: 1
-            │ KV pairs read: 2
-            │ KV bytes read: 8 B
-            │ KV gRPC calls: 1
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
+            │ actual row count: 0
             │ table: parent@parent_pkey
             │ equality: (column2) = (p)
             │ equality cols are key
@@ -613,16 +532,16 @@ quality of service: regular
             └── • filter
                 │ sql nodes: <hidden>
                 │ regions: <hidden>
-                │ actual row count: 1
                 │ execution time: 0µs
+                │ actual row count: 1
                 │ estimated row count: 1
                 │ filter: column2 IS NOT NULL
                 │
                 └── • scan buffer
                       sql nodes: <hidden>
                       regions: <hidden>
-                      actual row count: 1
                       execution time: 0µs
+                      actual row count: 1
                       estimated row count: 1
                       label: buffer 1
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
@@ -23,11 +23,8 @@ EXPLAIN ANALYZE (PLAN) SELECT * FROM kv WHERE k >= 2
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: read committed
 priority: low
@@ -37,13 +34,9 @@ quality of service: background
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 3
   KV time: 0µs
   KV rows decoded: 3
-  KV pairs read: 6
-  KV bytes read: 24 B
-  KV gRPC calls: 3
-  estimated max memory allocated: 0 B
+  actual row count: 3
   missing stats
   table: kv@kv_pkey
   spans: [/2 - ]
@@ -78,10 +71,10 @@ quality of service: regular
 │ columns: (k, v, a, b)
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 2
 │ vectorized batch count: 0
 │ execution time: 0µs
 │ estimated max memory allocated: 0 B
+│ actual row count: 2
 │ estimated row count: 990 (missing stats)
 │ equality: (v) = (a)
 │ right cols are key
@@ -91,7 +84,6 @@ quality of service: regular
 │     sql nodes: <hidden>
 │     kv nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 4
 │     vectorized batch count: 0
 │     KV time: 0µs
 │     KV rows decoded: 4
@@ -101,6 +93,7 @@ quality of service: regular
 │     estimated max memory allocated: 0 B
 │     MVCC step count (ext/int): 0/0
 │     MVCC seek count (ext/int): 0/0
+│     actual row count: 4
 │     estimated row count: 1,000 (missing stats)
 │     table: kv@kv_pkey
 │     spans: FULL SCAN
@@ -110,7 +103,6 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 3
       vectorized batch count: 0
       KV time: 0µs
       KV rows decoded: 3
@@ -120,6 +112,7 @@ quality of service: regular
       estimated max memory allocated: 0 B
       MVCC step count (ext/int): 0/0
       MVCC seek count (ext/int): 0/0
+      actual row count: 3
       estimated row count: 1,000 (missing stats)
       table: ab@ab_pkey
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -192,7 +192,6 @@ query T
 EXPLAIN (REDACT) INSERT INTO a VALUES (1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: a(a, rowid)
@@ -310,7 +309,6 @@ query T
 EXPLAIN (REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: bc(b, c)
@@ -882,7 +880,6 @@ query T
 EXPLAIN (REDACT) UPSERT INTO d VALUES (7.7)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: d(d)
@@ -1005,7 +1002,6 @@ query T
 EXPLAIN (REDACT) UPDATE ab SET a = a || 'ab' WHERE a > 'a'
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: ab
@@ -1198,7 +1194,6 @@ query T
 EXPLAIN (REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: e
@@ -1445,7 +1440,6 @@ query T
 EXPLAIN (REDACT) DELETE FROM f WHERE f = 8.5
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: f
@@ -1633,7 +1627,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM bc WHERE b >= 1.0 AND b < 2.0
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -1768,7 +1761,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM g WHERE (g || 'abc') LIKE '%ggg%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (g || ‹×›) LIKE ‹×›
@@ -1932,7 +1924,6 @@ query T
 EXPLAIN (REDACT) SELECT a FROM a WHERE a % 8 > 2
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a % ‹×›) > ‹×›
@@ -2050,7 +2041,6 @@ query T
 EXPLAIN (REDACT) SELECT 100, if(e != '', 12.0, 13.0), 'abc', coalesce(e, 'eee'), row(e, e || 'a', now()), 'POINT (1 1)'::GEOMETRY, '[true]'::JSON, false, NULL, e FROM e
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -2253,7 +2243,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM bc JOIN f ON b = f + 1
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (b) = (column13)
@@ -2607,7 +2596,6 @@ query T
 EXPLAIN (REDACT) SELECT f, g FROM f, LATERAL (SELECT count(DISTINCT c + f + 1) * 2 AS g FROM bc WHERE b * f < 10)
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -3047,7 +3035,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM a WHERE a > ALL (SELECT c::int + 2 FROM bc WHERE b > a::float * 3)
 ----
 distribution: local
-vectorized: true
 ·
 • apply join (anti)
 │ pred: (a <= "?column?") IS NOT ‹×›
@@ -3324,7 +3311,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM a WHERE a IN (2, 3, 4)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: a IN ‹(‹×›, ‹×›, ‹×›)›
@@ -3443,7 +3429,6 @@ query T
 EXPLAIN (REDACT) SELECT * FROM cd ORDER BY regexp_replace(c, '[0-9]', 'd') LIMIT 3
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column8
@@ -3643,7 +3628,6 @@ query T
 EXPLAIN (REDACT) SELECT covar_pop(d, d + 1) FROM d
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -3831,7 +3815,6 @@ query T
 EXPLAIN (REDACT) SELECT min(c || 'cccc') OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING EXCLUDE CURRENT ROW) FROM cd
 ----
 distribution: local
-vectorized: true
 ·
 • window
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_shape
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_shape
@@ -9,7 +9,6 @@ query T
 EXPLAIN (SHAPE) SELECT b FROM a WHERE a = 5
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   table: a@a_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/expression_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/expression_index
@@ -31,7 +31,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM t@t_a_plus_b_idx WHERE a + b = 110
 ] OFFSET 2
 ----
-·
 • index join
 │ table: t@t_pkey
 │
@@ -45,7 +44,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM t@t_a_plus_b_idx WHERE (a + b) > 110
 ] OFFSET 2
 ----
-·
 • index join
 │ table: t@t_pkey
 │
@@ -59,7 +57,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM t@t_lower_c_idx WHERE lower(c) = 'foo'
 ] OFFSET 2
 ----
-·
 • index join
 │ table: t@t_pkey
 │
@@ -73,7 +70,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM t@t_lower_c_idx WHERE lower(c) LIKE 'foo%'
 ] OFFSET 2
 ----
-·
 • index join
 │ table: t@t_pkey
 │
@@ -87,7 +83,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM t@t_lower_c_a_plus_b_idx WHERE lower(c) = 'foo' AND a + b > 110
 ] OFFSET 2
 ----
-·
 • index join
 │ table: t@t_pkey
 │
@@ -104,7 +99,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM mn INNER LOOKUP JOIN t ON n = lower(c)
 ] OFFSET 2
 ----
-·
 • lookup join
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -124,7 +118,6 @@ SELECT * FROM [
   EXPLAIN SELECT * FROM mn INNER LOOKUP JOIN t ON m = a + b AND n = lower(c)
 ] OFFSET 2
 ----
-·
 • lookup join
 │ table: t@t_pkey
 │ equality: (k) = (k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -16,7 +16,6 @@ query T
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -55,7 +54,6 @@ query T
 EXPLAIN INSERT INTO child VALUES (1,1), (2,2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -116,7 +114,6 @@ query T
 EXPLAIN INSERT INTO child SELECT x,y FROM xy
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -151,7 +148,6 @@ query T
 EXPLAIN INSERT INTO child SELECT x,y FROM xy
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -191,7 +187,6 @@ query T
 EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -229,7 +224,6 @@ query T
 EXPLAIN INSERT INTO child_nullable VALUES (100, 1), (200, NULL)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -279,7 +273,6 @@ query T
 EXPLAIN INSERT INTO multi_col_child VALUES (2, NULL, 20, 20), (3, 20, NULL, 20)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -329,7 +322,6 @@ query T
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL), (2, 3, 4, 5)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -381,7 +373,6 @@ query T
 EXPLAIN INSERT INTO multi_ref_child VALUES (1, NULL, NULL, NULL)
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: multi_ref_child(k, a, b, c)
@@ -396,7 +387,6 @@ query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -443,7 +433,6 @@ query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -491,7 +480,6 @@ query T
 EXPLAIN DELETE FROM parent WHERE p = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -556,7 +544,6 @@ query T
 EXPLAIN DELETE FROM doubleparent WHERE p1 = 10
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -589,7 +576,6 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -628,7 +614,6 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -692,7 +677,6 @@ query T
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -731,7 +715,6 @@ query T
 EXPLAIN UPDATE child SET p = 4 WHERE c = 10
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -770,7 +753,6 @@ query T
 EXPLAIN UPDATE parent SET p = p+1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -825,7 +807,6 @@ query T
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -883,7 +864,6 @@ query T
 EXPLAIN UPDATE child SET c = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -937,7 +917,6 @@ query T
 EXPLAIN UPDATE child SET c = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -989,7 +968,6 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1028,7 +1006,6 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1067,7 +1044,6 @@ query T
 EXPLAIN UPDATE child SET p = p
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1100,7 +1076,6 @@ query T
 EXPLAIN UPDATE child SET p = p+1, c = c+1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1164,7 +1139,6 @@ query T
 EXPLAIN UPDATE child SET p = p+1, c = c+1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1232,7 +1206,6 @@ query T
 EXPLAIN UPDATE child SET p = 4
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1270,7 +1243,6 @@ query T
 EXPLAIN UPDATE self SET y = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1309,7 +1281,6 @@ query T
 EXPLAIN UPDATE self SET y = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1348,7 +1319,6 @@ query T
 EXPLAIN UPDATE self SET x = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1401,7 +1371,6 @@ query T
 EXPLAIN UPDATE self SET x = 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1564,7 +1533,6 @@ query T
 EXPLAIN INSERT INTO nonunique_idx_child VALUES (0, 1, 10)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: nonunique_idx_child(k, ref1, ref2)
@@ -1740,7 +1708,6 @@ WHERE
   t.z IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: z IS NULL
@@ -1776,7 +1743,6 @@ WHERE
   t.z IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -1810,7 +1776,6 @@ query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: c(c, p)
@@ -1824,7 +1789,6 @@ query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: c(c, p)
@@ -1836,7 +1800,6 @@ query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1878,7 +1841,6 @@ query T
 EXPLAIN DELETE FROM p WHERE p > 0
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1915,7 +1877,6 @@ query T
 EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: c(c, p)
@@ -1927,7 +1888,6 @@ query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1968,7 +1928,6 @@ query T
 EXPLAIN DELETE FROM p WHERE p > 0
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2023,7 +1982,6 @@ query T
 EXPLAIN INSERT INTO large_child SELECT i, i % 10 + 1 FROM generate_series(1, 10000) AS i
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2075,7 +2033,6 @@ query T
 EXPLAIN DELETE FROM partial_parent WHERE id = 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2106,7 +2063,6 @@ query T
 EXPLAIN UPDATE partial_parent SET id = 2 WHERE id = 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -186,7 +186,6 @@ query T
 EXPLAIN SELECT * FROM g WHERE a >= 9 AND a < 12
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (25% of the table; stats collected <hidden> ago; using stats forecast)
@@ -414,7 +413,6 @@ query T
 EXPLAIN SELECT * FROM s WHERE b >= 0 AND b < 12
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (100% of the table; stats collected <hidden> ago; using stats forecast)
@@ -594,7 +592,6 @@ query T
 EXPLAIN SELECT * FROM c WHERE h >= '1988-08-07'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 24 (100% of the table; stats collected <hidden> ago; using stats forecast)
@@ -879,7 +876,6 @@ query T
 EXPLAIN SELECT * FROM d WHERE d >= '1999-12-16'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -909,7 +905,6 @@ query T
 EXPLAIN SELECT * FROM g WHERE a > 8
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (11% of the table; stats collected <hidden> ago)
@@ -933,7 +928,6 @@ query T
 EXPLAIN SELECT * FROM s WHERE b < 3
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -958,7 +952,6 @@ query T
 EXPLAIN SELECT * FROM c WHERE h > '1988-08-07'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (4.2% of the table; stats collected <hidden> ago)
@@ -982,7 +975,6 @@ query T
 EXPLAIN SELECT * FROM x WHERE a > 16
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (25% of the table; stats collected <hidden> ago)
@@ -1006,7 +998,6 @@ query T
 EXPLAIN SELECT * FROM d WHERE d >= '1999-12-16'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -1034,7 +1025,6 @@ query T
 EXPLAIN SELECT * FROM g WHERE a > 8
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (25% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1059,7 +1049,6 @@ query T
 EXPLAIN SELECT * FROM s WHERE b < 3
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (100% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1084,7 +1073,6 @@ query T
 EXPLAIN SELECT * FROM c WHERE h > '1988-08-07'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 23 (96% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1109,7 +1097,6 @@ query T
 EXPLAIN SELECT * FROM x WHERE a > 16
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 2 (50% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1134,7 +1121,6 @@ query T
 EXPLAIN SELECT * FROM d WHERE d >= '1999-12-16'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -1165,7 +1151,6 @@ query T
 EXPLAIN SELECT * FROM g WHERE a > 8
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (11% of the table; stats collected <hidden> ago)
@@ -1176,7 +1161,6 @@ query T
 EXPLAIN SELECT * FROM s WHERE b < 3
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -1187,7 +1171,6 @@ query T
 EXPLAIN SELECT * FROM c WHERE h > '1988-08-07'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (4.2% of the table; stats collected <hidden> ago)
@@ -1198,7 +1181,6 @@ query T
 EXPLAIN SELECT * FROM x WHERE a > 16
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (25% of the table; stats collected <hidden> ago)
@@ -1209,7 +1191,6 @@ query T
 EXPLAIN SELECT * FROM d WHERE d >= '1999-12-16'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -1226,7 +1207,6 @@ query T
 EXPLAIN SELECT * FROM c WHERE h > '1988-08-07'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 23 (96% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1243,7 +1223,6 @@ query T
 EXPLAIN SELECT * FROM g WHERE a > 8
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (25% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1254,7 +1233,6 @@ query T
 EXPLAIN SELECT * FROM s WHERE b < 3
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (100% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1265,7 +1243,6 @@ query T
 EXPLAIN SELECT * FROM c WHERE h > '1988-08-07'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 23 (96% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1276,7 +1253,6 @@ query T
 EXPLAIN SELECT * FROM x WHERE a > 16
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 2 (50% of the table; stats collected <hidden> ago; using stats forecast)
@@ -1287,7 +1263,6 @@ query T
 EXPLAIN SELECT * FROM d WHERE d >= '1999-12-16'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3 (100% of the table; stats collected <hidden> ago)
@@ -1544,7 +1519,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a = 3 AND b = 13
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ estimated row count: 1
@@ -1587,7 +1561,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a = 3 AND b = 13
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ estimated row count: 1
@@ -1869,7 +1842,6 @@ query T
 EXPLAIN SELECT * FROM t_103958
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 3,000 (100% of the table; stats collected <hidden> ago)
@@ -2349,7 +2321,6 @@ query T
 EXPLAIN UPDATE st SET t = '2024-04-09 19:05:00.000000' WHERE s >= 0 AND s < 10 AND t IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: st

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
@@ -18400,7 +18400,6 @@ query T
 EXPLAIN SELECT c FROM t1401 WHERE c >= '2022-01-25T21:17:27.216095Z'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
@@ -18423,7 +18422,6 @@ LIMIT
   100
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 100
@@ -18450,7 +18448,6 @@ query T
 EXPLAIN SELECT c FROM t1401 WHERE c >= '2022-01-25T21:17:27.216095Z'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 179,489,803 (2.7% of the table; stats collected <hidden> ago; using stats forecast)
@@ -18473,7 +18470,6 @@ LIMIT
   100
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 100

--- a/pkg/sql/opt/exec/execbuilder/testdata/group_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/group_join
@@ -12,7 +12,6 @@ query T
 EXPLAIN (DISTSQL) SELECT data1.a, sum(data1.d) FROM data AS data1 INNER HASH JOIN data AS data2 ON data1.a = data2.c GROUP BY data1.a
 ----
 distribution: local
-vectorized: true
 ·
 • group (hash)
 │ group by: a
@@ -40,7 +39,6 @@ query T
 EXPLAIN (DISTSQL) SELECT data1.a, sum(data1.d) FROM data AS data1 INNER HASH JOIN data AS data2 ON data1.a = data2.c GROUP BY data1.a
 ----
 distribution: local
-vectorized: true
 ·
 • group (hash)
 │ group by: a

--- a/pkg/sql/opt/exec/execbuilder/testdata/information_schema
+++ b/pkg/sql/opt/exec/execbuilder/testdata/information_schema
@@ -15,7 +15,6 @@ query T
 EXPLAIN SELECT * FROM system.information_schema.tables WHERE table_name='foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: table_name = 'foo'

--- a/pkg/sql/opt/exec/execbuilder/testdata/inner-join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inner-join
@@ -14,7 +14,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: a, b
@@ -61,7 +60,6 @@ query T
 EXPLAIN SELECT c FROM abc WHERE EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: a, b
@@ -108,7 +106,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 ----
 distribution: local
-vectorized: true
 ·
 • intersect all
 │
@@ -143,7 +140,6 @@ query T
 EXPLAIN SELECT c FROM abc WHERE NOT EXISTS (SELECT * FROM def WHERE a=d OR a=e)
 ----
 distribution: local
-vectorized: true
 ·
 • intersect all
 │
@@ -178,7 +174,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abc, def WHERE a=d OR a=e
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: a, b, d, e
@@ -216,7 +211,6 @@ query T
 EXPLAIN SELECT c FROM abc, def WHERE a=d OR a=e
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: a, b, d, e

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -364,7 +364,6 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -382,7 +381,6 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -402,7 +400,6 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -422,7 +419,6 @@ query T
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: insert_t(x, v, rowid)
@@ -484,7 +480,6 @@ query T
 EXPLAIN (PLAN) INSERT INTO kv@a VALUES (1,1), (2,2)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: kv(k, v)
@@ -559,7 +554,6 @@ query T
 EXPLAIN INSERT INTO kv VALUES (1, (SELECT v FROM kv))
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -591,7 +585,6 @@ query T
 EXPLAIN INSERT INTO kv VALUES (1, foo())
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: kv(k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial
@@ -15,7 +15,6 @@ query T
 EXPLAIN (DISTSQL) SELECT k FROM geo_table2 WHERE ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: st_intersects('010100000000000000000008400000000000000840', geom)
@@ -38,7 +37,6 @@ query T
 EXPLAIN (DISTSQL) SELECT k, k_plus_one FROM geo_table2 WHERE ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: st_intersects('010100000000000000000008400000000000000840', geom)
@@ -61,7 +59,6 @@ query T
 EXPLAIN SELECT k, k_plus_one FROM geo_table2 WHERE ST_Intersects('POINT(3.0 3.0)'::geometry, geom)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: st_intersects('010100000000000000000008400000000000000840', geom)
@@ -82,7 +79,6 @@ query T
 EXPLAIN SELECT k, k_plus_one FROM geo_table2 WHERE ST_DFullyWithin('POINT(3.0 3.0)'::geometry, geom, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: st_dfullywithin('010100000000000000000008400000000000000840', geom, 1.0)
@@ -107,7 +103,6 @@ query T
 EXPLAIN SELECT k FROM geo_table2 WHERE geom && 'POINT(3.0 3.0)'::geometry
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: geom && '010100000000000000000008400000000000000840'
@@ -128,7 +123,6 @@ query T
 EXPLAIN SELECT k FROM geo_table2 WHERE 'POINT(3.0 3.0)'::geometry::box2d && geom
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: 'BOX(3 3,3 3)' && geom
@@ -149,7 +143,6 @@ query T
 EXPLAIN SELECT k FROM geo_table2 WHERE 'LINESTRING(1.0 1.0, 5.0 5.0)'::geometry ~ geom
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: '010200000002000000000000000000F03F000000000000F03F00000000000014400000000000001440' ~ geom
@@ -170,7 +163,6 @@ query T
 EXPLAIN SELECT k FROM geo_table2 WHERE geom ~ 'LINESTRING(1.0 1.0, 5.0 5.0)'::geometry::box2d
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: geom ~ 'BOX(1 1,5 5)'

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
@@ -23,7 +23,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k
@@ -74,7 +73,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k
@@ -113,7 +111,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k
@@ -141,7 +138,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k
@@ -184,7 +180,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_Intersects('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +k
@@ -215,7 +210,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +k
@@ -263,7 +257,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE geom && 'POINT(3.0 3.0)'::geometry
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ filter: geom && '010100000000000000000008400000000000000840'
@@ -287,7 +280,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE 'POINT(3.0 3.0)'::geometry::box2d && geom
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ filter: 'BOX(3 3,3 3)' && geom
@@ -311,7 +303,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE 'LINESTRING(1.0 1.0, 5.0 5.0)'::geometry ~ geom
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ filter: '010200000002000000000000000000F03F000000000000F03F00000000000014400000000000001440' ~ geom
@@ -335,7 +326,6 @@ EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE geom ~ 'LINESTRING(1.0 1.0, 5.0 5.0)'::geometry::box2d
 ----
 distribution: full
-vectorized: true
 ·
 • filter
 │ filter: geom ~ 'BOX(1 1,5 5)'

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_json_array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_json_array
@@ -25,7 +25,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '1' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -40,7 +39,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '[1, 2]' OR b @> '[3, 4]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -59,7 +57,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '{"a": {}}' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -78,7 +75,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '{"a": []}' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -97,7 +93,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '[[1, 2]]' OR b @> '[[3, 4]]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b @> '[[1, 2]]') OR (b @> '[[3, 4]]')
@@ -122,7 +117,6 @@ query T
 EXPLAIN SELECT a FROM json_tab@foo_inv WHERE b @> '[1]' OR b @> '[2]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -141,7 +135,6 @@ query T
 EXPLAIN SELECT * FROM json_tab@foo_inv WHERE b @> '[3]' OR b @> '[[1, 2]]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b @> '[3]') OR (b @> '[[1, 2]]')
@@ -168,7 +161,6 @@ WHERE (b @> '[1]'::json OR b @> '[2]'::json) AND (b @> '3'::json OR b @> '"bar"'
 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -187,7 +179,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '[1]' AND a % 2 = 0 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -205,7 +196,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '[1]' OR a = 44 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: a
@@ -237,7 +227,6 @@ query T
 EXPLAIN SELECT a FROM json_tab WHERE b @> '[1]' OR sqrt(a::decimal) = 2 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b @> '[1]') OR (sqrt(a::DECIMAL) = 2)
@@ -252,7 +241,6 @@ query T
 EXPLAIN SELECT a FROM array_tab@foo_inv WHERE b @> '{}' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -271,7 +259,6 @@ query T
 EXPLAIN SELECT a FROM array_tab WHERE b @> '{1}' AND a % 2 = 0 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -289,7 +276,6 @@ query T
 EXPLAIN SELECT a FROM array_tab WHERE b @> '{1}' OR a = 1 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: a
@@ -321,7 +307,6 @@ query T
 EXPLAIN SELECT a FROM array_tab WHERE (b @> '{2}' AND a = 3) OR b[0] = a ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: ((b @> ARRAY[2]) AND (a = 3)) OR (a = b[0])

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_json_array_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_json_array_dist
@@ -82,7 +82,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '1' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -100,7 +99,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1, 2]' OR b @> '[3, 4]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -122,7 +120,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '{"a": {}}' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -144,7 +141,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '{"a": []}' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -166,7 +162,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[[1, 2]]' OR b @> '[[3, 4]]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b @> '[[1, 2]]') OR (b @> '[[3, 4]]')
@@ -194,7 +189,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1]' OR b @> '[2]' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -216,7 +210,6 @@ EXPLAIN (DISTSQL)
 SELECT * FROM json_tab WHERE b @> '[3]' OR b @> '[[1, 2]]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b @> '[3]') OR (b @> '[[1, 2]]')
@@ -246,7 +239,6 @@ WHERE (b @> '[1]'::json OR b @> '[2]'::json) AND (b @> '3'::json OR b @> '"bar"'
 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -268,7 +260,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1]' AND a % 2 = 0 ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -289,7 +280,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1]' OR a = 44 ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: a
@@ -321,7 +311,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM json_tab WHERE b @> '[1]' OR sqrt(a::decimal) = 2 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b @> '[1]') OR (sqrt(a::DECIMAL) = 2)
@@ -364,7 +353,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM array_tab WHERE b @> '{}' ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -386,7 +374,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM array_tab WHERE b @> '{1}' AND a % 2 = 0 ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -407,7 +394,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM array_tab WHERE b @> '{1}' OR a = 1 ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • distinct
 │ distinct on: a
@@ -439,7 +425,6 @@ EXPLAIN (DISTSQL)
 SELECT a FROM array_tab WHERE (b @> '{2}' AND a = 3) OR b[0] = a ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: ((b @> ARRAY[2]) AND (a = 3)) OR (a = b[0])

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -141,7 +141,6 @@ query T
 EXPLAIN SELECT * FROM e WHERE b @> ARRAY[8]
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: e@e_pkey
@@ -155,7 +154,6 @@ query T
 EXPLAIN SELECT * FROM e WHERE b = ARRAY[8]
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = ARRAY[8]
@@ -172,7 +170,6 @@ query T
 EXPLAIN SELECT * FROM e WHERE b @> ARRAY[8]
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: e@e_pkey
@@ -186,7 +183,6 @@ query T
 EXPLAIN SELECT * FROM e WHERE b = ARRAY[8]
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -782,7 +778,6 @@ query T
 EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -803,7 +798,6 @@ query T
 EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -2764,7 +2758,6 @@ query T
 EXPLAIN SELECT a FROM d WHERE b @> '[1, 2]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ estimated row count: 1,247
@@ -2789,7 +2782,6 @@ query T
 EXPLAIN SELECT a FROM d WHERE b @> '[1]' AND b @> '[2]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ estimated row count: 1,247
@@ -2814,7 +2806,6 @@ query T
 EXPLAIN SELECT a FROM d WHERE b @> '[[1, 2]]' ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1,247

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -25,52 +25,38 @@ EXPLAIN ANALYZE (DISTSQL) SELECT k FROM geo_table WHERE ST_Intersects('SRID=2691
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • sort
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 2
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 2
 │ order: +k
 │
 └── • filter
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 2
     │ execution time: 0µs
+    │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 2
         │ KV time: 0µs
         │ KV rows decoded: 2
-        │ KV pairs read: 4
-        │ KV bytes read: 16 B
-        │ KV gRPC calls: 2
-        │ estimated max memory allocated: 0 B
-        │ estimated max sql temp disk usage: 0 B
+        │ actual row count: 2
         │ table: geo_table@geo_table_pkey
         │
         └── • inverted filter
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 2
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
-            │ estimated max sql temp disk usage: 0 B
+            │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
@@ -78,13 +64,9 @@ quality of service: regular
                   sql nodes: <hidden>
                   kv nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 4
                   KV time: 0µs
                   KV rows decoded: 4
-                  KV pairs read: 8
-                  KV bytes read: 32 B
-                  KV gRPC calls: 4
-                  estimated max memory allocated: 0 B
+                  actual row count: 4
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans
@@ -120,52 +102,38 @@ EXPLAIN ANALYZE (DISTSQL) SELECT k FROM geo_table WHERE ST_Intersects('SRID=2691
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • sort
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 2
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 2
 │ order: +k
 │
 └── • filter
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 2
     │ execution time: 0µs
+    │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 2
         │ KV time: 0µs
         │ KV rows decoded: 2
-        │ KV pairs read: 4
-        │ KV bytes read: 16 B
-        │ KV gRPC calls: 2
-        │ estimated max memory allocated: 0 B
-        │ estimated max sql temp disk usage: 0 B
+        │ actual row count: 2
         │ table: geo_table@geo_table_pkey
         │
         └── • inverted filter
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 2
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
-            │ estimated max sql temp disk usage: 0 B
+            │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
@@ -173,13 +141,9 @@ quality of service: regular
                   sql nodes: <hidden>
                   kv nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 2
                   KV time: 0µs
                   KV rows decoded: 2
-                  KV pairs read: 4
-                  KV bytes read: 16 B
-                  KV gRPC calls: 2
-                  estimated max memory allocated: 0 B
+                  actual row count: 2
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans
@@ -199,52 +163,38 @@ EXPLAIN ANALYZE (DISTSQL) SELECT k FROM geo_table WHERE ST_Intersects('SRID=2691
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • sort
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 2
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 2
 │ order: +k
 │
 └── • filter
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 2
     │ execution time: 0µs
+    │ actual row count: 2
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 2
         │ KV time: 0µs
         │ KV rows decoded: 2
-        │ KV pairs read: 4
-        │ KV bytes read: 16 B
-        │ KV gRPC calls: 2
-        │ estimated max memory allocated: 0 B
-        │ estimated max sql temp disk usage: 0 B
+        │ actual row count: 2
         │ table: geo_table@geo_table_pkey
         │
         └── • inverted filter
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 2
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
-            │ estimated max sql temp disk usage: 0 B
+            │ actual row count: 2
             │ inverted column: geom_inverted_key
             │ num spans: 31
             │
@@ -252,13 +202,9 @@ quality of service: regular
                   sql nodes: <hidden>
                   kv nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 2
                   KV time: 0µs
                   KV rows decoded: 2
-                  KV pairs read: 4
-                  KV bytes read: 16 B
-                  KV gRPC calls: 2
-                  estimated max memory allocated: 0 B
+                  actual row count: 2
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -24,7 +24,6 @@ EXPLAIN (DISTSQL)
 SELECT lk, rk1 FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom1, rtable.geom)
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -47,7 +46,6 @@ EXPLAIN SELECT lk, rk1, rk2, rtable.geom
 FROM ltable JOIN rtable@geom_index ON ST_Intersects(ltable.geom1, rtable.geom)
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -68,7 +66,6 @@ EXPLAIN SELECT lk, rk1, rk2, rtable.geom
 FROM ltable JOIN rtable@geom_index ON ST_DWithin(ltable.geom1, rtable.geom, 5)
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -314,14 +311,8 @@ SELECT count(*), (SELECT count(*) FROM q) FROM (
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
@@ -330,22 +321,17 @@ quality of service: regular
 │   └── • group (hash)
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
-│       │ estimated max memory allocated: 0 B
-│       │ estimated max sql temp disk usage: 0 B
+│       │ actual row count: 0
 │       │ group by: lk
 │       │
 │       └── • lookup join (left outer) (streamer)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 0
 │           │ KV time: 0µs
 │           │ KV rows decoded: 0
-│           │ KV bytes read: 0 B
-│           │ KV gRPC calls: 0
 │           │ execution time: 0µs
-│           │ estimated max memory allocated: 0 B
+│           │ actual row count: 0
 │           │ table: rtable@rtable_pkey
 │           │ equality: (rk1, rk2) = (rk1, rk2)
 │           │ equality cols are key
@@ -354,21 +340,17 @@ quality of service: regular
 │           └── • inverted join (left outer)
 │               │ sql nodes: <hidden>
 │               │ regions: <hidden>
-│               │ actual row count: 0
 │               │ KV time: 0µs
 │               │ KV rows decoded: 0
-│               │ KV bytes read: 0 B
-│               │ KV gRPC calls: 0
 │               │ execution time: 0µs
-│               │ estimated max memory allocated: 0 B
-│               │ estimated max sql temp disk usage: 0 B
+│               │ actual row count: 0
 │               │ table: rtable@geom_index
 │               │
 │               └── • scan buffer
 │                     sql nodes: <hidden>
 │                     regions: <hidden>
-│                     actual row count: 0
 │                     execution time: 0µs
+│                     actual row count: 0
 │                     label: buffer 1 (q)
 │
 ├── • subquery
@@ -379,20 +361,17 @@ quality of service: regular
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │ label: buffer 1 (q)
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
 │             kv nodes: <hidden>
 │             regions: <hidden>
-│             actual row count: 0
 │             KV time: 0µs
 │             KV rows decoded: 0
-│             KV bytes read: 0 B
-│             KV gRPC calls: 0
-│             estimated max memory allocated: 0 B
+│             actual row count: 0
 │             missing stats
 │             table: ltable@ltable_pkey
 │             spans: [/3 - ]
@@ -405,14 +384,14 @@ quality of service: regular
     └── • group (scalar)
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 1
         │ execution time: 0µs
+        │ actual row count: 1
         │
         └── • scan buffer
               sql nodes: <hidden>
               regions: <hidden>
-              actual row count: 0
               execution time: 0µs
+              actual row count: 0
               label: buffer 1 (q)
 
 # Anti joins are also converted to paired joins by the optimizer.
@@ -623,7 +602,6 @@ query T
 EXPLAIN SELECT g1.k, g2.k FROM g@foo_inv AS g1, g@g_pkey AS g2 WHERE ST_Contains(g1.geom, g2.geom) ORDER BY g1.k, g2.k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k,+k
@@ -647,7 +625,6 @@ query T
 EXPLAIN SELECT g1.k, g2.k FROM g@g_pkey AS g1, g@g_pkey AS g2 WHERE ST_Contains(g1.geom, g2.geom) ORDER BY g1.k, g2.k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k,+k
@@ -674,7 +651,6 @@ WHERE ST_Contains(g1.geom, g2.geom)
 ORDER BY g1.k, g2.k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k,+k
@@ -702,7 +678,6 @@ WHERE ST_Contains(g1.geom, g2.geom)
 ORDER BY g1.k, g2.k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k,+k

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
@@ -49,7 +49,6 @@ EXPLAIN (DISTSQL) SELECT lk, rk FROM ltable JOIN rtable@geom_index
 ON ST_Intersects(ltable.geom1, rtable.geom) ORDER BY (lk, rk)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk
@@ -76,7 +75,6 @@ EXPLAIN (DISTSQL) SELECT lk, rk FROM ltable JOIN rtable@geom_index
 ON ST_Intersects(rtable.geom, ltable.geom1) OR ST_DWithin(ltable.geom1, rtable.geom, 2) ORDER BY (lk, rk)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk
@@ -103,7 +101,6 @@ EXPLAIN (DISTSQL) SELECT lk, rk FROM ltable JOIN rtable@geom_index
 ON ST_Intersects(ltable.geom1, rtable.geom) AND ST_DWithin(rtable.geom, ltable.geom1, 2) ORDER BY (lk, rk)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk
@@ -132,7 +129,6 @@ ON ST_Intersects(ltable.geom1, rtable.geom) AND ST_Covers(ltable.geom2, rtable.g
 AND (ST_DFullyWithin(rtable.geom, ltable.geom1, 100) OR ST_Intersects('POINT(1.0 1.0)', rtable.geom))
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -157,7 +153,6 @@ EXPLAIN (DISTSQL)
 SELECT lk FROM ltable WHERE EXISTS (SELECT * FROM rtable WHERE ST_Intersects(ltable.geom2, rtable.geom))
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (semi)
 │ table: rtable@rtable_pkey
@@ -181,7 +176,6 @@ EXPLAIN (DISTSQL)
 SELECT lk, rk FROM ltable LEFT JOIN rtable ON ST_Intersects(ltable.geom1, rtable.geom)
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (left outer)
 │ table: rtable@rtable_pkey
@@ -205,7 +199,6 @@ SELECT lk, rk FROM ltable LEFT JOIN rtable@geom_index
 ON ST_Intersects(rtable.geom, ltable.geom1) OR ST_DWithin(ltable.geom1, rtable.geom, 2) ORDER BY (lk, rk)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk
@@ -233,7 +226,6 @@ SELECT lk, rk FROM ltable LEFT JOIN rtable@geom_index
 ON ST_Intersects(ltable.geom1, rtable.geom) OR ST_DWithin(rtable.geom, ltable.geom2, 2) ORDER BY (lk, rk)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk
@@ -267,7 +259,6 @@ SELECT count(*), (SELECT count(*) FROM q) FROM (
 ) GROUP BY lk
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -319,7 +310,6 @@ EXPLAIN (DISTSQL)
 SELECT lk FROM ltable WHERE NOT EXISTS (SELECT * FROM rtable WHERE ST_Intersects(ltable.geom2, rtable.geom))
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (anti)
 │ table: rtable@rtable_pkey
@@ -345,7 +335,6 @@ WHERE NOT EXISTS (
 ) ORDER BY lk
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (anti)
 │ table: rtable@rtable_pkey
@@ -373,7 +362,6 @@ EXPLAIN (DISTSQL)
 SELECT lk, rk FROM ltable JOIN rtable@geom_index ON ltable.geom1 ~ rtable.geom
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -396,7 +384,6 @@ EXPLAIN (DISTSQL)
 SELECT lk, rk FROM ltable JOIN rtable@geom_index ON rtable.geom ~ ltable.geom1
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -419,7 +406,6 @@ EXPLAIN (DISTSQL)
 SELECT lk, rk FROM ltable JOIN rtable@geom_index ON rtable.geom && ltable.geom1
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
@@ -463,7 +449,6 @@ SELECT lk, rk1, rk2 FROM ltable JOIN rtable2@geom_index
 ON ST_Intersects(ltable.geom1, rtable2.geom) ORDER BY (lk, rk1, rk2)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk1,+rk2
@@ -491,7 +476,6 @@ SELECT lk, rk1, rk2 FROM ltable LEFT JOIN rtable2@geom_index
 ON ST_Intersects(ltable.geom1, rtable2.geom) ORDER BY (lk, rk1, rk2)
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +lk,+rk1,+rk2
@@ -519,7 +503,6 @@ SELECT lk FROM ltable WHERE EXISTS (SELECT * FROM rtable2@geom_index
 WHERE ST_Intersects(ltable.geom1, rtable2.geom)) ORDER BY lk
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (semi)
 │ table: rtable2@rtable2_pkey
@@ -543,7 +526,6 @@ SELECT lk FROM ltable WHERE NOT EXISTS (SELECT * FROM rtable2@geom_index
 WHERE ST_Intersects(ltable.geom1, rtable2.geom)) ORDER BY lk
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (anti)
 │ table: rtable2@rtable2_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array
@@ -23,7 +23,6 @@ query T
 EXPLAIN SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b @> j2.b ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -47,7 +46,6 @@ query T
 EXPLAIN SELECT * FROM json_tab@json_tab_pkey AS j1, json_tab AS j2 WHERE j1.b @> j2.b ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -70,7 +68,6 @@ query T
 EXPLAIN SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -94,7 +91,6 @@ query T
 EXPLAIN SELECT * FROM json_tab@json_tab_pkey AS j1 CROSS HASH JOIN json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -119,7 +115,6 @@ ON j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -145,7 +140,6 @@ WHERE j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -173,7 +167,6 @@ ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -199,7 +192,6 @@ ON j1.b ? (j2.b ->> 'a')
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -225,7 +217,6 @@ ON j1.b ? (j2.b ->> 'a') AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -251,7 +242,6 @@ ON j1.b @> j2.b AND j1.b ? (j2.b ->> 'a')
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -281,7 +271,6 @@ EXPLAIN SELECT * FROM text_array_tab AS t INNER INVERTED JOIN json_tab AS j
 ON j.b ?| t.b ORDER BY t.a, j.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -306,7 +295,6 @@ EXPLAIN SELECT * FROM text_array_tab AS t INNER INVERTED JOIN json_tab AS j
 ON j.b ?& t.b ORDER BY j.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -332,7 +320,6 @@ WHERE j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -360,7 +347,6 @@ ON j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -387,7 +373,6 @@ ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -416,7 +401,6 @@ EXPLAIN SELECT * FROM json_tab AS j2 WHERE EXISTS (
 ORDER BY j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (semi)
 │ table: json_tab@json_tab_pkey
@@ -441,7 +425,6 @@ EXPLAIN SELECT * FROM json_tab AS j2 WHERE EXISTS (
 ORDER BY j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (semi)
 │ table: json_tab@json_tab_pkey
@@ -466,7 +449,6 @@ EXPLAIN SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
 ORDER BY j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: json_tab@json_tab_pkey
@@ -492,7 +474,6 @@ EXPLAIN SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
 ORDER BY j2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: json_tab@json_tab_pkey
@@ -514,7 +495,6 @@ query T
 EXPLAIN SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -538,7 +518,6 @@ query T
 EXPLAIN SELECT * FROM array_tab@array_tab_pkey AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -561,7 +540,6 @@ query T
 EXPLAIN SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b <@ a2.b ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -585,7 +563,6 @@ query T
 EXPLAIN SELECT * FROM array_tab@array_tab_pkey AS a1 CROSS HASH JOIN array_tab AS a2 WHERE a1.b <@ a2.b ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -611,7 +588,6 @@ ON a1.b @> a2.b AND a1.b @> '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -637,7 +613,6 @@ WHERE a1.b @> a2.b AND a1.b @> '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -666,7 +641,6 @@ ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -695,7 +669,6 @@ ON a1.b && a2.b AND a2.a > 1 AND a2.a < 7
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -729,7 +702,6 @@ ON a2.b && a1.b AND a2.a > 1 AND a2.a < 7
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -755,7 +727,6 @@ WHERE a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -784,7 +755,6 @@ ON a1.b @> a2.b AND a1.b @> '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -812,7 +782,6 @@ ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -841,7 +810,6 @@ EXPLAIN SELECT a2.* FROM array_tab@array_tab_pkey AS a2 WHERE EXISTS (
 ORDER BY a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (semi)
 │ table: array_tab@array_tab_pkey
@@ -866,7 +834,6 @@ EXPLAIN SELECT a2.* FROM array_tab@array_tab_pkey AS a2 WHERE EXISTS (
 ORDER BY a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (semi)
 │ table: array_tab@array_tab_pkey
@@ -891,7 +858,6 @@ EXPLAIN SELECT a2.* FROM array_tab@array_tab_pkey AS a2 WHERE NOT EXISTS (
 ORDER BY a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: array_tab@array_tab_pkey
@@ -916,7 +882,6 @@ EXPLAIN SELECT a2.* FROM array_tab@array_tab_pkey AS a2 WHERE NOT EXISTS (
 ORDER BY a2.a
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: array_tab@array_tab_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array_dist
@@ -76,7 +76,6 @@ EXPLAIN (DISTSQL)
 SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b @> j2.b ORDER BY j1.a, j2.a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -105,7 +104,6 @@ SELECT info FROM [EXPLAIN (DISTSQL)
 SELECT * FROM json_tab@json_tab_pkey AS j1, json_tab AS j2 WHERE j1.b @> j2.b ORDER BY j1.a, j2.a
 ] WHERE info NOT LIKE 'distribution:%'
 ----
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -133,7 +131,6 @@ ON j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -162,7 +159,6 @@ WHERE j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ] WHERE info NOT LIKE 'distribution:%'
 ----
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -193,7 +189,6 @@ ON j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
 ORDER BY j1.a, j2.a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -225,7 +220,6 @@ SELECT * FROM json_tab AS j2 WHERE EXISTS (
 ORDER BY j2.a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (semi)
 │ table: json_tab@json_tab_pkey
@@ -253,7 +247,6 @@ SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
 ORDER BY j2.a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (anti)
 │ table: json_tab@json_tab_pkey
@@ -301,7 +294,6 @@ EXPLAIN (DISTSQL)
 SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER BY a1.a, a2.a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -328,7 +320,6 @@ SELECT info FROM [EXPLAIN (DISTSQL)
 SELECT * FROM array_tab@array_tab_pkey AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER BY a1.a, a2.a
 ] WHERE info NOT LIKE 'distribution:%'
 ----
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -357,7 +348,6 @@ ON a1.b @> a2.b AND a1.b @> '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -386,7 +376,6 @@ WHERE a1.b @> a2.b AND a1.b @> '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ] WHERE info NOT LIKE 'distribution:%'
 ----
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -418,7 +407,6 @@ ON a1.b @> a2.b AND a1.b @> '{1}' AND a2.a < 5
 ORDER BY a1.a, a2.a
 ----
 distribution: full
-vectorized: true
 ·
 • sort
 │ order: +a,+a
@@ -450,7 +438,6 @@ SELECT a2.* FROM array_tab@array_tab_pkey AS a2 WHERE EXISTS (
 ORDER BY a2.a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (semi)
 │ table: array_tab@array_tab_pkey
@@ -478,7 +465,6 @@ SELECT a2.* FROM array_tab@array_tab_pkey AS a2 WHERE NOT EXISTS (
 ORDER BY a2.a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (anti)
 │ table: array_tab@array_tab_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
@@ -30,7 +30,6 @@ FROM j1 INNER INVERTED JOIN j2
 ON i IN (10, 20) AND j2.j @> j1.j
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: j2@j2_pkey
@@ -57,7 +56,6 @@ FROM j1 INNER INVERTED JOIN j2@isj_idx
 ON i = 10 AND s IN ('foo', 'bar') AND j2.j @> j1.j
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: j2@j2_pkey
@@ -86,7 +84,6 @@ FROM j1 INNER INVERTED JOIN j2
 ON i IN (10, 20) AND j2.j <@ j1.j
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: j2@j2_pkey
@@ -113,7 +110,6 @@ FROM j1 INNER INVERTED JOIN j2@isj_idx
 ON i = 10 AND s IN ('foo', 'bar') AND j2.j <@ j1.j
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: j2@j2_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column_dist
@@ -92,7 +92,6 @@ EXPLAIN (DISTSQL)
 SELECT * FROM j2@ij_idx, j1 WHERE i IN (2, 3) AND j2.j @> j1.j ORDER BY j1.k, j2.k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k,+k
@@ -173,7 +172,6 @@ EXPLAIN (DISTSQL)
 SELECT * FROM a2@ia_idx, a1 WHERE i IN (2, 3) AND a2.a @> a1.a ORDER BY a1.k, a2.k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +k,+k

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -12,7 +12,6 @@ query T
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (x) = (x)
@@ -31,7 +30,6 @@ query T
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (x) = (y)
@@ -50,7 +48,6 @@ query T
 EXPLAIN SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 distribution: local
-vectorized: true
 ·
 • cross join
 │
@@ -71,7 +68,6 @@ query T
 EXPLAIN SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (x) = (y)
@@ -90,7 +86,6 @@ query T
 EXPLAIN SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (x) = (y)
@@ -114,7 +109,6 @@ EXPLAIN SELECT * FROM
 LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 1
@@ -539,7 +533,6 @@ query T
 EXPLAIN SELECT * FROM cards LEFT OUTER JOIN customers ON customers.id = cards.cust
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -561,7 +554,6 @@ query T
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (b) = (n)
@@ -1708,7 +1700,6 @@ query T
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (a, b) = (a, b)
@@ -1954,7 +1945,6 @@ query T
 EXPLAIN SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (a, c) = (a, c)
@@ -1987,7 +1977,6 @@ query T
 EXPLAIN SELECT a,b,c FROM zigzag@{NO_ZIGZAG_JOIN} WHERE b = 5 AND c = 6.0
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c = 6.0
@@ -2007,7 +1996,6 @@ query T
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c = 6.0
@@ -2029,7 +2017,6 @@ query T
 EXPLAIN SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 distribution: local
-vectorized: true
 ·
 • zigzag join
   pred: (b = 5) AND (c = 6.0)
@@ -2046,7 +2033,6 @@ query T
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: zigzag@zigzag_pkey
@@ -2067,7 +2053,6 @@ query T
 EXPLAIN SELECT a,b,c,d FROM zigzag WHERE b = 5 AND c = 6.0 AND d > 4
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: zigzag@zigzag_pkey
@@ -2102,7 +2087,6 @@ query T
 EXPLAIN SELECT * FROM zigzag2 WHERE a = 1 AND b = 2 AND c IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c IS NULL
@@ -2124,7 +2108,6 @@ query T
 EXPLAIN SELECT * FROM onecolumn INNER MERGE JOIN twocolumn USING(x)
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (x) = (x)
@@ -2150,7 +2133,6 @@ query T
 EXPLAIN SELECT * FROM onecolumn NATURAL INNER MERGE JOIN twocolumn
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (x) = (x)
@@ -2176,7 +2158,6 @@ query T
 EXPLAIN SELECT * FROM onecolumn CROSS MERGE JOIN twocolumn WHERE onecolumn.x = twocolumn.x
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (x) = (x)
@@ -2211,7 +2192,6 @@ query T
 EXPLAIN SELECT * FROM cards LEFT OUTER HASH JOIN customers ON customers.id = cards.cust
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/json
+++ b/pkg/sql/opt/exec/execbuilder/testdata/json
@@ -9,7 +9,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x = 'null'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -20,7 +19,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x = '"a"'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -31,7 +29,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x = '1'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -42,7 +39,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x = 'false'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -53,7 +49,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x = 'true'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -64,7 +59,6 @@ query T
 EXPLAIN SELECT x from t WHERE x = '[1, 2, 3]'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -76,7 +70,6 @@ query T
 EXPLAIN SELECT x from t WHERE x = '{"a": [1, 2, 3], "b": [1, 2]}'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -88,7 +81,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x < '1'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -99,7 +91,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x < '"ABCD"'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -110,7 +101,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x < '[1, 2, 3]'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -121,7 +111,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x <= '[]'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -132,7 +121,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x > '{"a": "b"}'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -143,7 +131,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x > '{"a": "b"}'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -154,7 +141,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x > '{"a": "b"}'::JSONB AND x < '[1, 2, 3]'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -162,7 +148,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x <= '{"a": "b"}'::JSONB AND x >= '[1, 2, 3]'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -173,7 +158,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x <= '"a"'::JSONB OR x >= 'null'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (x <= '"a"') OR (x >= 'null')
@@ -189,7 +173,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x IN ('1', '"a"', '[1, 2, 3]', '{"a": "b"}')
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -200,7 +183,6 @@ query T
 EXPLAIN SELECT x FROM t WHERE x IN ('null', '{}', '[]', '""')
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -217,7 +199,6 @@ query T
 EXPLAIN SELECT x, y, z FROM s WHERE x = 2 AND y < '[1, 2, 3]'::JSONB AND z = 100
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: z = 100
@@ -231,7 +212,6 @@ query T
 EXPLAIN SELECT x, y, z FROM s WHERE y >= '"a"'::JSONB
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: y >= '"a"'
@@ -297,7 +277,6 @@ query T
 EXPLAIN SELECT j from d where j->'a' = '"b"'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -312,7 +291,6 @@ query T
 EXPLAIN SELECT j from d where j->'a' = '"b"' OR j->'a' = '"bye"'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -327,7 +305,6 @@ query T
 EXPLAIN SELECT j from d where j > '{"a":"b"}'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: j > '{"a": "b"}'
@@ -341,7 +318,6 @@ query T
 EXPLAIN SELECT j from d where j->'a' = '1'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -355,7 +331,6 @@ query T
 EXPLAIN SELECT j from d where j->'a' = 'null'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -380,7 +355,6 @@ query T
 EXPLAIN SELECT j from d where j->'a' = '"forward"' AND j->'json' = '"inverted"'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: d@d_pkey
@@ -394,7 +368,6 @@ query T
 EXPLAIN SELECT j from d where j->'a' = '[1, 2, 3]' AND j->'json' = '{}'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (j->'json') = '{}'

--- a/pkg/sql/opt/exec/execbuilder/testdata/jsonb_path_query
+++ b/pkg/sql/opt/exec/execbuilder/testdata/jsonb_path_query
@@ -34,7 +34,6 @@ query T
 EXPLAIN SELECT jsonb_path_query(b, '$.a.b') FROM json_tab WHERE jsonb_path_exists(b, '$.a.b') ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -53,7 +52,6 @@ query T
 EXPLAIN SELECT jsonb_path_query(b, '$.a.b') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a.b') ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -76,7 +74,6 @@ query T
 EXPLAIN SELECT jsonb_path_query(b, '$.a.b.c') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a.b.c') ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -99,7 +96,6 @@ query T
 EXPLAIN SELECT a, jsonb_path_query(b, '$.a[*].b') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a[*].b') ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a
@@ -122,7 +118,6 @@ query T
 EXPLAIN SELECT a, jsonb_path_query(b, '$.a') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a') ORDER BY a;
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +a

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -1670,7 +1670,6 @@ EXPLAIN
     5;
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 5
@@ -1786,7 +1785,6 @@ query T retry
 EXPLAIN SELECT * FROM a INNER LOOKUP JOIN b ON k = j ORDER BY i LIMIT 5;
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 5
@@ -1806,7 +1804,6 @@ query T
 EXPLAIN SELECT oid, typname FROM pg_type ORDER BY oid LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 10
@@ -1819,7 +1816,6 @@ query T
 EXPLAIN SELECT oid, typname FROM pg_type LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table
   table: pg_type@primary
@@ -1831,7 +1827,6 @@ query T
 EXPLAIN SELECT oid, typname FROM pg_type WHERE OID BETWEEN 1 AND 1000 ORDER BY oid LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • limit
 │ count: 10
@@ -1846,7 +1841,6 @@ query T
 EXPLAIN SELECT * FROM generate_series(1, 10) ORDER BY row_number() OVER () LIMIT 1;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ estimated row count: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -555,7 +555,6 @@ FROM (SELECT * FROM data WHERE c = 1) AS l
 NATURAL JOIN (SELECT * FROM data WHERE c > 0) AS r
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join
 │ estimated row count: 1
@@ -694,7 +693,6 @@ query T
 EXPLAIN (DISTSQL) SELECT DISTINCT authors.name FROM books AS b1, books2 AS b2, authors WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ estimated row count: 96
@@ -777,7 +775,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books2 ON books2.edition = 1 WHERE books2.title = authors.book
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ estimated row count: 99
@@ -944,7 +941,6 @@ query T
 EXPLAIN (DISTSQL) SELECT t1.a, t2.b FROM small t1 LEFT JOIN large t2 ON t1.a = t2.a AND t2.b % 6 = 0 ORDER BY t1.a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (left outer)
 │ estimated row count: 100
@@ -1506,7 +1502,6 @@ query T
   SELECT a,b from small WHERE EXISTS (SELECT a FROM data WHERE small.a=data.a) ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (semi)
 │ estimated row count: 100
@@ -1525,7 +1520,6 @@ query T
   SELECT a,b from small WHERE a+b<20 AND EXISTS (SELECT a FROM data WHERE small.a=data.a AND small.b+data.c>15) ORDER BY a
 ----
 distribution: full
-vectorized: true
 ·
 • lookup join (semi)
 │ estimated row count: 11
@@ -2097,7 +2091,6 @@ ORDER BY numwait DESC, s_name
    LIMIT 100;
 ----
 distribution: full
-vectorized: true
 ·
 • top-k
 │ estimated row count: 1
@@ -2226,7 +2219,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1), (2)) AS u(y) LEFT JOIN t59615 t ON u.y = t.y
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (left outer)
 │ table: t59615@t59615_pkey
@@ -2243,7 +2235,6 @@ EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1), (2)) AS u(y) WHERE NOT EXISTS (
 )
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: t59615@t59615_pkey
@@ -2271,7 +2262,6 @@ EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, 10), (2, 20), (3, NULL)) AS u(w, x) 
 ON u.w = t.w AND u.x = t.x
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (left outer)
 │ table: lookup_expr@lookup_expr_r_x_y_z_w_idx
@@ -2290,7 +2280,6 @@ EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, 10), (2, 20), (3, NULL)) AS u(w, x) 
 )
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: lookup_expr@lookup_expr_r_x_y_z_w_idx
@@ -2344,7 +2333,6 @@ query T
 EXPLAIN SELECT * FROM abc INNER LOOKUP JOIN def_e_decimal ON f = b AND e <= a::DECIMAL ORDER BY a, b, c, d, e, f
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -85,15 +85,9 @@ EXPLAIN ANALYZE SELECT * FROM (SELECT * FROM a WHERE y = 1 UNION ALL SELECT * FR
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • limit
 │ count: 1
@@ -101,34 +95,25 @@ quality of service: regular
 └── • union all
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 1
     │ execution time: 0µs
+    │ actual row count: 1
     │
     ├── • index join (streamer)
     │   │ sql nodes: <hidden>
     │   │ kv nodes: <hidden>
     │   │ regions: <hidden>
-    │   │ actual row count: 1
     │   │ KV time: 0µs
     │   │ KV rows decoded: 1
-    │   │ KV pairs read: 2
-    │   │ KV bytes read: 8 B
-    │   │ KV gRPC calls: 1
-    │   │ estimated max memory allocated: 0 B
-    │   │ estimated max sql temp disk usage: 0 B
+    │   │ actual row count: 1
     │   │ table: a@a_pkey
     │   │
     │   └── • scan
     │         sql nodes: <hidden>
     │         kv nodes: <hidden>
     │         regions: <hidden>
-    │         actual row count: 1
     │         KV time: 0µs
     │         KV rows decoded: 1
-    │         KV pairs read: 2
-    │         KV bytes read: 8 B
-    │         KV gRPC calls: 1
-    │         estimated max memory allocated: 0 B
+    │         actual row count: 1
     │         missing stats
     │         table: a@a_y_idx
     │         spans: [/1 - /1]
@@ -136,24 +121,17 @@ quality of service: regular
     └── • index join (streamer)
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ KV time: 0µs
         │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
-        │ estimated max memory allocated: 0 B
-        │ estimated max sql temp disk usage: 0 B
+        │ actual row count: 0
         │ table: a@a_pkey
         │
         └── • scan
               sql nodes: <hidden>
               regions: <hidden>
-              actual row count: 0
               KV time: 0µs
               KV rows decoded: 0
-              KV bytes read: 0 B
-              KV gRPC calls: 0
-              estimated max memory allocated: 0 B
+              actual row count: 0
               missing stats
               table: a@a_y_idx
               spans: [/2 - /2]
@@ -172,12 +150,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, reused
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • limit
 │ count: 1
@@ -191,25 +164,18 @@ quality of service: regular
     │   │ sql nodes: <hidden>
     │   │ kv nodes: <hidden>
     │   │ regions: <hidden>
-    │   │ actual row count: 1
     │   │ KV time: 0µs
     │   │ KV rows decoded: 1
-    │   │ KV pairs read: 2
-    │   │ KV bytes read: 8 B
-    │   │ KV gRPC calls: 1
-    │   │ estimated max memory allocated: 0 B
+    │   │ actual row count: 1
     │   │ table: a@a_pkey
     │   │
     │   └── • scan
     │         sql nodes: <hidden>
     │         kv nodes: <hidden>
     │         regions: <hidden>
-    │         actual row count: 1
     │         KV time: 0µs
     │         KV rows decoded: 1
-    │         KV pairs read: 2
-    │         KV bytes read: 8 B
-    │         KV gRPC calls: 1
+    │         actual row count: 1
     │         missing stats
     │         table: a@a_y_idx
     │         spans: [/1 - /1]
@@ -217,22 +183,17 @@ quality of service: regular
     └── • index join (streamer)
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ KV time: 0µs
         │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 0
         │ table: a@a_pkey
         │
         └── • scan
               sql nodes: <hidden>
               regions: <hidden>
-              actual row count: 0
               KV time: 0µs
               KV rows decoded: 0
-              KV bytes read: 0 B
-              KV gRPC calls: 0
+              actual row count: 0
               missing stats
               table: a@a_y_idx
               spans: [/2 - /2]
@@ -329,15 +290,9 @@ EXPLAIN ANALYZE SELECT b.x FROM a, b WHERE a.x = b.x LIMIT 1
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • limit
 │ count: 1
@@ -346,14 +301,10 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ kv nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 1
     │ KV time: 0µs
     │ KV rows decoded: 1
-    │ KV pairs read: 2
-    │ KV bytes read: 8 B
-    │ KV gRPC calls: 1
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
+    │ actual row count: 1
     │ table: b@b_pkey
     │ equality: (x) = (x)
     │ equality cols are key
@@ -362,13 +313,9 @@ quality of service: regular
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 1
           KV time: 0µs
           KV rows decoded: 1
-          KV pairs read: 2
-          KV bytes read: 8 B
-          KV gRPC calls: 1
-          estimated max memory allocated: 0 B
+          actual row count: 1
           estimated row count: 1 (100% of the table; stats collected <hidden> ago)
           table: a@a_y_idx
           spans: FULL SCAN (SOFT LIMIT)
@@ -429,15 +376,9 @@ EXPLAIN ANALYZE SELECT a.x, a.y, xy.x, xy.y FROM a INNER LOOKUP JOIN xy ON xy.x 
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • limit
 │ count: 2
@@ -446,15 +387,10 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ kv nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 2
     │ KV time: 0µs
     │ KV rows decoded: 2
-    │ KV pairs read: 4
-    │ KV bytes read: 16 B
-    │ KV gRPC calls: 2
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
+    │ actual row count: 2
     │ table: xy@xy_pkey
     │ equality: (x) = (x)
     │
@@ -462,13 +398,9 @@ quality of service: regular
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 2
           KV time: 0µs
           KV rows decoded: 2
-          KV pairs read: 4
-          KV bytes read: 16 B
-          KV gRPC calls: 2
-          estimated max memory allocated: 0 B
+          actual row count: 2
           estimated row count: 1 (100% of the table; stats collected <hidden> ago)
           table: a@a_y_idx
           spans: FULL SCAN (SOFT LIMIT)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_local
@@ -45,22 +45,16 @@ SELECT ARRAY(SELECT cte.x FROM cte INNER LOOKUP JOIN uv ON cte.x = uv.u);
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • values
 │     sql nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 1
 │     execution time: 0µs
+│     actual row count: 1
 │     size: 1 column, 1 row
 │
 ├── • subquery
@@ -71,20 +65,17 @@ quality of service: regular
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │ label: buffer 1 (cte)
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
 │             kv nodes: <hidden>
 │             regions: <hidden>
-│             actual row count: 0
 │             KV time: 0µs
 │             KV rows decoded: 0
-│             KV bytes read: 0 B
-│             KV gRPC calls: 0
-│             estimated max memory allocated: 0 B
+│             actual row count: 0
 │             missing stats
 │             table: xyz@xyz_pkey
 │             spans: FULL SCAN
@@ -97,19 +88,16 @@ quality of service: regular
     └── • lookup join (streamer)
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ KV time: 0µs
         │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 0
         │ table: uv@uv_pkey
         │ equality: (x) = (u)
         │
         └── • scan buffer
               sql nodes: <hidden>
               regions: <hidden>
-              actual row count: 0
               execution time: 0µs
+              actual row count: 0
               label: buffer 1 (cte)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
@@ -116,7 +116,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -148,7 +147,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +value
@@ -178,7 +176,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -210,7 +207,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +value
@@ -239,7 +235,6 @@ WHERE
   name='cpu'
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ estimated row count: 33
@@ -266,7 +261,6 @@ WHERE
   name='cpu'
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: metric_values_desc@metric_values_desc_pkey
@@ -293,7 +287,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -325,7 +318,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +value
@@ -355,7 +347,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -387,7 +378,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +value
@@ -417,7 +407,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 11
@@ -449,7 +438,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +value
@@ -479,7 +467,6 @@ AND name='cpu'
 ORDER BY value, id
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 11
@@ -505,7 +492,6 @@ WHERE EXISTS (SELECT * FROM metric_values mv WHERE mv.metric_id = m.id AND time 
 ORDER BY m.id
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join (semi)
 │ estimated row count: 10
@@ -531,7 +517,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 3
@@ -570,7 +555,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1
@@ -609,7 +593,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1
@@ -648,7 +631,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1
@@ -688,7 +670,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1
@@ -727,7 +708,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1
@@ -767,7 +747,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 3
@@ -808,7 +787,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 1
@@ -849,7 +827,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -888,7 +865,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -927,7 +903,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -967,7 +942,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33
@@ -1006,7 +980,6 @@ WHERE
 ORDER BY value
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 33

--- a/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
+++ b/pkg/sql/opt/exec/execbuilder/testdata/materialized_view
@@ -14,7 +14,6 @@ query T
 EXPLAIN SELECT * FROM v
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -29,7 +28,6 @@ query T
 EXPLAIN SELECT * FROM v WHERE y = 3
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: v@v_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/merge_join_dist_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/merge_join_dist_vec
@@ -48,7 +48,6 @@ query T
 EXPLAIN (DISTSQL) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 2
 ----
 distribution: full
-vectorized: true
 ·
 • merge join (left outer)
 │ equality: (a) = (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/mvcc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/mvcc
@@ -10,7 +10,6 @@ query T
 EXPLAIN SELECT z FROM t WHERE x = 1
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -21,7 +20,6 @@ query T
 EXPLAIN SELECT crdb_internal_mvcc_timestamp, z FROM t WHERE x = 1
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -38,7 +36,6 @@ query T
 EXPLAIN SELECT x, crdb_internal_mvcc_timestamp FROM t
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -56,7 +53,6 @@ query T
 EXPLAIN SELECT * FROM [$t_id(4294967295) AS _]
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -181,7 +181,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE v = 2
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: t1@t1_pkey
@@ -202,7 +201,6 @@ query T
 EXPLAIN SELECT v FROM t1 WHERE v = 2
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: v = 2
@@ -217,7 +215,6 @@ query T
 EXPLAIN SELECT DISTINCT ON (v) t1 FROM t1
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: v
@@ -234,7 +231,6 @@ query T
 EXPLAIN UPDATE t1 SET k = 1 WHERE v > 0
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t1
@@ -256,7 +252,6 @@ query T
 EXPLAIN DELETE FROM t1 WHERE v > 0
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: t1
@@ -275,7 +270,6 @@ query T
 EXPLAIN SELECT DISTINCT v FROM t1
 ----
 distribution: local
-vectorized: true
 ·
 • distinct
 │ distinct on: v
@@ -290,7 +284,6 @@ query T
 EXPLAIN SELECT v FROM t1 ORDER BY v
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +v
@@ -308,7 +301,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE other > 100 ORDER BY other LIMIT 10;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +other
@@ -330,7 +322,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE (v + other) = 100
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (v + other) = 100
@@ -354,7 +345,6 @@ query T
 EXPLAIN SELECT v FROM t1@idx_v_invisible WHERE v = 2
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -372,7 +362,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE v > 10;
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: v > 10
@@ -387,7 +376,6 @@ query T
 EXPLAIN SELECT * FROM t1@{FORCE_INDEX=idx_v_invisible} WHERE v > 10;
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: t1@t1_pkey
@@ -425,7 +413,6 @@ query T
 EXPLAIN SELECT col1, col2 FROM t1 WHERE col1 = 1 AND col2 = 2
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (col1 = 1) AND (col2 = 2)
@@ -455,7 +442,6 @@ query T
 EXPLAIN SELECT t2.col1 FROM t2 JOIN t1 ON t1.col1 = t2.col1
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (col1) = (col1)
@@ -476,7 +462,6 @@ query T
 EXPLAIN SELECT t2.col1 FROM t2 CROSS MERGE JOIN t1 WHERE t1.col1 = t2.col1
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (col1) = (col1)
@@ -502,7 +487,6 @@ query T
 EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.col1 = 1
 ----
 distribution: local
-vectorized: true
 ·
 • cross join
 │
@@ -524,7 +508,6 @@ query T
 EXPLAIN SELECT * FROM t1, LATERAL (SELECT * FROM t2 WHERE col1 > 0) WHERE t1.col1 > 0;
 ----
 distribution: local
-vectorized: true
 ·
 • cross join
 │
@@ -568,7 +551,6 @@ query T
 EXPLAIN SELECT * FROM t1 ORDER BY v <-> '[3,1,2]' LIMIT 5;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column9
@@ -596,7 +578,6 @@ query T
 EXPLAIN SELECT * FROM t1 ORDER BY v <-> '[3,1,2]' LIMIT 5;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column9
@@ -618,7 +599,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE a IN (10, 20) ORDER BY v <-> '[3,1,2]' LIMIT 5;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column9
@@ -642,7 +622,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE a IN (20, 30) ORDER BY v <-> '[3,1,2]' LIMIT 5;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column9
@@ -679,7 +658,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE st_covers(geom, 'LINESTRING ( 0 0, 0 2 )'::geometry)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: st_covers(geom, '0102000000020000000000000000000000000000000000000000000000000000000000000000000040')
@@ -707,7 +685,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE st_covers(geom, 'LINESTRING ( 0 0, 0 2 )'::geometry)
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: st_covers(geom, '0102000000020000000000000000000000000000000000000000000000000000000000000000000040')
@@ -726,7 +703,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE data @> '{"foo": "1"}' AND id > 10
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (data @> '{"foo": "1"}') AND (id > 10)
@@ -753,7 +729,6 @@ query T
 EXPLAIN SELECT * FROM t1 INNER INVERTED JOIN t2@idx_geom2_invisible ON st_covers(t1.geom, t2.geom2)
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: t2@t2_pkey
@@ -789,7 +764,6 @@ query T
 EXPLAIN SELECT * FROM t1 WHERE v > 0
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: v > 0
@@ -804,7 +778,6 @@ query T
 EXPLAIN INSERT INTO t1 VALUES (1, 2) ON CONFLICT DO NOTHING
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: t1(k, v)
@@ -831,7 +804,6 @@ query T
 EXPLAIN INSERT INTO t1 VALUES (1, 2) ON CONFLICT(v) DO UPDATE SET k = t1.v
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t1(k, v)
@@ -856,7 +828,6 @@ query T
 EXPLAIN INSERT INTO t1 (k, v) SELECT * FROM t1 WHERE v IN (1, 2) ON CONFLICT DO NOTHING;
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: t1(k, v)
@@ -887,7 +858,6 @@ query T
 EXPLAIN UPSERT INTO t1(k, v) VALUES (1, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t1(k, v)
@@ -930,7 +900,6 @@ query T
 EXPLAIN DELETE FROM child WHERE p = 4
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: child
@@ -950,7 +919,6 @@ query T
 EXPLAIN DELETE FROM parent where p = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -983,7 +951,6 @@ query T
 EXPLAIN UPDATE parent SET p = p+1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1040,7 +1007,6 @@ query T
 EXPLAIN SELECT * FROM parent WHERE other > 0
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: other > 0
@@ -1056,7 +1022,6 @@ query T
 EXPLAIN INSERT INTO child VALUES (200, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: child(c, p)
@@ -1070,7 +1035,6 @@ query T
 EXPLAIN UPSERT INTO child VALUES (200, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1131,7 +1095,6 @@ query T
 EXPLAIN DELETE FROM parent where p = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1177,7 +1140,6 @@ query T
 EXPLAIN DELETE FROM parent WHERE other > 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1230,7 +1192,6 @@ query T
 EXPLAIN UPDATE parent SET p = p+1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1424,7 +1385,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE other > 2
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1448,7 +1408,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE other > 2
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: other > 2
@@ -1475,7 +1434,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE other > 2
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1500,7 +1458,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE v = 2
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: v = 2
@@ -1527,7 +1484,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE v = 2
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1729,7 +1685,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE v = 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: v = 'foo'
@@ -1746,7 +1701,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE v = 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: t@t_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -12,7 +12,6 @@ query T
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +b
@@ -26,7 +25,6 @@ query T
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: -b
@@ -41,7 +39,6 @@ query T
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +b
@@ -79,7 +76,6 @@ query T
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -91,7 +87,6 @@ query T
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -103,7 +98,6 @@ query T
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -114,7 +108,6 @@ query T
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -194,7 +187,6 @@ query T
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -205,7 +197,6 @@ query T
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -218,7 +209,6 @@ query T
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -319,7 +309,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -331,7 +320,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 AND b < 15 ORDER BY b, a, d
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +b,+a,+d
@@ -350,7 +338,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +b,+a,+d
@@ -401,7 +388,6 @@ query T
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -428,7 +414,6 @@ query T
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -439,7 +424,6 @@ query T
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -491,7 +475,6 @@ query T
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -502,7 +485,6 @@ query T
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -513,7 +495,6 @@ query T
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -573,7 +554,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -584,7 +564,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -595,7 +574,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -606,7 +584,6 @@ query T
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -633,7 +610,6 @@ query T
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
 distribution: local
-vectorized: true
 ·
 • ordinality
 │ estimated row count: 3
@@ -645,7 +621,6 @@ query T
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 3

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -37,7 +37,6 @@ query T
 EXPLAIN SELECT b FROM t WHERE b > 10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -48,7 +47,6 @@ query T
 EXPLAIN SELECT t1.a FROM t t1 INNER LOOKUP JOIN t t2 ON t1.a = t2.b AND t2.b > 10
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: t@b_partial (partial index)
@@ -63,7 +61,6 @@ query T
 EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -74,7 +71,6 @@ query T
 EXPLAIN SELECT a FROM inv@i WHERE b @> '{"x": "y"}' AND c = 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c = 'foo'
@@ -91,7 +87,6 @@ query T
 EXPLAIN SELECT * FROM inv@i WHERE b @> '{"x": "y"}' AND c IN ('foo', 'bar')
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: inv@inv_pkey
@@ -117,7 +112,6 @@ query T
 EXPLAIN SELECT * FROM a JOIN b ON a = b
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (a) = (b)
@@ -172,7 +166,6 @@ query T
 EXPLAIN SELECT count(1) FROM t70116@a_idx WHERE b > 0
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -1097,7 +1090,6 @@ query T
 EXPLAIN SELECT a FROM vec@i WHERE c IN ('foo', 'bar') ORDER BY b <-> '[1,2]' LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column8

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1401,7 +1401,6 @@ query T
 EXPLAIN SELECT * FROM ka WHERE a > 5
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 4 (40% of the table; stats collected <hidden> ago)
@@ -1412,7 +1411,6 @@ query T
 EXPLAIN SELECT * FROM ka WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -1426,7 +1424,6 @@ query T
 EXPLAIN SELECT * FROM ka WHERE a > 5
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 5 (45% of the table; stats collected <hidden> ago)
@@ -1437,7 +1434,6 @@ query T
 EXPLAIN SELECT * FROM ka WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   estimated row count: 1 (9.1% of the table; stats collected <hidden> ago)
@@ -1470,7 +1466,6 @@ query T
 EXPLAIN SELECT * FROM ka WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -12,7 +12,6 @@ query T nosort
 EXECUTE change_index
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 10
@@ -29,7 +28,6 @@ query T nosort
 EXECUTE change_index
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -43,7 +41,6 @@ query T nosort
 EXECUTE change_index
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 10
@@ -64,7 +61,6 @@ query T nosort
 EXECUTE change_stats
 ----
 distribution: local
-vectorized: true
 ·
 • merge join
 │ equality: (a) = (c)
@@ -91,7 +87,6 @@ query T retry,nosort
 EXECUTE change_stats
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: cd@cd_pkey
@@ -114,27 +109,17 @@ EXPLAIN ANALYZE EXECUTE pklookup(1)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 1
   KV time: 0µs
   KV rows decoded: 1
-  KV pairs read: 2
-  KV bytes read: 8 B
-  KV gRPC calls: 1
-  estimated max memory allocated: 0 B
+  actual row count: 1
   estimated row count: 1
   table: ab@ab_pkey
   spans: [/1 - /1]
@@ -145,25 +130,16 @@ EXPLAIN ANALYZE EXECUTE pklookup(2)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 0
   KV time: 0µs
   KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
+  actual row count: 0
   estimated row count: 1
   table: ab@ab_pkey
   spans: [/2 - /2]

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1311,7 +1311,6 @@ query T
 EXPLAIN SELECT 2-(9223372036854775807+436256318) < (CASE WHEN false THEN -1 END)
 ----
 distribution: local
-vectorized: true
 ·
 • values
   size: 1 column, 1 row
@@ -1320,7 +1319,6 @@ query T
 EXPLAIN SELECT (9223372036854775807+436256318)-2 < (CASE WHEN false THEN -1 END)
 ----
 distribution: local
-vectorized: true
 ·
 • values
   size: 1 column, 1 row
@@ -1329,7 +1327,6 @@ query T
 EXPLAIN SELECT (9223372036854775807+436256318)+2 < (CASE WHEN false THEN -1 END)
 ----
 distribution: local
-vectorized: true
 ·
 • values
   size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan_parallel
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan_parallel
@@ -46,7 +46,6 @@ query T
 EXPLAIN SELECT * FROM data WHERE a IN (0, 2, 4, 6, 8)
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -79,7 +78,6 @@ query T
 EXPLAIN SELECT * FROM data WHERE a IN (0, 2, 4, 6, 8)
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -293,7 +293,6 @@ query T
 EXPLAIN SELECT y, z, v FROM t@i WHERE y = 2.01 AND z = 3.001
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -646,7 +646,6 @@ query T
 EXPLAIN SELECT a FROM t14601 ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -672,7 +671,6 @@ query T
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -689,7 +687,6 @@ query T
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1964,7 +1961,6 @@ query T
 EXPLAIN SELECT e.z, s.z, n FROM e, s, generate_series(0, s.z, 1000) as n WHERE e.y = s.y ORDER BY s.z LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +z

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -284,7 +284,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -453,7 +452,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -461,7 +459,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a = 1 AND NULL
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -469,7 +466,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a = NULL AND a != NULL
 ----
 distribution: local
-vectorized: true
 ·
 • norows
 
@@ -912,7 +908,6 @@ GROUP BY resource_key
 ORDER BY total DESC
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: -count_rows
@@ -1296,7 +1291,6 @@ query T
 EXPLAIN SELECT * FROM noncover WHERE b = 2
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: noncover@noncover_pkey
@@ -1333,7 +1327,6 @@ query T
 EXPLAIN SELECT * FROM noncover WHERE c = 6
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: noncover@noncover_pkey
@@ -1426,7 +1419,6 @@ query T
 EXPLAIN SELECT * FROM noncover ORDER BY c
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +c
@@ -1440,7 +1432,6 @@ query T
 EXPLAIN SELECT * FROM noncover ORDER BY c LIMIT 5
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: noncover@noncover_pkey
@@ -1787,7 +1778,6 @@ query T
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1811,7 +1801,6 @@ query T
 EXPLAIN SELECT d FROM t4 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1836,7 +1825,6 @@ query T
 EXPLAIN SELECT d, e FROM t4 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1848,7 +1836,6 @@ query T
 EXPLAIN UPDATE t4 SET c = 30 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t4
@@ -1868,7 +1855,6 @@ query T
 EXPLAIN DELETE FROM t4 WHERE a = 10 and b = 20
 ----
 distribution: local
-vectorized: true
 ·
 • delete range
   from: t4
@@ -1880,7 +1866,6 @@ query T
 EXPLAIN SELECT c FROM t4 WHERE a = 10 and b >= 20 and b < 22
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1892,7 +1877,6 @@ query T
 EXPLAIN SELECT c FROM t4 WHERE a = 10
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1905,7 +1889,6 @@ query T
 EXPLAIN SELECT a FROM t4 WHERE a in (1, 5) and b in (1, 5)
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1927,7 +1910,6 @@ query T
 EXPLAIN SELECT a FROM t5 WHERE a @> 'A.B.C'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -1938,7 +1920,6 @@ query T
 EXPLAIN SELECT a FROM t5 WHERE a <@ 'A.B.C'
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -16,7 +16,6 @@ query T
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -28,7 +27,6 @@ query T
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -40,7 +38,6 @@ query T
 EXPLAIN SELECT * FROM abcd@abcd_pkey WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -52,7 +49,6 @@ query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=abcd_pkey,DESC} WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -64,7 +60,6 @@ query T
 EXPLAIN SELECT * FROM abcd@abcd_pkey WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
 distribution: local
-vectorized: true
 ·
 • revscan
   missing stats
@@ -76,7 +71,6 @@ query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=abcd_pkey,ASC} WHERE a >= 20 AND a <= 30 ORDER BY a DESC
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: -a
@@ -91,7 +85,6 @@ query T
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a >= 20) AND (a <= 30)
@@ -109,7 +102,6 @@ query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a >= 20) AND (a <= 30)
@@ -127,7 +119,6 @@ query T
 EXPLAIN SELECT * FROM abcd@b ORDER BY b DESC LIMIT 5
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: abcd@abcd_pkey
@@ -143,7 +134,6 @@ query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,DESC} ORDER BY b DESC LIMIT 5
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: abcd@abcd_pkey
@@ -160,7 +150,6 @@ query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b,ASC} ORDER BY b DESC LIMIT 5
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: abcd@abcd_pkey
@@ -179,7 +168,6 @@ query T
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a >= 20) AND (a <= 30)
@@ -197,7 +185,6 @@ query T
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a >= 20) AND (a <= 30)
@@ -212,7 +199,6 @@ query T
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a >= 20) AND (a <= 30)
@@ -227,7 +213,6 @@ query T
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (c >= 20) AND (c <= 30)
@@ -245,7 +230,6 @@ query T
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
 distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -257,7 +241,6 @@ query T
 EXPLAIN SELECT c, d FROM abcd@abcd_pkey WHERE c >= 20 AND c < 40
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (c >= 20) AND (c < 40)
@@ -272,7 +255,6 @@ query T
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (c >= 20) AND (c < 40)
@@ -289,7 +271,6 @@ query T
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (a >= 20) AND (a <= 30)
@@ -306,7 +287,6 @@ query T
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: abcd@abcd_pkey
@@ -320,7 +300,6 @@ query T
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c = 10
@@ -334,7 +313,6 @@ query T
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd} WHERE c = 10
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c = 10
@@ -348,7 +326,6 @@ query T
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=abcd_pkey} WHERE c = 10
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: c = 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_tables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_tables
@@ -4,7 +4,6 @@ query T
 EXPLAIN SELECT schema_name, table_name, type, owner, estimated_row_count, locality FROM [SHOW TABLES]
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -57,7 +56,6 @@ query T
 EXPLAIN SELECT schema_name, table_name, type, owner, locality FROM [SHOW TABLES]
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -12,7 +12,6 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -43,7 +42,6 @@ EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -76,7 +74,6 @@ EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -111,7 +108,6 @@ EXPLAIN WITH a AS (UPSERT INTO t VALUES (2), (3) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -142,7 +138,6 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -172,7 +167,6 @@ query T
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -203,7 +197,6 @@ query T
 EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -237,7 +230,6 @@ query T
 EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2), (3) RETURNING x] LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -268,7 +260,6 @@ query T
 EXPLAIN SELECT count(*) FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -297,7 +288,6 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x], t
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -336,7 +326,6 @@ EXPLAIN WITH a AS (INSERT INTO t SELECT * FROM t2 RETURNING x),
         SELECT * FROM b LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -383,7 +372,6 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -412,7 +400,6 @@ query T
 EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t SELECT * FROM t2 RETURNING x]
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -445,7 +432,6 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10 AS r] WHERE r < 3 LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -481,7 +467,6 @@ query T
 EXPLAIN SELECT * FROM [INSERT INTO t SELECT * FROM t2 RETURNING x+10 AS r] WHERE r < 3
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -6,7 +6,6 @@ query T
 EXPLAIN SELECT * FROM generate_series(1, 3)
 ----
 distribution: local
-vectorized: true
 ·
 • project set
 │ estimated row count: 10
@@ -17,7 +16,6 @@ query T
 EXPLAIN SELECT * FROM generate_series(1, 2), generate_series(1, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • cross join
 │ estimated row count: 100
@@ -36,7 +34,6 @@ query T
 EXPLAIN SELECT * FROM ROWS FROM (cos(1))
 ----
 distribution: local
-vectorized: true
 ·
 • project set
 │ estimated row count: 1
@@ -47,7 +44,6 @@ query T
 EXPLAIN SELECT generate_series(1, 3)
 ----
 distribution: local
-vectorized: true
 ·
 • project set
 │ estimated row count: 10
@@ -61,7 +57,6 @@ query T
 EXPLAIN SELECT generate_series(1, 2), generate_series(1, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • project set
 │ estimated row count: 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -537,7 +537,6 @@ WHERE
   a = 'a' AND b = 'b' AND c = 'c'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ estimated row count: 9
@@ -651,7 +650,6 @@ WHERE
   a = 'a' AND b = 'b' AND c = 'c'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ estimated row count: 9

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -11,7 +11,6 @@ query T
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
 distribution: local
-vectorized: true
 ·
 • split
 │ index: abc@abc_pkey
@@ -27,7 +26,6 @@ query T
 EXPLAIN ALTER RANGE RELOCATE FROM 11 TO 22 FOR VALUES ((SELECT 1))
 ----
 distribution: local
-vectorized: true
 ·
 • relocate range
 │ replicas: VOTERS
@@ -41,7 +39,6 @@ query T
 EXPLAIN ALTER RANGE 22 RELOCATE FROM ((SELECT 1)) TO ((SELECT 2))
 ----
 distribution: local
-vectorized: true
 ·
 • relocate range
 │ replicas: VOTERS
@@ -55,7 +52,6 @@ query T
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -180,7 +176,6 @@ query T
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ estimated row count: 3
@@ -194,7 +189,6 @@ query T
 EXPLAIN VALUES (1), ((SELECT random()::INT))
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery_correlated
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery_correlated
@@ -18,7 +18,6 @@ EXPLAIN SELECT
 FROM c ORDER BY c_id
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +c_id

--- a/pkg/sql/opt/exec/execbuilder/testdata/swap_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/swap_mutation
@@ -21,7 +21,6 @@ query T
 EXPLAIN UPDATE k SET k = 2 WHERE k = 1
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: k
@@ -48,7 +47,6 @@ query T
 EXPLAIN DELETE FROM k WHERE k = 2
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: k
@@ -86,7 +84,6 @@ query T
 EXPLAIN UPDATE kabc SET b = '2000-01-01 00:00:00' WHERE k = 1 AND a IS NULL AND b = '1999-12-31 23:59:59' AND c IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: kabc
@@ -112,7 +109,6 @@ query T
 EXPLAIN DELETE FROM kabc WHERE k = 1 AND a IS NULL AND b = '2000-01-01 00:00:00' AND c IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: kabc
@@ -153,7 +149,6 @@ query T
 EXPLAIN UPDATE abcde SET b = 0 WHERE a = 1 AND b = 1 AND e = 1
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: abcde
@@ -182,7 +177,6 @@ query T
 EXPLAIN DELETE FROM abcde WHERE a = 1 AND b = 1 AND e = 1
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: abcde
@@ -223,7 +217,6 @@ query T
 EXPLAIN UPDATE xyz SET x = 4, y = 7, z = 8 WHERE x = 4 AND y IS NOT DISTINCT FROM 5 AND z IS NOT DISTINCT FROM 6
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: xyz
@@ -253,7 +246,6 @@ query T
 EXPLAIN DELETE FROM xyz WHERE x = 1 AND y = 2 AND z = 3
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: xyz
@@ -292,7 +284,6 @@ query T
 EXPLAIN UPDATE pq SET q = NULL WHERE p IS NOT DISTINCT FROM 0 AND q IS NOT DISTINCT FROM 1
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: pq
@@ -320,7 +311,6 @@ query T
 EXPLAIN DELETE FROM pq WHERE p IS NOT DISTINCT FROM 0 AND q IS NOT DISTINCT FROM NULL
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: pq
@@ -360,7 +350,6 @@ query T
 EXPLAIN UPDATE mno SET o = 'o' || o WHERE m = 'm1' AND n = 'n1' AND o = 'o'
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: mno
@@ -405,7 +394,6 @@ query T
 EXPLAIN DELETE FROM mno WHERE m = 'm1' AND n = 'n1' AND o = 'oo'
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: mno
@@ -457,7 +445,6 @@ query T
 EXPLAIN UPDATE uvw SET v = v || 'f', w = w || 4 WHERE u = 'a8ebe7c3-7fd9-4a75-a56a-242a1088d295' AND v = 'abcde' AND w = '{1, 2, 3}'
 ----
 distribution: local
-vectorized: true
 ·
 • update swap
 │ table: uvw
@@ -487,7 +474,6 @@ query T
 EXPLAIN DELETE FROM uvw WHERE u = 'a8ebe7c3-7fd9-4a75-a56a-242a1088d295' AND v = 'abcdef' AND w = '{1, 2, 3, 4}'
 ----
 distribution: local
-vectorized: true
 ·
 • delete swap
 │ from: uvw
@@ -544,7 +530,6 @@ query T
 EXPLAIN UPDATE rstuv SET t = 27, u = 28, v = 29 WHERE r = 5 AND s = 6 AND t = 7 AND u = 8 AND v IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: rstuv
@@ -605,7 +590,6 @@ query T
 EXPLAIN DELETE FROM rstuv WHERE r = 5 AND s = 6 AND t = 27 AND u = 28 AND v = 29
 ----
 distribution: local
-vectorized: true
 ·
 • delete
 │ from: rstuv
@@ -665,7 +649,6 @@ query T
 EXPLAIN UPDATE rstuv SET t = 27 WHERE r = 5 AND s = 6 AND t = 7
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: rstuv
@@ -684,7 +667,6 @@ query T
 EXPLAIN UPDATE rstuv SET t = 27 WHERE r = 5 AND s = 6 AND t = 7 AND u = 8 AND v IS NULL
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: rstuv

--- a/pkg/sql/opt/exec/execbuilder/testdata/system
+++ b/pkg/sql/opt/exec/execbuilder/testdata/system
@@ -165,7 +165,6 @@ AND kind = 1
 FOR UPDATE OF table_statistics_locks
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/triggers
+++ b/pkg/sql/opt/exec/execbuilder/testdata/triggers
@@ -26,7 +26,6 @@ query T
 EXPLAIN INSERT INTO xy VALUES (1, 2);
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: xy(x, y, rowid)
@@ -122,9 +121,9 @@ quality of service: regular
 │ columns: ()
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ vectorized batch count: 0
 │ execution time: 0µs
+│ actual row count: 0
 │ estimated row count: 0 (missing stats)
 │ table: xy
 │ set: x, y
@@ -145,9 +144,9 @@ quality of service: regular
         │ columns: (f, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp, x_new, old, new)
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ vectorized batch count: 0
         │ execution time: 0µs
+        │ actual row count: 0
         │ estimated row count: 10 (missing stats)
         │ filter: f IS DISTINCT FROM NULL
         │
@@ -182,9 +181,9 @@ quality of service: regular
                     │ columns: (x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
                     │ sql nodes: <hidden>
                     │ regions: <hidden>
-                    │ actual row count: 0
                     │ vectorized batch count: 0
                     │ execution time: 0µs
+                    │ actual row count: 0
                     │ estimated row count: 10 (missing stats)
                     │ filter: y = 2
                     │
@@ -193,7 +192,6 @@ quality of service: regular
                           sql nodes: <hidden>
                           kv nodes: <hidden>
                           regions: <hidden>
-                          actual row count: 0
                           vectorized batch count: 0
                           KV time: 0µs
                           KV rows decoded: 0
@@ -203,6 +201,7 @@ quality of service: regular
                           estimated max memory allocated: 0 B
                           MVCC step count (ext/int): 0/0
                           MVCC seek count (ext/int): 0/0
+                          actual row count: 0
                           estimated row count: 1,000 (missing stats)
                           table: xy@xy_pkey
                           spans: FULL SCAN
@@ -223,7 +222,6 @@ query T
 EXPLAIN INSERT INTO xy VALUES (1, 2);
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -338,9 +336,9 @@ quality of service: regular
 │   │ columns: ()
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 0
 │   │ vectorized batch count: 0
 │   │ execution time: 0µs
+│   │ actual row count: 0
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -348,18 +346,18 @@ quality of service: regular
 │       │ columns: (rowid, x, y)
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ vectorized batch count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │ label: buffer 1
 │       │
 │       └── • filter
 │           │ columns: (rowid, x, y)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 0
 │           │ vectorized batch count: 0
 │           │ execution time: 0µs
+│           │ actual row count: 0
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -368,7 +366,6 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 kv nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 0
 │                 vectorized batch count: 0
 │                 KV time: 0µs
 │                 KV rows decoded: 0
@@ -378,6 +375,7 @@ quality of service: regular
 │                 estimated max memory allocated: 0 B
 │                 MVCC step count (ext/int): 0/0
 │                 MVCC seek count (ext/int): 0/0
+│                 actual row count: 0
 │                 estimated row count: 1,000 (missing stats)
 │                 table: xy@xy_pkey
 │                 spans: FULL SCAN
@@ -414,9 +412,9 @@ quality of service: regular
 │   │ columns: ()
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
 │   │ vectorized batch count: 0
 │   │ execution time: 0µs
+│   │ actual row count: 1
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -424,18 +422,18 @@ quality of service: regular
 │       │ columns: (rowid, x, y)
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 1
 │       │ vectorized batch count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 1
 │       │ label: buffer 1
 │       │
 │       └── • filter
 │           │ columns: (rowid, x, y)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 1
 │           │ vectorized batch count: 0
 │           │ execution time: 0µs
+│           │ actual row count: 1
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -444,7 +442,6 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 kv nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 1
 │                 vectorized batch count: 0
 │                 KV time: 0µs
 │                 KV rows decoded: 1
@@ -454,6 +451,7 @@ quality of service: regular
 │                 estimated max memory allocated: 0 B
 │                 MVCC step count (ext/int): 0/0
 │                 MVCC seek count (ext/int): 0/0
+│                 actual row count: 1
 │                 estimated row count: 1,000 (missing stats)
 │                 table: xy@xy_pkey
 │                 spans: FULL SCAN
@@ -483,9 +481,9 @@ quality of service: regular
                       columns: (rowid, x, y)
                       sql nodes: <hidden>
                       regions: <hidden>
-                      actual row count: 1
                       vectorized batch count: 0
                       execution time: 0µs
+                      actual row count: 1
                       estimated row count: 1
                       label: buffer 1000000
 
@@ -689,9 +687,9 @@ quality of service: regular
 │   │ columns: ()
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 0
 │   │ vectorized batch count: 0
 │   │ execution time: 0µs
+│   │ actual row count: 0
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -700,9 +698,9 @@ quality of service: regular
 │       │ columns: (k, k_new)
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ vectorized batch count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -715,7 +713,6 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 kv nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 0
 │                 vectorized batch count: 0
 │                 KV time: 0µs
 │                 KV rows decoded: 0
@@ -725,6 +722,7 @@ quality of service: regular
 │                 estimated max memory allocated: 0 B
 │                 MVCC step count (ext/int): 0/0
 │                 MVCC seek count (ext/int): 0/0
+│                 actual row count: 0
 │                 estimated row count: 1 (missing stats)
 │                 table: parent@parent_pkey
 │                 spans: /1/0
@@ -770,9 +768,9 @@ quality of service: regular
 │   │ columns: ()
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
 │   │ vectorized batch count: 0
 │   │ execution time: 0µs
+│   │ actual row count: 1
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -781,9 +779,9 @@ quality of service: regular
 │       │ columns: (k, k_new)
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 1
 │       │ vectorized batch count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 1
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -796,7 +794,6 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 kv nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 1
 │                 vectorized batch count: 0
 │                 KV time: 0µs
 │                 KV rows decoded: 1
@@ -806,6 +803,7 @@ quality of service: regular
 │                 estimated max memory allocated: 0 B
 │                 MVCC step count (ext/int): 0/0
 │                 MVCC seek count (ext/int): 0/0
+│                 actual row count: 1
 │                 estimated row count: 1 (missing stats)
 │                 table: parent@parent_pkey
 │                 spans: /1/0
@@ -821,9 +819,9 @@ quality of service: regular
         │   │ columns: ()
         │   │ sql nodes: <hidden>
         │   │ regions: <hidden>
-        │   │ actual row count: 1
         │   │ vectorized batch count: 0
         │   │ execution time: 0µs
+        │   │ actual row count: 1
         │   │ estimated row count: 0 (missing stats)
         │   │ table: child
         │   │ set: fk
@@ -835,18 +833,18 @@ quality of service: regular
         │       │ columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
-        │       │ actual row count: 1
         │       │ vectorized batch count: 0
         │       │ execution time: 0µs
+        │       │ actual row count: 1
         │       │ label: buffer 1
         │       │
         │       └── • filter
         │           │ columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
-        │           │ actual row count: 1
         │           │ vectorized batch count: 0
         │           │ execution time: 0µs
+        │           │ actual row count: 1
         │           │ estimated row count: 10 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -884,10 +882,10 @@ quality of service: regular
         │                           │ columns: (k, fk, k, k_new)
         │                           │ sql nodes: <hidden>
         │                           │ regions: <hidden>
-        │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
         │                           │ execution time: 0µs
         │                           │ estimated max memory allocated: 0 B
+        │                           │ actual row count: 1
         │                           │ estimated row count: 10 (missing stats)
         │                           │ equality: (fk) = (k)
         │                           │
@@ -896,7 +894,6 @@ quality of service: regular
         │                           │     sql nodes: <hidden>
         │                           │     kv nodes: <hidden>
         │                           │     regions: <hidden>
-        │                           │     actual row count: 1
         │                           │     vectorized batch count: 0
         │                           │     KV time: 0µs
         │                           │     KV rows decoded: 1
@@ -906,6 +903,7 @@ quality of service: regular
         │                           │     estimated max memory allocated: 0 B
         │                           │     MVCC step count (ext/int): 0/0
         │                           │     MVCC seek count (ext/int): 0/0
+        │                           │     actual row count: 1
         │                           │     estimated row count: 1,000 (missing stats)
         │                           │     table: child@child_pkey
         │                           │     spans: FULL SCAN
@@ -914,9 +912,9 @@ quality of service: regular
         │                               │ columns: (k, k_new)
         │                               │ sql nodes: <hidden>
         │                               │ regions: <hidden>
-        │                               │ actual row count: 1
         │                               │ vectorized batch count: 0
         │                               │ execution time: 0µs
+        │                               │ actual row count: 1
         │                               │ estimated row count: 1
         │                               │ filter: k IS DISTINCT FROM k_new
         │                               │
@@ -924,9 +922,9 @@ quality of service: regular
         │                                     columns: (k, k_new)
         │                                     sql nodes: <hidden>
         │                                     regions: <hidden>
-        │                                     actual row count: 1
         │                                     vectorized batch count: 0
         │                                     execution time: 0µs
+        │                                     actual row count: 1
         │                                     estimated row count: 1
         │                                     label: buffer 1000000
         │
@@ -936,16 +934,15 @@ quality of service: regular
         │       │ columns: ()
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
-        │       │ actual row count: 0
         │       │ vectorized batch count: 0
         │       │ execution time: 0µs
+        │       │ actual row count: 0
         │       │
         │       └── • lookup join (anti)
         │           │ columns: (fk_new)
         │           │ sql nodes: <hidden>
         │           │ kv nodes: <hidden>
         │           │ regions: <hidden>
-        │           │ actual row count: 0
         │           │ vectorized batch count: 0
         │           │ KV time: 0µs
         │           │ KV rows decoded: 1
@@ -956,6 +953,7 @@ quality of service: regular
         │           │ estimated max memory allocated: 0 B
         │           │ MVCC step count (ext/int): 0/0
         │           │ MVCC seek count (ext/int): 0/0
+        │           │ actual row count: 0
         │           │ estimated row count: 0 (missing stats)
         │           │ table: parent@parent_pkey
         │           │ equality: (fk_new) = (k)
@@ -966,9 +964,9 @@ quality of service: regular
         │               │ columns: (fk_new)
         │               │ sql nodes: <hidden>
         │               │ regions: <hidden>
-        │               │ actual row count: 1
         │               │ vectorized batch count: 0
         │               │ execution time: 0µs
+        │               │ actual row count: 1
         │               │ estimated row count: 10 (missing stats)
         │               │ filter: fk_new IS NOT NULL
         │               │
@@ -979,9 +977,9 @@ quality of service: regular
         │                         columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
         │                         sql nodes: <hidden>
         │                         regions: <hidden>
-        │                         actual row count: 1
         │                         vectorized batch count: 0
         │                         execution time: 0µs
+        │                         actual row count: 1
         │                         estimated row count: 10 (missing stats)
         │                         label: buffer 1
         │
@@ -1014,9 +1012,9 @@ quality of service: regular
                               columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
                               sql nodes: <hidden>
                               regions: <hidden>
-                              actual row count: 1
                               vectorized batch count: 0
                               execution time: 0µs
+                              actual row count: 1
                               estimated row count: 1
                               label: buffer 1000000
 
@@ -1051,9 +1049,9 @@ quality of service: regular
 │     columns: ()
 │     sql nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 1
 │     vectorized batch count: 0
 │     execution time: 0µs
+│     actual row count: 1
 │     estimated row count: 0 (missing stats)
 │     from: parent
 │     spans: /2/0
@@ -1068,9 +1066,9 @@ quality of service: regular
         │   │ columns: ()
         │   │ sql nodes: <hidden>
         │   │ regions: <hidden>
-        │   │ actual row count: 1
         │   │ vectorized batch count: 0
         │   │ execution time: 0µs
+        │   │ actual row count: 1
         │   │ estimated row count: 0 (missing stats)
         │   │ from: child
         │   │
@@ -1081,18 +1079,18 @@ quality of service: regular
         │       │ columns: (k, fk, old, f, "check-rows")
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
-        │       │ actual row count: 1
         │       │ vectorized batch count: 0
         │       │ execution time: 0µs
+        │       │ actual row count: 1
         │       │ label: buffer 1
         │       │
         │       └── • filter
         │           │ columns: (k, fk, old, f, "check-rows")
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
-        │           │ actual row count: 1
         │           │ vectorized batch count: 0
         │           │ execution time: 0µs
+        │           │ actual row count: 1
         │           │ estimated row count: 10 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -1121,9 +1119,9 @@ quality of service: regular
         │                           │ columns: (k, fk)
         │                           │ sql nodes: <hidden>
         │                           │ regions: <hidden>
-        │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
         │                           │ execution time: 0µs
+        │                           │ actual row count: 1
         │                           │ estimated row count: 10 (missing stats)
         │                           │ filter: fk = 2
         │                           │
@@ -1132,7 +1130,6 @@ quality of service: regular
         │                                 sql nodes: <hidden>
         │                                 kv nodes: <hidden>
         │                                 regions: <hidden>
-        │                                 actual row count: 1
         │                                 vectorized batch count: 0
         │                                 KV time: 0µs
         │                                 KV rows decoded: 1
@@ -1142,6 +1139,7 @@ quality of service: regular
         │                                 estimated max memory allocated: 0 B
         │                                 MVCC step count (ext/int): 0/0
         │                                 MVCC seek count (ext/int): 0/0
+        │                                 actual row count: 1
         │                                 estimated row count: 1,000 (missing stats)
         │                                 table: child@child_pkey
         │                                 spans: FULL SCAN
@@ -1171,9 +1169,9 @@ quality of service: regular
                               columns: (k, fk, old, f, "check-rows")
                               sql nodes: <hidden>
                               regions: <hidden>
-                              actual row count: 1
                               vectorized batch count: 0
                               execution time: 0µs
+                              actual row count: 1
                               estimated row count: 1
                               label: buffer 1000000
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/trigram_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/trigram_index
@@ -12,7 +12,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b LIKE '%foo%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b LIKE '%foo%'
@@ -29,7 +28,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b ILIKE '%foo%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b ILIKE '%foo%'
@@ -46,7 +44,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b LIKE '%foo%' OR b ILIKE '%bar%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b LIKE '%foo%') OR (b ILIKE '%bar%')
@@ -67,7 +64,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b LIKE '%foo%' OR b ILIKE '%bar%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (b LIKE '%foo%') OR (b ILIKE '%bar%')
@@ -88,7 +84,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b LIKE '%foo%zoo%'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b LIKE '%foo%zoo%'
@@ -110,7 +105,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b LIKE '%fo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b LIKE '%fo'
@@ -126,7 +120,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b LIKE b
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b LIKE b
@@ -141,7 +134,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b % 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b % 'foo'
@@ -163,7 +155,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b % 'foob'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b % 'foob'
@@ -185,7 +176,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b % 'fo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b % 'fo'
@@ -206,7 +196,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE 'blah' % b
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: 'blah' % b
@@ -228,7 +217,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b % b
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b % b
@@ -244,7 +232,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b = 'foobar'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 'foobar'
@@ -265,7 +252,6 @@ query T
 EXPLAIN SELECT * FROM a WHERE b = 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b = 'foo'
@@ -289,7 +275,6 @@ query T
 EXPLAIN SELECT * FROM b WHERE a % 'foob'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: a % 'foob'

--- a/pkg/sql/opt/exec/execbuilder/testdata/tsvector_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tsvector_index
@@ -13,7 +13,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: a@a_pkey
@@ -27,7 +26,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'Foo'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: a@a_pkey
@@ -41,7 +39,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo' OR b @@ 'bar'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: a@a_pkey
@@ -59,7 +56,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo | bar'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: a@a_pkey
@@ -77,7 +73,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo | bar' OR b @@ 'baz'
 ----
 distribution: local
-vectorized: true
 ·
 • index join
 │ table: a@a_pkey
@@ -98,7 +93,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo & bar'
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: a@a_pkey
@@ -117,7 +111,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo <-> bar'
 ----
 distribution: local
-vectorized: true
 ·
 • lookup join
 │ table: a@a_pkey
@@ -140,7 +133,6 @@ query T
 EXPLAIN SELECT * FROM a@a_b_idx WHERE b @@ 'foo & !bar'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: b @@ '''foo'' & !''bar'''
@@ -158,7 +150,6 @@ query T
 EXPLAIN SELECT a FROM a@a_b_idx WHERE b @@ 'ba:*'
 ----
 distribution: local
-vectorized: true
 ·
 • inverted filter
 │ inverted column: b_inverted_key

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -15,7 +15,6 @@ query T
 EXPLAIN SELECT one()
 ----
 distribution: local
-vectorized: true
 ·
 • values
   size: 1 column, 1 row
@@ -24,7 +23,6 @@ query T
 EXPLAIN SELECT * FROM t WHERE a = one()
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: a = 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -10,7 +10,6 @@ query T
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 distribution: local
-vectorized: true
 ·
 • union
 │
@@ -28,7 +27,6 @@ query T
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
 distribution: local
-vectorized: true
 ·
 • union all
 │
@@ -47,7 +45,6 @@ query T
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
 distribution: local
-vectorized: true
 ·
 • union
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -259,7 +259,6 @@ query T
 EXPLAIN INSERT INTO uniq VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -312,7 +311,6 @@ query T
 EXPLAIN INSERT INTO uniq VALUES (4, 4, NULL, NULL, 1), (5, 5, NULL, 2, NULL)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -414,7 +412,6 @@ query T
 EXPLAIN INSERT INTO uniq SELECT k, v, w, x, y FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -467,7 +464,6 @@ query T
 EXPLAIN INSERT INTO uniq_overlaps_pk VALUES (1, 1, 1, 1), (2, 2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -533,7 +529,6 @@ query T
 EXPLAIN INSERT INTO uniq_hidden_pk SELECT k, v, x, y FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -605,30 +600,24 @@ EXPLAIN ANALYZE INSERT INTO uniq_fk_parent VALUES (1, 1, 1), (2, 2, 2)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • insert
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 2
 │   │ execution time: 0µs
+│   │ actual row count: 2
 │   │ into: uniq_fk_parent(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 2
 │       │ execution time: 0µs
+│       │ actual row count: 2
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -636,8 +625,8 @@ quality of service: regular
 │           └── • values
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 2
 │                 execution time: 0µs
+│                 actual row count: 2
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -645,16 +634,14 @@ quality of service: regular
 │   └── • error if rows
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 0
 │           │ execution time: 0µs
-│           │ estimated max memory allocated: 0 B
-│           │ estimated max sql temp disk usage: 0 B
+│           │ actual row count: 0
 │           │ equality: (a) = (column1)
 │           │ pred: rowid_default != rowid
 │           │
@@ -662,13 +649,9 @@ quality of service: regular
 │           │     sql nodes: <hidden>
 │           │     kv nodes: <hidden>
 │           │     regions: <hidden>
-│           │     actual row count: 2
 │           │     KV time: 0µs
 │           │     KV rows decoded: 2
-│           │     KV pairs read: 4
-│           │     KV bytes read: 16 B
-│           │     KV gRPC calls: 2
-│           │     estimated max memory allocated: 0 B
+│           │     actual row count: 2
 │           │     missing stats
 │           │     table: uniq_fk_parent@uniq_fk_parent_pkey
 │           │     spans: FULL SCAN
@@ -676,8 +659,8 @@ quality of service: regular
 │           └── • scan buffer
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 2
 │                 execution time: 0µs
+│                 actual row count: 2
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -686,16 +669,14 @@ quality of service: regular
     └── • error if rows
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ execution time: 0µs
+        │ actual row count: 0
         │
         └── • hash join (right semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 0
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
-            │ estimated max sql temp disk usage: 0 B
+            │ actual row count: 0
             │ equality: (b, c) = (column2, column3)
             │ pred: rowid_default != rowid
             │
@@ -703,13 +684,9 @@ quality of service: regular
             │     sql nodes: <hidden>
             │     kv nodes: <hidden>
             │     regions: <hidden>
-            │     actual row count: 2
             │     KV time: 0µs
             │     KV rows decoded: 2
-            │     KV pairs read: 4
-            │     KV bytes read: 16 B
-            │     KV gRPC calls: 2
-            │     estimated max memory allocated: 0 B
+            │     actual row count: 2
             │     missing stats
             │     table: uniq_fk_parent@uniq_fk_parent_pkey
             │     spans: FULL SCAN
@@ -717,8 +694,8 @@ quality of service: regular
             └── • scan buffer
                   sql nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 2
                   execution time: 0µs
+                  actual row count: 2
                   estimated row count: 2
                   label: buffer 1
 
@@ -730,30 +707,24 @@ EXPLAIN ANALYZE INSERT INTO uniq_fk_child VALUES (1, 1, 1), (2, 2, 2)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • insert
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 2
 │   │ execution time: 0µs
+│   │ actual row count: 2
 │   │ into: uniq_fk_child(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 2
 │       │ execution time: 0µs
+│       │ actual row count: 2
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -761,8 +732,8 @@ quality of service: regular
 │           └── • values
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 2
 │                 execution time: 0µs
+│                 actual row count: 2
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -770,16 +741,14 @@ quality of service: regular
 │   └── • error if rows
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 0
 │           │ execution time: 0µs
-│           │ estimated max memory allocated: 0 B
-│           │ estimated max sql temp disk usage: 0 B
+│           │ actual row count: 0
 │           │ equality: (c) = (column3)
 │           │ pred: rowid_default != rowid
 │           │
@@ -787,13 +756,9 @@ quality of service: regular
 │           │     sql nodes: <hidden>
 │           │     kv nodes: <hidden>
 │           │     regions: <hidden>
-│           │     actual row count: 2
 │           │     KV time: 0µs
 │           │     KV rows decoded: 2
-│           │     KV pairs read: 4
-│           │     KV bytes read: 16 B
-│           │     KV gRPC calls: 2
-│           │     estimated max memory allocated: 0 B
+│           │     actual row count: 2
 │           │     missing stats
 │           │     table: uniq_fk_child@uniq_fk_child_pkey
 │           │     spans: FULL SCAN
@@ -801,8 +766,8 @@ quality of service: regular
 │           └── • scan buffer
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 2
 │                 execution time: 0µs
+│                 actual row count: 2
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -811,28 +776,23 @@ quality of service: regular
 │   └── • error if rows
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 0
 │       │ execution time: 0µs
+│       │ actual row count: 0
 │       │
 │       └── • hash join (right anti)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
-│           │ actual row count: 0
 │           │ execution time: 0µs
-│           │ estimated max memory allocated: 0 B
+│           │ actual row count: 0
 │           │ equality: (b, c) = (column2, column3)
 │           │
 │           ├── • scan
 │           │     sql nodes: <hidden>
 │           │     kv nodes: <hidden>
 │           │     regions: <hidden>
-│           │     actual row count: 2
 │           │     KV time: 0µs
 │           │     KV rows decoded: 2
-│           │     KV pairs read: 4
-│           │     KV bytes read: 16 B
-│           │     KV gRPC calls: 2
-│           │     estimated max memory allocated: 0 B
+│           │     actual row count: 2
 │           │     missing stats
 │           │     table: uniq_fk_parent@uniq_fk_parent_pkey
 │           │     spans: FULL SCAN
@@ -840,8 +800,8 @@ quality of service: regular
 │           └── • scan buffer
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 2
 │                 execution time: 0µs
+│                 actual row count: 2
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -850,28 +810,23 @@ quality of service: regular
     └── • error if rows
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ execution time: 0µs
+        │ actual row count: 0
         │
         └── • hash join (right anti)
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 0
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
+            │ actual row count: 0
             │ equality: (a) = (column1)
             │
             ├── • scan
             │     sql nodes: <hidden>
             │     kv nodes: <hidden>
             │     regions: <hidden>
-            │     actual row count: 2
             │     KV time: 0µs
             │     KV rows decoded: 2
-            │     KV pairs read: 4
-            │     KV bytes read: 16 B
-            │     KV gRPC calls: 2
-            │     estimated max memory allocated: 0 B
+            │     actual row count: 2
             │     missing stats
             │     table: uniq_fk_parent@uniq_fk_parent_pkey
             │     spans: FULL SCAN
@@ -879,8 +834,8 @@ quality of service: regular
             └── • scan buffer
                   sql nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 2
                   execution time: 0µs
+                  actual row count: 2
                   estimated row count: 2
                   label: buffer 1
 
@@ -1092,7 +1047,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1158,7 +1112,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial VALUES (1, NULL, 1), (2, NULL, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1268,7 +1221,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial SELECT k, v, w FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1333,7 +1285,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial_overlaps_pk VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: uniq_partial_overlaps_pk(k, a, b)
@@ -1346,7 +1297,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial_hidden_pk SELECT k, v, x FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1527,7 +1477,6 @@ query T
 EXPLAIN INSERT INTO uniq_computed_pk (i, s, d) VALUES (1, 'a', 1.0), (2, 'b', 2.0)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1570,7 +1519,6 @@ VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac',
   gen_random_uuid()::BYTES, gen_random_uuid(), gen_random_uuid(), gen_random_uuid())
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1651,7 +1599,6 @@ EXPLAIN INSERT INTO uniq_uuid (id1, id2, id3, id4, id5, id6)
 VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1725,7 +1672,6 @@ SELECT gen_random_uuid(), u, gen_random_uuid()::BYTES, gen_random_uuid(),
   gen_random_uuid(), gen_random_uuid(), gen_random_uuid() FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1797,7 +1743,6 @@ EXPLAIN INSERT INTO uniq_uuid (id4, id5, id6)
 VALUES (gen_random_uuid()::STRING, gen_random_uuid()::VARCHAR(4), gen_random_uuid()::CHAR)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1872,7 +1817,6 @@ EXPLAIN INSERT INTO uniq_uuid (id4, id5, id6)
 VALUES (gen_random_uuid()::VARCHAR(4), gen_random_uuid()::STRING, gen_random_uuid()::STRING)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1966,7 +1910,6 @@ query T
 EXPLAIN INSERT INTO uniq_uuid (id1, id2) VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2117,7 +2060,6 @@ query T
 EXPLAIN UPDATE uniq SET w = 1, x = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2174,7 +2116,6 @@ query T
 EXPLAIN UPDATE uniq SET k = 1, w = 2, x = NULL
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2214,7 +2155,6 @@ query T
 EXPLAIN UPDATE uniq SET k = 1, v = 2
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: uniq
@@ -2235,7 +2175,6 @@ query T
 EXPLAIN UPDATE uniq_overlaps_pk SET a = 1, b = 2, c = 3, d = 4 WHERE a = 5
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2314,7 +2253,6 @@ query T
 EXPLAIN UPDATE uniq_overlaps_pk SET a = 1, b = 2, c = 3, d = 4 WHERE a = 5
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2384,7 +2322,6 @@ query T
 EXPLAIN UPDATE uniq_overlaps_pk SET a = 1, b = 2, c = 3, d = 4 WHERE a = 5
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2456,7 +2393,6 @@ query T
 EXPLAIN UPDATE uniq_hidden_pk SET a = k FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2523,7 +2459,6 @@ query T
 EXPLAIN UPDATE uniq_fk_parent SET c = c + 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2626,31 +2561,25 @@ EXPLAIN ANALYZE UPDATE uniq_fk_parent SET c = c + 1
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • root
 │
 ├── • update
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 2
 │   │ execution time: 0µs
+│   │ actual row count: 2
 │   │ table: uniq_fk_parent
 │   │ set: c
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
-│       │ actual row count: 2
 │       │ execution time: 0µs
+│       │ actual row count: 2
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -2659,13 +2588,9 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 kv nodes: <hidden>
 │                 regions: <hidden>
-│                 actual row count: 2
 │                 KV time: 0µs
 │                 KV rows decoded: 2
-│                 KV pairs read: 4
-│                 KV bytes read: 16 B
-│                 KV gRPC calls: 2
-│                 estimated max memory allocated: 0 B
+│                 actual row count: 2
 │                 missing stats
 │                 table: uniq_fk_parent@uniq_fk_parent_pkey
 │                 spans: FULL SCAN
@@ -2679,37 +2604,32 @@ quality of service: regular
 │       ├── • update
 │       │   │ sql nodes: <hidden>
 │       │   │ regions: <hidden>
-│       │   │ actual row count: 2
 │       │   │ execution time: 0µs
+│       │   │ actual row count: 2
 │       │   │ table: uniq_fk_child
 │       │   │ set: b, c
 │       │   │
 │       │   └── • buffer
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
-│       │       │ actual row count: 2
 │       │       │ execution time: 0µs
+│       │       │ actual row count: 2
 │       │       │ label: buffer 1
 │       │       │
 │       │       └── • hash join
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
-│       │           │ actual row count: 2
 │       │           │ execution time: 0µs
-│       │           │ estimated max memory allocated: 0 B
+│       │           │ actual row count: 2
 │       │           │ equality: (b, c) = (b, c)
 │       │           │
 │       │           ├── • scan
 │       │           │     sql nodes: <hidden>
 │       │           │     kv nodes: <hidden>
 │       │           │     regions: <hidden>
-│       │           │     actual row count: 2
 │       │           │     KV time: 0µs
 │       │           │     KV rows decoded: 2
-│       │           │     KV pairs read: 4
-│       │           │     KV bytes read: 16 B
-│       │           │     KV gRPC calls: 2
-│       │           │     estimated max memory allocated: 0 B
+│       │           │     actual row count: 2
 │       │           │     missing stats
 │       │           │     table: uniq_fk_child@uniq_fk_child_pkey
 │       │           │     spans: FULL SCAN
@@ -2717,16 +2637,16 @@ quality of service: regular
 │       │           └── • filter
 │       │               │ sql nodes: <hidden>
 │       │               │ regions: <hidden>
-│       │               │ actual row count: 2
 │       │               │ execution time: 0µs
+│       │               │ actual row count: 2
 │       │               │ estimated row count: 1
 │       │               │ filter: (b IS DISTINCT FROM b) OR (c IS DISTINCT FROM c_new)
 │       │               │
 │       │               └── • scan buffer
 │       │                     sql nodes: <hidden>
 │       │                     regions: <hidden>
-│       │                     actual row count: 2
 │       │                     execution time: 0µs
+│       │                     actual row count: 2
 │       │                     estimated row count: 2
 │       │                     label: buffer 1000000
 │       │
@@ -2735,16 +2655,14 @@ quality of service: regular
 │       │   └── • error if rows
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
-│       │       │ actual row count: 0
 │       │       │ execution time: 0µs
+│       │       │ actual row count: 0
 │       │       │
 │       │       └── • hash join (right semi)
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
-│       │           │ actual row count: 0
 │       │           │ execution time: 0µs
-│       │           │ estimated max memory allocated: 0 B
-│       │           │ estimated max sql temp disk usage: 0 B
+│       │           │ actual row count: 0
 │       │           │ equality: (c) = (c_new)
 │       │           │ pred: rowid != rowid
 │       │           │
@@ -2752,13 +2670,9 @@ quality of service: regular
 │       │           │     sql nodes: <hidden>
 │       │           │     kv nodes: <hidden>
 │       │           │     regions: <hidden>
-│       │           │     actual row count: 2
 │       │           │     KV time: 0µs
 │       │           │     KV rows decoded: 2
-│       │           │     KV pairs read: 4
-│       │           │     KV bytes read: 16 B
-│       │           │     KV gRPC calls: 2
-│       │           │     estimated max memory allocated: 0 B
+│       │           │     actual row count: 2
 │       │           │     missing stats
 │       │           │     table: uniq_fk_child@uniq_fk_child_pkey
 │       │           │     spans: FULL SCAN
@@ -2766,8 +2680,8 @@ quality of service: regular
 │       │           └── • scan buffer
 │       │                 sql nodes: <hidden>
 │       │                 regions: <hidden>
-│       │                 actual row count: 2
 │       │                 execution time: 0µs
+│       │                 actual row count: 2
 │       │                 label: buffer 1
 │       │
 │       └── • constraint-check
@@ -2775,28 +2689,23 @@ quality of service: regular
 │           └── • error if rows
 │               │ sql nodes: <hidden>
 │               │ regions: <hidden>
-│               │ actual row count: 0
 │               │ execution time: 0µs
+│               │ actual row count: 0
 │               │
 │               └── • hash join (right anti)
 │                   │ sql nodes: <hidden>
 │                   │ regions: <hidden>
-│                   │ actual row count: 0
 │                   │ execution time: 0µs
-│                   │ estimated max memory allocated: 0 B
+│                   │ actual row count: 0
 │                   │ equality: (b, c) = (b, c_new)
 │                   │
 │                   ├── • scan
 │                   │     sql nodes: <hidden>
 │                   │     kv nodes: <hidden>
 │                   │     regions: <hidden>
-│                   │     actual row count: 2
 │                   │     KV time: 0µs
 │                   │     KV rows decoded: 2
-│                   │     KV pairs read: 4
-│                   │     KV bytes read: 16 B
-│                   │     KV gRPC calls: 2
-│                   │     estimated max memory allocated: 0 B
+│                   │     actual row count: 2
 │                   │     missing stats
 │                   │     table: uniq_fk_parent@uniq_fk_parent_pkey
 │                   │     spans: FULL SCAN
@@ -2804,15 +2713,15 @@ quality of service: regular
 │                   └── • filter
 │                       │ sql nodes: <hidden>
 │                       │ regions: <hidden>
-│                       │ actual row count: 2
 │                       │ execution time: 0µs
+│                       │ actual row count: 2
 │                       │ filter: (b IS NOT NULL) AND (c_new IS NOT NULL)
 │                       │
 │                       └── • scan buffer
 │                             sql nodes: <hidden>
 │                             regions: <hidden>
-│                             actual row count: 2
 │                             execution time: 0µs
+│                             actual row count: 2
 │                             label: buffer 1
 │
 └── • constraint-check
@@ -2820,37 +2729,31 @@ quality of service: regular
     └── • error if rows
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ execution time: 0µs
+        │ actual row count: 0
         │
         └── • hash join (semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 0
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
-            │ estimated max sql temp disk usage: 0 B
+            │ actual row count: 0
             │ equality: (b, c_new) = (b, c)
             │ pred: rowid != rowid
             │
             ├── • scan buffer
             │     sql nodes: <hidden>
             │     regions: <hidden>
-            │     actual row count: 2
             │     execution time: 0µs
+            │     actual row count: 2
             │     label: buffer 1
             │
             └── • scan
                   sql nodes: <hidden>
                   kv nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 2
                   KV time: 0µs
                   KV rows decoded: 2
-                  KV pairs read: 4
-                  KV bytes read: 16 B
-                  KV gRPC calls: 2
-                  estimated max memory allocated: 0 B
+                  actual row count: 2
                   missing stats
                   table: uniq_fk_parent@uniq_fk_parent_pkey
                   spans: FULL SCAN
@@ -2861,7 +2764,6 @@ query T
 EXPLAIN UPDATE uniq_fk_child SET a = 1, b = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -2920,7 +2822,6 @@ query T
 EXPLAIN UPDATE uniq_fk_child SET b = 1, c = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3070,7 +2971,6 @@ query T
 EXPLAIN UPDATE uniq_partial SET a = 1, b = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3139,7 +3039,6 @@ query T
 EXPLAIN UPDATE uniq_partial SET k = 1, a = NULL, b = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3185,7 +3084,6 @@ query T
 EXPLAIN UPDATE uniq_partial SET k = 1
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: uniq_partial
@@ -3205,7 +3103,6 @@ query T
 EXPLAIN UPDATE uniq_partial SET b = 2
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3346,7 +3243,6 @@ EXPLAIN UPDATE uniq_uuid SET id1 = '8597b0eb-7b89-4857-858a-fabf86f6a3ac', id2 =
 id3 = gen_random_uuid()::BYTES, id4 = gen_random_uuid(), id5 = gen_random_uuid(), id6 = gen_random_uuid()
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3422,7 +3318,6 @@ EXPLAIN UPDATE uniq_uuid SET id1 = '8597b0eb-7b89-4857-858a-fabf86f6a3ac', id2 =
 id3 = gen_random_uuid()::BYTES, id4 = gen_random_uuid(), id5 = gen_random_uuid(), id6 = gen_random_uuid()
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3549,7 +3444,6 @@ query T
 EXPLAIN UPSERT INTO uniq VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3609,7 +3503,6 @@ query T
 EXPLAIN UPSERT INTO uniq (k, v, w) VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3669,7 +3562,6 @@ query T
 EXPLAIN UPSERT INTO uniq (k, w, x) VALUES (1, NULL, 1), (2, NULL, NULL)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3730,7 +3622,6 @@ query T
 EXPLAIN INSERT INTO uniq VALUES (100, 1), (200, 1) ON CONFLICT (k) DO UPDATE SET w = excluded.w + 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3791,7 +3682,6 @@ query T
 EXPLAIN INSERT INTO uniq SELECT k, v FROM other ON CONFLICT (v) DO UPDATE SET w = uniq.k + 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3864,7 +3754,6 @@ query T
 EXPLAIN INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (w) DO UPDATE SET w = 10
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3928,7 +3817,6 @@ query T
 EXPLAIN UPSERT INTO uniq_overlaps_pk SELECT k, v, x FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -3979,7 +3867,6 @@ query T
 EXPLAIN UPSERT INTO uniq_hidden_pk SELECT k, v, x, y FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4050,7 +3937,6 @@ query T
 EXPLAIN UPSERT INTO uniq_fk_parent VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4199,7 +4085,6 @@ query T
 EXPLAIN UPSERT INTO uniq_fk_child VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4480,7 +4365,6 @@ query T
 EXPLAIN UPSERT INTO uniq_partial VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4547,7 +4431,6 @@ query T
 EXPLAIN UPSERT INTO uniq_partial (k, a) VALUES (1, 1), (2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4618,7 +4501,6 @@ query T
 EXPLAIN UPSERT INTO uniq_partial (k, a, b) VALUES (1, NULL, 1), (2, NULL, NULL)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4662,7 +4544,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial (k, a) VALUES (100, 1), (200, 1) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = excluded.a + 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4749,7 +4630,6 @@ query T
 EXPLAIN INSERT INTO uniq_partial SELECT k, v FROM other ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = uniq_partial.k + 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -4836,7 +4716,6 @@ query T
 EXPLAIN UPSERT INTO uniq_partial_overlaps_pk VALUES (1, 1, 1), (2, 2, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: uniq_partial_overlaps_pk(k, a, b)
@@ -4851,7 +4730,6 @@ query T
 EXPLAIN UPSERT INTO uniq_partial_hidden_pk SELECT k, v, x FROM other
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5079,7 +4957,6 @@ VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac',
   gen_random_uuid(), gen_random_uuid())
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5157,7 +5034,6 @@ VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac',
   gen_random_uuid(), gen_random_uuid())
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5321,7 +5197,6 @@ INSERT INTO t1 (pk, pk2, a, b, j) VALUES
    (2, 2, 1, 3, '{"a": "b"}'), (4, 5, 6, 7, '{"a": "b"}');
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5355,7 +5230,6 @@ INSERT INTO t1 (pk, pk2, a, b, j) VALUES
    (2, 2, 1, 3, '{"a": "b"}');
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: t1(pk, pk2, a, b, j)
@@ -5380,7 +5254,6 @@ EXPLAIN INSERT INTO users (name, email)
 VALUES ('Craig Roacher', 'craig@cockroachlabs.com')
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5434,7 +5307,6 @@ EXPLAIN INSERT INTO multiple_uniq
 VALUES (1,1,1,1), (2,2,2,2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5495,7 +5367,6 @@ EXPLAIN INSERT INTO multiple_uniq
 VALUES (1,1,1,1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: multiple_uniq(a, b, c, d, rowid)
@@ -5515,7 +5386,6 @@ EXPLAIN INSERT INTO multiple_uniq
 VALUES (1,1,1,1), (2,2,2,2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5589,7 +5459,6 @@ EXPLAIN INSERT INTO multiple_uniq
 VALUES (1,1,1,1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: multiple_uniq(a, b, c, d, rowid)
@@ -5610,7 +5479,6 @@ query T nosort
 EXECUTE e1(1, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5687,7 +5555,6 @@ query T nosort
 EXECUTE e2(1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: multiple_uniq(a, b, c, d, rowid)
@@ -5723,7 +5590,6 @@ EXPLAIN INSERT INTO multiple_uniq_partial
 VALUES (1,1,1,1)
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: multiple_uniq_partial(a, b, c, d, rowid)
@@ -5741,7 +5607,6 @@ EXPLAIN INSERT INTO multiple_uniq_partial
 VALUES (0,0,0,0)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5837,7 +5702,6 @@ EXPLAIN
 INSERT INTO tt VALUES (2, 'east', 10, 100)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -5891,7 +5755,6 @@ INSERT INTO t11 (pk, pk2, a, b, j) VALUES
    (2, 2, 1, 3, '{"a": "b"}');
 ----
 distribution: local
-vectorized: true
 ·
 • insert fast path
   into: t11(pk, pk2, a, b, j)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -102,7 +102,6 @@ query T
 EXPLAIN UPDATE xyz SET y = x
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: xyz
@@ -395,7 +394,6 @@ query T
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC LIMIT 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -418,7 +416,6 @@ query T
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -562,7 +559,6 @@ query T
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -581,7 +577,6 @@ query T
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -598,7 +593,6 @@ query T
 EXPLAIN UPDATE kv SET v = 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -626,7 +620,6 @@ query T
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv3
@@ -649,7 +642,6 @@ query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv3
@@ -673,7 +665,6 @@ query T
 EXPLAIN UPDATE kv SET v = 10 WHERE k = 3
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -691,7 +682,6 @@ query T
 EXPLAIN UPDATE kv SET v = k WHERE k > 1 AND k < 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -707,7 +697,6 @@ query T
 EXPLAIN UPDATE kv SET v = 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -752,7 +741,6 @@ query T
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv
@@ -771,7 +759,6 @@ query T
 EXPLAIN UPDATE kv3 SET k = 3 WHERE v = 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv3
@@ -792,7 +779,6 @@ query T
 EXPLAIN UPDATE kv3 SET k = v WHERE v > 1 AND v < 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: kv3
@@ -829,7 +815,6 @@ query T
 EXPLAIN UPDATE computed SET b=b*2 WHERE b BETWEEN 1 and 10
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: computed
@@ -921,7 +906,6 @@ query T
 EXPLAIN UPDATE tu SET c=c+1
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: tu
@@ -950,7 +934,6 @@ query T
 EXPLAIN UPDATE t121322_ab SET b = (SELECT sum(c) FROM t121322_c) WHERE a = 1
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1003,20 +986,14 @@ EXPLAIN ANALYZE EXECUTE p(1, 10)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ execution time: 0µs
+│ actual row count: 0
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1027,12 +1004,9 @@ quality of service: regular
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 0
           KV time: 0µs
           KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
+          actual row count: 0
           missing stats
           table: t137352@t137352_pkey
           spans: [/1 - /1]
@@ -1063,20 +1037,14 @@ EXPLAIN ANALYZE EXECUTE p(10, 100)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ execution time: 0µs
+│ actual row count: 0
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1086,13 +1054,10 @@ quality of service: regular
     └── • lookup join
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
         │ KV time: 0µs
         │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 0
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
         │ equality cols are key
@@ -1102,13 +1067,10 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ kv nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 0
             │ KV time: 0µs
             │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
+            │ actual row count: 0
             │ table: t137352@t137352_a_idx
             │ equality: ($1) = (a)
             │ locking strength: for update
@@ -1116,8 +1078,8 @@ quality of service: regular
             └── • values
                   sql nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 1
                   execution time: 0µs
+                  actual row count: 1
                   size: 1 column, 1 row
 
 statement count 1
@@ -1150,21 +1112,15 @@ EXPLAIN ANALYZE EXECUTE p(1, 10)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
 │ execution time: 0µs
+│ actual row count: 1
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1175,14 +1131,10 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 1
         │ KV time: 0µs
         │ KV rows decoded: 1
-        │ KV pairs read: 2
-        │ KV bytes read: 8 B
-        │ KV gRPC calls: 1
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 1
         │ table: t137352@t137352_pkey
         │ equality: ($1) = (k)
         │ equality cols are key
@@ -1191,8 +1143,8 @@ quality of service: regular
         └── • values
               sql nodes: <hidden>
               regions: <hidden>
-              actual row count: 1
               execution time: 0µs
+              actual row count: 1
               size: 1 column, 1 row
 
 statement count 1
@@ -1236,21 +1188,15 @@ EXPLAIN ANALYZE EXECUTE p(1)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
 │ execution time: 0µs
+│ actual row count: 0
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1263,13 +1209,10 @@ quality of service: regular
         └── • lookup join
             │ sql nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 0
             │ KV time: 0µs
             │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
+            │ actual row count: 0
             │ estimated row count: 10
             │ table: t137352@t137352_pkey
             │ equality: (k) = (k)
@@ -1279,13 +1222,10 @@ quality of service: regular
                 │ sql nodes: <hidden>
                 │ kv nodes: <hidden>
                 │ regions: <hidden>
-                │ actual row count: 0
                 │ KV time: 0µs
                 │ KV rows decoded: 0
-                │ KV bytes read: 0 B
-                │ KV gRPC calls: 0
                 │ execution time: 0µs
-                │ estimated max memory allocated: 0 B
+                │ actual row count: 0
                 │ estimated row count: 10
                 │ table: t137352@t137352_a_idx
                 │ equality: (k) = (a)
@@ -1295,13 +1235,9 @@ quality of service: regular
                       sql nodes: <hidden>
                       kv nodes: <hidden>
                       regions: <hidden>
-                      actual row count: 1
                       KV time: 0µs
                       KV rows decoded: 1
-                      KV pairs read: 2
-                      KV bytes read: 8 B
-                      KV gRPC calls: 1
-                      estimated max memory allocated: 0 B
+                      actual row count: 1
                       estimated row count: 1
                       table: t137352@t137352_pkey
                       spans: [/1 - /1]
@@ -1353,7 +1289,6 @@ query T
 EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE k = 1
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t139160
@@ -1412,7 +1347,6 @@ query T
 EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE i = 2
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t139160
@@ -1478,7 +1412,6 @@ query T
 EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE u = 3
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t139160
@@ -1544,7 +1477,6 @@ query T
 EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE v = 4
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t139160
@@ -1609,7 +1541,6 @@ query T
 EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE w = 5
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: t139160
@@ -1886,7 +1817,6 @@ UPDATE entity_address SET id = 'bar' WHERE id IN (
 );
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -8,7 +8,6 @@ query T
 EXPLAIN UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = other.a
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: abc
@@ -33,7 +32,6 @@ query T
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = other.a
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: abc
@@ -66,7 +64,6 @@ RETURNING
   abc.a, abc.b AS new_b, old.b as old_b, abc.c as new_c, old.c as old_c
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: abc
@@ -129,7 +126,6 @@ query T
 EXPLAIN UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as other ("a", "b", "c") WHERE abc.a = other.a
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: abc
@@ -158,7 +154,6 @@ query T
 EXPLAIN UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.a
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: abc
@@ -200,7 +195,6 @@ RETURNING
   *
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: abc

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_read_committed
@@ -35,7 +35,6 @@ query T
 EXPLAIN UPDATE multi_col_fam_checks SET a = 5, b = 6
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: multi_col_fam_checks
@@ -55,7 +54,6 @@ query T
 EXPLAIN UPDATE multi_col_fam_checks SET a = 5, b = 6, e = 3
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: multi_col_fam_checks
@@ -75,7 +73,6 @@ query T
 EXPLAIN UPDATE multi_col_fam_checks SET e = 3 WHERE a = 5
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: multi_col_fam_checks
@@ -95,7 +92,6 @@ query T
 EXPLAIN UPDATE multi_col_fam_checks SET e = 3
 ----
 distribution: local
-vectorized: true
 ·
 • update
 │ table: multi_col_fam_checks

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1120,7 +1120,6 @@ query T
 EXPLAIN UPSERT INTO t121322_ab SELECT 1, (SELECT sum(c) FROM t121322_c)
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1175,20 +1174,14 @@ EXPLAIN ANALYZE EXECUTE p(1, 10, 100)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • upsert
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
 │ execution time: 0µs
+│ actual row count: 1
 │ into: t137352(k, a, b)
 │ auto commit
 │ arbiter indexes: t137352_pkey
@@ -1197,13 +1190,10 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ kv nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 1
     │ KV time: 0µs
     │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
     │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
+    │ actual row count: 1
     │ table: t137352@t137352_pkey
     │ equality: (column1) = (k)
     │ equality cols are key
@@ -1212,8 +1202,8 @@ quality of service: regular
     └── • values
           sql nodes: <hidden>
           regions: <hidden>
-          actual row count: 1
           execution time: 0µs
+          actual row count: 1
           size: 3 columns, 1 row
 
 # Only need to update 'b' - no need to modify the secondary index.
@@ -1247,20 +1237,14 @@ EXPLAIN ANALYZE EXECUTE p(1, 10, 100)
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • upsert
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
 │ execution time: 0µs
+│ actual row count: 1
 │ into: t137352(k, a, b)
 │ auto commit
 │ arbiter indexes: t137352_a_key
@@ -1270,13 +1254,10 @@ quality of service: regular
     └── • lookup join (left outer)
         │ sql nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 1
         │ KV time: 0µs
         │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
         │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
+        │ actual row count: 1
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
         │ equality cols are key
@@ -1286,13 +1267,10 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ kv nodes: <hidden>
             │ regions: <hidden>
-            │ actual row count: 1
             │ KV time: 0µs
             │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
             │ execution time: 0µs
-            │ estimated max memory allocated: 0 B
+            │ actual row count: 1
             │ table: t137352@t137352_a_key
             │ equality: (column2) = (a)
             │ equality cols are key
@@ -1301,8 +1279,8 @@ quality of service: regular
             └── • values
                   sql nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 1
                   execution time: 0µs
+                  actual row count: 1
                   size: 3 columns, 1 row
 
 # Conflict on 'a', so we're only updating the value of 'b'.
@@ -1337,7 +1315,6 @@ query T
 EXPLAIN UPSERT INTO t139105 VALUES (1, 1)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t139105(k, v)
@@ -1378,7 +1355,6 @@ query T
 EXPLAIN UPSERT INTO t139160 VALUES (1, 2, 3, 4)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t139160(k, i, u, v)
@@ -1412,7 +1388,6 @@ query T
 EXPLAIN INSERT INTO t139160 VALUES (11, 12, 3, 14) ON CONFLICT (u) DO UPDATE SET k = 11, i = 12, v = 14;
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: t139160(k, i, u, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_read_committed
@@ -40,7 +40,6 @@ query T
 EXPLAIN UPSERT INTO multi_col_fam_checks VALUES (5, 6)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks(a, b, c, d)
@@ -66,7 +65,6 @@ query T
 EXPLAIN UPSERT INTO multi_col_fam_checks_simple VALUES (1, 2)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks_simple(a, b, c, d)
@@ -85,7 +83,6 @@ query T
 EXPLAIN UPSERT INTO multi_col_fam_checks (a, d) VALUES (3, 5)
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks(a, b, c, d)
@@ -121,7 +118,6 @@ EXPLAIN INSERT INTO multi_col_fam_checks VALUES (1, 2, 3)
 ON CONFLICT (a, b) DO UPDATE SET b = 3, c = 4
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks(a, b, c, d)
@@ -151,7 +147,6 @@ EXPLAIN INSERT INTO multi_col_fam_checks (a) VALUES (1)
 ON CONFLICT (a) DO UPDATE SET b = 3, c = 4, d = 5
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks(a, b, c, d)
@@ -179,7 +174,6 @@ EXPLAIN INSERT INTO multi_col_fam_checks (a, b, c, d) VALUES (1, 2, 3, 4)
 ON CONFLICT (b, c) DO UPDATE SET a = 5
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks(a, b, c, d)
@@ -207,7 +201,6 @@ EXPLAIN INSERT INTO multi_col_fam_checks (a) VALUES (1)
 ON CONFLICT (a) DO UPDATE SET d = 5
 ----
 distribution: local
-vectorized: true
 ·
 • upsert
 │ into: multi_col_fam_checks(a, b, c, d)

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_search
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_search
@@ -34,7 +34,6 @@ query T
 EXPLAIN SELECT * FROM t ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column7
@@ -210,7 +209,6 @@ query T
 EXPLAIN SELECT * FROM t_multi_idx ORDER BY v <=> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column7
@@ -232,7 +230,6 @@ query T
 EXPLAIN SELECT * FROM t_multi_idx ORDER BY v <#> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: true
 ·
 • top-k
 │ order: +column7
@@ -257,7 +254,6 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, '[1, 2, 3]');
 ----
 distribution: local
-vectorized: true
 ·
 • insert
 │ into: t(k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -41,27 +41,17 @@ EXPLAIN ANALYZE (DISTSQL) SELECT a FROM a
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2,001 (16 KiB, 4,002 KVs, 2,001 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • scan
   sql nodes: <hidden>
   kv nodes: <hidden>
   regions: <hidden>
-  actual row count: 2,001
   KV time: 0µs
   KV rows decoded: 2,001
-  KV pairs read: 4,002
-  KV bytes read: 16 KiB
-  KV gRPC calls: 2,001
-  estimated max memory allocated: 0 B
+  actual row count: 2,001
   missing stats
   table: a@a_pkey
   spans: FULL SCAN
@@ -74,28 +64,18 @@ EXPLAIN ANALYZE (DISTSQL) SELECT c.a FROM c JOIN d ON d.b = c.b
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • lookup join (streamer)
 │ sql nodes: <hidden>
 │ kv nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 2
 │ KV time: 0µs
 │ KV rows decoded: 1
-│ KV pairs read: 2
-│ KV bytes read: 8 B
-│ KV gRPC calls: 1
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
+│ actual row count: 2
 │ table: d@d_pkey
 │ equality: (b) = (b)
 │
@@ -103,13 +83,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 2
       KV time: 0µs
       KV rows decoded: 2
-      KV pairs read: 4
-      KV bytes read: 16 B
-      KV gRPC calls: 2
-      estimated max memory allocated: 0 B
+      actual row count: 2
       estimated row count: 1 (100% of the table; stats collected <hidden> ago)
       table: c@sec
       spans: FULL SCAN
@@ -125,23 +101,17 @@ EXPLAIN ANALYZE (DISTSQL) SELECT c.a::REGNAMESPACE FROM c JOIN d ON d.b = c.b
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • render
 │
 └── • lookup join
     │ sql nodes: <hidden>
     │ regions: <hidden>
-    │ actual row count: 2
     │ execution time: 0µs
+    │ actual row count: 2
     │ table: d@d_pkey
     │ equality: (b) = (b)
     │
@@ -149,13 +119,9 @@ quality of service: regular
           sql nodes: <hidden>
           kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 2
           KV time: 0µs
           KV rows decoded: 2
-          KV pairs read: 4
-          KV bytes read: 16 B
-          KV gRPC calls: 2
-          estimated max memory allocated: 0 B
+          actual row count: 2
           estimated row count: 1 (100% of the table; stats collected <hidden> ago)
           table: c@sec
           spans: FULL SCAN
@@ -210,36 +176,24 @@ EXPLAIN ANALYZE (DISTSQL) SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b
 planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
-maximum memory usage: <hidden>
-DistSQL network usage: <hidden>
 regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
 ·
 • merge join
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 2
 │ execution time: 0µs
-│ estimated max memory allocated: 0 B
-│ estimated max sql temp disk usage: 0 B
+│ actual row count: 2
 │ equality: (a) = (b)
 │
 ├── • scan
 │     sql nodes: <hidden>
 │     kv nodes: <hidden>
 │     regions: <hidden>
-│     actual row count: 2
 │     KV time: 0µs
 │     KV rows decoded: 2
-│     KV pairs read: 4
-│     KV bytes read: 16 B
-│     KV gRPC calls: 2
-│     estimated max memory allocated: 0 B
+│     actual row count: 2
 │     estimated row count: 1 (100% of the table; stats collected <hidden> ago)
 │     table: c@c_pkey
 │     spans: FULL SCAN
@@ -248,13 +202,9 @@ quality of service: regular
       sql nodes: <hidden>
       kv nodes: <hidden>
       regions: <hidden>
-      actual row count: 2
       KV time: 0µs
       KV rows decoded: 2
-      KV pairs read: 4
-      KV bytes read: 16 B
-      KV gRPC calls: 2
-      estimated max memory allocated: 0 B
+      actual row count: 2
       missing stats
       table: d@d_pkey
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -4,7 +4,6 @@ query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table
   table: pg_class@pg_class_oid_idx
@@ -14,7 +13,6 @@ query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE relname = 'blah'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: relname = 'blah'
@@ -29,7 +27,6 @@ query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: table_name = 'blah'
@@ -44,7 +41,6 @@ query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name > 'blah' ORDER BY table_name
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +table_name
@@ -61,7 +57,6 @@ query T
 EXPLAIN SELECT * FROM information_schema.tables WHERE table_name = 'blah' AND table_type = 'foo'
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: (table_name = 'blah') AND (table_type = 'foo')
@@ -75,7 +70,6 @@ query T
 EXPLAIN SELECT * FROM pg_constraint INNER LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table lookup join
 │ table: pg_class@pg_class_oid_idx
@@ -88,7 +82,6 @@ query T
 EXPLAIN SELECT * FROM pg_constraint LEFT LOOKUP JOIN pg_class on conrelid=pg_class.oid
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table lookup join (left outer)
 │ table: pg_class@pg_class_oid_idx
@@ -128,7 +121,6 @@ ORDER BY
         c.conname
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +conname
@@ -183,7 +175,6 @@ query T
 EXPLAIN SELECT * FROM pg_catalog.pg_class WHERE oid = 50 LIMIT 1
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table
   table: pg_class@pg_class_oid_idx
@@ -199,7 +190,6 @@ query T
 EXPLAIN SHOW GRANTS ON DATABASE t
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -246,7 +236,6 @@ query T
 EXPLAIN SELECT * FROM crdb_internal.tables WHERE database_name = 'foo';
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: database_name = 'foo'
@@ -258,7 +247,6 @@ query T
 EXPLAIN SELECT * FROM crdb_internal.tables WHERE parent_id = 1;
 ----
 distribution: local
-vectorized: true
 ·
 • filter
 │ filter: parent_id = 1
@@ -271,7 +259,6 @@ query T
 EXPLAIN SELECT * FROM crdb_internal.tables WHERE database_name = 'foo' AND drop_time IS NULL;
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table
   table: tables@tables_database_name_idx (partial index)
@@ -281,7 +268,6 @@ query T
 EXPLAIN SELECT * FROM crdb_internal.tables WHERE parent_id = 1 AND drop_time IS NULL;
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table
   table: tables@tables_parent_id_idx (partial index)
@@ -379,7 +365,6 @@ WHERE
     AND a.atttypid IN (SELECT oid FROM pg_type WHERE typname = ANY (ARRAY['int8']));
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table lookup join
 │ table: pg_class@pg_class_oid_idx
@@ -410,7 +395,6 @@ WHERE
     AND NOT EXISTS(SELECT 1 FROM pg_type WHERE typname = ANY (ARRAY['typefoo']) AND a.atttypid = oid);
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table lookup join
 │ table: pg_class@pg_class_oid_idx
@@ -444,7 +428,6 @@ WHERE
     AND t.typname LIKE 'myt%';
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table lookup join (anti)
 │ table: pg_type@pg_type_oid_idx
@@ -469,7 +452,6 @@ WHERE
     AND t.typname LIKE 'myt%';
 ----
 distribution: local
-vectorized: true
 ·
 • virtual table lookup join (semi)
 │ table: pg_type@pg_type_oid_idx
@@ -495,7 +477,6 @@ ORDER BY
 	database_name
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +datname
@@ -517,7 +498,6 @@ EXPLAIN SELECT i.relname, ix.indisprimary FROM pg_class AS t, pg_class AS i, pg_
         WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND t.relkind = 'r';
 ----
 distribution: local
-vectorized: true
 ·
 • hash join
 │ equality: (oid) = (indexrelid)

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -1467,7 +1467,6 @@ query T
 EXPLAIN SELECT * FROM t65343 WHERE s COLLATE en_US = 'foo' COLLATE en_US
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -1483,7 +1482,6 @@ query T
 EXPLAIN SELECT * FROM t65343 WHERE s COLLATE "en_US" = 'foo' COLLATE en_US
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -1499,7 +1497,6 @@ query T
 EXPLAIN SELECT * FROM t65343 WHERE s COLLATE "en_us" = 'foo' COLLATE en_US
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -1515,7 +1512,6 @@ query T
 EXPLAIN SELECT * FROM t65343 WHERE s COLLATE "en-US" = 'foo' COLLATE en_US
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -111,7 +111,6 @@ query T
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
 distribution: local
-vectorized: true
 ·
 • sort
 │ order: +variance,+k

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -203,7 +203,6 @@ EXPLAIN
   ) FROM y
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │
@@ -235,7 +234,6 @@ EXPLAIN
     LATERAL (WITH foo AS MATERIALIZED (SELECT a FROM y WHERE y.a <= x) SELECT * FROM foo)
 ----
 distribution: local
-vectorized: true
 ·
 • apply join
 │
@@ -263,7 +261,6 @@ EXPLAIN WITH RECURSIVE
  SELECT * FROM y
 ----
 distribution: local
-vectorized: true
 ·
 • root
 │
@@ -299,7 +296,6 @@ EXPLAIN WITH RECURSIVE
  SELECT * FROM y
 ----
 distribution: local
-vectorized: true
 ·
 • render
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -12,7 +12,6 @@ query T
 EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -29,7 +28,6 @@ query T
 EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND c = 2 AND d = 3
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -46,7 +44,6 @@ query T
 EXPLAIN SELECT count(*) FROM t71093 WHERE a = 0 AND b = 1 AND c = 2 AND d = 3
 ----
 distribution: local
-vectorized: true
 ·
 • group (scalar)
 │
@@ -67,7 +64,6 @@ query T
 EXPLAIN SELECT d FROM t71271 WHERE c = 3 AND d = 4
 ----
 distribution: local
-vectorized: true
 ·
 • zigzag join
   pred: (c = 3) AND (d = 4)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -527,11 +527,6 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		if s.UsedFollowerRead {
 			e.ob.AddField("used follower read", "")
 		}
-		if s.RowCount.HasValue() {
-			actualRowCount = s.RowCount.Value()
-			hasActualRowCount = true
-			e.ob.AddField("actual row count", string(humanizeutil.Count(actualRowCount)))
-		}
 		// Omit vectorized batches in non-verbose mode.
 		if e.ob.flags.Verbose {
 			if s.VectorizedBatchCount.HasValue() {
@@ -548,7 +543,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		if s.KVRowsRead.HasValue() {
 			e.ob.AddField("KV rows decoded", string(humanizeutil.Count(s.KVRowsRead.Value())))
 		}
-		if s.KVPairsRead.HasValue() {
+		if e.ob.flags.Verbose && s.KVPairsRead.HasValue() {
 			pairs := s.KVPairsRead.Value()
 			rows := s.KVRowsRead.Value()
 			if pairs != rows || e.ob.flags.Verbose {
@@ -558,19 +553,19 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 				e.ob.AddField("KV pairs read", string(humanizeutil.Count(s.KVPairsRead.Value())))
 			}
 		}
-		if s.KVBytesRead.HasValue() {
+		if e.ob.flags.Verbose && s.KVBytesRead.HasValue() {
 			e.ob.AddField("KV bytes read", humanize.IBytes(s.KVBytesRead.Value()))
 		}
-		if s.KVBatchRequestsIssued.HasValue() {
+		if e.ob.flags.Verbose && s.KVBatchRequestsIssued.HasValue() {
 			e.ob.AddField("KV gRPC calls", string(humanizeutil.Count(s.KVBatchRequestsIssued.Value())))
 		}
 		if s.ExecTime.HasValue() {
 			e.ob.AddField("execution time", string(humanizeutil.Duration(s.ExecTime.Value())))
 		}
-		if s.MaxAllocatedMem.HasValue() {
+		if e.ob.flags.Verbose && s.MaxAllocatedMem.HasValue() {
 			e.ob.AddField("estimated max memory allocated", humanize.IBytes(s.MaxAllocatedMem.Value()))
 		}
-		if s.MaxAllocatedDisk.HasValue() {
+		if e.ob.flags.Verbose && s.MaxAllocatedDisk.HasValue() {
 			e.ob.AddField("estimated max sql temp disk usage", humanize.IBytes(s.MaxAllocatedDisk.Value()))
 		}
 		if s.SQLCPUTime.HasValue() {
@@ -587,6 +582,11 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 					humanizeutil.Count(s.SeekCount.Value()), humanizeutil.Count(s.InternalSeekCount.Value()),
 				))
 			}
+		}
+		if s.RowCount.HasValue() {
+			actualRowCount = s.RowCount.Value()
+			hasActualRowCount = true
+			e.ob.AddField("actual row count", string(humanizeutil.Count(actualRowCount)))
 		}
 	}
 

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -300,7 +300,9 @@ func (ob *OutputBuilder) AddDistribution(value string) {
 // AddVectorized adds a top-level vectorized field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddVectorized(value bool) {
-	ob.AddFlakyTopLevelField(DeflakeVectorized, "vectorized", fmt.Sprintf("%t", value))
+	if ob.flags.Verbose || !value {
+		ob.AddFlakyTopLevelField(DeflakeVectorized, "vectorized", fmt.Sprintf("%t", value))
+	}
 }
 
 // AddPlanType adds a top-level generic field, if value is true. Cannot be called
@@ -369,8 +371,10 @@ func (ob *OutputBuilder) AddKVReadStats(rows, bytes, kvPairs, batchRequests int6
 
 // AddKVTime adds a top-level field for the cumulative time spent in KV.
 func (ob *OutputBuilder) AddKVTime(kvTime time.Duration) {
-	ob.AddFlakyTopLevelField(
-		DeflakeVolatile, "cumulative time spent in KV", string(humanizeutil.Duration(kvTime)))
+	if ob.flags.Verbose {
+		ob.AddFlakyTopLevelField(
+			DeflakeVolatile, "cumulative time spent in KV", string(humanizeutil.Duration(kvTime)))
+	}
 }
 
 // AddContentionTime adds a top-level field for the cumulative contention time.
@@ -430,18 +434,22 @@ func (ob *OutputBuilder) AddAdmissionWaitTime(admissionWaitTime time.Duration) {
 
 // AddMaxMemUsage adds a top-level field for the memory used by the query.
 func (ob *OutputBuilder) AddMaxMemUsage(bytes int64) {
-	ob.AddFlakyTopLevelField(
-		DeflakeVolatile, "maximum memory usage", string(humanizeutil.IBytes(bytes)),
-	)
+	if ob.flags.Verbose {
+		ob.AddFlakyTopLevelField(
+			DeflakeVolatile, "maximum memory usage", string(humanizeutil.IBytes(bytes)),
+		)
+	}
 }
 
 // AddDistSQLNetworkStats adds a top-level field for DistSQL network statistics.
 func (ob *OutputBuilder) AddDistSQLNetworkStats(messages, bytes int64) {
-	ob.AddFlakyTopLevelField(
-		DeflakeVolatile,
-		"DistSQL network usage",
-		fmt.Sprintf("%s (%s messages)", humanizeutil.IBytes(bytes), humanizeutil.Count(uint64(messages))),
-	)
+	if ob.flags.Verbose || bytes > 0 {
+		ob.AddFlakyTopLevelField(
+			DeflakeVolatile,
+			"DistSQL network usage",
+			fmt.Sprintf("%s (%s messages)", humanizeutil.IBytes(bytes), humanizeutil.Count(uint64(messages))),
+		)
+	}
 }
 
 // AddMaxDiskUsage adds a top-level field for the sql temporary disk space used
@@ -462,14 +470,14 @@ func (ob *OutputBuilder) AddMaxDiskUsage(bytes int64) {
 // independent of platform because the grunning library isn't currently
 // supported on all platforms.
 func (ob *OutputBuilder) AddSQLCPUTime(cpuTime time.Duration) {
-	if !ob.flags.Deflake.HasAny(DeflakeVolatile) {
+	if ob.flags.Verbose && !ob.flags.Deflake.HasAny(DeflakeVolatile) {
 		ob.AddTopLevelField("sql cpu time", string(humanizeutil.Duration(cpuTime)))
 	}
 }
 
 // AddKVCPUTime adds a top-level field for the cumulative CPU time spent in KV.
 func (ob *OutputBuilder) AddKVCPUTime(kvCPUTime time.Duration) {
-	if !ob.flags.Deflake.HasAny(DeflakeVolatile) {
+	if ob.flags.Verbose && !ob.flags.Deflake.HasAny(DeflakeVolatile) {
 		ob.AddTopLevelField("kv cpu time", string(humanizeutil.Duration(kvCPUTime)))
 	}
 }
@@ -501,9 +509,15 @@ func (ob *OutputBuilder) AddTxnInfo(
 	txnQoSLevel sessiondatapb.QoSLevel,
 	asOfSystemTime *eval.AsOfSystemTime,
 ) {
-	ob.AddTopLevelField("isolation level", txnIsoLevel.StringLower())
-	ob.AddTopLevelField("priority", txnPriority.String())
-	ob.AddTopLevelField("quality of service", txnQoSLevel.String())
+	if ob.flags.Verbose || txnIsoLevel != isolation.Serializable {
+		ob.AddTopLevelField("isolation level", txnIsoLevel.StringLower())
+	}
+	if ob.flags.Verbose || txnPriority != roachpb.NormalUserPriority {
+		ob.AddTopLevelField("priority", txnPriority.String())
+	}
+	if ob.flags.Verbose || txnQoSLevel != sessiondatapb.Normal {
+		ob.AddTopLevelField("quality of service", txnQoSLevel.String())
+	}
 	if asOfSystemTime != nil {
 		var boundedStaleness string
 		if asOfSystemTime.BoundedStaleness {

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -705,7 +705,6 @@ func TestPGPreparedQuery(t *testing.T) {
 		{"EXPLAIN SELECT 1", []preparedQueryTest{
 			baseTest.SetArgs().
 				Results("distribution: local").
-				Results("vectorized: true").
 				Results("").
 				Results("• values").
 				Results("  size: 1 column, 1 row"),

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_fk/alter_table_drop_constraint_fk.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_fk/alter_table_drop_constraint_fk.definition
@@ -24,7 +24,6 @@ EXPLAIN SELECT * FROM t1 JOIN t2 ON t1.i = t2.i LIMIT 1
 ----
 ----
 distribution: local
-vectorized: true
 
 • limit
 │ count: 1

--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/virtual_view_no_full_scans
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/virtual_view_no_full_scans
@@ -15,7 +15,6 @@ WHERE
 ----
 ----
 distribution: local
-vectorized: true
 
 • group (hash)
 │ group by: aggregated_ts, fingerprint_id, app_name, aggregation_interval

--- a/pkg/sql/tablemetadatacache/testdata/explain_tmj_select
+++ b/pkg/sql/tablemetadatacache/testdata/explain_tmj_select
@@ -38,7 +38,6 @@ LIMIT $4
 
 ---
 distribution: local
-vectorized: true
 
 • sort
 │ order: +"parentID",+"parentSchemaID",+name

--- a/pkg/sql/ttl/ttljob/ttljob_plans_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_plans_test.go
@@ -48,12 +48,11 @@ func TestQueryPlansDataDriven(t *testing.T) {
 		rows := runner.Query(t, fmt.Sprintf(`SELECT crdb_internal.execute_internally('EXPLAIN %s', '%s');`, query, overrides))
 		var sb strings.Builder
 		for i := 0; rows.Next(); i++ {
-			// Omit first three rows that are of the form:
+			// Omit first two rows that are of the form:
 			//  distribution: local
-			//  vectorized: true
 			//
-			if i >= 3 {
-				if i > 3 {
+			if i >= 2 {
+				if i > 2 {
 					sb.WriteString("\n")
 				}
 				var explainRow string


### PR DESCRIPTION
The output of `EXPLAIN [ANALYZE]` in non-`VERBOSE` mode is now more succinct.

In the header above the query plan the following changes have been made:

  1. "isolation level" is only shown if it is not "serializable".
  2. "priority" is only shown if it is not "normal".
  3. "quality of service" is only shown if it is not "regular".
  4. "kv cpu time" is not shown.
  5. "sql cpu time" is not shown.
  6. "DistSQL network usage" is only show if it is greater than 0.
  7. "maximum memory usage" is not shown.
  8. "cumulative time spent in KV" is not shown.
  9. "vectorized" is only shown if it is "false".
 10. "buffered writes enabled" is not shown.

In each node of the query plan the following changes have been made:

  1. "KV pairs read" is not shown.
  2. "KV bytes read" is not shown.
  3. "KV gRPC calls" is not shown.
  4. "estimated max memory allocated" is not shown.
  5. "estimated max sql temp disk usage" is not shown.
  6. "actual row count" is directly above "estimated row count".

Here's an example of what `EXPLAIN ANALYZE` looked like before:

```
planning time: 243µs
execution time: 632µs
distribution: local
vectorized: true
plan type: generic, reused
cumulative time spent in KV: 331µs
maximum memory usage: 20 KiB
DistSQL network usage: 0 B (0 messages)
regions: us-east1
sql cpu time: 20µs
estimated RUs consumed: 0
isolation level: serializable
priority: normal
quality of service: regular

• scan
  sql nodes: n1
  kv nodes: n1
  regions: us-east1
  actual row count: 0
  KV time: 331µs
  KV rows decoded: 0
  KV bytes read: 0 B
  KV gRPC calls: 1
  estimated max memory allocated: 20 KiB
  sql cpu time: 20µs
  missing stats
  table: t@t_pkey
  spans: [/0 - /0]
```

And here's the output with the same query after the changes in this commit:

```
planning time: 325µs
execution time: 974µs
distribution: local
plan type: generic, reused
regions: us-east1
estimated RUs consumed: 0

• scan
  sql nodes: n1
  kv nodes: n1
  regions: us-east1
  KV time: 610µs
  KV rows decoded: 0
  sql cpu time: 29µs
  actual row count: 0
  missing stats
  table: t@t_pkey
  spans: [/0 - /0]
```

Epic: None
Release note (sql change): The output of `EXPLAIN [ANALYZE]` in non-`VERBOSE` mode is now more succinct.