### PR TITLE
ui: bump cluster-ui to 25.4 prerelease

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.3.0-prerelease.0",
+  "version": "25.4.0-prerelease.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves: CC-33581
Epic: None
Release note: None