### PR TITLE
release-25.3: workload: detect self-referencing FK for column dependency

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -292,7 +292,8 @@ func (og *operationGenerator) columnIsDependedOn(
 	// so performing unions and joins is easier.
 	//
 	// To check if any foreign key references exist to this table, we use pg_constraint
-	// and check if any columns are dependent.
+	// and check if any columns are dependent. We check both confrelid (table is referenced)
+	// and self-referential foreign keys (where conrelid = confrelid).
 	return og.scanBool(ctx, tx, `SELECT EXISTS(
 		SELECT source.column_id
 			FROM (
@@ -320,6 +321,12 @@ func (og *operationGenerator) columnIsDependedOn(
 			           SELECT unnest(confkey) AS column_id
 			             FROM pg_catalog.pg_constraint
 			            WHERE confrelid = $1::REGCLASS
+			          )
+			   UNION  (
+			           SELECT unnest(conkey) AS column_id
+			             FROM pg_catalog.pg_constraint
+			            WHERE conrelid = $1::REGCLASS
+			              AND confrelid = $1::REGCLASS
 			          )
 			 ) AS cons
 			 INNER JOIN (


### PR DESCRIPTION
Backport 1/1 commits from #153665 on behalf of @spilchen.

----

In the schemachanger workload we have a function to detect dependencies on a given column. It would look up and check for foreign keys, but it didn't account for self-referencing foreign keys. This updates the query to detect that.

Fixes #153547

Epic: none
Release note: none

----

Release justification: