### PR TITLE
server: only auto-upgrade system tenant from meta1 leaseholder

### DIFF
--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -252,6 +252,23 @@ var PreserveDowngradeVersion = settings.RegisterStringSetting(
 	settings.WithPublic,
 )
 
+// AutoUpgradeEnabled is used to enable and disable automatic upgrade.
+var AutoUpgradeEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"cluster.auto_upgrade.enabled",
+	"disable automatic cluster version upgrade until reset",
+	true,
+	settings.WithReportable(true),
+	settings.WithPublic,
+)
+
+var AutoUpgradeSystemClusterFromMeta1Leaseholder = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"cluster.auto_upgrade.initiate_from_meta1leaseholder.enabled",
+	"only initiate automatic cluster version upgrade from the Meta1 leaseholder (system-cluster only)",
+	true,
+)
+
 var metaPreserveDowngradeLastUpdated = metric.Metadata{
 	Name:        "cluster.preserve-downgrade-option.last-updated",
 	Help:        "Unix timestamp of last updated time for cluster.preserve_downgrade_option",
@@ -291,13 +308,3 @@ func MakeMetricsAndRegisterOnVersionChangeCallback(sv *settings.Values) Metrics 
 		PreserveDowngradeLastUpdated: gauge,
 	}
 }
-
-// AutoUpgradeEnabled is used to enable and disable automatic upgrade.
-var AutoUpgradeEnabled = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"cluster.auto_upgrade.enabled",
-	"disable automatic cluster version upgrade until reset",
-	true,
-	settings.WithReportable(true),
-	settings.WithPublic,
-)

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -47,6 +47,14 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 		}
 
 		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+			if clusterversion.AutoUpgradeSystemClusterFromMeta1Leaseholder.Get(&s.ClusterSettings().SV) {
+				isMeta1LH, err := s.sqlServer.isMeta1Leaseholder(ctx, s.clock.NowAsClockTimestamp())
+				if err != nil || !isMeta1LH {
+					log.Ops.VInfof(ctx, 2, "not upgrading since we are not the Meta1 leaseholder; err=%v", err)
+					continue
+				}
+			}
+
 			clusterVersion, err := s.clusterVersion(ctx)
 			if err != nil {
 				log.Dev.Errorf(ctx, "unable to retrieve cluster version: %v", err)


### PR DESCRIPTION
Running the auto-upgrade process from all nodes does some amount of wasted work. Let's avoid that by only running it from the meta1 leaseholder. This only applies to the system tenant.

For shared-process multi-tenancy, we may consider allowing secondary tenants access to this same information.

For separate process multi-tenancy, a different solution would be needed.

Informs #152916

Release note: None