### PR TITLE
sql/importer: add hint to vector index IMPORT INTO error

### DIFF
--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -650,8 +650,9 @@ func importPlanHook(
 		// Check if the table has any vector indexes
 		for _, idx := range found.NonDropIndexes() {
 			if idx.GetType() == idxtype.VECTOR {
-				return unimplemented.NewWithIssueDetail(145227, "import.vector-index",
-					"IMPORT INTO is not supported for tables with vector indexes")
+				return errors.WithHint(unimplemented.NewWithIssueDetail(145227, "import.vector-index",
+					"IMPORT INTO is not supported for tables with vector indexes"),
+					"Consider dropping the vector index before importing, then recreating it afterwards.")
 			}
 		}
 


### PR DESCRIPTION
Previously, the error message for attempting IMPORT INTO on tables with vector indexes only stated that the operation is not supported. This change adds a helpful hint suggesting users drop the vector index before importing and recreate it afterwards.

The hint provides a clear workaround for users encountering this limitation, improving the user experience when working with vector indexes and bulk imports.

Release Notes: None

Informs: #145227

🤖 Generated with [Claude Code](https://claude.ai/code)