### PR TITLE
sem/eval: fix TestCastMap properly for AnyTuple

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -239,21 +239,16 @@ func RandDatumWithNullChance(
 		}
 		return tree.NewDJsonpath(*jp.AST)
 	case types.TupleFamily:
-		tuple := tree.DTuple{D: make(tree.Datums, len(typ.TupleContents()))}
 		if nullChance == 0 {
-			// Even if nullOk=false (which is when nullChance=0), we still want
-			// to generate a NULL _element_ in 10% of cases.
 			nullChance = 10
 		}
+		datums := make([]tree.Datum, len(typ.TupleContents()))
 		for i := range typ.TupleContents() {
-			tuple.D[i] = RandDatumWithNullChance(
+			datums[i] = RandDatumWithNullChance(
 				rng, typ.TupleContents()[i], nullChance, favorCommonData, targetColumnIsUnique,
 			)
 		}
-		// Calling ResolvedType causes the internal TupleContents types to be
-		// populated (as well as resolves the type of each tuple element).
-		tuple.ResolvedType()
-		return &tuple
+		return tree.NewDTuple(typ, datums...)
 	case types.BitFamily:
 		width := typ.Width()
 		if width == 0 {

--- a/pkg/sql/randgen/types_test.go
+++ b/pkg/sql/randgen/types_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -67,30 +66,7 @@ func TestCanonical(t *testing.T) {
 		datum := RandDatum(rng, typ, false)
 		datumTyp := datum.ResolvedType()
 		if !datumTyp.Equivalent(typ.Canonical()) {
-			var tupleHasNullElement func(tree.Datum) bool
-			tupleHasNullElement = func(d tree.Datum) bool {
-				tup, ok := d.(*tree.DTuple)
-				if !ok {
-					return false
-				}
-				for _, el := range tup.D {
-					if el == tree.DNull {
-						return true
-					}
-					if tupleHasNullElement(el) {
-						return true
-					}
-				}
-				return false
-			}
-			// If we have a tuple, then we might have included a NULL element.
-			// By construction in RandDatum, TupleContents[i] has been updated
-			// to types.Unknown. In such case, we give an exception and don't
-			// fail the test.
-			tupleException := tupleHasNullElement(datum)
-			if !tupleException {
-				t.Errorf("fail: canonical type of %+v is %+v and the datum's type is %+v", typ, typ.Canonical(), datumTyp)
-			}
+			t.Errorf("fail: canonical type of %+v is %+v and the datum's type is %+v", typ, typ.Canonical(), datumTyp)
 		}
 
 		if datumTyp.Oid() != typ.Canonical().Oid() {

--- a/pkg/sql/sem/eval/cast_map_test.go
+++ b/pkg/sql/sem/eval/cast_map_test.go
@@ -38,6 +38,21 @@ func TestCastMap(t *testing.T) {
 
 	cast.ForEachCast(func(src, tgt oid.Oid, _ cast.Context, _ cast.ContextOrigin, _ volatility.V) {
 		srcType := types.OidToType[src]
+		if srcType.Oid() == oid.T_record {
+			// We're looking at the types.AnyTuple that is a wildcard that
+			// cannot be used during execution. In order to make it a valid
+			// execution type, we construct an equivalent with the tuple element
+			// resolved to a random type.
+			var emptyLocale = ""
+			srcType = &types.T{
+				InternalType: types.InternalType{
+					Family:        types.TupleFamily,
+					TupleContents: []*types.T{randgen.RandType(rng)},
+					Oid:           oid.T_record,
+					Locale:        &emptyLocale,
+				},
+			}
+		}
 		tgtType := types.OidToType[tgt]
 		srcDatum := randgen.RandDatum(rng, srcType, false /* nullOk */)
 


### PR DESCRIPTION
**Revert "randgen: fix recent regression in tuple generation"**

This reverts commit ed045f3.

**sem/eval: fix TestCastMap properly for AnyTuple**

`TestCastMap` iterates over `types.OidToType` map to find all
interesting pairs to perform the cast between. One of the representative
types in the map is `types.AnyTuple` that is actually not a valid
execution-time type (it's a wildcard used only during static analysis).
Previously we could crash in the test if we happen to pick a float value
as the element corresponding to the single Any type element (because
float width is 0 there). This commit fixes the test by effectively
"resolving" `AnyTuple` type to a concrete tuple type with a single
random type as the element.

Informs: #153805.
Epic: None
Release note: None