### PR TITLE
release-24.1: roachtest: relax WAL failover latency requirement

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -163,7 +163,7 @@ func runDiskStalledWALFailover(
 		})
 
 	for _, dp := range data.Results[0].Datapoints {
-		if dur := time.Duration(dp.Value); dur > time.Second {
+		if dur := time.Duration(dp.Value); dur > 2*time.Second {
 			t.Errorf("unexpectedly high p99.99 latency %s at %s", dur, timeutil.Unix(0, dp.TimestampNanos).Format(time.RFC3339))
 		}
 	}


### PR DESCRIPTION
Relax the passing p99.99 latency requirement in the WAL failover disk stall roachtest. On this branch (24.1) where WAL failover was first introduced in public preview, we frequently see latency spikes just barely beyond 1s. We don't intend to do work to attempt to further constrain latencies on 24.1, so we should deflake the test by codifying our more relaxed requirement.

Close #153399.
Close #133804.
Epic: none
Release note: none
Release justification: non-production, test-only code changes