### PR TITLE
vecindex_test: disable data driven tests on s390x

### DIFF
--- a/pkg/sql/vecindex/vecindex_test.go
+++ b/pkg/sql/vecindex/vecindex_test.go
@@ -45,6 +45,10 @@ func TestDatadrivenVecIndex(t *testing.T) {
 
 	skip.UnderRace(t, "test is too slow under race")
 
+	// Skip on s390x due to floating point precision differences.
+	// See: https://github.com/cockroachdb/cockroach/issues/151766
+	skip.OnArch(t, "s390x", "data driven vector index tests disabled on s390x due to issue #151766")
+
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		if !strings.HasSuffix(path, ".ddt") {
 			// Skip files that are not data-driven tests.

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -212,6 +213,14 @@ func UnderRemoteExecutionWithIssue(t SkippableTest, githubIssueID int, args ...i
 		maybeSkip(t, withIssue("disabled under race", githubIssueID), args...)
 	}
 
+}
+
+func OnArch(t SkippableTest, arch string, args ...interface{}) {
+	t.Helper()
+	if runtime.GOARCH == arch {
+		skipReason := fmt.Sprintf("on-arch %s (current config %s)", arch, testConfig())
+		maybeSkip(t, skipReason, args...)
+	}
 }
 
 func testConfig() string {


### PR DESCRIPTION
Vector indexing is very sensitive to diffences in floating point computation. S390x is different enough from x86 and ARM that we don't really expect the same recall rates as we would on those platforms. These data driven tests thus fail frequently, creating a bunch of noise that distracts us from real issues.

Fixes: #151766
Release note: None