### PR TITLE
server: always use dropDRPCHeaderListener with drpc server

### DIFF
--- a/pkg/server/start_drpc_listener.go
+++ b/pkg/server/start_drpc_listener.go
@@ -44,23 +44,3 @@ func (ln *dropDRPCHeaderListener) Close() error {
 func (ln *dropDRPCHeaderListener) Addr() net.Addr {
 	return ln.wrapped.Addr()
 }
-
-type noopListener struct{ done chan struct{} }
-
-func (l *noopListener) Accept() (net.Conn, error) {
-	<-l.done
-	return nil, net.ErrClosed
-}
-
-func (l *noopListener) Close() error {
-	if l.done == nil {
-		return nil
-	}
-	close(l.done)
-	l.done = nil
-	return nil
-}
-
-func (l *noopListener) Addr() net.Addr {
-	return nil
-}


### PR DESCRIPTION
Previously, the DRPC listener was conditionally created based on the DRPC setting. When DRPC was disabled, we used a noopListener that would block on Accept() until closed, effectively rejecting all DRPC connections.

In #153503 we changed the DRPC server to always run regardless of the setting, but missed updating the corresponding listener logic. This commit completes that change by always using the dropDRPCHeaderListener to properly handle incoming DRPC connections.

Fixes: #153612

Epic: none
Release note: none