### PR TITLE
kvcoord: use separate flush for EndTxn with Prepare=true

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
@@ -28,7 +28,7 @@ ok
 exec-privileged-op-tenant
 PREPARE TRANSACTION 'txn1'
 ----
-pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(commit) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
+pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(prepare) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
 
 
 # Grant the capability.
@@ -78,7 +78,7 @@ ok
 exec-privileged-op-tenant
 PREPARE TRANSACTION 'txn3'
 ----
-pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(commit) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
+pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(prepare) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
 
 
 # However, transactions that have not acquired locks are able to be prepared,

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
@@ -3,14 +3,15 @@ SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_
 ----
 10 cluster-10 ready external can_prepare_txns false
 
-# TODO(#144252): remove this.
-exec-sql-tenant
-SET kv_transaction_buffered_writes_enabled = false
-----
-ok
 
 exec-sql-tenant
 CREATE TABLE t(a INT PRIMARY KEY)
+----
+ok
+
+# Disable buffered writes so that the failing batch has the same requests.
+exec-privileged-op-tenant
+SET kv_transaction_buffered_writes_enabled = false
 ----
 ok
 
@@ -30,6 +31,10 @@ PREPARE TRANSACTION 'txn1'
 ----
 pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(prepare) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
 
+exec-privileged-op-tenant
+RESET kv_transaction_buffered_writes_enabled
+----
+ok
 
 # Grant the capability.
 update-capabilities
@@ -57,10 +62,15 @@ ROLLBACK PREPARED 'txn2'
 ----
 ok
 
-
 # Revoke the capability using REVOKE syntax.
 update-capabilities
 ALTER TENANT [10] REVOKE CAPABILITY can_prepare_txns
+----
+ok
+
+# Disable buffered writes so that the failing batch has the same requests.
+exec-privileged-op-tenant
+SET kv_transaction_buffered_writes_enabled = false
 ----
 ok
 
@@ -80,6 +90,10 @@ PREPARE TRANSACTION 'txn3'
 ----
 pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(prepare) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
 
+exec-privileged-op-tenant
+RESET kv_transaction_buffered_writes_enabled
+----
+ok
 
 # However, transactions that have not acquired locks are able to be prepared,
 # since they don't actually prepare a transaction record in the KV layer. This

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -2186,7 +2186,7 @@ func TestTxnWriteBufferSplitsBatchesWhenNecessary(t *testing.T) {
 			br.Txn = ba.Txn
 			if requestCount == 0 {
 				// The buffer flush should not have any problematic settings.
-				require.False(t, separateBatchIsNeeded(ba))
+				require.False(t, separateBatchIsNeeded(ba, nil))
 			}
 			requestCount++
 			return br, nil
@@ -4090,7 +4090,7 @@ needs to be accounted for in the following functions:
 				}
 			}
 			req := &kvpb.BatchRequest{Header: header}
-			require.True(t, separateBatchIsNeeded(req),
+			require.True(t, separateBatchIsNeeded(req, nil),
 				"non-zero value for %s not handled in separateBatchIsNeeded", fieldName)
 
 			clearBatchRequestOptions(req)

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -248,7 +248,9 @@ var _ SafeFormatterRequest = (*EndTxnRequest)(nil)
 func (etr *EndTxnRequest) SafeFormat(s redact.SafePrinter, _ rune) {
 	s.Printf("%s(", etr.Method())
 	if etr.Commit {
-		if etr.IsParallelCommit() {
+		if etr.Prepare {
+			s.Printf("prepare")
+		} else if etr.IsParallelCommit() {
 			s.Printf("parallel commit")
 		} else {
 			s.Printf("commit")

--- a/pkg/sql/logictest/testdata/logic_test/two_phase_commit
+++ b/pkg/sql/logictest/testdata/logic_test/two_phase_commit
@@ -1,9 +1,5 @@
 # LogicTest: !3node-tenant-default-configs !local-prepared
 
-# TODO(#144252): remove this.
-statement ok
-SET kv_transaction_buffered_writes_enabled = false;
-
 query T
 SHOW max_prepared_transactions
 ----


### PR DESCRIPTION
Because of #153513 it is not safe to send a batch with writes and an
EndTxn where Prepare=true as it might be immediately committed as a 1PC
transaction.

I've forgone a release note here because as far as I can tell
XA-transactions are not yet a documented feature.

Informs #153513
Fixes #144252

Release note: None