### PR TITLE
asim: fix lower_bound

### DIFF
--- a/pkg/kv/kvserver/asim/tests/helpers_test.go
+++ b/pkg/kv/kvserver/asim/tests/helpers_test.go
@@ -105,7 +105,7 @@ func scanThreshold(t *testing.T, d *datadriven.TestData) (th assertion.Threshold
 		th.ThresholdType = assertion.UpperBound
 		return th
 	}
-	scanArg(t, d, "lower_bound", &th.Value)
+	scanMustExist(t, d, "lower_bound", &th.Value)
 	th.ThresholdType = assertion.LowerBound
 	return th
 }


### PR DESCRIPTION
It wasn't being removed from the args, so using it necessarily tripped the test.
Epic: CRDB-49117