### PR TITLE
roachprod: load balancing mode

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -2323,13 +2323,16 @@ func (p *Provider) CreateLoadBalancer(l *logger.Logger, vms vm.List, port int) e
 		spinner := ui.NewDefaultCountingSpinner(l, "adding backends to load balancer", len(groups))
 		defer spinner.Start()()
 		for n, group := range groups {
+			// We use balancing mode CONNECTION and set an "unlimited" number of max
+			// connections per group to force the load-balancer to run in round-robin
+			// mode.
 			args = []string{"compute", "backend-services", "add-backend", loadBalancerName,
 				"--project", project,
 				"--global",
 				"--instance-group", group.Name,
 				"--instance-group-zone", group.Zone,
-				"--balancing-mode", "UTILIZATION",
-				"--max-utilization", "0.8",
+				"--balancing-mode", "CONNECTION",
+				"--max-connections", "9999999",
 			}
 			cmd := exec.Command("gcloud", args...)
 			output, err = cmd.CombinedOutput()


### PR DESCRIPTION
Previously, the load balancer was set to use utilization, but for most testing purposes we want this to be round-robin. This change updates the load balancer to use a max connections setting per instance group which essentially causes the load balancer to use round-robin amongst each group.

Epic: None
Release note: None