### PR TITLE
changefeedccl: restore persisted span frontier from job_info

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -656,6 +656,12 @@ func (ca *changeAggregator) setupSpansAndFrontier() (spans []roachpb.Span, err e
 		return nil, errors.Wrapf(err, "failed to restore span-level checkpoint")
 	}
 
+	for _, rs := range ca.spec.ResolvedSpans {
+		if _, err := ca.frontier.Forward(rs.Span, rs.Timestamp); err != nil {
+			return nil, errors.Wrapf(err, "failed to restore frontier")
+		}
+	}
+
 	return spans, nil
 }
 
@@ -1478,6 +1484,15 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 			"moving to draining due to error restoring span-level checkpoint: %v", err)
 		cf.MoveToDraining(err)
 		return
+	}
+
+	for _, rs := range cf.spec.ResolvedSpans {
+		if _, err := cf.frontier.Forward(rs.Span, rs.Timestamp); err != nil {
+			log.Changefeed.Warningf(cf.Ctx(),
+				"moving to draining due to error restoring frontier: %v", err)
+			cf.MoveToDraining(err)
+			return
+		}
 	}
 
 	if cf.knobs.AfterCoordinatorFrontierRestore != nil {

--- a/pkg/ccl/changefeedccl/changefeed_progress_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_progress_test.go
@@ -11,14 +11,20 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobfrontier"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -54,9 +60,9 @@ func TestChangefeedFrontierPersistence(t *testing.T) {
 
 		// Make sure frontier gets persisted to job_info table.
 		jobID := foo.(cdctest.EnterpriseTestFeed).JobID()
+		var allSpans []jobspb.ResolvedSpan
 		testutils.SucceedsSoon(t, func() error {
 			var found bool
-			var allSpans []jobspb.ResolvedSpan
 			if err := s.Server.InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 				var err error
 				allSpans, found, err = jobfrontier.GetAllResolvedSpans(ctx, txn, jobID)
@@ -74,6 +80,17 @@ func TestChangefeedFrontierPersistence(t *testing.T) {
 			return nil
 		})
 
+		// Make sure the persisted spans cover the entire table.
+		fooTableSpan := desctestutils.
+			TestingGetPublicTableDescriptor(s.Server.DB(), s.Codec, "d", "foo").
+			PrimaryIndexSpan(s.Codec)
+		var spanGroup roachpb.SpanGroup
+		spanGroup.Add(fooTableSpan)
+		for _, rs := range allSpans {
+			spanGroup.Sub(rs.Span)
+		}
+		require.Zero(t, spanGroup.Len())
+
 		// Verify metric count and average latency have sensible values.
 		testutils.SucceedsSoon(t, func() error {
 			metricSnapshot := metric.CumulativeSnapshot()
@@ -86,6 +103,77 @@ func TestChangefeedFrontierPersistence(t *testing.T) {
 			require.Greater(t, count, int64(0))
 			require.Greater(t, avgLatency, time.Duration(0))
 			return nil
+		})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
+// TestChangefeedFrontierRestore verifies that changefeeds will correctly
+// restore progress from persisted span frontiers.
+func TestChangefeedFrontierRestore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		ctx := context.Background()
+
+		// Disable span-level checkpointing.
+		changefeedbase.SpanCheckpointInterval.Override(ctx, &s.Server.ClusterSettings().SV, 0)
+
+		// Create a table and a changefeed on it.
+		sqlDB.Exec(t, "CREATE TABLE foo (a INT PRIMARY KEY)")
+		foo := feed(t, f, "CREATE CHANGEFEED FOR foo WITH initial_scan='no'")
+		defer closeFeed(t, foo)
+		jobFeed := foo.(cdctest.EnterpriseTestFeed)
+
+		// Pause the changefeed.
+		require.NoError(t, jobFeed.Pause())
+
+		// Insert a few rows into the table and save the insert time.
+		var tsStr string
+		sqlDB.QueryRow(t, `INSERT INTO foo VALUES (1), (2), (3), (4), (5), (6)
+RETURNING cluster_logical_timestamp()`).Scan(&tsStr)
+		ts := parseTimeToHLC(t, tsStr)
+
+		// Make function to create spans for single rows in the table.
+		codec := s.Server.Codec()
+		fooDesc := desctestutils.TestingGetPublicTableDescriptor(s.Server.DB(), codec, "d", "foo")
+		rowSpan := func(key int64) roachpb.Span {
+			keyPrefix := func() []byte {
+				return rowenc.MakeIndexKeyPrefix(codec, fooDesc.GetID(), fooDesc.GetPrimaryIndexID())
+			}
+			return roachpb.Span{
+				Key:    encoding.EncodeVarintAscending(keyPrefix(), key),
+				EndKey: encoding.EncodeVarintAscending(keyPrefix(), key+1),
+			}
+		}
+
+		// Manually persist a span frontier that manually marks some of the
+		// inserted rows as resolved already.
+		hw, err := jobFeed.HighWaterMark()
+		require.NoError(t, err)
+		frontier, err := span.MakeFrontierAt(hw, fooDesc.PrimaryIndexSpan(codec))
+		require.NoError(t, err)
+		for _, id := range []int64{2, 5} {
+			_, err := frontier.Forward(rowSpan(id), ts)
+			require.NoError(t, err)
+		}
+		err = s.Server.InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return jobfrontier.Store(ctx, txn, jobFeed.JobID(), "test frontier", frontier)
+		})
+		require.NoError(t, err)
+
+		// Resume the changefeed.
+		require.NoError(t, jobFeed.Resume())
+
+		// We should receive rows 1, 3, 4, 6 (rows 2 and 5 were marked as resolved).
+		assertPayloads(t, foo, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+			`foo: [3]->{"after": {"a": 3}}`,
+			`foo: [4]->{"after": {"a": 4}}`,
+			`foo: [6]->{"after": {"a": 6}}`,
 		})
 	}
 

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -64,6 +64,10 @@ message ChangeAggregatorSpec {
 
   // ProgressConfig is the configuration for the changefeed's progress tracking.
   optional ChangefeedProgressConfig progress_config = 10;
+
+  // ResolvedSpans contains the resolved spans that should be restored
+  // when the changefeed resumes.
+  repeated cockroach.sql.jobs.jobspb.ResolvedSpan resolved_spans = 11 [(gogoproto.nullable) = false];
 }
 
 // ChangeFrontierSpec is the specification for a processor that receives
@@ -98,6 +102,10 @@ message ChangeFrontierSpec {
 
   // ProgressConfig is the configuration for the changefeed's progress tracking.
   optional ChangefeedProgressConfig progress_config = 7;
+
+  // ResolvedSpans contains the resolved spans that should be restored
+  // when the changefeed resumes.
+  repeated cockroach.sql.jobs.jobspb.ResolvedSpan resolved_spans = 8 [(gogoproto.nullable) = false];
 }
 
 // ChangefeedProgressConfig is the configuration for the changefeed's progress tracking.


### PR DESCRIPTION
Changefeeds will now restore their persisted span frontiers on restart.

Fixes #153201

Release note: None