### PR TITLE
tracingpb: fix tag group formatting

### DIFF
--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -266,7 +266,7 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	for _, tg := range sp.TagGroups {
 		var prefix redact.RedactableString
 		if tg.Name != AnonymousTagGroupName {
-			prefix = redact.Sprint("%s-", redact.SafeString(tg.Name))
+			prefix = redact.Sprintf("%s-", redact.SafeString(tg.Name))
 		}
 		for _, tag := range tg.Tags {
 			sb.Printf(" %s%s:%s", prefix, redact.SafeString(tag.Key), tag.Value)


### PR DESCRIPTION
This fixes trace entries that include literal %s:

    0.049ms 0.002ms === operation:/cockroach.roachpb.Internal/Batch
    gid:11120 _verbose:1 node:1 span.kind:server
    request:ReverseScan(Exclusive,Unreplicated)
    [/Table/100/"378826c2b6399273",/Table/100/"805b55ddf1552ea3")
    %s-locksnum:1 %s-lockswait:-2562047h47m16.853592s

It doesn't solve the unlikely value for lockswait.

Epic: none
Release note: None