### PR TITLE
admission: introduce a granter for CPU time tokens

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "admission",
     srcs = [
         "admission.go",
+        "cpu_time_token_granter.go",
         "disk_bandwidth.go",
         "elastic_cpu_grant_coordinator.go",
         "elastic_cpu_granter.go",
@@ -50,12 +51,14 @@ go_library(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_tokenbucket//:tokenbucket",
+        "@com_github_olekukonko_tablewriter//:tablewriter",
     ],
 )
 
 go_test(
     name = "admission_test",
     srcs = [
+        "cpu_time_token_granter_test.go",
         "disk_bandwidth_test.go",
         "elastic_cpu_granter_test.go",
         "elastic_cpu_work_handle_test.go",

--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -121,6 +121,7 @@
 package admission
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
@@ -142,6 +143,17 @@ const (
 	noBurst
 	numBurstQualifications
 )
+
+func (bq burstQualification) String() string {
+	switch bq {
+	case canBurst:
+		return "canBurst"
+	case noBurst:
+		return "noBurst"
+	default:
+		return fmt.Sprintf("burstQualification(%d)", bq)
+	}
+}
 
 // requester is an interface implemented by an object that orders admission
 // work for a particular WorkKind. See WorkQueue for the implementation of

--- a/pkg/util/admission/cpu_time_token_granter.go
+++ b/pkg/util/admission/cpu_time_token_granter.go
@@ -1,0 +1,246 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/olekukonko/tablewriter"
+)
+
+// resourceTier specifies the tier of a resource group, in descending levels of importance.
+// That is, tier 0 is the most important. The token bucket sizes must be such that the
+// non-burstable token bucket size of tier-i must be greater than the burstable token bucket
+// size of tier-(i+1); see cpuTimeTokenGranter for details on this.
+//
+// The tier determination for a request happens at a layer outside the admission package.
+//
+// TODO(josh): Add docs re: tentative usage after a discussion with Sumeer.
+//
+// NB: Inter-tenant fair sharing only works within a tier.
+//
+// TODO(josh): Move ths definition to admission.go. Export publicly.
+type resourceTier uint8
+
+const numResourceTiers resourceTier = 2
+
+// cpuTimeTokenChildGranter implements granter. It stores resourceTier and proxies
+// proxies to cpuTimeTokenGranter. See the declaration comment for cpuTimeTokenGranter
+// for more details.
+//
+// Each "child" granter is paired with a requester, since the requester (in practice, a
+// WorkQueue for a certain resourceTier) does not need to know about the others.
+// An alternative would be to make resourceTier an argument to the various granter methods,
+// but this approach seems cleaner.
+type cpuTimeTokenChildGranter struct {
+	tier   resourceTier
+	parent *cpuTimeTokenGranter
+}
+
+var _ granter = &cpuTimeTokenChildGranter{}
+
+// tryGet implements granter.
+func (cg *cpuTimeTokenChildGranter) tryGet(qual burstQualification, count int64) bool {
+	return cg.parent.tryGet(cg.tier, qual, count)
+}
+
+// returnGrant implements granter.
+func (cg *cpuTimeTokenChildGranter) returnGrant(count int64) {
+	cg.parent.returnGrant(count)
+}
+
+// tookWithoutPermission implements granter.
+func (cg *cpuTimeTokenChildGranter) tookWithoutPermission(count int64) {
+	cg.parent.tookWithoutPermission(count)
+}
+
+// continueGrantChain implements granter.
+func (cg *cpuTimeTokenChildGranter) continueGrantChain(grantChainID grantChainID) {
+	// Ignore since grant chains are not used.
+}
+
+// cpuTimeTokenGranter uses token buckets to limit CPU usage. There is one
+// token bucket per type of request. Requests are only admitted (tryGet
+// only returns true), if the bucket for the type of request to be done has
+// positive tokens. Before a request is admitted, tokens are deducated from all
+// buckets, not just the bucket that was checked initially. This enables
+// setting up a hierarchy of types of requests, where some types can use more
+// CPU than others.
+//
+// For example, on an 8 vCPU machine, it might be set up like this:
+//
+// - Burstable tier-0 work -> 6 seconds of CPU time per second
+// - Non-burstable tier-0 work -> 5 seconds of CPU time per second
+// - Burstable tier-1 work -> 2 seconds of CPU time per second
+// - Non-burstable tier-1 work -> 1 seconds of CPU time per second
+//
+// A request for 5s of burstable tier-0 work would be admitted immediately,
+// since the burstable tier-0 bucket is positive. It would deduct from all
+// four buckets, resulting in a balance of (1,0,-3,-4). Non-burstable tier-0
+// work and all tier-1 work would now have to wait for their respective buckets
+// to refill, while burstable tier-0 work is still admissible.
+//
+// The immediate purpose of this is to achieve low goroutine scheduling latencies
+// even in the case of a Serverless tenant sending a large workload to a multi-host
+// cluster. The above rates will be set so as to limit CPU utilization to some
+// cluster-setting-configurable maximum. For example, if the target max is 80%, and
+// if the machine has 8 vCPUs, then the non-burstable tier-0 work will be allowed
+// 6.4 seconds of CPU time per second. In limiting CPU usage to some max, goroutine
+// scheduling latency can be kept low.
+//
+// TODO(josh): Add docs about resourceTier after a discussion with Sumeer.
+//
+// Note that cpuTimeTokenGranter does not handle replenishing the buckets.
+//
+// For more, see the initial design sketch:
+// https://docs.google.com/document/d/1-Kr2gRFTk0QV8kBs7AXRXUwFpK2ZxR1cqIwWCuOx22Q/edit?tab=t.0
+// TODO(josh): Turn into a proper design documnet.
+type cpuTimeTokenGranter struct {
+	requester [numResourceTiers]requester
+	mu        struct {
+		// TODO(josh): I suspect putting the mutex here is better than in
+		// CPUTimeTokenGrantCoordinator, but for now the decision is tentative.
+		// Think better to decice when I put up a PR that introduces
+		// CPUTimeTokenGrantCoordinator & cpuTimeTokenAdjusterNew.
+		syncutil.Mutex
+		// Invariant #1: For any two buckets A & B, if A has a lower ordinal resourceTier,
+		// then A must have more tokens than B.
+		// Invariant #2: For any two buckets A & B, if A & B have the same resourceTier,
+		// and if A has a lower ordinal burstQualification, then A must have more tokens than B.
+		//
+		// Since admission deducts from all buckets, these invariants are true, so long as token bucket
+		// replenishing respects it also. Token bucket replenishing is not yet implemented. See
+		// tryGrantLocked for a situation where invariant #1 is relied on.
+		buckets [numResourceTiers][numBurstQualifications]tokenBucket
+	}
+}
+
+// TODO(josh): Make this observable. See here for one approach:
+// https://github.com/cockroachdb/cockroach/commit/06967f5fa72115348d57fc66fe895aec514261d5#diff-6212d039fab53dd464bd989bdbd537947b11d37a9c8fe77ca497870b49e28a9cR367
+type tokenBucket struct {
+	tokens int64
+}
+
+func (stg *cpuTimeTokenGranter) String() string {
+	stg.mu.Lock()
+	defer stg.mu.Unlock()
+	var buf strings.Builder
+	tw := tablewriter.NewWriter(&buf)
+	hdrs := [numBurstQualifications + 1]string{}
+	hdrs[0] = "cpuTTG"
+	for gk := canBurst; gk < numBurstQualifications; gk++ {
+		hdrs[1+gk] = gk.String()
+	}
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetAutoFormatHeaders(false)
+	tw.SetBorder(false)
+	tw.SetColumnSeparator("")
+	tw.SetHeader(hdrs[:])
+	tw.SetHeaderLine(false)
+	tw.SetNoWhiteSpace(true)
+	tw.SetTablePadding(" ")
+	tw.SetTrimWhiteSpaceAtEOL(true)
+
+	for tier := 0; tier < int(numResourceTiers); tier++ {
+		row := [1 + numBurstQualifications]string{}
+		row[0] = "tier" + strconv.Itoa(tier)
+		for gk := canBurst; gk < numBurstQualifications; gk++ {
+			row[gk+1] = fmt.Sprint(stg.mu.buckets[tier][gk].tokens)
+		}
+		tw.Append(row[:])
+	}
+	tw.Render()
+	return buf.String()
+}
+
+// tryGet is the helper for implementing granter.tryGet.
+func (stg *cpuTimeTokenGranter) tryGet(
+	tier resourceTier, qual burstQualification, count int64,
+) bool {
+	stg.mu.Lock()
+	defer stg.mu.Unlock()
+	if stg.mu.buckets[tier][qual].tokens <= 0 {
+		return false
+	}
+	stg.tookWithoutPermissionLocked(count)
+	return true
+}
+
+// returnGrant is the helper for implementing granter.returnGrant.
+func (stg *cpuTimeTokenGranter) returnGrant(count int64) {
+	stg.mu.Lock()
+	defer stg.mu.Unlock()
+	stg.tookWithoutPermissionLocked(-count)
+	// count must be positive. Thus above always adds tokens to the buckets.
+	// Thus returnGrant should always attempt to grant admission to waiting requests.
+	stg.grantUntilNoWaitingRequestsLocked()
+}
+
+// tookWithoutPermission is the helper for implementing granter.tookWithoutPermission.
+func (stg *cpuTimeTokenGranter) tookWithoutPermission(count int64) {
+	stg.mu.Lock()
+	defer stg.mu.Unlock()
+	stg.tookWithoutPermissionLocked(count)
+}
+
+func (stg *cpuTimeTokenGranter) tookWithoutPermissionLocked(count int64) {
+	for tier := range stg.mu.buckets {
+		for qual := range stg.mu.buckets[tier] {
+			stg.mu.buckets[tier][qual].tokens -= count
+		}
+	}
+}
+
+// grantUntilNoWaitingRequestsLocked grants admission to all queued requests
+// that can be granted, given the current state of the token buckets, etc.
+// It prioritizes requesters from higher class work in the sense of resourceTier
+// That is, multiple waiting tier-0 requests will be granted before a single tier-1
+// request.
+func (stg *cpuTimeTokenGranter) grantUntilNoWaitingRequestsLocked() {
+	// TODO(josh): If there are a lot of tokens, this could hold the mutex for a long
+	// time. We may want to drop and reacquire the mutex after every 1000 requests or so.
+	for stg.tryGrantLocked() {
+	}
+}
+
+// tryGrantLocked attempts to grant admission to a single queued request.
+// It prioritizes requesters from higher class work, in the sense of
+// resourceTier.
+func (stg *cpuTimeTokenGranter) tryGrantLocked() bool {
+	for tier := range stg.requester {
+		hasWaitingRequests, qual := stg.requester[tier].hasWaitingRequests()
+		if !hasWaitingRequests {
+			continue
+		}
+		if stg.mu.buckets[tier][qual].tokens <= 0 {
+			// tryGrantLocked does not need to continue here, since there are
+			// no more requests to grant. The detailed reason for this is:
+			//
+			// - stg.requester is ordered by resourceTier.
+			// - Given two buckets A & B, if A is for a lower ordinal resourceTier,
+			//   more tokens will be in bucket A than bucket B (see cpuTimeTokenGranter
+			//   for more on this invariant).
+			// - Thus, if no tokens in A, there are no tokens in B.
+			//
+			// Note that it is up to the requester which is the next request
+			// to admit. So tryGrantLocked only needs to check the bucket that
+			// corresponds to the burstQualification of that request, as is done
+			// below.
+			return false
+		}
+		tokens := stg.requester[tier].granted(noGrantChain)
+		if tokens == 0 {
+			// Did not accept grant.
+			continue
+		}
+		stg.tookWithoutPermissionLocked(tokens)
+		return true
+	}
+	return false
+}

--- a/pkg/util/admission/cpu_time_token_granter_test.go
+++ b/pkg/util/admission/cpu_time_token_granter_test.go
@@ -1,0 +1,174 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+)
+
+const (
+	testTier0 resourceTier = iota
+	testTier1
+)
+
+func TestCPUTimeTokenGranter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var requesters [numResourceTiers]*testRequester
+	granter := &cpuTimeTokenGranter{}
+	tier0Granter := &cpuTimeTokenChildGranter{
+		tier:   testTier0,
+		parent: granter,
+	}
+	tier1Granter := &cpuTimeTokenChildGranter{
+		tier:   testTier1,
+		parent: granter,
+	}
+	var buf strings.Builder
+	var lastGranterStateStr string
+	flushAndReset := func(init bool) string {
+		granterStateStr := granter.String()
+		if granterStateStr != lastGranterStateStr {
+			fmt.Fprint(&buf, granterStateStr)
+		}
+		lastGranterStateStr = granterStateStr
+		if init {
+			fmt.Fprint(&buf, "tier0requester: "+requesters[0].String()+"\n")
+			fmt.Fprint(&buf, "tier1requester: "+requesters[1].String()+"\n")
+		}
+		str := buf.String()
+		buf.Reset()
+		return str
+	}
+	requesters[testTier0] = &testRequester{
+		additionalID: "tier0",
+		granter:      tier0Granter,
+		buf:          &buf,
+	}
+	requesters[testTier1] = &testRequester{
+		additionalID: "tier1",
+		granter:      tier1Granter,
+		buf:          &buf,
+	}
+	granter.requester[testTier0] = requesters[testTier0]
+	granter.requester[testTier1] = requesters[testTier1]
+
+	requesters[testTier0].returnValueFromHasWaitingRequests = noBurst
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "cpu_time_token_granter"), func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "init":
+			granter.mu.buckets[testTier0][canBurst].tokens = 0
+			granter.mu.buckets[testTier0][noBurst].tokens = 0
+			granter.mu.buckets[testTier1][canBurst].tokens = 0
+			granter.mu.buckets[testTier1][noBurst].tokens = 0
+			if d.HasArg("tier0burst") {
+				var n int64
+				d.ScanArgs(t, "tier0burst", &n)
+				granter.mu.buckets[testTier0][canBurst].tokens = n
+			}
+			if d.HasArg("tier0") {
+				var n int64
+				d.ScanArgs(t, "tier0", &n)
+				granter.mu.buckets[testTier0][noBurst].tokens = n
+			}
+			if d.HasArg("tier1burst") {
+				var n int64
+				d.ScanArgs(t, "tier1burst", &n)
+				granter.mu.buckets[testTier1][canBurst].tokens = n
+			}
+			if d.HasArg("tier1") {
+				var n int64
+				d.ScanArgs(t, "tier1", &n)
+				granter.mu.buckets[testTier1][noBurst].tokens = n
+			}
+			if d.HasArg("tier0waiter") {
+				var n int64
+				d.ScanArgs(t, "tier0waiter", &n)
+				requesters[testTier0].waitingRequests = true
+				requesters[testTier0].returnValueFromGranted = n
+			} else {
+				requesters[testTier0].waitingRequests = false
+				requesters[testTier0].returnValueFromGranted = 0
+			}
+			if d.HasArg("tier1waiter") {
+				var n int64
+				d.ScanArgs(t, "tier1waiter", &n)
+				requesters[testTier1].waitingRequests = true
+				requesters[testTier1].returnValueFromGranted = n
+			} else {
+				requesters[testTier1].waitingRequests = false
+				requesters[testTier1].returnValueFromGranted = 0
+			}
+			if d.HasArg("tier1burstwaiter") {
+				if !d.HasArg("tier1waiter") {
+					panic("must set tier1waiter")
+				}
+				requesters[testTier1].returnValueFromHasWaitingRequests = canBurst
+			} else {
+				requesters[testTier1].returnValueFromHasWaitingRequests = noBurst
+			}
+			return flushAndReset(true /* init */)
+
+		case "try-get":
+			v := 1
+			if d.HasArg("v") {
+				d.ScanArgs(t, "v", &v)
+			}
+			qual := noBurst
+			if d.HasArg("burst") {
+				qual = canBurst
+			}
+			requesters[scanResourceTier(t, d)].tryGet(qual, int64(v))
+			return flushAndReset(false /* init */)
+
+		case "return-grant":
+			v := 1
+			if d.HasArg("v") {
+				d.ScanArgs(t, "v", &v)
+			}
+			requesters[scanResourceTier(t, d)].returnGrant(int64(v))
+			return flushAndReset(false /* init */)
+
+		case "took-without-permission":
+			v := 1
+			if d.HasArg("v") {
+				d.ScanArgs(t, "v", &v)
+			}
+			requesters[scanResourceTier(t, d)].tookWithoutPermission(int64(v))
+			return flushAndReset(false /* init */)
+
+		// For cpuTimeTokenChildGranter, this is a NOP. Still, it will be
+		// called in production. So best to test it doesn't panic, or similar.
+		case "continue-grant-chain":
+			requesters[scanResourceTier(t, d)].continueGrantChain()
+			return flushAndReset(false /* init */)
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}
+
+func scanResourceTier(t *testing.T, d *datadriven.TestData) resourceTier {
+	var kindStr string
+	d.ScanArgs(t, "tier", &kindStr)
+	switch kindStr {
+	case "tier0":
+		return testTier0
+	case "tier1":
+		return testTier1
+	}
+	panic("unknown resourceTier")
+}

--- a/pkg/util/admission/testdata/cpu_time_token_granter
+++ b/pkg/util/admission/testdata/cpu_time_token_granter
@@ -1,0 +1,207 @@
+# Simple tryGet calls.
+init tier0=1
+----
+cpuTTG canBurst noBurst
+tier0  0        1
+tier1  0        0
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+
+try-get tier=tier1 v=1
+----
+kvtier1: tryGet(1) returned false
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned true
+cpuTTG canBurst noBurst
+tier0  -1       0
+tier1  -1       -1
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned false
+
+# More simple tryGet calls. This time, tier1 work is admitted.
+init tier0=2 tier1=1
+----
+cpuTTG canBurst noBurst
+tier0  0        2
+tier1  0        1
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+
+# For cpuTimeTokenChildGranter, this is a NOP. Still, it will be
+# called in production. So best to test it doesn't panic, or similar.
+continue-grant-chain tier=tier0
+----
+kvtier0: continueGrantChain
+
+try-get tier=tier1 v=1
+----
+kvtier1: tryGet(1) returned true
+cpuTTG canBurst noBurst
+tier0  -1       1
+tier1  -1       0
+
+try-get tier=tier1 v=1
+----
+kvtier1: tryGet(1) returned false
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned true
+cpuTTG canBurst noBurst
+tier0  -2       0
+tier1  -2       -1
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned false
+
+# returnGrant adds tokens to the buckets, when a positive count is used.
+init tier0=1 tier1=1
+----
+cpuTTG canBurst noBurst
+tier0  0        1
+tier1  0        1
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+
+return-grant tier=tier0 v=1
+----
+kvtier0: returnGrant(1)
+cpuTTG canBurst noBurst
+tier0  1        2
+tier1  1        2
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned true
+cpuTTG canBurst noBurst
+tier0  0        1
+tier1  0        1
+
+try-get tier=tier1 v=1
+----
+kvtier1: tryGet(1) returned true
+cpuTTG canBurst noBurst
+tier0  -1       0
+tier1  -1       0
+
+# Simple tookWithoutPermission test.
+init tier0=3 tier1=3
+----
+cpuTTG canBurst noBurst
+tier0  0        3
+tier1  0        3
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+
+took-without-permission tier=tier1 v=3
+----
+kvtier1: tookWithoutPermission(3)
+cpuTTG canBurst noBurst
+tier0  -3       0
+tier1  -3       0
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned false
+
+try-get tier=tier1 v=1
+----
+kvtier1: tryGet(1) returned false
+
+# Test granting. A single tier0 request will be admitted.
+init tier0waiter=2 tier1waiter=1
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+tier0requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 2
+tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 1
+
+return-grant tier=tier0 v=2
+----
+kvtier0: returnGrant(2)
+kvtier0: granted in chain 0, and returning 2
+
+# Test granting. Two tier1 requests will be admitted.
+init tier0=-1 tier0burst=-1 tier1=-1 tier1burst=-1 tier1waiter=1
+----
+cpuTTG canBurst noBurst
+tier0  -1       -1
+tier1  -1       -1
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 1
+
+# With three returned, tier1 burst will have two tokens. Thus two tier1
+# requests can be granted admission. Note that the test requester is not
+# stateful. In init, tier1water=1 means the tier1 requester always has a waiting
+# request, and the ret value from granted is always 1. Thus, after two tier1 requests
+# are granted admission, the bucket is empty again.
+return-grant tier=tier0 v=3
+----
+kvtier0: returnGrant(3)
+kvtier1: granted in chain 0, and returning 1
+kvtier1: granted in chain 0, and returning 1
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# Simple tryGet calls, with burst this time.
+init tier0burst=1
+----
+cpuTTG canBurst noBurst
+tier0  1        0
+tier1  0        0
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+
+try-get tier=tier0 v=1
+----
+kvtier0: tryGet(1) returned false
+
+try-get tier=tier0 burst v=1
+----
+kvtier0: tryGet(1) returned true
+cpuTTG canBurst noBurst
+tier0  0        -1
+tier1  -1       -1
+
+try-get tier=tier0 burst v=1
+----
+kvtier0: tryGet(1) returned false
+
+# Test granting, with burst. After the call to return-grant, only tier1 burst will
+# have enough tokens to grant. So grant a tier1 request.
+init tier0burst=-1 tier0=-1 tier1burst=0 tier1=-1 tier1waiter=1 tier1burstwaiter
+----
+cpuTTG canBurst noBurst
+tier0  -1       -1
+tier1  0        -1
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: canBurst, returnValueFromGranted: 1
+
+return-grant tier=tier0 v=1
+----
+kvtier0: returnGrant(1)
+kvtier1: granted in chain 0, and returning 1
+
+# Test granting, with burst. After the call to return-grant, only tier1 no-burst will
+# have enough tokens to grant. So no grant, since the tier1 waiting request is a burst request.
+init tier0burst=-1 tier0=-1 tier1burst=-1 tier1=0 tier1waiter=1 tier1burstwaiter
+----
+cpuTTG canBurst noBurst
+tier0  -1       -1
+tier1  -1       0
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: canBurst, returnValueFromGranted: 1
+
+return-grant tier=tier0 v=1
+----
+kvtier0: returnGrant(1)
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        1


### PR DESCRIPTION
**admission: introduce a granter for CPU time tokens**

This commit introduces a granter called cpuTimeTokenGranter. cpuTimeTokenGranter uses token buckets to limit CPU usage. This commit introduces the granter, but it does not implement any logic to periodically refill the token buckets, or compute the token rates, based on observed CPU usage. That will come in later PRs.

Fixes: #154469

Release note: None.