### PR TITLE
sql: return pgerror when creating ARRAY of type VOID

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/void
+++ b/pkg/sql/logictest/testdata/logic_test/void
@@ -174,3 +174,17 @@ query B
 WITH tab(x) AS (VALUES (NULL:::VOID)) SELECT x IS NOT NULL FROM tab
 ----
 false
+
+# Regression test for #84224. Arrays of type VOID are not allowed.
+statement error pgcode 42704 pq: array of type VOID is not supported
+SELECT ARRAY[''::VOID]
+
+statement error pgcode 42704 pq: array of type VOID is not supported
+SELECT ARRAY[NULL::VOID]
+
+statement ok
+CREATE TABLE t84224 (a STRING)
+
+statement error pgcode 42704 pq: array of type VOID is not supported
+SELECT ARRAY[a::VOID] FROM t84224
+

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1943,6 +1943,9 @@ func (expr *Array) TypeCheck(
 		return nil, err
 	}
 
+	if typ.Family() == types.VoidFamily {
+		return nil, pgerror.Newf(pgcode.UndefinedObject, "array of type VOID is not supported")
+	}
 	expr.typ = types.MakeArray(typ)
 	for i := range typedSubExprs {
 		expr.Exprs[i] = typedSubExprs[i]


### PR DESCRIPTION
Arrays of type `VOID` are not supported. This commit replaces an
internal error with a user error when trying to create them.

Fixes #84224

Release note: None
