### PR TITLE
asim: fix more one-off formatting with rand output

### DIFF
--- a/pkg/kv/kvserver/asim/gen/event_generator.go
+++ b/pkg/kv/kvserver/asim/gen/event_generator.go
@@ -20,9 +20,9 @@ type EventGen interface {
 	// Generate returns an eventExecutor storing a sorted list of events and
 	// being ready execute events for the simulation execution.
 	Generate(seed int64, settings *config.SimulationSettings) scheduled.EventExecutor
-	// String returns the concise string representation of the event executor,
-	// detailing the number of scheduled events.
-	String() string
+	// StringWithTag returns the concise string representation of the event
+	// executor, detailing the number of scheduled events.
+	StringWithTag(tag string) string
 }
 
 // StaticEvents implements the EventGen interface. For proper initialization,
@@ -85,14 +85,14 @@ func (se StaticEvents) ScheduleMutationWithAssertionEvent(
 
 }
 
-// String returns the concise string representation of the event executor,
-// detailing the number of scheduled events.
-func (se StaticEvents) String() string {
+// StringWithTag returns the concise string representation of the event
+// executor, detailing the number of scheduled events.
+func (se StaticEvents) StringWithTag(tag string) string {
 	if se.eventExecutor == nil {
 		panic("StaticEvents.eventExecutor is a nil interface; " +
 			"use NewStaticEventsWithNoEvents for proper initialization.")
 	}
-	return se.eventExecutor.PrintEventSummary()
+	return se.eventExecutor.PrintEventSummary(tag)
 }
 
 // Generate returns an eventExecutor populated with a sorted list of events. It

--- a/pkg/kv/kvserver/asim/gen/printer.go
+++ b/pkg/kv/kvserver/asim/gen/printer.go
@@ -87,10 +87,10 @@ func generateClusterVisualization(
 		}
 		return s
 	}
-	clusterSetUp := emptyIfBlank(s.NodesString())
+	clusterSetUp := emptyIfBlank(s.NodesStringWithTag("\t"))
 	rangeState := emptyIfBlank(rangeStateStr)
-	event := emptyIfBlank(eventGen.String())
-	workloadSetUp := emptyIfBlank(loadGen.String())
+	event := emptyIfBlank(eventGen.StringWithTag("\t"))
+	workloadSetUp := emptyIfBlank(loadGen.StringWithTag("\t"))
 	settingsChanges := emptyIfBlank(compareSettingsToDefault(settings))
 	_, _ = fmt.Fprintf(buf, "Cluster Set Up\n%s\n", clusterSetUp)
 	_, _ = fmt.Fprintf(buf, "Key Space\n%s\n", rangeState)

--- a/pkg/kv/kvserver/asim/scheduled/scheduled_event.go
+++ b/pkg/kv/kvserver/asim/scheduled/scheduled_event.go
@@ -39,9 +39,9 @@ type ScheduledEvent struct {
 	TargetEvent event.Event
 }
 
-func (se ScheduledEvent) String() string {
+func (se ScheduledEvent) StringWithTag(tag string) string {
 	buf := strings.Builder{}
-	buf.WriteString(fmt.Sprintf("\t%s", se.TargetEvent.String()))
+	buf.WriteString(fmt.Sprintf("%s%s", tag, se.TargetEvent.String()))
 	if !se.At.Equal(config.DefaultStartTime) {
 		buf.WriteString(fmt.Sprintf(" at %s", se.At.Format("15:04:05")))
 	}

--- a/pkg/kv/kvserver/asim/scheduled/scheduled_event_executor.go
+++ b/pkg/kv/kvserver/asim/scheduled/scheduled_event_executor.go
@@ -31,7 +31,7 @@ type EventExecutor interface {
 	TickEvents(context.Context, time.Time, state.State, history.History) bool
 	// PrintEventSummary returns a string summarizing the executed mutation and
 	// assertion events.
-	PrintEventSummary() string
+	PrintEventSummary(tag string) string
 	// PrintEventsExecuted returns a detailed string representation of executed
 	// events including details of mutation events, assertion checks, and assertion
 	// results.
@@ -68,16 +68,16 @@ func newExecutorWithNoEvents() *eventExecutor {
 
 // PrintEventSummary returns a string summarizing the executed mutation and
 // assertion events.
-func (e *eventExecutor) PrintEventSummary() string {
+func (e *eventExecutor) PrintEventSummary(tag string) string {
 	mutationEvents, assertionEvents := 0, 0
 	var buf strings.Builder
 	sort.Sort(e.scheduledEvents)
-	for i, event := range e.scheduledEvents {
-		_, _ = fmt.Fprintf(&buf, "%v", event)
+	for i, ev := range e.scheduledEvents {
+		_, _ = fmt.Fprintf(&buf, "%v", ev.StringWithTag(tag))
 		if i != len(e.scheduledEvents)-1 {
 			_, _ = fmt.Fprintf(&buf, "\n")
 		}
-		if event.IsMutationEvent() {
+		if ev.IsMutationEvent() {
 			mutationEvents++
 		} else {
 			assertionEvents++
@@ -110,7 +110,7 @@ func (e *eventExecutor) PrintEventsExecuted() string {
 		buf := strings.Builder{}
 		buf.WriteString(fmt.Sprintf("%d events executed:\n", len(e.scheduledEvents)))
 		for i, event := range e.scheduledEvents {
-			_, _ = fmt.Fprintf(&buf, "%v", event.String())
+			_, _ = fmt.Fprintf(&buf, "%v", event.StringWithTag(""))
 			if i != len(e.scheduledEvents)-1 {
 				_, _ = fmt.Fprintf(&buf, "\n")
 			}

--- a/pkg/kv/kvserver/asim/state/config_loader.go
+++ b/pkg/kv/kvserver/asim/state/config_loader.go
@@ -294,8 +294,7 @@ func (c ClusterInfo) String() (s string) {
 				buf.WriteString(", ")
 			}
 		}
-		buf.WriteString("]")
-		buf.WriteString("\n")
+		buf.WriteString("]\n")
 	}
 	buf.WriteString(fmt.Sprintf("store_disk_capacity=%d bytes, node_cpu_rate_capacity=%d cpu-ns/sec",
 		c.StoreDiskCapacityBytes, c.NodeCPURateCapacityNanos))

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1425,7 +1425,7 @@ func (s *state) SetSimulationSettings(Key string, Value interface{}) {
 	}
 }
 
-func (s *state) NodesString() string {
+func (s *state) NodesStringWithTag(tag string) string {
 	var buf strings.Builder
 
 	nodes := make([]*node, 0, len(s.nodes))
@@ -1437,7 +1437,7 @@ func (s *state) NodesString() string {
 	})
 
 	for nID, n := range nodes {
-		_, _ = fmt.Fprintf(&buf, "\tn%d(", n.nodeID)
+		_, _ = fmt.Fprintf(&buf, "%sn%d(", tag, n.nodeID)
 		for _, locality := range n.desc.Locality.Tiers {
 			_, _ = fmt.Fprintf(&buf, "%s,", locality.Value)
 		}

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -64,7 +64,7 @@ type State interface {
 	// Nodes returns all nodes that exist in this state.
 	Nodes() []Node
 	// NodesString returns a string representation of all nodes.
-	NodesString() string
+	NodesStringWithTag(tag string) string
 	// RangeFor returns the range containing Key in [StartKey, EndKey). This
 	// cannot fail.
 	RangeFor(Key) Range

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -539,7 +539,7 @@ func TestDataDriven(t *testing.T) {
 							}
 							simulator := gen.GenerateSimulation(
 								duration, clusterGen, rangeGen, loadGen,
-								settingsGen, eventGen, seedGen.Int63(), tmpStrB,
+								settingsGen, eventGen, seedGen.Int63(), tmpStrB, "\t",
 							)
 							if stateStrForOnce == "" {
 								stateStrForOnce = tmpStrB.String()

--- a/pkg/kv/kvserver/asim/tests/output.go
+++ b/pkg/kv/kvserver/asim/tests/output.go
@@ -150,17 +150,22 @@ func (tr testResultsReport) String() string {
 		if failed || tr.flags.Has(OutputConfigGen) {
 			buf.WriteString(fmt.Sprintf("configurations generated using seed %d\n", output.seed))
 			clusterGenStr, rangeGenStr, loadGenStr, eventGenStr :=
-				output.clusterGen.String(), output.rangeGen.String(), output.loadGen.String(), output.eventGen.String()
-			emptyIfBlank := func(s string) string {
+				output.clusterGen.String(), output.rangeGen.String(), output.loadGen.StringWithTag(""), output.eventGen.StringWithTag("")
+			emptyIfBlank := func(tag string, s string) string {
 				if s == "" {
-					return "empty"
+					return fmt.Sprintf("%s: empty", tag)
 				}
 				return s
 			}
-			buf.WriteString(fmt.Sprintf("\t%v\n", emptyIfBlank(clusterGenStr)))
-			buf.WriteString(fmt.Sprintf("\t%v\n", emptyIfBlank(rangeGenStr)))
-			buf.WriteString(fmt.Sprintf("%v\n", emptyIfBlank(loadGenStr)))
-			buf.WriteString(fmt.Sprintf("\t%v\n", emptyIfBlank(eventGenStr)))
+			buf.WriteString(fmt.Sprintf("\t%v\n", emptyIfBlank("cluster", clusterGenStr)))
+			buf.WriteString(fmt.Sprintf("\t%v\n", emptyIfBlank("range", rangeGenStr)))
+			buf.WriteString(fmt.Sprintf("\t%v\n", emptyIfBlank("load", loadGenStr)))
+			buf.WriteString("\tscheduled_event:\n")
+			if eventGenStr == "" {
+				eventGenStr = "\t\tempty"
+			}
+			buf.WriteString(fmt.Sprintf("%v\n", eventGenStr))
+
 		}
 		if failed || tr.flags.Has(OutputInitialState) {
 			buf.WriteString(fmt.Sprintf("initial state at %s:\n", output.initialTime.Format("2006-01-02 15:04:05")))

--- a/pkg/kv/kvserver/asim/tests/rand_framework.go
+++ b/pkg/kv/kvserver/asim/tests/rand_framework.go
@@ -118,7 +118,7 @@ func (f randTestingFramework) runRandTest() testResult {
 	staticSettings := f.getStaticSettings()
 	staticEvents := f.getStaticEvents(cluster, staticSettings)
 	seed := f.s.randSource.Int63()
-	simulator := gen.GenerateSimulation(f.s.duration, cluster, ranges, load, staticSettings, staticEvents, seed, nil)
+	simulator := gen.GenerateSimulation(f.s.duration, cluster, ranges, load, staticSettings, staticEvents, seed, nil, "")
 	initialStateStr, initialTime := simulator.State().PrettyPrint(), simulator.Curr()
 	simulator.RunSim(ctx)
 	history := simulator.History()

--- a/pkg/kv/kvserver/asim/tests/rand_gen.go
+++ b/pkg/kv/kvserver/asim/tests/rand_gen.go
@@ -58,7 +58,7 @@ func (r RandomizedBasicRanges) String() string {
 }
 
 func (r RandomizedBasicRanges) Generate(
-	seed int64, settings *config.SimulationSettings, s state.State,
+	_ string, seed int64, settings *config.SimulationSettings, s state.State,
 ) (state.State, string) {
 	if r.placementType != gen.Random {
 		panic("RandomizedBasicRanges generate only randomized distributions")
@@ -84,7 +84,7 @@ func (wr WeightedRandomizedBasicRanges) String() string {
 }
 
 func (wr WeightedRandomizedBasicRanges) Generate(
-	seed int64, settings *config.SimulationSettings, s state.State,
+	_ string, seed int64, settings *config.SimulationSettings, s state.State,
 ) (state.State, string) {
 	if wr.placementType != gen.WeightedRandom || len(wr.weightedRand) == 0 {
 		panic("RandomizedBasicRanges generate only weighted randomized distributions with non-empty weightedRand")

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/default_settings.txt
@@ -76,7 +76,8 @@ configurations generated using seed 3440579354231278675
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample1: pass
 ----------------------------------
 sample2: start running
@@ -84,7 +85,8 @@ configurations generated using seed 608747136543856411
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample2: pass
 ----------------------------------
 sample3: start running
@@ -92,7 +94,8 @@ configurations generated using seed 5571782338101878760
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample3: pass
 ----------------------------------
 
@@ -174,7 +177,8 @@ configurations generated using seed 3440579354231278675
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample1: pass
@@ -184,7 +188,8 @@ configurations generated using seed 608747136543856411
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample2: pass
@@ -194,7 +199,8 @@ configurations generated using seed 5571782338101878760
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 sample3: pass
@@ -224,7 +230,8 @@ configurations generated using seed 3440579354231278675
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 topology:
@@ -239,7 +246,8 @@ configurations generated using seed 608747136543856411
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 topology:
@@ -254,7 +262,8 @@ configurations generated using seed 5571782338101878760
 	[nodes: 3, stores_per_node:1, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(3)=[s1n1=(replicas(10)),s2n2=(replicas(10)),s3n3=(replicas(10))]
 topology:

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/events.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/events.txt
@@ -12,36 +12,36 @@ eval duration=20m num_iterations=3 verbose=(events)
 ----------------------------------
 sample1: start running
 4 events executed:
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=US_East}] [lease:{region=US_East}]
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=US_East}] [lease:{region=US_East}]
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:10:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_East}] [lease:{region=US_East}] at 11:10:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_East}] [lease:{region=US_East}] at 11:10:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:20:00
 sample1: pass
 ----------------------------------
 sample2: start running
 4 events executed:
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=US_East}] [lease:{region=US_East}]
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=US_East}] [lease:{region=US_East}]
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:10:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_East}] [lease:{region=US_East}] at 11:10:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_East}] [lease:{region=US_East}] at 11:10:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:20:00
 sample2: pass
 ----------------------------------
 sample3: start running
 4 events executed:
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=US_East}] [lease:{region=US_East}]
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=US_East}] [lease:{region=US_East}]
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:10:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_East}] [lease:{region=US_East}] at 11:10:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_East}] [lease:{region=US_East}] at 11:10:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:20:00
 sample3: pass

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_cluster.txt
@@ -11,29 +11,35 @@ eval duration=5m num_iterations=3 verbose=(config_gen)
 ----------------------------------
 sample1: start running
 configurations generated using seed 608747136543856411
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample1: pass
 ----------------------------------
 sample2: start running
 configurations generated using seed 1926012586526624009
-	cluster: region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
+	cluster: 
+region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample2: pass
 ----------------------------------
 sample3: start running
 configurations generated using seed 3534334367214237261
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample3: pass
 ----------------------------------
 
@@ -59,13 +65,15 @@ generating settings configurations using static option
 ----------------------------------
 sample1: start running
 configurations generated using seed 608747136543856411
-	cluster: region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
+	cluster: 
+region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
 region:US_West [zone=US_West_1(nodes=2,stores=1)]
 region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 store_disk_capacity=2199023255552 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(28)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(1)),s5n5=(replicas(1)),s6n6=(replicas(1)),s7n7=(replicas(1)),s8n8=(replicas(1)),s9n9=(replicas(2)),s10n10=(replicas(1)),s11n11=(replicas(1)),s12n12=(replicas(1)),s13n13=(replicas(1)),s14n14=(replicas(1)),s15n15=(replicas(1)),s16n16=(replicas(1)),s17n17=(replicas(1)),s18n18=(replicas(1)),s19n19=(replicas(1)),s20n20=(replicas(1)),s21n21=(replicas(1)),s22n22=(replicas(2)),s23n23=(replicas(1)),s24n24=(replicas(1)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(1)),s28n28=(replicas(1))]
 topology:
@@ -93,13 +101,15 @@ sample1: pass
 ----------------------------------
 sample2: start running
 configurations generated using seed 1926012586526624009
-	cluster: region:US_East [zone=US_East_1(nodes=4,stores=1), zone=US_East_2(nodes=4,stores=1), zone=US_East_3(nodes=4,stores=1)]
+	cluster: 
+region:US_East [zone=US_East_1(nodes=4,stores=1), zone=US_East_2(nodes=4,stores=1), zone=US_East_3(nodes=4,stores=1)]
 region:US_West [zone=US_West_1(nodes=4,stores=1), zone=US_West_2(nodes=4,stores=1), zone=US_West_3(nodes=4,stores=1)]
 region:EU [zone=EU_1(nodes=4,stores=1), zone=EU_2(nodes=4,stores=1), zone=EU_3(nodes=4,stores=1)]
 store_disk_capacity=2199023255552 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(36)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(1)),s5n5=(replicas(1)),s6n6=(replicas(1)),s7n7=(replicas(0)),s8n8=(replicas(1)),s9n9=(replicas(1)),s10n10=(replicas(1)),s11n11=(replicas(1)),s12n12=(replicas(1)),s13n13=(replicas(0)),s14n14=(replicas(1)),s15n15=(replicas(0)),s16n16=(replicas(0)),s17n17=(replicas(1)),s18n18=(replicas(1)),s19n19=(replicas(1)),s20n20=(replicas(1)),s21n21=(replicas(1)),s22n22=(replicas(1)),s23n23=(replicas(1)),s24n24=(replicas(1)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(1)),s28n28=(replicas(0)),s29n29=(replicas(1)),s30n30=(replicas(1)),s31n31=(replicas(0)),s32n32=(replicas(1)),s33n33=(replicas(1)),s34n34=(replicas(1)),s35n35=(replicas(1)),s36n36=(replicas(1))]
 topology:
@@ -129,13 +139,15 @@ sample2: pass
 ----------------------------------
 sample3: start running
 configurations generated using seed 3534334367214237261
-	cluster: region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
+	cluster: 
+region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
 region:US_West [zone=US_West_1(nodes=2,stores=1)]
 region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 store_disk_capacity=2199023255552 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(28)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(1)),s5n5=(replicas(1)),s6n6=(replicas(1)),s7n7=(replicas(1)),s8n8=(replicas(1)),s9n9=(replicas(2)),s10n10=(replicas(1)),s11n11=(replicas(1)),s12n12=(replicas(1)),s13n13=(replicas(1)),s14n14=(replicas(1)),s15n15=(replicas(1)),s16n16=(replicas(1)),s17n17=(replicas(1)),s18n18=(replicas(1)),s19n19=(replicas(1)),s20n20=(replicas(1)),s21n21=(replicas(1)),s22n22=(replicas(2)),s23n23=(replicas(1)),s24n24=(replicas(1)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(1)),s28n28=(replicas(1))]
 topology:
@@ -173,30 +185,36 @@ eval duration=5m num_iterations=3 verbose=(config_gen)
 ----------------------------------
 sample1: start running
 configurations generated using seed 608747136543856411
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample1: pass
 ----------------------------------
 sample2: start running
 configurations generated using seed 1926012586526624009
-	cluster: region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
+	cluster: 
+region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample2: pass
 ----------------------------------
 sample3: start running
 configurations generated using seed 3534334367214237261
-	cluster: region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
+	cluster: 
+region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
 region:US_West [zone=US_West_1(nodes=2,stores=1)]
 region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 store_disk_capacity=2199023255552 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 10(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample3: pass
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event.txt
@@ -24,61 +24,63 @@ generating settings configurations using static option
 ----------------------------------
 sample1: start running
 configurations generated using seed 7894140303635748408
-	cluster: region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
+	cluster: 
+region:US_East [zone=US_East_1(nodes=1,stores=1), zone=US_East_2(nodes=2,stores=1), zone=US_East_3(nodes=3,stores=1), zone=US_East_4(nodes=10,stores=1)]
 region:US_West [zone=US_West_1(nodes=2,stores=1)]
 region:EU [zone=EU_1(nodes=3,stores=1), zone=EU_2(nodes=3,stores=1), zone=EU_3(nodes=4,stores=1)]
 store_disk_capacity=2199023255552 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
 	[0,200000): 1(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-		[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}]
-	assertion checking event
+	scheduled_event:
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}]
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:05:00
-	[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:05:00
-	assertion checking event
+[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:05:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:10:00
-	[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:10:00
-	assertion checking event
+[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:10:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:15:00
-	[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:15:00
-	assertion checking event
+[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:15:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:20:00
-	[0000000000,9999999999): 3voters [voters:{0:region=US_West}] [lease:{region=US_West}] at 11:20:00
-	assertion checking event
+[0000000000,9999999999): 3voters [voters:{0:region=US_West}] [lease:{region=US_West}] at 11:20:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			failed:   conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
   actual unavailable=0 under=0, over=0 violating=1 lease-violating=0 lease-less-preferred=0
 violating constraints:
   r1:{0000000000-9999999999} [(n18,s18):13, (n17,s17):14, (n21,s21):7] applying num_voters=3 voter_constraints=[+region=US_West] lease_preferences=[{[+region=US_West]}] at 11:25:00
-	[0000000000,9999999999): 5voters [voters:{2:region=EU}] [lease:{region=EU}] at 11:25:00
-	assertion checking event
+[0000000000,9999999999): 5voters [voters:{2:region=EU}] [lease:{region=EU}] at 11:25:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:30:00
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:30:00
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:30:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:35:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:35:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:35:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:40:00
-	[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:40:00
-	assertion checking event
+[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:40:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:45:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:45:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:45:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:50:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=EU}] [lease:{region=EU}] at 11:50:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=EU}] [lease:{region=EU}] at 11:50:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:55:00
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:55:00
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:55:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 12:00:00
 initial state at 2022-03-21 11:00:00:
@@ -104,55 +106,55 @@ US_West
   US_West_1
     └── [17 18]
 24 events executed:
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}]
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}]
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:05:00
-	[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:05:00
-	assertion checking event
+[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:05:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:10:00
-	[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:10:00
-	assertion checking event
+[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:10:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:15:00
-	[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:15:00
-	assertion checking event
+[0000000000,9999999999): 5voters [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:15:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:20:00
-	[0000000000,9999999999): 3voters [voters:{0:region=US_West}] [lease:{region=US_West}] at 11:20:00
-	assertion checking event
+[0000000000,9999999999): 3voters [voters:{0:region=US_West}] [lease:{region=US_West}] at 11:20:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			failed:   conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
   actual unavailable=0 under=0, over=0 violating=1 lease-violating=0 lease-less-preferred=0
 violating constraints:
   r1:{0000000000-9999999999} [(n18,s18):13, (n17,s17):14, (n21,s21):7] applying num_voters=3 voter_constraints=[+region=US_West] lease_preferences=[{[+region=US_West]}] at 11:25:00
-	[0000000000,9999999999): 5voters [voters:{2:region=EU}] [lease:{region=EU}] at 11:25:00
-	assertion checking event
+[0000000000,9999999999): 5voters [voters:{2:region=EU}] [lease:{region=EU}] at 11:25:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:30:00
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:30:00
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:30:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:35:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:35:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:35:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:40:00
-	[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:40:00
-	assertion checking event
+[0000000000,9999999999): 3voters [voters:{0:region=EU}] [lease:{region=EU}] at 11:40:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:45:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:45:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=US_West}] [lease:{region=US_West}] at 11:45:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:50:00
-	[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=EU}] [lease:{region=EU}] at 11:50:00
-	assertion checking event
+[0000000000,9999999999): 5voters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{2:region=EU}] [lease:{region=EU}] at 11:50:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 11:55:00
-	[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:55:00
-	assertion checking event
+[0000000000,9999999999): 3voters,2nonvoters [replicas:{1:region=US_East}{1:region=US_West}{1:region=EU}] [voters:{0:region=EU}] [lease:{region=EU}] at 11:55:00
+assertion checking event
 			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed at 12:00:00
 sample1: pass

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges.txt
@@ -39,92 +39,112 @@ generating settings configurations using static option
 ----------------------------------
 sample1: start running
 configurations generated using seed 1926012586526624009
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {305 0 1015 3 0 }
+	randomized ranges with placement_type=random, [0,1015): 305(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample1: pass
 ----------------------------------
 sample2: start running
 configurations generated using seed 2643318057788968173
-	cluster: region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
+	cluster: 
+region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {944 0 1357 3 0 }
+	randomized ranges with placement_type=random, [0,1357): 944(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample2: pass
 ----------------------------------
 sample3: start running
 configurations generated using seed 6972490225919430754
-	cluster: region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
+	cluster: 
+region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {479 0 1003 3 0 }
+	randomized ranges with placement_type=random, [0,1003): 479(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample3: pass
 ----------------------------------
 sample4: start running
 configurations generated using seed 8427801741804500990
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {487 0 2171 3 0 }
+	randomized ranges with placement_type=random, [0,2171): 487(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample4: pass
 ----------------------------------
 sample5: start running
 configurations generated using seed 8063729658764635782
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {285 0 1060 3 0 }
+	randomized ranges with placement_type=random, [0,1060): 285(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample5: pass
 ----------------------------------
 sample6: start running
 configurations generated using seed 3814222400681984302
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {611 0 1000 3 0 }
+	randomized ranges with placement_type=random, [0,1000): 611(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample6: pass
 ----------------------------------
 sample7: start running
 configurations generated using seed 13013938835543503
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {271 0 1439 3 0 }
+	randomized ranges with placement_type=random, [0,1439): 271(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample7: pass
 ----------------------------------
 sample8: start running
 configurations generated using seed 2207144605302255518
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {502 0 1198 3 0 }
+	randomized ranges with placement_type=random, [0,1198): 502(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample8: pass
 ----------------------------------
 sample9: start running
 configurations generated using seed 5888461606762344739
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {865 0 1427 3 0 }
+	randomized ranges with placement_type=random, [0,1427): 865(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample9: pass
 ----------------------------------
 sample10: start running
 configurations generated using seed 6738330972202035110
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {787 0 1001 3 0 }
+	randomized ranges with placement_type=random, [0,1001): 787(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample10: pass
 ----------------------------------
 
@@ -155,28 +175,34 @@ generating settings configurations using static option
 ----------------------------------
 sample1: start running
 configurations generated using seed 1926012586526624009
-	cluster: region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
+	cluster: 
+region:US [zone=US_1(nodes=1,stores=5), zone=US_2(nodes=1,stores=5), zone=US_3(nodes=1,stores=5)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {305 0 96760 1 0 }
+	randomized ranges with placement_type=random, [0,96760): 305(rf=1), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample1: pass
 ----------------------------------
 sample2: start running
 configurations generated using seed 2643318057788968173
-	cluster: region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
+	cluster: 
+region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {944 0 150098 1 0 }
+	randomized ranges with placement_type=random, [0,150098): 944(rf=1), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample2: pass
 ----------------------------------
 sample3: start running
 configurations generated using seed 6972490225919430754
-	cluster: region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
+	cluster: 
+region:US [zone=US_1(nodes=5,stores=1), zone=US_2(nodes=5,stores=1), zone=US_3(nodes=5,stores=1)]
 store_disk_capacity=1099511627776 bytes, node_cpu_rate_capacity=0 cpu-ns/sec
-	randomized ranges with placement_type=random, {479 0 199954 1 0 }
+	randomized ranges with placement_type=random, [0,199954): 479(rf=1), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 sample3: pass
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand.txt
@@ -69,9 +69,10 @@ generating settings configurations using static option
 sample1: start running
 configurations generated using seed 5571782338101878760
 	[nodes: 3, stores_per_node:2, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
-	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], {563 0 160411 3 0 }
+	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], [0,160411): 563(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(6)=[s1n1=(replicas(22)),s2n1=(replicas(23)),s3n2=(replicas(23)),s4n2=(replicas(529)),s5n3=(replicas(563)),s6n3=(replicas(529))]
 sample1: pass
@@ -79,9 +80,10 @@ sample1: pass
 sample2: start running
 configurations generated using seed 4299969443970870044
 	[nodes: 3, stores_per_node:2, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
-	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], {299 0 9542 3 0 }
+	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], [0,9542): 299(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(6)=[s1n1=(replicas(53)),s2n1=(replicas(52)),s3n2=(replicas(52)),s4n2=(replicas(299)),s5n3=(replicas(142)),s6n3=(replicas(299))]
 sample2: pass
@@ -89,9 +91,10 @@ sample2: pass
 sample3: start running
 configurations generated using seed 4157513341729910236
 	[nodes: 3, stores_per_node:2, store_disk_capacity: 256GiB, node_capacity: 0cpu-sec/sec]
-	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], {521 0 82660 3 0 }
+	weighted randomized ranges with placement_type=weighted_rand, weighted_rand=[0 0 0 0.3 0.3 0.4], [0,82660): 521(rf=3), 0MiB
 	[0,200000): write-only [1B/op, 0ops/s]
-	empty
+	scheduled_event:
+		empty
 initial state at 2022-03-21 11:00:00:
 	stores(6)=[s1n1=(replicas(91)),s2n1=(replicas(91)),s3n2=(replicas(92)),s4n2=(replicas(521)),s5n3=(replicas(247)),s6n3=(replicas(521))]
 sample3: pass


### PR DESCRIPTION
Rebased on top of https://github.com/cockroachdb/cockroach/pull/153545. Only the last commit is for this PR. 
Informs: https://github.com/cockroachdb/cockroach/issues/153572
Release note: none 

----

Previously, some of the rand testing output formats were one-off because "\t"
wasn’t explicitly passed by the caller, and the same string functions were
reused for both random and non-random output. This commit fixes that by
explicitly passing a tag for strings, giving the caller control over the number
of tabs.