### PR TITLE
randgen: fix recent regression in tuple generation

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -239,16 +239,21 @@ func RandDatumWithNullChance(
 		}
 		return tree.NewDJsonpath(*jp.AST)
 	case types.TupleFamily:
+		tuple := tree.DTuple{D: make(tree.Datums, len(typ.TupleContents()))}
 		if nullChance == 0 {
+			// Even if nullOk=false (which is when nullChance=0), we still want
+			// to generate a NULL _element_ in 10% of cases.
 			nullChance = 10
 		}
-		datums := make([]tree.Datum, len(typ.TupleContents()))
 		for i := range typ.TupleContents() {
-			datums[i] = RandDatumWithNullChance(
+			tuple.D[i] = RandDatumWithNullChance(
 				rng, typ.TupleContents()[i], nullChance, favorCommonData, targetColumnIsUnique,
 			)
 		}
-		return tree.NewDTuple(typ, datums...)
+		// Calling ResolvedType causes the internal TupleContents types to be
+		// populated (as well as resolves the type of each tuple element).
+		tuple.ResolvedType()
+		return &tuple
 	case types.BitFamily:
 		width := typ.Width()
 		if width == 0 {

--- a/pkg/sql/randgen/types_test.go
+++ b/pkg/sql/randgen/types_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -66,7 +67,30 @@ func TestCanonical(t *testing.T) {
 		datum := RandDatum(rng, typ, false)
 		datumTyp := datum.ResolvedType()
 		if !datumTyp.Equivalent(typ.Canonical()) {
-			t.Errorf("fail: canonical type of %+v is %+v and the datum's type is %+v", typ, typ.Canonical(), datumTyp)
+			var tupleHasNullElement func(tree.Datum) bool
+			tupleHasNullElement = func(d tree.Datum) bool {
+				tup, ok := d.(*tree.DTuple)
+				if !ok {
+					return false
+				}
+				for _, el := range tup.D {
+					if el == tree.DNull {
+						return true
+					}
+					if tupleHasNullElement(el) {
+						return true
+					}
+				}
+				return false
+			}
+			// If we have a tuple, then we might have included a NULL element.
+			// By construction in RandDatum, TupleContents[i] has been updated
+			// to types.Unknown. In such case, we give an exception and don't
+			// fail the test.
+			tupleException := tupleHasNullElement(datum)
+			if !tupleException {
+				t.Errorf("fail: canonical type of %+v is %+v and the datum's type is %+v", typ, typ.Canonical(), datumTyp)
+			}
 		}
 
 		if datumTyp.Oid() != typ.Canonical().Oid() {


### PR DESCRIPTION
In 1a751b5328b7b042608169cb503301c678b7d231 we made a slight change to how we generate random tuples. Namely, we no longer call `ResolvedType` on each tuple element. This can be problematic since we might have generated an element with some Any modifier, which could later lead to "illegal AppendFloat/FormatFloat bitSize" panic when operating with floats.

This commit simply reverts the relevant changes from the commit mentioned above.

This required some minor adjustments to `TestCanonical` since there tuple with NULL elements will have their resolved type differ from the originally requested one.

Fixes: #153805.
Release note: None