### PR TITLE
asim: add explanatory output to `assert` command

### DIFF
--- a/pkg/kv/kvserver/asim/assertion/assert.go
+++ b/pkg/kv/kvserver/asim/assertion/assert.go
@@ -34,9 +34,9 @@ func (tht ThresholdType) String() string {
 	case ExactBound:
 		return "="
 	case UpperBound:
-		return "<"
+		return "≤"
 	case LowerBound:
-		return ">"
+		return "≥"
 	default:
 		panic("unknown threshold type")
 	}

--- a/pkg/kv/kvserver/asim/assertion/assert.go
+++ b/pkg/kv/kvserver/asim/assertion/assert.go
@@ -128,10 +128,28 @@ func (sa SteadyStateAssertion) Assert(
 		max, _ := stats.Max(trimmedStoreStats)
 		min, _ := stats.Min(trimmedStoreStats)
 
-		maxMean := math.Abs(max/mean - 1)
-		minMean := math.Abs(min/mean - 1)
+		var maxMean, minMean float64
+		if mean == 0 {
+			if min == 0 || max == 0 {
+				// If the min is zero, all datapoints are nonnegative, so for the mean
+				// to be zero, they must all be zero. If the max is zero, vice versa.
+				// Define 0/0=1 to capture that they're equal, which is what matters
+				// here (0/0 defaults to NaN in Go, but we don't want that here).
+				maxMean = 0
+				minMean = 0
+			} else {
+				// The datapoints cross zero, and their mean is zero, for example
+				// [-1, 1]. The values here would also result from the "regular"
+				// computation below, but it doesn't hurt to be explicit.
+				minMean = math.Inf(1)
+				maxMean = math.Inf(1)
+			}
+		} else {
+			maxMean = math.Abs(max/mean - 1)
+			minMean = math.Abs(min/mean - 1)
+		}
 
-		if sa.Threshold.isViolated(maxMean) || sa.Threshold.isViolated(minMean) {
+		if sa.Threshold.isViolated(maxMean) || sa.Threshold.isViolated(minMean) || math.IsNaN(maxMean) || math.IsNaN(minMean) {
 			if holds {
 				fmt.Fprintf(&buf, "  %s\n", sa)
 				holds = false

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_add_node.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_add_node.txt
@@ -19,6 +19,7 @@ add_node
 # Assert that the replica counts balance within 5% of each other among stores.
 assertion type=balance stat=replicas ticks=6 upper_bound=1.05
 ----
+asserting: max_{stores}(replicas)/mean_{stores}(replicas) < 1.05 at each of last 6 ticks
 
 # Update the replication factor for the keyspace to be 3, instead of the
 # initial replication factor of 1 set during generation.

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_add_node.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_add_node.txt
@@ -19,7 +19,7 @@ add_node
 # Assert that the replica counts balance within 5% of each other among stores.
 assertion type=balance stat=replicas ticks=6 upper_bound=1.05
 ----
-asserting: max_{stores}(replicas)/mean_{stores}(replicas) < 1.05 at each of last 6 ticks
+asserting: max_{stores}(replicas)/mean_{stores}(replicas) ≤ 1.05 at each of last 6 ticks
 
 # Update the replication factor for the keyspace to be 3, instead of the
 # initial replication factor of 1 set during generation.
@@ -36,7 +36,7 @@ replicas#1: first: [s1=301, s2=0, s3=0] (stddev=141.89, mean=100.33, sum=301)
 replicas#1: last:  [s1=301, s2=271, s3=267] (stddev=15.17, mean=279.67, sum=839)
 artifacts[sma-count]: 866426beb5ad043b
 failed assertion sample 1
-  balance stat=replicas threshold=(<1.05) ticks=6
+  balance stat=replicas threshold=(≤1.05) ticks=6
 	max/mean=1.08 tick=0
 	max/mean=1.08 tick=1
 	max/mean=1.08 tick=2

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
@@ -13,11 +13,11 @@ gen_load rate=7000 min_block=512 max_block=512
 
 assertion stat=leases type=balance ticks=6 upper_bound=1
 ----
-asserting: max_{stores}(leases)/mean_{stores}(leases) < 1.00 at each of last 6 ticks
+asserting: max_{stores}(leases)/mean_{stores}(leases) ≤ 1.00 at each of last 6 ticks
 
 assertion stat=leases type=steady ticks=6 upper_bound=0
 ----
-asserting: |leases(t)/mean_{T}(leases) - 1| < 0.00 ∀ t∈T and each store (T=last 6 ticks)
+asserting: |leases(t)/mean_{T}(leases) - 1| ≤ 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
 eval duration=5m seed=42 metrics=(leases) cfgs=(sma-count,mma-only)
 ----
@@ -28,7 +28,7 @@ leases#1: first: [s1=8, s2=3, s3=0, s4=0, s5=0, s6=0, s7=0, s8=0, s9=1, s10=0, s
 leases#1: last:  [s1=4, s2=1, s3=0, s4=0, s5=0, s6=1, s7=0, s8=0, s9=1, s10=1, s11=1, s12=1, s13=2, s14=2] (stddev=1.07, mean=1.00, sum=14)
 artifacts[mma-only]: 3c31149bdddfe022
 failed assertion sample 1
-  balance stat=leases threshold=(<1.00) ticks=6
+  balance stat=leases threshold=(≤1.00) ticks=6
 	max/mean=4.00 tick=0
 	max/mean=4.00 tick=1
 	max/mean=4.00 tick=2

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
@@ -15,10 +15,11 @@ assertion stat=leases type=balance ticks=6 upper_bound=1
 ----
 asserting: max_{stores}(leases)/mean_{stores}(leases) ≤ 1.00 at each of last 6 ticks
 
-assertion stat=leases type=steady ticks=6 upper_bound=0
+assertion stat=leases type=steady ticks=6 exact_bound=0
 ----
-asserting: |leases(t)/mean_{T}(leases) - 1| ≤ 0.00 ∀ t∈T and each store (T=last 6 ticks)
+asserting: |leases(t)/mean_{T}(leases) - 1| = 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
+# TODO(tbg): fix the NaN issue here.
 eval duration=5m seed=42 metrics=(leases) cfgs=(sma-count,mma-only)
 ----
 leases#1: first: [s1=8, s2=3, s3=0, s4=0, s5=0, s6=0, s7=0, s8=0, s9=1, s10=0, s11=1, s12=0, s13=1, s14=0] (stddev=2.10, mean=1.00, sum=14)
@@ -35,3 +36,9 @@ failed assertion sample 1
 	max/mean=4.00 tick=3
 	max/mean=4.00 tick=4
 	max/mean=4.00 tick=5
+  steady state stat=leases threshold=(=0.00) ticks=6
+	store=3 min/mean=NaN max/mean=NaN
+	store=4 min/mean=NaN max/mean=NaN
+	store=5 min/mean=NaN max/mean=NaN
+	store=7 min/mean=NaN max/mean=NaN
+	store=8 min/mean=NaN max/mean=NaN

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
@@ -19,7 +19,6 @@ assertion stat=leases type=steady ticks=6 exact_bound=0
 ----
 asserting: |leases(t)/mean_{T}(leases) - 1| = 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
-# TODO(tbg): fix the NaN issue here.
 eval duration=5m seed=42 metrics=(leases) cfgs=(sma-count,mma-only)
 ----
 leases#1: first: [s1=8, s2=3, s3=0, s4=0, s5=0, s6=0, s7=0, s8=0, s9=1, s10=0, s11=1, s12=0, s13=1, s14=0] (stddev=2.10, mean=1.00, sum=14)
@@ -36,9 +35,3 @@ failed assertion sample 1
 	max/mean=4.00 tick=3
 	max/mean=4.00 tick=4
 	max/mean=4.00 tick=5
-  steady state stat=leases threshold=(=0.00) ticks=6
-	store=3 min/mean=NaN max/mean=NaN
-	store=4 min/mean=NaN max/mean=NaN
-	store=5 min/mean=NaN max/mean=NaN
-	store=7 min/mean=NaN max/mean=NaN
-	store=8 min/mean=NaN max/mean=NaN

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_multi_store.txt
@@ -13,9 +13,11 @@ gen_load rate=7000 min_block=512 max_block=512
 
 assertion stat=leases type=balance ticks=6 upper_bound=1
 ----
+asserting: max_{stores}(leases)/mean_{stores}(leases) < 1.00 at each of last 6 ticks
 
 assertion stat=leases type=steady ticks=6 upper_bound=0
 ----
+asserting: |leases(t)/mean_{T}(leases) - 1| < 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
 eval duration=5m seed=42 metrics=(leases) cfgs=(sma-count,mma-only)
 ----

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_rebalancing.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_rebalancing.txt
@@ -21,7 +21,7 @@ gen_load rate=7000 rw_ratio=0.95 access_skew=false min_block=128 max_block=256
 # seconds) the max/mean QPS of the cluster does not exceed 1.15.
 assertion stat=qps type=balance ticks=6 upper_bound=1.15
 ----
-asserting: max_{stores}(qps)/mean_{stores}(qps) < 1.15 at each of last 6 ticks
+asserting: max_{stores}(qps)/mean_{stores}(qps) ≤ 1.15 at each of last 6 ticks
 
 # The second is a steady state assertion. The steady state assertion requires
 # that during the last 6 ticks (60 seconds), the value of QPS per-store doesn't
@@ -32,7 +32,7 @@ asserting: max_{stores}(qps)/mean_{stores}(qps) < 1.15 at each of last 6 ticks
 # to take a duration, not ticks.
 assertion stat=qps type=steady ticks=6 upper_bound=0.05
 ----
-asserting: |qps(t)/mean_{T}(qps) - 1| < 0.05 ∀ t∈T and each store (T=last 6 ticks)
+asserting: |qps(t)/mean_{T}(qps) - 1| ≤ 0.05 ∀ t∈T and each store (T=last 6 ticks)
 
 # The generators are then called and 2 simulation runs, named samples are
 # created and evaluated. Each sample has a fixed duration of 3 minutes.
@@ -50,7 +50,7 @@ qps#1: last:  [s1=3999, s2=1997, s3=0, s4=0, s5=0, s6=1003, s7=0] (stddev=1413.6
 qps#2: last:  [s1=3996, s2=1996, s3=0, s4=0, s5=0, s6=1006, s7=0] (stddev=1412.60, mean=999.71, sum=6998)
 artifacts[mma-only]: c48e80aec15208d6
 failed assertion sample 1
-  balance stat=qps threshold=(<1.15) ticks=6
+  balance stat=qps threshold=(≤1.15) ticks=6
 	max/mean=4.00 tick=0
 	max/mean=4.00 tick=1
 	max/mean=4.00 tick=2
@@ -58,7 +58,7 @@ failed assertion sample 1
 	max/mean=4.00 tick=4
 	max/mean=4.00 tick=5
 failed assertion sample 2
-  balance stat=qps threshold=(<1.15) ticks=6
+  balance stat=qps threshold=(≤1.15) ticks=6
 	max/mean=4.00 tick=0
 	max/mean=4.00 tick=1
 	max/mean=4.00 tick=2
@@ -90,7 +90,7 @@ qps#1: last:  [s1=3995, s2=1998, s3=0, s4=0, s5=0, s6=1005, s7=0] (stddev=1412.5
 qps#2: last:  [s1=4000, s2=1995, s3=0, s4=0, s5=0, s6=1004, s7=0] (stddev=1413.71, mean=999.86, sum=6999)
 artifacts[mma-only]: fc6f065395b9a390
 failed assertion sample 1
-  balance stat=qps threshold=(<1.15) ticks=6
+  balance stat=qps threshold=(≤1.15) ticks=6
 	max/mean=4.00 tick=0
 	max/mean=4.00 tick=1
 	max/mean=4.00 tick=2
@@ -98,7 +98,7 @@ failed assertion sample 1
 	max/mean=4.00 tick=4
 	max/mean=4.00 tick=5
 failed assertion sample 2
-  balance stat=qps threshold=(<1.15) ticks=6
+  balance stat=qps threshold=(≤1.15) ticks=6
 	max/mean=4.00 tick=0
 	max/mean=4.00 tick=1
 	max/mean=4.00 tick=2

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_rebalancing.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_rebalancing.txt
@@ -21,6 +21,7 @@ gen_load rate=7000 rw_ratio=0.95 access_skew=false min_block=128 max_block=256
 # seconds) the max/mean QPS of the cluster does not exceed 1.15.
 assertion stat=qps type=balance ticks=6 upper_bound=1.15
 ----
+asserting: max_{stores}(qps)/mean_{stores}(qps) < 1.15 at each of last 6 ticks
 
 # The second is a steady state assertion. The steady state assertion requires
 # that during the last 6 ticks (60 seconds), the value of QPS per-store doesn't
@@ -31,6 +32,7 @@ assertion stat=qps type=balance ticks=6 upper_bound=1.15
 # to take a duration, not ticks.
 assertion stat=qps type=steady ticks=6 upper_bound=0.05
 ----
+asserting: |qps(t)/mean_{T}(qps) - 1| < 0.05 ∀ t∈T and each store (T=last 6 ticks)
 
 # The generators are then called and 2 simulation runs, named samples are
 # created and evaluated. Each sample has a fixed duration of 3 minutes.

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
@@ -22,6 +22,7 @@ setting split_qps_threshold=2500
 # ticks of the simulation.
 assertion stat=replicas type=steady ticks=6 upper_bound=0.00
 ----
+asserting: |replicas(t)/mean_{T}(replicas) - 1| < 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
 
 # Examine the number of replicas. Here there were 5 load based splits. This

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
@@ -20,9 +20,9 @@ setting split_qps_threshold=2500
 
 # Assert that the number of replicas should not change at all during the last 6
 # ticks of the simulation.
-assertion stat=replicas type=steady ticks=6 upper_bound=0.00
+assertion stat=replicas type=steady ticks=6 exact_bound=0.00
 ----
-asserting: |replicas(t)/mean_{T}(replicas) - 1| ≤ 0.00 ∀ t∈T and each store (T=last 6 ticks)
+asserting: |replicas(t)/mean_{T}(replicas) - 1| = 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
 
 # Examine the number of replicas. Here there were 5 load based splits. This

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
@@ -22,7 +22,7 @@ setting split_qps_threshold=2500
 # ticks of the simulation.
 assertion stat=replicas type=steady ticks=6 upper_bound=0.00
 ----
-asserting: |replicas(t)/mean_{T}(replicas) - 1| < 0.00 ∀ t∈T and each store (T=last 6 ticks)
+asserting: |replicas(t)/mean_{T}(replicas) - 1| ≤ 0.00 ∀ t∈T and each store (T=last 6 ticks)
 
 
 # Examine the number of replicas. Here there were 5 load based splits. This


### PR DESCRIPTION
I find that I have to check my understanding on this regularly,
so perhaps this output can help understand that `balance` checks
at each point in time that stores are close together, whereas `steady`
checks that for each store, its min/max does not deviate from its mean (over time),
in other words that the metric only changes within a small band. (Which does not
imply any kind of convergence across the cluster; each store might settle on its
own value for the metric).

Epic: CRDB-49117