### PR TITLE
rpc, server: add interceptor to catch panics in DRPC for DB console requests

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -219,6 +219,9 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 	unaryInterceptors = append(unaryInterceptors, stopUnary)
 	streamInterceptors = append(streamInterceptors, stopStream)
 
+	// Recover from any uncaught panics caused by DB Console requests.
+	unaryInterceptors = append(unaryInterceptors, DRPCGatewayRequestRecoveryInterceptor)
+
 	if !rpcCtx.ContextOptions.Insecure {
 		a := kvAuth{
 			sv: &rpcCtx.Settings.SV,

--- a/pkg/server/apiinternal/BUILD.bazel
+++ b/pkg/server/apiinternal/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/rpc/rpcbase",
         "//pkg/server/authserver",
         "//pkg/server/serverpb",

--- a/pkg/server/apiinternal/api_internal.go
+++ b/pkg/server/apiinternal/api_internal.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -120,6 +121,7 @@ func executeRPC[TReq, TResp protoutil.Message](
 ) error {
 	ctx := req.Context()
 	ctx = authserver.ForwardHTTPAuthInfoToRPCCalls(ctx, req)
+	ctx = rpc.MarkDRPCGatewayRequest(ctx)
 
 	if err := decoder.Decode(rpcReq, req.URL.Query()); err != nil {
 		return err


### PR DESCRIPTION
Previously if a DRPC handler experienced an uncaught panic, the entire node would crash. When serving a DB console request, uncaught panics due to its functionality should not cause the CRDB node to crash.

To address this, this patch introduces metadata into the context for all requests originating from the gateway and this is used by a panic recovery interceptor to detect such requests. This allows the server to decide whether to recover from the panic instead of letting it propagate and crash the node.

Epic: none
Fixes: #153452
Release note: None