### PR TITLE
sql: avoid offsetting merge timestamp to reduce unnecessary waiting

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2994,12 +2994,11 @@ func indexTruncateInTxn(
 // the next resume, a mergeTimestamp newer than the GC time will be picked and
 // the job can continue.
 func getMergeTimestamp(ctx context.Context, clock *hlc.Clock) hlc.Timestamp {
-	// Use the current timestamp plus the maximum allowed offset to account for
-	// potential clock skew across nodes. The chosen timestamp must be greater
-	// than all commit timestamps used so far. This may result in seeing rows
-	// that are already present in the index being merged, but that’s fine as
-	// they will be treated as no-ops.
-	ts := clock.Now().AddDuration(clock.MaxOffset())
+	// Use the current timestamp since by this point we only have one descriptor
+	// version and no one can commit with the old version due to transaction
+	// deadlines from the lease manager. Anything after that version will write to
+	// both the backfilled and temporary index.
+	ts := clock.Now()
 	log.Dev.Infof(ctx, "merging all keys in temporary index before time %v", ts)
 	return ts
 }


### PR DESCRIPTION
In 149731515152ae81196d7120d6968e9c74aaeb32 we added an offset to the merge timestamp to attempt to diagnose an issue we were seeing with backfills.

That issue ended up being caused by #144650.

The offset makes schema changes wait longer before completing, so since it turned out not to be necessary, this commit reverts to the old behavior.

Epic: None
Informs: #142917
Release note: None