### PR TITLE
roachtest: deflake disk-full roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -54,7 +54,8 @@ func registerDiskFull(r registry.Registry) {
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf(
 					"./cockroach workload run kv --tolerate-errors --init --read-percent=0"+
-						" --concurrency=10 --duration=4m {pgurl:2-%d}",
+						" --min-block-bytes=512 --max-block-bytes=512"+
+						" --concurrency=10 --duration=10m {pgurl:2-%d}",
 					len(c.CRDBNodes()))
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil


### PR DESCRIPTION
This is a speculative fix for a disk-full roachtest failure. This roachtest induces an out-of-disk scenario on a node and ensures that removing the automatic emergency ballast allows recovery. In #153445 it appears disk space is exhausted on the node, but the node never notices because the write workload is insufficient to trigger any write I/O to new pages. This commit adjusts the disk-full roachtest's workload to run a little longer (10m vs 4m) and to write larger-sized values (512-byte) to ensure we continue to write a nontrivial volume of data after we intentionally exhaust available disk space.

Epic: none
Fixes: #153445.
Release note: none