### PR TITLE
backup: teach ContainsManifest to use the up to date manifest file

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -428,7 +428,10 @@ func backup(
 	}
 
 	// TODO(msbutler): version gate writing the old manifest once we can guarantee
-	// a cluster version that will not read the old manifest.
+	// a cluster version that will not read the old manifest. This will occur when we delete
+	// LegacyFindPriorBackups and the fallback path in
+	// ListFullBackupsInCollection, which can occur when we completely rely on the
+	// backup index.
 	if err := backupinfo.WriteBackupManifest(ctx, defaultStore, backupbase.DeprecatedBackupManifestName,
 		encryption, &kmsEnv, backupManifest); err != nil {
 		return roachpb.RowCount{}, 0, err

--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -52,7 +52,7 @@ const (
 // On some cloud storage platforms (i.e. GS, S3), backups in a base bucket may
 // omit a leading slash. However, backups in a subdirectory of a base bucket
 // will contain one.
-var backupPathRE = regexp.MustCompile("^/?[^\\/]+/[^\\/]+/[^\\/]+/" + backupbase.DeprecatedBackupManifestName + "$")
+var deprecatedBackupPathRE = regexp.MustCompile("^/?[^\\/]+/[^\\/]+/[^\\/]+/" + backupbase.DeprecatedBackupManifestName + "$")
 
 // ResolvedDestination encapsulates information that is populated while
 // resolving the destination of a backup.
@@ -483,7 +483,7 @@ func ListFullBackupsInCollection(
 
 	var backupPaths []string
 	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(f string) error {
-		if backupPathRE.MatchString(f) {
+		if deprecatedBackupPathRE.MatchString(f) {
 			backupPaths = append(backupPaths, f)
 		}
 		return nil

--- a/pkg/backup/backupdest/incrementals.go
+++ b/pkg/backup/backupdest/incrementals.go
@@ -122,6 +122,9 @@ func FindAllIncrementalPaths(
 //
 // Note: store should be rooted at the directory containing the incremental
 // backups (i.e. gs://my-bucket/backup/incrementals/2025/07/29-123456.00/)
+//
+// TODO (msbutler): we didn't bother to update this to use the up to date
+// manifest as this will eventually be deleted when all reads use the index.
 func LegacyFindPriorBackups(
 	ctx context.Context, store cloud.ExternalStorage, includeManifest bool,
 ) ([]string, error) {


### PR DESCRIPTION
In addition, this patch adds some todos on the plan to delete the deprecated
backup manifest.

Informs https://github.com/cockroachdb/cockroach/issues/139159

Release note: none