### PR TITLE
metric: add an AgeGauge with constructor

### DIFF
--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "//pkg/util/timeutil",
         "@com_github_gogo_protobuf//proto",
         "@com_github_kr_pretty//:pretty",
         "@com_github_prometheus_client_golang//prometheus",

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -18,6 +18,7 @@ import (
 
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/kr/pretty"
 	"github.com/prometheus/client_golang/prometheus"
 	prometheusgo "github.com/prometheus/client_model/go"
@@ -97,6 +98,15 @@ func TestFunctionalGauge(t *testing.T) {
 	if v := g.Value(); v != 15 {
 		t.Fatalf("unexpected value: %d", v)
 	}
+}
+
+func TestAgeGauge(t *testing.T) {
+	ts := timeutil.NewManualTime(timeutil.FromUnixNanos(100))
+	g := NewAgeGauge(emptyMetadata, timeutil.FromUnixNanos(0), ts)
+	require.Equal(t, int64(100), g.Value())
+
+	ts.AdvanceTo(timeutil.FromUnixNanos(200))
+	require.Equal(t, int64(200), g.Value())
 }
 
 func TestGaugeFloat64(t *testing.T) {


### PR DESCRIPTION
We currently have an implementation of a FunctionalGauge which can be used to report values computed at runtime. This can be a bit unwieldy for the common use case of reporting how "long ago" a timestamp was. The new constructor `NewAgeGauge` helps out with that by taking a function that uses the gauge "value" as input. This way the value itself can be updated, but the value reported is computed using the `Since` function.

Resolves: #152292
Epic: None
Release note: None