### PR TITLE
util: introduce LabelSliceCache in metric

### DIFF
--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "hdrhistogram.go",
         "histogram_buckets.go",
         "histogram_snapshot.go",
+        "label_slice_cache.go",
         "metric.go",
         "prometheus_exporter.go",
         "prometheus_rule_exporter.go",
@@ -24,6 +25,7 @@ go_library(
     deps = [
         "//pkg/settings",
         "//pkg/util/buildutil",
+        "//pkg/util/cache",
         "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/metamorphic",
@@ -48,6 +50,7 @@ go_test(
     size = "small",
     srcs = [
         "histogram_buckets_test.go",
+        "label_slice_cache_test.go",
         "metric_ext_test.go",
         "metric_test.go",
         "prometheus_exporter_test.go",

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -11,6 +11,7 @@ package aggmetric
 import (
 	"hash/fnv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -23,8 +24,10 @@ import (
 var delimiter = []byte{'_'}
 
 const (
-	dbLabel  = "database"
-	appLabel = "application_name"
+	dbLabel        = "database"
+	appLabel       = "application_name"
+	cacheSize      = 5000
+	childMetricTTL = 20 * time.Second
 )
 
 // Builder is used to ease constructing metrics with the same labels.
@@ -97,7 +100,6 @@ func (cs *childSet) initWithBTreeStorageType(labels []string) {
 }
 
 func getCacheStorage() *cache.UnorderedCache {
-	const cacheSize = 5000
 	cacheStorage := cache.NewUnorderedCache(cache.Config{
 		Policy: cache.CacheLRU,
 		//TODO (aa-joshi) : make cacheSize configurable in the future
@@ -311,6 +313,16 @@ type ChildMetric interface {
 	ToPrometheusMetric() *io_prometheus_client.Metric
 }
 
+// LabelSliceCachedChildMetric extends ChildMetric with label slice caching capabilities.
+// This interface is designed for child metrics that relies on label slice reference
+// counting system. Metrics implementing this interface can have their label values
+// cached and shared among multiple metrics with identical label combinations,
+// reducing memory usage and improving performance in scenarios with many similar metrics.
+type LabelSliceCachedChildMetric interface {
+	ChildMetric
+	CreatedAt() time.Time
+}
+
 type labelValuer interface {
 	labelValues() []string
 }
@@ -330,9 +342,10 @@ func metricKey(labels ...string) uint64 {
 
 type ChildrenStorage interface {
 	Get(labelVals ...string) (ChildMetric, bool)
+	GetValue(key uint64) (ChildMetric, bool)
 	Add(metric ChildMetric)
+	AddKey(key uint64, metric ChildMetric) error
 	Del(key ChildMetric)
-
 	// ForEach calls f for each child metric, in arbitrary order.
 	ForEach(f func(metric ChildMetric))
 	Clear()
@@ -343,6 +356,22 @@ var _ ChildrenStorage = &BtreeWrapper{}
 
 type UnorderedCacheWrapper struct {
 	cache *cache.UnorderedCache
+}
+
+func (ucw *UnorderedCacheWrapper) GetValue(key uint64) (ChildMetric, bool) {
+	value, ok := ucw.cache.Get(key)
+	if !ok {
+		return nil, false
+	}
+	return value.(ChildMetric), ok
+}
+
+func (ucw *UnorderedCacheWrapper) AddKey(key uint64, metric ChildMetric) error {
+	if _, ok := ucw.cache.Get(key); ok {
+		return errors.Newf("child %v already exists\n", metric.labelValues())
+	}
+	ucw.cache.Add(key, metric)
+	return nil
 }
 
 func (ucw *UnorderedCacheWrapper) Get(labelVals ...string) (ChildMetric, bool) {
@@ -382,6 +411,18 @@ func (ucw *UnorderedCacheWrapper) Clear() {
 
 type BtreeWrapper struct {
 	tree *btree.BTreeG[MetricItem]
+}
+
+func (b BtreeWrapper) GetValue(key uint64) (ChildMetric, bool) {
+	// GetValue method is not relevant for BtreeWrapper as it uses ChildMetric
+	// as an item in Btree. We are going to remove BtreeWrapper as ChildrenStorage.
+	panic("unimplemented")
+}
+
+func (b BtreeWrapper) AddKey(_ uint64, _ ChildMetric) error {
+	// AddKey method is not relevant for BtreeWrapper as it uses ChildMetric
+	// as an item in Btree. We are going to remove BtreeWrapper as ChildrenStorage.
+	panic("unimplemented")
 }
 
 func (b BtreeWrapper) Get(labelVals ...string) (ChildMetric, bool) {

--- a/pkg/util/metric/label_slice_cache.go
+++ b/pkg/util/metric/label_slice_cache.go
@@ -1,0 +1,117 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package metric
+
+import (
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// LabelSliceCacheKey is the hash key type for the cache.
+type LabelSliceCacheKey uint64
+
+// LabelSliceCacheValue is the value stored in the cache.
+type LabelSliceCacheValue struct {
+	LabelValues []string
+	Counter     atomic.Int64
+}
+
+// LabelSliceCache is a thread-safe cache mapping hash keys to label value/counter pairs.
+type LabelSliceCache struct {
+	mu struct {
+		syncutil.Mutex
+		cache *cache.UnorderedCache
+	}
+}
+
+// NewLabelSliceCache creates a new LabelSliceCache.
+func NewLabelSliceCache() *LabelSliceCache {
+	labelSliceCache := &LabelSliceCache{}
+	labelSliceCache.mu.cache = cache.NewUnorderedCache(cache.Config{})
+	return labelSliceCache
+}
+
+// Get returns the value for the given key, or nil if not present.
+func (lsc *LabelSliceCache) Get(key LabelSliceCacheKey) (*LabelSliceCacheValue, bool) {
+	lsc.mu.Lock()
+	defer lsc.mu.Unlock()
+	val, ok := lsc.mu.cache.Get(key)
+	if !ok {
+		return nil, false
+	}
+	return val.(*LabelSliceCacheValue), true
+}
+
+// Upsert adds or updates the value for the given key with reference counting.
+// This method implements the "add reference" part of the reference counting mechanism.
+// When a new metric with a specific label combination is created, this method performs
+// either:
+//  1. Add a new entry to the cache with a reference count of 1 (if the label combination
+//     is being used for the first time)
+//  2. Increment the existing reference count by 1 (if the label combination is already
+//     cached and being used by other metrics)
+//
+// This ensures that the cache tracks how many metrics are currently using each
+// label combination, enabling proper cleanup via DecrementAndDeleteIfZero when
+// metrics are no longer needed.
+func (lsc *LabelSliceCache) Upsert(key LabelSliceCacheKey, value *LabelSliceCacheValue) {
+	lsc.mu.Lock()
+	defer lsc.mu.Unlock()
+	val, ok := lsc.mu.cache.Get(key)
+
+	if !ok {
+		value.Counter.Store(1)
+		lsc.mu.cache.Add(key, value)
+	} else {
+		existingValue := val.(*LabelSliceCacheValue)
+		existingValue.Counter.Add(1)
+		lsc.mu.cache.Add(key, existingValue)
+	}
+}
+
+// Delete removes the value for the given key.
+func (lsc *LabelSliceCache) Delete(key LabelSliceCacheKey) {
+	lsc.mu.Lock()
+	defer lsc.mu.Unlock()
+	lsc.mu.cache.Del(key)
+}
+
+// DecrementAndDeleteIfZero decrements the reference counter for the given key by 1.
+// This method implements reference counting for cached label value combinations.
+// When metrics with specific label combinations are created, the cache counter
+// is incremented via Upsert. When those metrics are no longer needed or go out
+// of scope, this method should be called to decrement the reference count.
+//
+// The automatic deletion when the counter reaches zero is crucial for preventing
+// memory leaks in long-running processes where metrics with dynamic label values
+// might be created and destroyed frequently. Without this cleanup mechanism,
+// the cache would accumulate unused label combinations indefinitely.
+//
+// Returns true if the entry was deleted due to the counter reaching zero,
+// false if the entry still has references or didn't exist.
+func (lsc *LabelSliceCache) DecrementAndDeleteIfZero(key LabelSliceCacheKey) bool {
+	lsc.mu.Lock()
+	defer lsc.mu.Unlock()
+
+	val, ok := lsc.mu.cache.Get(key)
+	if !ok {
+		// Key doesn't exist, return 0 and false
+		return false
+	}
+
+	existingValue := val.(*LabelSliceCacheValue)
+	newCount := existingValue.Counter.Add(-1)
+
+	if newCount <= 0 {
+		// Remove the entry when counter reaches 0 or below
+		lsc.mu.cache.Del(key)
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/metric/label_slice_cache_test.go
+++ b/pkg/util/metric/label_slice_cache_test.go
@@ -1,0 +1,436 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package metric
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelSliceCache_NewLabelSliceCache(t *testing.T) {
+	cache := NewLabelSliceCache()
+	require.NotNil(t, cache)
+	require.NotNil(t, cache.mu.cache)
+}
+
+func TestLabelSliceCache_GetEmpty(t *testing.T) {
+	cache := NewLabelSliceCache()
+
+	value, ok := cache.Get(LabelSliceCacheKey(123))
+	require.False(t, ok)
+	require.Nil(t, value)
+}
+
+func TestLabelSliceCache_UpsertAndGet(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(456)
+	labelValues := []string{"app1", "db1"}
+
+	// Create initial value
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+
+	// Upsert should initialize counter to 1
+	cache.Upsert(key, value)
+
+	// Get the value back
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, retrievedValue)
+	require.Equal(t, labelValues, retrievedValue.LabelValues)
+	require.Equal(t, int64(1), retrievedValue.Counter.Load())
+}
+
+func TestLabelSliceCache_UpsertIncrementsCounter(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(789)
+	labelValues := []string{"app2", "db2"}
+
+	// Create initial value
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+
+	// First upsert - should set counter to 1
+	cache.Upsert(key, value)
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(1), retrievedValue.Counter.Load())
+
+	// Second upsert with same key - should increment counter to 2
+	cache.Upsert(key, value)
+	retrievedValue, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(2), retrievedValue.Counter.Load())
+
+	// Third upsert - should increment to 3
+	cache.Upsert(key, value)
+	retrievedValue, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(3), retrievedValue.Counter.Load())
+}
+
+func TestLabelSliceCache_Delete(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(101112)
+	labelValues := []string{"app3", "db3"}
+
+	// Add a value
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+	cache.Upsert(key, value)
+
+	// Verify it exists
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, retrievedValue)
+
+	// Delete it
+	cache.Delete(key)
+
+	// Verify it's gone
+	retrievedValue, ok = cache.Get(key)
+	require.False(t, ok)
+	require.Nil(t, retrievedValue)
+}
+
+func TestLabelSliceCache_DeleteNonExistent(t *testing.T) {
+	cache := NewLabelSliceCache()
+
+	// Deleting a non-existent key should not panic
+	cache.Delete(LabelSliceCacheKey(999999))
+
+	// Cache should still be usable
+	key := LabelSliceCacheKey(111111)
+	value := &LabelSliceCacheValue{
+		LabelValues: []string{"test"},
+	}
+	cache.Upsert(key, value)
+
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, retrievedValue)
+}
+
+func TestLabelSliceCache_MultipleKeys(t *testing.T) {
+	cache := NewLabelSliceCache()
+
+	// Add multiple different keys
+	keys := []LabelSliceCacheKey{1, 2, 3, 4, 5}
+	values := [][]string{
+		{"app1", "db1"},
+		{"app2", "db2"},
+		{"app3", "db3"},
+		{"app4", "db4"},
+		{"app5", "db5"},
+	}
+
+	// Insert all values
+	for i, key := range keys {
+		value := &LabelSliceCacheValue{
+			LabelValues: values[i],
+		}
+		cache.Upsert(key, value)
+	}
+
+	// Verify all values exist
+	for i, key := range keys {
+		retrievedValue, ok := cache.Get(key)
+		require.True(t, ok)
+		require.Equal(t, values[i], retrievedValue.LabelValues)
+		require.Equal(t, int64(1), retrievedValue.Counter.Load())
+	}
+
+	// Increment one of them
+	value := &LabelSliceCacheValue{
+		LabelValues: values[2],
+	}
+	cache.Upsert(keys[2], value)
+
+	// Verify only that one was incremented
+	for i, key := range keys {
+		retrievedValue, ok := cache.Get(key)
+		require.True(t, ok)
+		if i == 2 {
+			require.Equal(t, int64(2), retrievedValue.Counter.Load())
+		} else {
+			require.Equal(t, int64(1), retrievedValue.Counter.Load())
+		}
+	}
+}
+
+func TestLabelSliceCache_ConcurrentAccess(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(12345)
+	labelValues := []string{"concurrent", "test"}
+
+	const numGoroutines = 100
+	const numIterations = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Launch multiple goroutines to concurrently upsert the same key
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				value := &LabelSliceCacheValue{
+					LabelValues: labelValues,
+				}
+				cache.Upsert(key, value)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify the final counter value
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, retrievedValue)
+	require.Equal(t, labelValues, retrievedValue.LabelValues)
+	require.Equal(t, int64(numGoroutines*numIterations), retrievedValue.Counter.Load())
+}
+
+func TestLabelSliceCache_ConcurrentReadWrite(t *testing.T) {
+	cache := NewLabelSliceCache()
+	keys := []LabelSliceCacheKey{1, 2, 3, 4, 5}
+
+	const numReaders = 10
+	const numWriters = 5
+	const numIterations = 20
+
+	var wg sync.WaitGroup
+
+	// Launch reader goroutines
+	wg.Add(numReaders)
+	for i := 0; i < numReaders; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				for _, key := range keys {
+					_, _ = cache.Get(key)
+				}
+			}
+		}()
+	}
+
+	// Launch writer goroutines
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		go func(writerID int) {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				for keyIdx, key := range keys {
+					value := &LabelSliceCacheValue{
+						LabelValues: []string{fmt.Sprintf("db%d", writerID), fmt.Sprintf("app%d", keyIdx)},
+					}
+					cache.Upsert(key, value)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all keys have some data and correct counter values
+	for _, key := range keys {
+		retrievedValue, ok := cache.Get(key)
+		require.True(t, ok)
+		require.NotNil(t, retrievedValue)
+		require.Equal(t, int64(numWriters*numIterations), retrievedValue.Counter.Load())
+	}
+}
+
+func TestLabelSliceCache_EmptyLabelValues(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(999)
+
+	// Test with empty label values
+	value := &LabelSliceCacheValue{
+		LabelValues: []string{},
+	}
+
+	cache.Upsert(key, value)
+
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, retrievedValue)
+	require.Equal(t, []string{}, retrievedValue.LabelValues)
+	require.Equal(t, int64(1), retrievedValue.Counter.Load())
+}
+
+func TestLabelSliceCache_NilLabelValues(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(888)
+
+	// Test with nil label values
+	value := &LabelSliceCacheValue{
+		LabelValues: nil,
+	}
+
+	cache.Upsert(key, value)
+
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.NotNil(t, retrievedValue)
+	require.Nil(t, retrievedValue.LabelValues)
+	require.Equal(t, int64(1), retrievedValue.Counter.Load())
+}
+
+func TestLabelSliceCache_DecrementAndDeleteIfZero_NonExistent(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(123)
+
+	// Decrementing a non-existent key should return false
+	deleted := cache.DecrementAndDeleteIfZero(key)
+	require.False(t, deleted)
+}
+
+func TestLabelSliceCache_DecrementAndDeleteIfZero_SingleCounter(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(456)
+	labelValues := []string{"app1", "db1"}
+
+	// Add a value with counter 1
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+	cache.Upsert(key, value)
+
+	// Verify counter is 1
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(1), retrievedValue.Counter.Load())
+
+	// Decrement should delete the entry
+	deleted := cache.DecrementAndDeleteIfZero(key)
+	require.True(t, deleted)
+
+	// Verify entry is gone
+	retrievedValue, ok = cache.Get(key)
+	require.False(t, ok)
+	require.Nil(t, retrievedValue)
+}
+
+func TestLabelSliceCache_DecrementAndDeleteIfZero_MultipleCounter(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(789)
+	labelValues := []string{"app2", "db2"}
+
+	// Add a value multiple times to get counter 3
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+	cache.Upsert(key, value)
+	cache.Upsert(key, value)
+	cache.Upsert(key, value)
+
+	// Verify counter is 3
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(3), retrievedValue.Counter.Load())
+
+	// First decrement should reduce to 2, not delete
+	deleted := cache.DecrementAndDeleteIfZero(key)
+	require.False(t, deleted)
+
+	// Entry should still exist and counter should be 2
+	retrievedValue, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(2), retrievedValue.Counter.Load())
+
+	// Second decrement should reduce to 1, not delete
+	deleted = cache.DecrementAndDeleteIfZero(key)
+	require.False(t, deleted)
+
+	// Entry should still exist and counter should be 1
+	retrievedValue, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(1), retrievedValue.Counter.Load())
+
+	// Third decrement should delete
+	deleted = cache.DecrementAndDeleteIfZero(key)
+	require.True(t, deleted)
+
+	// Entry should be gone
+	retrievedValue, ok = cache.Get(key)
+	require.False(t, ok)
+	require.Nil(t, retrievedValue)
+}
+
+func TestLabelSliceCache_DecrementAndDeleteIfZero_ConcurrentAccess(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(12345)
+	labelValues := []string{"concurrent", "test"}
+
+	const numGoroutines = 50
+	const numIncrements = 10
+
+	// First, populate the cache with a high counter value
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+	for i := 0; i < numGoroutines*numIncrements; i++ {
+		cache.Upsert(key, value)
+	}
+
+	// Verify initial counter value
+	retrievedValue, ok := cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(numGoroutines*numIncrements), retrievedValue.Counter.Load())
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Launch multiple goroutines to concurrently decrement
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIncrements; j++ {
+				cache.DecrementAndDeleteIfZero(key)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Final state should be that the entry is deleted
+	retrievedValue, ok = cache.Get(key)
+	require.False(t, ok)
+	require.Nil(t, retrievedValue)
+}
+
+func TestLabelSliceCache_DecrementAndDeleteIfZero_NegativeCounter(t *testing.T) {
+	cache := NewLabelSliceCache()
+	key := LabelSliceCacheKey(999)
+	labelValues := []string{"negative", "test"}
+
+	// Create a value with counter starting at 1
+	value := &LabelSliceCacheValue{
+		LabelValues: labelValues,
+	}
+	cache.Upsert(key, value)
+
+	// First decrement should delete (counter goes to 0)
+	deleted := cache.DecrementAndDeleteIfZero(key)
+	require.True(t, deleted)
+
+	// Entry should be gone
+	retrievedValue, ok := cache.Get(key)
+	require.False(t, ok)
+	require.Nil(t, retrievedValue)
+
+	// Further decrements on non-existent key should return false
+	deleted = cache.DecrementAndDeleteIfZero(key)
+	require.False(t, deleted)
+}

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -133,6 +133,17 @@ type PrometheusReinitialisable interface {
 	ReinitialiseChildMetrics(labelConfig LabelConfig)
 }
 
+// PrometheusEvictable is an extension of PrometheusIterable to indicate that
+// this metric uses cache as a storage and children metric can be evicted
+// based on eviction policy.
+// The InitializeMetrics method accepts a reference of LabelSliceCache which is
+// initialised at metric registry and settings values for configurable eviction policy.
+type PrometheusEvictable interface {
+	PrometheusIterable
+
+	InitializeMetrics(*LabelSliceCache)
+}
+
 // WindowedHistogram represents a histogram with data over recent window of
 // time. It's used primarily to record histogram data into CRDB's internal
 // time-series database, which does not know how to encode cumulative


### PR DESCRIPTION
Previously, we were persisting label value slice at each child metrics of
aggregated metric type. This was inadequate because it will create redundant
memory allocations for same label value slice across difference metrics. To
address this, this patch introduces `LabelSliceCache` which would persist the
label values at registry level and metrics would reference them through the
key. The LabelSliceCache is referenced in metrics through `PrometheusEvictable`
interface. The LabelSliceCache contains 2 critical methods:
        1. Upsert: This method implements the add reference part of the
reference counting mechanism.  This method increments the reference count for
label values by 1, if already exists. Otherwise, It will create a new entry for
the label values with default value as 1.
        2. DecrementAndDeleteIfZero: This method decrements the reference
counter for the given label values by 1. If the count is reached to zero then
it means that no metrics are relying on the particular label values. In that
case, it deletes the entry from cache.

These methods ensure that the cache tracks how many metrics are currently using
each label combination, enabling proper cleanup when metrics are no longer
needed.

Epic: CRDB-53398
Part of: CRDB-53830
Release note: None