### PR TITLE
roachprod-microbench: guard against panics in math util

### DIFF
--- a/pkg/cmd/roachprod-microbench/model/builder.go
+++ b/pkg/cmd/roachprod-microbench/model/builder.go
@@ -89,7 +89,7 @@ func (b *Builder) ComputeMetricMap() MetricMap {
 // from. Iff either run does not exist, nil is returned.
 func (m *Metric) ComputeComparison(benchmarkName, oldID, newID string) *Comparison {
 	benchmarkEntry := m.BenchmarkEntries[benchmarkName]
-	// Check that an entry for both runs exist. If not, return nil.
+	// Check that entries for both runs exist. If not, return nil.
 	for _, run := range []string{oldID, newID} {
 		if benchmarkEntry.Samples[run] == nil || benchmarkEntry.Summaries[run] == nil {
 			return nil

--- a/pkg/cmd/roachprod-microbench/model/math_test.go
+++ b/pkg/cmd/roachprod-microbench/model/math_test.go
@@ -117,7 +117,7 @@ func TestCalculateConfidenceInterval(t *testing.T) {
 				}
 			}
 
-			// Calculate confidence interval using the internal method.
+			// Calculate the confidence interval using the internal method.
 			newCI := calculateConfidenceInterval(tc.newValues, tc.oldValues)
 
 			// Assert that the two methods give the same result, within a small tolerance.

--- a/pkg/cmd/roachprod-microbench/model/metric.go
+++ b/pkg/cmd/roachprod-microbench/model/metric.go
@@ -6,7 +6,11 @@
 
 package model
 
-import "golang.org/x/perf/benchmath"
+import (
+	"math"
+
+	"golang.org/x/perf/benchmath"
+)
 
 // MetricMap is a map from metric name to metric.
 type MetricMap map[string]*Metric
@@ -50,6 +54,15 @@ type ConfidenceInterval struct {
 	Low    float64
 	High   float64
 	Center float64
+}
+
+// UndefinedConfidenceInterval indicates that the confidence interval could not
+// be computed, e.g. because the input values were empty or all baseline medians
+// were zero.
+var UndefinedConfidenceInterval = ConfidenceInterval{
+	Low:    math.NaN(),
+	High:   math.NaN(),
+	Center: math.NaN(),
 }
 
 // ComparisonResult holds the comparison results for a specific metric.

--- a/pkg/cmd/roachprod-microbench/testdata/compare.txt
+++ b/pkg/cmd/roachprod-microbench/testdata/compare.txt
@@ -33,18 +33,18 @@ BenchmarkEntry pkg/server→SetupSpanForIncomingRPC/no_parent-8 +6886.35% [0.000
 BenchmarkEntry pkg/server→SetupSpanForIncomingRPC/traceInfo-8 +6916.60% [0.000001 0.000063] p=0.000 n=10 68.970457 70.040743 71.606694
 Package pkg/util
 Metric B/op
-BenchmarkEntry pkg/util/hlc→DecimalToHLC-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
-BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/all-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
-BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/empty-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
-BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/walltime-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
+BenchmarkEntry pkg/util/hlc→DecimalToHLC-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
+BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/all-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
+BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/empty-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
+BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/walltime-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
 BenchmarkEntry pkg/util/hlc→TimestampString-8 ~ [24.000000 24.000000] p=1.000 n=10 1.000000 1.000000 1.000000
 BenchmarkEntry pkg/util/hlc→TimestampStringSynthetic-8 ~ [24.000000 24.000000] p=1.000 n=10 1.000000 1.000000 1.000000
 BenchmarkEntry pkg/util/hlc→Update-8 ~ [6066.000000 6074.500000] p=0.971 n=10 0.893916 0.997651 1.119517
 Metric allocs/op
-BenchmarkEntry pkg/util/hlc→DecimalToHLC-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
-BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/all-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
-BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/empty-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
-BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/walltime-8 ~ [0.000000 0.000000] p=1.000 n=10 0.000000 0.000000 0.000000
+BenchmarkEntry pkg/util/hlc→DecimalToHLC-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
+BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/all-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
+BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/empty-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
+BenchmarkEntry pkg/util/hlc→TimestampIsEmpty/walltime-8 ~ [0.000000 0.000000] p=1.000 n=10  NaN  NaN  NaN
 BenchmarkEntry pkg/util/hlc→TimestampString-8 ~ [1.000000 1.000000] p=1.000 n=10 1.000000 1.000000 1.000000
 BenchmarkEntry pkg/util/hlc→TimestampStringSynthetic-8 ~ [1.000000 1.000000] p=1.000 n=10 1.000000 1.000000 1.000000
 BenchmarkEntry pkg/util/hlc→Update-8 ~ [47.000000 46.500000] p=0.926 n=10 0.957447 1.000000 1.055556


### PR DESCRIPTION
The resample and median calculations could panic if empty arrays are passed into them. This could theoretically happen under highly unlikely scenarios, where the benchmark data is problematic.

This change introduces an `UndefinedConfidenceInterval` to handle
invalid data, or when the confidence interval cannot be calculated.

Release note: None
Epic: None