### PR TITLE
changefeedccl: have aggregators send their frontiers regularly

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -203,6 +203,7 @@ go_test(
         "alter_changefeed_test.go",
         "changefeed_dist_test.go",
         "changefeed_job_info_test.go",
+        "changefeed_processors_test.go",
         "changefeed_progress_test.go",
         "changefeed_stmt_test.go",
         "changefeed_test.go",

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1524,13 +1524,7 @@ func TestAlterChangefeedAddTargetsDuringBackfill(t *testing.T) {
 			defer rndMu.Unlock()
 
 			if r.Span.Equal(fooTableSpan) {
-				// Do not emit resolved events for the entire table span.
-				// We "simulate" large table by splitting single table span into many parts, so
-				// we want to resolve those sub-spans instead of the entire table span.
-				// However, we have to emit something -- otherwise the entire changefeed
-				// machine would not work.
-				r.Span.EndKey = fooTableSpan.Key.Next()
-				return false, nil
+				return true, nil
 			}
 			if haveGaps {
 				return rndMu.rnd.Intn(10) > 7, nil

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -1,0 +1,154 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveRateLimiter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	intervals := map[string]time.Duration{
+		"positive interval":   30 * time.Second,
+		"negative interval":   -30 * time.Second,
+		"zero interval":       0,
+		"very small interval": time.Nanosecond,
+	}
+
+	jitters := map[string]float64{
+		"positive jitter":   0.1,
+		"negative jitter":   -0.1,
+		"zero jitter":       0,
+		"very small jitter": 1e-12,
+	}
+
+	for intervalName, interval := range intervals {
+		for jitterName, jitter := range jitters {
+			t.Run(fmt.Sprintf("%s with %s", intervalName, jitterName), func(t *testing.T) {
+				// Set up the mock clock for testing.
+				now := timeutil.Now()
+				clock := timeutil.NewManualTime(now)
+
+				// Create the save rate limiter.
+				l, err := newSaveRateLimiter(saveRateConfig{
+					name: "test",
+					intervalName: func() redact.SafeValue {
+						return redact.SafeString(intervalName)
+					},
+					interval: func() time.Duration {
+						return interval
+					},
+					jitter: func() float64 {
+						return jitter
+					},
+				}, clock)
+				require.NoError(t, err)
+
+				// A non-positive interval indicates that saving is disabled so we only
+				// need to test that we can't save at all.
+				if interval <= 0 {
+					require.False(t, l.canSave(ctx))
+					clock.Advance(24 * time.Hour)
+					require.False(t, l.canSave(ctx))
+					return
+				}
+
+				// We can do one save right away if the interval.
+				require.True(t, l.canSave(ctx))
+				l.doneSave(0 /* saveDuration */)
+
+				// Can't immediately save again.
+				require.False(t, l.canSave(ctx))
+
+				// Make sure interval and jitter works correctly.
+				var maxJitter time.Duration
+				if jitter > 0 {
+					maxJitter = time.Duration(jitter * float64(interval))
+				}
+				clock.Advance(interval + maxJitter)
+				require.True(t, l.canSave(ctx))
+
+				// Set the save duration to something high to make sure we can't save
+				// due to high average save duration.
+				l.doneSave(time.Hour)
+				clock.Advance(interval + maxJitter)
+				require.False(t, l.canSave(ctx))
+				clock.Advance(time.Hour - (interval + maxJitter))
+				require.True(t, l.canSave(ctx))
+
+				// Set the save duration to something even higher to make sure the
+				// average algorithm works.
+				l.doneSave(2 * time.Hour)
+				clock.Advance(time.Hour)
+				require.False(t, l.canSave(ctx))
+				clock.Advance(time.Hour)
+				require.True(t, l.canSave(ctx))
+				l.doneSave(0 /* saveDuration */)
+			})
+		}
+	}
+}
+
+func TestSaveRateLimiterError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	name := redact.SafeString("test")
+	intervalName := func() redact.SafeValue {
+		return redact.SafeString("interval")
+	}
+	interval := func() time.Duration {
+		return 30 * time.Second
+	}
+
+	for testName, tc := range map[string]struct {
+		config      saveRateConfig
+		expectedErr string
+	}{
+		"missing name": {
+			config: saveRateConfig{
+				intervalName: intervalName,
+				interval:     interval,
+			},
+			expectedErr: "name is required",
+		},
+		"missing interval name": {
+			config: saveRateConfig{
+				name:     name,
+				interval: interval,
+			},
+			expectedErr: "interval name is required",
+		},
+		"missing interval": {
+			config: saveRateConfig{
+				name:         name,
+				intervalName: intervalName,
+			},
+			expectedErr: "interval is required",
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			if tc.expectedErr == "" {
+				t.Fatal("missing expected error")
+			}
+			_, err := newSaveRateLimiter(tc.config, timeutil.DefaultTimeSource{})
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9299,7 +9299,7 @@ func TestCoreChangefeedBackfillScanCheckpoint(t *testing.T) {
 			return nil
 		}
 
-		foo := feed(t, f, `CREATE CHANGEFEED FOR TABLE foo`)
+		foo := feed(t, f, `CREATE CHANGEFEED FOR TABLE foo WITH min_checkpoint_frequency='1ns'`)
 		defer closeFeed(t, foo)
 
 		payloads := make([]string, rowCount+1)
@@ -9362,139 +9362,6 @@ func TestCheckpointFrequency(t *testing.T) {
 	js.checkpointCompleted(ctx, 42*time.Second)
 	require.Equal(t, completionTime, js.lastProgressUpdate)
 	require.False(t, js.progressUpdatesSkipped)
-}
-
-func TestFlushJitter(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	// Test the logic around applying jitter to the flush logic.
-	// The more involved test that would try to capture flush times would likely
-	// be pretty flaky due to the fact that flush times do not happen at exactly
-	// min_flush_frequency period, and thus it would be hard to tell if the
-	// difference is due to jitter or not.  Just verify nextFlushWithJitter function
-	// works as expected with controlled time source.
-
-	ts := timeutil.NewManualTime(timeutil.Now())
-	const numIters = 100
-
-	for _, tc := range []struct {
-		flushFrequency        time.Duration
-		jitter                float64
-		expectedFlushDuration time.Duration
-		expectedErr           bool
-	}{
-		// Negative jitter.
-		{
-			flushFrequency:        -1,
-			jitter:                -0.1,
-			expectedFlushDuration: 0,
-			expectedErr:           true,
-		},
-		{
-			flushFrequency:        0,
-			jitter:                -0.1,
-			expectedFlushDuration: 0,
-			expectedErr:           true,
-		},
-		{
-			flushFrequency:        10 * time.Millisecond,
-			jitter:                -0.1,
-			expectedFlushDuration: 0,
-			expectedErr:           true,
-		},
-		{
-			flushFrequency:        100 * time.Millisecond,
-			jitter:                -0.1,
-			expectedFlushDuration: 0,
-			expectedErr:           true,
-		},
-		// Disable Jitter.
-		{
-			flushFrequency:        -1,
-			jitter:                0,
-			expectedFlushDuration: 0,
-			expectedErr:           true,
-		},
-		{
-			flushFrequency:        0,
-			jitter:                0,
-			expectedFlushDuration: 0,
-			expectedErr:           false,
-		},
-		{
-			flushFrequency:        10 * time.Millisecond,
-			jitter:                0,
-			expectedFlushDuration: 10 * time.Millisecond,
-			expectedErr:           false,
-		},
-		{
-			flushFrequency:        100 * time.Millisecond,
-			jitter:                0,
-			expectedFlushDuration: 100 * time.Millisecond,
-			expectedErr:           false,
-		},
-		// Enable Jitter.
-		{
-			flushFrequency:        -1,
-			jitter:                0.1,
-			expectedFlushDuration: 0,
-			expectedErr:           true,
-		},
-		{
-			flushFrequency:        0,
-			jitter:                0.1,
-			expectedFlushDuration: 0,
-			expectedErr:           false,
-		},
-		{
-			flushFrequency:        10 * time.Millisecond,
-			jitter:                0.1,
-			expectedFlushDuration: 10 * time.Millisecond,
-			expectedErr:           false,
-		},
-		{
-			flushFrequency:        100 * time.Millisecond,
-			jitter:                0.1,
-			expectedFlushDuration: 100 * time.Millisecond,
-			expectedErr:           false,
-		},
-		// Expect actual jitter to be 0 since flushFrequency * jitter < 1.
-		{
-			flushFrequency:        1,
-			jitter:                0.1,
-			expectedFlushDuration: 1,
-			expectedErr:           false,
-		},
-		// Expect actual jitter to be 0 since flushFrequency * jitter < 1.
-		{
-			flushFrequency:        10,
-			jitter:                0.01,
-			expectedFlushDuration: 10,
-			expectedErr:           false,
-		},
-	} {
-		t.Run(fmt.Sprintf("flushfrequency=%sjitter=%f", tc.flushFrequency, tc.jitter), func(t *testing.T) {
-			for i := 0; i < numIters; i++ {
-				next, err := nextFlushWithJitter(ts, tc.flushFrequency, tc.jitter)
-				if tc.expectedErr {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-				}
-				if tc.jitter > 0 {
-					minBound := tc.expectedFlushDuration
-					maxBound := tc.expectedFlushDuration + time.Duration(float64(tc.expectedFlushDuration)*tc.jitter)
-					actualDuration := next.Sub(ts.Now())
-					require.LessOrEqual(t, minBound, actualDuration)
-					require.LessOrEqual(t, actualDuration, maxBound)
-				} else {
-					require.Equal(t, tc.expectedFlushDuration, next.Sub(ts.Now()))
-				}
-				ts.AdvanceTo(next)
-			}
-		})
-	}
 }
 
 func TestChangefeedOrderingWithErrors(t *testing.T) {

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -129,7 +129,7 @@ func TestShowChangefeedJobsShowsHighWaterTimestamp(t *testing.T) {
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo(a INT PRIMARY KEY)`)
-		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved='0s',min_checkpoint_frequency='0s'`)
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved, min_checkpoint_frequency='1s'`)
 
 		defer closeFeed(t, foo)
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1039,6 +1039,7 @@ type cdcCheckpointType int
 const (
 	cdcNormalCheckpoint cdcCheckpointType = iota
 	cdcShutdownCheckpoint
+	cdcFrontierPersistence
 )
 
 // runCDCInitialScanRollingRestart runs multiple initial-scan-only changefeeds
@@ -1086,8 +1087,9 @@ func runCDCInitialScanRollingRestart(
 	// Setup a large table with 1M rows and a small table with 5 rows.
 	// Keep ranges off n1 so that our plans use 2, 3, and 4.
 	const (
-		largeRowCount = 1000000
-		smallRowCount = 5
+		largeRowCount   = 1000000
+		largeSplitCount = 500
+		smallRowCount   = 5
 	)
 	t.L().Printf("setting up test data...")
 	setupStmts := []string{
@@ -1096,24 +1098,31 @@ func runCDCInitialScanRollingRestart(
 		`ALTER TABLE large SCATTER`,
 		fmt.Sprintf(`CREATE TABLE small (id PRIMARY KEY) AS SELECT generate_series(%d, %d)`, largeRowCount+1, largeRowCount+smallRowCount),
 		`ALTER TABLE small SCATTER`,
+		// Split some bigger chunks up to scatter it a bit more.
+		fmt.Sprintf(`ALTER TABLE large SPLIT AT SELECT id FROM large ORDER BY random() LIMIT %d`, largeSplitCount/4),
+		`ALTER TABLE large SCATTER`,
+		// Finish splitting, so that drained ranges spread out evenly.
+		fmt.Sprintf(`ALTER TABLE large SPLIT AT SELECT id FROM large ORDER BY random() LIMIT %d`, largeSplitCount),
+		`ALTER TABLE large SCATTER`,
 	}
 	switch checkpointType {
 	case cdcNormalCheckpoint:
 		setupStmts = append(setupStmts,
-			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '1s'`,
+			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '5s'`,
 			`SET CLUSTER SETTING changefeed.shutdown_checkpoint.enabled = 'false'`,
+			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '10m'`,
 		)
 	case cdcShutdownCheckpoint:
-		const largeSplitCount = 5
 		setupStmts = append(setupStmts,
 			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '0'`,
 			`SET CLUSTER SETTING changefeed.shutdown_checkpoint.enabled = 'true'`,
-			// Split some bigger chunks up to scatter it a bit more.
-			fmt.Sprintf(`ALTER TABLE large SPLIT AT SELECT id FROM large ORDER BY random() LIMIT %d`, largeSplitCount/4),
-			`ALTER TABLE large SCATTER`,
-			// Finish splitting, so that drained ranges spread out evenly.
-			fmt.Sprintf(`ALTER TABLE large SPLIT AT SELECT id FROM large ORDER BY random() LIMIT %d`, largeSplitCount),
-			`ALTER TABLE large SCATTER`,
+			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '10m'`,
+		)
+	case cdcFrontierPersistence:
+		setupStmts = append(setupStmts,
+			`SET CLUSTER SETTING changefeed.span_checkpoint.interval = '0'`,
+			`SET CLUSTER SETTING changefeed.shutdown_checkpoint.enabled = 'false'`,
+			`SET CLUSTER SETTING changefeed.progress.frontier_persistence.interval = '5s'`,
 		)
 	}
 	for _, s := range setupStmts {
@@ -1179,7 +1188,9 @@ func runCDCInitialScanRollingRestart(
 			t.L().Printf("starting changefeed %d...", i)
 			var job int
 			if err := db.QueryRow(
-				fmt.Sprintf("CREATE CHANGEFEED FOR TABLE large, small INTO 'webhook-%s/?insecure_tls_skip_verify=true' WITH initial_scan='only'", sinkURL),
+				fmt.Sprintf(`CREATE CHANGEFEED FOR TABLE large, small
+INTO 'webhook-%s/?insecure_tls_skip_verify=true'
+WITH initial_scan='only', min_checkpoint_frequency='1s'`, sinkURL),
 			).Scan(&job); err != nil {
 				t.Fatal(err)
 			}
@@ -1963,6 +1974,17 @@ func registerCDC(r registry.Registry) {
 		Timeout:          30 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCInitialScanRollingRestart(ctx, t, c, cdcShutdownCheckpoint)
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:             "cdc/initial-scan-rolling-restart/frontier-persistence",
+		Owner:            registry.OwnerCDC,
+		Cluster:          r.MakeClusterSpec(4),
+		CompatibleClouds: registry.OnlyGCE,
+		Suites:           registry.Suites(registry.Nightly),
+		Timeout:          30 * time.Minute,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runCDCInitialScanRollingRestart(ctx, t, c, cdcFrontierPersistence)
 		},
 	})
 	r.Add(registry.TestSpec{


### PR DESCRIPTION
This patch updates the aggregators to send their frontiers regularly
every `min_checkpoint_frequency` (limited by average time to flush)
to support periodic span frontier persistence.

Fixes #153749

Release note: None