### PR TITLE
kvnemesis: add MutateBatchHeaderOperation

### DIFF
--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -266,6 +266,8 @@ func TestRandStep(t *testing.T) {
 				client.Barrier++
 			case *FlushLockTableOperation:
 				client.FlushLockTable++
+			case *MutateBatchHeaderOperation:
+				client.MutateBatchHeader++
 			case *BatchOperation:
 				batch.Batch++
 				countClientOps(&batch.Ops, nil, o.Ops...)
@@ -303,7 +305,8 @@ func TestRandStep(t *testing.T) {
 			*DeleteRangeUsingTombstoneOperation,
 			*AddSSTableOperation,
 			*BarrierOperation,
-			*FlushLockTableOperation:
+			*FlushLockTableOperation,
+			*MutateBatchHeaderOperation:
 			countClientOps(&counts.DB, &counts.Batch, step.Op)
 		case *ClosureTxnOperation:
 			countClientOps(&counts.ClosureTxn.TxnClientOps, &counts.ClosureTxn.TxnBatchOps, o.Ops...)

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -165,6 +165,13 @@ message SavepointRollbackOperation {
   Result result = 2 [(gogoproto.nullable) = false];
 }
 
+message MutateBatchHeaderOperation {
+  int64 max_span_request_keys = 1;
+  int64 target_bytes = 2;
+
+  Result result = 3 [(gogoproto.nullable) = false];
+}
+
 message Operation {
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.onlyone) = true;
@@ -195,6 +202,7 @@ message Operation {
   SavepointRollbackOperation savepoint_rollback = 22;
   BarrierOperation barrier = 23;
   FlushLockTableOperation flush_lock_table = 24;
+  MutateBatchHeaderOperation mutate_batch_header = 25;
 }
 
 enum ResultType {
@@ -223,6 +231,7 @@ message Result {
   // Only set if Type is ResultType_Values. The RawBytes of a roachpb.Value.
   repeated KeyValue values = 5 [(gogoproto.nullable) = false];
   util.hlc.Timestamp optional_timestamp = 6 [(gogoproto.nullable) = false];
+  roachpb.Span resume_span = 7;
 }
 
 message Step {


### PR DESCRIPTION
This adds a new operation which sets the TargetBytes or
MaxSpanRequestKeys on the header of a batch operation. These header
options substantially change the how requests are processed in dist
sender and can lead to early termination of a batch.

Since they can lead to early termination of a batch, there is a
trade-off here since this operation may result in other operations being
no-ops.

Fixes #152668
Release note: None