### PR TITLE
roachprod: fix NewPromClient creating IAP token source when disabled

### DIFF
--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -113,8 +113,8 @@ func NewPromClient(options ...Option) (*PromClient, error) {
 		option.apply(c)
 	}
 
-	// If the client is not set, create a new client
-	if c.httpClient == nil {
+	// If the client is not set and not disabled, create a new client
+	if c.httpClient == nil && !c.disabled {
 		iapTokenSource, err := roachprodutil.NewIAPTokenSource(roachprodutil.IAPTokenSourceOptions{
 			OAuthClientID:       OAuthClientID,
 			ServiceAccountEmail: ServiceAccountEmail,


### PR DESCRIPTION
## Summary

Fixes a bug introduced in the IAP authentication refactor (ba62711b69a) where `NewPromClient()` would always attempt to create an IAP token source, even when Prometheus integration was disabled.

## Problem

After the recent IAP authentication refactor, users running `roachprod start` outside of Google Cloud environments would encounter this error:

```
failed to create IAP token source: failed to get default credentials: glcoud not on path
```

This happens even when `ROACHPROD_PROM_HOST_URL=""` is set to disable Prometheus integration.

## Root Cause

The condition in `NewPromClient()` only checked `if c.httpClient == nil` but didn't verify whether the client was disabled. When `ROACHPROD_PROM_HOST_URL=""` is set, `promRegistrationUrl` becomes `""` which correctly sets `disabled: true`, but the IAP token source creation was still being attempted.

## Solution

Modified the condition to also check `!c.disabled`, ensuring that when Prometheus integration is disabled, no IAP authentication is attempted.

🤖 Generated with [Claude Code](https://claude.ai/code)