### PR TITLE
release-24.3: roachtest: disable auto stats in atomic copyfrom

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -156,6 +156,11 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 		"CREATE USER importer WITH PASSWORD '123'",
 		fmt.Sprintf("ALTER ROLE importer SET copy_from_atomic_enabled = %t", atomic),
 	}
+	if atomic {
+		// Disable auto stats collection so that it doesn't contend with the
+		// long-running atomic COPY txn.
+		stmts = append(stmts, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
+	}
 	for _, stmt := range stmts {
 		_, err = db.ExecContext(ctx, stmt)
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #153696 on behalf of @yuzefovich.

----

Previously, the following scenario was possible:
- we have atomic COPY meaning that we create multiple KV batches within a single txn. That txn lasts for about 2 minutes
- a concurrent AUTO CREATE STATS job is kicked off, and it uses AOST -30s, so it'll contend with the long-running COPY txn.

This commit simply disables auto stats to avoid this type of flake (this is kinda a known limitation of the atomic COPY).

Fixes: #151905.
Release note: None

----

Release justification: test-only change.