### PR TITLE
cli/debug: add decode-proto --dump-descriptor-set

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -285,6 +285,8 @@ go_library(
         "@org_golang_google_grpc//status",
         "@org_golang_x_oauth2//google",
         "@org_golang_x_sync//errgroup",
+        "@com_github_gogo_protobuf//proto",
+        "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -724,6 +724,7 @@ var debugDecodeProtoEmitDefaults bool
 var debugDecodeProtoSingleProto bool
 var debugDecodeProtoBinaryOutput bool
 var debugDecodeProtoOutputFile string
+var debugDecodeProtoDumpDescriptorSet bool
 var debugDecodeProtoCmd = &cobra.Command{
 	Use:   "decode-proto",
 	Short: "decode-proto <proto> --name=<fully qualified proto name>",
@@ -753,6 +754,11 @@ $ curl -X POST  'http://localhost:8080/ts/query' \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/x-protobuf' \
   --data-binary @<file>
+
+If --dump-descriptor-set is specified, the tool will output a FileDescriptorSet
+containing all registered .proto files instead of decoding input.
+Use --out to specify the output file:
+cockroach debug decode-proto --dump-descriptor-set --out=descriptors.pb
 `,
 	Args: cobra.ArbitraryArgs,
 	RunE: runDebugDecodeProto,
@@ -1594,6 +1600,8 @@ func init() {
 		"output the protos as binary instead of JSON. If specified, --out also needs to be specified.")
 	f.StringVar(&debugDecodeProtoOutputFile, "out", "",
 		"path to output file. If not specified, output goes to stdout.")
+	f.BoolVar(&debugDecodeProtoDumpDescriptorSet, "dump-descriptor-set", false,
+		"dump the file descriptor set for the specified proto schema instead of decoding input")
 
 	f = debugCheckLogConfigCmd.Flags()
 	f.Var(&debugLogChanSel, "only-channels", "selection of channels to include in the output diagram.")


### PR DESCRIPTION
We have a very complex graph of proto -> proto dependencies and imports that is handled by bazel whenever we need to generate proto-based code or file descriptor sets. However if you want to decode a crdb proto elsewhere, or example to decode a file in a debug.zip or mcp or something, you need those same file descriptor sets, but will find it quite challenging to generate them yourself without the grpah information that Bazel uses. However we already have the exact descriptors we use to decode messages built right in to CRDB, and we already have a helper debug command that allows using them to decode individual messages ad-hoc. This change extends that command to also offer the full set of proto descriptors up as a FileDescriptorSet for those who wish to do their own decoding.

Release note: none.
Epic: none.