### PR TITLE
asim: skip more asim tests under CI

### DIFF
--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 
 go_test(
     name = "tests_test",
+    size = "large",
     srcs = [
         "datadriven_simulation_test.go",
         "helpers_test.go",

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/load_distribution_movement_disabled_enable_later.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/load_distribution_movement_disabled_enable_later.txt
@@ -1,3 +1,6 @@
+skip_under_ci
+----
+
 # 16vCPU machines.
 gen_cluster nodes=10 node_cpu_rate_capacity=16000000000
 ----

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma_constraint_satisfaction1_full_disk.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma_constraint_satisfaction1_full_disk.txt
@@ -1,3 +1,6 @@
+skip_under_ci
+----
+
 # specify zone survivability (2, 2, 1) replicas across 3 regions.
 # a(n1.n2) b(n3,n4) c(n5) d(n6-n9)
 # 10737418240 is 10GB

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma_high_cpu_skewed_placement.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma_high_cpu_skewed_placement.txt
@@ -1,3 +1,6 @@
+skip_under_ci
+----
+
 gen_cluster nodes=7 node_cpu_rate_capacity=50000
 ----
 WARNING: node CPU capacity of ≈0.00 cores is likely accidental

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma_high_cpu_unable_to_shed_leases.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/mma_high_cpu_unable_to_shed_leases.txt
@@ -1,3 +1,6 @@
+skip_under_ci
+----
+
 # Want to test two cases:
 # (1) Where its impossible to shed leases from the CPU overloaded store, so we
 #     should initially observe a period of no rebalancing activity away from


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/153824
Epic: none 

---- 

**asim: skip more asim tests under CI**

This commit skips certain long-running asim tests in CI to reduce
kv/kvserver/asim/tests test time.

---
**asim: bump timeout to 15 min**

This commit bumps tests timeout to 15 min since tests under
asim/tests tend to take longer.


