### PR TITLE
sql: don't check privilege per-row of crdb_internal.tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -615,11 +615,6 @@ CREATE TABLE crdb_internal.tables (
 			if !isTable {
 				continue
 			}
-			if ok, err := p.HasAnyPrivilege(ctx, table); err != nil {
-				return err
-			} else if !ok {
-				continue
-			}
 			dbName := dbNames[table.GetParentID()]
 			if dbName == "" {
 				// The parent database was deleted. This is possible e.g. when
@@ -690,11 +685,6 @@ func crdbInternalTablesDatabaseLookupFunc(
 		}
 		table, isTable := desc.(catalog.TableDescriptor)
 		if !isTable {
-			return nil
-		}
-		if ok, err := p.HasAnyPrivilege(ctx, table); err != nil {
-			return err
-		} else if !ok {
 			return nil
 		}
 		seenAny = true


### PR DESCRIPTION
The privilege check here is from quite a long time ago, and it no longer
is desired. The similar tables pg_catalog.pg_class and
information_schema.tables allow one to view table metadata without any
special privileges, so crdb_internal.tables should match that as well.

No release note since this is an internal introspection API.

Epic: None
Release note: None