### PR TITLE
release-25.3: sql: fix node panic on SIGINT during CHECK EXTERNAL CONNECTION

### DIFF
--- a/pkg/sql/check_external_connection.go
+++ b/pkg/sql/check_external_connection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -26,6 +27,7 @@ func (p *planner) CheckExternalConnection(
 
 type checkExternalConnectionNode struct {
 	zeroInputPlanNode
+	execGrp ctxgroup.Group
 	node    *tree.CheckExternalConnection
 	loc     string
 	params  CloudCheckParams
@@ -101,7 +103,9 @@ func (n *checkExternalConnectionNode) startExec(params runParams) error {
 		return nil
 	})
 
-	go func() {
+	grp := ctxgroup.WithContext(ctx)
+	n.execGrp = grp
+	grp.GoCtx(func(ctx context.Context) error {
 		recv := MakeDistSQLReceiver(
 			ctx,
 			rowWriter,
@@ -117,7 +121,9 @@ func (n *checkExternalConnectionNode) startExec(params runParams) error {
 		// Copy the eval.Context, as dsp.Run() might change it.
 		evalCtxCopy := params.extendedEvalCtx.Context.Copy()
 		dsp.Run(ctx, planCtx, nil, plan, recv, evalCtxCopy, nil /* finishedSetupFn */)
-	}()
+		return nil
+	})
+
 	return nil
 }
 
@@ -130,7 +136,6 @@ func (n *checkExternalConnectionNode) Next(params runParams) (bool, error) {
 		return false, params.ctx.Err()
 	case row, more := <-n.rows:
 		if !more {
-			n.rows = nil
 			return false, nil
 		}
 		n.row = row
@@ -143,10 +148,8 @@ func (n *checkExternalConnectionNode) Values() tree.Datums {
 }
 
 func (n *checkExternalConnectionNode) Close(_ context.Context) {
-	if n.rows != nil {
-		close(n.rows)
-		n.rows = nil
-	}
+	_ = n.execGrp.Wait()
+	n.rows = nil
 }
 
 func (n *checkExternalConnectionNode) parseParams(params runParams) error {


### PR DESCRIPTION
Backport 1/1 commits from #153380.

/cc @cockroachdb/release

---

`CHECK EXTERNAL CONNECTION` defers a close of the `rows` channel as part of its execution. It also closes that same channel in its `Close` method. Under normal execution, if `CHECK EXTERNAL CONNECTION` is allowed to complete, that `rows` channel is set to `nil`, so `Close` skips the attempt to close to the channel.

However, if a `SIGINT` is sent during the execution to cancel the query, `rows` is never set to `nil` and `Close` will attempt to close a closed channel, causing a node panic.

Epic: None

Release note (bug fix): Fixed a bug introduced in v25.1.0 that would cause a node panic if a `SIGINT` signal was sent during the execution of a `CHECK EXTERNAL CONNECTION` command.

---

Release justification: Fixing critical bug that can cause node panics. 