### PR TITLE
kvserver: trace reason for OptimisticEvalConflictsError

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -147,6 +147,7 @@ func (r *Replica) executeReadOnlyBatch(
 			// conflicts for by using collectSpansRead as done below in the
 			// non-error path.
 			if !g.CheckOptimisticNoLatchConflicts() {
+				log.Eventf(ctx, "optimistic evaluation failed with %s", pErr)
 				return nil, g, nil, kvpb.NewError(kvpb.NewOptimisticEvalConflictsError())
 			}
 		}


### PR DESCRIPTION
This would have helped to understand #153350.

Epic: none