### PR TITLE
kv: enable DRPC randomly

### DIFF
--- a/pkg/kv/bulk/main_test.go
+++ b/pkg/kv/bulk/main_test.go
@@ -32,6 +32,10 @@ func TestMain(m *testing.M) {
 		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
 	)()
 
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	code := m.Run()
 
 	os.Exit(code)

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -738,6 +738,9 @@ func TestDBDecommissionedOperations(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual, // saves time
+		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
+		},
 	})
 	defer tc.Stopper().Stop(ctx)
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4255,6 +4255,9 @@ func TestProxyTracing(t *testing.T) {
 
 		var p rpc.Partitioner
 		tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
+			},
 			ServerArgsPerNode: func() map[int]base.TestServerArgs {
 				perNode := make(map[int]base.TestServerArgs)
 				for i := 0; i < numServers; i++ {

--- a/pkg/kv/kvclient/kvcoord/main_test.go
+++ b/pkg/kv/kvclient/kvcoord/main_test.go
@@ -29,5 +29,9 @@ func TestMain(m *testing.M) {
 		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
 	)()
 
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }

--- a/pkg/kv/kvclient/kvcoord/partial_partition_test.go
+++ b/pkg/kv/kvclient/kvcoord/partial_partition_test.go
@@ -87,6 +87,9 @@ func testPartialPartition(t *testing.T, useProxy bool, numServers int) {
 
 			var p rpc.Partitioner
 			tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+				ServerArgs: base.TestServerArgs{
+					DefaultDRPCOption: base.TestDRPCDisabled,
+				},
 				ServerArgsPerNode: func() map[int]base.TestServerArgs {
 					perNode := make(map[int]base.TestServerArgs)
 					for i := 0; i < numServers; i++ {

--- a/pkg/kv/kvclient/kvtenant/main_test.go
+++ b/pkg/kv/kvclient/kvtenant/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -26,5 +27,10 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }

--- a/pkg/kv/kvclient/rangefeed/main_test.go
+++ b/pkg/kv/kvclient/rangefeed/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -23,6 +24,11 @@ func init() {
 func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/kv/kvnemesis/main_test.go
+++ b/pkg/kv/kvnemesis/main_test.go
@@ -29,6 +29,10 @@ func TestMain(m *testing.M) {
 		base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 	)()
 
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/kv/kvprober/main_test.go
+++ b/pkg/kv/kvprober/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -22,5 +23,10 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1504,6 +1504,7 @@ func TestReceiveSnapshotLogging(t *testing.T) {
 
 		tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
 						DisableRaftSnapshotQueue: true,
@@ -5036,7 +5037,10 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 		base.TestClusterArgs{
 			ReplicationMode:     base.ReplicationManual,
 			ReusableListenerReg: lisReg,
-			ServerArgsPerNode:   stickyServerArgs,
+			ServerArgs: base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
+			},
+			ServerArgsPerNode: stickyServerArgs,
 		})
 	defer tc.Stopper().Stop(ctx)
 	// Make a key that's in the user data space.
@@ -6277,7 +6281,8 @@ func TestRaftPreVote(t *testing.T) {
 			tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{
-					Settings: st,
+					DefaultDRPCOption: base.TestDRPCDisabled,
+					Settings:          st,
 					RaftConfig: base.RaftConfig{
 						RaftEnableCheckQuorum: true,
 						RaftTickInterval:      200 * time.Millisecond, // speed up test

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -554,7 +554,8 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 		tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
-				Settings: settings,
+				DefaultDRPCOption: base.TestDRPCDisabled,
+				Settings:          settings,
 				RaftConfig: base.RaftConfig{
 					// Reduce the RangeLeaseDuration to speeds up failure detection
 					// below.
@@ -1800,7 +1801,10 @@ func TestFlowControlSendQueue(t *testing.T) {
 	}
 
 	tc := testcluster.StartTestCluster(t, 5, base.TestClusterArgs{
-		ReplicationMode:   base.ReplicationManual,
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
+		},
 		ServerArgsPerNode: stickyArgsPerServer,
 	})
 	defer tc.Stopper().Stop(ctx)
@@ -3329,7 +3333,10 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 	}
 
 	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
-		ReplicationMode:   base.ReplicationManual,
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
+		},
 		ServerArgsPerNode: argsPerServer,
 	})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/main_test.go
+++ b/pkg/kv/kvserver/main_test.go
@@ -34,5 +34,9 @@ func TestMain(m *testing.M) {
 		base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 	)()
 
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -926,7 +926,10 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 
 	tc := testcluster.StartTestCluster(
 		t, 2, base.TestClusterArgs{
-			ServerArgs:      base.TestServerArgs{Knobs: knobs},
+			ServerArgs: base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
+				Knobs:             knobs,
+			},
 			ReplicationMode: base.ReplicationManual,
 		},
 	)
@@ -1050,6 +1053,9 @@ func TestSnapshotsToDrainingNodes(t *testing.T) {
 		tc := testcluster.StartTestCluster(
 			t, 2, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
+				ServerArgs: base.TestServerArgs{
+					DefaultDRPCOption: base.TestDRPCDisabled,
+				},
 			},
 		)
 		defer tc.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1090,6 +1090,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{
+					DefaultDRPCOption: base.TestDRPCDisabled,
 					Knobs: base.TestingKnobs{
 						Store: &kvserver.StoreTestingKnobs{
 							BaseQueueDisabledBypassFilter: func(rangeID roachpb.RangeID) bool {
@@ -1821,6 +1822,7 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationAuto,
 			ServerArgs: base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						DefaultZoneConfigOverride: &zcfg,

--- a/pkg/kv/main_test.go
+++ b/pkg/kv/main_test.go
@@ -29,6 +29,10 @@ func TestMain(m *testing.M) {
 		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
 	)()
 
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This change introduces a package-level setting that randomly enables DRPC.

Epic: CRDB-48935
Informs: #153923
Release note: None