### PR TITLE
cmd/roachtest: reproduce kafka-topics timeout error

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2720,6 +2720,25 @@ func registerCDC(r registry.Registry) {
 				// kgo. There isn't a direct equivalent, however, so check a few
 				// things.
 				logSearchStr := `(client/metadata fetching metadata for|updating kafka metadata for topics|fetching metadata to learn its partitions|waiting for metadata for new topic)`
+				// ct.cluster.FetchLogs(ct.ctx, t.L())
+				sanityResults, sanityCheckLogsErr := ct.cluster.RunWithDetails(ct.ctx, t.L(),
+					option.WithNodes(ct.cluster.Range(1, c.Spec().NodeCount-1)),
+					fmt.Sprintf(`grep -E "%s" logs/cockroach.log`, "client.*"))
+				if sanityCheckLogsErr != nil {
+					t.Fatal(sanityCheckLogsErr)
+				}
+				for _, result := range sanityResults {
+					t.L().Printf("node %d stdout: %s", result.Node, result.Stdout)
+				}
+				logLineResults, logLineCheckLogsErr := ct.cluster.RunWithDetails(ct.ctx, t.L(),
+					option.WithNodes(ct.cluster.Range(1, c.Spec().NodeCount-1)),
+					fmt.Sprintf(`wc -L logs/cockroach.log`))
+				if logLineCheckLogsErr != nil {
+					t.Fatal(logLineCheckLogsErr)
+				}
+				for _, result := range logLineResults {
+					t.L().Printf("node %d stdout: %s", result.Node, result.Stdout)
+				}
 				results, checkLogsErr := ct.cluster.RunWithDetails(ct.ctx, t.L(),
 					option.WithNodes(ct.cluster.Range(1, c.Spec().NodeCount-1)),
 					fmt.Sprintf(`grep -E "%s" logs/cockroach.log`, logSearchStr))


### PR DESCRIPTION
The roachtest cdc/kafak-topics is timing out. This is attempting to reproduce.