### PR TITLE
changefeedccl: explicitly set per-table PTS cluster setting in tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1819,10 +1819,8 @@ func runCDCMultiTablePTSBenchmark(
 		numRanges = params.numRanges
 	}
 
-	if params.perTablePTS {
-		if _, err := db.Exec("SET CLUSTER SETTING changefeed.protected_timestamp.per_table.enabled = true"); err != nil {
-			t.Fatalf("failed to set per-table protected timestamps: %v", err)
-		}
+	if _, err := db.Exec("SET CLUSTER SETTING changefeed.protected_timestamp.per_table.enabled = $1", params.perTablePTS); err != nil {
+		t.Fatalf("failed to set per-table protected timestamps: %v", err)
 	}
 
 	initCmd := fmt.Sprintf("./cockroach workload init bank --rows=%d --ranges=%d --tables=%d {pgurl%s}",


### PR DESCRIPTION
Previously, the per-table protected timestamp cluster setting was only explicitly set to true in tests, which matched the default value. As a result, when tests attempted to disable the setting, it remained enabled, leading to unexpected behavior and assertion failures.

This change ensures the cluster setting is always explicitly set to the value provided by the test, avoiding reliance on defaults and making test behavior consistent and predictable.

Fixes: #153088
Epic: CRDB-1421
Release note: None