### PR TITLE
kvnemesis: add CPut

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_exp//maps",
     ],
 )
 
@@ -112,6 +113,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_exp//maps",
     ],
 )
 

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -26,6 +26,8 @@ func (op Operation) Result() *Result {
 		return &o.Result
 	case *PutOperation:
 		return &o.Result
+	case *CPutOperation:
+		return &o.Result
 	case *ScanOperation:
 		return &o.Result
 	case *DeleteOperation:
@@ -137,6 +139,8 @@ func (op Operation) format(w *strings.Builder, fctx formatCtx) {
 	case *GetOperation:
 		o.format(w, fctx)
 	case *PutOperation:
+		o.format(w, fctx)
+	case *CPutOperation:
 		o.format(w, fctx)
 	case *ScanOperation:
 		o.format(w, fctx)
@@ -273,6 +277,15 @@ func (op PutOperation) format(w *strings.Builder, fctx formatCtx) {
 	op.Result.format(w)
 }
 
+func (op CPutOperation) format(w *strings.Builder, fctx formatCtx) {
+	verb := "CPut"
+	if op.AllowIfDoesNotExist {
+		verb = "CPutAllowIfDoesNotExist"
+	}
+	fmt.Fprintf(w, `%s.%s(%s%s, sv(%d), exp(%s))`, fctx.receiver, verb, fctx.maybeCtx(), fmtKey(op.Key), op.Seq, op.ExpVal)
+	op.Result.format(w)
+}
+
 // sv stands for sequence value, i.e. the value dictated by the given sequence number.
 func sv(seq kvnemesisutil.Seq) string {
 	return `v` + strconv.Itoa(int(seq))
@@ -281,6 +294,12 @@ func sv(seq kvnemesisutil.Seq) string {
 // Value returns the value written by this put. This is a function of the
 // sequence number.
 func (op PutOperation) Value() string {
+	return sv(op.Seq)
+}
+
+// Value returns the value written by this cput. This is a function of the
+// sequence number.
+func (op CPutOperation) Value() string {
 	return sv(op.Seq)
 }
 

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -65,6 +65,15 @@ message PutOperation {
   Result result = 3 [(gogoproto.nullable) = false];
 }
 
+message CPutOperation {
+  bytes key = 1;
+  uint32 seq = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil.Seq"];
+  bytes exp_val = 3;
+  bool allow_if_does_not_exist = 4;
+
+  Result result = 5 [(gogoproto.nullable) = false];
+}
+
 message DeleteOperation {
   bytes key = 1;
   uint32 seq = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil.Seq"];
@@ -203,6 +212,7 @@ message Operation {
   BarrierOperation barrier = 23;
   FlushLockTableOperation flush_lock_table = 24;
   MutateBatchHeaderOperation mutate_batch_header = 25;
+  CPutOperation cput = 26 [(gogoproto.customname) = "CPut"];
 }
 
 enum ResultType {


### PR DESCRIPTION
This commit adds the following CPut operations to kvnemesis:

- `CPutMatchExisting`: the CPut condition matches an existing key's  value. Both the write and the preceding read are validated.
- `CPutMatchMissing`: the CPut condition matches a missing key's nil  value. This corresponds to the CPut generated by a typical `INSERT` statement. Again both the write and the preceding read are validated.
- `CPutNoMatch`: the CPut condition is not satisfied and the request/batch/transaction fails. These errors are expected and ignored by the test, but we still do some validation on the observed values for the condition to fail.
- `CPutAllowIfDoesNotExist`: the CPut condition is not satisfied but the operation succeeds if the value does not exist. The test is set up in a way that the value most likely does not exist.

Fixes: #64810

Release note: None