### PR TITLE
drpc,roachtest: test enabling DRPC with rolling restart of nodes

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "dotnet_helpers.go",
         "drain.go",
         "drop.go",
+        "drpc.go",
         "drt.go",
         "encryption.go",
         "event_log.go",

--- a/pkg/cmd/roachtest/tests/drpc.go
+++ b/pkg/cmd/roachtest/tests/drpc.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/testutils/release"
+)
+
+func registerDRPCTests(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:             "drpc/enable-setting",
+		Owner:            registry.OwnerServer,
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNodeCount(1)),
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.Suites(registry.Weekly),
+		Leases:           registry.MetamorphicLeases,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runEnableSettingWithRollingRestart(ctx, t, c)
+		},
+	})
+}
+
+func runEnableSettingWithRollingRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
+	currentVersion := clusterupgrade.CurrentVersion()
+	previousVersionStr, err := release.LatestPredecessor(&currentVersion.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousVersion := clusterupgrade.MustParseVersion(previousVersionStr)
+
+	t.Status("starting cluster with predecessor version: ", previousVersionStr)
+	predecessorBinary, err := clusterupgrade.UploadCockroach(
+		ctx, t, t.L(), c, c.All(), previousVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := option.DefaultStartOpts()
+	settings := install.MakeClusterSettings(install.BinaryOption(predecessorBinary))
+	c.Start(ctx, t.L(), opts, settings, c.CRDBNodes())
+
+	t.Status("upgrading all nodes to current version")
+	if err := clusterupgrade.RestartNodesWithNewBinary(
+		ctx, t, t.L(), c, c.CRDBNodes(), option.DefaultStartOpts(), currentVersion,
+	); err != nil {
+		t.Fatal(err)
+	}
+	conns := make(map[int]*gosql.DB)
+	dbFunc := func(node int) *gosql.DB {
+		if _, ok := conns[node]; !ok {
+			conns[node] = c.Conn(ctx, t.L(), node)
+		}
+		return conns[node]
+	}
+	defer func() {
+		for _, db := range conns {
+			db.Close()
+		}
+	}()
+	if err := clusterupgrade.WaitForClusterUpgrade(
+		ctx, t.L(), c.CRDBNodes(), dbFunc, clusterupgrade.DefaultUpgradeTimeout); err != nil {
+	}
+
+	t.Status("enabling DRPC setting")
+	upgradedDB := c.Conn(ctx, t.L(), 1)
+	defer upgradedDB.Close()
+
+	if _, err := upgradedDB.ExecContext(
+		ctx, "SET CLUSTER SETTING rpc.experimental_drpc.enabled = true"); err != nil {
+		t.Fatalf("failed to set DRPC setting: %v", err)
+	}
+
+	t.Status("running TPCC workload")
+	initCmd := roachtestutil.NewCommand("./cockroach workload init tpcc").
+		Arg("{pgurl%s}", c.CRDBNodes())
+	runCmd := roachtestutil.NewCommand("./cockroach workload run tpcc").
+		Arg("{pgurl%s}", c.CRDBNodes()).
+		Flag("duration", "30s")
+
+	if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), initCmd.String()); err != nil {
+		t.Fatalf("failed to initialize TPCC workload: %v", err)
+	}
+	if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runCmd.String()); err != nil {
+		t.Fatalf("failed to run TPCC workload with DRPC: %v", err)
+	}
+
+	t.Status("restarting all nodes gradually")
+	for _, nodeID := range c.CRDBNodes() {
+		t.L().Printf("stopping node %d", nodeID)
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(nodeID))
+
+		t.L().Printf("starting node %d", nodeID)
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(nodeID))
+
+		// Wait for node to be ready by performing a simple query
+		t.L().Printf("waiting for readiness of node %d", nodeID)
+		db := c.Conn(ctx, t.L(), nodeID)
+		if _, err := db.ExecContext(ctx, `SELECT 1`); err != nil {
+			db.Close()
+			t.Fatalf("node %d failed to become ready: %v", nodeID, err)
+		}
+		db.Close()
+		t.Status("running TPCC workload after restarting: %d", nodeID)
+		if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runCmd.String()); err != nil {
+			t.Fatalf("failed to run TPCC workload after restarting: %d", nodeID)
+		}
+	}
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -57,6 +57,7 @@ func RegisterTests(r registry.Registry) {
 	registerDjango(r)
 	registerDrain(r)
 	registerDrop(r)
+	registerDRPCTests(r)
 	registerEncryption(r)
 	registerFailover(r)
 	registerFixtures(r)


### PR DESCRIPTION
This tests that enabling DRPC on an upgraded (and finalized) cluster should not break the cluster immediately. Since we require nodes to be restarted for most RPC clients to start using DRPC, we want to ensure nothing breaks in a mixed state where some nodes are restarted while others are not during the rolling restart process.

To address this, this patch adds a roachtest that:
1. Starts a cluster with a predecessor version
2. Upgrades all nodes to the current version
3. Enables the DRPC cluster setting
4. Runs a TPCC workload to validate connectivity
5. Performs rolling restarts of all nodes
6. Validates that DRPC continues to work after each restart

Release note: none
Epic: none