### PR TITLE
drpc,server: add support for `admin` and `timeseries` service

### DIFF
--- a/pkg/server/apiinternal/BUILD.bazel
+++ b/pkg/server/apiinternal/BUILD.bazel
@@ -4,7 +4,9 @@ go_library(
     name = "apiinternal",
     srcs = [
         "api_internal.go",
+        "api_internal_admin.go",
         "api_internal_status.go",
+        "api_internal_ts.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/apiinternal",
     visibility = ["//visibility:public"],
@@ -16,6 +18,7 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/server/srverrors",
         "//pkg/settings/cluster",
+        "//pkg/ts/tspb",
         "//pkg/util/httputil",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/server/apiinternal/api_internal_admin.go
+++ b/pkg/server/apiinternal/api_internal_admin.go
@@ -1,0 +1,59 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package apiinternal
+
+// registerAdminRoutes sets up all admin REST endpoints.
+func (r *apiInternalServer) registerAdminRoutes() {
+	routes := []route{
+		// User and database metadata.
+		{GET, "/_admin/v1/users", createHandler(r.admin.Users)},
+		{GET, "/_admin/v1/databases", createHandler(r.admin.Databases)},
+		{GET, "/_admin/v1/databases/{database}", createHandler(r.admin.DatabaseDetails)},
+		{GET, "/_admin/v1/databases/{database}/tables/{table}", createHandler(r.admin.TableDetails)},
+		{GET, "/_admin/v1/databases/{database}/tables/{table}/stats", createHandler(r.admin.TableStats)},
+		{GET, "/_admin/v1/nontablestats", createHandler(r.admin.NonTableStats)},
+		{GET, "/_admin/v1/events", createHandler(r.admin.Events)},
+
+		// Admin UI persisted state.
+		{POST, "/_admin/v1/uidata", createHandler(r.admin.SetUIData)},
+		{GET, "/_admin/v1/uidata", createHandler(r.admin.GetUIData)},
+
+		// Cluster-level information.
+		{GET, "/_admin/v1/cluster", createHandler(r.admin.Cluster)},
+		{GET, "/_admin/v1/settings", createHandler(r.admin.Settings)},
+		{GET, "/_admin/v1/health", createHandler(r.admin.Health)},
+		{GET, "/health", createHandler(r.admin.Health)},
+		{GET, "/_admin/v1/liveness", createHandler(r.admin.Liveness)},
+
+		// Job and node management.
+		{GET, "/_admin/v1/jobs", createHandler(r.admin.Jobs)},
+		{GET, "/_admin/v1/jobs/{job_id}", createHandler(r.admin.Job)},
+		{GET, "/_admin/v1/locations", createHandler(r.admin.Locations)},
+		{GET, "/_admin/v1/queryplan", createHandler(r.admin.QueryPlan)},
+
+		// Range and replication utilities.
+		{GET, "/_admin/v1/rangelog", createHandler(r.admin.RangeLog)},
+		{GET, "/_admin/v1/rangelog/{range_id}", createHandler(r.admin.RangeLog)},
+		{GET, "/_admin/v1/data_distribution", createHandler(r.admin.DataDistribution)},
+		{GET, "/_admin/v1/metricmetadata", createHandler(r.admin.AllMetricMetadata)},
+		{GET, "/_admin/v1/chartcatalog", createHandler(r.admin.ChartCatalog)},
+		{POST, "/_admin/v1/enqueue_range", createHandler(r.admin.EnqueueRange)},
+
+		// Tracing utilities.
+		{GET, "/_admin/v1/trace_snapshots", createHandler(r.admin.ListTracingSnapshots)},
+		{POST, "/_admin/v1/trace_snapshots", createHandler(r.admin.TakeTracingSnapshot)},
+		{GET, "/_admin/v1/trace_snapshots/{snapshot_id}", createHandler(r.admin.GetTracingSnapshot)},
+		{POST, "/_admin/v1/traces", createHandler(r.admin.GetTrace)},
+		{POST, "/_admin/v1/settracerecordingtype", createHandler(r.admin.SetTraceRecordingType)},
+
+		// Multi-tenant metadata.
+		{GET, "/_admin/v1/tenants", createHandler(r.admin.ListTenants)},
+	}
+
+	for _, route := range routes {
+		r.mux.HandleFunc(route.path, route.handler).Methods(string(route.method))
+	}
+}

--- a/pkg/server/apiinternal/api_internal_ts.go
+++ b/pkg/server/apiinternal/api_internal_ts.go
@@ -1,0 +1,17 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package apiinternal
+
+// registerTimeSeriesRoutes sets up all the time series REST endpoints.
+func (r *apiInternalServer) registerTimeSeriesRoutes() {
+	routes := []route{
+		{POST, "/ts/query", createHandler(r.timeseries.Query)},
+	}
+
+	for _, route := range routes {
+		r.mux.HandleFunc(route.path, route.handler).Methods(string(route.method))
+	}
+}

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -220,14 +220,14 @@ func (s *httpServer) setupRoutes(
 		s.mux.Handle(authserver.DemoLoginPath, http.HandlerFunc(authnServer.DemoLogin))
 	}
 
-	s.mux.Handle(apiconstants.AdminPrefix, authenticatedGWMux)
+	s.mux.Handle(apiconstants.AdminPrefix, authenticatedAPIInternalServer)
 
 	// The timeseries endpoint, used to produce graphs.
-	s.mux.Handle(ts.URLPrefix, authenticatedGWMux)
+	s.mux.Handle(ts.URLPrefix, authenticatedAPIInternalServer)
 
 	// Exempt the 2nd health check endpoint from authentication.
 	// (This simply mirrors /health and exists for backward compatibility.)
-	s.mux.Handle(apiconstants.AdminHealth, unauthenticatedGWMux)
+	s.mux.Handle(apiconstants.AdminHealth, authenticatedAPIInternalServer)
 	// The /_status/vars and /metrics endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(apiconstants.StatusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings, false /* useStaticLabels */}.handleVars))
 	s.mux.Handle(apiconstants.MetricsPath, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings, true /* useStaticLabels */}.handleVars))


### PR DESCRIPTION
Previously, the `admin` and `timeseries` services exposed their RPCs as HTTP REST APIs via the grpc-gateway.
Now, we are migrating from the grpc-gateway to DRPC HTTP and hence all these RPCs needed to be migrated.
In this patch, we add the DRPC HTTP support for all these endpoints.

Epic: CRDB-48924
Fixes: #152821 and #152824
Release note: None