### PR TITLE
sql: clarify recent change around soft limits

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -726,7 +726,7 @@ func checkSupportForPlanNode(
 			var suffix string
 			estimate := n.estimatedRowCount
 			if n.softLimit != 0 && sd.UseSoftLimitForDistributeScan {
-				estimate = uint64(n.softLimit)
+				estimate = n.softLimit
 				suffix = " (using soft limit)"
 			}
 			if estimate >= sd.DistributeScanRowCountThreshold {
@@ -2205,8 +2205,8 @@ func initTableReaderSpecTemplate(
 	var post execinfrapb.PostProcessSpec
 	if n.hardLimit != 0 {
 		post.Limit = uint64(n.hardLimit)
-	} else if n.softLimit != 0 {
-		s.LimitHint = n.softLimit
+	} else if softLimit := int64(n.softLimit); softLimit > 0 {
+		s.LimitHint = softLimit
 	}
 	return s, post, nil
 }

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -337,8 +337,8 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	post := execinfrapb.PostProcessSpec{}
 	if params.HardLimit != 0 {
 		post.Limit = uint64(params.HardLimit)
-	} else if params.SoftLimit != 0 {
-		trSpec.LimitHint = params.SoftLimit
+	} else if softLimit := int64(params.SoftLimit); softLimit > 0 {
+		trSpec.LimitHint = softLimit
 	}
 
 	err = e.dsp.planTableReaders(

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -737,7 +737,7 @@ func (b *Builder) scanParams(
 		sqltelemetry.IncrementPartitioningCounter(sqltelemetry.PartitionConstrainedScan)
 	}
 
-	softLimit := reqProps.LimitHintInt64()
+	softLimit := uint64(reqProps.LimitHintInt64())
 	hardLimit := scan.HardLimit.RowCount()
 	maxResults, maxResultsOk := b.indexConstraintMaxResults(scan, relProps)
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1319,7 +1319,7 @@ func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.Sca
 		if scanParams.HardLimit != 0 {
 			return "LIMITED SCAN"
 		}
-		if scanParams.SoftLimit > 0 {
+		if scanParams.SoftLimit != 0 {
 			return "FULL SCAN (SOFT LIMIT)"
 		}
 		return "FULL SCAN"

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -118,12 +118,17 @@ type ScanParams struct {
 	InvertedConstraint inverted.Spans
 
 	// If non-zero, the scan returns this many rows.
+	//
+	// Additionally, in plan-gist decoding path, this will be set to -1 to
+	// indicate presence of a limit, regardless of its value.
+	// TODO(yuzefovich): we could refactor this special case by adding an
+	// additional boolean that would allow us to switch to using uint64.
 	HardLimit int64
 
 	// If non-zero, the scan may still be required to return up to all its rows
 	// (or up to the HardLimit if it is set, but can be optimized under the
 	// assumption that only SoftLimit rows will be needed.
-	SoftLimit int64
+	SoftLimit uint64
 
 	Reverse bool
 

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -52,7 +52,7 @@ type scanNode struct {
 	// if non-zero, softLimit is an estimation that only this many rows might be
 	// needed. It is a (potentially optimistic) "hint". If hardLimit is set
 	// (non-zero), softLimit must be unset (zero).
-	softLimit int64
+	softLimit uint64
 
 	// See exec.Factory.ConstructScan.
 	parallelize bool


### PR DESCRIPTION
AI review spotted a "bug" in a recent change around soft limits when that limit is negative. This is impossible by construction, so this commit clarifies the code a bit by switching to `uint64` in non-proto code. We also have "hard limit" that still remains `int64` due to one special case (I was being lazy so only left a TODO to clean this up).

Epic: None
Release note: None