### PR TITLE
changefeedccl: batch PTS reads and updates for performance

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1986,6 +1986,8 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 	pts := cf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
 	tableIDsToRelease := make([]descpb.ID, 0)
 	tableIDsToCreate := make(map[descpb.ID]hlc.Timestamp)
+	tableIDsToUpdate := make(map[descpb.ID]hlc.Timestamp)
+
 	for tableID, frontier := range cf.frontier.Frontiers() {
 		tableHighWater := func() hlc.Timestamp {
 			// If this table has not yet finished its initial scan, we use the highwater
@@ -2010,11 +2012,7 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 		}
 
 		if ptsEntries.ProtectedTimestampRecords[tableID] != nil {
-			if updated, err := cf.advancePerTableProtectedTimestampRecord(ctx, ptsEntries, tableID, tableHighWater, pts); err != nil {
-				return hlc.Timestamp{}, false, err
-			} else if updated {
-				updatedPerTablePTS = true
-			}
+			tableIDsToUpdate[tableID] = tableHighWater
 		} else {
 			// TODO(#152448): Do not include system table protections in these records.
 			tableIDsToCreate[tableID] = tableHighWater
@@ -2035,6 +2033,13 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 		updatedPerTablePTS = true
 	}
 
+	if len(tableIDsToUpdate) > 0 {
+		if updated, err := cf.advancePerTableProtectedTimestampRecords(ctx, ptsEntries, tableIDsToUpdate, pts); err != nil {
+			return hlc.Timestamp{}, false, err
+		} else if updated {
+			updatedPerTablePTS = true
+		}
+	}
 	return newPTS, updatedPerTablePTS, nil
 }
 
@@ -2054,27 +2059,39 @@ func (cf *changeFrontier) releasePerTableProtectedTimestampRecords(
 	return writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, ptsEntries, txn, cf.spec.JobID)
 }
 
-func (cf *changeFrontier) advancePerTableProtectedTimestampRecord(
+func (cf *changeFrontier) advancePerTableProtectedTimestampRecords(
 	ctx context.Context,
 	ptsEntries *cdcprogresspb.ProtectedTimestampRecords,
-	tableID descpb.ID,
-	tableHighWater hlc.Timestamp,
+	tableHighWaterByTableID map[descpb.ID]hlc.Timestamp,
 	pts protectedts.Storage,
 ) (updated bool, err error) {
-	rec, err := pts.GetRecord(ctx, *ptsEntries.ProtectedTimestampRecords[tableID])
+	recordIDs := make([]uuid.UUID, 0, len(tableHighWaterByTableID))
+	tableIDsByRecordID := make(map[uuid.UUID]descpb.ID)
+	for tableID := range tableHighWaterByTableID {
+		recordIDs = append(recordIDs, *ptsEntries.ProtectedTimestampRecords[tableID])
+
+		tableIDsByRecordID[*ptsEntries.ProtectedTimestampRecords[tableID]] = tableID
+	}
+	records, err := pts.GetRecords(ctx, recordIDs)
 	if err != nil {
 		return false, err
 	}
-
 	ptsUpdateLag := changefeedbase.ProtectTimestampLag.Get(&cf.FlowCtx.Cfg.Settings.SV)
-	if rec.Timestamp.AddDuration(ptsUpdateLag).After(tableHighWater) {
-		return false, nil
-	}
 
-	if err := pts.UpdateTimestamp(ctx, *ptsEntries.ProtectedTimestampRecords[tableID], tableHighWater); err != nil {
+	recordsToUpdate := make(map[uuid.UUID]hlc.Timestamp)
+	for _, record := range records {
+		recordID := uuid.UUID(record.ID)
+		tableHighWater := tableHighWaterByTableID[tableIDsByRecordID[recordID]]
+		if record.Timestamp.AddDuration(ptsUpdateLag).After(tableHighWater) {
+			continue
+		}
+		recordsToUpdate[recordID] = tableHighWater
+		updated = true
+	}
+	if err = pts.UpdateTimestamps(ctx, recordsToUpdate); err != nil {
 		return false, err
 	}
-	return true, nil
+	return updated, nil
 }
 
 func (cf *changeFrontier) createPerTableProtectedTimestampRecords(

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1791,6 +1791,7 @@ type multiTablePTSBenchmarkParams struct {
 	numRows     int
 	duration    string
 	perTablePTS bool
+	runWorkload bool
 }
 
 // runCDCMultiTablePTSBenchmark is a benchmark for changefeeds with multiple tables,
@@ -1836,6 +1837,13 @@ func runCDCMultiTablePTSBenchmark(
 		defer ct.workloadWg.Done()
 		workloadCmd := fmt.Sprintf("./cockroach workload run bank --rows=%d --duration=%s --num-tables=%d {pgurl%s}",
 			params.numRows, params.duration, params.numTables, ct.crdbNodes)
+		if !params.runWorkload {
+			t.L().Printf("not running workload")
+			t.L().Printf("skipped: %s", workloadCmd)
+			time.Sleep(2 * time.Minute)
+			t.L().Printf("workload finished")
+			return nil
+		}
 		return c.RunE(ctx, option.WithNodes(ct.workloadNode), workloadCmd)
 	})
 
@@ -2934,12 +2942,53 @@ func registerCDC(r registry.Registry) {
 						numRows:     100,
 						duration:    "20m",
 						perTablePTS: perTablePTS,
+						runWorkload: true,
 					}
 					runCDCMultiTablePTSBenchmark(ctx, t, c, params)
 				},
 			})
 		}
 	}
+	r.Add(registry.TestSpec{
+		Name:             "cdc/pts-test/with-workload",
+		Owner:            registry.OwnerCDC,
+		Benchmark:        true,
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.Suites(registry.Nightly),
+		Timeout:          1 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			params := multiTablePTSBenchmarkParams{
+				numTables:   1000,
+				numRanges:   1,
+				numRows:     10,
+				duration:    "2m",
+				perTablePTS: true,
+				runWorkload: true,
+			}
+			runCDCMultiTablePTSBenchmark(ctx, t, c, params)
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:             "cdc/pts-test/no-workload",
+		Owner:            registry.OwnerCDC,
+		Benchmark:        true,
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.Suites(registry.Nightly),
+		Timeout:          1 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			params := multiTablePTSBenchmarkParams{
+				numTables:   1000,
+				numRanges:   1,
+				numRows:     10,
+				duration:    "2m",
+				perTablePTS: true,
+				runWorkload: false,
+			}
+			runCDCMultiTablePTSBenchmark(ctx, t, c, params)
+		},
+	})
 }
 
 const (

--- a/pkg/kv/kvserver/protectedts/protectedts.go
+++ b/pkg/kv/kvserver/protectedts/protectedts.go
@@ -79,6 +79,11 @@ type Storage interface {
 	// this method can be used to provide such a timestamp.
 	GetRecord(context.Context, uuid.UUID) (*ptpb.Record, error)
 
+	// GetRecords retrieves multiple records with the specified UUIDs. Records
+	// that do not exist are omitted from the result. If no records exist for
+	// the provided IDs, an empty slice is returned.
+	GetRecords(context.Context, []uuid.UUID) ([]ptpb.Record, error)
+
 	// MarkVerified will mark a protected timestamp as verified.
 	//
 	// This method is generally used by an implementation of Verifier.
@@ -101,6 +106,10 @@ type Storage interface {
 	// UpdateTimestamp updates the timestamp protected by the record with the
 	// specified UUID.
 	UpdateTimestamp(ctx context.Context, id uuid.UUID, timestamp hlc.Timestamp) error
+
+	// UpdateTimestamps updates the timestamps protected by the records with the
+	// specified UUIDs and timestamps.
+	UpdateTimestamps(ctx context.Context, recordsToUpdate map[uuid.UUID]hlc.Timestamp) error
 }
 
 // Iterator iterates records in a cache until wantMore is false or all Records

--- a/pkg/kv/kvserver/protectedts/ptstorage/sql.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/sql.go
@@ -171,6 +171,10 @@ FROM
 WHERE
     id = $1;`
 
+	getRecordsByIDsQuery = getRecordsQueryBase + `
+WHERE
+    id = ANY($1);`
+
 	markVerifiedQuery = `
 UPDATE
     system.protected_ts_records
@@ -274,6 +278,13 @@ WHERE
 RETURNING
     id
 `
+
+	updateTimestampsBatchQuery = `
+UPDATE system.protected_ts_records
+SET ts = updates.ts::DECIMAL
+FROM (VALUES %s) AS updates(id, ts)
+WHERE system.protected_ts_records.id = updates.id::UUID
+RETURNING system.protected_ts_records.id;`
 
 	getMetadataQuery = `
 WITH

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_with_database.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_with_database.go
@@ -41,6 +41,15 @@ func (s *storageWithDatabase) GetRecord(
 	})
 }
 
+func (s *storageWithDatabase) GetRecords(
+	ctx context.Context, ids []uuid.UUID,
+) (rs []ptpb.Record, err error) {
+	return rs, s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
+		rs, err = s.s.WithTxn(txn).GetRecords(ctx, ids)
+		return err
+	})
+}
+
 func (s *storageWithDatabase) MarkVerified(ctx context.Context, id uuid.UUID) error {
 	return s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		return s.s.WithTxn(txn).MarkVerified(ctx, id)
@@ -72,5 +81,13 @@ func (s *storageWithDatabase) UpdateTimestamp(
 ) (err error) {
 	return s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
 		return s.s.WithTxn(txn).UpdateTimestamp(ctx, id, timestamp)
+	})
+}
+
+func (s *storageWithDatabase) UpdateTimestamps(
+	ctx context.Context, recordsToUpdate map[uuid.UUID]hlc.Timestamp,
+) error {
+	return s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return s.s.WithTxn(txn).UpdateTimestamps(ctx, recordsToUpdate)
 	})
 }


### PR DESCRIPTION
This change introduces new functions to the protected timestamp storage layer that support batched reads and updates of PTS records. Changefeed now uses these batching primitives to reduce overhead and improve performance during PTS management.

Fixes: #147788
Epic: CRDB-1421
Release note: None