### PR TITLE
builtins,sql: Add new request_transaction_bundle builtin

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3825,6 +3825,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			ConsistencyChecker:               p.execCfg.ConsistencyChecker,
 			RangeProber:                      p.execCfg.RangeProber,
 			StmtDiagnosticsRequestInserter:   ex.server.cfg.StmtDiagnosticsRecorder.InsertRequest,
+			TxnDiagnosticsRequestInserter:    ex.server.cfg.TxnDiagnosticsRecorder.InsertTxnRequest,
 			CatalogBuiltins:                  &p.evalCatalogBuiltins,
 			QueryCancelKey:                   ex.queryCancelKey,
 			DescIDGenerator:                  ex.getDescIDGenerator(),

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -556,6 +556,7 @@ func internalExtendedEvalCtx(
 			IndexUsageStatsController:      indexUsageStatsController,
 			ConsistencyChecker:             execCfg.ConsistencyChecker,
 			StmtDiagnosticsRequestInserter: execCfg.StmtDiagnosticsRecorder.InsertRequest,
+			TxnDiagnosticsRequestInserter:  execCfg.TxnDiagnosticsRecorder.InsertTxnRequest,
 			RangeStatsFetcher:              execCfg.RangeStatsFetcher,
 		},
 		Tracing:           &SessionTracing{},

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2859,6 +2859,7 @@ var builtinOidsArray = []string{
 	2904: `lca(ltree[]: ltree[]) -> ltree`,
 	2905: `levenshtein_less_equal(source: string, target: string, max_d: int) -> int`,
 	2906: `levenshtein_less_equal(source: string, target: string, ins_cost: int, del_cost: int, sub_cost: int, max_d: int) -> int`,
+	2907: `crdb_internal.request_transaction_bundle(transaction_fingerprint_id: string, sampling_probability: float, min_execution_latency: interval, expires_after: interval, redacted: bool) -> tuple{int AS request_id, bool AS created}`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -246,6 +246,11 @@ type Context struct {
 	// bundle request.
 	StmtDiagnosticsRequestInserter StmtDiagnosticsRequestInsertFunc
 
+	// TxnDiagnosticsRequestInsertFunc is used by the
+	// crdb_internal.request_transaction_bundle builtin to insert a transaction
+	// bundle request.
+	TxnDiagnosticsRequestInserter TxnDiagnosticsRequestInsertFunc
+
 	// CatalogBuiltins is used by various builtins which depend on looking up
 	// catalog information. Unlike the Planner, it is available in DistSQL.
 	CatalogBuiltins CatalogBuiltins

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -765,6 +765,20 @@ type StmtDiagnosticsRequestInsertFunc func(
 	username string,
 ) error
 
+// TxnDiagnosticsRequestInsertFunc is an interface embedded in EvalCtx that can
+// be used by the builtins to insert a transaction diagnostics request. This
+// interface is introduced to avoid circular dependency.
+type TxnDiagnosticsRequestInsertFunc func(
+	ctx context.Context,
+	txnFingerprintId uint64,
+	stmtFingerprintIds []uint64,
+	username string,
+	samplingProbability float64,
+	minExecutionLatency time.Duration,
+	expiresAfter time.Duration,
+	redacted bool,
+) (int, error)
+
 // AsOfSystemTime represents the result from the evaluation of AS OF SYSTEM TIME
 // clause.
 type AsOfSystemTime struct {

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -35,8 +35,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -992,7 +994,250 @@ LIMIT 1`)
 
 		require.Equal(t, 3, count)
 	})
+}
 
+func TestRequestTxnBundleBuiltin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	knobs := sqlstats.CreateTestingKnobs()
+	knobs.SynchronousSQLStats = true
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{Knobs: base.TestingKnobs{
+		SQLStatsKnobs: knobs,
+	}})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(srv.SQLConn(t))
+
+	txnStatements := []string{"SELECT 'aaaaaa', 'bbbbbb'",
+		"SELECT 'aaaaaa', 'bbbbbb', 'ccccc' UNION select 'ddddd', 'eeeee', 'fffff'"}
+
+	// The built-in requires that the transaction fingerprint exists in
+	// the system.transaction_statistics table, so we execute the transaction
+	// once.
+	executeTransactions(t, runner, txnStatements)
+
+	// Get the fingerprint id and statement fingerprint ids for the transaction
+	// to make the txn diagnostics request
+	row := runner.QueryRow(t,
+		`
+SELECT
+  encode(ts.fingerprint_id, 'hex') AS fingerprint_id,
+  ts.metadata->'stmtFingerprintIDs' as fingerprint_ids
+FROM crdb_internal.transaction_statistics ts
+JOIN crdb_internal.statement_statistics ss on ss.transaction_fingerprint_id = ts.fingerprint_id
+WHERE ss.metadata->>'query' LIKE 'SELECT _, _'
+LIMIT 1`)
+	var expectedTxnFpId string
+	var fingerprintIdsBytes []byte
+
+	row.Scan(&expectedTxnFpId, &fingerprintIdsBytes)
+	var statementFingerprintIds []uint64
+	var statementFingerprintStrs []string
+	err := json.Unmarshal(fingerprintIdsBytes, &statementFingerprintStrs)
+	require.NoError(t, err)
+
+	for _, s := range statementFingerprintStrs {
+		value, err := strconv.ParseUint(s, 16, 64)
+		require.NoError(t, err)
+		statementFingerprintIds = append(statementFingerprintIds, value)
+	}
+
+	runner.Exec(t, "CREATE USER alloweduser")
+	runner.Exec(t, "GRANT SYSTEM VIEWACTIVITY TO alloweduser")
+
+	runner.Exec(t, "CREATE USER alloweduserredacted")
+	runner.Exec(t, "GRANT SYSTEM VIEWACTIVITYREDACTED TO alloweduserredacted")
+
+	runner.Exec(t, "CREATE USER notalloweduser")
+
+	for _, tc := range []struct {
+		name                        string
+		expectedMinExecutionLatency string
+		expectedExpiresAt           string
+		expectedSampleProbability   float64
+		expectedRedacted            bool
+		expectedError               string
+		expectedUser                string
+	}{
+		{
+			name:                        "conditional",
+			expectedMinExecutionLatency: "00:00:00.1",
+			expectedSampleProbability:   0.5,
+			expectedExpiresAt:           "0",
+			expectedRedacted:            false,
+		},
+		{
+			name:                        "conditional_no_min_latency",
+			expectedSampleProbability:   0.5,
+			expectedMinExecutionLatency: "0",
+			expectedExpiresAt:           "0",
+			expectedRedacted:            false,
+			expectedError:               "got non-zero sampling probability",
+		},
+		{
+			name:                        "conditional_probability_out_of_bounds",
+			expectedSampleProbability:   1.5,
+			expectedMinExecutionLatency: "0",
+			expectedExpiresAt:           "0",
+			expectedRedacted:            false,
+			expectedError:               "expected sampling probability in range",
+		},
+		{
+			name:                        "not_conditional",
+			expectedMinExecutionLatency: "0",
+			expectedExpiresAt:           "0",
+			expectedSampleProbability:   0,
+			expectedRedacted:            false,
+		},
+		{
+			name:                        "with_expiration",
+			expectedExpiresAt:           "1h",
+			expectedMinExecutionLatency: "0",
+			expectedSampleProbability:   0,
+			expectedRedacted:            false,
+		},
+		{
+			name:                        "redacted",
+			expectedMinExecutionLatency: "0",
+			expectedExpiresAt:           "0",
+			expectedSampleProbability:   0,
+			expectedRedacted:            true,
+		},
+		{
+			name:                        "alloweduser",
+			expectedMinExecutionLatency: "0",
+			expectedSampleProbability:   0,
+			expectedExpiresAt:           "0",
+			expectedRedacted:            false,
+			expectedUser:                "alloweduser",
+		},
+		{
+			name:                        "alloweduserredacted",
+			expectedMinExecutionLatency: "0",
+			expectedSampleProbability:   0,
+			expectedExpiresAt:           "0",
+			expectedRedacted:            true,
+			expectedUser:                "alloweduserredacted",
+		},
+		{
+			name:                        "alloweduserredacted must be redacted",
+			expectedMinExecutionLatency: "0",
+			expectedSampleProbability:   0,
+			expectedExpiresAt:           "0",
+			expectedRedacted:            false,
+			expectedError:               "users with VIEWACTIVITYREDACTED privilege can only request redacted statement bundles",
+			expectedUser:                "alloweduserredacted",
+		},
+		{
+			name:                        "notalloweduser",
+			expectedMinExecutionLatency: "0",
+			expectedSampleProbability:   0,
+			expectedExpiresAt:           "0",
+			expectedRedacted:            false,
+			expectedError:               "requesting statement bundle requires VIEWACTIVITY privilege",
+			expectedUser:                "notalloweduser",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				runner.Exec(t, "RESET ROLE")
+				runner.Exec(t, "DELETE FROM system.transaction_diagnostics_requests")
+			}()
+
+			if tc.expectedUser != "" {
+				runner.Exec(t, "SET ROLE "+tc.expectedUser)
+			} else {
+				tc.expectedUser = "root"
+			}
+			var requestId int
+			var created bool
+			if tc.expectedError != "" {
+				runner.ExpectErr(t, tc.expectedError, "SELECT crdb_internal.request_transaction_bundle($1, $2, $3, $4, $5)",
+					expectedTxnFpId,
+					tc.expectedSampleProbability,
+					tc.expectedMinExecutionLatency,
+					tc.expectedExpiresAt,
+					tc.expectedRedacted)
+			} else {
+				requestTime := timeutil.Now()
+				runner.QueryRow(t, "SELECT request_id, created FROM crdb_internal.request_transaction_bundle($1, $2, $3::INTERVAL, $4, $5)",
+					expectedTxnFpId,
+					tc.expectedSampleProbability,
+					tc.expectedMinExecutionLatency,
+					tc.expectedExpiresAt,
+					tc.expectedRedacted,
+				).Scan(&requestId, &created)
+				require.True(t, created)
+
+				var (
+					txnFpId             string
+					stmtFingerprintIds  [][]byte
+					minExecutionLatency gosql.NullString
+					expiresAt           gosql.NullTime
+					sampleProbability   *float64
+					redacted            bool
+					username            string
+				)
+
+				runner.Exec(t, "RESET ROLE")
+				runner.QueryRow(t, "SELECT "+
+					"encode(transaction_fingerprint_id, 'hex') as txn_fingerprint_id, "+
+					"statement_fingerprint_ids, "+
+					"min_execution_latency, "+
+					"expires_at, "+
+					"sampling_probability, "+
+					"redacted, "+
+					"username "+
+					"FROM system.transaction_diagnostics_requests "+
+					"WHERE id = $1", requestId).Scan(&txnFpId, pq.Array(&stmtFingerprintIds), &minExecutionLatency, &expiresAt, &sampleProbability, &redacted, &username)
+				var expectedSampleProbability *float64
+				if tc.expectedSampleProbability != 0 {
+					expectedSampleProbability = &tc.expectedSampleProbability
+				}
+
+				if tc.expectedMinExecutionLatency != "0" {
+					require.True(t, minExecutionLatency.Valid)
+					require.Equal(t, tc.expectedMinExecutionLatency, minExecutionLatency.String)
+				}
+
+				if tc.expectedExpiresAt != "0" {
+					require.True(t, expiresAt.Valid, "expiresAt should not be NULL when expectedExpiresAt is set")
+					expectedExpiresAt, err := time.ParseDuration(tc.expectedExpiresAt)
+					require.NoError(t, err)
+					require.WithinDuration(t, requestTime.Add(expectedExpiresAt), expiresAt.Time, time.Minute)
+				}
+
+				require.Equal(t, expectedTxnFpId, txnFpId)
+				require.Equal(t, statementFingerprintIds, stmtdiagnostics.ToUint64Slice(t, stmtFingerprintIds))
+				require.Equal(t, expectedSampleProbability, sampleProbability)
+				require.Equal(t, tc.expectedRedacted, redacted)
+				require.Equal(t, tc.expectedUser, username)
+			}
+		})
+	}
+
+	t.Run("non-existent transaction fingerprint id", func(t *testing.T) {
+		var found bool
+		runner.QueryRow(t, "SELECT created FROM crdb_internal.request_transaction_bundle($1, $2, $3, $4, $5)",
+			"ffffffffffffffff",
+			0,
+			"0",
+			0,
+			false).Scan(&found)
+		require.False(t, found)
+	})
+
+	t.Run("non-hex encoded transaction fingerprint id", func(t *testing.T) {
+		runner.ExpectErr(t, "invalid transaction fingerprint id", "SELECT crdb_internal.request_transaction_bundle($1, $2, $3, $4, $5)",
+			"zzzz",
+			0,
+			"0",
+			0,
+			false)
+	})
 }
 
 func executeTransactions(t *testing.T, runner *sqlutils.SQLRunner, statements []string) {

--- a/pkg/sql/stmtdiagnostics/txn_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/txn_diagnostics.go
@@ -198,10 +198,10 @@ func (r *TxnRegistry) InsertTxnRequest(
 	minExecutionLatency time.Duration,
 	expiresAfter time.Duration,
 	redacted bool,
-) error {
-	_, err := r.insertTxnRequestInternal(
+) (int, error) {
+	reqId, err := r.insertTxnRequestInternal(
 		ctx, txnFingerprintId, stmtFingerprintIds, username, samplingProbability, minExecutionLatency, expiresAfter, redacted)
-	return err
+	return int(reqId), err
 }
 
 func (r *TxnRegistry) insertTxnRequestInternal(

--- a/pkg/sql/stmtdiagnostics/txn_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/txn_diagnostics_test.go
@@ -205,7 +205,7 @@ func TestTxnRegistry_InsertTxnRequest(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := registry.InsertTxnRequest(
+			_, err := registry.InsertTxnRequest(
 				ctx,
 				uint64(i),
 				[]uint64{1111, 2222, 3333},
@@ -417,7 +417,7 @@ func TestTxnRegistry_InsertTxnDiagnostic(t *testing.T) {
 		row.Scan(&dbTxnFingerprintBytes, &dbTxnFingerprint, pq.Array(&dbStmtFingerprintIdsBytes), &dbCollectedAt, &dbRequestCompleted)
 
 		require.Equal(t, request.txnFingerprintId, toUint64(t, dbTxnFingerprintBytes), "transaction fingerprint ID should match")
-		require.Equal(t, request.stmtFingerprintIds, toUint64Slice(t, dbStmtFingerprintIdsBytes), "statement fingerprint IDs should match")
+		require.Equal(t, request.stmtFingerprintIds, ToUint64Slice(t, dbStmtFingerprintIdsBytes), "statement fingerprint IDs should match")
 		require.Contains(t, dbTxnFingerprint, req1.fingerprint, "transaction fingerprint string should contain statement 1 fingerprint")
 		require.Contains(t, dbTxnFingerprint, req2.fingerprint, "transaction fingerprint string should contain statement 2 fingerprint")
 		require.True(t, dbRequestCompleted, "request should be completed")
@@ -471,7 +471,7 @@ func toUint64(t *testing.T, bytes []byte) uint64 {
 	return fpId
 }
 
-func toUint64Slice(t *testing.T, bytes [][]byte) []uint64 {
+func ToUint64Slice(t *testing.T, bytes [][]byte) []uint64 {
 	t.Helper()
 	var ids []uint64
 	for _, b := range bytes {
@@ -509,7 +509,7 @@ func checkDatabaseForRequest(
 	row.Scan(&txnFingerprintBytes,
 		&minExecutionLatencyNanos, &expiresAt, &samplingProbability, &redacted, &username, pq.Array(&statementFpIdBytes))
 
-	statementFpIds = toUint64Slice(t, statementFpIdBytes)
+	statementFpIds = ToUint64Slice(t, statementFpIdBytes)
 
 	actualRequest := TxnRequest{
 		txnFingerprintId:   toUint64(t, txnFingerprintBytes),

--- a/pkg/sql/txn_instrumentation_test.go
+++ b/pkg/sql/txn_instrumentation_test.go
@@ -581,7 +581,7 @@ func TestTxnDiagnosticsCollector_MaybeStartDiagnostics(t *testing.T) {
 			helper := baseHelper
 			helper.TxnDiagnosticsRecorder = stmtdiagnostics.NewTxnRegistry(ts.InternalDB().(isql.DB), nil, nil, timeutil.DefaultTimeSource{})
 
-			err := helper.TxnDiagnosticsRecorder.InsertTxnRequest(ctx, 1, []uint64{123}, "testuser", 0, 0, 0, redacted)
+			_, err := helper.TxnDiagnosticsRecorder.InsertTxnRequest(ctx, 1, []uint64{123}, "testuser", 0, 0, 0, redacted)
 			require.NoError(t, err)
 
 			newCtx, started := helper.MaybeStartDiagnostics(ctx, 123, ts.Tracer())


### PR DESCRIPTION
This new builtin creates a transaction diagnostic request
to capture and generate a transaction bundle for a specified
transaction fingerprint id.

This builting has the following signature:
`crdb_internal.request_transaction_bundle(transaction_fingerprint_id: string, sampling_probability: float, min_execution_latency: interval, expires_after: interval, redacted: bool) -> bool`

transaction_fingerprint_id - a hex-encoded fingerprint id for the transaction
                             intended to be captured
sampling_probability - the probability used to determine if a transaction bundle
                       should be recorded. This value must be between [0,1].
min_execution_latency - the minimum execution latency for a transaction. If the
                        execution time of a transaction is lower than this value,
                        the request will not be considered fulfilled and will remain
                        uncompleted. If sampling_probability is non-zero, this value
                        must also be non-zero.
expires_after - the duration in which a request will remain open. If zero is provided,
                the request will exist until it is completed or deleted.
redacted - whether or not the collected bundle will be redacted or unredacted

The builtin will return true if the request is generated successfully, or false
if creating a request for transaction fingerprint id that doesn't exist. Existence
of a transaction fingerprint id is determined by its existence in
`crdb_internal.transaction_statistics`. This is necessary because it is currently
the only system of record for transaction fingerprints in cockroachdb.

The user making the request for a transaction diagnostics bundle must have either
VIEWACTIVITY or VIEWACTIVITYREDACTED grants to call this builtin. If they have
VIEWACTIVITYREDACTED, only redacted bundles can be requested.

Resolves: [CRDB-54322](https://cockroachlabs.atlassian.net/browse/CRDB-54322)
Epic: [CRDB-53541](https://cockroachlabs.atlassian.net/browse/CRDB-53541)
Release note (sql change): adds a new builtin:
`crdb_internal.request_transaction_bundle(transaction_fingerprint_id: string, sampling_probability: float, min_execution_latency: interval, expires_after: interval, redacted: bool) -> bool`

transaction_fingerprint_id - a hex-encoded fingerprint id for the transaction
                             intended to be captured
sampling_probability - the probability used to determine if a transaction bundle
                       should be recorded. This value must be between [0,1].
min_execution_latency - the minimum execution latency for a transaction. If the
                        execution time of a transaction is lower than this value,
                        the request will not be considered fulfilled and will remain
                        uncompleted. If sampling_probability is non-zero, this value
                        must also be non-zero.
expires_after - the duration in which a request will remain open. If zero is provided,
                the request will exist until it is completed or deleted.
redacted - whether or not the collected bundle will be redacted or unredacted

The built-in will return true if the request is generated successfully, or false
if creating a request for transaction fingerprint id that doesn't exist.

The user making the request for a transaction diagnostics bundle must have either
VIEWACTIVITY or VIEWACTIVITYREDACTED grants to call this builtin. If they have
VIEWACTIVITYREDACTED, only redacted bundles can be requested.

----
note: This is a stacked PR, only the last commit should be reviewed 