### PR TITLE
release-25.3: plpgsql: fix handling of annotations for DO blocks

### DIFF
--- a/pkg/sql/catalog/redact/redact_test.go
+++ b/pkg/sql/catalog/redact/redact_test.go
@@ -32,15 +32,18 @@ func TestRedactQueries(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	codec := srv.ApplicationLayer().Codec()
 	tdb := sqlutils.MakeSQLRunner(db)
-	tdb.Exec(t, "CREATE TABLE kv (k INT PRIMARY KEY, v STRING)")
-	tdb.Exec(t, "CREATE VIEW view AS SELECT k, v FROM kv WHERE v <> 'constant literal'")
-	tdb.Exec(t, "CREATE TABLE ctas AS SELECT k, v FROM kv WHERE v <> 'constant literal'")
+	tdb.Exec(t, "CREATE TYPE my_enum AS ENUM ('foo', 'bar')")
+	tdb.Exec(t, "CREATE TABLE kv (k INT PRIMARY KEY, v STRING, e my_enum)")
+	tdb.Exec(t, "CREATE VIEW view AS SELECT k, v, e FROM kv WHERE v <> 'constant literal' AND e <> 'foo'")
+	tdb.Exec(t, "CREATE TABLE ctas AS SELECT k, v, e FROM kv WHERE v <> 'constant literal' AND e <> 'foo'")
 	tdb.Exec(t, `
 CREATE FUNCTION f1() RETURNS INT
 LANGUAGE SQL
 AS $$
 SELECT k FROM kv WHERE v != 'foo';
 SELECT k FROM kv WHERE v = 'bar';
+SELECT k FROM kv WHERE e != 'foo';
+SELECT k FROM kv WHERE e = 'bar';
 $$`)
 	tdb.Exec(t, `
 CREATE FUNCTION f2() RETURNS INT
@@ -49,8 +52,9 @@ AS $$
 DECLARE
 x INT := 0;
 y TEXT := 'bar';
+z my_enum;
 BEGIN
-SELECT k FROM kv WHERE v != 'foo';
+SELECT k FROM kv WHERE v != 'foo' AND e != 'bar'::my_enum;
 RETURN x + 3;
 END;
 $$`)
@@ -61,7 +65,7 @@ $$`)
 		)
 		mut := tabledesc.NewBuilder(view.TableDesc()).BuildCreatedMutableTable()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k, v FROM defaultdb.public.kv WHERE v != '_'`, mut.ViewQuery)
+		require.Equal(t, `SELECT k, v, e FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_')`, mut.ViewQuery)
 	})
 
 	t.Run("create table as", func(t *testing.T) {
@@ -70,14 +74,14 @@ $$`)
 		)
 		mut := tabledesc.NewBuilder(ctas.TableDesc()).BuildCreatedMutableTable()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k, v FROM defaultdb.public.kv WHERE v != '_'`, mut.CreateQuery)
+		require.Equal(t, `SELECT k, v, e FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_')`, mut.CreateQuery)
 	})
 
 	t.Run("create function sql", func(t *testing.T) {
 		fn := desctestutils.TestingGetFunctionDescriptor(kvDB, codec, "defaultdb", "public", "f1")
 		mut := funcdesc.NewBuilder(fn.FuncDesc()).BuildCreatedMutableFunction()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k FROM defaultdb.public.kv WHERE v != '_'; SELECT k FROM defaultdb.public.kv WHERE v = '_';`, mut.FunctionBody)
+		require.Equal(t, `SELECT k FROM defaultdb.public.kv WHERE v != '_'; SELECT k FROM defaultdb.public.kv WHERE v = '_'; SELECT k FROM defaultdb.public.kv WHERE e != '_'; SELECT k FROM defaultdb.public.kv WHERE e = '_';`, mut.FunctionBody)
 	})
 
 	t.Run("create function plpgsql", func(t *testing.T) {
@@ -87,8 +91,9 @@ $$`)
 		require.Equal(t, `DECLARE
 x INT8 := _;
 y STRING := '_';
+z @100104;
 BEGIN
-SELECT k FROM defaultdb.public.kv WHERE v != '_';
+SELECT k FROM defaultdb.public.kv WHERE (v != '_') AND (e != '_':::@100104);
 RETURN x + _;
 END;
 `, mut.FunctionBody)

--- a/pkg/sql/logictest/testdata/logic_test/do
+++ b/pkg/sql/logictest/testdata/logic_test/do
@@ -285,3 +285,23 @@ END
 $$;
 
 subtest end
+
+subtest regression_151848
+
+statement error pgcode 42704 type \"bar\" does not exist
+DO $$
+DECLARE
+  foo bar;
+BEGIN
+END;
+$$;
+
+statement error pgcode 42704 type \"_\" does not exist
+DO $$
+DECLARE
+  foo _[];
+BEGIN
+END;
+$$;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -840,8 +840,19 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 	// TODO(drewk): Enable memo reuse with DO statements.
 	b.DisableMemoReuse = true
 
-	defer func(oldInsideFuncDep bool) { b.insideFuncDef = oldInsideFuncDep }(b.insideFuncDef)
+	doBlockImpl, ok := do.Code.(*plpgsqltree.DoBlock)
+	if !ok {
+		panic(errors.AssertionFailedf("expected a plpgsql block"))
+	}
+
+	defer func(oldInsideFuncDep bool, oldAnn tree.Annotations) {
+		b.insideFuncDef = oldInsideFuncDep
+		b.semaCtx.Annotations = oldAnn
+		b.evalCtx.Annotations = &b.semaCtx.Annotations
+	}(b.insideFuncDef, b.semaCtx.Annotations)
 	b.insideFuncDef = true
+	b.semaCtx.Annotations = doBlockImpl.Annotations
+	b.evalCtx.Annotations = &b.semaCtx.Annotations
 
 	// Build the routine body.
 	var bodyStmts []string
@@ -849,10 +860,6 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 		fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
 		fmtCtx.FormatNode(do.Code)
 		bodyStmts = []string{fmtCtx.CloseAndGetString()}
-	}
-	doBlockImpl, ok := do.Code.(*plpgsqltree.DoBlock)
-	if !ok {
-		panic(errors.AssertionFailedf("expected a plpgsql block"))
 	}
 	bodyScope := b.buildPLpgSQLDoBody(doBlockImpl)
 

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/sql/sem/tree/treecmp",  # keep
         "//pkg/sql/sem/tree/treewindow",  # keep
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/vector",  # keep
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -38,13 +38,17 @@ type lexer struct {
 	lastError error
 }
 
-func (l *lexer) init(sql string, tokens []sqlSymType, nakedIntType *types.T) {
+// numAnnotations indicates the number of annotations that have already been
+// claimed.
+func (l *lexer) init(
+	sql string, tokens []sqlSymType, nakedIntType *types.T, numAnnotations tree.AnnotationIdx,
+) {
 	l.in = sql
 	l.tokens = tokens
 	l.lastPos = -1
 	l.stmt = nil
 	l.numPlaceholders = 0
-	l.numAnnotations = 0
+	l.numAnnotations = numAnnotations
 	l.lastError = nil
 
 	l.nakedIntType = nakedIntType

--- a/pkg/sql/parser/lexer_test.go
+++ b/pkg/sql/parser/lexer_test.go
@@ -36,7 +36,7 @@ func TestLexer(t *testing.T) {
 			scanTokens = append(scanTokens, lval)
 		}
 		var l lexer
-		l.init(d.sql, scanTokens, defaultNakedIntType)
+		l.init(d.sql, scanTokens, defaultNakedIntType, 0 /* numAnnotations */)
 		var lexTokens []int
 		for {
 			var lval sqlSymType

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/scanner"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -47,6 +48,7 @@ type Parser struct {
 type ParseOptions struct {
 	intType        *types.T
 	retainComments bool
+	numAnnotations *tree.AnnotationIdx
 }
 
 var DefaultParseOptions = ParseOptions{
@@ -61,6 +63,18 @@ func (po ParseOptions) RetainComments() ParseOptions {
 
 func (po ParseOptions) WithIntType(t *types.T) ParseOptions {
 	po.intType = t
+	return po
+}
+
+// WithNumAnnotations overrides how annotations are handled. If this option is
+// used, then
+// - the given integer indicates the number of annotations already claimed, and
+// - if multiple stmts are parsed, then unique annotation indexes are used
+// across all stmts.
+//
+// When this option is not used, then each stmt is parsed indepedently.
+func (po ParseOptions) WithNumAnnotations(numAnnotations tree.AnnotationIdx) ParseOptions {
+	po.numAnnotations = &numAnnotations
 	return po
 }
 
@@ -168,14 +182,29 @@ func (p *Parser) parseWithDepth(
 		p.scanner.RetainComments()
 	}
 	defer p.scanner.Cleanup()
+	var numAnnotations tree.AnnotationIdx
+	if options.numAnnotations != nil {
+		numAnnotations = *options.numAnnotations
+	}
 	for {
 		sql, tokens, done := p.scanOneStmt()
-		stmt, err := p.parse(depth+1, sql, tokens, options.intType)
+		stmt, err := p.parse(depth+1, sql, tokens, options.intType, numAnnotations)
 		if err != nil {
 			return nil, err
 		}
 		if stmt.AST != nil {
 			stmts = append(stmts, stmt)
+			if options.numAnnotations != nil {
+				if buildutil.CrdbTestBuild && numAnnotations > stmt.NumAnnotations {
+					return nil, errors.AssertionFailedf(
+						"annotation index has regressed: numAnnotations=%d, stmt.NumAnnotations=%d ",
+						numAnnotations, stmt.NumAnnotations,
+					)
+				}
+				// If this stmt used any annotations, we need to advance the
+				// number of annotations accordingly.
+				numAnnotations = stmt.NumAnnotations
+			}
 		}
 		if done {
 			break
@@ -186,9 +215,13 @@ func (p *Parser) parseWithDepth(
 
 // parse parses a statement from the given scanned tokens.
 func (p *Parser) parse(
-	depth int, sql string, tokens []sqlSymType, nakedIntType *types.T,
+	depth int,
+	sql string,
+	tokens []sqlSymType,
+	nakedIntType *types.T,
+	numAnnotations tree.AnnotationIdx,
 ) (statements.Statement[tree.Statement], error) {
-	p.lexer.init(sql, tokens, nakedIntType)
+	p.lexer.init(sql, tokens, nakedIntType, numAnnotations)
 	defer p.lexer.cleanup()
 	if p.parserImpl.Parse(&p.lexer) != 0 {
 		if p.lexer.lastError == nil {
@@ -371,7 +404,8 @@ func ParseTablePattern(sql string) (tree.TablePattern, error) {
 // the results are undefined if the string contains invalid SQL
 // syntax.
 func ParseExprs(exprs []string) (tree.Exprs, error) {
-	return ParseExprsWithOptions(exprs, DefaultParseOptions)
+	res, _, err := ParseExprsWithOptions(exprs, DefaultParseOptions)
+	return res, err
 }
 
 // ParseExprsWithOptions parses a comma-delimited sequence of SQL scalar
@@ -379,19 +413,23 @@ func ParseExprs(exprs []string) (tree.Exprs, error) {
 // ensuring that the input is, in fact, a comma-delimited sequence of SQL
 // scalar expressions — the results are undefined if the string contains
 // invalid SQL syntax.
-func ParseExprsWithOptions(exprs []string, opts ParseOptions) (tree.Exprs, error) {
+//
+// It also returns the number of annotations used.
+func ParseExprsWithOptions(
+	exprs []string, opts ParseOptions,
+) (tree.Exprs, tree.AnnotationIdx, error) {
 	if len(exprs) == 0 {
-		return tree.Exprs{}, nil
+		return tree.Exprs{}, 0, nil
 	}
 	stmt, err := ParseOneWithOptions(fmt.Sprintf("SET ROW (%s)", strings.Join(exprs, ",")), opts)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	set, ok := stmt.AST.(*tree.SetVar)
 	if !ok {
-		return nil, errors.AssertionFailedf("expected a SET statement, but found %T", stmt)
+		return nil, 0, errors.AssertionFailedf("expected a SET statement, but found %T", stmt)
 	}
-	return set.Values, nil
+	return set.Values, stmt.NumAnnotations, nil
 }
 
 // ParseExpr parses a SQL scalar expression. The caller is responsible

--- a/pkg/sql/parser/testdata/do
+++ b/pkg/sql/parser/testdata/do
@@ -406,3 +406,45 @@ END IF;
 END;
 $$;
  -- identifiers removed
+
+parse
+DO $$
+DECLARE
+  foo bar;
+  _ _[];
+BEGIN
+END;
+$$;
+----
+DO $$
+DECLARE
+foo bar;
+_ _[];
+BEGIN
+END;
+$$;
+ -- normalized!
+DO $$
+DECLARE
+foo bar;
+_ _[];
+BEGIN
+END;
+$$;
+ -- fully parenthesized
+DO $$
+DECLARE
+foo bar;
+_ _[];
+BEGIN
+END;
+$$;
+ -- literals removed
+DO $$
+DECLARE
+_ _;
+_ _[];
+BEGIN
+END;
+$$;
+ -- identifiers removed

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -115,6 +115,20 @@ func (l *lexer) Lex(lval *plpgsqlSymType) int {
 	return int(lval.id)
 }
 
+func (l *lexer) parseOptions() parser.ParseOptions {
+	return parser.DefaultParseOptions.WithNumAnnotations(l.numAnnotations)
+}
+
+// parseOne parses a single SQL statement updating numAnnotations accordingly.
+func (l *lexer) parseOne(sql string) (tree.Statement, error) {
+	sqlStmt, err := parser.ParseOneWithOptions(sql, l.parseOptions())
+	if err != nil {
+		return nil, err
+	}
+	l.numAnnotations = sqlStmt.NumAnnotations
+	return sqlStmt.AST, nil
+}
+
 // MakeExecSqlStmt makes an Execute node.
 func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 	if l.parser.Lookahead() != -1 {
@@ -169,7 +183,7 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 	} else {
 		sql = l.getStr(startPos, endPos)
 	}
-	sqlStmt, err := parser.ParseOne(sql)
+	sqlStmt, err := l.parseOne(sql)
 	if err != nil {
 		return nil, err
 	}
@@ -178,15 +192,13 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 	// a SELECT or a mutation with RETURNING. It is difficult to determine this
 	// for all possible statements, and execution is able to handle it, so we
 	// allow SQL statements that return rows.
-	if target != nil && sqlStmt.AST.StatementReturnType() != tree.Rows {
+	if target != nil && sqlStmt.StatementReturnType() != tree.Rows {
 		return nil, pgerror.New(pgcode.Syntax, "INTO used with a command that cannot return data")
 	}
-	ann := tree.MakeAnnotations(sqlStmt.NumAnnotations)
 	return &plpgsqltree.Execute{
-		SqlStmt:     sqlStmt.AST,
-		Strict:      haveStrict,
-		Target:      target,
-		Annotations: &ann,
+		SqlStmt: sqlStmt,
+		Strict:  haveStrict,
+		Target:  target,
 	}, nil
 }
 
@@ -259,12 +271,12 @@ func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) 
 		return nil, err
 	}
 	sqlStr = prefix + sqlStr
-	sqlStmt, err := parser.ParseOne(sqlStr)
+	sqlStmt, err := l.parseOne(sqlStr)
 	if err != nil {
 		return nil, err
 	}
 	var cursor tree.CursorStmt
-	switch t := sqlStmt.AST.(type) {
+	switch t := sqlStmt.(type) {
 	case *tree.FetchCursor:
 		cursor = t.CursorStmt
 	case *tree.MoveCursor:
@@ -297,12 +309,10 @@ func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) 
 	}
 	// Move past the semicolon.
 	l.lastPos++
-	ann := tree.MakeAnnotations(sqlStmt.NumAnnotations)
 	return &plpgsqltree.Fetch{
-		Cursor:      cursor,
-		Target:      target,
-		IsMove:      isMove,
-		Annotations: &ann,
+		Cursor: cursor,
+		Target: target,
+		IsMove: isMove,
 	}, nil
 }
 
@@ -374,7 +384,12 @@ func makeDoStmt(options tree.DoBlockOptions) (*plpgsqltree.DoBlock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &plpgsqltree.DoBlock{Block: parsedStmt.AST}, nil
+	return &plpgsqltree.DoBlock{
+		Block: parsedStmt.AST,
+		// Note that here we only initialize the annotations container, and the
+		// annotations will be set during the optbuild.
+		Annotations: tree.MakeAnnotations(parsedStmt.NumAnnotations),
+	}, nil
 }
 
 // ParseReturnExpr handles reading and parsing the expression for a RETURN or
@@ -396,14 +411,12 @@ func (l *lexer) ParseReturnQuery() (plpgsqltree.Statement, error) {
 		return nil, err
 	}
 	queryStr := l.getStr(startPos, endPos)
-	stmt, err := parser.ParseOne(queryStr)
+	sqlStmt, err := l.parseOne(queryStr)
 	if err != nil {
 		return nil, err
 	}
-	ann := tree.MakeAnnotations(stmt.NumAnnotations)
 	return &plpgsqltree.ReturnQuery{
-		SqlStmt:     stmt.AST,
-		Annotations: &ann,
+		SqlStmt: sqlStmt,
 	}, nil
 }
 
@@ -626,13 +639,14 @@ func (l *lexer) Unimplemented(feature string) {
 func (l *lexer) ParseExpr(sqlStr string) (plpgsqltree.Expr, error) {
 	// Use ParseExprs instead of ParseExpr in order to correctly handle the case
 	// when multiple expressions are incorrectly passed.
-	exprs, err := parser.ParseExprs([]string{sqlStr})
+	exprs, numAnnotations, err := parser.ParseExprsWithOptions([]string{sqlStr}, l.parseOptions())
 	if err != nil {
 		return nil, err
 	}
 	if len(exprs) != 1 {
 		return nil, pgerror.Newf(pgcode.Syntax, "query returned %d columns", len(exprs))
 	}
+	l.numAnnotations = numAnnotations
 	return exprs[0], nil
 }
 

--- a/pkg/sql/plpgsql/parser/parse.go
+++ b/pkg/sql/plpgsql/parser/parse.go
@@ -133,6 +133,15 @@ func (p *Parser) parse(
 }
 
 // Parse parses a sql statement string and returns a list of Statements.
+//
+// Note that most callers ignore the number of annotations set in the
+// PLpgStatement. (Annotations are used for different object names like table
+// names and type names.) Ignoring them is usually safe for different reasons
+// (depending on the context):
+// - in some cases (like in the optbuilder), we will replace the annotated node
+// during type checking with an expression that has resolved types;
+// - in other cases (like when operating on descriptors / with backups), we
+// operate with table OIDTypeReferences.
 func Parse(sql string) (statements.PLpgStatement, error) {
 	var p Parser
 	return p.parseWithDepth(1, sql, defaultNakedIntType)

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -183,10 +183,9 @@ func (s *Declaration) WalkStmt(visitor StatementVisitor) Statement {
 
 type CursorDeclaration struct {
 	StatementImpl
-	Name        Variable
-	Scroll      tree.CursorScrollOption
-	Query       tree.Statement
-	Annotations *tree.Annotations
+	Name   Variable
+	Scroll tree.CursorScrollOption
+	Query  tree.Statement
 }
 
 func (s *CursorDeclaration) CopyNode() *CursorDeclaration {
@@ -195,18 +194,16 @@ func (s *CursorDeclaration) CopyNode() *CursorDeclaration {
 }
 
 func (s *CursorDeclaration) Format(ctx *tree.FmtCtx) {
-	ctx.WithAnnotations(s.Annotations, func() {
-		ctx.FormatNode(&s.Name)
-		switch s.Scroll {
-		case tree.Scroll:
-			ctx.WriteString(" SCROLL")
-		case tree.NoScroll:
-			ctx.WriteString(" NO SCROLL")
-		}
-		ctx.WriteString(" CURSOR FOR ")
-		ctx.FormatNode(s.Query)
-		ctx.WriteString(";\n")
-	})
+	ctx.FormatNode(&s.Name)
+	switch s.Scroll {
+	case tree.Scroll:
+		ctx.WriteString(" SCROLL")
+	case tree.NoScroll:
+		ctx.WriteString(" NO SCROLL")
+	}
+	ctx.WriteString(" CURSOR FOR ")
+	ctx.FormatNode(s.Query)
+	ctx.WriteString(";\n")
 }
 
 func (s *CursorDeclaration) PlpgSQLStatementTag() string {
@@ -855,8 +852,7 @@ func (s *ReturnNext) WalkStmt(visitor StatementVisitor) Statement {
 
 type ReturnQuery struct {
 	StatementImpl
-	SqlStmt     tree.Statement
-	Annotations *tree.Annotations
+	SqlStmt tree.Statement
 }
 
 func (s *ReturnQuery) CopyNode() *ReturnQuery {
@@ -865,14 +861,12 @@ func (s *ReturnQuery) CopyNode() *ReturnQuery {
 }
 
 func (s *ReturnQuery) Format(ctx *tree.FmtCtx) {
-	ctx.WithAnnotations(s.Annotations, func() {
-		ctx.WriteString("RETURN QUERY")
-		if s.SqlStmt != nil {
-			ctx.WriteByte(' ')
-			ctx.FormatNode(s.SqlStmt)
-		}
-		ctx.WriteString(";\n")
-	})
+	ctx.WriteString("RETURN QUERY")
+	if s.SqlStmt != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(s.SqlStmt)
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *ReturnQuery) PlpgSQLStatementTag() string {
@@ -983,10 +977,9 @@ func (s *Assert) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_execsql
 type Execute struct {
 	StatementImpl
-	SqlStmt     tree.Statement
-	Strict      bool // INTO STRICT flag
-	Target      []Variable
-	Annotations *tree.Annotations
+	SqlStmt tree.Statement
+	Strict  bool // INTO STRICT flag
+	Target  []Variable
 }
 
 func (s *Execute) CopyNode() *Execute {
@@ -996,22 +989,20 @@ func (s *Execute) CopyNode() *Execute {
 }
 
 func (s *Execute) Format(ctx *tree.FmtCtx) {
-	ctx.WithAnnotations(s.Annotations, func() {
-		ctx.FormatNode(s.SqlStmt)
-		if s.Target != nil {
-			ctx.WriteString(" INTO ")
-			if s.Strict {
-				ctx.WriteString("STRICT ")
-			}
-			for i := range s.Target {
-				if i > 0 {
-					ctx.WriteString(", ")
-				}
-				ctx.FormatNode(&s.Target[i])
-			}
+	ctx.FormatNode(s.SqlStmt)
+	if s.Target != nil {
+		ctx.WriteString(" INTO ")
+		if s.Strict {
+			ctx.WriteString("STRICT ")
 		}
-		ctx.WriteString(";\n")
-	})
+		for i := range s.Target {
+			if i > 0 {
+				ctx.WriteString(", ")
+			}
+			ctx.FormatNode(&s.Target[i])
+		}
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *Execute) PlpgSQLStatementTag() string {
@@ -1113,26 +1104,33 @@ type DoBlock struct {
 
 	// Block is the code block that defines the logic of the DO statement.
 	Block *Block
+
+	// Annotations is allocated during initial parsing of user input, and then
+	// each annotation is set by the optbuilder when the optimizer processes
+	// the DO block statements.
+	Annotations tree.Annotations
 }
 
 var _ Statement = (*DoBlock)(nil)
 var _ tree.DoBlockBody = (*DoBlock)(nil)
 
 func (s *DoBlock) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString("DO ")
+	ctx.WithAnnotations(&s.Annotations, func() {
+		ctx.WriteString("DO ")
 
-	// Format the body of the DO block separately so that FormatStringDollarQuotes
-	// can examine the resulting string and determine how to quote the block.
-	bodyCtx := ctx.Clone()
-	bodyCtx.FormatNode(s.Block)
-	bodyStr := "\n" + bodyCtx.CloseAndGetString()
+		// Format the body of the DO block separately so that FormatStringDollarQuotes
+		// can examine the resulting string and determine how to quote the block.
+		bodyCtx := ctx.Clone()
+		bodyCtx.FormatNode(s.Block)
+		bodyStr := "\n" + bodyCtx.CloseAndGetString()
 
-	// Avoid replacing the entire formatted string with '_' if any redaction flags
-	// are set. They will have already been applied when the body was formatted.
-	ctx.WithoutConstantRedaction(func() {
-		ctx.FormatStringDollarQuotes(bodyStr)
+		// Avoid replacing the entire formatted string with '_' if any redaction flags
+		// are set. They will have already been applied when the body was formatted.
+		ctx.WithoutConstantRedaction(func() {
+			ctx.FormatStringDollarQuotes(bodyStr)
+		})
+		ctx.WriteString(";\n")
 	})
-	ctx.WriteString(";\n")
 }
 
 func (s *DoBlock) IsDoBlockBody() {}
@@ -1215,10 +1213,9 @@ func (s *GetDiagnostics) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_open
 type Open struct {
 	StatementImpl
-	CurVar      Variable
-	Scroll      tree.CursorScrollOption
-	Query       tree.Statement
-	Annotations *tree.Annotations
+	CurVar Variable
+	Scroll tree.CursorScrollOption
+	Query  tree.Statement
 }
 
 func (s *Open) CopyNode() *Open {
@@ -1227,21 +1224,19 @@ func (s *Open) CopyNode() *Open {
 }
 
 func (s *Open) Format(ctx *tree.FmtCtx) {
-	ctx.WithAnnotations(s.Annotations, func() {
-		ctx.WriteString("OPEN ")
-		ctx.FormatNode(&s.CurVar)
-		switch s.Scroll {
-		case tree.Scroll:
-			ctx.WriteString(" SCROLL")
-		case tree.NoScroll:
-			ctx.WriteString(" NO SCROLL")
-		}
-		if s.Query != nil {
-			ctx.WriteString(" FOR ")
-			ctx.FormatNode(s.Query)
-		}
-		ctx.WriteString(";\n")
-	})
+	ctx.WriteString("OPEN ")
+	ctx.FormatNode(&s.CurVar)
+	switch s.Scroll {
+	case tree.Scroll:
+		ctx.WriteString(" SCROLL")
+	case tree.NoScroll:
+		ctx.WriteString(" NO SCROLL")
+	}
+	if s.Query != nil {
+		ctx.WriteString(" FOR ")
+		ctx.FormatNode(s.Query)
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *Open) PlpgSQLStatementTag() string {
@@ -1257,40 +1252,37 @@ func (s *Open) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_move (where IsMove = true)
 type Fetch struct {
 	StatementImpl
-	Cursor      tree.CursorStmt
-	Target      []Variable
-	IsMove      bool
-	Annotations *tree.Annotations
+	Cursor tree.CursorStmt
+	Target []Variable
+	IsMove bool
 }
 
 func (s *Fetch) Format(ctx *tree.FmtCtx) {
-	ctx.WithAnnotations(s.Annotations, func() {
-		if s.IsMove {
-			ctx.WriteString("MOVE ")
-		} else {
-			ctx.WriteString("FETCH ")
-		}
-		if dir := s.Cursor.FetchType.String(); dir != "" {
-			ctx.WriteString(dir)
-			ctx.WriteString(" ")
-		}
-		if s.Cursor.FetchType.HasCount() {
-			ctx.WriteString(strconv.Itoa(int(s.Cursor.Count)))
-			ctx.WriteString(" ")
-		}
-		ctx.WriteString("FROM ")
-		ctx.FormatName(string(s.Cursor.Name))
-		if s.Target != nil {
-			ctx.WriteString(" INTO ")
-			for i := range s.Target {
-				if i > 0 {
-					ctx.WriteString(", ")
-				}
-				ctx.FormatNode(&s.Target[i])
+	if s.IsMove {
+		ctx.WriteString("MOVE ")
+	} else {
+		ctx.WriteString("FETCH ")
+	}
+	if dir := s.Cursor.FetchType.String(); dir != "" {
+		ctx.WriteString(dir)
+		ctx.WriteString(" ")
+	}
+	if s.Cursor.FetchType.HasCount() {
+		ctx.WriteString(strconv.Itoa(int(s.Cursor.Count)))
+		ctx.WriteString(" ")
+	}
+	ctx.WriteString("FROM ")
+	ctx.FormatName(string(s.Cursor.Name))
+	if s.Target != nil {
+		ctx.WriteString(" INTO ")
+		for i := range s.Target {
+			if i > 0 {
+				ctx.WriteString(", ")
 			}
+			ctx.FormatNode(&s.Target[i])
 		}
-		ctx.WriteString(";\n")
-	})
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *Fetch) PlpgSQLStatementTag() string {

--- a/pkg/sql/sem/tree/annotation.go
+++ b/pkg/sql/sem/tree/annotation.go
@@ -5,6 +5,8 @@
 
 package tree
 
+import "github.com/cockroachdb/cockroach/pkg/util/buildutil"
+
 // AnnotationIdx is the 1-based index of an annotation. AST nodes that can
 // be annotated store such an index (unique within that AST).
 type AnnotationIdx int32
@@ -20,6 +22,12 @@ type AnnotatedNode struct {
 // GetAnnotation retrieves the annotation associated with this node.
 func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
 	if n.AnnIdx == NoAnnotation {
+		return nil
+	}
+	if (len(*ann) < int(n.AnnIdx) || int(n.AnnIdx) < 1) && !buildutil.CrdbTestBuild {
+		// Avoid index-out-of bounds panics in production builds. The impact is
+		// that the node will be treated as if it doesn't have the annotation,
+		// which is better than the process crash.
 		return nil
 	}
 	return ann.Get(n.AnnIdx)


### PR DESCRIPTION
Backport 2/2 commits from #151849 on behalf of @yuzefovich.

----

**plpgsql: fix handling of annotations for DO blocks**

This commit should fix for good annotations handling for DO blocks that
was recently attempted to be fixed in 3b8ab38a67a7792200bf033a850513359fb527a8.
(That commit is partially reversed too).

The general issue is that in the PLpgSQL parser we use an ephemeral SQL
parser instance to process SQL statements. However, when processing the
DO block stmts we need to preserve the annotations state between each
stmt. This is now achieved by extending the SQL parser infrastructure to
give an option to override the initial annotations index as well as keep
on reusing the counter across multiple stmts. This allows us to
correctly count the number of annotations that we need for the whole DO
block during the initial parsing, and then we use the allocated
annotations container to set the items in the optbuild.

Fixes: #151848.

Release note (bug fix): Previously, CockroachDB node could crash when
executing DO stmts when they contain user-defined types (possibly
non-existing) in non-default configuration (additional logging like the
one controlled via `sql.log.all_statements.enabled` cluster setting needed
to be enabled). This bug was introduced in 25.1 release and is now fixed.

**tree: avoid index-of-bounds panics in GetAnnotation in production**

We've recently seen two panics when trying to access the Annotations
container and hitting the out-of-bounds condition. The annotations are
used to provide additional information about unresolved object names, so
if we simply return `nil` on an invalid access, we'll keep on using the
unresolved object name, which seems like a better option than process
crash. In test builds we'll keep on crashing.

Release note: None

----

Release justification: bug fix.