### PR TITLE
builtins: deflake TestGetSSTableMetricsSingleNode

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins_test.go
+++ b/pkg/sql/sem/builtins/generator_builtins_test.go
@@ -11,12 +11,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -157,27 +159,30 @@ func TestGetSSTableMetricsSingleNode(t *testing.T) {
 	ts, hostDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(ctx)
 
-	nodeIDArg := 1
+	nodeIDArg := int(ts.NodeID())
 	storeIDArg := int(ts.GetFirstStoreID())
 
 	r := sqlutils.MakeSQLRunner(hostDB)
-	r.Exec(t, `CREATE TABLE t(k INT PRIMARY KEY, v INT)`)
-	r.Exec(t, `INSERT INTO t SELECT i, i*10 FROM generate_series(1, 10000) AS g(i)`)
 
-	r.Exec(t, fmt.Sprintf(`
-	 SELECT crdb_internal.compact_engine_span(
-		 %d, %d,
-		 (SELECT raw_start_key FROM [SHOW RANGES FROM TABLE t WITH KEYS] LIMIT 1),
-		 (SELECT raw_end_key FROM [SHOW RANGES FROM TABLE t WITH KEYS] LIMIT 1))`,
-		nodeIDArg, storeIDArg))
+	// Seed some data.
+	r.Exec(t, `CREATE TABLE t(k INT PRIMARY KEY, v STRING)`)
+	r.Exec(t, `INSERT INTO t SELECT i, CAST(gen_random_uuid() AS STRING) FROM generate_series(1, 10000) AS g(i)`)
 
-	rows := r.Query(t, fmt.Sprintf(`
-	 SELECT * FROM crdb_internal.sstable_metrics(
-		 %d, %d,
-		 (SELECT raw_start_key FROM [SHOW RANGES FROM TABLE t WITH KEYS] LIMIT 1),
-		 (SELECT raw_end_key FROM [SHOW RANGES FROM TABLE t WITH KEYS] LIMIT 1))`,
-		nodeIDArg, storeIDArg))
+	// Construct min and max engine keys. We append a 0x00 byte to the end of
+	// each to make them valid engine keys (the last byte indicates the length
+	// of the version, in this case none).
+	minEngineKey := append(slices.Clone(roachpb.KeyMin), 0x00)
+	maxEngineKey := append(slices.Clone(roachpb.KeyMax), 0x00)
 
+	// Manually compact the entire user key space. This will trigger a memtable
+	// flush if needed, ensuring that the data written above has been flushed to
+	// sstables.
+	r.Exec(t, `SELECT crdb_internal.compact_engine_span($1, $2, $3, $4)`,
+		nodeIDArg, storeIDArg, minEngineKey, maxEngineKey)
+
+	// Now there must exist at least one sstable.
+	rows := r.Query(t, `SELECT * FROM crdb_internal.sstable_metrics($1, $2, $3, $4)`,
+		nodeIDArg, storeIDArg, minEngineKey, maxEngineKey)
 	count := 0
 	var nodeID int
 	var storeID int
@@ -195,6 +200,7 @@ func TestGetSSTableMetricsSingleNode(t *testing.T) {
 		require.NotEqual(t, approximateSpanBytes, 0)
 		count++
 	}
+	require.NoError(t, rows.Err())
 	require.GreaterOrEqual(t, count, 1)
 }
 


### PR DESCRIPTION
Refactor and deflake TestGetSSTableMetricsSingleNode.

Fixes: #151742
Epic: none
Release note: none