### PR TITLE
mmaprototype: make conf read only in makeNormalizedSpanConfig

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
@@ -97,7 +97,7 @@ func parseSpanConfig(t *testing.T, d *datadriven.TestData) roachpb.SpanConfig {
 }
 
 func printSpanConfig(b *strings.Builder, conf roachpb.SpanConfig) {
-	fmt.Fprintf(b, " num-replicas=%d num-voters=%d\n", conf.NumReplicas, conf.NumVoters)
+	fmt.Fprintf(b, " num-replicas=%d num-voters=%d\n", conf.NumReplicas, conf.GetNumVoters())
 	if len(conf.Constraints) > 0 {
 		fmt.Fprintf(b, " constraints:\n")
 		for _, cc := range conf.Constraints {


### PR DESCRIPTION
Previously, when fixing how makeNormalizedSpanConfig uses conf.NumVoters to
determine the number of voters, we incorrectly changed conf.NumVoters directly
to conf.NumReplicas when its value was 0. This commit corrects the behavior by
ensuring that the input conf is not modified when falling back to NumReplicas.

Epic: none 
Release note: none 