### PR TITLE
ui: add isolation level information to SQL activity pages

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2342,6 +2342,7 @@ ActiveQuery represents a query in flight on some Session.
 | plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 | placeholders | [string](#cockroach.server.serverpb.ListSessionsResponse-string) | repeated | The placeholders if any. | [reserved](#support-status) |
 | database | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The database the statement was executed on. | [reserved](#support-status) |
+| isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The isolation level the query was run in. | [reserved](#support-status) |
 
 
 
@@ -2493,6 +2494,7 @@ ActiveQuery represents a query in flight on some Session.
 | plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 | placeholders | [string](#cockroach.server.serverpb.ListSessionsResponse-string) | repeated | The placeholders if any. | [reserved](#support-status) |
 | database | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The database the statement was executed on. | [reserved](#support-status) |
+| isolation_level | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The isolation level the query was run in. | [reserved](#support-status) |
 
 
 

--- a/docs/tech-notes/observability/sql_stats.md
+++ b/docs/tech-notes/observability/sql_stats.md
@@ -79,7 +79,7 @@ cleanup jobs run (see [Data Cleanup](#data-cleanup) below).
 ## Data Aggregation and Cardinality
 When the statement is being recorded in memory, it gets aggregated with other 
 executions of the same fingerprint, and when the flush happens it gets aggregated with 
-all other executions for thar fingerprint on the current aggregation timestamp, which is
+all other executions for that fingerprint on the current aggregation timestamp, which is
 defined by `sql.stats.aggregation.interval` (default 1h). This mean everything executed 
 on hour 1:XX will be stored as hour 1:00.
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1022,6 +1022,9 @@ message ActiveQuery {
 
   // The database the statement was executed on.
   string database = 14;
+
+  // The isolation level the query was run in.
+  string isolation_level = 15;
 }
 
 // Request object for ListSessions and ListLocalSessions.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4467,6 +4467,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			IsFullScan:     query.isFullScan,
 			PlanGist:       query.planGist,
 			Database:       query.database,
+			IsolationLevel: activeTxnInfo.IsolationLevel,
 		})
 	}
 	lastActiveQuery := ""

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
@@ -56,6 +56,7 @@ const defaultActiveStatement: ActiveStatement = {
   user: "user",
   clientAddress: "clientAddress",
   isFullScan: false,
+  isolationLevel: "SERIALIZABLE",
 };
 
 // makeActiveStatement creates an ActiveStatement object with the default active statement above
@@ -181,7 +182,7 @@ describe("test activeStatementUtils", () => {
   });
 
   describe("getActiveExecutionsFromSessions", () => {
-    it("should convert sessions response to active statements result", () => {
+    it("should convert sessions response to active statements result with isolation levels", () => {
       const sessionsResponse: SessionsResponse = {
         sessions: [
           {
@@ -189,14 +190,18 @@ describe("test activeStatementUtils", () => {
             username: "bar",
             application_name: "application",
             client_address: "clientAddress",
-            active_queries: [makeActiveQuery({ id: "1" })],
+            active_queries: [
+              makeActiveQuery({ id: "1", isolation_level: "SERIALIZABLE" }),
+            ],
           },
           {
             id: new Uint8Array(),
             username: "foo",
             application_name: "application2",
             client_address: "clientAddress2",
-            active_queries: [makeActiveQuery({ id: "2" })],
+            active_queries: [
+              makeActiveQuery({ id: "2", isolation_level: "READ COMMITTED" }),
+            ],
           },
           {
             id: new Uint8Array(),
@@ -221,13 +226,14 @@ describe("test activeStatementUtils", () => {
         if (stmt.user === "bar") {
           expect(stmt.application).toBe("application");
           expect(stmt.clientAddress).toBe("clientAddress");
+          expect(stmt.isolationLevel).toBe("SERIALIZABLE");
         } else if (stmt.user === "foo") {
           expect(stmt.application).toBe("application2");
           expect(stmt.clientAddress).toBe("clientAddress2");
+          expect(stmt.isolationLevel).toBe("READ COMMITTED");
         } else {
           fail(`stmt user should be foo or bar, got ${stmt.user}`);
         }
-        // expect(stmt.transactionID).toBe(defaultActiveStatement.transactionID);
         expect(stmt.status).toBe(ExecutionStatus.Executing);
         expect(stmt.start.unix()).toBe(
           TimestampToMoment(defaultActiveQuery.start).unix(),
@@ -252,6 +258,7 @@ describe("test activeStatementUtils", () => {
               }),
               num_auto_retries: 3,
               num_statements_executed: 4,
+              isolation_level: "SERIALIZABLE",
             },
           },
           {
@@ -267,6 +274,7 @@ describe("test activeStatementUtils", () => {
               }),
               num_auto_retries: 4,
               num_statements_executed: 3,
+              isolation_level: "READ COMMITTED",
             },
           },
           {
@@ -328,6 +336,11 @@ describe("test activeStatementUtils", () => {
         expect(txn.start.unix()).toBe(
           TimestampToMoment(defaultActiveQuery.start).unix(),
         );
+        if (txn.application === "application") {
+          expect(txn.isolationLevel).toBe("SERIALIZABLE");
+        } else if (txn.application === "application2") {
+          expect(txn.isolationLevel).toBe("READ COMMITTED");
+        }
       });
 
       expect(executingCnt).toEqual(2);

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -132,6 +132,7 @@ export function getActiveExecutionsFromSessions(
           clientAddress: session.client_address,
           isFullScan: query.is_full_scan || false, // Or here is for conversion in case the field is null.
           planGist: query.plan_gist,
+          isolationLevel: query.isolation_level,
         };
 
         statements.push(activeStmt);
@@ -158,6 +159,7 @@ export function getActiveExecutionsFromSessions(
         statementCount: activeTxn.num_statements_executed,
         lastAutoRetryReason: activeTxn.last_auto_retry_reason,
         priority: activeTxn.priority,
+        isolationLevel: activeTxn.isolation_level,
       });
     });
 

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
@@ -39,6 +39,7 @@ export function makeActiveStatementsColumns(
     activeStatementColumnsFromCommon.startTime,
     activeStatementColumnsFromCommon.elapsedTime,
     !isTenant ? activeStatementColumnsFromCommon.timeSpentWaiting : null,
+    activeStatementColumnsFromCommon.isolationLevel,
     activeStatementColumnsFromCommon.applicationName,
   ].filter(col => col != null);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
@@ -59,6 +59,7 @@ export function makeActiveTransactionsColumns(
       cell: (item: ActiveTransaction) => item.retries,
       sort: (item: ActiveTransaction) => item.retries,
     },
+    activeTransactionColumnsFromCommon.isolationLevel,
     activeTransactionColumnsFromCommon.applicationName,
   ].filter(col => col != null);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
@@ -26,7 +26,8 @@ export type ExecutionsColumn =
   | "statementCount"
   | "status"
   | "timeSpentBlocking"
-  | "timeSpentWaiting";
+  | "timeSpentWaiting"
+  | "isolationLevel";
 
 export const executionsColumnLabels: Record<
   ExecutionsColumn,
@@ -55,6 +56,7 @@ export const executionsColumnLabels: Record<
   status: () => "Status",
   timeSpentBlocking: () => "Time Spent Blocking",
   timeSpentWaiting: () => "Time Spent Waiting",
+  isolationLevel: () => "Isolation Level",
 };
 
 export type ExecutionsTableColumnKeys = keyof typeof executionsColumnLabels;
@@ -148,6 +150,15 @@ export const executionsTableTitles: ExecutionsTableTitleType = {
       {getLabel("timeSpentWaiting")}
     </Tooltip>
   ),
+  isolationLevel: () => (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={<p>Isolation level of this transaction.</p>}
+    >
+      {getLabel("isolationLevel")}
+    </Tooltip>
+  ),
 };
 
 function getID(item: ActiveExecution, execType: ExecutionType) {
@@ -214,6 +225,12 @@ function makeActiveExecutionColumns(
       title: executionsTableTitles.applicationName(execType),
       cell: (item: ActiveExecution) => item.application,
       sort: (item: ActiveExecution) => item.application,
+    },
+    isolationLevel: {
+      name: "isolationLevel",
+      title: executionsTableTitles.isolationLevel(execType),
+      cell: (item: ActiveExecution) => item.isolationLevel,
+      sort: (item: ActiveExecution) => item.isolationLevel,
     },
   };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -37,6 +37,7 @@ export interface ActiveExecution {
   database?: string;
   query?: string; // For transactions, this is the latest query executed.
   timeSpentWaiting?: moment.Duration;
+  isolationLevel?: string;
 }
 
 export type ActiveStatement = ActiveExecution &

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -84,6 +84,7 @@ export const idleTransactionSession: SessionInfo = {
       implicit: false,
       num_retries: 5,
       num_auto_retries: 3,
+      isolation_level: "SERIALIZABLE",
     },
     last_active_query_no_constants: "SHOW database",
     active_queries: [],
@@ -113,6 +114,7 @@ export const activeSession: SessionInfo = {
         phase: Phase.EXECUTING,
         txn_id: toUuid("e8NTvpOvScO1tSMreygtcg=="),
         sql_no_constants: "SELECT pg_sleep(_)",
+        isolation_level: "SERIALIZABLE",
       },
     ],
     start: {
@@ -141,6 +143,7 @@ export const activeSession: SessionInfo = {
       implicit: true,
       num_retries: 5,
       num_auto_retries: 3,
+      isolation_level: "SERIALIZABLE",
     },
     last_active_query_no_constants: "SHOW database",
     status: Status.ACTIVE,

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -255,6 +255,13 @@ export function makeSessionsColumns(
       sort: session => session.session.application_name,
     },
     {
+      name: "isolationLevel",
+      title: statisticsTableTitles.isolationLevel(statType),
+      className: cx("cl-table__col-session"),
+      cell: session => session.session.default_isolation_level || "N/A",
+      sort: session => session.session.default_isolation_level,
+    },
+    {
       name: "actions",
       title: statisticsTableTitles.actions(statType),
       className: cx("cl-table__col-session-actions"),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.fixture.ts
@@ -29,6 +29,7 @@ export const getActiveStatementDetailsPropsFixture =
         clientAddress: "127.0.0.1",
         isFullScan: true,
         planGist: "AgICABoCBQQf0AEB",
+        isolationLevel: "SERIALIZABLE",
       },
       match: {
         path: "/execution/statement/:statement",

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -38,6 +38,7 @@ export const statisticsColumnLabels = {
   memUsage: "Memory Usage",
   mostRecentStatement: "Most Recent Statement",
   networkBytes: "Network",
+  isolationLevel: "Default Isolation Level",
   numRetries: "Retries",
   numStatements: "Statements Run",
   regions: "Regions",
@@ -232,6 +233,17 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={"The user that opened the session."}
       >
         {getLabel("username")}
+      </Tooltip>
+    );
+  },
+  isolationLevel: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={"The isolation level of the session."}
+      >
+        {getLabel("isolationLevel")}
       </Tooltip>
     );
   },


### PR DESCRIPTION
Introduce a column for 'Isolation Level' to the
active stmts/txns details pages, as well as the sessions page.

The change is achieved by augmenting the query to `crdb_internal.cluster_locks`
table via the SQL api in `/api/v2/`.

closes: [https://github.com/cockroachdb/cockroach/issues/152688](https://github.com/cockroachdb/cockroach/issues/152688)

Epic: None
Release note (ui change): A new section, 'Isolation Level' has
been added to the active statement and transaction details page and session page.

