### PR TITLE
server: always enable DRPC listener irrespective of the setting

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
@@ -2134,7 +2135,7 @@ func (s *adminServer) checkReadinessForHealthCheck(ctx context.Context) error {
 		return err
 	}
 
-	if s.drpc.enabled {
+	if rpcbase.ExperimentalDRPCEnabled.Get(&s.st.SV) {
 		if err := s.drpc.health(ctx); err != nil {
 			return err
 		}
@@ -2180,7 +2181,7 @@ func (s *systemAdminServer) checkReadinessForHealthCheck(ctx context.Context) er
 		return err
 	}
 
-	if s.drpc.enabled {
+	if rpcbase.ExperimentalDRPCEnabled.Get(&s.st.SV) {
 		if err := s.drpc.health(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the DRPC server was only started when the experimental DRPC
setting was enabled. This created a problem where enabling DRPC after a
node had already started would not work, as the listener would not be
running and would reject all DRPC requests until the node was restarted.

To address this, this patch always enables the DRPC listener regardless of
the experimental setting. The cost of leaving the DRPC listener on all the
time is low, and this change simplifies the codebase by removing the need
to check cluster settings when creating clients (see #153449). This could even help us
avoid the need for a restart to enable DRPC entirely, if we can also figure
out how to swap our gRPC clients for DRPC clients in various subsystems.

Fixes #153450
Release note: None
Epic: CRDB-52378