### PR TITLE
roachtest: fix division by zero in metric aggregation functions

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -29,6 +29,9 @@ var PrometheusNameSpace = "roachtest"
 var DefaultProcessFunction = func(test string, histograms *roachtestutil.HistogramMetric) (roachtestutil.AggregatedPerfMetrics, error) {
 	totalOps := 0.0
 	for _, summary := range histograms.Summaries {
+		if summary.TotalElapsed == 0 {
+			continue
+		}
 		totalOps += float64(summary.TotalCount*1000) / float64(summary.TotalElapsed)
 	}
 

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -42,6 +42,10 @@ import (
 )
 
 var restoreAggregateFunction = func(test string, histogram *roachtestutil.HistogramMetric) (roachtestutil.AggregatedPerfMetrics, error) {
+	if len(histogram.Summaries) == 0 {
+		return roachtestutil.AggregatedPerfMetrics{}, errors.New("histogram has no summaries")
+	}
+
 	metricValue := histogram.Summaries[0].HighestTrackableValue / 1e9
 
 	return roachtestutil.AggregatedPerfMetrics{

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -134,6 +134,9 @@ func registerTPCHBenchSpec(r registry.Registry, b tpchBenchSpec) {
 				totalMeanCount++
 			}
 
+			if totalMeanCount == 0 {
+				totalMeanCount = 1 // Avoid division by zero.
+			}
 			aggregatedMetrics := roachtestutil.AggregatedPerfMetrics{
 				{
 					Name:           test + "_mean_latency",


### PR DESCRIPTION
Add safety checks to prevent division by zero and handle empty data in metric processing:

- Skip summaries with TotalElapsed=0 in `DefaultProcessFunction`.
- Return error for empty histogram summaries in `restoreAggregateFunction`.
- Only calculate mean when totalMeanCount > 0 in `tpchbench` aggregation.

These changes prevent runtime panics when processing metrics with missing or invalid data.

The changes were initially introduced in #138617

Epic: none

Release note: None