### PR TITLE
restore: set correct number of link workers

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -1061,6 +1061,6 @@ func getNumOnlineRestoreLinkWorkers(ctx context.Context, execCtx sql.JobExecCont
 	if err != nil {
 		return 0, err
 	}
-	numNodes := min(len(sqlInstanceIDs), 1)
+	numNodes := max(len(sqlInstanceIDs), 1)
 	return defaultLinkWorkersPerNode * numNodes, nil
 }


### PR DESCRIPTION
#153065 contains a typo that ensures the number of link workers is always 0 or 1. This patch fixes the bug.

Epic: None

Release note: None