### PR TITLE
kvcoord: set ResumeSpan on unprocessed point requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2411,8 +2411,8 @@ func fillSkippedResponses(
 func maybeSetResumeSpan(
 	req kvpb.Request, hdr *kvpb.ResponseHeader, nextKey roachpb.RKey, isReverse bool,
 ) {
-	if _, ok := req.(*kvpb.GetRequest); ok {
-		// This is a Get request. There are three possibilities:
+	if !kvpb.IsRange(req) {
+		// This is a point request. There are three possibilities:
 		//
 		//  1. The request was completed. In this case we don't want a ResumeSpan.
 		//
@@ -2440,10 +2440,6 @@ func maybeSetResumeSpan(
 				hdr.ResumeSpan = &roachpb.Span{Key: key}
 			}
 		}
-		return
-	}
-
-	if !kvpb.IsRange(req) {
 		return
 	}
 


### PR DESCRIPTION
Previously, if batch execution was stopped early in dist sender, the returned batch could have requests that were not processed but which didn't have a resume-span sent.

The impact of this oversight was minimal since SQL does not create such read-write batches. The txnWriteBuffer may create such batches, but only if undocumented, test-only settings were in use.

We might want to consider whether such read-write batches are _ever_ needed by SQL or other internal database users.

Fixes #153357
Release note: None