### PR TITLE
changefeedccl: disable per-table PTS by default

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -213,7 +213,7 @@ var ProtectTimestampBucketingInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"changefeed.protect_timestamp_bucketing_interval",
 	"controls the amount a table is allowed to lag behind the most advanced table before a per-table protected timestamp record is created; "+
-		"only used when changefeed.protected_timestamp.per_table.enabled is true",
+		"only used when changefeed.protect_timestamp.per_table.enabled is true",
 	2*time.Minute,
 	settings.PositiveDuration)
 
@@ -229,10 +229,10 @@ var ProtectTimestampLag = settings.RegisterDurationSetting(
 // instead of a single record for all tables in a changefeed.
 var PerTableProtectedTimestamps = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
-	"changefeed.protected_timestamp.per_table.enabled",
+	"changefeed.protect_timestamp.per_table.enabled",
 	"if true, creates separate protected timestamp records for each table in a changefeed; "+
 		"if false, uses a single protected timestamp record for all tables",
-	metamorphic.ConstantWithTestBool("changefeed.protected_timestamp.per_table.enabled", true))
+	metamorphic.ConstantWithTestBool("changefeed.protect_timestamp.per_table.enabled", false))
 
 // MaxProtectedTimestampAge controls the frequency of protected timestamp record updates
 var MaxProtectedTimestampAge = settings.RegisterDurationSetting(

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1831,7 +1831,7 @@ func runCDCMultiTablePTSBenchmark(
 		numRanges = params.numRanges
 	}
 
-	if _, err := db.Exec("SET CLUSTER SETTING changefeed.protected_timestamp.per_table.enabled = $1", params.perTablePTS); err != nil {
+	if _, err := db.Exec("SET CLUSTER SETTING changefeed.protect_timestamp.per_table.enabled = $1", params.perTablePTS); err != nil {
 		t.Fatalf("failed to set per-table protected timestamps: %v", err)
 	}
 
@@ -3163,7 +3163,7 @@ func registerCDC(r registry.Registry) {
 						// when frontier persistence is on.
 						"changefeed.span_checkpoint.interval": "'0'",
 						// Disable per-table PTS to avoid impact on results.
-						"changefeed.protected_timestamp.per_table.enabled": "false",
+						"changefeed.protect_timestamp.per_table.enabled": "false",
 					} {
 						stmt := fmt.Sprintf(`SET CLUSTER SETTING %s = %s`, name, value)
 						if _, err := db.ExecContext(ctx, stmt); err != nil {


### PR DESCRIPTION
This change updates the default value of the per-table protected timestamp cluster setting to false. Changefeeds will continue to  use the existing single-record format for protected timestamps, even when there are multiple tables.

Fixes: #153900
Epic: CRDB-1421
Release note: None