### PR TITLE
rpc, server: add DRPC metrics server interceptor

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -7272,7 +7272,7 @@ layers:
       derivative: NONE
     - name: rpc.server.request.duration.nanos
       exported_name: rpc_server_request_duration_nanos
-      description: Duration of an grpc request in nanoseconds.
+      description: Duration of an RPC request in nanoseconds.
       y_axis_label: Duration
       type: HISTOGRAM
       unit: NANOSECONDS

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -168,6 +168,10 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 	var unaryInterceptors []drpcmux.UnaryServerInterceptor
 	var streamInterceptors []drpcmux.StreamServerInterceptor
 
+	if o.drpcMetricsInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, drpcmux.UnaryServerInterceptor(o.drpcMetricsInterceptor))
+	}
+
 	if !rpcCtx.ContextOptions.Insecure {
 		a := kvAuth{
 			sv: &rpcCtx.Settings.SV,
@@ -194,19 +198,6 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 	})
 	d.Mux = mux
 
-	// NB: any server middleware (server interceptors in gRPC parlance) would go
-	// here:
-	//     dmux = whateverMiddleware1(dmux)
-	//     dmux = whateverMiddleware2(dmux)
-	//     ...
-	//
-	// Each middleware must implement the Handler interface:
-	//
-	//   HandleRPC(stream Stream, rpc string) error
-	//
-	// where Stream
-	// See here for an example:
-	// https://github.com/bryk-io/pkg/blob/4da5fbfef47770be376e4022eab5c6c324984bf7/net/drpc/server.go#L91-L101
 	return d, nil
 }
 

--- a/pkg/rpc/metrics.go
+++ b/pkg/rpc/metrics.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"storj.io/drpc/drpcmux"
 )
 
 // gwRequestKey is a field set on the context to indicate a request
@@ -205,7 +206,7 @@ over this connection.
 	}
 	metaRequestDuration = metric.Metadata{
 		Name:        "rpc.server.request.duration.nanos",
-		Help:        "Duration of an grpc request in nanoseconds.",
+		Help:        "Duration of an RPC request in nanoseconds.",
 		Measurement: "Duration",
 		Unit:        metric.Unit_NANOSECONDS,
 		MetricType:  prometheusgo.MetricType_HISTOGRAM,
@@ -430,6 +431,7 @@ func (m *Metrics) acquire(k peerKey, l roachpb.Locality) (peerMetrics, localityM
 const (
 	RpcMethodLabel     = "methodName"
 	RpcStatusCodeLabel = "statusCode"
+	RpcServerLabel     = "rpcServer"
 )
 
 // RequestMetrics contains metrics for RPC requests.
@@ -442,7 +444,7 @@ func NewRequestMetrics() *RequestMetrics {
 		Duration: metric.NewExportedHistogramVec(
 			metaRequestDuration,
 			metric.ResponseTime30sBuckets,
-			[]string{RpcMethodLabel, RpcStatusCodeLabel}),
+			[]string{RpcMethodLabel, RpcStatusCodeLabel, RpcServerLabel}),
 	}
 }
 
@@ -478,6 +480,44 @@ func NewRequestMetricsInterceptor(
 		requestMetrics.Duration.Observe(map[string]string{
 			RpcMethodLabel:     info.FullMethod,
 			RpcStatusCodeLabel: code.String(),
+			RpcServerLabel:     "grpc",
+		}, float64(duration.Nanoseconds()))
+		return resp, err
+	}
+}
+
+type DRPCRequestMetricsInterceptor drpcmux.UnaryServerInterceptor
+
+// NewDRPCRequestMetricsInterceptor creates a new DRPC server interceptor that records
+// the duration of each RPC. The metric is labeled by the method name and the
+// status code of the RPC. The interceptor will only record durations if
+// shouldRecord returns true. Otherwise, this interceptor will be a no-op.
+func NewDRPCRequestMetricsInterceptor(
+	requestMetrics *RequestMetrics, shouldRecord func(rpc string) bool,
+) DRPCRequestMetricsInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		rpc string,
+		handler drpcmux.UnaryHandler,
+	) (interface{}, error) {
+		if !shouldRecord(rpc) {
+			return handler(ctx, req)
+		}
+		startTime := timeutil.Now()
+		resp, err := handler(ctx, req)
+		duration := timeutil.Since(startTime)
+		var code codes.Code
+		if err != nil {
+			code = status.Code(err)
+		} else {
+			code = codes.OK
+		}
+
+		requestMetrics.Duration.Observe(map[string]string{
+			RpcMethodLabel:     rpc,
+			RpcStatusCodeLabel: code.String(),
+			RpcServerLabel:     "drpc",
 		}, float64(duration.Nanoseconds()))
 		return resp, err
 	}

--- a/pkg/rpc/settings.go
+++ b/pkg/rpc/settings.go
@@ -122,8 +122,9 @@ var sourceAddr = func() net.Addr {
 }()
 
 type serverOpts struct {
-	interceptor        func(fullMethod string) error
-	metricsInterceptor RequestMetricsInterceptor
+	interceptor            func(fullMethod string) error
+	metricsInterceptor     RequestMetricsInterceptor
+	drpcMetricsInterceptor DRPCRequestMetricsInterceptor
 }
 
 // ServerOption is a configuration option passed to NewServer.
@@ -151,5 +152,12 @@ func WithInterceptor(f func(fullMethod string) error) ServerOption {
 func WithMetricsServerInterceptor(interceptor RequestMetricsInterceptor) ServerOption {
 	return func(opts *serverOpts) {
 		opts.metricsInterceptor = interceptor
+	}
+}
+
+// WithDRPCMetricsServerInterceptor adds a DRPCRequestMetricsInterceptor to the DRPC server.
+func WithDRPCMetricsServerInterceptor(interceptor DRPCRequestMetricsInterceptor) ServerOption {
+	return func(opts *serverOpts) {
+		opts.drpcMetricsInterceptor = interceptor
 	}
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -30,12 +29,10 @@ type grpcServer struct {
 }
 
 func newGRPCServer(
-	ctx context.Context, rpcCtx *rpc.Context, metricsRegistry *metric.Registry,
+	ctx context.Context, rpcCtx *rpc.Context, requestMetrics *rpc.RequestMetrics,
 ) (*grpcServer, error) {
 	s := &grpcServer{}
 	s.mode.set(modeInitializing)
-	requestMetrics := rpc.NewRequestMetrics()
-	metricsRegistry.AddMetricStruct(requestMetrics)
 	srv, interceptorInfo, err := rpc.NewServerEx(
 		ctx, rpcCtx, rpc.WithInterceptor(func(path string) error {
 			return s.intercept(path)
@@ -66,31 +63,6 @@ func (s *grpcServer) health(ctx context.Context) error {
 	default:
 		return srverrors.ServerError(ctx, errors.Newf("unknown mode: %v", sm))
 	}
-}
-
-var rpcsAllowedWhileBootstrapping = map[string]struct{}{
-	"/cockroach.rpc.Heartbeat/Ping":             {},
-	"/cockroach.gossip.Gossip/Gossip":           {},
-	"/cockroach.server.serverpb.Init/Bootstrap": {},
-	"/cockroach.server.serverpb.Admin/Health":   {},
-}
-
-// intercept implements filtering rules for each server state.
-func (s *grpcServer) intercept(fullName string) error {
-	if s.operational() {
-		return nil
-	}
-	if _, allowed := rpcsAllowedWhileBootstrapping[fullName]; !allowed {
-		return NewWaitingForInitError(fullName)
-	}
-	return nil
-}
-
-// NewWaitingForInitError creates an error indicating that the server cannot run
-// the specified method until the node has been initialized.
-func NewWaitingForInitError(methodName string) error {
-	// NB: this error string is sadly matched in grpcutil.IsWaitingForInit().
-	return grpcstatus.Errorf(codes.Unavailable, "node waiting for init; %s not available", methodName)
 }
 
 const (

--- a/pkg/server/serve_mode.go
+++ b/pkg/server/serve_mode.go
@@ -5,7 +5,12 @@
 
 package server
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
 
 type serveModeHandler struct {
 	mode serveMode
@@ -20,6 +25,33 @@ func (s *serveModeHandler) setMode(mode serveMode) {
 func (s *serveModeHandler) operational() bool {
 	sMode := s.mode.get()
 	return sMode == modeOperational || sMode == modeDraining
+}
+
+var rpcsAllowedWhileBootstrapping = map[string]struct{}{
+	"/cockroach.rpc.Heartbeat/Ping":             {},
+	"/cockroach.gossip.Gossip/Gossip":           {},
+	"/cockroach.server.serverpb.Init/Bootstrap": {},
+	"/cockroach.server.serverpb.Admin/Health":   {},
+	"/cockroach.roachpb.KVBatch/BatchStream":    {},
+	"/cockroach.roachpb.KVBatch/Batch":          {},
+}
+
+// intercept implements filtering rules for each server state.
+func (s *serveModeHandler) intercept(fullName string) error {
+	if s.operational() {
+		return nil
+	}
+	if _, allowed := rpcsAllowedWhileBootstrapping[fullName]; !allowed {
+		return NewWaitingForInitError(fullName)
+	}
+	return nil
+}
+
+// NewWaitingForInitError creates an error indicating that the server cannot run
+// the specified method until the node has been initialized.
+func NewWaitingForInitError(methodName string) error {
+	// NB: this error string is sadly matched in grpcutil.IsWaitingForInit().
+	return grpcstatus.Errorf(codes.Unavailable, "node waiting for init; %s not available", methodName)
 }
 
 // A list of the server states for bootstrap process.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -405,12 +405,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	// and after ValidateAddrs().
 	rpcContext.CheckCertificateAddrs(ctx)
 
-	grpcServer, err := newGRPCServer(ctx, rpcContext, appRegistry)
+	requestMetrics := rpc.NewRequestMetrics()
+	appRegistry.AddMetricStruct(requestMetrics)
+
+	grpcServer, err := newGRPCServer(ctx, rpcContext, requestMetrics)
 	if err != nil {
 		return nil, err
 	}
 
-	drpcServer, err := newDRPCServer(ctx, rpcContext)
+	drpcServer, err := newDRPCServer(ctx, rpcContext, requestMetrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1311,11 +1311,14 @@ func makeTenantSQLServerArgs(
 	externalStorage := esb.makeExternalStorage
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
-	grpcServer, err := newGRPCServer(startupCtx, rpcContext, registry)
+	requestMetrics := rpc.NewRequestMetrics()
+	registry.AddMetricStruct(requestMetrics)
+
+	grpcServer, err := newGRPCServer(startupCtx, rpcContext, requestMetrics)
 	if err != nil {
 		return sqlServerArgs{}, err
 	}
-	drpcServer, err := newDRPCServer(startupCtx, rpcContext)
+	drpcServer, err := newDRPCServer(startupCtx, rpcContext, requestMetrics)
 	if err != nil {
 		return sqlServerArgs{}, err
 	}


### PR DESCRIPTION
In this PR, we add metrics interceptor support in DRPC and extend the RPC request duration histogram to add an ``rpcServer`` label and record both gRPC and DRPC latency through interceptors.

Epic: CRDB-49359
Fixes: #144373
Release note: None