### PR TITLE
opt: reduce regression in join reordering allocations

### DIFF
--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -262,17 +262,16 @@ func (s *Set) ExtractCols() opt.ColSet {
 	return res
 }
 
-// ExtractNotNullCols returns a set of columns that cannot be NULL for the
-// constraints in the set to hold.
-func (s *Set) ExtractNotNullCols(ctx context.Context, evalCtx *eval.Context) opt.ColSet {
+// ExtractNotNullCols finds the set of columns that cannot be NULL without
+// violating the constraints in the set, and adds them to the given column set.
+func (s *Set) ExtractNotNullCols(ctx context.Context, evalCtx *eval.Context, cols *opt.ColSet) {
 	if s == Unconstrained || s == Contradiction {
-		return opt.ColSet{}
+		return
 	}
-	res := s.Constraint(0).ExtractNotNullCols(ctx, evalCtx)
+	s.Constraint(0).ExtractNotNullCols(ctx, evalCtx, cols)
 	for i := 1; i < s.Length(); i++ {
-		res.UnionWith(s.Constraint(i).ExtractNotNullCols(ctx, evalCtx))
+		s.Constraint(i).ExtractNotNullCols(ctx, evalCtx, cols)
 	}
-	return res
 }
 
 // ExtractConstCols returns a set of columns which can only have one value

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -1229,7 +1229,8 @@ func TestExtractNotNullCols(t *testing.T) {
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			c := ParseConstraint(&evalCtx, tc.c)
-			cols := c.ExtractNotNullCols(ctx, &evalCtx)
+			var cols opt.ColSet
+			c.ExtractNotNullCols(ctx, &evalCtx, &cols)
 			if exp := opt.MakeColSet(tc.e...); !cols.Equals(exp) {
 				t.Errorf("expected %s; got %s", exp, cols)
 			}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -872,7 +872,7 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 		// Add any not-null columns from the predicate constraints.
 		for i := range pred {
 			if c := pred[i].ScalarProps().Constraints; c != nil {
-				notNullCols.UnionWith(c.ExtractNotNullCols(sb.ctx, sb.evalCtx))
+				c.ExtractNotNullCols(sb.ctx, sb.evalCtx, &notNullCols)
 			}
 		}
 		sb.filterRelExpr(pred, scan, notNullCols, relProps, s, MakeTableFuncDep(sb.md, scan.Table))
@@ -1046,12 +1046,12 @@ func (sb *statisticsBuilder) constrainScan(
 	notNullCols := relProps.NotNullCols.Copy()
 	if constraint != nil {
 		// Add any not-null columns from this constraint.
-		notNullCols.UnionWith(constraint.ExtractNotNullCols(sb.ctx, sb.evalCtx))
+		constraint.ExtractNotNullCols(sb.ctx, sb.evalCtx, &notNullCols)
 	}
 	// Add any not-null columns from the predicate constraints.
 	for i := range pred {
 		if c := pred[i].ScalarProps().Constraints; c != nil {
-			notNullCols.UnionWith(c.ExtractNotNullCols(sb.ctx, sb.evalCtx))
+			c.ExtractNotNullCols(sb.ctx, sb.evalCtx, &notNullCols)
 		}
 	}
 	sb.updateNullCountsFromNotNullCols(notNullCols, s)
@@ -3710,7 +3710,7 @@ func (sb *statisticsBuilder) constrainExpr(
 	// ---------------------------------------------
 	notNullCols := relProps.NotNullCols.Copy()
 	// Add any not-null columns from this constraint set.
-	notNullCols.UnionWith(cs.ExtractNotNullCols(sb.ctx, sb.evalCtx))
+	cs.ExtractNotNullCols(sb.ctx, sb.evalCtx, &notNullCols)
 	sb.updateNullCountsFromNotNullCols(notNullCols, s)
 
 	// Calculate row count and selectivity

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -110,7 +110,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		sel := mem.MemoizeSelect(scan, TrueFilter)
 
 		relProps := &props.Relational{Cardinality: props.AnyCardinality}
-		relProps.NotNullCols = cs.ExtractNotNullCols(ctx, &evalCtx)
+		cs.ExtractNotNullCols(ctx, &evalCtx, &relProps.NotNullCols)
 		s := relProps.Statistics()
 		const minRowCount = 0
 		s.Init(relProps, minRowCount)

--- a/pkg/sql/opt/norm/reject_nulls_funcs.go
+++ b/pkg/sql/opt/norm/reject_nulls_funcs.go
@@ -35,7 +35,8 @@ func (c *CustomFuncs) HasNullRejectingFilter(
 			continue
 		}
 
-		notNullFilterCols := constraints.ExtractNotNullCols(c.f.ctx, c.f.evalCtx)
+		var notNullFilterCols opt.ColSet
+		constraints.ExtractNotNullCols(c.f.ctx, c.f.evalCtx, &notNullFilterCols)
 		if notNullFilterCols.Intersects(nullRejectCols) {
 			return true
 		}
@@ -286,7 +287,7 @@ func (c *CustomFuncs) GetNullRejectedCols(filters memo.FiltersExpr) opt.ColSet {
 			continue
 		}
 
-		nullRejectedCols.UnionWith(constraints.ExtractNotNullCols(c.f.ctx, c.f.evalCtx))
+		constraints.ExtractNotNullCols(c.f.ctx, c.f.evalCtx, &nullRejectedCols)
 	}
 	return nullRejectedCols
 }

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1221,7 +1221,8 @@ func (c *CustomFuncs) FindLeftJoinCanaryColumn(
 	// Find any column from the right which is null-rejected by the ON condition.
 	// right rows where such a column is NULL will never contribute to the join
 	// result.
-	nullRejectedCols := memo.NullColsRejectedByFilter(c.e.ctx, c.e.evalCtx, on)
+	var nullRejectedCols opt.ColSet
+	memo.ExtractNullColsRejectedByFilter(c.e.ctx, c.e.evalCtx, on, &nullRejectedCols)
 	nullRejectedCols.IntersectionWith(right.Relational().OutputCols)
 
 	canaryCol, ok = nullRejectedCols.Next(0)

--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -642,7 +642,7 @@ func (jb *JoinOrderBuilder) addJoins(s1, s2 vertexSet) {
 			redundant := areFiltersRedundant(&jb.equivs, e.filters, notNullCols)
 			// Update notNullCols based on null-rejecting filters to aid in
 			// finding subsequent redundant filters.
-			notNullCols.UnionWith(memo.NullColsRejectedByFilter(jb.ctx, jb.evalCtx, e.filters))
+			memo.ExtractNullColsRejectedByFilter(jb.ctx, jb.evalCtx, e.filters, &notNullCols)
 			if redundant {
 				// Avoid adding redundant filters.
 				continue
@@ -1256,7 +1256,7 @@ func (e *edge) calcNullRejectedRels(jb *JoinOrderBuilder) {
 	var nullRejectedCols opt.ColSet
 	for i := range e.filters {
 		if constraints := e.filters[i].ScalarProps().Constraints; constraints != nil {
-			nullRejectedCols.UnionWith(constraints.ExtractNotNullCols(jb.ctx, jb.evalCtx))
+			constraints.ExtractNotNullCols(jb.ctx, jb.evalCtx, &nullRejectedCols)
 		}
 	}
 	e.nullRejectedRels = jb.getRelations(nullRejectedCols)


### PR DESCRIPTION
PR #151504 fixed a bug but caused a regression in allocations,
particularly for `slow-query-1`. This commit reduces the regression by
altering methods which extract not-null columns from filters and
constraints—they now add columns to existing sets instead of creating
new sets.

Release note: None
