### PR TITLE
changefeedccl: revert to single PTS if per-table PTS is disabled

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1425,6 +1425,33 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 			initialHighwater = *ts
 		}
 
+		var perTableProtectedTimestamps bool
+		if cf.spec.ProgressConfig != nil {
+			perTableProtectedTimestamps = cf.spec.ProgressConfig.PerTableProtectedTimestamps
+		}
+
+		if !perTableProtectedTimestamps {
+			if err := cf.js.job.DebugNameNoTxn(changefeedJobProgressTxnName).Update(cf.Ctx(), func(
+				txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+			) error {
+				progress := md.Progress
+				changefeedProgress := progress.Details.(*jobspb.Progress_Changefeed).Changefeed
+				if err := cf.revertPerTableProtectedTimestampRecords(ctx, txn, changefeedProgress); err != nil {
+					return err
+				}
+				ju.UpdateProgress(progress)
+				return nil
+			}); err != nil {
+				log.Changefeed.Warningf(
+					cf.Ctx(),
+					"moving to draining due to error reverting per-table protected ts records: %v",
+					err,
+				)
+				cf.MoveToDraining(err)
+				return
+			}
+		}
+
 		// latestResolvedKV timestamp is set to the current time to make
 		// sure that even if the target table does not have any
 		// KV events coming in, the changefeed will remain
@@ -1455,6 +1482,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	if cf.spec.ProgressConfig != nil {
 		perTableTracking = cf.spec.ProgressConfig.PerTableTracking
 	}
+
 	cf.frontier, err = resolvedspan.NewCoordinatorFrontier(
 		cf.spec.Feed.StatementTime, initialHighwater, cf.FlowCtx.Codec(),
 		perTableTracking,
@@ -1954,6 +1982,36 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		}
 		return updatedMainPTS || updatedPerTablePTS, nil
 	}
+	if len(ptsEntries.ProtectedTimestampRecords) > 0 {
+		// In this case, we should have tried to revert the per-table protected timestamp records,
+		// but we didn't because there were still lagging tables.
+		// We now try to advance the protected timestamp for the lagging tables unless
+		// there are no lagging tables and all can be protected with the primary PTS record.
+		updatedPerTablePTS, err :=
+			cf.advanceLaggingPerTableProtectedTimestamps(ctx, txn, progress, &ptsEntries, highwater)
+		if err != nil {
+			return false, err
+		}
+
+		// Check if the call to advanceLaggingPerTableProtectedTimestamps resulted in
+		// all lagging tables catching up.
+		if len(ptsEntries.ProtectedTimestampRecords) == 0 {
+			// If no tables are lagging, we can revert the new per-table style PTS records.
+			if err := cf.revertPerTableProtectedTimestampRecords(ctx, txn, progress); err != nil {
+				return false, err
+			}
+			_, err := cf.advanceProtectedTimestamp(ctx, progress, pts, highwater)
+			if err != nil {
+				return false, err
+			}
+			// Since we went from having lagging tables to not having any lagging
+			// tables, we have advanced the primary PTS record even if we don't
+			// end up advancing it in advanceProtectedTimestamp.
+			return true, err
+		}
+
+		return updatedPerTablePTS, nil
+	}
 
 	return cf.advanceProtectedTimestamp(ctx, progress, pts, highwater)
 }
@@ -2041,6 +2099,73 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 	}
 
 	return newPTS, updatedPerTablePTS, nil
+}
+
+func (cf *changeFrontier) advanceLaggingPerTableProtectedTimestamps(
+	ctx context.Context,
+	txn isql.Txn,
+	progress *jobspb.ChangefeedProgress,
+	ptsEntries *cdcprogresspb.ProtectedTimestampRecords,
+	highwater hlc.Timestamp,
+) (updatedPerTablePTS bool, err error) {
+	pts := cf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
+
+	primaryPTS, err := pts.GetRecord(ctx, progress.ProtectedTimestampRecord)
+	if err != nil {
+		return false, err
+	}
+	primaryPTSTimestamp := primaryPTS.Timestamp
+	isLagging := highwater.Less(primaryPTSTimestamp)
+	if cf.knobs.IsPTSReversionLagging != nil {
+		isLagging = cf.knobs.IsPTSReversionLagging()
+	}
+
+	// If the highwater has caught up to the primary PTS timestamp,
+	// we should release all per-table PTS records. Otherwise, we should
+	// advance them with the highwater.
+	if !isLagging {
+		allLaggingTableIDs := make([]descpb.ID, 0)
+		for tableID := range ptsEntries.ProtectedTimestampRecords {
+			allLaggingTableIDs = append(allLaggingTableIDs, tableID)
+		}
+		if err := cf.releasePerTableProtectedTimestampRecords(ctx, ptsEntries, allLaggingTableIDs, pts); err != nil {
+			return false, err
+		}
+		ptsEntries.ProtectedTimestampRecords = nil
+		if err := writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, ptsEntries, txn, cf.spec.JobID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	for tableID := range ptsEntries.ProtectedTimestampRecords {
+		if updated, err := cf.advancePerTableProtectedTimestampRecord(ctx, ptsEntries, tableID, highwater, pts); err != nil {
+			return false, err
+		} else if updated {
+			updatedPerTablePTS = true
+		}
+	}
+
+	return updatedPerTablePTS, nil
+}
+
+func (cf *changeFrontier) revertPerTableProtectedTimestampRecords(
+	ctx context.Context, txn isql.Txn, progress *jobspb.ChangefeedProgress,
+) error {
+	var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+	if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, cf.spec.JobID); err != nil {
+		return err
+	}
+	if len(ptsEntries.ProtectedTimestampRecords) > 0 {
+		// If there are any lagging tables records, we don't revert until these
+		// lagging tables have caught up to the highwater.
+		return nil
+	}
+	ptsEntries.ProtectedTimestampRecords = nil
+	if err := writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, cf.spec.JobID); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (cf *changeFrontier) releasePerTableProtectedTimestampRecords(

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -1208,6 +1208,305 @@ func TestChangefeedPerTableProtectedTimestampProgression(t *testing.T) {
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
 
+// TestChangefeedPerTableProtectedTimestampsRevert tests that a
+// changefeed created with per-table protected timestamps enabled is not reverted
+// while there are still lagging tables.
+func TestChangefeedPerTableProtectedTimestampsRevert(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Configure frequent checkpointing and PTS updates for faster testing
+		changefeedbase.SpanCheckpointInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 50*time.Millisecond)
+
+		// Enable per-table protected timestamps and progress tracking
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
+		sqlDB.Exec(t, `CREATE TABLE table1 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table2 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table3 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (1, 'data1'), (2, 'data2')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (1, 'data1'), (2, 'data2')`)
+		sqlDB.Exec(t, `INSERT INTO table3 VALUES (1, 'data1'), (2, 'data2')`)
+
+		// Get table ID for controlling lagging behavior
+		var table1ID descpb.ID
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table1' AND database_name = current_database()`).Scan(&table1ID)
+
+		knobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		var table1Lagging atomic.Bool
+		knobs.IsTableLagging = func(tableID descpb.ID) bool {
+			switch tableID {
+			case table1ID:
+				return table1Lagging.Load()
+			default:
+				return false
+			}
+		}
+
+		createStmt := `CREATE CHANGEFEED FOR table1, table2, table3 WITH resolved='100ms'`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`table1: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table1: [2]->{"after": {"id": 2, "s": "data2"}}`,
+			`table2: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table2: [2]->{"after": {"id": 2, "s": "data2"}}`,
+			`table3: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table3: [2]->{"after": {"id": 2, "s": "data2"}}`,
+		})
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+
+		getPTSEntries := func() cdcprogresspb.ProtectedTimestampRecords {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				return readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID())
+			}))
+			return ptsEntries
+		}
+
+		assertPTSRecords := func(expectedLaggingTables map[descpb.ID]struct{}) {
+			testutils.SucceedsSoon(t, func() error {
+				ptsEntries := getPTSEntries()
+
+				if len(ptsEntries.ProtectedTimestampRecords) != len(expectedLaggingTables) {
+					return errors.Newf("expected %d per-table PTS records, got %d", len(expectedLaggingTables), len(ptsEntries.ProtectedTimestampRecords))
+				}
+				for tableID := range expectedLaggingTables {
+					if ptsEntries.ProtectedTimestampRecords[tableID] == nil {
+						return errors.Newf("expected PTS record for table %d", tableID)
+					}
+				}
+
+				progress, err := eFeed.Progress()
+				if err != nil {
+					return err
+				}
+				if progress.ProtectedTimestampRecord.Equal(uuid.Nil) {
+					return errors.New("expected feed-level PTS record to exist")
+				}
+				return nil
+			})
+		}
+
+		table1Lagging.Store(true)
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+		assertPTSRecords(map[descpb.ID]struct{}{table1ID: {}})
+
+		// We are going to turn off per-table protected timestamps. Once we do,
+		// we will use only the changefeed's highwater to determine if per table
+		// protected timestamps have caught up to the primary PTS record, because
+		// we no longer have access to per-table highwaters.
+		knobs.IsPTSReversionLagging = func() bool {
+			return table1Lagging.Load()
+		}
+
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+
+		require.NoError(t, eFeed.Pause())
+		require.NoError(t, eFeed.Resume())
+
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		assertPTSRecords(map[descpb.ID]struct{}{table1ID: {}})
+
+		getTable1PTS := func() hlc.Timestamp {
+			ptsEntries := getPTSEntries()
+			require.NotEqual(t, uuid.Nil, ptsEntries.ProtectedTimestampRecords[table1ID])
+			var ts hlc.Timestamp
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				ptp := s.Server.DistSQLServer().(*distsql.ServerImpl).ServerConfig.ProtectedTimestampProvider
+				rec, err := ptp.WithTxn(txn).GetRecord(ctx, *ptsEntries.ProtectedTimestampRecords[table1ID])
+				if err != nil {
+					return err
+				}
+				ts = rec.Timestamp
+				return nil
+			}))
+			return ts
+		}
+
+		table1PTSBefore := getTable1PTS()
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+		testutils.SucceedsSoon(t, func() error {
+			table1PTSAfter := getTable1PTS()
+			if !table1PTSBefore.Less(table1PTSAfter) {
+				return errors.Newf("expected table 1 PTS to advance from %v, got %v", table1PTSBefore, table1PTSAfter)
+			}
+			return nil
+		})
+
+		// Once the changefeed's highwater has caught up to the primary PTS record,
+		// we should revert the per-table protected timestamp records as soon as
+		// the highwater has caught up to the primary PTS record.
+		table1Lagging.Store(false)
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+		assertPTSRecords(map[descpb.ID]struct{}{})
+
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (3, 'data3')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (3, 'data3')`)
+		sqlDB.Exec(t, `INSERT INTO table3 VALUES (3, 'data3')`)
+		assertPayloads(t, testFeed, []string{
+			`table1: [3]->{"after": {"id": 3, "s": "data3"}}`,
+			`table2: [3]->{"after": {"id": 3, "s": "data3"}}`,
+			`table3: [3]->{"after": {"id": 3, "s": "data3"}}`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
+// TestChangefeedPerTablePTSReleaseWithDisabledTracking tests that per-table PTS
+// records cannot be released when per-table tracking is disabled, even after
+// tables stop lagging.
+func TestChangefeedPerTablePTSReleaseWithDisabledTracking(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Configure frequent checkpointing and PTS updates for faster testing
+		changefeedbase.SpanCheckpointInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 50*time.Millisecond)
+
+		// Enable per-table protected timestamps and progress tracking
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, true)
+
+		sqlDB.Exec(t, `CREATE TABLE table1 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE table2 (id INT PRIMARY KEY, s STRING)`)
+		sqlDB.Exec(t, `INSERT INTO table1 VALUES (1, 'data1')`)
+		sqlDB.Exec(t, `INSERT INTO table2 VALUES (1, 'data1')`)
+
+		var table1ID, table2ID descpb.ID
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table1' AND database_name = current_database()`).Scan(&table1ID)
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table2' AND database_name = current_database()`).Scan(&table2ID)
+
+		knobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		var table1Lagging, table2Lagging atomic.Bool
+		knobs.IsTableLagging = func(tableID descpb.ID) bool {
+			switch tableID {
+			case table1ID:
+				return table1Lagging.Load()
+			case table2ID:
+				return table2Lagging.Load()
+			default:
+				return false
+			}
+		}
+
+		createStmt := `CREATE CHANGEFEED FOR table1, table2 WITH resolved='100ms'`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`table1: [1]->{"after": {"id": 1, "s": "data1"}}`,
+			`table2: [1]->{"after": {"id": 1, "s": "data1"}}`,
+		})
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+
+		getPTSEntries := func() cdcprogresspb.ProtectedTimestampRecords {
+			var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+			require.NoError(t, execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				return readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID())
+			}))
+			return ptsEntries
+		}
+
+		assertPerTablePTSExist := func(expectedTables map[descpb.ID]struct{}) {
+			testutils.SucceedsSoon(t, func() error {
+				ptsEntries := getPTSEntries()
+				if len(ptsEntries.ProtectedTimestampRecords) != len(expectedTables) {
+					return errors.Newf("expected %d per-table PTS records, got %d", len(expectedTables), len(ptsEntries.ProtectedTimestampRecords))
+				}
+				for tableID := range expectedTables {
+					if ptsEntries.ProtectedTimestampRecords[tableID] == nil {
+						return errors.Newf("expected PTS record for table %d", tableID)
+					}
+				}
+				return nil
+			})
+		}
+
+		table1Lagging.Store(true)
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		assertPerTablePTSExist(map[descpb.ID]struct{}{table1ID: {}})
+
+		require.NoError(t, eFeed.Pause())
+		changefeedbase.TrackPerTableProgress.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
+
+		table1Lagging.Store(false)
+		require.NoError(t, eFeed.Resume())
+
+		{
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+		}
+
+		assertPerTablePTSExist(map[descpb.ID]struct{}{})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
 func fetchRoleMembers(
 	ctx context.Context, execCfg *sql.ExecutorConfig, ts hlc.Timestamp,
 ) ([][]string, error) {

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -98,6 +98,11 @@ type TestingKnobs struct {
 	// to check if the table is lagging.
 	IsTableLagging func(tableID descpb.ID) bool
 
+	// IsPTSReversionLagging is a callback that's invoked by manage protected timestamp
+	// to check if the changefeed's highwater has caught up to the primary PTS record
+	// when reverting per-table protected timestamps.
+	IsPTSReversionLagging func() bool
+
 	// PulsarClientSkipCreation skips creating the sink client when
 	// dialing.
 	PulsarClientSkipCreation bool


### PR DESCRIPTION
When per-table protected timestamp records are disabled via the
cluster setting, a restarted changefeed should eventually fall
back to the legacy single-record format. However, if any tables
are still lagging, we retain their individual PTS records and
continue attempting to advance them using the highwater timestamp
on each management cycle. Once all lagging tables have caught up,
the changefeed cleans up the per-table records and reverts fully
to a single protected timestamp record.

Fixes: https://github.com/cockroachdb/cockroach/issues/147790
Epic: [CRDB-1421](https://cockroachlabs.atlassian.net/browse/CRDB-1421)
Release note: None