### PR TITLE
catalog/lease: initial work for support timestamp locking leasing

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -74,7 +74,7 @@ func (f *dbTableDescFetcher) FetchTableDesc(
 ) (catalog.TableDescriptor, error) {
 	// Retrieve the target TableDescriptor from the lease manager. No caching
 	// is attempted because the lease manager does its own caching.
-	desc, err := f.leaseMgr.Acquire(ctx, ts, tableID)
+	desc, err := f.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(ts), tableID)
 	if err != nil {
 		// Manager can return all kinds of errors during chaos, but based on
 		// its usage, none of them should ever be terminal.

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -323,14 +323,14 @@ type testLeaseAcquirer struct {
 }
 
 func (t *testLeaseAcquirer) Acquire(
-	ctx context.Context, timestamp hlc.Timestamp, id descpb.ID,
+	ctx context.Context, timestamp lease.ReadTimestamp, id descpb.ID,
 ) (lease.LeasedDescriptor, error) {
 	if id != t.id {
 		return nil, errors.Newf("unknown id: %d", id)
 	}
 
-	i, ok := slices.BinarySearchFunc(t.descs, timestamp, func(desc *testLeasedDescriptor, timestamp hlc.Timestamp) int {
-		return desc.timestamp.Compare(timestamp)
+	i, ok := slices.BinarySearchFunc(t.descs, timestamp, func(desc *testLeasedDescriptor, timestamp lease.ReadTimestamp) int {
+		return desc.timestamp.Compare(timestamp.GetTimestamp())
 	})
 	if ok {
 		return t.descs[i], nil

--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -384,7 +384,7 @@ func (p *kvRowProcessor) getWriter(
 		}
 	}
 
-	l, err := p.cfg.LeaseManager.(*lease.Manager).Acquire(ctx, ts, id)
+	l, err := p.cfg.LeaseManager.(*lease.Manager).Acquire(ctx, lease.TimestampToReadTimestamp(ts), id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crosscluster/logical/tombstone_updater.go
+++ b/pkg/crosscluster/logical/tombstone_updater.go
@@ -159,7 +159,7 @@ func (tu *tombstoneUpdater) getDeleter(ctx context.Context, txn *kv.Txn) (row.De
 		tu.ReleaseLeases(ctx)
 
 		var err error
-		tu.leased.descriptor, err = tu.leaseMgr.Acquire(ctx, timestamp, tu.descID)
+		tu.leased.descriptor, err = tu.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(timestamp), tu.descID)
 		if err != nil {
 			return row.Deleter{}, err
 		}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1373,7 +1373,7 @@ func (tc *Collection) GetIndexComment(
 // MaybeSetReplicationSafeTS modifies a txn to apply the replication safe timestamp,
 // if we are executing against a PCR reader catalog.
 func (tc *Collection) MaybeSetReplicationSafeTS(ctx context.Context, txn *kv.Txn) error {
-	now := txn.DB().Clock().Now()
+	now := tc.leased.lm.GetReadTimestamp(txn.DB().Clock().Now())
 	desc, err := tc.leased.lm.Acquire(ctx, now, keys.SystemDatabaseID)
 	if err != nil {
 		return err

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "kv_writer.go",
         "lease.go",
         "lease_test_utils.go",
+        "lease_timestamp.go",
         "name_cache.go",
         "storage.go",
         "testutils.go",

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -177,7 +177,7 @@ func (t *leaseTest) expectLeases(descID descpb.ID, expected string) {
 }
 
 func (t *leaseTest) acquire(nodeID uint32, descID descpb.ID) (lease.LeasedDescriptor, error) {
-	return t.node(nodeID).Acquire(context.Background(), t.server.Clock().Now(), descID)
+	return t.node(nodeID).Acquire(context.Background(), lease.TimestampToReadTimestamp(t.server.Clock().Now()), descID)
 }
 
 func (t *leaseTest) acquireMinVersion(
@@ -667,7 +667,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 func acquire(
 	ctx context.Context, s serverutils.ApplicationLayerInterface, descID descpb.ID,
 ) (lease.LeasedDescriptor, error) {
-	return s.LeaseManager().(*lease.Manager).Acquire(ctx, s.Clock().Now(), descID)
+	return s.LeaseManager().(*lease.Manager).Acquire(ctx, lease.TimestampToReadTimestamp(s.Clock().Now()), descID)
 }
 
 // Test that once a table is marked as deleted, a lease's refcount dropping to 0
@@ -1237,7 +1237,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	// Acquire the lease so it is put into the nameCache.
 	_, err := leaseManager.AcquireByName(
 		context.Background(),
-		t.server.Clock().Now(),
+		lease.TimestampToReadTimestamp(t.server.Clock().Now()),
 		dbID,
 		tableDesc.GetParentSchemaID(),
 		tableName,
@@ -1252,7 +1252,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		for pb.Next() {
 			_, err := leaseManager.AcquireByName(
 				context.Background(),
-				t.server.Clock().Now(),
+				lease.TimestampToReadTimestamp(t.server.Clock().Now()),
 				dbID,
 				tableDesc.GetParentSchemaID(),
 				tableName,
@@ -1917,7 +1917,7 @@ CREATE TABLE t.after (k CHAR PRIMARY KEY, v CHAR);
 	// Acquire a lease on "before" by name.
 	beforeTable, err := t.node(1).AcquireByName(
 		ctx,
-		t.server.Clock().Now(),
+		lease.TimestampToReadTimestamp(t.server.Clock().Now()),
 		dbID,
 		beforeDesc.GetParentSchemaID(),
 		"before",
@@ -1935,7 +1935,7 @@ CREATE TABLE t.after (k CHAR PRIMARY KEY, v CHAR);
 	// Acquire a lease on "after" by name after server startup.
 	afterTable, err := t.node(1).AcquireByName(
 		ctx,
-		t.server.Clock().Now(),
+		lease.TimestampToReadTimestamp(t.server.Clock().Now()),
 		dbID,
 		afterDesc.GetParentSchemaID(),
 		"after",
@@ -2002,7 +2002,7 @@ func TestLeaseAcquisitionDoesntBlock(t *testing.T) {
 
 	require.NoError(t, <-schemaCh)
 
-	l, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, s.Clock().Now(), descID)
+	l, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, lease.TimestampToReadTimestamp(s.Clock().Now()), descID)
 	require.NoError(t, err)
 
 	// Release the lease so that the schema change can proceed.
@@ -2534,7 +2534,7 @@ func TestHistoricalDescriptorAcquire(t *testing.T) {
 	require.NoError(t, err)
 	_, err = s.LeaseManager().(*lease.Manager).WaitForOneVersion(ctx, tableID.Load().(descpb.ID), cachedDatabaseRegions, base.DefaultRetryOptions())
 	require.NoError(t, err, "Failed to wait for one version of descriptor: %s", err)
-	acquiredDescriptor, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, ts1, tableID.Load().(descpb.ID))
+	acquiredDescriptor, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, lease.TimestampToReadTimestamp(ts1), tableID.Load().(descpb.ID))
 	assert.NoError(t, err)
 
 	// Ensure the modificationTime <= timestamp < expirationTime
@@ -3688,7 +3688,7 @@ func BenchmarkAcquireLeaseConcurrent(b *testing.B) {
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					l, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, s.Clock().Now(), tableID)
+					l, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, lease.TimestampToReadTimestamp(s.Clock().Now()), tableID)
 					if err != nil {
 						panic(err)
 					}

--- a/pkg/sql/catalog/lease/lease_timestamp.go
+++ b/pkg/sql/catalog/lease/lease_timestamp.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package lease
+
+import "github.com/cockroachdb/cockroach/pkg/util/hlc"
+
+// ReadTimestamp is a wrapper for the transaction timestamp
+// that allows us to support locked timestamps for leasing.
+type ReadTimestamp interface {
+	// GetTimestamp returns the timestamp at which descriptors will
+	// be read for this transaction, which will guarantee a transactionally
+	// consistent view between descriptors read.
+	GetTimestamp() hlc.Timestamp
+	// GetBaseTimestamp returns the original read timestamp for
+	// the transaction.
+	GetBaseTimestamp() hlc.Timestamp
+}
+
+// TimestampToReadTimestamp converts a hlc.Timestamp into a ReadTimestamp,
+// without any timestamp locking applied.
+func TimestampToReadTimestamp(timestamp hlc.Timestamp) ReadTimestamp {
+	return LeaseTimestamp{
+		ReadTimestamp: timestamp,
+	}
+}
+
+// LeaseTimestamp implements a locked read timestamp.
+type LeaseTimestamp struct {
+	ReadTimestamp  hlc.Timestamp
+	LeaseTimestamp hlc.Timestamp
+}
+
+// GetTimestamp implements ReadTimestamp.
+func (ls LeaseTimestamp) GetTimestamp() hlc.Timestamp {
+	if !ls.LeaseTimestamp.IsEmpty() {
+		return ls.LeaseTimestamp
+	}
+	return ls.ReadTimestamp
+}
+
+// GetBaseTimestamp implements ReadTimestamp.
+func (ls LeaseTimestamp) GetBaseTimestamp() hlc.Timestamp {
+	return ls.ReadTimestamp
+}
+
+var _ ReadTimestamp = LeaseTimestamp{}

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -68,6 +68,10 @@ type ManagerTestingKnobs struct {
 	// has been reset.
 	RangeFeedResetChannel chan struct{}
 
+	// TestingOnRangeFeedCheckPoint is invoked when a range feed checkpoint is
+	// hit.
+	TestingOnRangeFeedCheckPoint func()
+
 	LeaseStoreTestingKnobs StorageTestingKnobs
 }
 
@@ -88,7 +92,7 @@ func (m *Manager) TestingAcquireAndAssertMinVersion(
 	if err := ensureVersion(ctx, id, minVersion, m); err != nil {
 		return nil, err
 	}
-	desc, _, err := t.findForTimestamp(ctx, timestamp)
+	desc, _, err := t.findForTimestamp(ctx, TimestampToReadTimestamp(timestamp))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schematelemetry/schematelemetrycontroller"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention/txnidcache"
@@ -3846,7 +3847,7 @@ func (ex *connExecutor) initPCRReaderCatalog(ctx context.Context) {
 	err := timeutil.RunWithTimeout(ctx, "detect-pcr-reader-catalog", initPCRReaderCatalogTimeout,
 		func(ctx context.Context) error {
 			if lm := ex.server.cfg.LeaseManager; ex.executorType == executorTypeExec && lm != nil {
-				desc, err := lm.Acquire(ctx, ex.server.cfg.Clock.Now(), keys.SystemDatabaseID)
+				desc, err := lm.Acquire(ctx, lease.TimestampToReadTimestamp(ex.server.cfg.Clock.Now()), keys.SystemDatabaseID)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/regions/cached_db_regions.go
+++ b/pkg/sql/regions/cached_db_regions.go
@@ -30,7 +30,8 @@ func NewCachedDatabaseRegionsAt(
 	ctx context.Context, _ *kv.DB, lm *lease.Manager, at hlc.Timestamp,
 ) (cdr *CachedDatabaseRegions, err error) {
 	cdr = &CachedDatabaseRegions{}
-	desc, err := lm.Acquire(ctx, at, keys.SystemDatabaseID)
+	rs := lm.GetReadTimestamp(at)
+	desc, err := lm.Acquire(ctx, rs, keys.SystemDatabaseID)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +45,7 @@ func NewCachedDatabaseRegionsAt(
 		return nil, err
 	}
 
-	desc, err = lm.Acquire(ctx, at, enumID)
+	desc, err = lm.Acquire(ctx, rs, enumID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -188,7 +188,7 @@ type fakeLeaseManager struct {
 
 func (f fakeLeaseManager) AcquireByName(
 	ctx context.Context,
-	timestamp hlc.Timestamp,
+	timestamp lease.ReadTimestamp,
 	parentID descpb.ID,
 	parentSchemaID descpb.ID,
 	name string,
@@ -197,7 +197,7 @@ func (f fakeLeaseManager) AcquireByName(
 }
 
 func (f fakeLeaseManager) Acquire(
-	ctx context.Context, timestamp hlc.Timestamp, id descpb.ID,
+	ctx context.Context, timestamp lease.ReadTimestamp, id descpb.ID,
 ) (lease.LeasedDescriptor, error) {
 	if err, ok := f.errs[id]; ok {
 		return nil, err
@@ -216,6 +216,10 @@ func (f fakeLeaseManager) GetSafeReplicationTS() hlc.Timestamp {
 
 func (f fakeLeaseManager) GetLeaseGeneration() int64 {
 	return 0
+}
+
+func (f fakeLeaseManager) GetReadTimestamp(timestamp hlc.Timestamp) lease.ReadTimestamp {
+	return lease.TimestampToReadTimestamp(timestamp)
 }
 
 var _ descs.LeaseManager = (*fakeLeaseManager)(nil)


### PR DESCRIPTION
Previously, when descriptors were leased it was possible to lease different versions of dependent descriptors, since the range feed used by the lease manager would make them instantly available. This meant that using leased descriptors for crdb_internal / pg_catalog functions with on going schema changes was not safe. To address this, this patch lays the initial ground work for locking leased descriptors to timestamps that the lease manager is aware of as consistent (i.e. all updates are received).

Informs: #153618
Release note: None