### PR TITLE
sql/inspect: give test package more resources

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -60,6 +60,10 @@ go_test(
         "runner_test.go",
     ],
     embed = [":inspect"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
We have seen the inspect tests timeout when run during race. This adds more resources to those tests to try and avoid the timeout.

Fixes #153349

Release note: none
Epic: none