### PR TITLE
release-24.3: changefeedccl: replace incorrect usage of QueryRow in tests

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1828,7 +1828,7 @@ func TestAlterChangefeedAddDropSameTarget(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar DROP bar`, feed.JobID()))
 		require.NoError(t, feed.Resume())
 		var tsStr string
-		sqlDB.QueryRow(t, `INSERT INTO bar VALUES(1)`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES(1)`)
 		sqlDB.QueryRow(t, `INSERT INTO foo VALUES(2) RETURNING cluster_logical_timestamp()`).Scan(&tsStr)
 		ts := parseTimeToHLC(t, tsStr)
 		require.NoError(t, feed.WaitForHighWaterMark(ts))


### PR DESCRIPTION
Backport 1/1 commits from #153424.

/cc @cockroachdb/release

---

Two recently added ALTER CHANGEFEED unit tests use `QueryRow` instead of
`Exec` for queries that don't return values, which technically could
allow an error to go unnoticed. This patch corrects that.

Epic: None

Release note: None

---

Release justification: test-only fix
