### PR TITLE
kvserver/rangefeed: add capacity to node level buffered sender

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -383,3 +383,16 @@ var MaxCommandSize = settings.RegisterByteSizeSetting(
 	MaxCommandSizeDefault,
 	settings.ByteSizeWithMinimum(MaxCommandSizeFloor),
 )
+
+// DefaultRangefeedEventCap is the channel capacity of the rangefeed processor
+// and each registration. It is also used to calculate the default capacity
+// limit for the buffered sender.
+//
+// The size of an event is 72 bytes, so this will result in an allocation on the
+// order of ~300KB per RangeFeed. That's probably ok given the number of ranges
+// on a node that we'd like to support with active rangefeeds, but it's
+// certainly on the upper end of the range.
+//
+// Note that processors also must reserve memory from one of two memory monitors
+// for each event.
+const DefaultRangefeedEventCap = 4096

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -45,6 +48,38 @@ import (
 //               BufferedPerRangeEventSink.Send    BufferedPerRangeEventSink.SendError
 //
 
+// RangefeedSingleBufferedSenderQueueMaxSize is the maximum number of events
+// that the buffered sender will buffer before it starts returning capacity
+// exceeded errors. Updates to this setting are only applied to need
+// MuxRangefeedCalls, existing streams will use the previous value until
+// restarted.
+//
+// # The main goal of this limit is to provide a backstop against the
+//
+// The default here has been somewhat arbitrarily chosen considering that:
+//
+//   - We want to avoid capacity exceeded errors that wouldn't have occurred
+//     when the buffered registrations were in use.
+//
+//   - We don't want to drastically increase the amount of queueing allowed for a
+//     single registration.
+//
+//   - One buffered sender is feeding a single gRPC client.
+//
+//   - Events emitted during catchup scans have their own per-registration buffer
+//     still.
+//
+// TODO(ssd): This is a bit of a stop-gap so that we have a knob to turn if we
+// need to. We probably want each buffered sender (or each consumerID) to be
+// able to hold up to some fraction of the total rangefeed budget. But we are
+// starting here for now.
+var RangefeedSingleBufferedSenderQueueMaxSize = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"kv.rangefeed.buffered_sender.queue_max_size",
+	"max size of a buffered senders event queue (0 for no max)",
+	kvserverbase.DefaultRangefeedEventCap*8,
+)
+
 // BufferedSender is embedded in every rangefeed.BufferedPerRangeEventSink,
 // serving as a helper which buffers events before forwarding events to the
 // underlying gRPC stream.
@@ -58,21 +93,7 @@ type BufferedSender struct {
 		syncutil.Mutex
 		stopped bool
 		buffer  *eventQueue
-		// capacity is the maximum number of events that can be buffered. It
-		// dynamically scales based on the number of active registrations.
-		//
-		// The capacity is calculated as:
-		// - Minimum: minBufferedSenderQueueCapacity (20 registrations)
-		// - Active streams: perUnbufferedRegCapacity * number of active
-		// registrations
-		//
-		// This scaling is based on the intuition that each stream should have
-		// equivalent buffer space to what unbuffered registrations receive (4096
-		// events per registration). Since all registrations share the same buffered
-		// sender, registrations may affect each other.
-		//
-		// Note that when capacity shrinks, events already buffered will not be
-		// dropped. Capacity is not adjusted during shutdown.
+		// capacity is the maximum number of events that can be buffered.
 		capacity   int64
 		overflowed bool
 	}
@@ -88,14 +109,8 @@ type BufferedSender struct {
 	metrics *BufferedSenderMetrics
 }
 
-// TODO(wenyihu6): This value is set to the same value as
-// https://github.com/cockroachdb/cockroach/blob/5536f0828f50bb21ec1577c77d388c4303d124a4/pkg/kv/kvserver/replica_rangefeed.go#L121.
-// Should I move this const to kvserverbase and import this value?
-const perUnbufferedRegCapacity = int64(4096)
-const minBufferedSenderQueueCapacity = int64(4096 * 20)
-
 func NewBufferedSender(
-	sender ServerStreamSender, bsMetrics *BufferedSenderMetrics,
+	sender ServerStreamSender, settings *cluster.Settings, bsMetrics *BufferedSenderMetrics,
 ) *BufferedSender {
 	bs := &BufferedSender{
 		sender:  sender,
@@ -104,7 +119,7 @@ func NewBufferedSender(
 	bs.queueMu.buffer = newEventQueue()
 	bs.notifyDataC = make(chan struct{}, 1)
 	bs.queueMu.buffer = newEventQueue()
-	bs.queueMu.capacity = minBufferedSenderQueueCapacity
+	bs.queueMu.capacity = RangefeedSingleBufferedSenderQueueMaxSize.Get(&settings.SV)
 	return bs
 }
 
@@ -123,7 +138,7 @@ func (bs *BufferedSender) sendBuffered(
 	if bs.queueMu.overflowed {
 		return newRetryErrBufferCapacityExceeded()
 	}
-	if bs.queueMu.buffer.len() >= bs.queueMu.capacity {
+	if bs.queueMu.capacity > 0 && bs.queueMu.buffer.len() >= bs.queueMu.capacity {
 		bs.queueMu.overflowed = true
 		return newRetryErrBufferCapacityExceeded()
 	}
@@ -208,21 +223,16 @@ func (bs *BufferedSender) cleanup(ctx context.Context) {
 	bs.metrics.BufferedSenderQueueSize.Dec(remaining)
 }
 
-// onStreamConnectOrDisconnect is called when a stream is added or removed. This
-// is currently used to dynamically adjust its queue capacity based on number of
-// active registrations. Note that this is not called during shutdown, so strict
-// dependency on this contract is discouraged. And note that we do not drop
-// events if the capacity is shrunk.
-func (bs *BufferedSender) onStreamConnectOrDisconnect(activeStreamCount int64) {
-	bs.queueMu.Lock()
-	defer bs.queueMu.Unlock()
-	bs.queueMu.capacity = max(minBufferedSenderQueueCapacity, activeStreamCount*perUnbufferedRegCapacity)
-}
-
 func (bs *BufferedSender) len() int {
 	bs.queueMu.Lock()
 	defer bs.queueMu.Unlock()
 	return int(bs.queueMu.buffer.len())
+}
+
+func (bs *BufferedSender) overflowed() bool {
+	bs.queueMu.Lock()
+	defer bs.queueMu.Unlock()
+	return bs.queueMu.overflowed
 }
 
 // Used for testing only.

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -56,8 +57,10 @@ type BufferedSender struct {
 	// queueMu protects the buffer queue.
 	queueMu struct {
 		syncutil.Mutex
-		stopped bool
-		buffer  *eventQueue
+		stopped  bool
+		buffer   *eventQueue
+		capacity int64
+		overflow bool
 	}
 
 	// notifyDataC is used to notify the BufferedSender.run goroutine that there
@@ -72,7 +75,7 @@ type BufferedSender struct {
 }
 
 func NewBufferedSender(
-	sender ServerStreamSender, bsMetrics *BufferedSenderMetrics,
+	sender ServerStreamSender, bsMetrics *BufferedSenderMetrics, maxQueueSize int64,
 ) *BufferedSender {
 	bs := &BufferedSender{
 		sender:  sender,
@@ -80,6 +83,8 @@ func NewBufferedSender(
 	}
 	bs.queueMu.buffer = newEventQueue()
 	bs.notifyDataC = make(chan struct{}, 1)
+	bs.queueMu.buffer = newEventQueue()
+	bs.queueMu.capacity = maxQueueSize
 	return bs
 }
 
@@ -94,6 +99,15 @@ func (bs *BufferedSender) sendBuffered(
 	defer bs.queueMu.Unlock()
 	if bs.queueMu.stopped {
 		return errors.New("stream sender is stopped")
+	}
+	if bs.queueMu.overflow {
+		// Is this too spammy
+		log.Dev.Error(context.Background(), "buffer capacity exceeded")
+		return newRetryErrBufferCapacityExceeded()
+	}
+	if bs.queueMu.buffer.len() >= bs.queueMu.capacity {
+		bs.queueMu.overflow = true
+		return newRetryErrBufferCapacityExceeded()
 	}
 	// TODO(wenyihu6): pass an actual context here
 	alloc.Use(context.Background())
@@ -130,7 +144,7 @@ func (bs *BufferedSender) run(
 			return nil
 		case <-bs.notifyDataC:
 			for {
-				e, success := bs.popFront()
+				e, success, overflowed, remains := bs.popFront()
 				if !success {
 					break
 				}
@@ -143,6 +157,9 @@ func (bs *BufferedSender) run(
 				if err != nil {
 					return err
 				}
+				if overflowed && remains == int64(0) {
+					return newRetryErrBufferCapacityExceeded()
+				}
 			}
 		}
 	}
@@ -150,11 +167,16 @@ func (bs *BufferedSender) run(
 
 // popFront pops the front event from the buffer queue. It returns the event and
 // a boolean indicating if the event was successfully popped.
-func (bs *BufferedSender) popFront() (e sharedMuxEvent, success bool) {
+func (bs *BufferedSender) popFront() (
+	e sharedMuxEvent,
+	success bool,
+	overflowed bool,
+	remains int64,
+) {
 	bs.queueMu.Lock()
 	defer bs.queueMu.Unlock()
 	event, ok := bs.queueMu.buffer.popFront()
-	return event, ok
+	return event, ok, bs.queueMu.overflow, bs.queueMu.buffer.len()
 }
 
 // cleanup is called when the sender is stopped. It is expected to free up

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -34,7 +34,7 @@ func TestBufferedSenderDisconnectStream(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 	defer sm.Stop(ctx)
@@ -87,7 +87,7 @@ func TestBufferedSenderChaosWithStop(t *testing.T) {
 	testServerStream := newTestServerStream()
 
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -35,7 +36,8 @@ func TestBufferedSenderDisconnectStream(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	st := cluster.MakeTestingClusterSettings()
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 	defer sm.Stop(ctx)
@@ -88,7 +90,8 @@ func TestBufferedSenderChaosWithStop(t *testing.T) {
 	testServerStream := newTestServerStream()
 
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	st := cluster.MakeTestingClusterSettings()
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 
@@ -176,18 +179,22 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
-	require.Equal(t, minBufferedSenderQueueCapacity, bs.queueMu.capacity)
+	st := cluster.MakeTestingClusterSettings()
+
+	queueCap := int64(24)
+	RangefeedSingleBufferedSenderQueueMaxSize.Override(ctx, &st.SV, queueCap)
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
+	require.Equal(t, queueCap, bs.queueMu.capacity)
 
 	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1 := new(kvpb.RangeFeedEvent)
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})
 	muxEv := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: *ev1, RangeID: 0, StreamID: 1}
 
-	for i := int64(0); i < minBufferedSenderQueueCapacity; i++ {
+	for range queueCap {
 		require.NoError(t, bs.sendBuffered(muxEv, nil))
 	}
-	require.Equal(t, minBufferedSenderQueueCapacity, int64(bs.len()))
+	require.Equal(t, queueCap, int64(bs.len()))
 	e, success, overflowed, remains := bs.popFront()
 	require.Equal(t, sharedMuxEvent{
 		ev:    muxEv,
@@ -195,10 +202,10 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 	}, e)
 	require.True(t, success)
 	require.False(t, overflowed)
-	require.Equal(t, minBufferedSenderQueueCapacity-1, remains)
-	require.Equal(t, minBufferedSenderQueueCapacity-1, int64(bs.len()))
+	require.Equal(t, queueCap-1, remains)
+	require.Equal(t, queueCap-1, int64(bs.len()))
 	require.NoError(t, bs.sendBuffered(muxEv, nil))
-	require.Equal(t, minBufferedSenderQueueCapacity, int64(bs.len()))
+	require.Equal(t, queueCap, int64(bs.len()))
 
 	// Overflow now.
 	require.Equal(t, bs.sendBuffered(muxEv, nil).Error(),
@@ -207,7 +214,6 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 
 // TestBufferedSenderOnStreamShutdown tests that BufferedSender and
 // StreamManager handle overflow and shutdown properly.
-
 func TestBufferedSenderOnStreamShutdown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -217,101 +223,70 @@ func TestBufferedSenderOnStreamShutdown(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
-	require.Equal(t, minBufferedSenderQueueCapacity, bs.queueMu.capacity)
+	st := cluster.MakeTestingClusterSettings()
+
+	queueCap := int64(24)
+	RangefeedSingleBufferedSenderQueueMaxSize.Override(ctx, &st.SV, queueCap)
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
+	require.Equal(t, queueCap, bs.queueMu.capacity)
+
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 	defer sm.Stop(ctx)
 
 	p, h, pStopper := newTestProcessor(t, withRangefeedTestType(scheduledProcessorWithBufferedSender))
 	defer pStopper.Stop(ctx)
+
+	streamID := int64(42)
 
 	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1 := new(kvpb.RangeFeedEvent)
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})
-	muxEv := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: *ev1, RangeID: 0, StreamID: 1}
+	muxEv := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: *ev1, RangeID: 0, StreamID: streamID}
 
-	// Add 21 streams and overflow the buffer.
-	t.Run("add 21 streams", func(t *testing.T) {
-		numStreams := int64(21)
-		expectedCapacity := perUnbufferedRegCapacity * numStreams
-		// Block the stream to help the queue to overflow.
-		unblock := testServerStream.BlockSend()
-		for id := int64(0); id < numStreams; id++ {
-			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
-				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-				sm.NewStream(id, 1 /*rangeID*/))
-			require.True(t, registered)
-			sm.AddStream(id, d)
-		}
-		require.Equal(t, expectedCapacity, bs.queueMu.capacity)
-		for int64(bs.len()) != expectedCapacity {
-			require.NoError(t, sm.sender.sendBuffered(muxEv, nil))
-		}
-		require.Equal(t, expectedCapacity, int64(bs.len()))
-		require.Equal(t, bs.sendBuffered(muxEv, nil).Error(),
-			newRetryErrBufferCapacityExceeded().Error())
-		require.True(t, bs.queueMu.overflowed)
-		unblock()
-	})
+	// Block the stream so that we can overflow later.
+	unblock := testServerStream.BlockSend()
+	defer unblock()
 
-	t.Run("overflow clean up", func(t *testing.T) {
-		// All events buffered should still be sent to the stream.
+	waitForQueueLen := func(len int) {
 		testutils.SucceedsSoon(t, func() error {
-			if bs.len() == 0 {
+			if bs.len() == len {
 				return nil
 			}
-			return errors.Newf("expected 0 registrations, found %d", bs.len())
+			return errors.Newf("expected %d events, found %d", len, bs.len())
 		})
-		// Overflow cleanup.
-		err := <-sm.Error()
-		require.Equal(t, newRetryErrBufferCapacityExceeded().Error(), err.Error())
-		// Note that we expect the stream manager to shut down here, but no actual
-		// error events would be sent during the shutdown.
-		require.Equal(t, bs.sendBuffered(muxEv, nil).Error(), newRetryErrBufferCapacityExceeded().Error())
-	})
-}
-
-// TestBufferedSenderOnStreamDisconnect tests that BufferedSender dynamically
-// adjusts its capacity when streams are connected or disconnected.
-func TestBufferedSenderOnStreamDisconnect(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	testServerStream := newTestServerStream()
-	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
-	require.Equal(t, minBufferedSenderQueueCapacity, bs.queueMu.capacity)
-
-	sm := NewStreamManager(bs, smMetrics)
-	require.NoError(t, sm.Start(ctx, stopper))
-
-	p, h, pStopper := newTestProcessor(t, withRangefeedTestType(scheduledProcessorWithBufferedSender))
-	defer pStopper.Stop(ctx)
-	defer sm.Stop(ctx)
-
-	numStreams := int64(21)
-	expectedCapacity := perUnbufferedRegCapacity * numStreams
-	for id := int64(0); id < numStreams; id++ {
-		registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
-			false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
-			sm.NewStream(id, 1 /*rangeID*/))
-		require.True(t, registered)
-		sm.AddStream(id, d)
 	}
-	require.Equal(t, expectedCapacity, bs.queueMu.capacity)
-	sm.DisconnectStream(int64(0), newErrBufferCapacityExceeded())
-	testServerStream.waitForEvent(t, makeMuxRangefeedErrorEvent(0, 1, newErrBufferCapacityExceeded()))
-	testutils.SucceedsSoon(t, func() error {
-		bs.queueMu.Lock()
-		defer bs.queueMu.Unlock()
-		if bs.queueMu.capacity == expectedCapacity-perUnbufferedRegCapacity {
-			return nil
-		}
-		return errors.Newf("expected %d cap to be %d", bs.queueMu.capacity,
-			expectedCapacity-perUnbufferedRegCapacity)
-	})
+
+	// Add our stream to the stream manager.
+	registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
+		sm.NewStream(streamID, 1 /*rangeID*/))
+	require.True(t, registered)
+	sm.AddStream(streamID, d)
+
+	require.NoError(t, sm.sender.sendBuffered(muxEv, nil))
+	// At this point we actually have sent 2 events. 1 checkpoint event sent by
+	// register and 1 event sent on the line above. We wait for 1 of these events
+	// to be pulled off the queue and block in the sender, leaving 1 in the queue.
+	waitForQueueLen(1)
+	// Now fill the rest of the queue.
+	for range queueCap - 1 {
+		require.NoError(t, sm.sender.sendBuffered(muxEv, nil))
+	}
+
+	// The next write should overflow.
+	capExceededErrStr := newRetryErrBufferCapacityExceeded().Error()
+	err := sm.sender.sendBuffered(muxEv, nil)
+	require.EqualError(t, err, capExceededErrStr)
+	require.True(t, bs.overflowed())
+
+	unblock()
+	waitForQueueLen(0)
+	// Overflow cleanup.
+	err = <-sm.Error()
+	require.EqualError(t, err, capExceededErrStr)
+	// Note that we expect the stream manager to shut down here, but no actual
+	// error events would be sent during the shutdown.
+	err = sm.sender.sendBuffered(muxEv, nil)
+	require.EqualError(t, err, capExceededErrStr)
 }

--- a/pkg/kv/kvserver/rangefeed/sender_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/sender_helper_test.go
@@ -35,6 +35,9 @@ type testServerStream struct {
 	eventsSent int
 	// streamEvents is a map of streamID to a list of events sent to that stream.
 	streamEvents map[int64][]*kvpb.MuxRangeFeedEvent
+
+	// t can optionally set for additional logging.
+	t *testing.T
 }
 
 var _ ServerStreamSender = &testServerStream{}
@@ -121,6 +124,9 @@ func (s *testServerStream) SendIsThreadSafe() {}
 // Send mocks grpc.ServerStream Send method. It only counts events and stores
 // events by streamID in streamEvents.
 func (s *testServerStream) Send(e *kvpb.MuxRangeFeedEvent) error {
+	if s.t != nil {
+		s.t.Logf("Sending event for StreamID %d: %v", e.StreamID, e)
+	}
 	s.Lock()
 	defer s.Unlock()
 	s.eventsSent++

--- a/pkg/kv/kvserver/rangefeed/stream_manager.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager.go
@@ -78,6 +78,12 @@ type sender interface {
 	// cleanup is called when the sender is stopped. It is expected to clean up
 	// any resources used by the sender.
 	cleanup(ctx context.Context)
+	// onStreamConnectOrDisconnect is called when a stream is added or removed.
+	// This is currently used for buffered sender to dynamically adjust its queue
+	// capacity based on number of active registrations. Note that this is not
+	// called during shutdown, so strict dependency on this contract is
+	// discouraged.
+	onStreamConnectOrDisconnect(activeStreamCount int64)
 }
 
 func NewStreamManager(sender sender, metrics *StreamManagerMetrics) *StreamManager {
@@ -108,12 +114,18 @@ func (sm *StreamManager) NewStream(streamID int64, rangeID roachpb.RangeID) (sin
 // streamID to avoid metrics inaccuracy when the error is sent before the stream
 // is added to the StreamManager.
 func (sm *StreamManager) OnError(streamID int64) {
-	sm.streams.Lock()
-	defer sm.streams.Unlock()
-	if _, ok := sm.streams.m[streamID]; ok {
-		delete(sm.streams.m, streamID)
-		sm.metrics.ActiveMuxRangeFeed.Dec(1)
-	}
+	func() {
+		sm.streams.Lock()
+		defer sm.streams.Unlock()
+		if _, ok := sm.streams.m[streamID]; ok {
+			delete(sm.streams.m, streamID)
+			sm.metrics.ActiveMuxRangeFeed.Dec(1)
+		}
+	}()
+
+	// Call onStreamConnectOrDisconnect regardless of whether ActiveMuxRangeFeed
+	// has changed for simplicity.
+	sm.sender.onStreamConnectOrDisconnect(sm.metrics.ActiveMuxRangeFeed.Value())
 }
 
 // DisconnectStream disconnects the stream with the given streamID.
@@ -138,19 +150,27 @@ func (sm *StreamManager) AddStream(streamID int64, d Disconnector) {
 	// At this point, the stream had been registered with the processor and
 	// started receiving events. We need to lock here to avoid race conditions
 	// with a disconnect error passing through before the stream is added.
-	sm.streams.Lock()
-	defer sm.streams.Unlock()
-	if d.IsDisconnected() {
-		// If the stream is already disconnected, we don't add it to streams. The
-		// registration will have already sent an error to the client.
-		return
-	}
-	if _, ok := sm.streams.m[streamID]; ok {
-		log.KvDistribution.Fatalf(context.Background(), "stream %d already exists", streamID)
-	}
-	sm.streams.m[streamID] = d
-	sm.metrics.ActiveMuxRangeFeed.Inc(1)
-	sm.metrics.NumMuxRangeFeed.Inc(1)
+	func() {
+		sm.streams.Lock()
+		defer sm.streams.Unlock()
+		if d.IsDisconnected() {
+			// If the stream is already disconnected, we don't add it to streams. The
+			// registration will have already sent an error to the client.
+			return
+		}
+		if _, ok := sm.streams.m[streamID]; ok {
+			log.KvDistribution.Fatalf(context.Background(), "stream %d already exists", streamID)
+		}
+		sm.streams.m[streamID] = d
+		sm.metrics.ActiveMuxRangeFeed.Inc(1)
+		sm.metrics.NumMuxRangeFeed.Inc(1)
+	}()
+
+	// TODO(during review) Is it okay to trust the metrics gauge value here? We
+	// can maintain our own counter here as well
+	// Call onStreamConnectOrDisconnect regardless of whether ActiveMuxRangeFeed
+	// has changed for simplicity.
+	sm.sender.onStreamConnectOrDisconnect(sm.metrics.ActiveMuxRangeFeed.Value())
 }
 
 // Start launches sender.run in the background if no error is returned.
@@ -186,6 +206,8 @@ func (sm *StreamManager) Start(ctx context.Context, stopper *stop.Stopper) error
 func (sm *StreamManager) Stop(ctx context.Context) {
 	sm.taskCancel()
 	sm.wg.Wait()
+	// Since this is called during shutdown, sm.sender.onStreamConnectOrDisconnect
+	// is not being called explicitly to update the queue capacity.
 	sm.sender.cleanup(ctx)
 	sm.streams.Lock()
 	defer sm.streams.Unlock()

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -175,12 +176,13 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 	testutils.RunValues(t, "feed type", testTypes, func(t *testing.T, rt rangefeedTestType) {
 		testServerStream := newTestServerStream()
 		smMetrics := NewStreamManagerMetrics()
+		st := cluster.MakeTestingClusterSettings()
 		var s sender
 		switch rt {
 		case scheduledProcessorWithUnbufferedSender:
 			s = NewUnbufferedSender(testServerStream)
 		case scheduledProcessorWithBufferedSender:
-			s = NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+			s = NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
 		default:
 			t.Fatalf("unknown rangefeed test type %v", rt)
 		}

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -180,7 +180,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 		case scheduledProcessorWithUnbufferedSender:
 			s = NewUnbufferedSender(testServerStream)
 		case scheduledProcessorWithBufferedSender:
-			s = NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+			s = NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
 		default:
 			t.Fatalf("unknown rangefeed test type %v", rt)
 		}

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -180,7 +180,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 		case scheduledProcessorWithUnbufferedSender:
 			s = NewUnbufferedSender(testServerStream)
 		case scheduledProcessorWithBufferedSender:
-			s = NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
+			s = NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
 		default:
 			t.Fatalf("unknown rangefeed test type %v", rt)
 		}

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -34,7 +34,7 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 
@@ -106,7 +106,7 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 	defer sm.Stop(ctx)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -65,13 +65,14 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 		})
 	})
 	testServerStream.reset()
-	t.Run("publish 20 logical ops to 50 registrations", func(t *testing.T) {
-		for i := 0; i < 20; i++ {
+	eventCount := testProcessorEventCCap - 1
+	t.Run(fmt.Sprintf("publish %d logical ops to 50 registrations", eventCount), func(t *testing.T) {
+		for range eventCount {
 			p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: 1}))
 		}
-		testServerStream.waitForEventCount(t, 20*50)
+		testServerStream.waitForEventCount(t, eventCount*50)
 		testServerStream.iterateEventsByStreamID(func(_ int64, events []*kvpb.MuxRangeFeedEvent) {
-			require.Equal(t, 20, len(events))
+			require.Equal(t, eventCount, len(events))
 			require.NotNil(t, events[0].RangeFeedEvent.Val)
 		})
 	})

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -34,7 +35,9 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	st := cluster.MakeTestingClusterSettings()
+
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 
@@ -106,7 +109,8 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
+	st := cluster.MakeTestingClusterSettings()
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 	defer sm.Stop(ctx)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -34,7 +34,7 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
+	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 
@@ -106,7 +106,7 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	defer stopper.Stop(ctx)
 	testServerStream := newTestServerStream()
 	smMetrics := NewStreamManagerMetrics()
-	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics(), 1000)
+	bs := NewBufferedSender(testServerStream, NewBufferedSenderMetrics())
 	sm := NewStreamManager(bs, smMetrics)
 	require.NoError(t, sm.Start(ctx, stopper))
 	defer sm.Stop(ctx)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -188,5 +188,4 @@ func (ubs *UnbufferedSender) detachMuxErrors() []*kvpb.MuxRangeFeedEvent {
 
 // The following methods are no-op implementations to satisfy the sender
 // interface.
-func (ubs *UnbufferedSender) cleanup(context.Context)             {}
-func (ubs *UnbufferedSender) onStreamConnectOrDisconnect(_ int64) { return }
+func (ubs *UnbufferedSender) cleanup(context.Context) {}

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -186,4 +186,7 @@ func (ubs *UnbufferedSender) detachMuxErrors() []*kvpb.MuxRangeFeedEvent {
 	return toSend
 }
 
-func (ubs *UnbufferedSender) cleanup(context.Context) {}
+// The following methods are no-op implementations to satisfy the sender
+// interface.
+func (ubs *UnbufferedSender) cleanup(context.Context)             {}
+func (ubs *UnbufferedSender) onStreamConnectOrDisconnect(_ int64) { return }

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -98,19 +98,6 @@ func init() {
 	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval
 }
 
-// defaultEventChanCap is the channel capacity of the rangefeed processor and
-// each registration.
-//
-// The size of an event is 72 bytes, so this will result in an allocation on the
-// order of ~300KB per RangeFeed. That's probably ok given the number of ranges
-// on a node that we'd like to support with active rangefeeds, but it's
-// certainly on the upper end of the range.
-//
-// TODO(dan): Everyone seems to agree that this memory limit would be better set
-// at a store-wide level, but there doesn't seem to be an easy way to accomplish
-// that.
-const defaultEventChanCap = 4096
-
 // defaultEventChanTimeout is the send timeout for events published to a
 // rangefeed processor or rangefeed client channels. When exceeded, the
 // rangefeed or client is disconnected to prevent blocking foreground traffic
@@ -516,7 +503,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 		Span:             desc.RSpan(),
 		TxnPusher:        &tp,
 		PushTxnsAge:      r.store.TestingKnobs().RangeFeedPushTxnsAge,
-		EventChanCap:     defaultEventChanCap,
+		EventChanCap:     kvserverbase.DefaultRangefeedEventCap,
 		EventChanTimeout: defaultEventChanTimeout,
 		Metrics:          r.store.metrics.RangeFeedMetrics,
 		MemBudget:        feedBudget,

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -93,6 +93,15 @@ var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
 	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", true),
 )
 
+var RangefeedSingleBufferedSenderQueueMaxSize = settings.RegisterIntSetting(
+	settings.SystemOnly,
+	"kv.rangefeed.buffered_sender_queue.max_size",
+	"max size of the buffered sender queue",
+	// what should we set here a single buffered sender here for one Rangefeed
+	// call
+	2048,
+)
+
 func init() {
 	// Inject into kvserverbase to allow usage from kvcoord.
 	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -93,15 +93,6 @@ var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
 	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", true),
 )
 
-var RangefeedSingleBufferedSenderQueueMaxSize = settings.RegisterIntSetting(
-	settings.SystemOnly,
-	"kv.rangefeed.buffered_sender_queue.max_size",
-	"max size of the buffered sender queue",
-	// what should we set here a single buffered sender here for one Rangefeed
-	// call
-	2048,
-)
-
 func init() {
 	// Inject into kvserverbase to allow usage from kvcoord.
 	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2224,10 +2224,13 @@ func (n *Node) muxRangeFeed(muxStream kvpb.RPCInternal_MuxRangeFeedStream) error
 
 	sm := &rangefeed.StreamManager{}
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
-		sm = rangefeed.NewStreamManager(rangefeed.NewBufferedSender(lockedMuxStream, n.metrics.BufferedSenderMetrics),
+		sm = rangefeed.NewStreamManager(
+			rangefeed.NewBufferedSender(lockedMuxStream, n.storeCfg.Settings, n.metrics.BufferedSenderMetrics),
 			n.metrics.StreamManagerMetrics)
 	} else {
-		sm = rangefeed.NewStreamManager(rangefeed.NewUnbufferedSender(lockedMuxStream), n.metrics.StreamManagerMetrics)
+		sm = rangefeed.NewStreamManager(
+			rangefeed.NewUnbufferedSender(lockedMuxStream),
+			n.metrics.StreamManagerMetrics)
 	}
 
 	if err := sm.Start(ctx, n.stopper); err != nil {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2224,8 +2224,8 @@ func (n *Node) muxRangeFeed(muxStream kvpb.RPCInternal_MuxRangeFeedStream) error
 
 	sm := &rangefeed.StreamManager{}
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
-		sm = rangefeed.NewStreamManager(rangefeed.NewBufferedSender(lockedMuxStream, n.metrics.BufferedSenderMetrics),
-			n.metrics.StreamManagerMetrics)
+		sm = rangefeed.NewStreamManager(rangefeed.NewBufferedSender(lockedMuxStream, n.metrics.BufferedSenderMetrics,
+			kvserver.RangefeedSingleBufferedSenderQueueMaxSize.Get(&n.storeCfg.Settings.SV)), n.metrics.StreamManagerMetrics)
 	} else {
 		sm = rangefeed.NewStreamManager(rangefeed.NewUnbufferedSender(lockedMuxStream), n.metrics.StreamManagerMetrics)
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2224,8 +2224,8 @@ func (n *Node) muxRangeFeed(muxStream kvpb.RPCInternal_MuxRangeFeedStream) error
 
 	sm := &rangefeed.StreamManager{}
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
-		sm = rangefeed.NewStreamManager(rangefeed.NewBufferedSender(lockedMuxStream, n.metrics.BufferedSenderMetrics,
-			kvserver.RangefeedSingleBufferedSenderQueueMaxSize.Get(&n.storeCfg.Settings.SV)), n.metrics.StreamManagerMetrics)
+		sm = rangefeed.NewStreamManager(rangefeed.NewBufferedSender(lockedMuxStream, n.metrics.BufferedSenderMetrics),
+			n.metrics.StreamManagerMetrics)
 	} else {
 		sm = rangefeed.NewStreamManager(rangefeed.NewUnbufferedSender(lockedMuxStream), n.metrics.StreamManagerMetrics)
 	}


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/152505
Release note: none

---
**kvserver/rangefeed: add capacity to node level buffered sender**

This patch adds capacity to node level buffered sender which will shut down all
registrations if the node level buffer had overflowed.

Part of: https://github.com/cockroachdb/cockroach/issues/129813
Release note: none

---
**kvserver/rangefeed: rename overflow to overflowed**

This commit renames overflow to overflowed in BufferedSender for clarity.

---
**kvserver/rangefeed: dynamically adjust capacity per buffered sender**

Previously, buffered sender capacity was configured via a cluster setting. This
commit removes that setting and makes capacity scale dynamically with the number
of active registrations. The minimum (and default) is 4096 * 20, and capacity
never drops below that. Above the minimum, it grows as 4096 * <active
registrations>. Events already buffered will not dropped when capacity
decreases, and capacity is not adjusted during shutdown (0).

---
**rangefeed: move back to static (bug configurable) send queue limit**

The interactions here probably require more thought before doing
anything more complicated than a simple static limit.

Epic: none
Release note: None

---
**rangefeed: fix incorrect comment**

Epic: none
Release note: None

---
**rangefeed: deflake TestUnbufferedRegWithStreamManager**

Under stress, this test would fail because attempting to publish 20
events in a tight loop would overwhelm the processor's event buffer
(which has a capacity of 16).

Epic: none
Release note: None

