### PR TITLE
release-25.2: serverccl, application_api: Fix some tests relying on statement_statistics

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -501,11 +501,6 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 
 		var actualStatements []string
 		for _, respStatement := range actual.Statements {
-			if respStatement.Stats.FailureCount > 0 {
-				// We ignore failed statements here as the INSERT statement can fail and
-				// be automatically retried, confusing the test success check.
-				continue
-			}
 			if strings.HasPrefix(respStatement.Key.KeyData.App, catconstants.InternalAppNamePrefix) {
 				// We ignore internal queries, these are not relevant for the
 				// validity of this test.


### PR DESCRIPTION
Backport 1/1 commits from #153366.

/cc @cockroachdb/release

---

This commit sets the SynchronousSQLStats testing knob on for TestTenantCannotSeeNonTenantStats.

Additionally, it fixes a testing bug in TestTenantCannotSeeNonTenantStats, TestStatusAPIStatements, TestStatusAPICombinedStatementsWithFullScans, and TestStatusAPICombinedStatements.

These tests involve executing a set of statements and verifying that the statement stats response contains the same set of statements. However, they filter out statements with a failure count > 0.

This was a bug introduced by pull #120236 which changed the way failed statements were collected in the SQL stats system. Previously, a stmt with the same query that failed to execute would recieve a different fingerprint and thus be included as a different entry in the statements response.

These existing tests filtered out statement entries that failed b/c they used to be an additional entry that would fail when comparing with the set of stmts executed. This filtering out from the tests should have been removed as part of pull #120236.

Fixes: #152175
Release note: None

----

Release justification: test changes
