### PR TITLE
rpc, server: add DRPC metrics server interceptor

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -7198,7 +7198,7 @@ layers:
       derivative: NONE
     - name: rpc.server.request.duration.nanos
       exported_name: rpc_server_request_duration_nanos
-      description: Duration of an grpc request in nanoseconds.
+      description: Duration of an RPC request in nanoseconds.
       y_axis_label: Duration
       type: HISTOGRAM
       unit: NANOSECONDS

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -222,6 +222,12 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 	// Recover from any uncaught panics caused by DB Console requests.
 	unaryInterceptors = append(unaryInterceptors, DRPCGatewayRequestRecoveryInterceptor)
 
+	// If the metrics interceptor is set, it should be registered second so
+	// that all other interceptors are included in the response time durations.
+	if o.drpcRequestMetricsInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, drpcmux.UnaryServerInterceptor(o.drpcRequestMetricsInterceptor))
+	}
+
 	if !rpcCtx.ContextOptions.Insecure {
 		a := kvAuth{
 			sv: &rpcCtx.Settings.SV,

--- a/pkg/rpc/metrics_test.go
+++ b/pkg/rpc/metrics_test.go
@@ -134,7 +134,7 @@ func TestServerRequestInstrumentInterceptor(t *testing.T) {
 			if tc.shouldRecord {
 				expectedCount = 1
 			}
-			assertGrpcMetrics(t, requestMetrics.Duration.ToPrometheusMetrics(), map[string]uint64{
+			assertRpcMetrics(t, requestMetrics.Duration.ToPrometheusMetrics(), map[string]uint64{
 				fmt.Sprintf("%s %s", tc.methodName, tc.statusCode): expectedCount,
 			})
 		})
@@ -209,7 +209,7 @@ func TestGatewayRequestRecoveryInterceptor(t *testing.T) {
 	})
 }
 
-func assertGrpcMetrics(
+func assertRpcMetrics(
 	t *testing.T, metrics []*io_prometheus_client.Metric, expected map[string]uint64,
 ) {
 	t.Helper()

--- a/pkg/rpc/settings.go
+++ b/pkg/rpc/settings.go
@@ -122,8 +122,9 @@ var sourceAddr = func() net.Addr {
 }()
 
 type serverOpts struct {
-	interceptor        func(fullMethod string) error
-	metricsInterceptor RequestMetricsInterceptor
+	interceptor                   func(fullMethod string) error
+	metricsInterceptor            RequestMetricsInterceptor
+	drpcRequestMetricsInterceptor DRPCRequestMetricsInterceptor
 }
 
 // ServerOption is a configuration option passed to NewServer.
@@ -151,5 +152,12 @@ func WithInterceptor(f func(fullMethod string) error) ServerOption {
 func WithMetricsServerInterceptor(interceptor RequestMetricsInterceptor) ServerOption {
 	return func(opts *serverOpts) {
 		opts.metricsInterceptor = interceptor
+	}
+}
+
+// WithDRPCMetricsServerInterceptor adds a DRPCRequestMetricsInterceptor to the DRPC server.
+func WithDRPCMetricsServerInterceptor(interceptor DRPCRequestMetricsInterceptor) ServerOption {
+	return func(opts *serverOpts) {
+		opts.drpcRequestMetricsInterceptor = interceptor
 	}
 }

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -7,13 +7,9 @@ package server
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
-	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -30,12 +26,10 @@ type grpcServer struct {
 }
 
 func newGRPCServer(
-	ctx context.Context, rpcCtx *rpc.Context, metricsRegistry *metric.Registry,
+	ctx context.Context, rpcCtx *rpc.Context, requestMetrics *rpc.RequestMetrics,
 ) (*grpcServer, error) {
 	s := &grpcServer{}
 	s.mode.set(modeInitializing)
-	requestMetrics := rpc.NewRequestMetrics()
-	metricsRegistry.AddMetricStruct(requestMetrics)
 	srv, interceptorInfo, err := rpc.NewServerEx(
 		ctx, rpcCtx, rpc.WithInterceptor(func(path string) error {
 			return s.intercept(path)
@@ -66,33 +60,4 @@ func (s *grpcServer) health(ctx context.Context) error {
 	default:
 		return srverrors.ServerError(ctx, errors.Newf("unknown mode: %v", sm))
 	}
-}
-
-// NewWaitingForInitError creates an error indicating that the server cannot run
-// the specified method until the node has been initialized.
-func NewWaitingForInitError(methodName string) error {
-	// NB: this error string is sadly matched in grpcutil.IsWaitingForInit().
-	return grpcstatus.Errorf(codes.Unavailable, "node waiting for init; %s not available", methodName)
-}
-
-const (
-	serverPrefix = "/cockroach.server"
-	tsdbPrefix   = "/cockroach.ts"
-)
-
-// serverGRPCRequestMetricsEnabled is a cluster setting that enables the
-// collection of gRPC request duration metrics. This uses export only
-// metrics so the metrics are only exported to external sources such as
-// /_status/vars and DataDog.
-var serverGRPCRequestMetricsEnabled = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"server.grpc.request_metrics.enabled",
-	"enables the collection of grpc metrics",
-	false,
-)
-
-func shouldRecordRequestDuration(settings *cluster.Settings, method string) bool {
-	return serverGRPCRequestMetricsEnabled.Get(&settings.SV) &&
-		(strings.HasPrefix(method, serverPrefix) ||
-			strings.HasPrefix(method, tsdbPrefix))
 }

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -43,7 +43,7 @@ func TestRequestMetricRegistered(t *testing.T) {
 
 	_, _ = ts.GetAdminClient(t).Settings(ctx, &serverpb.SettingsRequest{})
 	require.Len(t, histogramVec.ToPrometheusMetrics(), 0, "Should not have recorded any metrics yet")
-	serverGRPCRequestMetricsEnabled.Override(context.Background(), &ts.ClusterSettings().SV, true)
+	serverRPCRequestMetricsEnabled.Override(context.Background(), &ts.ClusterSettings().SV, true)
 	_, _ = ts.GetAdminClient(t).Settings(ctx, &serverpb.SettingsRequest{})
 	require.Len(t, histogramVec.ToPrometheusMetrics(), 1, "Should have recorded metrics for request")
 }
@@ -67,7 +67,7 @@ func TestShouldRecordRequestDuration(t *testing.T) {
 	settings := cluster.MakeTestingClusterSettings()
 	for _, tt := range tests {
 		t.Run(tt.methodName, func(t *testing.T) {
-			serverGRPCRequestMetricsEnabled.Override(context.Background(), &settings.SV, tt.metricsEnabled)
+			serverRPCRequestMetricsEnabled.Override(context.Background(), &settings.SV, tt.metricsEnabled)
 			require.Equal(t, tt.expected, shouldRecordRequestDuration(settings, tt.methodName))
 		})
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -406,12 +406,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	// and after ValidateAddrs().
 	rpcContext.CheckCertificateAddrs(ctx)
 
-	grpcServer, err := newGRPCServer(ctx, rpcContext, appRegistry)
+	requestMetrics := rpc.NewRequestMetrics()
+	appRegistry.AddMetricStruct(requestMetrics)
+
+	grpcServer, err := newGRPCServer(ctx, rpcContext, requestMetrics)
 	if err != nil {
 		return nil, err
 	}
 
-	drpcServer, err := newDRPCServer(ctx, rpcContext)
+	drpcServer, err := newDRPCServer(ctx, rpcContext, requestMetrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1329,11 +1329,14 @@ func makeTenantSQLServerArgs(
 	externalStorage := esb.makeExternalStorage
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
-	grpcServer, err := newGRPCServer(startupCtx, rpcContext, registry)
+	requestMetrics := rpc.NewRequestMetrics()
+	registry.AddMetricStruct(requestMetrics)
+
+	grpcServer, err := newGRPCServer(startupCtx, rpcContext, requestMetrics)
 	if err != nil {
 		return sqlServerArgs{}, err
 	}
-	drpcServer, err := newDRPCServer(startupCtx, rpcContext)
+	drpcServer, err := newDRPCServer(startupCtx, rpcContext, requestMetrics)
 	if err != nil {
 		return sqlServerArgs{}, err
 	}


### PR DESCRIPTION
Previously, there was no support for metrics interceptor in
DRPC, and capturing drpc metrics wouldn't be possible.

In this PR, we add metrics server interceptor support in DRPC and
reuse the `rpc_server_request_duration_nanos` metric
for both gRPC and DRPC since the metric reflects server-side
duration agnostic of transport and interceptor chains are not expected
to differ materially in practice. When differentiation is needed, it
can be correlated with other metadata. This way we can observe both
gRPC and DRPC latency through interceptors.

Since this metric is behind a cluster setting, we also had to
change the key of the metric to `server.rpc.request_metrics.enabled`
so that it can be related to both the rpc framework and set an alias
as its retired name `server.grpc.request_metrics.enabled`.

Epic: CRDB-49359
Fixes: #144373
Release note: None