### PR TITLE
release-24.1: sql/sem/tree: fix width handling for BIT column default values

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -71,6 +71,13 @@ func TestBackupRollbacks_base_add_column_with_stored_family(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_add_check_udf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -495,6 +502,13 @@ func TestBackupRollbacksMixedVersion_base_add_column_with_stored_family(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -925,6 +939,13 @@ func TestBackupSuccess_base_add_column_with_stored_family(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_add_check_udf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1349,6 +1370,13 @@ func TestBackupSuccessMixedVersion_base_add_column_with_stored_family(t *testing
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -71,6 +71,13 @@ func TestEndToEndSideEffects_add_column_with_stored_family(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_add_check_udf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -495,6 +502,13 @@ func TestExecuteWithDMLInjection_add_column_with_stored_family(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -925,6 +939,13 @@ func TestGenerateSchemaChangeCorpus_add_column_with_stored_family(t *testing.T) 
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_add_check_udf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1349,6 +1370,13 @@ func TestPause_add_column_with_stored_family(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1779,6 +1807,13 @@ func TestPauseMixedVersion_add_column_with_stored_family(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_add_check_udf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2203,6 +2238,13 @@ func TestRollback_add_column_with_stored_family(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_add_bit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.definition
@@ -1,0 +1,31 @@
+setup
+CREATE TABLE bittab (c1 INT);
+----
+
+# Insert is blocked prior to setting the NULL attribute on the column due to a
+# temporary constraint.
+stage-exec phase=PostCommitPhase stage=4
+INSERT INTO bittab(c1) VALUES (1);
+----
+pq: failed to satisfy CHECK constraint .*
+
+# At this stage, the NULL attribute is now added to the column and temp
+# constraint is dropped. We allow the INSERT. A suitable value for the new
+# column is selected in tree.NewDefaultDatum.
+stage-exec phase=PostCommitPhase stage=5
+INSERT INTO bittab(c1) VALUES (1);
+----
+
+stage-query phase=PostCommitPhase stage=6
+SELECT count(*) FROM bittab
+----
+1
+
+# Confirm that we can delete the new column value.
+stage-exec phase=PostCommitPhase stage=7
+DELETE FROM bittab
+----
+
+test
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.explain
@@ -1,0 +1,196 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 13 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (bittab), ColumnID: 3 (vb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 1 (bittab_pkey)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → PUBLIC        IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (bittab), ColumnID: 4 (fb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb+)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb+), IndexID: 1 (bittab_pkey)}
+ │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+ │         └── 15 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"vb","TableID":104}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":3,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── SetIndexName {"IndexID":2,"Name":"bittab_vb_key","TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"fb","TableID":104}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":4,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 13 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 1 (bittab_pkey)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 2 (bittab_vb_key+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key+)}
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb+)}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb+), IndexID: 1 (bittab_pkey)}
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+ │    │    │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 13 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (bittab), ColumnID: 3 (vb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 1 (bittab_pkey)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → PUBLIC        IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key+)}
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (bittab), ColumnID: 4 (fb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb+)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb+), IndexID: 1 (bittab_pkey)}
+ │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+ │         └── 19 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"vb","TableID":104}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":3,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
+ │              ├── SetIndexName {"IndexID":2,"Name":"bittab_vb_key","TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":104}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"fb","TableID":104}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":4,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 8 in PostCommitPhase
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb+)}
+ │    │    │    ├── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 1 (bittab_pkey)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb+)}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb+), IndexID: 1 (bittab_pkey)}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (bittab), IndexID: 3}
+ │    │    └── 7 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":3,"TableID":104}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":3,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":4,"TableID":104}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":104}
+ │    ├── Stage 3 of 8 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 1 (bittab_pkey)}
+ │    │    │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb+), IndexID: 1 (bittab_pkey)}
+ │    │    └── 2 Validation operations
+ │    │         ├── ValidateColumnNotNull {"ColumnID":3,"IndexIDForValidation":1,"TableID":104}
+ │    │         └── ValidateColumnNotNull {"ColumnID":4,"IndexIDForValidation":1,"TableID":104}
+ │    ├── Stage 4 of 8 in PostCommitPhase
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── VALIDATED  → PUBLIC      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 1 (bittab_pkey)}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │    │    │    └── VALIDATED  → PUBLIC      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb+), IndexID: 1 (bittab_pkey)}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 6 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
+ │    ├── Stage 7 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 8 of 8 in PostCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+ │         └── 1 Validation operation
+ │              └── ValidateIndex {"IndexID":2,"TableID":104}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 104 (bittab), ColumnID: 3 (vb+)}
+           │    ├── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+           │    └── WRITE_ONLY            → PUBLIC           Column:{DescID: 104 (bittab), ColumnID: 4 (fb+)}
+           ├── 4 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb+), IndexID: 3}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           └── 12 Mutation operations
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
+                ├── RefreshStats {"TableID":104}
+                ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+                ├── RefreshStats {"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+                ├── RefreshStats {"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.explain_shape
@@ -1,0 +1,18 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index bittab_pkey in relation bittab
+ │    └── into bittab_vb_key+ (vb+: rowid)
+ ├── validate NOT NULL constraint on column vb+ in index bittab_pkey in relation bittab
+ ├── validate NOT NULL constraint on column fb+ in index bittab_pkey in relation bittab
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation bittab
+ │    └── from bittab@[3] into bittab_vb_key+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index bittab_vb_key+ in relation bittab
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit.side_effects
@@ -1,0 +1,709 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+----
+...
++object {100 101 bittab} -> 104
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.new_column_type.varbit_25_
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.new_column_type.bit_25_
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.bittab
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.bittab
+## StatementPhase stage 1 of 1 with 15 MutationType ops
+upsert descriptor #104
+  ...
+       - 1
+       - 2
+  +    - 3
+  +    - 4
+       columnNames:
+       - c1
+       - rowid
+  +    - vb
+  +    - fb
+       defaultColumnId: 1
+       name: primary
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      id: 3
+  +      name: vb
+  +      nullable: true
+  +      type:
+  +        family: BitFamily
+  +        oid: 1562
+  +        visibleType: 10
+  +        width: 25
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - vb
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: bittab_vb_key
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - vb
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - column:
+  +      id: 4
+  +      name: fb
+  +      nullable: true
+  +      type:
+  +        family: BitFamily
+  +        oid: 1560
+  +        width: 25
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: bittab
+  -  nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextColumnId: 5
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 100
+  ...
+       storeColumnIds:
+       - 1
+  +    - 3
+  +    - 4
+       storeColumnNames:
+       - c1
+  +    - vb
+  +    - fb
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 19 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": c1
+  +        "2": rowid
+  +        "3": vb
+  +        "4": fb
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "1": bittab_pkey
+  +        "2": bittab_vb_key
+  +      name: bittab
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL
+  +        statement: ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+       - 2
+  +    - 3
+  +    - 4
+       columnNames:
+       - c1
+       - rowid
+  +    - vb
+  +    - fb
+       defaultColumnId: 1
+       name: primary
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      id: 3
+  +      name: vb
+  +      nullable: true
+  +      type:
+  +        family: BitFamily
+  +        oid: 1562
+  +        visibleType: 10
+  +        width: 25
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - vb
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: bittab_vb_key
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - vb
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - column:
+  +      id: 4
+  +      name: fb
+  +      nullable: true
+  +      type:
+  +        family: BitFamily
+  +        oid: 1560
+  +        width: 25
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: bittab
+  -  nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextColumnId: 5
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 100
+  ...
+       storeColumnIds:
+       - 1
+  +    - 3
+  +    - 4
+       storeColumnNames:
+       - c1
+  +    - vb
+  +    - fb
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 8 with 7 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 3
+  +    expr: vb IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: vb_auto_not_null
+  +    validity: Validating
+  +  - columnIds:
+  +    - 4
+  +    expr: fb IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: fb_auto_not_null
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - column:
+         id: 4
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        expr: vb IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: vb_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: vb_auto_not_null
+  +      notNullColumn: 3
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        expr: fb IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: fb_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: fb_auto_not_null
+  +      notNullColumn: 4
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: bittab
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 8 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 8 with 1 BackfillType op
+backfill indexes [2] from index #1 in table #104
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 8 with 2 ValidationType ops
+validate CHECK constraint vb_auto_not_null in table #104
+validate CHECK constraint fb_auto_not_null in table #104
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 8 with 5 MutationType ops
+upsert descriptor #104
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
+  -    expr: vb IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: vb_auto_not_null
+  -    validity: Validating
+  -  - columnIds:
+  -    - 4
+  -    expr: fb IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: fb_auto_not_null
+  -    validity: Validating
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+         id: 3
+         name: vb
+  -      nullable: true
+         type:
+           family: BitFamily
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         id: 4
+         name: fb
+  -      nullable: true
+         type:
+           family: BitFamily
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        expr: vb IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: vb_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: vb_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 4
+  -        expr: fb IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: fb_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: fb_auto_not_null
+  -      notNullColumn: 4
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     name: bittab
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 8 with 1 MutationType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 8 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 6 of 8 with 1 BackfillType op pending"
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 8 with 1 BackfillType op
+merge temporary indexes [3] into backfilled indexes [2] in table #104
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 8 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         id: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 8 of 8 with 1 ValidationType op pending"
+commit transaction #9
+begin transaction #10
+## PostCommitPhase stage 8 of 8 with 1 ValidationType op
+validate forward indexes [2] in table #104
+commit transaction #10
+begin transaction #11
+## PostCommitNonRevertiblePhase stage 1 of 1 with 12 MutationType ops
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  +  - id: 3
+  +    name: vb
+  +    type:
+  +      family: BitFamily
+  +      oid: 1562
+  +      visibleType: 10
+  +      width: 25
+  +  - id: 4
+  +    name: fb
+  +    type:
+  +      family: BitFamily
+  +      oid: 1560
+  +      width: 25
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": c1
+  -        "2": rowid
+  -        "3": vb
+  -        "4": fb
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "1": bittab_pkey
+  -        "2": bittab_vb_key
+  -      name: bittab
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL
+  -        statement: ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     formatVersion: 3
+     id: 104
+  +  indexes:
+  +  - constraintId: 2
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 2
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 3
+  +    keyColumnNames:
+  +    - vb
+  +    keySuffixColumnIds:
+  +    - 2
+  +    name: bittab_vb_key
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    version: 4
+     modificationTime: {}
+  -  mutations:
+  -  - column:
+  -      id: 3
+  -      name: vb
+  -      type:
+  -        family: BitFamily
+  -        oid: 1562
+  -        visibleType: 10
+  -        width: 25
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 2
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - vb
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: bittab_vb_key
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 3
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - vb
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_3_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      id: 4
+  -      name: fb
+  -      type:
+  -        family: BitFamily
+  -        oid: 1560
+  -        width: 25
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  +  mutations: []
+     name: bittab
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL"
+  descriptor IDs: [104]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #11
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_1_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_1_of_8.explain
@@ -1,0 +1,44 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 16 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── PUBLIC        → ABSENT IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+           └── 16 Mutation operations
+                ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_2_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_2_of_8.explain
@@ -1,0 +1,61 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 2 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           └── 7 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_3_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_3_of_8.explain
@@ -1,0 +1,61 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 3 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           └── 7 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_4_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_4_of_8.explain
@@ -1,0 +1,61 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 4 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           └── 7 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_5_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_5_of_8.explain
@@ -1,0 +1,65 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 5 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC      → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── PUBLIC      → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           │    └── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+           └── 9 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_6_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_6_of_8.explain
@@ -1,0 +1,67 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 6 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           │    └── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+           └── 10 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_7_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_7_of_8.explain
@@ -1,0 +1,67 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 7 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           │    └── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+           └── 10 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_8_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_bit/alter_table_add_bit__rollback_8_of_8.explain
@@ -1,0 +1,65 @@
+/* setup */
+CREATE TABLE bittab (c1 INT);
+
+/* test */
+ALTER TABLE bittab ADD COLUMN vb VARBIT(25) NOT NULL UNIQUE, ADD COLUMN fb BIT(25) NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 8 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹bittab› ADD COLUMN ‹vb› VARBIT(25) NOT NULL UNIQUE, ADD COLUMN ‹fb› BIT(25) NOT NULL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "vb", ColumnID: 3 (vb-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (bittab), Name: "bittab_vb_key", IndexID: 2 (bittab_vb_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 2 (rowid), IndexID: 3}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (bittab), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (bittab_pkey)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (bittab), Name: "fb", ColumnID: 4 (fb-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    │    └── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+      │    └── 17 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 3 (vb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 3 (vb-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 3 (vb-), IndexID: 1 (bittab_pkey)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (bittab_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 2 (bittab_vb_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (bittab), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (bittab), ColumnID: 4 (fb-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (bittab), ColumnFamilyID: 0 (primary), ColumnID: 4 (fb-)}
+           │    └── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (bittab), ColumnID: 4 (fb-), IndexID: 1 (bittab_pkey)}
+           └── 9 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -6077,7 +6077,15 @@ func NewDefaultDatum(collationEnv *CollationEnvironment, t *types.T) (d Datum, e
 		}
 		return NewDTuple(t, datums...), nil
 	case types.BitFamily:
-		return bitArrayZero, nil
+		// For fixed-width BIT columns, we need the width to create the
+		// default value. Otherwise, we end up getting an error like:
+		// "bit string length 0 does not match type length 5"
+		var w uint
+		switch t.Oid() {
+		case oid.T_bit:
+			w = uint(t.Width())
+		}
+		return NewDBitArray(w), nil
 	case types.EnumFamily:
 		// The scenario in which this arises is when the column is being dropped and
 		// is NOT NULL. If there are no values for this enum, there's nothing that

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -1320,7 +1320,7 @@ func TestNewDefaultDatum(t *testing.T) {
 		{t: types.MakeTuple([]*types.T{types.Int, types.MakeChar(1)}), expected: "(0:::INT8, '':::STRING)"},
 		{t: types.MakeTuple([]*types.T{types.OidVector, types.MakeTuple([]*types.T{types.Float})}), expected: "(ARRAY[]:::OID[], (0.0:::FLOAT8,))"},
 		{t: types.VarBit, expected: "B''"},
-		{t: types.MakeBit(5), expected: "B''"},
+		{t: types.MakeBit(5), expected: "B'00000'"},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Backport 1/1 commits from #152910.

/cc @cockroachdb/release

Release justification: low risk bug fix to prevent application facing errors during a routine schema change operation

---

Previously, when a column was being added or dropped and had NOT NULL with no default value, the parseComputedExpr logic would generate a placeholder value to avoid NULL violations (see #46285 for historical context). For columns of type BIT(n), this fallback value was incorrectly set as BIT(0), which has a width mismatch and caused errors during row insertions or deletions.

This change ensures that the fallback value matches the column's specified BIT(n) width, allowing operations to proceed without errors during schema changes involving such columns.

Fixes #152326
Fixes https://github.com/cockroachdb/cockroach/issues/149567
Fixes https://github.com/cockroachdb/cockroach/issues/151451

Release note (bug fix): Fixed a bug where INSERTs could fail with a type checking error while adding a BIT(n) column.

Epic: None
