### PR TITLE
release-25.2: plpgsql: fix handling of annotations for DO blocks

### DIFF
--- a/pkg/sql/sem/tree/annotation.go
+++ b/pkg/sql/sem/tree/annotation.go
@@ -5,6 +5,8 @@
 
 package tree
 
+import "github.com/cockroachdb/cockroach/pkg/util/buildutil"
+
 // AnnotationIdx is the 1-based index of an annotation. AST nodes that can
 // be annotated store such an index (unique within that AST).
 type AnnotationIdx int32
@@ -20,6 +22,12 @@ type AnnotatedNode struct {
 // GetAnnotation retrieves the annotation associated with this node.
 func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
 	if n.AnnIdx == NoAnnotation {
+		return nil
+	}
+	if (len(*ann) < int(n.AnnIdx) || int(n.AnnIdx) < 1) && !buildutil.CrdbTestBuild {
+		// Avoid index-out-of bounds panics in production builds. The impact is
+		// that the node will be treated as if it doesn't have the annotation,
+		// which is better than the process crash.
 		return nil
 	}
 	return ann.Get(n.AnnIdx)


### PR DESCRIPTION
Backport 1/2 commits from #151849.

/cc @cockroachdb/release

---

**tree: avoid index-of-bounds panics in GetAnnotation in production**

We've recently seen two panics when trying to access the Annotations
container and hitting the out-of-bounds condition. The annotations are
used to provide additional information about unresolved object names, so
if we simply return `nil` on an invalid access, we'll keep on using the
unresolved object name, which seems like a better option than process
crash. In test builds we'll keep on crashing.

Epic: None
Release note: None

Release justification: bug fix.