### PR TITLE
release-25.3: roachprod: refactor IAP authentication

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1148,6 +1148,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_binxio_gcloudconfig",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/binxio/gcloudconfig",
+        sha256 = "82797ef5d9fa4cba09d64ca885a3b6b8867d046c8f144ed15dc102085b0c6ceb",
+        strip_prefix = "github.com/binxio/gcloudconfig@v0.1.5",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/binxio/gcloudconfig/com_github_binxio_gcloudconfig-v0.1.5.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_biogo_store",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/biogo/store",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -292,6 +292,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/beorn7/perks/com_github_beorn7_perks-v1.0.1.zip": "25bd9e2d94aca770e6dbc1f53725f84f6af4432f631d35dd2c46f96ef0512f1a",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/bgentry/go-netrc/com_github_bgentry_go_netrc-v0.0.0-20140422174119-9fd32a8b3d3d.zip": "59fbb1e8e307ccd7052f77186990d744284b186e8b1c5ebdfb12405ae8d7f935",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/bgentry/speakeasy/com_github_bgentry_speakeasy-v0.1.0.zip": "d4bfd48b9bf68c87f92c94478ac910bcdab272e15eb909d58f1fb939233f75f0",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/binxio/gcloudconfig/com_github_binxio_gcloudconfig-v0.1.5.zip": "82797ef5d9fa4cba09d64ca885a3b6b8867d046c8f144ed15dc102085b0c6ceb",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/biogo/store/com_github_biogo_store-v0.0.0-20160505134755-913427a1d5e8.zip": "26551f8829c5ada84a68ef240732375be6747252aba423cf5c88bc03002c3600",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/bitly/go-hostpool/com_github_bitly_go_hostpool-v0.0.0-20171023180738-a3a6125de932.zip": "9a55584d7fa2c1639d0ea11cd5b437786c2eadc2401d825e699ad6445fc8e476",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/bitly/go-simplejson/com_github_bitly_go_simplejson-v0.5.0.zip": "53930281dc7fba8947c1b1f07c82952a38dcaefae23bd3c8e71d70a6daa6cb40",

--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/aws/smithy-go v1.22.3
 	github.com/axiomhq/hyperloglog v0.2.5
 	github.com/bazelbuild/rules_go v0.26.0
+	github.com/binxio/gcloudconfig v0.1.5
 	github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8
 	github.com/blevesearch/snowballstem v0.9.0
 	github.com/buchgr/bazel-remote v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/binxio/gcloudconfig v0.1.5 h1:nbvWtpqn7yJs4qPuXxTu9D3DYrSyc0FHkXraseMMCV4=
+github.com/binxio/gcloudconfig v0.1.5/go.mod h1:IpQXzgqmv2JS1i+hbhqhHqzeYWg5zWkdN4sZJznJDUM=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8 h1:tYoz1OeRpx3dJZlh9T4dQt4kAndcmpl+VNdzbSgFC/0=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=

--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -1684,9 +1684,9 @@ func (cr *commandRegistry) buildGrafanaAnnotationCmd() *cobra.Command {
 		Long: fmt.Sprintf(`Adds an annotation to the specified grafana instance
 
 By default, we assume the grafana instance needs an authentication token to connect
-to. A service account json and audience will be read in from the environment
-variables %s and %s to attempt authentication through google IDP. Use the --insecure
-option when a token is not necessary.
+to. Unless the %s environment variable exists, the default Google Application Credentials
+will be used to derive an Access Token to authenticate against Google Identity-Aware Proxy.
+Use the --insecure option when a token is not necessary.
 
 --tags specifies the tags the annotation should have.
 
@@ -1701,7 +1701,7 @@ creates an annotation over time range.
 Example:
 # Create an annotation over time range 1-100 on the centralized grafana instance, which needs authentication.
 roachprod grafana-annotation grafana.testeng.crdb.io example-annotation-event --tags my-cluster --tags test-run-1 --dashboard-uid overview --time-range 1,100
-`, roachprodutil.ServiceAccountJson, roachprodutil.ServiceAccountAudience),
+`, roachprodutil.CredentialsEnvironmentVariable),
 		Args: cobra.ExactArgs(2),
 		Run: wrap(func(cmd *cobra.Command, args []string) error {
 			req := grafana.AddAnnotationRequest{

--- a/pkg/cmd/roachprod/grafana/BUILD.bazel
+++ b/pkg/cmd/roachprod/grafana/BUILD.bazel
@@ -22,12 +22,12 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/promhelperclient",
         "//pkg/roachprod/roachprodutil",
         "//pkg/util/httputil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_go_openapi_strfmt//:strfmt",
         "@com_github_grafana_grafana_openapi_client_go//client",
         "@com_github_grafana_grafana_openapi_client_go//models",
-        "@org_golang_google_api//idtoken",
     ],
 )

--- a/pkg/roachprod/promhelperclient/BUILD.bazel
+++ b/pkg/roachprod/promhelperclient/BUILD.bazel
@@ -16,8 +16,6 @@ go_library(
         "//pkg/util/httputil",
         "@com_github_cockroachdb_errors//:errors",
         "@in_gopkg_yaml_v2//:yaml_v2",
-        "@org_golang_google_api//idtoken",
-        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -27,10 +25,8 @@ go_test(
     embed = [":promhelperclient"],
     deps = [
         "//pkg/roachprod/logger",
-        "//pkg/roachprod/roachprodutil",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
-        "@org_golang_google_api//idtoken",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -26,8 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/ibm"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/errors"
-	"golang.org/x/oauth2"
-	"google.golang.org/api/idtoken"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,8 +35,13 @@ const (
 
 	// ErrorMessage is the generic error message used to return an error
 	// when a requests to the prometheus helper service yields a non 200 status.
-	ErrorMessage       = ErrorMessagePrefix + ` on url %s and error %s`
-	ErrorMessagePrefix = "request failed with status %d"
+	ErrorMessage = `request failed with status %d on url %s and error %s`
+
+	// OauthClientID is the client ID for the OAuth client.
+	OAuthClientID = "1063333028845-p47csl1ukrgnpnnjc7lrtrto6uqs9t37.apps.googleusercontent.com"
+	// ServiceAccountEmail is the service account email to impersonate to access
+	// the Identity-Aware Proxy protected backend.
+	ServiceAccountEmail = "prom-helper-service@cockroach-testeng-infra.iam.gserviceaccount.com"
 )
 
 // CloudEnvironment is the environment of Cloud provider.
@@ -95,131 +98,78 @@ type PromClient struct {
 	promUrl  string
 	disabled bool
 
-	// httpPut is used for http PUT operation.
-	httpPut func(
-		ctx context.Context, url string, h *http.Header, body io.Reader,
-	) (resp *http.Response, err error)
-	// httpDelete is used for http DELETE operation.
-	httpDelete func(ctx context.Context, url string, h *http.Header) (
-		resp *http.Response, err error)
-	// newTokenSource is the token generator source.
-	newTokenSource func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (
-		oauth2.TokenSource, error)
-}
-
-// IsNotFoundError returns true if the error is a 404 error.
-func IsNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), fmt.Sprintf(ErrorMessagePrefix, http.StatusNotFound))
+	// client is the http client
+	httpClient *http.Client
 }
 
 // NewPromClient returns a new instance of PromClient
-func NewPromClient() *PromClient {
-	return &PromClient{
-		promUrl:        promRegistrationUrl,
-		disabled:       promRegistrationUrl == "",
-		httpPut:        httputil.Put,
-		httpDelete:     httputil.Delete,
-		newTokenSource: idtoken.NewTokenSource,
+func NewPromClient(options ...Option) (*PromClient, error) {
+	c := &PromClient{
+		promUrl:  promRegistrationUrl,
+		disabled: promRegistrationUrl == "",
 	}
-}
 
-func (c *PromClient) setUrl(url string) {
-	c.promUrl = url
-	c.disabled = false
-}
+	for _, option := range options {
+		option.apply(c)
+	}
 
-// instanceConfigRequest is the HTTP request received for generating instance config
-type instanceConfigRequest struct {
-	// Config is the content of the yaml file
-	Config   string `json:"config"`
-	Insecure bool   `json:"insecure"`
+	// If the client is not set, create a new client
+	if c.httpClient == nil {
+		iapTokenSource, err := roachprodutil.NewIAPTokenSource(roachprodutil.IAPTokenSourceOptions{
+			OAuthClientID:       OAuthClientID,
+			ServiceAccountEmail: ServiceAccountEmail,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create IAP token source")
+		}
+		c.httpClient = iapTokenSource.GetHTTPClient()
+	}
+
+	return c, nil
 }
 
 // UpdatePrometheusTargets updates the cluster config in the promUrl
 func (c *PromClient) UpdatePrometheusTargets(
-	ctx context.Context,
-	clusterName string,
-	forceFetchCreds bool,
-	nodeTargets NodeTargets,
-	insecure bool,
-	l *logger.Logger,
+	ctx context.Context, clusterName string, nodeTargets NodeTargets, l *logger.Logger,
 ) error {
 	if c.disabled {
 		l.Printf("Prometheus registration is disabled")
 		return nil
 	}
-	req, err := buildCreateRequest(nodeTargets, insecure)
+
+	request, err := c.buildCreateRequest(ctx, clusterName, nodeTargets)
 	if err != nil {
 		return err
 	}
-	token, err := c.getToken(ctx, forceFetchCreds, l)
+
+	l.Printf("invoking PUT for URL: %s", request.URL)
+
+	err = c.makeRequest(request)
 	if err != nil {
-		return err
-	}
-	url := getUrl(c.promUrl, clusterName)
-	l.Printf("invoking PUT for URL: %s", url)
-	h := &http.Header{}
-	h.Set("ContentType", "application/json")
-	if token != "" {
-		h.Set("Authorization", token)
-	}
-	response, err := c.httpPut(ctx, url, h, req)
-	if err != nil {
-		return err
-	}
-	if response.StatusCode != http.StatusOK {
-		defer func() { _ = response.Body.Close() }()
-		if response.StatusCode == http.StatusUnauthorized && !forceFetchCreds {
-			l.Printf("request failed - this may be due to a stale token. retrying with forceFetchCreds true ...")
-			return c.UpdatePrometheusTargets(ctx, clusterName, true, nodeTargets, insecure, l)
-		}
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			return err
-		}
-		return errors.Newf(ErrorMessage, response.StatusCode, url, string(body))
+		return errors.Wrapf(err, "UpdatePrometheusTargets: failed on url: %s", request.URL)
 	}
 	return nil
 }
 
 // DeleteClusterConfig deletes the cluster config in the promUrl
 func (c *PromClient) DeleteClusterConfig(
-	ctx context.Context, clusterName string, forceFetchCreds, insecure bool, l *logger.Logger,
+	ctx context.Context, clusterName string, l *logger.Logger,
 ) error {
 
 	if c.disabled {
 		return nil
 	}
-	token, err := c.getToken(ctx, forceFetchCreds, l)
+
+	request, err := c.buildDeleteRequest(ctx, clusterName)
 	if err != nil {
 		return err
 	}
-	url := getUrl(c.promUrl, clusterName)
-	if insecure {
-		url = fmt.Sprintf("%s?insecure=true", url)
-	}
-	h := &http.Header{}
-	h.Set("Authorization", token)
-	response, err := c.httpDelete(ctx, url, h)
+
+	err = c.makeRequest(request)
 	if err != nil {
-		return errors.Wrapf(err, "DeleteClusterConfig: failed on url: %s", url)
-	}
-	if response.StatusCode != http.StatusNoContent {
-		defer func() { _ = response.Body.Close() }()
-		if response.StatusCode == http.StatusUnauthorized && !forceFetchCreds {
-			return c.DeleteClusterConfig(ctx, clusterName, true, insecure, l)
-		}
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			return err
-		}
-		return errors.Newf(ErrorMessage, response.StatusCode, url, string(body))
+		return errors.Wrapf(err, "DeleteClusterConfig: failed on url: %s", request.URL)
 	}
 	return nil
-}
-
-func getUrl(promUrl, clusterName string) string {
-	return fmt.Sprintf("%s/%s/%s/%s", promUrl, resourceVersion, resourceName, clusterName)
 }
 
 // ProviderReachability returns the reachability of the provider
@@ -241,16 +191,34 @@ func ProviderReachability(provider string, cloudEnvironment CloudEnvironment) Re
 	return providerReachability[Default]
 }
 
-// CCParams are the params for the cluster configs
-type CCParams struct {
-	Targets []string          `yaml:"targets"`
-	Labels  map[string]string `yaml:"labels"`
+// getUrl returns the URL for the prometheus helper service for a given cluster
+func (c *PromClient) getUrl(clusterName string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", c.promUrl, resourceVersion, resourceName, clusterName)
 }
 
-// NodeInfo contains the target and labels for the node
-type NodeInfo struct {
-	Target       string            // Name of the node
-	CustomLabels map[string]string // Custom labels to be added to the cluster config
+// makeRequest makes the http request and returns an error with the body if an error occurs
+func (c *PromClient) makeRequest(request *http.Request) error {
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			return err
+		}
+		return errors.Newf(ErrorMessage, response.StatusCode, request.URL, string(body))
+	}
+	return nil
+}
+
+// buildDeleteRequest creates the http.Request to delete the cluster config
+func (c *PromClient) buildDeleteRequest(
+	ctx context.Context, clusterName string,
+) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, http.MethodDelete, c.getUrl(clusterName), nil)
 }
 
 // NodeTargets contains prometheus scrape targets for each node.
@@ -268,8 +236,24 @@ func (nt NodeTargets) String() string {
 	return strings.Join(parts, " ")
 }
 
-// createClusterConfigFile creates the cluster config file per node
-func buildCreateRequest(nodes NodeTargets, insecure bool) (io.Reader, error) {
+// buildCreateRequest builds the http.Request to create the cluster config
+func (c *PromClient) buildCreateRequest(
+	ctx context.Context, clusterName string, nodes NodeTargets,
+) (*http.Request, error) {
+	body, err := c.buildCreateRequestBody(nodes)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.getUrl(clusterName), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", httputil.JSONContentType)
+	return req, nil
+}
+
+// createBuildRequestBody creates the cluster config file per node
+func (c *PromClient) buildCreateRequestBody(nodes NodeTargets) (io.Reader, error) {
 	configs := make([]*CCParams, 0)
 	for _, n := range nodes {
 		for _, node := range n {
@@ -288,30 +272,51 @@ func buildCreateRequest(nodes NodeTargets, insecure bool) (io.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	b, err := json.Marshal(&instanceConfigRequest{Config: string(cb), Insecure: insecure})
+	b, err := json.Marshal(&instanceConfigRequest{
+		Config: string(cb),
+	})
 	if err != nil {
 		return nil, err
 	}
 	return bytes.NewReader(b), nil
 }
 
-// getToken gets the Authorization token for grafana
-func (c *PromClient) getToken(
-	ctx context.Context, forceFetchCreds bool, l *logger.Logger,
-) (string, error) {
-	if strings.HasPrefix(c.promUrl, "http:/") {
-		// no token needed for insecure URL
-		return "", nil
+// instanceConfigRequest is the HTTP request received for generating instance config
+type instanceConfigRequest struct {
+	//Config is the content of the yaml file
+	Config   string `json:"config"`
+	Insecure bool   `json:"insecure"`
+}
+
+// CCParams are the params for the cluster configs
+type CCParams struct {
+	Targets []string          `yaml:"targets"`
+	Labels  map[string]string `yaml:"labels"`
+}
+
+// NodeInfo contains the target and labels for the node
+type NodeInfo struct {
+	Target       string            // Name of the node
+	CustomLabels map[string]string // Custom labels to be added to the cluster config
+}
+
+type Option interface {
+	apply(*PromClient)
+}
+
+type OptionFunc func(*PromClient)
+
+func (o OptionFunc) apply(c *PromClient) { o(c) }
+
+func WithIAPTokenSource(tokenSource roachprodutil.IAPTokenSource) OptionFunc {
+	return func(c *PromClient) {
+		c.httpClient = tokenSource.GetHTTPClient()
 	}
-	// Read in the service account key and audience, so we can retrieve the identity token.
-	if credSrc, err := roachprodutil.SetServiceAccountCredsEnv(ctx, forceFetchCreds); err != nil {
-		return "", err
-	} else {
-		l.Printf("Prometheus credentials obtained from %s", credSrc)
+}
+
+func WithCustomURL(url string) OptionFunc {
+	return func(c *PromClient) {
+		c.promUrl = url
+		c.disabled = false
 	}
-	token, err := roachprodutil.GetServiceAccountToken(ctx, c.newTokenSource)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("Bearer %s", token), nil
 }

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -8,226 +8,180 @@ package promhelperclient
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/roachprodutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
-	"google.golang.org/api/idtoken"
 	"gopkg.in/yaml.v2"
 )
 
-func TestUpdatePrometheusTargets(t *testing.T) {
-	l := func() *logger.Logger {
-		l, err := logger.RootLogger("", logger.TeeToStdout)
-		if err != nil {
-			panic(err)
-		}
-		return l
-	}()
-	ctx := context.Background()
-	promUrl := "http://prom_url.com"
-	c := NewPromClient()
-	c.setUrl(promUrl)
-	t.Run("UpdatePrometheusTargets fails with 400", func(t *testing.T) {
-		c.httpPut = func(ctx context.Context, reqUrl string, h *http.Header, body io.Reader) (
-			resp *http.Response, err error) {
-			require.Equal(t, getUrl(promUrl, "c1"), reqUrl)
-			return &http.Response{
-				StatusCode: 400,
-				Body:       io.NopCloser(strings.NewReader("failed")),
-			}, nil
-		}
-		err := c.UpdatePrometheusTargets(ctx, "c1", false,
-			NodeTargets{1: {{Target: "n1"}}}, true, l)
-		require.NotNil(t, err)
-		require.Equal(t, fmt.Sprintf(ErrorMessage, 400, getUrl(promUrl, "c1"), "failed"), err.Error())
-	})
-	t.Run("UpdatePrometheusTargets succeeds", func(t *testing.T) {
-		nodeInfos := NodeTargets{
-			1: {{
-				Target: "n1",
-			}},
-			3: {{
-				Target:       "n3",
-				CustomLabels: map[string]string{"custom": "label"},
-			}},
-		}
-		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (
-			resp *http.Response, err error) {
-			require.Equal(t, getUrl(promUrl, "c1"), url)
-			ir, err := getInstanceConfigRequest(io.NopCloser(body))
-			require.Nil(t, err)
-			require.NotNil(t, ir.Config)
-			configs := make([]*CCParams, 0)
-			require.Nil(t, yaml.UnmarshalStrict([]byte(ir.Config), &configs))
-			require.Len(t, configs, 2)
-			for _, c := range configs {
-				if c.Targets[0] == "n1" {
-					require.Empty(t, nodeInfos[1][0].CustomLabels)
-				} else {
-					require.Equal(t, "n3", c.Targets[0])
-					for k, v := range nodeInfos[3][0].CustomLabels {
-						require.Equal(t, v, c.Labels[k])
-					}
-				}
-			}
-			return &http.Response{
-				StatusCode: 200,
-			}, nil
-		}
-		err := c.UpdatePrometheusTargets(ctx, "c1", false, nodeInfos, true, l)
-		require.Nil(t, err)
-	})
-}
+func TestNewPromClient(t *testing.T) {
+	mockToken := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+	}
+	mockSource := &mockIAPTokenSource{
+		token:      mockToken,
+		httpClient: &http.Client{},
+	}
 
-func TestDeleteClusterConfig(t *testing.T) {
-	l := func() *logger.Logger {
-		l, err := logger.RootLogger(filepath.Join(t.TempDir(), "test.log"), logger.TeeToStdout)
-		if err != nil {
-			panic(err)
-		}
-		return l
-	}()
-	ctx := context.Background()
-	promUrl := "http://prom_url.com"
-	c := NewPromClient()
-	c.setUrl(promUrl)
-	t.Run("DeleteClusterConfig fails with 400", func(t *testing.T) {
-		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
-			resp *http.Response, err error) {
-			require.Equal(t, getUrl(promUrl, "c1"), url)
-			return &http.Response{
-				StatusCode: 400,
-				Body:       io.NopCloser(strings.NewReader("failed")),
-			}, nil
-		}
-		err := c.DeleteClusterConfig(ctx, "c1", false, false, l)
-		require.NotNil(t, err)
-		require.Equal(
-			t,
-			fmt.Sprintf(ErrorMessage, 400, "http://prom_url.com/v1/instance-configs/c1", "failed"),
-			err.Error(),
+	t.Run("with custom URL and IAP token source", func(t *testing.T) {
+		promURL := "http://test.com"
+		client, err := NewPromClient(
+			WithCustomURL(promURL),
+			WithIAPTokenSource(mockSource),
 		)
+		require.NoError(t, err)
+		require.Equal(t, promURL, client.promUrl)
+		require.False(t, client.disabled)
+		require.Equal(t, mockSource.GetHTTPClient(), client.httpClient)
 	})
-	t.Run("DeleteClusterConfig succeeds", func(t *testing.T) {
-		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
-			resp *http.Response, err error) {
-			require.Equal(t, getUrl(promUrl, "c1"), url)
-			return &http.Response{
-				StatusCode: 204,
-			}, nil
-		}
-		err := c.DeleteClusterConfig(ctx, "c1", false, false /* insecure */, l)
-		require.Nil(t, err)
+
+	t.Run("with default URL", func(t *testing.T) {
+		client, err := NewPromClient(
+			WithIAPTokenSource(mockSource),
+		)
+		require.NoError(t, err)
+		require.Equal(t, promRegistrationUrl, client.promUrl)
+		require.NotNil(t, client.httpClient)
 	})
-	t.Run("DeleteClusterConfig insecure succeeds", func(t *testing.T) {
-		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
-			resp *http.Response, err error) {
-			require.Equal(t, fmt.Sprintf("%s?insecure=true", getUrl(promUrl, "c1")), url)
-			return &http.Response{
-				StatusCode: 204,
-			}, nil
+
+	t.Run("verify supported providers", func(t *testing.T) {
+		tests := []struct {
+			provider    string
+			environment CloudEnvironment
+			expected    Reachability
+		}{
+			{"gce", "cockroach-ephemeral", Private},
+			{"gce", Default, Public},
+			{"aws", Default, Public},
+			{"azure", Default, Public},
+			{"unknown", Default, None},
 		}
-		err := c.DeleteClusterConfig(ctx, "c1", false, true /* insecure */, l)
-		require.Nil(t, err)
+
+		for _, tc := range tests {
+			reachability := ProviderReachability(tc.provider, tc.environment)
+			require.Equal(t, tc.expected, reachability)
+		}
 	})
 }
 
-// getInstanceConfigRequest returns the instanceConfigRequest after parsing the request json
-func getInstanceConfigRequest(body io.ReadCloser) (*instanceConfigRequest, error) {
-	var insConfigReq instanceConfigRequest
-	if err := json.NewDecoder(body).Decode(&insConfigReq); err != nil {
-		return nil, err
-	}
-	return &insConfigReq, nil
-}
-
-func Test_getToken(t *testing.T) {
-	ctx := context.Background()
+func TestPromClientDisabled(t *testing.T) {
 	l := func() *logger.Logger {
 		l, err := logger.RootLogger("", logger.TeeToStdout)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 		return l
 	}()
-	c := NewPromClient()
-	t.Run("insecure url", func(t *testing.T) {
-		c.setUrl("http://test.com")
-		token, err := c.getToken(ctx, false, l)
-		require.Nil(t, err)
-		require.Empty(t, token)
-	})
-	t.Run("invalid credentials", func(t *testing.T) {
-		err := os.Setenv(roachprodutil.ServiceAccountJson, "{}")
-		require.Nil(t, err)
-		err = os.Setenv(roachprodutil.ServiceAccountAudience, "dummy_audience")
-		require.Nil(t, err)
-		c.newTokenSource = func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
-			return nil, fmt.Errorf("invalid")
-		}
-		c.setUrl("https://test.com")
-		token, err := c.getToken(ctx, false, l)
-		require.NotNil(t, err)
-		require.Empty(t, token)
-		require.Equal(t, "error creating GCS oauth token source from specified credential: invalid", err.Error())
-	})
-	t.Run("invalid token", func(t *testing.T) {
-		err := os.Setenv(roachprodutil.ServiceAccountJson, "{}")
-		require.Nil(t, err)
-		err = os.Setenv(roachprodutil.ServiceAccountAudience, "dummy_audience")
-		require.Nil(t, err)
-		c.newTokenSource = func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
-			return &mockToken{token: "", err: fmt.Errorf("failed")}, nil
-		}
-		c.setUrl("https://test.com")
-		token, err := c.getToken(ctx, false, l)
-		require.NotNil(t, err)
-		require.Empty(t, token)
-		require.Equal(t, "error getting identity token: failed", err.Error())
-	})
-	t.Run("success", func(t *testing.T) {
-		err := os.Setenv(roachprodutil.ServiceAccountJson, "{}")
-		require.Nil(t, err)
-		err = os.Setenv(roachprodutil.ServiceAccountAudience, "dummy_audience")
-		require.Nil(t, err)
-		c.newTokenSource = func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
-			return &mockToken{token: "token"}, nil
-		}
-		c.setUrl("https://test.com")
-		token, err := c.getToken(ctx, false, l)
-		require.Nil(t, err)
-		require.Equal(t, "Bearer token", token)
-	})
-}
 
-type mockToken struct {
-	token string
-	err   error
-}
-
-func (tk *mockToken) Token() (*oauth2.Token, error) {
-	if tk.err != nil {
-		return nil, tk.err
+	c := &PromClient{
+		disabled: true,
 	}
-	return &oauth2.Token{AccessToken: tk.token}, nil
+
+	ctx := context.Background()
+	err := c.UpdatePrometheusTargets(ctx, "test-cluster", NodeTargets{}, l)
+	require.NoError(t, err)
+
+	err = c.DeleteClusterConfig(ctx, "test-cluster", l)
+	require.NoError(t, err)
 }
 
-func TestIsNotFoundError(t *testing.T) {
-	t.Run("IsNotFoundError true", func(t *testing.T) {
-		err := fmt.Errorf(ErrorMessage, 404, "http://prom_url.com/v1/instance-configs/c1", "failed")
-		require.True(t, IsNotFoundError(err))
+func TestUpdatePrometheusTargets(t *testing.T) {
+
+	mockToken := &oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+	}
+	mockSource := &mockIAPTokenSource{
+		token:      mockToken,
+		httpClient: &http.Client{},
+	}
+
+	ctx := context.Background()
+	promURL := "http://test.com"
+
+	t.Run("buildCreateRequestBody", func(t *testing.T) {
+		nodes := NodeTargets{
+			1: {
+				{
+					Target: "127.0.0.1:8080",
+					CustomLabels: map[string]string{
+						"label1": "value1",
+					},
+				},
+			},
+			2: {
+				{
+					Target: "127.0.0.1:8081",
+				},
+			},
+		}
+
+		client, err := NewPromClient(WithCustomURL(promURL), WithIAPTokenSource(mockSource))
+		require.NoError(t, err)
+		body, err := client.buildCreateRequestBody(nodes)
+		require.NoError(t, err)
+
+		buf := new([]byte)
+		_, err = body.Read(*buf)
+		require.NoError(t, err)
+
+		// Unmarshal the json
+		var instanceConfig instanceConfigRequest
+		err = json.NewDecoder(body).Decode(&instanceConfig)
+		require.NoError(t, err)
+
+		// Unmarshal the yaml
+		var ccParams []*CCParams
+		err = yaml.UnmarshalStrict([]byte(instanceConfig.Config), &ccParams)
+		require.NoError(t, err)
+
+		require.Len(t, ccParams, 2)
+
+		for _, params := range ccParams {
+			if params.Targets[0] == "127.0.0.1:8080" {
+				require.Equal(t, map[string]string{"label1": "value1"}, params.Labels)
+			} else if params.Targets[0] == "127.0.0.1:8081" {
+				require.Empty(t, params.Labels)
+			} else {
+				t.Fatalf("unexpected target: %s", params.Targets[0])
+			}
+		}
 	})
-	t.Run("IsNotFoundError false", func(t *testing.T) {
-		err := fmt.Errorf(ErrorMessage, 500, "http://prom_url.com/v1/instance-configs/c1", "failed")
-		require.False(t, IsNotFoundError(err))
+
+	t.Run("buildCreateRequest", func(t *testing.T) {
+		nodes := NodeTargets{
+			1: {
+				{
+					Target: "127.0.0.1:8080",
+					CustomLabels: map[string]string{
+						"label1": "value1",
+					},
+				},
+			},
+		}
+
+		client, err := NewPromClient(WithCustomURL(promURL), WithIAPTokenSource(mockSource))
+		require.NoError(t, err)
+		req, err := client.buildCreateRequest(ctx, "test-cluster", nodes)
+		require.NoError(t, err)
+
+		require.Equal(t, promURL+"/v1/instance-configs/test-cluster", req.URL.String())
+		require.Equal(t, "PUT", req.Method)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
 	})
+}
+
+type mockIAPTokenSource struct {
+	token      *oauth2.Token
+	httpClient *http.Client
+}
+
+func (m *mockIAPTokenSource) Token() (*oauth2.Token, error) {
+	return m.token, nil
+}
+
+func (m *mockIAPTokenSource) GetHTTPClient() *http.Client {
+	return m.httpClient
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -813,7 +813,6 @@ func updatePrometheusTargets(
 		return err
 	}
 
-	cl := promhelperclient.NewPromClient()
 	nodeIPPorts := promhelperclient.NodeTargets{}
 	nodeIPPortsMutex := syncutil.RWMutex{}
 	var wg sync.WaitGroup
@@ -886,8 +885,11 @@ func updatePrometheusTargets(
 	}
 	wg.Wait()
 	if len(nodeIPPorts) > 0 {
-		if err := cl.UpdatePrometheusTargets(ctx,
-			c.Name, false, nodeIPPorts, false, l); err != nil {
+		cl, err := promhelperclient.NewPromClient()
+		if err != nil {
+			return err
+		}
+		if err := cl.UpdatePrometheusTargets(ctx, c.Name, nodeIPPorts, l); err != nil {
 			l.Errorf("creating cluster config failed for the ip:ports %v: %v", nodeIPPorts, err)
 		}
 	}

--- a/pkg/roachprod/roachprodutil/BUILD.bazel
+++ b/pkg/roachprod/roachprodutil/BUILD.bazel
@@ -11,10 +11,12 @@ go_library(
     deps = [
         "//pkg/roachprod/logger",
         "//pkg/util/debugutil",
+        "//pkg/util/httputil",
+        "@com_github_binxio_gcloudconfig//:gcloudconfig",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_google_cloud_go_storage//:storage",
-        "@org_golang_google_api//idtoken",
+        "@org_golang_google_api//impersonate",
         "@org_golang_google_api//option",
         "@org_golang_x_oauth2//:oauth2",
+        "@org_golang_x_oauth2//google",
     ],
 )

--- a/pkg/roachprod/roachprodutil/identity.go
+++ b/pkg/roachprod/roachprodutil/identity.go
@@ -7,129 +7,173 @@ package roachprodutil
 
 import (
 	"context"
-	"io"
+	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
+	"time"
 
-	"cloud.google.com/go/storage"
+	"github.com/binxio/gcloudconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/oauth2"
-	"google.golang.org/api/idtoken"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 )
 
-var (
-	userHome, _ = os.UserHomeDir()
-	// serviceAccountCredFile is where the service account credentials are
-	// stored that enable Google IDP auth.
-	serviceAccountCredFile = filepath.Join(userHome, ".roachprod", "service-account-secrets")
-)
-
-// FetchedFrom indicates where the credentials have been fetched from.
-// this helps in debugging and testing.
-type FetchedFrom string
-
 const (
-	ServiceAccountJson     = "ROACHPROD_SERVICE_ACCOUNT_JSON"
-	ServiceAccountAudience = "ROACHPROD_SERVICE_ACCOUNT_AUDIENCE"
-
-	Env   FetchedFrom = "Env"   // fetched from environment
-	File  FetchedFrom = "File"  // fetched from the serviceAccountCredFile
-	Store FetchedFrom = "Store" // fetched from the store
-
-	// secretsDelimiter is used as a delimiter between service account audience and JSON when stored in
-	// serviceAccountCredFile or cloud storage
-	secretsDelimiter = "--||--"
-
-	// bucket and objectLocation are for fetching the creds for store.
-	//
-	// N.B. although the bucket is called promhelpers, the service account stored
-	// works for any service that requires Google IDP, i.e. Grafana annotations.
-	bucket         = "promhelpers"
-	objectLocation = "promhelpers-secrets"
+	// CredentialsEnvironmentVariable is the environment variable that takes
+	// precedence over the GCP default credentials mechanism.
+	CredentialsEnvironmentVariable = "GOOGLE_EPHEMERAL_CREDENTIALS"
+	cloudPlatformScope             = "https://www.googleapis.com/auth/cloud-platform"
 )
 
-// SetServiceAccountCredsEnv sets the environment variables ServiceAccountAudience and
-// ServiceAccountJson based on the following conditions:
-// > check if forceFetch is false
-//
-//	> forceFetch is false
-//	  > if env is set return
-//	  > if env is not set read from the serviceAccountCredFile
-//	  > if file is available and the creds can be read, set env return
-//	> read the creds from secrets manager
-//
-// > set the env variable and save the creds to the serviceAccountCredFile
-func SetServiceAccountCredsEnv(ctx context.Context, forceFetch bool) (FetchedFrom, error) {
-	creds := ""
-	fetchedFrom := Env
-	if !forceFetch { // bypass environment and creds file if forceFetch is false
-		// check if environment is set
-		audience := os.Getenv(ServiceAccountAudience)
-		saJson := os.Getenv(ServiceAccountJson)
-		if audience != "" && saJson != "" {
-			return fetchedFrom, nil
-		}
-		// check if the secrets file is available
-		b, err := os.ReadFile(serviceAccountCredFile)
-		if err == nil {
-			creds = string(b)
-			fetchedFrom = File
-		}
-	}
-	if creds == "" {
-		// creds == "" means (env is not set and the file does not have the creds) or forceFetch is true
-		options := []option.ClientOption{option.WithScopes(storage.ScopeReadOnly)}
-		cj := os.Getenv("GOOGLE_EPHEMERAL_CREDENTIALS")
-		if cj != "" {
-			options = append(options, option.WithCredentialsJSON([]byte(cj)))
-		}
-
-		client, err := storage.NewClient(ctx, options...)
-		if err != nil {
-			return "", err
-		}
-		defer func() { _ = client.Close() }()
-		fetchedFrom = Store
-		obj := client.Bucket(bucket).Object(objectLocation)
-		r, err := obj.NewReader(ctx)
-		if err != nil {
-			return "", err
-		}
-		defer func() { _ = r.Close() }()
-		body, err := io.ReadAll(r)
-		creds = string(body)
-		if err != nil {
-			return "", err
-		}
-		_ = os.WriteFile(serviceAccountCredFile, body, 0700)
-	}
-	secretValues := strings.Split(creds, secretsDelimiter)
-	if len(secretValues) == 2 {
-		_ = os.Setenv(ServiceAccountAudience, secretValues[0])
-		_ = os.Setenv(ServiceAccountJson, secretValues[1])
-		return fetchedFrom, nil
-	}
-	return "", errors.Newf("invalid secret values - %s", creds)
+// IAPTokenSource is an interface that defines the methods
+// for the IAPTokenSource.
+type IAPTokenSource interface {
+	Token() (*oauth2.Token, error)
+	GetHTTPClient() *http.Client
 }
 
-// GetServiceAccountToken returns a GCS oauth token based on the service account key and audience
-// set through the ServiceAccountJson and ServiceAccountAudience env vars.
-// Assumes that the env vars have been set already, i.e. through SetServiceAccountCredsEnv.
-func GetServiceAccountToken(
-	ctx context.Context,
-	tokenSource func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error),
-) (string, error) {
-	key := os.Getenv(ServiceAccountJson)
-	audience := os.Getenv(ServiceAccountAudience)
-	ts, err := tokenSource(ctx, audience, idtoken.WithCredentialsJSON([]byte(key)))
-	if err != nil {
-		return "", errors.Wrap(err, "error creating GCS oauth token source from specified credential")
+// IAPTokenSourceImpl is a struct that holds the token source and HTTP client
+// authenticated with the Identity-Aware Proxy.
+// This struct satisfies the oauth2.TokenSource interface.
+type IAPTokenSourceImpl struct {
+	tokenSource oauth2.TokenSource
+	httpClient  *http.Client
+}
+
+// IAPTokenSourceOptions is a struct that holds the options for the IAPTokenSource.
+type IAPTokenSourceOptions struct {
+	// OAuthClientID is the OAuth client ID for the Identity-Aware Proxy.
+	OAuthClientID string
+	// ServiceAccountEmail is the service account email to impersonate.
+	ServiceAccountEmail string
+	// Force gcloud credentials to be used.
+	ForceGcloud bool
+}
+
+type IAPAuthMethod int
+
+const (
+	// Env is used when a GOOGLE_EPHEMERAL_CREDENTIALS env var is detected.
+	Env IAPAuthMethod = iota
+	// ADC means authentication went through Application Default Credentials.
+	ADC
+	// GCloud means authentication went through gcloud auth print-identity-token.
+	GCloud
+)
+
+// NewIAPTokenSource returns a new IAPTokenSource struct with the given options.
+func NewIAPTokenSource(opts IAPTokenSourceOptions) (*IAPTokenSourceImpl, error) {
+
+	if opts.OAuthClientID == "" {
+		return nil, errors.New("OAuthClientID is required")
 	}
-	token, err := ts.Token()
-	if err != nil {
-		return "", errors.Wrap(err, "error getting identity token")
+
+	if opts.ServiceAccountEmail == "" {
+		return nil, errors.New("ServiceAccountEmail is required")
 	}
-	return token.AccessToken, nil
+
+	var method IAPAuthMethod
+
+	ctx := context.Background()
+	var err error
+	var creds *google.Credentials
+	if cj := os.Getenv(CredentialsEnvironmentVariable); cj != "" {
+		// In case a GOOGLE_EPHEMERAL_CREDENTIALS environment variable exist,
+		// it takes precedence over other sources, and we use it as our identity.
+		creds, err = google.CredentialsFromJSON(ctx, []byte(cj), cloudPlatformScope)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get credentials from environment variable")
+		}
+
+		method = Env
+	} else {
+		// Unless ForceGcloud is set, we try to use ADC first.
+		// ForceGcloud might be set if we were able to detect ADC, but there was
+		// an error obtaining the credentials during the impersonation.
+		if !opts.ForceGcloud {
+			// Try and access Google's Application Default Credentials (ADC).
+			// This is the default way to get credentials in a GCP environment,
+			// and it checks the following sources, in order:
+			// - Environment variable GOOGLE_APPLICATION_CREDENTIALS
+			// - Default service account file (APP_DATA/application_default_credentials.json)
+			// - App Engine standard environment
+			// - GCE metadata server
+			creds, err = google.FindDefaultCredentials(ctx, cloudPlatformScope)
+
+			method = ADC
+		}
+
+		// Either error while looking for ADC or ForceGcloud is set (meaning ADC
+		// was not attempted).
+		if err != nil || opts.ForceGcloud {
+			// We default to using `gcloud auth print-identity-token`.
+			// This is useful if `gcloud auth application-default login` was not run
+			// or if the user has a different set of credentials for application default.
+			creds, err = gcloudconfig.GetCredentials("")
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get default credentials")
+			}
+
+			method = GCloud
+		}
+	}
+
+	// Create a new ID token source with the impersonate config.
+	// This allows us to impersonate the service account and get an OAuth token.
+	// The IncludeEmail field is required for Identity-Aware Proxy.
+	ts, err := impersonate.IDTokenSource(ctx, impersonate.IDTokenConfig{
+		Audience:        opts.OAuthClientID,
+		TargetPrincipal: opts.ServiceAccountEmail,
+		IncludeEmail:    true,
+	}, option.WithCredentials(creds))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create impersonated token source")
+	}
+
+	// Test the token source by trying to get a token. If this fails and we used ADC,
+	// try falling back to gcloud credentials. This handles cases where ADC is detected
+	// but lacks impersonation permissions, while the gcloud account has the necessary permissions.
+	_, err = ts.Token()
+	if err != nil && method == ADC {
+		// Try again with ForceGcloud to use gcloud credentials
+		gcloudOpts := opts
+		gcloudOpts.ForceGcloud = true
+		return NewIAPTokenSource(gcloudOpts)
+	} else if err != nil {
+		// ForceGcloud was set or other error, return the error
+		return nil, errors.Wrapf(err, "failed to get token")
+	}
+
+	// oauth2.ReuseTokenSourceWithExpiry caches the token and reuses it,
+	// or refreshes it if it's expired. The token will be refreshed 30 seconds
+	// before it expires to avoid any race condition in the token refresh.
+	iapTokenSource := &IAPTokenSourceImpl{
+		tokenSource: oauth2.ReuseTokenSourceWithExpiry(nil, ts, time.Second*30),
+	}
+
+	// Create a new HTTP client with the IAP token source.
+	// It automatically adds the Authorization header with the OAuth token.
+	// This client uses the httputil.StandardHTTPTimeout as the default timeout.
+	iapTokenSource.httpClient = &http.Client{
+		Timeout: httputil.StandardHTTPTimeout,
+		Transport: &oauth2.Transport{
+			Source: iapTokenSource,
+			Base:   http.DefaultTransport,
+		},
+	}
+
+	return iapTokenSource, nil
+}
+
+// Token returns the token from the IAPTokenSource.
+// This methods satisfies the oauth2.TokenSource interface.
+func (ts *IAPTokenSourceImpl) Token() (*oauth2.Token, error) {
+	return ts.tokenSource.Token()
+}
+
+// GetHTTPClient returns the HTTP client authenticated with the IAPTokenSource.
+func (ts *IAPTokenSourceImpl) GetHTTPClient() *http.Client {
+	return ts.httpClient
 }


### PR DESCRIPTION
Backport 1/1 commits from #141454.

/cc @cockroachdb/release

---

Previously, the authentication mechanism for testeng Identity-Aware Proxy protected endpoints was relying on a shared service account key accessed via an encrypted GCS bucket. This was causing the need for secret rotation and was limiting auditability as everyone was using the same JSON key that was cached in the `~/.roachprod` directory.

This patch introduces a new mechanism based on short-lived OAuth tokens and service account impersonation through the default local credentials.

The identity of the caller is determined with the following precedence:
1. `GOOGLE_EPHEMERAL_CREDENTIALS` environment variable
2. Application Default Credentials (ADC):
  a) `GOOGLE_APPLICATION_CREDENTIALS` environment variable
  b) Default service account (application_default_credentials.json) file
  c) App Engine standard environment
  d) GCE metadata server
4. `gcloud config config-helper` output

The caller needs to have the `roles/iam.serviceAccountTokenCreator` role on the service account to be able to impersonate the service account and generate short lived OAuth AccessTokens.

Both `promhelperclient` and `grafana annotations` switch to this new method, via the new `IAPTokenSourceIface` interface that handles the service account impersonation, the AccessToken caching and renewal and that provides a pre-authenticated `http.Client`.


@cockroachdb/dev-inf, the added dependency (`github.com/binxio/gcloudconfig`) is a helper that runs `gcloud config config-helper` to get credentials from the account logged in in gcloud without the need for application default credentials file (when someone ran `gcloud auth login`, but not `gcloud auth application-default login`).

Epic: none
Release note: None

Release justification: Test only change.
