### PR TITLE
backup: check `backup.index.read` cluster setting before checking index

### DIFF
--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -581,12 +581,20 @@ func ResolveBackupManifests(
 	}
 	defer rootStore.Close()
 
+	if !ReadBackupIndexEnabled.Get(&execCfg.Settings.SV) || isCustomIncLocation {
+		return legacyResolveBackupManifests(
+			ctx, execCfg, mem, defaultCollectionURI, mkStore,
+			resolvedSubdir, fullyResolvedBaseDirectory, fullyResolvedIncrementalsDirectory,
+			endTime, encryption, kmsEnv, user, includeSkipped, includeCompacted,
+		)
+	}
+
 	exists, err := IndexExists(ctx, rootStore, resolvedSubdir)
 	if err != nil {
 		return nil, nil, nil, 0, err
 	}
 
-	if !ReadBackupIndexEnabled.Get(&execCfg.Settings.SV) || !exists || isCustomIncLocation {
+	if !exists {
 		return legacyResolveBackupManifests(
 			ctx, execCfg, mem, defaultCollectionURI, mkStore,
 			resolvedSubdir, fullyResolvedBaseDirectory, fullyResolvedIncrementalsDirectory,


### PR DESCRIPTION
Currently, `ResolveBackupManifests` will check for the existence of an index before checking if `backup.index.read.enabled` is `false`. From a semantic standpoint, the cluster setting should be checked first. Additionally, this caused a suite of roachtests to fail because checking for the existence of the backup index requires `subdir` to be formatted correctly, which some of our older tests do not do.

Epic: None

Release note: None