### PR TITLE
batcheval: reliably remove GCHint when it expires

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -265,9 +265,7 @@ func GC(
 	// Check if optional GC hint on the range is expired (e.g. delete operation is
 	// older than GC threshold) and remove it. Otherwise this range could be
 	// unnecessarily GC'd with high priority again.
-	// We should only do that when we are doing actual cleanup as we want to have
-	// a hint when request is being handled.
-	if len(args.Keys) != 0 || len(args.RangeKeys) != 0 || args.ClearRange != nil {
+	{
 		sl := MakeStateLoader(cArgs.EvalCtx)
 		hint, err := sl.LoadGCHint(ctx, readWriter)
 		if err != nil {

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -783,6 +783,12 @@ func (mgcq *mvccGCQueue) process(
 	if scoreAfter.ShouldQueue {
 		// The scores are very long, so splitting into multiple lines manually for
 		// readability.
+		//
+		// NB: there are likely situations in which this check triggers incorrectly,
+		// for example when the GC hint triggers GC but a protected timestamp
+		// prevents the GC threshold from advancing. In that case, not only did we
+		// run a GC cycle without improving anything, but we also pile up a stats
+		// recomputation. This is hopefully too rare to matter.
 		log.Dev.Infof(ctx, "GC still needed following GC, recomputing MVCC stats")
 		log.Dev.Infof(ctx, "old score %s", r)
 		log.Dev.Infof(ctx, "new score %s", scoreAfter)


### PR DESCRIPTION
The GCHint would previously only be adjusted when GC would actually do work. However, conceivably (and reproducably), sometimes all of the GC work would be done under a GCThreshold that did not yet allow the GCHint to be collected. This would leave the GCHint dangling, and endlessly queue the range for GC over and over again.

Unconditionally clear the GCHint to avoid this.

The problem could reliably be reproduced using an [experiment]. It no longer reproduces as of this commit.

[experiment]: https://docs.google.com/document/d/1QajDmDPgICvwYeRmrFVKvqVRW_kwWMD5RAe_q6irCXc/edit?tab=t.0

See also this [Slack thread].

Found while investigating https://github.com/cockroachlabs/support/issues/3424.

https://github.com/cockroachdb/cockroach/issues/153564 was filed as a result of looking further into a log message involved in this investigation leading up to this PR.

[Slack thread]: https://cockroachlabs.slack.com/archives/G01G8LK77DK/p1757580849424569?thread_ts=1757428752.120299&cid=G01G8LK77DK

Epic: none