### PR TITLE
kvcoord: remove `noop` target

### DIFF
--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -1,7 +1,5 @@
 exports_files(["nogo_config.json"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
 # The output file will be empty unless we're using the force_build_cdeps config.
 genrule(
     name = "test_force_build_cdeps",
@@ -10,12 +8,4 @@ genrule(
         "//build/toolchains:force_build_cdeps": "echo 1 > $@",
         "//conditions:default": "touch $@",
     }),
-)
-
-# This noop target is a workaround for https://github.com/bazelbuild/bazel-gazelle/issues/1078.
-# We use it in //pkg/kv/kvclient/{kvcoord,rangefeed}.
-go_library(
-    name = "noop",
-    importpath = "noop",
-    visibility = ["//pkg:__subpackages__"],
 )

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -122,10 +122,6 @@ gomock(
     ],
 )
 
-# This noop target is a workaround for https://github.com/bazelbuild/bazel-gazelle/issues/1078.
-#
-# gazelle:resolve go github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord //build/bazelutil:noop
-
 go_test(
     name = "kvcoord_test",
     size = "large",
@@ -174,7 +170,6 @@ go_test(
     }),
     shard_count = 16,
     deps = [
-        "//build/bazelutil:noop",
         "//pkg/base",
         "//pkg/config",
         "//pkg/config/zonepb",

--- a/pkg/kv/kvclient/kvcoord/txncorrectnesstest/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/txncorrectnesstest/BUILD.bazel
@@ -16,7 +16,6 @@ go_test(
         "write_skew_anomaly_test.go",
     ],
     deps = [
-        "//build/bazelutil:noop",
         "//pkg/base",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",  # keep


### PR DESCRIPTION
This was apparently there to fix some sort of gazelle issue, but isn't necessary any more.

Epic: none
Release note: None