### PR TITLE
backup: pass URIs instead of stores to ResolveBackupManifests

### DIFF
--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -396,22 +396,6 @@ func TestResolveBackupManifests(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	baseStores, err := util.MapE(fullyResolvedBaseDirs, func(uri string) (cloud.ExternalStorage, error) {
-		return execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, username.RootUserName())
-	})
-	require.NoError(t, err)
-	for i := range baseStores {
-		defer baseStores[i].Close()
-	}
-
-	incStores, err := util.MapE(fullyResolvedIncDirs, func(uri string) (cloud.ExternalStorage, error) {
-		return execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, username.RootUserName())
-	})
-	require.NoError(t, err)
-	for i := range incStores {
-		defer incStores[i].Close()
-	}
-
 	t.Run("resolve backup manifests with latest AOST", func(t *testing.T) {
 		uris, manifests, locality, memSize, err := ResolveBackupManifests(
 			ctx,
@@ -419,8 +403,6 @@ func TestResolveBackupManifests(t *testing.T) {
 			&mem,
 			collections[0],
 			collections,
-			baseStores,
-			incStores,
 			execCfg.DistSQLSrv.ExternalStorageFromURI,
 			fullSubdir,
 			fullyResolvedBaseDirs,
@@ -448,8 +430,6 @@ func TestResolveBackupManifests(t *testing.T) {
 			&mem,
 			collections[0],
 			collections,
-			baseStores,
-			incStores,
 			execCfg.DistSQLSrv.ExternalStorageFromURI,
 			fullSubdir,
 			fullyResolvedBaseDirs,

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -745,17 +745,6 @@ func getBackupChain(
 			log.Dev.Warningf(ctx, "failed to cleanup base backup stores: %+v", err)
 		}
 	}()
-	incStores, incCleanup, err := backupdest.MakeBackupDestinationStores(
-		ctx, user, mkStore, resolvedIncDirs,
-	)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	defer func() {
-		if err := incCleanup(); err != nil {
-			log.Dev.Warningf(ctx, "failed to cleanup incremental backup stores: %+v", err)
-		}
-	}()
 	baseEncryptionInfo := encryptionOpts
 	if encryptionOpts != nil && !encryptionOpts.HasKey() {
 		baseEncryptionInfo, err = backupencryption.GetEncryptionFromBaseStore(
@@ -770,7 +759,7 @@ func getBackupChain(
 	defer mem.Close(ctx)
 
 	_, manifests, localityInfo, memReserved, err := backupdest.ResolveBackupManifests(
-		ctx, execCfg, &mem, defaultCollectionURI, dest.To, baseStores, incStores, mkStore, resolvedSubdir,
+		ctx, execCfg, &mem, defaultCollectionURI, dest.To, mkStore, resolvedSubdir,
 		resolvedBaseDirs, resolvedIncDirs, endTime, baseEncryptionInfo, kmsEnv,
 		user, false /*includeSkipped */, true /*includeCompacted */, len(dest.IncrementalStorage) > 0,
 	)

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1738,18 +1738,7 @@ func doRestorePlan(
 	}
 	defer func() {
 		if err := cleanupFn(); err != nil {
-			log.Dev.Warningf(ctx, "failed to close incremental store: %+v", err)
-		}
-	}()
-
-	incStores, cleanupFn, err := backupdest.MakeBackupDestinationStores(ctx, p.User(), mkStore,
-		fullyResolvedIncrementalsDirectory)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := cleanupFn(); err != nil {
-			log.Dev.Warningf(ctx, "failed to close incremental store: %+v", err)
+			log.Dev.Warningf(ctx, "failed to close base store: %+v", err)
 		}
 	}()
 
@@ -1805,7 +1794,7 @@ func doRestorePlan(
 	// directories, return the URIs and manifests of all backup layers in all
 	// localities. Incrementals will be searched for automatically.
 	defaultURIs, mainBackupManifests, localityInfo, memReserved, err := backupdest.ResolveBackupManifests(
-		ctx, p.ExecCfg(), &mem, defaultCollectionURI, from, baseStores, incStores, mkStore,
+		ctx, p.ExecCfg(), &mem, defaultCollectionURI, from, mkStore,
 		fullyResolvedSubdir, fullyResolvedBaseDirectory, fullyResolvedIncrementalsDirectory, endTime,
 		encryption, &kmsEnv, p.User(), false, includeCompacted, len(incFrom) > 0,
 	)

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -346,20 +346,10 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 		info.enc = encryption
 
 		mkStore := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
-		incStores, cleanupFn, err := backupdest.MakeBackupDestinationStores(ctx, p.User(), mkStore,
-			fullyResolvedIncrementalsDirectory)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if err := cleanupFn(); err != nil {
-				log.Dev.Warningf(ctx, "failed to close incremental store: %+v", err)
-			}
-		}()
 
 		info.defaultURIs, info.manifests, info.localityInfo, memReserved,
 			err = backupdest.ResolveBackupManifests(
-			ctx, p.ExecCfg(), &mem, defaultCollectionURI, dest, baseStores, incStores, mkStore, subdir,
+			ctx, p.ExecCfg(), &mem, defaultCollectionURI, dest, mkStore, subdir,
 			fullyResolvedDest, fullyResolvedIncrementalsDirectory, hlc.Timestamp{},
 			encryption, &kmsEnv, p.User(), true /* includeSkipped */, true, /* includeCompacted */
 			len(explicitIncPaths) > 0,


### PR DESCRIPTION
First attempt to reduce ResolveBackupManifests signature and metadata loading
logic bloat.

Epic: none

Release note: none