### PR TITLE
logical: deflake TestRandomStream

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/utilccl",
         "//pkg/cloud",
-        "//pkg/cloud/externalconn",
         "//pkg/clusterversion",
         "//pkg/crosscluster",
         "//pkg/crosscluster/physical",


### PR DESCRIPTION
TestRandomStream passes a non-external URI. This causes the external connection polling logic added by #149261 to return an error which results in the processor shutting down right away. The only reason the test mostly works is the tear down takes some time and we are usually able to replicate a few rows before shutdown completes.

Release note: none
Fixes: #153666
Fixes: #152435