### PR TITLE
kvserver: fix missing locking in test helper

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -167,6 +167,8 @@ func (s *Store) SplitQueuePurgatoryLength() int {
 // LeaseQueuePurgatory returns a map of RangeIDs representing the purgatory.
 func (s *Store) LeaseQueuePurgatory() map[roachpb.RangeID]struct{} {
 	defer s.leaseQueue.baseQueue.lockProcessing()()
+	s.leaseQueue.baseQueue.mu.Lock()
+	defer s.leaseQueue.baseQueue.mu.Unlock()
 	m := make(map[roachpb.RangeID]struct{}, len(s.leaseQueue.baseQueue.mu.purgatory))
 	for k := range s.leaseQueue.baseQueue.mu.purgatory {
 		m[k] = struct{}{}


### PR DESCRIPTION
Accidentally missed this in #134653.

Epic: none