### PR TITLE
sql/schemachanger: fix index creation failures after pause/resume

### DIFF
--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -106,7 +106,7 @@ func (ib *IndexBackfillPlanner) BackfillIndexes(
 
 		knobs := &ib.execCfg.DistSQLSrv.TestingKnobs
 		if knobs.RunBeforeIndexBackfillProgressUpdate != nil {
-			knobs.RunBeforeIndexBackfillProgressUpdate(ctx, progress.CompletedSpans)
+			knobs.RunBeforeIndexBackfillProgressUpdate(ctx, meta.BulkProcessorProgress.CompletedSpans)
 		}
 		return tracker.SetBackfillProgress(ctx, progress)
 	}


### PR DESCRIPTION
Previously, when the index backfiller was tracking completed spans, the final chunk of a span would cause an update to be emitted that incorrectly indicated the entire span was complete.  While this was not an issue with a single ingest goroutine, it caused problems with the introduction of multiple ingest goroutines. As a result, if the job was paused and resumed after this incorrect progress update, the backfiller could skip rows, leading to validation errors.  To address this, this patch ensures that progress updates for the final chunk of a span correctly report only the work completed in that chunk.

Fixes: #153522

Release note (bug fix): Addressed a bug where index creation could fail due to validation errors if the schema change was retried or paused/resumed during the backfill.