### PR TITLE
admission: add getterQualification to granter/requester interfaces

### DIFF
--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -146,7 +146,7 @@ func (e *elasticCPUGranter) grantKind() grantKind {
 }
 
 // tryGet implements granter.
-func (e *elasticCPUGranter) tryGet(count int64) (granted bool) {
+func (e *elasticCPUGranter) tryGet(_ burstQualification, count int64) (granted bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -182,7 +182,7 @@ func (e *elasticCPUGranter) continueGrantChain(grantChainID) {
 
 // tryGrant is used to attempt to grant to waiting requests.
 func (e *elasticCPUGranter) tryGrant() {
-	for e.requester.hasWaitingRequests() && e.tryGet(1) {
+	for e.hasWaitingRequests() && e.tryGet(canBurst /*arbitrary*/, 1) {
 		tokens := e.requester.granted(noGrantChain)
 		if tokens == 0 {
 			e.returnGrantWithoutGrantingElsewhere(1)
@@ -235,7 +235,8 @@ func (e *elasticCPUGranter) getUtilizationLimit() float64 {
 
 // hasWaitingRequests is part of the elasticCPULimiter interface.
 func (e *elasticCPUGranter) hasWaitingRequests() bool {
-	return e.requester.hasWaitingRequests()
+	hasWaiting, _ := e.requester.hasWaitingRequests()
+	return hasWaiting
 }
 
 // computeUtilizationMetric is part of the elasticCPULimiter interface.

--- a/pkg/util/admission/elastic_cpu_granter_test.go
+++ b/pkg/util/admission/elastic_cpu_granter_test.go
@@ -152,7 +152,7 @@ func TestElasticCPUGranter(t *testing.T) {
 				return ""
 
 			case "try-get":
-				granted := elasticCPUGranter.tryGet(duration.Nanoseconds())
+				granted := elasticCPUGranter.tryGet(canBurst /*arbitrary*/, duration.Nanoseconds())
 				return fmt.Sprintf("granted:         %t\n", granted)
 
 			case "return-grant":
@@ -189,13 +189,13 @@ type testElasticCPURequester struct {
 
 var _ requester = &testElasticCPURequester{}
 
-func (t *testElasticCPURequester) hasWaitingRequests() bool {
+func (t *testElasticCPURequester) hasWaitingRequests() (bool, burstQualification) {
 	var padding string
 	if t.buf.Len() > 0 {
 		padding = "                 "
 	}
 	t.buf.WriteString(fmt.Sprintf("%shas-waiting=%t ", padding, t.numWaitingRequests > 0))
-	return t.numWaitingRequests > 0
+	return t.numWaitingRequests > 0, canBurst /*arbitrary*/
 }
 
 func (t *testElasticCPURequester) granted(grantChainID grantChainID) int64 {

--- a/pkg/util/admission/elastic_cpu_work_queue_test.go
+++ b/pkg/util/admission/elastic_cpu_work_queue_test.go
@@ -130,7 +130,7 @@ func (t *testElasticCPUGranter) grantKind() grantKind {
 	return token
 }
 
-func (t *testElasticCPUGranter) tryGet(count int64) (granted bool) {
+func (t *testElasticCPUGranter) tryGet(_ burstQualification, count int64) (granted bool) {
 	panic("unimplemented")
 }
 
@@ -175,7 +175,7 @@ func (t *testElasticCPUInternalWorkQueue) adjustTenantUsed(
 	}
 }
 
-func (t *testElasticCPUInternalWorkQueue) hasWaitingRequests() bool {
+func (t *testElasticCPUInternalWorkQueue) hasWaitingRequests() (bool, burstQualification) {
 	panic("unimplemented")
 }
 

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -512,8 +512,8 @@ type testRequester struct {
 
 var _ requester = &testRequester{}
 
-func (tr *testRequester) hasWaitingRequests() bool {
-	return tr.waitingRequests
+func (tr *testRequester) hasWaitingRequests() (bool, burstQualification) {
+	return tr.waitingRequests, canBurst /*arbitrary*/
 }
 
 func (tr *testRequester) granted(grantChainID grantChainID) int64 {
@@ -527,7 +527,7 @@ func (tr *testRequester) granted(grantChainID grantChainID) int64 {
 func (tr *testRequester) close() {}
 
 func (tr *testRequester) tryGet(count int64) {
-	rv := tr.granter.tryGet(count)
+	rv := tr.granter.tryGet(canBurst /*arbitrary*/, count)
 	fmt.Fprintf(tr.buf, "%s%s: tryGet(%d) returned %t\n", tr.workKind,
 		tr.additionalID, count, rv)
 }

--- a/pkg/util/admission/replicated_write_admission_test.go
+++ b/pkg/util/admission/replicated_write_admission_test.go
@@ -384,7 +384,7 @@ func (tg *testReplicatedWriteGranter) grantKind() grantKind {
 	return token
 }
 
-func (tg *testReplicatedWriteGranter) tryGet(count int64) bool {
+func (tg *testReplicatedWriteGranter) tryGet(_ burstQualification, count int64) bool {
 	if count > tg.tokens {
 		tg.buf.printf("[%s] try-get=%s available=%s => insufficient tokens",
 			tg.wc, printTrimmedBytes(count), printTrimmedBytes(tg.tokens))
@@ -414,7 +414,8 @@ func (tg *testReplicatedWriteGranter) grant() {
 		if tg.tokens <= 0 {
 			return // nothing left to do
 		}
-		if !tg.r.hasWaitingRequests() {
+		hasWaiting, _ := tg.r.hasWaitingRequests()
+		if !hasWaiting {
 			return // nothing left to do
 		}
 		_ = tg.r.granted(0 /* unused */)

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -74,7 +74,7 @@ func (tg *testGranter) grantKind() grantKind {
 	return tg.gk
 }
 
-func (tg *testGranter) tryGet(count int64) bool {
+func (tg *testGranter) tryGet(_ burstQualification, count int64) bool {
 	tg.buf.printf("tryGet%s: returning %t", tg.name, tg.returnValueFromTryGet)
 	return tg.returnValueFromTryGet
 }


### PR DESCRIPTION
This is in preparation for the CPU time token scheme, where the WorkQueue will distinguish between burstable and non-burstable tenants.

This is just an interface change, with no behavioral change.

Informs #153591

Epic: none

Release note: None