### PR TITLE
*: drop `TODODRPC` override in favor of cluster setting

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -478,7 +478,7 @@ func (n *Node) StatusClient(ctx context.Context) serverpb.RPCStatusClient {
 		return existingClient
 	}
 
-	if !rpcbase.TODODRPC {
+	if !rpcbase.DRPCEnabled(ctx, n.rpcCtx.Settings) {
 		conn, err := n.rpcCtx.GRPCUnvalidatedDial(n.RPCAddr(), roachpb.Locality{}).Connect(ctx)
 		if err != nil {
 			log.Dev.Fatalf(context.Background(), "failed to initialize status client: %s", err)

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -101,7 +101,7 @@ func makeRPCClientConfig(cfg server.Config) rpc.ClientConnConfig {
 
 func newClientConn(ctx context.Context, cfg server.Config) (rpcConn, func(), error) {
 	ccfg := makeRPCClientConfig(cfg)
-	if !rpcbase.TODODRPC {
+	if !rpcbase.DRPCEnabled(ctx, cfg.Settings) {
 		cc, finish, err := rpc.NewClientConn(ctx, ccfg)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to connect to the node")

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -437,7 +437,7 @@ func (c *client) drpcDial(ctx context.Context, rpcCtx *rpc.Context) (drpc.Conn, 
 func (c *client) dialGossipClient(
 	ctx context.Context, rpcCtx *rpc.Context,
 ) (RPCGossipClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.DRPCEnabled(ctx, rpcCtx.Settings) {
 		conn, err := c.dial(ctx, rpcCtx)
 		if err != nil {
 			return nil, err

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -979,7 +979,7 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 		// Try each address on each retry iteration (in random order).
 		for _, i := range rand.Perm(len(c.addrs)) {
 			addr := c.addrs[i]
-			if !rpcbase.TODODRPC {
+			if !rpcbase.DRPCEnabled(ctx, c.rpcContext.Settings) {
 				conn, err := c.dialAddr(ctx, addr)
 				if err != nil {
 					log.Dev.Warningf(ctx, "error dialing tenant KV address %s: %v", addr, err)

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -171,7 +171,7 @@ func (n *Dialer) DialInternalClient(
 
 	var client rpc.RestrictedInternalClient
 	useStreamPoolClient := shouldUseBatchStreamPoolClient(ctx, n.rpcContext.Settings)
-	if !rpcbase.ExperimentalDRPCEnabled.Get(&n.rpcContext.Settings.SV) {
+	if !rpcbase.DRPCEnabled(ctx, n.rpcContext.Settings) {
 		gc, conn, err := dial(ctx, n.resolver, n.rpcContext.GRPCDialNode, nodeID, class, true /* checkBreaker */)
 		if err != nil {
 			return nil, errors.Wrapf(err, "gRPC")

--- a/pkg/rpc/rpcbase/nodedialer.go
+++ b/pkg/rpc/rpcbase/nodedialer.go
@@ -39,10 +39,6 @@ var ExperimentalDRPCEnabled = settings.RegisterBoolSetting(
 		return nil
 	}))
 
-// TODODRPC is a marker to identify each RPC client creation site that needs to
-// be updated to support DRPC.
-const TODODRPC = false
-
 // NodeDialer interface defines methods for dialing peer nodes using their
 // node IDs.
 type NodeDialer interface {
@@ -70,10 +66,8 @@ func DialRPCClient[C any](
 	drpcClientFn func(drpc.Conn) C,
 	st *cluster.Settings,
 ) (C, error) {
-	useDRPC := ExperimentalDRPCEnabled.Get(&st.SV)
-
 	var nilC C
-	if !TODODRPC && !useDRPC {
+	if !DRPCEnabled(ctx, st) {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nilC, err
@@ -99,10 +93,8 @@ func DialRPCClientNoBreaker[C any](
 	drpcClientFn func(drpc.Conn) C,
 	st *cluster.Settings,
 ) (C, error) {
-	useDRPC := ExperimentalDRPCEnabled.Get(&st.SV)
-
 	var nilC C
-	if !TODODRPC && !useDRPC {
+	if !DRPCEnabled(ctx, st) {
 		conn, err := nd.DialNoBreaker(ctx, nodeID, class)
 		if err != nil {
 			return nilC, err
@@ -115,4 +107,8 @@ func DialRPCClientNoBreaker[C any](
 		return nilC, err
 	}
 	return drpcClientFn(conn), nil
+}
+
+func DRPCEnabled(ctx context.Context, st *cluster.Settings) bool {
+	return st != nil && ExperimentalDRPCEnabled.Get(&st.SV)
 }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2135,7 +2135,7 @@ func (s *adminServer) checkReadinessForHealthCheck(ctx context.Context) error {
 		return err
 	}
 
-	if rpcbase.ExperimentalDRPCEnabled.Get(&s.st.SV) {
+	if rpcbase.DRPCEnabled(ctx, s.st) {
 		if err := s.drpc.health(ctx); err != nil {
 			return err
 		}
@@ -2181,7 +2181,7 @@ func (s *systemAdminServer) checkReadinessForHealthCheck(ctx context.Context) er
 		return err
 	}
 
-	if rpcbase.ExperimentalDRPCEnabled.Get(&s.st.SV) {
+	if rpcbase.DRPCEnabled(ctx, s.st) {
 		if err := s.drpc.health(ctx); err != nil {
 			return err
 		}

--- a/pkg/server/application_api/main_test.go
+++ b/pkg/server/application_api/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -25,9 +24,6 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	rangetestutils.InitRangeTestServerFactory(server.TestServerFactory)
 	kvtenant.InitTestConnectorFactory()
-	defer serverutils.TestingGlobalDRPCOption(
-		base.TestDRPCEnabledRandomly,
-	)()
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -466,10 +466,8 @@ func (s *initServer) attemptJoinTo(
 		BinaryVersion: &latestVersion,
 	}
 
-	var initClient kvpb.RPCNodeClient
-	if !rpcbase.TODODRPC {
-		initClient = kvpb.NewGRPCInternalClientAdapter(conn)
-	}
+	// TODO(server): add support for DRPC initClient
+	var initClient kvpb.RPCNodeClient = kvpb.NewGRPCInternalClientAdapter(conn)
 	resp, err := initClient.Join(ctx, req)
 	if err != nil {
 		status, ok := grpcstatus.FromError(errors.UnwrapAll(err))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2129,7 +2129,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		}
 	}
 	var apiInternalServer http.Handler
-	if rpcbase.ExperimentalDRPCEnabled.Get(&s.cfg.Settings.SV) {
+	if rpcbase.DRPCEnabled(ctx, s.cfg.Settings) {
 		// Pass our own node ID to connect to local RPC servers
 		apiInternalServer, err = apiinternal.NewAPIInternalServer(
 			ctx, s.kvNodeDialer, s.rpcContext.NodeID.Get(), s.cfg.Settings)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -825,7 +825,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	}
 
 	var apiInternalServer http.Handler
-	if rpcbase.ExperimentalDRPCEnabled.Get(&s.cfg.Settings.SV) {
+	if rpcbase.DRPCEnabled(ctx, s.cfg.Settings) {
 		// Pass our own instance ID to connect to local RPC servers
 		apiInternalServer, err = apiinternal.NewAPIInternalServer(ctx,
 			s.sqlServer.sqlInstanceDialer,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2640,7 +2640,7 @@ func (ts *testServer) RPCClientConn(
 func (ts *testServer) RPCClientConnE(user username.SQLUsername) (serverutils.RPCConn, error) {
 	ctx := context.Background()
 	rpcCtx := ts.NewClientRPCContext(ctx, user)
-	if !rpcbase.TODODRPC {
+	if !rpcbase.DRPCEnabled(ctx, rpcCtx.Settings) {
 		conn, err := rpcCtx.GRPCDialNode(ts.AdvRPCAddr(), ts.NodeID(), ts.Locality(), rpcbase.DefaultClass).Connect(ctx)
 		if err != nil {
 			return nil, err
@@ -2692,7 +2692,7 @@ func (t *testTenant) RPCClientConn(
 func (t *testTenant) RPCClientConnE(user username.SQLUsername) (serverutils.RPCConn, error) {
 	ctx := context.Background()
 	rpcCtx := t.NewClientRPCContext(ctx, user)
-	if !rpcbase.TODODRPC {
+	if !rpcbase.DRPCEnabled(ctx, rpcCtx.Settings) {
 		conn, err := rpcCtx.GRPCDialPod(t.AdvRPCAddr(), t.SQLInstanceID(), t.Locality(), rpcbase.DefaultClass).Connect(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently, at many call sites, we disable DRPC using TODODRPC override. This change drops `TODODRPC` override and ensure DRPC is controlled exclusively through the `rpc.experimental_drpc.enabled` cluster setting.

Epic: CRDB-48935
Fixes: #153922
Release note: None