### PR TITLE
backup: add deprecation warning for incremental_location

### DIFF
--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -49,6 +49,8 @@ const (
 	deprecatedPrivilegesRestorePreamble = "The existing privileges are being deprecated " +
 		"in favour of a fine-grained privilege model explained here " +
 		"https://www.cockroachlabs.com/docs/stable/restore.html#required-privileges. In a future release, to run"
+
+	deprecatedIncrementalLocationMessage = "the incremental_location option is deprecated and will be removed in a future release"
 )
 
 type tableAndIndex struct {
@@ -440,6 +442,10 @@ func backupPlanHook(
 	)
 	if err != nil {
 		return nil, nil, false, err
+	}
+
+	if len(incrementalStorage) > 0 {
+		p.BufferClientNotice(ctx, pgnotice.Newf(deprecatedIncrementalLocationMessage))
 	}
 
 	var revisionHistory bool

--- a/pkg/backup/create_scheduled_backup.go
+++ b/pkg/backup/create_scheduled_backup.go
@@ -339,6 +339,7 @@ func doCreateBackupSchedules(
 
 		var incDests []string
 		if eval.incrementalStorage != nil {
+			p.BufferClientNotice(ctx, pgnotice.Newf(deprecatedIncrementalLocationMessage))
 			incDests = eval.incrementalStorage
 			for _, incDest := range incDests {
 				backupNode.Options.IncrementalStorage = append(backupNode.Options.IncrementalStorage, tree.NewStrVal(incDest))

--- a/pkg/backup/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/backup/testdata/backup-restore/alter-schedule/backup-options
@@ -74,6 +74,7 @@ exec-sql
 alter backup schedule $incID set with encryption_passphrase = '';
 alter backup schedule $incID set with kms = ('aws:///key1?region=r1', 'aws:///key2?region=r2'), set with incremental_location = 'inc';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 query-sql
 with schedules as (show schedules for backup) select command from schedules where label='datatest' order by backup_type asc;

--- a/pkg/backup/testdata/backup-restore/encrypted-backups
+++ b/pkg/backup/testdata/backup-restore/encrypted-backups
@@ -16,6 +16,7 @@ BACKUP INTO 'nodelocal://1/full' WITH encryption_passphrase='123';
 exec-sql
 BACKUP INTO 'nodelocal://1/full2' WITH encryption_passphrase='456', incremental_location='nodelocal://1/inc';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 exec-sql
 BACKUP INTO 'nodelocal://1/full3' WITH kms='testkms:///cmk?AUTH=implicit';
@@ -92,6 +93,7 @@ BACKUP INTO LATEST IN 'nodelocal://1/full' WITH encryption_passphrase='123';
 exec-sql
 BACKUP INTO LATEST IN 'nodelocal://1/full2' WITH encryption_passphrase='456', incremental_location='nodelocal://1/inc';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 exec-sql
 BACKUP INTO LATEST IN 'nodelocal://1/full3' WITH kms='testkms:///cmk?AUTH=implicit';

--- a/pkg/backup/testdata/backup-restore/external-connections-nodelocal
+++ b/pkg/backup/testdata/backup-restore/external-connections-nodelocal
@@ -177,6 +177,7 @@ BACKUP DATABASE d INTO 'external://full';
 exec-sql
 BACKUP DATABASE d INTO LATEST IN 'external://full' WITH incremental_location = 'external://inc';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 query-sql
 SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full' WITH
@@ -202,6 +203,7 @@ BACKUP DATABASE d INTO 'external://full/nested';
 exec-sql
 BACKUP DATABASE d INTO LATEST IN 'external://full/nested' WITH incremental_location = 'external://inc/nested';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 query-sql
 SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full/nested'

--- a/pkg/backup/testdata/backup-restore/external-connections-userfile
+++ b/pkg/backup/testdata/backup-restore/external-connections-userfile
@@ -156,6 +156,7 @@ BACKUP DATABASE d INTO 'external://full';
 exec-sql
 BACKUP DATABASE d INTO LATEST IN 'external://full' WITH incremental_location = 'external://inc';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 query-sql
 SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full' WITH
@@ -181,6 +182,7 @@ BACKUP DATABASE d INTO 'external://full/nested';
 exec-sql
 BACKUP DATABASE d INTO LATEST IN 'external://full/nested' WITH incremental_location = 'external://inc/nested';
 ----
+NOTICE: the incremental_location option is deprecated and will be removed in a future release
 
 query-sql
 SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full/nested'


### PR DESCRIPTION
Epic: none

Release note (ops change): the incremental_location option is now deprecated and will be removed in a future release. This feature was added so customers could define different TTL policies for incremental backups vs full backups. Users can still do this since incremental backups are by default stored in a distinct directory relative to full backups ({collection_root}/incrementals).