### PR TITLE
jobs: add user to status change event log

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -660,6 +660,7 @@ An event of type `status_change` is recorded when a job changes statuses.
 | `RunNum` | The run number of the job. | no |
 | `Error` | An error that may have occurred while the job was running. | yes |
 | `FinalResumeErr` | An error that occurred that requires the job to be reverted. | yes |
+| `User` | User is the owner of the job. | yes |
 
 
 #### Common fields

--- a/pkg/jobs/structured_log.go
+++ b/pkg/jobs/structured_log.go
@@ -43,6 +43,7 @@ func LogStateChangeStructured(
 
 		if payload.Error != "" {
 			out.Error = payload.Error
+			out.User = payload.UsernameProto.Decode().Normalized()
 		}
 	}
 

--- a/pkg/util/log/eventpb/job_events.proto
+++ b/pkg/util/log/eventpb/job_events.proto
@@ -67,4 +67,7 @@ message StatusChange {
 
   // An error that occurred that requires the job to be reverted.
   string final_resume_err = 9 [(gogoproto.jsontag) = ",omitempty"];
+
+  // User is the owner of the job.
+  string user = 10 [(gogoproto.jsontag) = ",omitempty"];
 }

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -6002,6 +6002,18 @@ func (m *StatusChange) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
+	if m.User != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"User\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.User)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 


### PR DESCRIPTION
Informs #153276

Release note (ops change): In an upcoming release, we're ~deprecating~ removing the bespoke restore and import event logs. For any customer that relies on those logs, we can maintain UX parity by plumbing the sql user that created the job to the status change event log.