### PR TITLE
release-25.2: roachtest: make failure in follower-reads more helpful

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -756,7 +756,8 @@ func verifySQLLatency(
 		}
 	}
 	if permitted := int(.2 * float64(len(perTenSeconds))); len(above) > permitted {
-		t.Fatalf("%d latency values (%v) are above target latency %v, %d permitted",
+		t.Fatalf("%d latency values (%v) are above target latency %v, %d permitted "+
+			`(search the cluster logs for 'SELECT v FROM "".mr_db.test WHERE k = $1' to look at the traces)`,
 			len(above), above, targetLatency, permitted)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #153552 on behalf of @tbg.

----

... by telling the reader what to look for to dig in.

Improves https://github.com/cockroachdb/cockroach/issues/153404.

Epic: none

----

Release justification: