### PR TITLE
kvserver: add TestReplicateQueueDiversify

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -1526,6 +1526,12 @@ func rankedCandidateListForRebalancing(
 				continue
 			}
 			valid, necessary := removalConstraintsChecker(store)
+			if ctx.Value("magic") != nil && (store.StoreID == 6 || store.StoreID == 7) && !valid &&
+				len(existingReplicasForType) == 5 {
+				// NB: this is left-over from when I didn't sleep enough in the test
+				// and the old constraints would kick in.
+				valid, necessary = removalConstraintsChecker(store) // TODO(tbg): investigate using breakpoint here
+			}
 			fullDisk := !options.getDiskOptions().maxCapacityCheck(store)
 
 			if !valid {

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -51,6 +51,10 @@ func (s *Store) ForceReplicationScanAndProcess() error {
 	return forceScanAndProcess(context.TODO(), s, s.replicateQueue.baseQueue)
 }
 
+func (s *Store) ForceReplicationScanAndProcessCtx(ctx context.Context) error {
+	return forceScanAndProcess(ctx, s, s.replicateQueue.baseQueue)
+}
+
 // MustForceReplicaGCScanAndProcess iterates over all ranges and enqueues any that
 // may need to be GC'd.
 func (s *Store) MustForceReplicaGCScanAndProcess() {


### PR DESCRIPTION
This test verifies that when a 5x replicated range is in three regions but has
two replicas on the same rack within a region (region,datacenter,rack
hierarchy), rebalancing will move one double-racked replica to a unique rack due
to diversity scoring.

The rangelog output shows that (commonly) that movement also works against
replica count balance, i.e. demonstrates that diversity is taken seriously.

Touches #3421.
