### PR TITLE
opt/bench: properly set EvalCtx.Annotations in the harness

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -854,6 +854,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 		semaCtx: tree.MakeSemaContext(nil /* resolver */),
 		evalCtx: eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
+	h.evalCtx.Annotations = &h.semaCtx.Annotations
 
 	// Set session settings to their global defaults.
 	if err := sql.TestingResetSessionVariables(h.ctx, h.evalCtx); err != nil {


### PR DESCRIPTION
This was exposed recently via 8d772022e1237c165821cfd9f5cd2262897dcf5e that triggered some warnings in a couple of benchmarks (before this patch we'd crash with "no Annotations provided" error since we forgot to properly initialize the eval context).

Fixes: #153530.
Fixes: #153535.

Release note: None