### PR TITLE
kvserver: move off Dev logging channel in subpackages

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -986,9 +986,9 @@ func (a *Allocator) ComputeAction(
 	// to be processed with the correct priority.
 	if priority == -1 {
 		if buildutil.CrdbTestBuild {
-			log.Dev.Fatalf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+			log.KvDistribution.Fatalf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
 		} else {
-			log.Dev.Warningf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
+			log.KvDistribution.Warningf(ctx, "allocator returned -1 priority for range %s: %v", desc, action)
 		}
 	}
 	return action, priority

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -2852,7 +2852,7 @@ func TestAllocatorRebalanceDifferentLocalitySizes(t *testing.T) {
 	}
 
 	for i, tc := range testCases2 {
-		log.Dev.Infof(ctx, "case #%d", i)
+		log.KvDistribution.Infof(ctx, "case #%d", i)
 		var rangeUsageInfo allocator.RangeUsageInfo
 		result, _, details, ok := a.RebalanceVoter(
 			ctx,
@@ -8764,13 +8764,13 @@ func (ts *testStore) rebalance(ots *testStore, bytes int64, qps float64, do Disk
 	// almost out of disk. (In a real allocator this is, for example, in
 	// rankedCandidateListFor{Allocation,Rebalancing}).
 	if !do.maxCapacityCheck(ots.StoreDescriptor) {
-		log.Dev.Infof(
+		log.KvDistribution.Infof(
 			context.Background(),
 			"s%d too full to accept snapshot from s%d: %v", ots.StoreID, ts.StoreID, ots.Capacity,
 		)
 		return
 	}
-	log.Dev.Infof(context.Background(), "s%d accepting snapshot from s%d", ots.StoreID, ts.StoreID)
+	log.KvDistribution.Infof(context.Background(), "s%d accepting snapshot from s%d", ots.StoreID, ts.StoreID)
 	ts.Capacity.RangeCount--
 	ts.Capacity.QueriesPerSecond -= qps
 	if ts.immediateCompaction {
@@ -8801,7 +8801,7 @@ func Example_rangeCountRebalancing() {
 			alloc.ScorerOptions(ctx),
 		)
 		if ok {
-			log.Dev.Infof(ctx, "rebalancing to %v; details: %s", target, details)
+			log.KvDistribution.Infof(ctx, "rebalancing to %v; details: %s", target, details)
 			ts.rebalance(
 				&testStores[int(target.StoreID)],
 				alloc.randGen.Int63n(1<<20),
@@ -8916,7 +8916,7 @@ func qpsBasedRebalanceFn(
 		opts,
 	)
 	if ok {
-		log.Dev.Infof(ctx, "rebalancing from %v to %v; details: %s", remove, add, details)
+		log.KvDistribution.Infof(ctx, "rebalancing from %v to %v; details: %s", remove, add, details)
 		candidate.rebalance(&testStores[int(add.StoreID)], alloc.randGen.Int63n(1<<20), jitteredQPS, opts.BaseScorerOptions.DiskCapacity)
 	}
 }

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -353,7 +353,7 @@ func makeRebalanceReplicaChanges(
 		}
 	}
 	if remove == (StoreIDAndReplicaState{}) {
-		log.Dev.Fatalf(context.Background(), "remove target %s not in existing replicas", removeTarget)
+		log.KvDistribution.Fatalf(context.Background(), "remove target %s not in existing replicas", removeTarget)
 	}
 
 	addState := ReplicaState{
@@ -1169,7 +1169,7 @@ func (cs *clusterState) processStoreLoadMsg(ctx context.Context, storeMsg *Store
 	// corresponding delta adjustment as the reported load already contains the
 	// effect.
 	for _, change := range ss.computePendingChangesReflectedInLatestLoad(storeMsg.LoadTime) {
-		log.Dev.VInfof(ctx, 2, "s%d not-pending %v", storeMsg.StoreID, change)
+		log.KvDistribution.VInfof(ctx, 2, "s%d not-pending %v", storeMsg.StoreID, change)
 		delete(ss.adjusted.loadPendingChanges, change.ChangeID)
 	}
 
@@ -1179,7 +1179,7 @@ func (cs *clusterState) processStoreLoadMsg(ctx context.Context, storeMsg *Store
 		// replicas.
 		cs.applyChangeLoadDelta(change.ReplicaChange)
 	}
-	log.Dev.VInfof(ctx, 2, "processStoreLoadMsg for store s%v: %v",
+	log.KvDistribution.VInfof(ctx, 2, "processStoreLoadMsg for store s%v: %v",
 		storeMsg.StoreID, ss.adjusted.load)
 }
 
@@ -1279,7 +1279,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		// rs.pendingChanges is the union of remainingChanges and enactedChanges.
 		// These changes are also in cs.pendingChanges.
 		if len(enactedChanges) > 0 {
-			log.Dev.Infof(ctx, "enactedChanges %v", enactedChanges)
+			log.KvDistribution.Infof(ctx, "enactedChanges %v", enactedChanges)
 		}
 		for _, change := range enactedChanges {
 			// Mark the change as enacted. Enacting a change does not remove the
@@ -1301,7 +1301,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		// effect is also incorporated into the storeStates, but not in the range
 		// membership (since we undid that above).
 		if len(remainingChanges) > 0 {
-			log.Dev.Infof(ctx, "remainingChanges %v", remainingChanges)
+			log.KvDistribution.Infof(ctx, "remainingChanges %v", remainingChanges)
 			// Temporarily set the rs.pendingChanges to nil, since
 			// preCheckOnApplyReplicaChanges returns false if there are any pending
 			// changes, and these are the changes that are pending. This is hacky
@@ -1324,7 +1324,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 				// changes, so we need to drop them. This should be rare, but can happen
 				// if the leaseholder executed a change that MMA was completely unaware
 				// of.
-				log.Dev.Infof(ctx, "remainingChanges %v are no longer valid due to %v",
+				log.KvDistribution.Infof(ctx, "remainingChanges %v are no longer valid due to %v",
 					remainingChanges, reason)
 				if metrics != nil {
 					metrics.DroppedDueToStateInconsistency.Inc(1)
@@ -1556,7 +1556,7 @@ func (cs *clusterState) gcPendingChanges(now time.Time) {
 	}
 	if len(replicaChanges) > 0 {
 		if valid, reason := cs.preCheckOnUndoReplicaChanges(replicaChanges); !valid {
-			log.Dev.Infof(context.Background(), "did not undo change %v: due to %v", removeChangeIds, reason)
+			log.KvDistribution.Infof(context.Background(), "did not undo change %v: due to %v", removeChangeIds, reason)
 			return
 		}
 		for _, rmChange := range removeChangeIds {
@@ -1664,7 +1664,7 @@ func (cs *clusterState) createPendingChanges(changes ...ReplicaChange) []*pendin
 		cs.pendingChanges[cid] = pendingChange
 		storeState.adjusted.loadPendingChanges[cid] = pendingChange
 		rangeState.pendingChanges = append(rangeState.pendingChanges, pendingChange)
-		log.Dev.VInfof(context.Background(), 3, "createPendingChanges: change_id=%v, range_id=%v, change=%v", cid, change.rangeID, change)
+		log.KvDistribution.VInfof(context.Background(), 3, "createPendingChanges: change_id=%v, range_id=%v, change=%v", cid, change.rangeID, change)
 		pendingChanges = append(pendingChanges, pendingChange)
 	}
 	return pendingChanges
@@ -1691,7 +1691,7 @@ func (cs *clusterState) preCheckOnApplyReplicaChanges(
 		return false, "range does not exist in cluster state"
 	}
 	if len(curr.pendingChanges) > 0 {
-		log.Dev.VInfof(context.Background(), 2, "range %d has pending changes: %v",
+		log.KvDistribution.VInfof(context.Background(), 2, "range %d has pending changes: %v",
 			rangeID, curr.pendingChanges)
 		return false, "range has pending changes"
 	}
@@ -1792,7 +1792,7 @@ func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange
 		panic(fmt.Sprintf("range %v not found in cluster state", change.rangeID))
 	}
 
-	log.Dev.VInfof(context.Background(), 2, "applying replica change %v to range %d on store %d",
+	log.KvDistribution.VInfof(context.Background(), 2, "applying replica change %v to range %d on store %d",
 		change, change.rangeID, change.target.StoreID)
 	if change.isRemoval() {
 		delete(storeState.adjusted.replicas, change.rangeID)
@@ -1823,7 +1823,7 @@ func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange
 }
 
 func (cs *clusterState) undoReplicaChange(change ReplicaChange) {
-	log.Dev.Infof(context.Background(), "undoing replica change %v to range %d on store %d",
+	log.KvDistribution.Infof(context.Background(), "undoing replica change %v to range %d on store %d",
 		change, change.rangeID, change.target.StoreID)
 	rangeState := cs.ranges[change.rangeID]
 	storeState := cs.stores[change.target.StoreID]
@@ -1987,11 +1987,11 @@ func (cs *clusterState) canShedAndAddLoad(
 	var reason strings.Builder
 	defer func() {
 		if canAddLoad {
-			log.Dev.VInfof(ctx, 3, "can add load to n%vs%v: %v targetSLS[%v] srcSLS[%v]",
+			log.KvDistribution.VInfof(ctx, 3, "can add load to n%vs%v: %v targetSLS[%v] srcSLS[%v]",
 				targetNS.NodeID, targetSS.StoreID, canAddLoad, targetSLS, srcSLS)
 		} else {
-			log.Dev.VInfof(ctx, 2, "cannot add load to n%vs%v: due to %s", targetNS.NodeID, targetSS.StoreID, reason.String())
-			log.Dev.VInfof(ctx, 2, "[target_sls:%v,src_sls:%v]", targetSLS, srcSLS)
+			log.KvDistribution.VInfof(ctx, 2, "cannot add load to n%vs%v: due to %s", targetNS.NodeID, targetSS.StoreID, reason.String())
+			log.KvDistribution.VInfof(ctx, 2, "[target_sls:%v,src_sls:%v]", targetSLS, srcSLS)
 		}
 	}()
 	if targetSLS.highDiskSpaceUtilization {
@@ -2078,7 +2078,7 @@ func (cs *clusterState) canShedAndAddLoad(
 		}
 		// The use of 33% is arbitrary.
 		if dimFractionIncrease > overloadedDimFractionIncrease/3 {
-			log.Dev.Infof(ctx, "%v: %f > %f/3", dim, dimFractionIncrease, overloadedDimFractionIncrease)
+			log.KvDistribution.Infof(ctx, "%v: %f > %f/3", dim, dimFractionIncrease, overloadedDimFractionIncrease)
 			otherDimensionsBecameWorseInTarget = true
 			break
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -510,10 +510,10 @@ func loadSummaryForDimension(
 	defer func() {
 		if log.V(2) {
 			if storeID == 0 {
-				log.Dev.Infof(ctx, "n%d[%v]: load=%d, mean_load=%d, fraction above=%.2f, load_summary=%v",
+				log.KvDistribution.Infof(ctx, "n%d[%v]: load=%d, mean_load=%d, fraction above=%.2f, load_summary=%v",
 					nodeID, dim, load, meanLoad, fractionAbove, summary)
 			} else {
-				log.Dev.Infof(ctx, "s%d[%v]: load=%d, mean_load=%d, fraction above=%.2f, load_summary=%v",
+				log.KvDistribution.Infof(ctx, "s%d[%v]: load=%d, mean_load=%d, fraction above=%.2f, load_summary=%v",
 					storeID, dim, load, meanLoad, fractionAbove, summary)
 			}
 		}
@@ -575,7 +575,7 @@ func loadSummaryForDimension(
 
 func highDiskSpaceUtilization(load LoadValue, capacity LoadValue) bool {
 	if capacity == UnknownCapacity {
-		log.Dev.Errorf(context.Background(), "disk capacity is unknown")
+		log.KvDistribution.Errorf(context.Background(), "disk capacity is unknown")
 		return false
 	}
 	fractionUsed := float64(load) / float64(capacity)

--- a/pkg/kv/kvserver/allocator/mmaprototype/top_k_replicas.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/top_k_replicas.go
@@ -40,7 +40,7 @@ func (t *topKReplicas) addReplica(
 	msgStoreID roachpb.StoreID,
 ) {
 	if loadValue < t.threshold {
-		log.Dev.VInfof(ctx, 3, "(r%d,s%d,lhs%d): load%v<threshold%v, skipping for dim %s",
+		log.KvDistribution.VInfof(ctx, 3, "(r%d,s%d,lhs%d): load%v<threshold%v, skipping for dim %s",
 			rangeID, replicaStoreID, msgStoreID, loadValue, t.threshold, t.dim)
 		return
 	}

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -487,7 +487,7 @@ func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value, _ int64)
 
 	if err := content.GetProto(&storeDesc); err != nil {
 		ctx := sp.AnnotateCtx(context.TODO())
-		log.Dev.Errorf(ctx, "%v", err)
+		log.KvDistribution.Errorf(ctx, "%v", err)
 		return
 	}
 
@@ -930,7 +930,7 @@ func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 				liveReplicas = append(liveReplicas, repl)
 			}
 		default:
-			log.Dev.Fatalf(context.TODO(), "unknown store status %d", status)
+			log.KvDistribution.Fatalf(context.TODO(), "unknown store status %d", status)
 		}
 	}
 	return
@@ -1278,11 +1278,11 @@ func (sp *StorePool) Throttle(reason ThrottleReason, why string, storeID roachpb
 		detail.ThrottledUntil = sp.clock.Now().AddDuration(timeout)
 		if log.V(2) {
 			ctx := sp.AnnotateCtx(context.TODO())
-			log.Dev.Infof(ctx, "snapshot failed (%s), s%d will be throttled for %s until %s",
+			log.KvDistribution.Infof(ctx, "snapshot failed (%s), s%d will be throttled for %s until %s",
 				why, storeID, timeout, detail.ThrottledUntil)
 		}
 	default:
-		log.Dev.Warningf(sp.AnnotateCtx(context.TODO()), "unknown throttle reason %v", reason)
+		log.KvDistribution.Warningf(sp.AnnotateCtx(context.TODO()), "unknown throttle reason %v", reason)
 	}
 }
 

--- a/pkg/kv/kvserver/asim/assertion/assert.go
+++ b/pkg/kv/kvserver/asim/assertion/assert.go
@@ -108,7 +108,7 @@ func (sa SteadyStateAssertion) Assert(
 	m := h.Recorded
 	ticks := len(m)
 	if sa.Ticks > ticks {
-		log.Dev.VInfof(ctx, 2,
+		log.KvDistribution.VInfof(ctx, 2,
 			"The history to run assertions against (%d) is shorter than "+
 				"the assertion duration (%d)", ticks, sa.Ticks)
 		return true, ""
@@ -213,7 +213,7 @@ func (ba BalanceAssertion) Assert(
 	m := h.Recorded
 	ticks := len(m)
 	if ba.Ticks > ticks {
-		log.Dev.VInfof(ctx, 2,
+		log.KvDistribution.VInfof(ctx, 2,
 			"The history to run assertions against (%d) is shorter than "+
 				"the assertion duration (%d)", ticks, ba.Ticks)
 		return true, ""
@@ -235,7 +235,7 @@ func (ba BalanceAssertion) Assert(
 		max, _ := stats.Max(tickStats)
 		maxMeanRatio := max / mean
 
-		log.Dev.VInfof(ctx, 2,
+		log.KvDistribution.VInfof(ctx, 2,
 			"Balance assertion: stat=%s, max/mean=%.2f, threshold=%+v raw=%v",
 			ba.Stat, maxMeanRatio, ba.Threshold, tickStats)
 		if ba.Threshold.isViolated(maxMeanRatio) {
@@ -276,7 +276,7 @@ func (sa StoreStatAssertion) Assert(
 	m := h.Recorded
 	ticks := len(m)
 	if sa.Ticks > ticks {
-		log.Dev.VInfof(ctx, 2,
+		log.KvDistribution.VInfof(ctx, 2,
 			"The history to run assertions against (%d) is shorter than "+
 				"the assertion duration (%d)", ticks, sa.Ticks)
 		return true, ""

--- a/pkg/kv/kvserver/asim/event/mutation_event.go
+++ b/pkg/kv/kvserver/asim/event/mutation_event.go
@@ -164,7 +164,7 @@ func (sne SetNodeLivenessEvent) String() string {
 
 func (sce SetCapacityOverrideEvent) Func() EventFunc {
 	return MutationFunc(func(ctx context.Context, s state.State) {
-		log.Dev.Infof(ctx, "setting capacity override %v", sce.CapacityOverride)
+		log.KvDistribution.Infof(ctx, "setting capacity override %v", sce.CapacityOverride)
 		s.SetCapacityOverride(sce.StoreID, sce.CapacityOverride)
 	})
 }
@@ -175,7 +175,7 @@ func (sce SetCapacityOverrideEvent) String() string {
 
 func (sne SetNodeLocalityEvent) Func() EventFunc {
 	return MutationFunc(func(ctx context.Context, s state.State) {
-		log.Dev.Infof(ctx, "setting node locality %v", sne.LocalityString)
+		log.KvDistribution.Infof(ctx, "setting node locality %v", sne.LocalityString)
 		if sne.LocalityString != "" {
 			var locality roachpb.Locality
 			if err := locality.Set(sne.LocalityString); err != nil {

--- a/pkg/kv/kvserver/asim/metrics/cluster_tracker.go
+++ b/pkg/kv/kvserver/asim/metrics/cluster_tracker.go
@@ -103,6 +103,6 @@ func (m *ClusterMetricsTracker) Listen(ctx context.Context, sms []StoreMetrics) 
 	record = append(record, fmt.Sprintf("%d", totalBytesRebalanced))
 
 	if err := m.write(record); err != nil {
-		log.Dev.Errorf(ctx, "Error writing cluster metrics %s", err.Error())
+		log.KvDistribution.Errorf(ctx, "Error writing cluster metrics %s", err.Error())
 	}
 }

--- a/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
@@ -132,15 +132,15 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 				msr.pendingTicket = -1
 				success := true
 				if err := op.Errors(); err != nil {
-					log.Dev.Infof(ctx, "operation for pendingChange=%v failed: %v", curChange, err)
+					log.KvDistribution.Infof(ctx, "operation for pendingChange=%v failed: %v", curChange, err)
 					success = false
 				} else {
-					log.Dev.VInfof(ctx, 1, "operation for pendingChange=%v completed successfully", curChange)
+					log.KvDistribution.VInfof(ctx, 1, "operation for pendingChange=%v completed successfully", curChange)
 				}
 				msr.as.PostApply(curChange.syncChangeID, success)
 				msr.pendingChangeIdx++
 			} else {
-				log.Dev.VInfof(ctx, 1, "operation for pendingChange=%v is still in progress", curChange)
+				log.KvDistribution.VInfof(ctx, 1, "operation for pendingChange=%v is still in progress", curChange)
 				// Operation is still in progress, nothing to do this tick.
 				return
 			}
@@ -151,7 +151,7 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 			msr.pendingChanges = nil
 			msr.pendingChangeIdx = 0
 			msr.lastRebalanceTime = tick
-			log.Dev.VInfof(ctx, 1, "no more pending changes to process, will call compute changes again")
+			log.KvDistribution.VInfof(ctx, 1, "no more pending changes to process, will call compute changes again")
 			storeLeaseholderMsg := MakeStoreLeaseholderMsgFromState(s, msr.localStoreID)
 			pendingChanges := msr.allocator.ComputeChanges(ctx, &storeLeaseholderMsg, mmaprototype.ChangeOptions{
 				LocalStoreID: roachpb.StoreID(msr.localStoreID),
@@ -163,11 +163,11 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 					usage:  usageInfo,
 				})
 			}
-			log.Dev.Infof(ctx, "store %d: computed %d changes %v", msr.localStoreID, len(msr.pendingChanges), msr.pendingChanges)
+			log.KvDistribution.Infof(ctx, "store %d: computed %d changes %v", msr.localStoreID, len(msr.pendingChanges), msr.pendingChanges)
 			if len(msr.pendingChanges) == 0 {
 				// Nothing to do, there were no changes returned.
 				msr.currentlyRebalancing = false
-				log.Dev.VInfof(ctx, 1, "no pending changes to process, will wait for next tick")
+				log.KvDistribution.VInfof(ctx, 1, "no pending changes to process, will wait for next tick")
 				return
 			}
 
@@ -202,7 +202,7 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 		} else {
 			panic(fmt.Sprintf("unexpected pending change type: %v", curChange))
 		}
-		log.Dev.VInfof(ctx, 1, "dispatching operation for pendingChange=%v", curChange)
+		log.KvDistribution.VInfof(ctx, 1, "dispatching operation for pendingChange=%v", curChange)
 		msr.pendingChanges[msr.pendingChangeIdx].syncChangeID =
 			msr.as.MMAPreApply(curChange.usage, curChange.change)
 		msr.pendingTicket = msr.controller.Dispatch(ctx, tick, s, curOp)

--- a/pkg/kv/kvserver/asim/queue/lease_queue.go
+++ b/pkg/kv/kvserver/asim/queue/lease_queue.go
@@ -79,7 +79,7 @@ func (lq *leaseQueue) MaybeAdd(ctx context.Context, replica state.Replica, s sta
 	desc := repl.Desc()
 	conf, err := repl.SpanConfig()
 	if err != nil {
-		log.Dev.Fatalf(ctx, "conf not found err=%v", err)
+		log.KvDistribution.Fatalf(ctx, "conf not found err=%v", err)
 	}
 	log.VEventf(ctx, 1, "maybe add replica=%s, config=%s", desc, conf)
 	shouldPlanChange, priority := lq.planner.ShouldPlanChange(
@@ -160,7 +160,7 @@ func (lq *leaseQueue) Tick(ctx context.Context, tick time.Time, s state.State) {
 			CanTransferLease: true,
 		})
 		if err != nil {
-			log.Dev.Errorf(ctx, "error planning change %s", err.Error())
+			log.KvDistribution.Errorf(ctx, "error planning change %s", err.Error())
 			continue
 		}
 

--- a/pkg/kv/kvserver/asim/queue/replicate_queue.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue.go
@@ -77,7 +77,7 @@ func (rq *replicateQueue) MaybeAdd(ctx context.Context, replica state.Replica, s
 	desc := repl.Desc()
 	conf, err := repl.SpanConfig()
 	if err != nil {
-		log.Dev.Fatalf(ctx, "conf not found err=%v", err)
+		log.KvDistribution.Fatalf(ctx, "conf not found err=%v", err)
 	}
 	log.VEventf(ctx, 1, "maybe add replica=%s, config=%s", desc, conf)
 
@@ -154,7 +154,7 @@ func (rq *replicateQueue) Tick(ctx context.Context, tick time.Time, s state.Stat
 		}
 		change, err := rq.planner.PlanOneChange(ctx, repl, desc, conf, plan.PlannerOptions{})
 		if err != nil {
-			log.Dev.Errorf(ctx, "error planning change %s", err.Error())
+			log.KvDistribution.Errorf(ctx, "error planning change %s", err.Error())
 			continue
 		}
 

--- a/pkg/kv/kvserver/asim/scheduled/scheduled_event_executor.go
+++ b/pkg/kv/kvserver/asim/scheduled/scheduled_event_executor.go
@@ -134,7 +134,7 @@ func (e *eventExecutor) TickEvents(
 	// to.
 	for e.nextEventIndex < len(e.scheduledEvents) {
 		if !tick.Before(e.scheduledEvents[e.nextEventIndex].At) {
-			log.Dev.Infof(ctx, "applying event (scheduled=%s tick=%s)", e.scheduledEvents[e.nextEventIndex].At, tick)
+			log.KvDistribution.Infof(ctx, "applying event (scheduled=%s tick=%s)", e.scheduledEvents[e.nextEventIndex].At, tick)
 			scheduledEvent := e.scheduledEvents[e.nextEventIndex]
 			fn := scheduledEvent.TargetEvent.Func()
 			if scheduledEvent.IsMutationEvent() {

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
@@ -226,7 +226,7 @@ func setupData(
 
 	dir := testfixtures.ReuseOrGenerate(b, name, func(dir string) {
 		eng := emk(b, dir, opts.lBaseMaxBytes, fs.ReadWrite)
-		log.Dev.Infof(ctx, "creating refresh range benchmark data: %s", dir)
+		log.KvExec.Infof(ctx, "creating refresh range benchmark data: %s", dir)
 
 		// Generate the same data every time.
 		rng := rand.New(rand.NewSource(1449168817))
@@ -265,7 +265,7 @@ func setupData(
 			// optimizations which change the data size result in the same number of
 			// sstables.
 			if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
-				log.Dev.Infof(ctx, "committing (%d/~%d) (%d/%d)", i/scaled, 20, i, len(order))
+				log.KvExec.Infof(ctx, "committing (%d/~%d) (%d/%d)", i/scaled, 20, i, len(order))
 				if err := batch.Commit(false /* sync */); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/kv/kvserver/closedts/policyrefresher/policy_refresher.go
+++ b/pkg/kv/kvserver/closedts/policyrefresher/policy_refresher.go
@@ -69,7 +69,7 @@ func NewPolicyRefresher(
 	knobs *TestingKnobs,
 ) *PolicyRefresher {
 	if getLeaseholderReplicas == nil || getNodeLatencies == nil {
-		log.Dev.Fatalf(context.Background(), "getLeaseholderReplicas and getNodeLatencies must be non-nil")
+		log.KvDistribution.Fatalf(context.Background(), "getLeaseholderReplicas and getNodeLatencies must be non-nil")
 		return nil
 	}
 	refresher := &PolicyRefresher{

--- a/pkg/kv/kvserver/closedts/sidetransport/receiver.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/receiver.go
@@ -147,7 +147,7 @@ func (s *Receiver) onRecvErr(ctx context.Context, nodeID roachpb.NodeID, err err
 	defer s.mu.Unlock()
 
 	if err != io.EOF {
-		log.Dev.Warningf(ctx, "closed timestamps side-transport connection dropped from node: %d (%s)", nodeID, err)
+		log.KvDistribution.Warningf(ctx, "closed timestamps side-transport connection dropped from node: %d (%s)", nodeID, err)
 	} else {
 		log.VEventf(ctx, 2, "closed timestamps side-transport connection dropped from node: %d (%s)", nodeID, err)
 	}
@@ -236,11 +236,11 @@ func (r *incomingStream) processUpdate(ctx context.Context, msg *ctpb.Update) {
 	log.VEventf(ctx, 4, "received side-transport update: %v", msg)
 
 	if msg.NodeID == 0 {
-		log.Dev.Fatalf(ctx, "missing NodeID in message: %s", msg)
+		log.KvDistribution.Fatalf(ctx, "missing NodeID in message: %s", msg)
 	}
 
 	if msg.NodeID != r.nodeID {
-		log.Dev.Fatalf(ctx, "wrong NodeID; expected %d, got %d", r.nodeID, msg.NodeID)
+		log.KvDistribution.Fatalf(ctx, "wrong NodeID; expected %d, got %d", r.nodeID, msg.NodeID)
 	}
 
 	// Handle the removed ranges. In order to not lose closed ts info, before we
@@ -259,11 +259,11 @@ func (r *incomingStream) processUpdate(ctx context.Context, msg *ctpb.Update) {
 		for _, rangeID := range msg.Removed {
 			info, ok := r.mu.tracked[rangeID]
 			if !ok {
-				log.Dev.Fatalf(ctx, "attempting to unregister a missing range: r%d", rangeID)
+				log.KvDistribution.Fatalf(ctx, "attempting to unregister a missing range: r%d", rangeID)
 			}
 			ts, ok := r.mu.lastClosed[info.policy]
 			if !ok {
-				log.Dev.Fatalf(ctx, "missing closed timestamp policy %v for range r%d", info.policy, rangeID)
+				log.KvDistribution.Fatalf(ctx, "missing closed timestamp policy %v for range r%d", info.policy, rangeID)
 			}
 			r.stores.ForwardSideTransportClosedTimestampForRange(ctx, rangeID, ts, info.lai)
 		}
@@ -279,7 +279,7 @@ func (r *incomingStream) processUpdate(ctx context.Context, msg *ctpb.Update) {
 		r.mu.lastClosed = make(map[ctpb.RangeClosedTimestampPolicy]hlc.Timestamp, len(r.mu.lastClosed))
 		r.mu.tracked = make(map[roachpb.RangeID]trackedRange, len(r.mu.tracked))
 	} else if msg.SeqNum != r.mu.lastSeqNum+1 {
-		log.Dev.Fatalf(ctx, "expected closed timestamp side-transport message with sequence number "+
+		log.KvDistribution.Fatalf(ctx, "expected closed timestamp side-transport message with sequence number "+
 			"%d, got %d", r.mu.lastSeqNum+1, msg.SeqNum)
 	}
 	r.mu.lastSeqNum = msg.SeqNum
@@ -328,13 +328,13 @@ func (r *incomingStream) Run(
 				r.nodeID = msg.NodeID
 
 				if err := r.server.onFirstMsg(ctx, r, r.nodeID); err != nil {
-					log.Dev.Warningf(ctx, "%s", err.Error())
+					log.KvDistribution.Warningf(ctx, "%s", err.Error())
 					return
 				} else if ch := r.testingKnobs.onFirstMsg; ch != nil {
 					ch <- struct{}{}
 				}
 				if !msg.Snapshot {
-					log.Dev.Fatal(ctx, "expected the first message to be a snapshot")
+					log.KvDistribution.Fatal(ctx, "expected the first message to be a snapshot")
 				}
 				r.AddLogTag("remote", r.nodeID)
 				ctx = r.AnnotateCtx(ctx)

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -575,7 +575,7 @@ func (b *updatesBuf) Push(ctx context.Context, update *ctpb.Update) {
 	if b.sizeLocked() != 0 {
 		lastIdx := b.lastIdxLocked()
 		if prevSeq := b.mu.data[lastIdx].SeqNum; prevSeq != update.SeqNum-1 {
-			log.Dev.Fatalf(ctx, "bad sequence number; expected %d, got %d", prevSeq+1, update.SeqNum)
+			log.KvDistribution.Fatalf(ctx, "bad sequence number; expected %d, got %d", prevSeq+1, update.SeqNum)
 		}
 	}
 
@@ -634,7 +634,7 @@ func (b *updatesBuf) GetBySeq(ctx context.Context, seqNum ctpb.SeqNum) (*ctpb.Up
 			continue
 		}
 		if seqNum > lastSeq+1 {
-			log.Dev.Fatalf(ctx, "skipping sequence numbers; requested: %d, last: %d", seqNum, lastSeq)
+			log.KvDistribution.Fatalf(ctx, "skipping sequence numbers; requested: %d, last: %d", seqNum, lastSeq)
 		}
 		idx := (b.mu.head + (int)(seqNum-firstSeq)) % len(b.mu.data)
 		return b.mu.data[idx], true
@@ -826,7 +826,7 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 				}
 				if err := r.maybeConnect(ctx, stopper); err != nil {
 					if !errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) && everyN.ShouldLog() {
-						log.Dev.Infof(ctx, "side-transport failed to connect to n%d: %s", r.nodeID, err)
+						log.KvDistribution.Infof(ctx, "side-transport failed to connect to n%d: %s", r.nodeID, err)
 					}
 					time.Sleep(errSleepTime)
 					continue
@@ -856,7 +856,7 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 				}
 				if err := r.stream.Send(msg); err != nil {
 					if err != io.EOF && everyN.ShouldLog() {
-						log.Dev.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
+						log.KvDistribution.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
 							r.lastSent, r.nodeID, err)
 					}
 					// Keep track of the fact that we need a new connection.

--- a/pkg/kv/kvserver/closedts/tracker/heap_tracker.go
+++ b/pkg/kv/kvserver/closedts/tracker/heap_tracker.go
@@ -103,7 +103,7 @@ func (h *heapTracker) Track(ctx context.Context, ts hlc.Timestamp) RemovalToken 
 func (h *heapTracker) Untrack(ctx context.Context, tok RemovalToken) {
 	idx := tok.(heapToken).index
 	if idx == -1 {
-		log.Dev.Fatalf(ctx, "attempting to untrack already-untracked item")
+		log.KvDistribution.Fatalf(ctx, "attempting to untrack already-untracked item")
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/pkg/kv/kvserver/closedts/tracker/lockfree_tracker.go
+++ b/pkg/kv/kvserver/closedts/tracker/lockfree_tracker.go
@@ -168,7 +168,7 @@ func (t *lockfreeTracker) Untrack(ctx context.Context, tok RemovalToken) {
 	// types.
 	refcnt := b.refcnt.Add(-1)
 	if refcnt < 0 {
-		log.Dev.Fatalf(ctx, "negative bucket refcount: %d", refcnt)
+		log.KvDistribution.Fatalf(ctx, "negative bucket refcount: %d", refcnt)
 	}
 	if refcnt == 0 {
 		// Reset the bucket, so that future Track() calls can create a new one.

--- a/pkg/kv/kvserver/closedts/tracker/tracker_test.go
+++ b/pkg/kv/kvserver/closedts/tracker/tracker_test.go
@@ -167,7 +167,7 @@ func TestLockfreeTrackerRandomStress(t *testing.T) {
 	// hours of stressrace on GCE worker (and it failed once on CI stress too).
 	// Figure out why.
 	maxToleratedErrorMillis := 3 * c.maxEvaluationTime.Milliseconds()
-	log.Dev.Infof(ctx, "maximum lower bound error: %dms. maximum request evaluation time: %s",
+	log.KvDistribution.Infof(ctx, "maximum lower bound error: %dms. maximum request evaluation time: %s",
 		maxOvershotMillis, c.maxEvaluationTime)
 	require.Lessf(t, maxOvershotMillis, maxToleratedErrorMillis,
 		"maximum tracker lowerbound error was %dms, above maximum tolerated %dms",
@@ -446,7 +446,7 @@ func (c *trackerChecker) run(ctx context.Context) error {
 		if c.maxOvershotNanos < overshotNanos {
 			c.maxOvershotNanos = overshotNanos
 		}
-		log.Dev.VInfof(ctx, 1, "lower bound error: %dms", overshotNanos/1000000)
+		log.KvDistribution.VInfof(ctx, 1, "lower bound error: %dms", overshotNanos/1000000)
 	}
 }
 
@@ -517,7 +517,7 @@ func benchmarkTracker(ctx context.Context, b *testing.B, t Tracker) {
 				toks[i] = toks[i][:0]
 			}
 			mu.Unlock()
-			log.Dev.VInfof(ctx, 1, "cleared %d reqs", n)
+			log.KvDistribution.VInfof(ctx, 1, "cleared %d reqs", n)
 		}
 	}()
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -508,7 +508,7 @@ func (m *managerImpl) HandleLockConflictError(
 	ctx context.Context, g *Guard, seq roachpb.LeaseSequence, t *kvpb.LockConflictError,
 ) (*Guard, *Error) {
 	if g.ltg == nil {
-		log.Dev.Fatalf(ctx, "cannot handle LockConflictError %v for request without "+
+		log.KvExec.Fatalf(ctx, "cannot handle LockConflictError %v for request without "+
 			"lockTableGuard; were lock spans declared for this request?", t)
 	}
 
@@ -538,7 +538,7 @@ func (m *managerImpl) HandleLockConflictError(
 		foundLock := &t.Locks[i]
 		added, err := m.lt.AddDiscoveredLock(foundLock, seq, consultTxnStatusCache, g.ltg)
 		if err != nil {
-			log.Dev.Fatalf(ctx, "%v", err)
+			log.KvExec.Fatalf(ctx, "%v", err)
 		}
 		if !added {
 			log.VEventf(ctx, 2,
@@ -584,14 +584,14 @@ func (m *managerImpl) HandleTransactionPushError(
 func (m *managerImpl) OnLockAcquired(ctx context.Context, acq *roachpb.LockAcquisition) {
 	if err := m.lt.AcquireLock(acq); err != nil {
 		if errors.IsAssertionFailure(err) {
-			log.Dev.Fatalf(ctx, "%v", err)
+			log.KvExec.Fatalf(ctx, "%v", err)
 		}
 		// It's reasonable to expect benign errors here that the layer above
 		// (command evaluation) isn't equipped to deal with. As long as we're not
 		// violating any assertions, we simply log and move on. One benign case is
 		// when an unreplicated lock is being acquired by a transaction at an older
 		// epoch.
-		log.Dev.Errorf(ctx, "%v", err)
+		log.KvExec.Errorf(ctx, "%v", err)
 	}
 }
 
@@ -600,14 +600,14 @@ func (m *managerImpl) OnLockMissing(ctx context.Context, acq *roachpb.LockAcquis
 	if err := m.lt.MarkIneligibleForExport(acq); err != nil {
 		// We don't currently expect any errors other than assertion failures that represent
 		// programming errors from this method.
-		log.Dev.Fatalf(ctx, "%v", err)
+		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 }
 
 // OnLockUpdated implements the LockManager interface.
 func (m *managerImpl) OnLockUpdated(ctx context.Context, up *roachpb.LockUpdate) {
 	if err := m.lt.UpdateLocks(up); err != nil {
-		log.Dev.Fatalf(ctx, "%v", err)
+		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -2036,7 +2036,7 @@ func BenchmarkLockTable(b *testing.B) {
 							runRequests(b, iters, requestsPerGroup[0], env)
 						}
 						if log.V(1) {
-							log.Dev.Infof(context.Background(), "num requests that waited: %d, num scan calls: %d\n",
+							log.KvExec.Infof(context.Background(), "num requests that waited: %d, num scan calls: %d\n",
 								atomic.LoadUint64(&numRequestsWaited), atomic.LoadUint64(&numScanCalls))
 						}
 					})

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -1144,7 +1144,7 @@ func (tag *contentionTag) notify(ctx context.Context, s waitingState) *kvpb.Cont
 		return res
 	default:
 		kind := s.kind // escapes to the heap
-		log.Dev.Fatalf(ctx, "unhandled waitingState.kind: %v", kind)
+		log.KvExec.Fatalf(ctx, "unhandled waitingState.kind: %v", kind)
 	}
 	panic("unreachable")
 }

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -202,7 +202,7 @@ func (q *consistencyQueue) process(
 			return false, nil
 		}
 		err := pErr.GoError()
-		log.Dev.Errorf(ctx, "%v", err)
+		log.KvDistribution.Errorf(ctx, "%v", err)
 		return false, err
 	}
 	if fn := repl.store.cfg.TestingKnobs.ConsistencyTestingKnobs.ConsistencyQueueResultHook; fn != nil {

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -379,7 +379,7 @@ func Run(
 		if errors.Is(err, ctx.Err()) {
 			return Info{}, err
 		}
-		log.Dev.Warningf(ctx, "while gc'ing local key range: %s", err)
+		log.KvExec.Warningf(ctx, "while gc'ing local key range: %s", err)
 	}
 
 	// Clean up the AbortSpan.
@@ -388,7 +388,7 @@ func Run(
 		if errors.Is(err, ctx.Err()) {
 			return Info{}, err
 		}
-		log.Dev.Warningf(ctx, "while gc'ing abort span: %s", err)
+		log.KvExec.Warningf(ctx, "while gc'ing abort span: %s", err)
 	}
 
 	log.Eventf(ctx, "GC'ed keys; stats %+v", info)
@@ -445,7 +445,7 @@ func processReplicatedKeyRange(
 				excludeUserKeySpan = true
 				info.ClearRangeSpanOperations++
 			} else {
-				log.Dev.Warningf(ctx, "failed to perform GC clear range operation on range %s: %s",
+				log.KvExec.Warningf(ctx, "failed to perform GC clear range operation on range %s: %s",
 					desc.String(), err)
 				info.ClearRangeSpanFailures++
 			}
@@ -580,7 +580,7 @@ func processReplicatedLocks(
 					if errors.Is(err, ctx.Err()) {
 						return err
 					}
-					log.Dev.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+					log.KvExec.Warningf(ctx, "failed to cleanup intents batch: %v", err)
 				}
 			}
 		}
@@ -606,7 +606,7 @@ func processReplicatedLocks(
 		if errors.Is(err, ctx.Err()) {
 			return err
 		}
-		log.Dev.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+		log.KvExec.Warningf(ctx, "failed to cleanup intents batch: %v", err)
 	}
 	return nil
 }
@@ -934,7 +934,7 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(ctx context.Context) (err error)
 			// safe to continue because we bumped the GC
 			// thresholds. We may leave some inconsistent history
 			// behind, but nobody can read it.
-			log.Dev.Warningf(ctx, "failed to GC keys with clear range: %v", err)
+			log.KvExec.Warningf(ctx, "failed to GC keys with clear range: %v", err)
 			b.info.ClearRangeSpanFailures++
 		}
 		b.clearRangeCounters.updateGcInfo(b.info)
@@ -981,7 +981,7 @@ func (b *gcKeyBatcher) flushPointsBatch(ctx context.Context, batch *pointsBatch)
 		// safe to continue because we bumped the GC
 		// thresholds. We may leave some inconsistent history
 		// behind, but nobody can read it.
-		log.Dev.Warningf(ctx, "failed to GC a batch of keys: %v", err)
+		log.KvExec.Warningf(ctx, "failed to GC a batch of keys: %v", err)
 	}
 	batch.gcBatchCounters.updateGcInfo(b.info)
 	b.totalMemUsed -= batch.gcBatchCounters.memUsed
@@ -1194,7 +1194,7 @@ func processLocalKeyRange(
 	gcer PureGCer,
 ) error {
 	b := makeBatchingInlineGCer(gcer, func(err error) {
-		log.Dev.Warningf(ctx, "failed to GC from local key range: %s", err)
+		log.KvExec.Warningf(ctx, "failed to GC from local key range: %s", err)
 	})
 	defer b.Flush(ctx)
 
@@ -1286,7 +1286,7 @@ func processAbortSpan(
 	gcer PureGCer,
 ) error {
 	b := makeBatchingInlineGCer(gcer, func(err error) {
-		log.Dev.Warningf(ctx, "unable to GC from abort span: %s", err)
+		log.KvExec.Warningf(ctx, "unable to GC from abort span: %s", err)
 	})
 	defer b.Flush(ctx)
 	abortSpan := abortspan.New(rangeID)

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -435,9 +435,9 @@ func assertLiveData(
 	// 1000 elements is ok, but 10k or 100k entries might become unreadable.
 	if log.V(1) {
 		ctx := context.Background()
-		log.Dev.Info(ctx, "Expected data:")
+		log.KvExec.Info(ctx, "Expected data:")
 		for _, l := range formatTable(engineData(t, before, desc), desc.StartKey.AsRawKey()) {
-			log.Dev.Infof(ctx, "%s", l)
+			log.KvExec.Infof(ctx, "%s", l)
 		}
 	}
 

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -1145,14 +1145,14 @@ func runTest(t *testing.T, data testRunData, verify gcVerifier) {
 	expectedStats := dataItems.liveDistribution().setupTest(t, ctrlEng, desc)
 
 	if log.V(1) {
-		log.Dev.Info(ctx, "Expected data:")
+		log.KvExec.Info(ctx, "Expected data:")
 		for _, l := range formatTable(engineData(t, ctrlEng, desc), tablePrefix) {
-			log.Dev.Infof(ctx, "%s", l)
+			log.KvExec.Infof(ctx, "%s", l)
 		}
 
-		log.Dev.Info(ctx, "Actual data:")
+		log.KvExec.Info(ctx, "Actual data:")
 		for _, l := range formatTable(engineData(t, eng, desc), tablePrefix) {
-			log.Dev.Infof(ctx, "%s", l)
+			log.KvExec.Infof(ctx, "%s", l)
 		}
 	}
 

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -43,7 +43,7 @@ type Options struct {
 	Incrementer Incrementer
 	BlockSize   int64
 	Stopper     *stop.Stopper
-	Fatalf      func(context.Context, string, ...interface{}) // defaults to log.Dev.Fatalf
+	Fatalf      func(context.Context, string, ...interface{}) // defaults to log.KvExec.Fatalf
 }
 
 // An Allocator is used to increment a key in allocation blocks of arbitrary
@@ -66,7 +66,7 @@ func NewAllocator(opts Options) (*Allocator, error) {
 		return nil, errors.Errorf("blockSize must be a positive integer: %d", opts.BlockSize)
 	}
 	if opts.Fatalf == nil {
-		opts.Fatalf = log.Dev.Fatalf
+		opts.Fatalf = log.KvExec.Fatalf
 	}
 	opts.AmbientCtx.AddLogTag("idalloc", nil)
 	return &Allocator{
@@ -112,7 +112,7 @@ func (ia *Allocator) start() {
 					break
 				}
 
-				log.Dev.Warningf(
+				log.KvExec.Warningf(
 					ctx,
 					"unable to allocate %d ids from %s: %+v",
 					ia.opts.BlockSize,

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -339,7 +339,7 @@ func updateIntentTxnStatus(
 		if !ok {
 			// The intent was not pushed.
 			if !skipIfInFlight {
-				log.Dev.Fatalf(ctx, "no PushTxn response for intent %+v", intent)
+				log.KvExec.Fatalf(ctx, "no PushTxn response for intent %+v", intent)
 			}
 			// It must have been skipped.
 			continue
@@ -369,7 +369,7 @@ func (ir *IntentResolver) PushTransaction(
 	}
 	pushedTxn, ok := pushedTxns[pushTxn.ID]
 	if !ok {
-		log.Dev.Fatalf(ctx, "missing PushTxn responses for %s", pushTxn)
+		log.KvExec.Fatalf(ctx, "missing PushTxn responses for %s", pushTxn)
 	}
 	return pushedTxn, ambiguousAbort, nil
 }
@@ -421,7 +421,7 @@ func (ir *IntentResolver) MaybePushTransactions(
 			// Another goroutine is working on this transaction so we can
 			// skip it.
 			if log.V(1) {
-				log.Dev.Infof(ctx, "skipping PushTxn for %s; attempt already in flight", txnID)
+				log.KvExec.Infof(ctx, "skipping PushTxn for %s; attempt already in flight", txnID)
 			}
 			delete(pushTxns, txnID)
 		} else {
@@ -476,7 +476,7 @@ func (ir *IntentResolver) MaybePushTransactions(
 		txn := &resp.PusheeTxn
 		anyAmbiguousAbort = anyAmbiguousAbort || resp.AmbiguousAbort
 		if _, ok := pushedTxns[txn.ID]; ok {
-			log.Dev.Fatalf(ctx, "have two PushTxn responses for %s", txn.ID)
+			log.KvExec.Fatalf(ctx, "have two PushTxn responses for %s", txn.ID)
 		}
 		pushedTxns[txn.ID] = txn
 		log.Eventf(ctx, "%s is now %s", txn.ID, txn.Status)
@@ -546,7 +546,7 @@ func (ir *IntentResolver) CleanupIntentsAsync(
 				return err
 			})
 		if err != nil && ir.every.ShouldLog() {
-			log.Dev.Warningf(ctx, "%v", err)
+			log.KvExec.Warningf(ctx, "%v", err)
 		}
 	})
 }
@@ -664,7 +664,7 @@ func (ir *IntentResolver) CleanupTxnIntentsAsync(
 				ctx, kv.AdmissionHeaderForLockUpdateForTxn(et.Txn), rangeID, et.Txn, et.Poison, onComplete,
 			); err != nil {
 				if ir.every.ShouldLog() {
-					log.Dev.Warningf(ctx, "failed to cleanup transaction intents: %v", err)
+					log.KvExec.Warningf(ctx, "failed to cleanup transaction intents: %v", err)
 				}
 			}
 		}); err != nil {
@@ -784,7 +784,7 @@ func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
 			ctx, admissionHeader, rangeID, txn, false /* poison */, onCleanupComplete)
 		if err != nil {
 			if ir.every.ShouldLog() {
-				log.Dev.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
+				log.KvExec.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
 			}
 		}
 	}(ctx)
@@ -887,7 +887,7 @@ func (ir *IntentResolver) cleanupFinishedTxnIntents(
 		}
 		if err != nil {
 			if ir.every.ShouldLog() {
-				log.Dev.Warningf(ctx, "failed to gc transaction record: %v", err)
+				log.KvExec.Warningf(ctx, "failed to gc transaction record: %v", err)
 			}
 		}
 	}(ctx)
@@ -937,14 +937,14 @@ func (ir *IntentResolver) lookupRangeID(ctx context.Context, key roachpb.Key) ro
 	rKey, err := keys.Addr(key)
 	if err != nil {
 		if ir.every.ShouldLog() {
-			log.Dev.Warningf(ctx, "failed to resolve addr for key %q: %+v", key, err)
+			log.KvExec.Warningf(ctx, "failed to resolve addr for key %q: %+v", key, err)
 		}
 		return 0
 	}
 	rangeID, err := ir.rdc.LookupRangeID(ctx, rKey)
 	if err != nil {
 		if ir.every.ShouldLog() {
-			log.Dev.Warningf(ctx, "failed to look up range descriptor for key %q: %+v", key, err)
+			log.KvExec.Warningf(ctx, "failed to look up range descriptor for key %q: %+v", key, err)
 		}
 		return 0
 	}
@@ -1068,7 +1068,7 @@ func (ir *IntentResolver) resolveIntents(
 	// TODO(aaditya): reconsider this once #112680 is resolved.
 	// if !build.IsRelease() && h == (kvpb.AdmissionHeader{}) && ir.everyAdmissionHeaderMissing.ShouldLog() {
 	if false {
-		log.Dev.Warningf(ctx,
+		log.KvExec.Warningf(ctx,
 			"test-only warning: if you see this, please report to https://github.com/cockroachdb/cockroach/issues/112680. empty admission header provided by %s", debugutil.Stack())
 	}
 	// Send the requests ...

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -435,7 +435,7 @@ func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, writeBytes *StoreWriteByt
 			// This issue is tracked by
 			// https://github.com/cockroachdb/cockroach/issues/126681.
 			if buildutil.CrdbTestBuild {
-				log.Dev.Warningf(context.Background(), "grunning.Time() should be non-decreasing, cpuTime=%s", cpuTime)
+				log.KvDistribution.Warningf(context.Background(), "grunning.Time() should be non-decreasing, cpuTime=%s", cpuTime)
 			}
 			cpuTime = 1
 		}
@@ -450,10 +450,10 @@ func (n *controllerImpl) AdmittedKVWorkDone(ah Handle, writeBytes *StoreWriteByt
 		if err != nil {
 			// This shouldn't be happening.
 			if buildutil.CrdbTestBuild {
-				log.Dev.Fatalf(context.Background(), "%s", errors.WithAssertionFailure(err))
+				log.KvDistribution.Fatalf(context.Background(), "%s", errors.WithAssertionFailure(err))
 			}
 			if n.every.ShouldLog() {
-				log.Dev.Errorf(context.Background(), "%s", err)
+				log.KvDistribution.Errorf(context.Background(), "%s", err)
 			}
 		}
 	}
@@ -554,12 +554,12 @@ var _ replica_rac2.ACWorkQueue = &controllerImpl{}
 func (n *controllerImpl) Admit(ctx context.Context, entry replica_rac2.EntryForAdmission) bool {
 	storeAdmissionQ := n.storeGrantCoords.TryGetQueueForStore(entry.StoreID)
 	if storeAdmissionQ == nil {
-		log.Dev.Errorf(ctx, "unable to find queue for store: %s", entry.StoreID)
+		log.KvDistribution.Errorf(ctx, "unable to find queue for store: %s", entry.StoreID)
 		return false // nothing to do
 	}
 
 	if entry.RequestedCount == 0 {
-		log.Dev.Fatal(ctx, "found (unexpected) empty raft command for below-raft admission")
+		log.KvDistribution.Fatal(ctx, "found (unexpected) empty raft command for below-raft admission")
 	}
 	wi := admission.WorkInfo{
 		TenantID:        entry.TenantID,
@@ -585,11 +585,11 @@ func (n *controllerImpl) Admit(ctx context.Context, entry replica_rac2.EntryForA
 		WorkInfo: wi,
 	})
 	if err != nil {
-		log.Dev.Errorf(ctx, "error while admitting to store admission queue: %v", err)
+		log.KvDistribution.Errorf(ctx, "error while admitting to store admission queue: %v", err)
 		return false
 	}
 	if handle.UseAdmittedWorkDone() {
-		log.Dev.Fatalf(ctx, "unexpected handle.UseAdmittedWorkDone")
+		log.KvDistribution.Fatalf(ctx, "unexpected handle.UseAdmittedWorkDone")
 	}
 	return true
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
@@ -349,7 +349,7 @@ func (l *LogTracker) errorf(ctx context.Context, format string, args ...any) {
 	if buildutil.CrdbTestBuild {
 		panic(errors.AssertionFailedf(format, args...))
 	} else {
-		log.Dev.Errorf(ctx, format, args...)
+		log.KvDistribution.Errorf(ctx, format, args...)
 	}
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -708,7 +708,7 @@ func NewRangeController(
 	ctx context.Context, o RangeControllerOptions, init RangeControllerInitState,
 ) *rangeController {
 	if log.V(1) {
-		log.Dev.VInfof(ctx, 1, "r%v creating range controller", o.RangeID)
+		log.KvDistribution.VInfof(ctx, 1, "r%v creating range controller", o.RangeID)
 	}
 	if o.RaftMaxInflightBytes == 0 {
 		o.RaftMaxInflightBytes = math.MaxUint64
@@ -1563,7 +1563,7 @@ func (rc *rangeController) SetLeaseholderRaftMuLocked(
 		return
 	}
 	if log.V(1) {
-		log.Dev.VInfof(ctx, 1, "r%v setting range leaseholder replica_id=%v", rc.opts.RangeID, replica)
+		log.KvDistribution.VInfof(ctx, 1, "r%v setting range leaseholder replica_id=%v", rc.opts.RangeID, replica)
 	}
 	rc.leaseholder = replica
 	rc.updateWaiterSetsRaftMuLocked()
@@ -1582,7 +1582,7 @@ func (rc *rangeController) ForceFlushIndexChangedLocked(ctx context.Context, ind
 func (rc *rangeController) CloseRaftMuLocked(ctx context.Context) {
 	rc.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
 	if log.V(1) {
-		log.Dev.VInfof(ctx, 1, "r%v closing range controller", rc.opts.RangeID)
+		log.KvDistribution.VInfof(ctx, 1, "r%v closing range controller", rc.opts.RangeID)
 	}
 	func() {
 		rc.mu.Lock()
@@ -2273,7 +2273,7 @@ func (rss *replicaSendStream) admitRaftMuLocked(ctx context.Context, av Admitted
 			}
 			printReturned("send", returnedSend)
 			printReturned(" eval", returnedEval)
-			log.Dev.VInfof(ctx, 2, "r%v:%v stream %v admit %v returned %s",
+			log.KvDistribution.VInfof(ctx, 2, "r%v:%v stream %v admit %v returned %s",
 				rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream, av,
 				redact.SafeString(b.String()))
 		}
@@ -2366,7 +2366,7 @@ type entryFCState struct {
 func getEntryFCStateOrFatal(ctx context.Context, entry raftpb.Entry) entryFCState {
 	enc, pri, err := raftlog.EncodingOf(entry)
 	if err != nil {
-		log.Dev.Fatalf(ctx, "error getting encoding of entry: %v", err)
+		log.KvDistribution.Fatalf(ctx, "error getting encoding of entry: %v", err)
 	}
 
 	if enc == raftlog.EntryEncodingStandardWithAC || enc == raftlog.EntryEncodingSideloadedWithAC {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1605,7 +1605,7 @@ func TestRangeController(t *testing.T) {
 				}
 				stats := RangeSendStreamStats{}
 				r.rc.SendStreamStats(&stats)
-				log.Dev.Infof(ctx, "stats: %v", stats)
+				log.KvDistribution.Infof(ctx, "stats: %v", stats)
 				var buf strings.Builder
 				for _, repl := range sortReplicas(r) {
 					replStats, ok := stats.ReplicaSendStreamStats(repl.ReplicaID)

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
@@ -1034,7 +1034,7 @@ func (rc *rangeController) testingNonBlockingAdmit(
 	// connected to the leader. Expect there to be at least one voter set and no
 	// joint configuration (multiple voter sets).
 	if len(vss) != 1 {
-		log.Dev.Fatalf(ctx, "expected exactly one voter set, found %d", len(vss))
+		log.KvDistribution.Fatalf(ctx, "expected exactly one voter set, found %d", len(vss))
 	}
 	// Similar to the token counter non-blocking admit, we also don't care about
 	// replica types, or waiting for only a quorum. We just wait for all
@@ -1084,7 +1084,7 @@ func (r *testingRCRange) testingDeductTokens(
 	t *testing.T, ctx context.Context, pri admissionpb.WorkPriority, tokens kvflowcontrol.Tokens,
 ) {
 	if r.rc == nil {
-		log.Dev.Fatal(ctx, "operating on a closed RangeController")
+		log.KvDistribution.Fatal(ctx, "operating on a closed RangeController")
 	}
 	r.mu.quorumPosition.Index++
 	entry := testingCreateEntry(t, entryInfo{
@@ -1136,7 +1136,7 @@ func (r *testingRCRange) testingReturnTokens(
 	rid := r.testingFindReplStreamOrFatal(ctx, stream)
 	rs := r.rc.replicaMap[rid]
 	if rs == nil || rs.sendStream == nil {
-		log.Dev.Fatalf(ctx, "expected to find non-closed replica send stream for %v", stream)
+		log.KvDistribution.Fatalf(ctx, "expected to find non-closed replica send stream for %v", stream)
 	}
 
 	// We need to determine the index at which we're returning tokens via
@@ -1177,7 +1177,7 @@ func (r *testingRCRange) testingFindReplStreamOrFatal(
 			return rs.desc.ReplicaID
 		}
 	}
-	log.Dev.Fatalf(ctx, "expected to find replica for stream %v", stream)
+	log.KvDistribution.Fatalf(ctx, "expected to find replica for stream %v", stream)
 	panic("unreachable")
 }
 
@@ -1188,7 +1188,7 @@ func (r *testingRCRange) testingConnectStream(
 	t *testing.T, ctx context.Context, stream kvflowcontrol.Stream,
 ) {
 	if r.rc == nil {
-		log.Dev.Fatal(ctx, "operating on a closed RangeController")
+		log.KvDistribution.Fatal(ctx, "operating on a closed RangeController")
 	}
 	r.mu.r.replicaSet[roachpb.ReplicaID(stream.StoreID)] = testingReplica{
 		desc: roachpb.ReplicaDescriptor{

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -238,11 +238,11 @@ func (b *blockedStreamLogger) willLog() bool {
 
 func (b *blockedStreamLogger) flushLogs() {
 	if b.blockedRegularCount > 0 {
-		log.Dev.Warningf(context.Background(), "%d blocked %s regular replication stream(s): %s",
+		log.KvDistribution.Warningf(context.Background(), "%d blocked %s regular replication stream(s): %s",
 			b.blockedRegularCount, b.metricType, redact.SafeString(b.regBuf.String()))
 	}
 	if b.blockedElasticCount > 0 {
-		log.Dev.Warningf(context.Background(), "%d blocked %s elastic replication stream(s): %s",
+		log.KvDistribution.Warningf(context.Background(), "%d blocked %s elastic replication stream(s): %s",
 			b.blockedElasticCount, b.metricType, redact.SafeString(b.elaBuf.String()))
 	}
 	b.elaBuf.Reset()
@@ -321,9 +321,9 @@ func (b *blockedStreamLogger) observeStream(
 		}
 		deductionKindFunc("regular", regularStats)
 		deductionKindFunc("elastic", elasticStats)
-		log.Dev.Infof(context.Background(), "%s", redact.SafeString(bb.String()))
+		log.KvDistribution.Infof(context.Background(), "%s", redact.SafeString(bb.String()))
 	} else if b.blockedCount == streamStatsCountCap+1 {
-		log.Dev.Infof(context.Background(), "skipped logging some streams that were blocked")
+		log.KvDistribution.Infof(context.Background(), "skipped logging some streams that were blocked")
 	}
 }
 
@@ -487,7 +487,7 @@ func (w *sendStreamTokenWatcher) add(
 			"flow-control-send-stream-token-watcher", w.run); err == nil {
 			w.mu.started = true
 		} else {
-			log.Dev.Warningf(ctx, "failed to start send stream token watcher: %v", err)
+			log.KvDistribution.Warningf(ctx, "failed to start send stream token watcher: %v", err)
 		}
 	}
 
@@ -567,7 +567,7 @@ func (w *sendStreamTokenWatcher) run(_ context.Context) {
 		// unblocked and confirmed that there are tokens available. Notify the next
 		// handle in line.
 		if grant, found := w.nextGrant(); found {
-			log.Dev.VInfof(ctx, 4,
+			log.KvDistribution.VInfof(ctx, 4,
 				"notifying %v of available tokens for stream %v", grant, w.tc.stream)
 			grant.Notify(ctx)
 		}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
@@ -77,7 +77,7 @@ func TestBlockedStreamLogging(t *testing.T) {
 	}
 	// 25th stream will also be blocked. The detailed stats will only cover an
 	// arbitrary subset of 20 streams.
-	log.Dev.Infof(ctx, "creating stream id %d", id)
+	log.KvDistribution.Infof(ctx, "creating stream id %d", id)
 	createStreamAndExhaustTokens(id, true)
 
 	// Total 104 streams are blocked.
@@ -86,7 +86,7 @@ func TestBlockedStreamLogging(t *testing.T) {
 	}
 	// 105th stream will also be blocked. The blocked stream names will only
 	// list 100 streams.
-	log.Dev.Infof(ctx, "creating stream id %d", id)
+	log.KvDistribution.Infof(ctx, "creating stream id %d", id)
 	createStreamAndExhaustTokens(id, true)
 
 	log.FlushFiles()

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -107,7 +107,7 @@ func (twc *tokenCounterPerWorkClass) adjustTokensLocked(
 		}
 	}
 	if buildutil.CrdbTestBuild && !isReset && unaccounted != 0 {
-		log.Dev.Fatalf(ctx, "unaccounted[%s]=%d delta=%d limit=%d",
+		log.KvDistribution.Fatalf(ctx, "unaccounted[%s]=%d delta=%d limit=%d",
 			twc.wc, unaccounted, delta, twc.limit)
 	}
 
@@ -502,7 +502,7 @@ func WaitForEval(
 ) (state WaitEndState, scratch2 []reflect.SelectCase) {
 	scratch = scratch[:0]
 	if len(handles) < requiredQuorum {
-		log.Dev.Fatalf(ctx, "%v", errors.AssertionFailedf(
+		log.KvDistribution.Fatalf(ctx, "%v", errors.AssertionFailedf(
 			"invalid arguments to WaitForEval: len(handles)=%d < required_quorum=%d",
 			len(handles), requiredQuorum))
 	}
@@ -528,7 +528,7 @@ func WaitForEval(
 			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: chanValue})
 	}
 	if requiredQuorum == 0 && requiredWaitCount == 0 {
-		log.Dev.Fatalf(ctx, "both requiredQuorum and requiredWaitCount are zero")
+		log.KvDistribution.Fatalf(ctx, "both requiredQuorum and requiredWaitCount are zero")
 	}
 
 	// m is the current length of the scratch slice.
@@ -685,7 +685,7 @@ func (t *tokenCounter) adjustLockedAndUnlock(
 		t.metrics.onUnaccounted(unaccounted)
 	}
 	if expensiveLog {
-		log.Dev.Infof(ctx, "adjusted %v flow tokens (wc=%v stream=%v delta=%v flag=%v): regular=%v elastic=%v",
+		log.KvDistribution.Infof(ctx, "adjusted %v flow tokens (wc=%v stream=%v delta=%v flag=%v): regular=%v elastic=%v",
 			t.tokenType, class, t.stream, delta, flag, regularTokens, elasticTokens)
 	}
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
@@ -79,7 +79,7 @@ func (t *Tracker) Track(
 		// span the leader losing leadership and regaining it. So the entry IDs must
 		// advance.
 		if id.index <= last.index || id.term < last.term {
-			log.Dev.Fatalf(ctx, "expected in order tracked log entries: last=%+v, entry=%+v", last, id)
+			log.KvDistribution.Fatalf(ctx, "expected in order tracked log entries: last=%+v, entry=%+v", last, id)
 			return false
 		}
 	}
@@ -87,7 +87,7 @@ func (t *Tracker) Track(
 	t.deducted[pri] += tokens
 
 	if log.V(1) {
-		log.Dev.Infof(ctx, "tracking %v flow control tokens for pri=%s stream=%s log-position=%d/%d",
+		log.KvDistribution.Infof(ctx, "tracking %v flow control tokens for pri=%s stream=%s log-position=%d/%d",
 			tokens, pri, t.stream, id.term, id.index)
 	}
 	return true

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -537,7 +537,7 @@ func (p *processorImpl) InitRaftLocked(
 	p.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
 	p.opts.ReplicaMutexAsserter.ReplicaMuAssertHeld()
 	if p.desc.replicas != nil {
-		log.Dev.Fatalf(ctx, "initializing RaftNode after replica is initialized")
+		log.KvDistribution.Fatalf(ctx, "initializing RaftNode after replica is initialized")
 	}
 	p.raftInterface = rn
 	p.logTracker.init(logMark)
@@ -623,7 +623,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLocked(
 	ctx context.Context, state RaftNodeBasicState,
 ) {
 	if state.Term < p.term {
-		log.Dev.Fatalf(ctx, "term regressed from %d to %d", p.term, state.Term)
+		log.KvDistribution.Fatalf(ctx, "term regressed from %d to %d", p.term, state.Term)
 	}
 	termChanged := state.Term > p.term
 	if termChanged {
@@ -666,7 +666,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLocked(
 				// Is leader, but not in the set of replicas. We expect this should not
 				// be happening anymore, due to raft.Config.StepDownOnRemoval being set
 				// to true. But we tolerate it.
-				log.Dev.Errorf(ctx, "leader=%d is not in the set of replicas=%v",
+				log.KvDistribution.Errorf(ctx, "leader=%d is not in the set of replicas=%v",
 					state.Leader, p.desc.replicas)
 				p.leaderNodeID = p.opts.NodeID
 				p.leaderStoreID = p.opts.StoreID
@@ -695,7 +695,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLocked(
 	// Existing RangeController.
 	if replicasChanged {
 		if err := p.leader.rc.SetReplicasRaftMuLocked(ctx, p.desc.replicas); err != nil {
-			log.Dev.Errorf(ctx, "error setting replicas: %v", err)
+			log.KvDistribution.Errorf(ctx, "error setting replicas: %v", err)
 		}
 	}
 	p.leader.rc.SetLeaseholderRaftMuLocked(ctx, state.Leaseholder)
@@ -767,7 +767,7 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(
 		return
 	}
 	if p.raftInterface == nil {
-		log.Dev.Fatal(ctx, "RaftInterface is not initialized")
+		log.KvDistribution.Fatal(ctx, "RaftInterface is not initialized")
 		return
 	}
 
@@ -783,7 +783,7 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(
 		if knobs := p.opts.Knobs; knobs == nil || !knobs.UseOnlyForScratchRanges ||
 			p.opts.ReplicaForTesting.IsScratchRange() {
 			if err := rc.HandleRaftEventRaftMuLocked(ctx, e); err != nil {
-				log.Dev.Errorf(ctx, "error handling raft event: %v", err)
+				log.KvDistribution.Errorf(ctx, "error handling raft event: %v", err)
 			}
 		}
 	}
@@ -891,7 +891,7 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 
 		if log.V(1) {
 			if isV2Encoding {
-				log.Dev.Infof(ctx,
+				log.KvDistribution.Infof(ctx,
 					"decoded v2 raft admission meta below-raft: pri=%v create-time=%d "+
 						"proposer=n%v receiver=[n%d,s%v] tenant=t%d tokens≈%v "+
 						"sideloaded=%t raft-entry=%d/%d",
@@ -907,7 +907,7 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 					entry.Index,
 				)
 			} else {
-				log.Dev.Infof(ctx,
+				log.KvDistribution.Infof(ctx,
 					"decoded v1 raft admission meta below-raft: pri=%v create-time=%d "+
 						"proposer=n%v receiver=[n%d,s%v] tenant=t%d tokens≈%v "+
 						"sideloaded=%t raft-entry=%d/%d",
@@ -937,7 +937,7 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 			raftPri = raftpb.LowPri
 			if admissionpb.WorkClassFromPri(admissionpb.WorkPriority(meta.AdmissionPriority)) ==
 				admissionpb.RegularWorkClass && p.v1EncodingPriorityMismatch.ShouldLog() {
-				log.Dev.Errorf(ctx,
+				log.KvDistribution.Errorf(ctx,
 					"do not use RACv1 encoding for pri %s, which is regular work",
 					admissionpb.WorkPriority(meta.AdmissionPriority))
 			}

--- a/pkg/kv/kvserver/kvserverbase/forced_error.go
+++ b/pkg/kv/kvserver/kvserverbase/forced_error.go
@@ -84,7 +84,7 @@ func CheckForcedErr(
 			if isLeaseRequest {
 				op = "request"
 			}
-			log.Dev.Infof(ctx, "rejected lease %s %s; current lease %s; err: %s",
+			log.KvExec.Infof(ctx, "rejected lease %s %s; current lease %s; err: %s",
 				op, raftCmd.ReplicatedEvalResult.State.Lease, replicaState.Lease, res.ForcedError)
 		}
 	}()

--- a/pkg/kv/kvserver/kvserverbase/syncing_write.go
+++ b/pkg/kv/kvserver/kvserverbase/syncing_write.go
@@ -52,7 +52,7 @@ func LimitBulkIOWrite(ctx context.Context, limiter *rate.Limiter, cost int) erro
 	}
 
 	if d := timeutil.Since(begin); d > bulkIOWriteLimiterLongWait {
-		log.Dev.Warningf(ctx, "bulk io write limiter took %s (>%s):\n%s",
+		log.KvExec.Warningf(ctx, "bulk io write limiter took %s (>%s):\n%s",
 			d, bulkIOWriteLimiterLongWait, debugutil.Stack())
 	}
 	return nil

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -247,7 +247,7 @@ func ReadStoreIdent(ctx context.Context, eng storage.Engine) (roachpb.StoreIdent
 func IterateRangeDescriptorsFromDisk(
 	ctx context.Context, reader storage.Reader, fn func(desc roachpb.RangeDescriptor) error,
 ) error {
-	log.Dev.Info(ctx, "beginning range descriptor iteration")
+	log.KvExec.Info(ctx, "beginning range descriptor iteration")
 
 	// We are going to find all range descriptor keys. This code is equivalent to
 	// using MVCCIterate on all range-local keys in Inconsistent mode and with
@@ -277,7 +277,7 @@ func IterateRangeDescriptorsFromDisk(
 		const reportPeriod = 10 * time.Second
 		if timeutil.Since(lastReportTime) >= reportPeriod {
 			stats := iter.Stats().Stats
-			log.Dev.Infof(ctx, "range descriptor iteration in progress: %d range descriptors, %d intents, %d tombstones; stats: %s",
+			log.KvExec.Infof(ctx, "range descriptor iteration in progress: %d range descriptors, %d intents, %d tombstones; stats: %s",
 				descriptorCount, intentCount, tombstoneCount, stats.String())
 		}
 
@@ -371,7 +371,7 @@ func IterateRangeDescriptorsFromDisk(
 	}
 
 	stats := iter.Stats().Stats
-	log.Dev.Infof(ctx, "range descriptor iteration done: %d range descriptors, %d intents, %d tombstones; stats: %s",
+	log.KvExec.Infof(ctx, "range descriptor iteration done: %d range descriptors, %d intents, %d tombstones; stats: %s",
 		descriptorCount, intentCount, tombstoneCount, stats.String())
 	return nil
 }
@@ -490,7 +490,7 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 			return keys.RaftReplicaIDKey(rangeID)
 		}, &msg, func(rangeID roachpb.RangeID) error {
 			if logEvery.ShouldLog() && i > 0 { // only log if slow
-				log.Dev.Infof(ctx, "loaded replica ID for %d/%d replicas", i, len(s))
+				log.KvExec.Infof(ctx, "loaded replica ID for %d/%d replicas", i, len(s))
 			}
 			i++
 			s.setReplicaID(rangeID, msg.ReplicaID)
@@ -498,7 +498,7 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 		}); err != nil {
 			return nil, err
 		}
-		log.Dev.Infof(ctx, "loaded replica ID for %d/%d replicas", len(s), len(s))
+		log.KvExec.Infof(ctx, "loaded replica ID for %d/%d replicas", len(s), len(s))
 
 		logEvery = log.Every(10 * time.Second)
 		i = 0
@@ -507,7 +507,7 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 			return keys.RaftHardStateKey(rangeID)
 		}, &hs, func(rangeID roachpb.RangeID) error {
 			if logEvery.ShouldLog() && i > 0 { // only log if slow
-				log.Dev.Infof(ctx, "loaded Raft state for %d/%d replicas", i, len(s))
+				log.KvExec.Infof(ctx, "loaded Raft state for %d/%d replicas", i, len(s))
 			}
 			i++
 			s.setHardState(rangeID, hs)
@@ -515,7 +515,7 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 		}); err != nil {
 			return nil, err
 		}
-		log.Dev.Infof(ctx, "loaded Raft state for %d/%d replicas", len(s), len(s))
+		log.KvExec.Infof(ctx, "loaded Raft state for %d/%d replicas", len(s), len(s))
 	}
 	sl := make([]Replica, 0, len(s))
 	for _, repl := range s {
@@ -542,7 +542,7 @@ func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replic
 	if err != nil {
 		return nil, err
 	}
-	log.Dev.Infof(ctx, "loaded %d replicas", len(sl))
+	log.KvExec.Infof(ctx, "loaded %d replicas", len(sl))
 
 	// Check invariants.
 	//
@@ -552,7 +552,7 @@ func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replic
 		// Log progress regularly, but not for the first replica (we only want to
 		// log when this is slow). The last replica is logged after iteration.
 		if logEvery.ShouldLog() && i > 0 {
-			log.Dev.Infof(ctx, "verified %d/%d replicas", i, len(sl))
+			log.KvExec.Infof(ctx, "verified %d/%d replicas", i, len(sl))
 		}
 
 		// INVARIANT: a Replica always has a replica ID.
@@ -573,7 +573,7 @@ func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replic
 			}
 		}
 	}
-	log.Dev.Infof(ctx, "verified %d/%d replicas", len(sl), len(sl))
+	log.KvExec.Infof(ctx, "verified %d/%d replicas", len(sl), len(sl))
 
 	return sl, nil
 }

--- a/pkg/kv/kvserver/leases/status.go
+++ b/pkg/kv/kvserver/leases/status.go
@@ -133,7 +133,7 @@ func Status(ctx context.Context, nl NodeLiveness, i StatusInput) kvserverpb.Leas
 					lease.Replica, lease.Replica.NodeID, lease, l.Liveness)
 			}
 			if leaseStatusLogLimiter.ShouldLog() {
-				log.Dev.Infof(ctx, "%s", msg)
+				log.KvExec.Infof(ctx, "%s", msg)
 			}
 			status.State = kvserverpb.LeaseState_ERROR
 			status.ErrInfo = msg.String()

--- a/pkg/kv/kvserver/leases/verify.go
+++ b/pkg/kv/kvserver/leases/verify.go
@@ -124,7 +124,7 @@ func verifyAcquisition(ctx context.Context, st Settings, i VerifyInput) error {
 	leaderKnown := leader != roachpb.ReplicaID(raft.None)
 	iAmTheLeader := i.RaftStatus.RaftState == raftpb.StateLeader
 	if (leader == i.LocalReplicaID) != iAmTheLeader {
-		log.Dev.Fatalf(ctx, "inconsistent Raft state: %s", i.RaftStatus)
+		log.KvExec.Fatalf(ctx, "inconsistent Raft state: %s", i.RaftStatus)
 	}
 
 	// If the local replica is the raft leader, it can proceed with the lease

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -110,7 +110,7 @@ func (c *Cache) livenessGossipUpdate(_ string, content roachpb.Value, _ int64) {
 	ctx := context.TODO()
 	var liveness livenesspb.Liveness
 	if err := content.GetProto(&liveness); err != nil {
-		log.Dev.Errorf(ctx, "%v", err)
+		log.KvExec.Errorf(ctx, "%v", err)
 		return
 	}
 
@@ -122,12 +122,12 @@ func (c *Cache) storeGossipUpdate(_ string, content roachpb.Value, _ int64) {
 	ctx := context.TODO()
 	var storeDesc roachpb.StoreDescriptor
 	if err := content.GetProto(&storeDesc); err != nil {
-		log.Dev.Errorf(ctx, "%v", err)
+		log.KvExec.Errorf(ctx, "%v", err)
 		return
 	}
 	nodeID := storeDesc.Node.NodeID
 	if nodeID == 0 {
-		log.Dev.Errorf(ctx, "unexpected update for node 0, %v", storeDesc)
+		log.KvExec.Errorf(ctx, "unexpected update for node 0, %v", storeDesc)
 		return
 	}
 	c.mu.Lock()
@@ -144,11 +144,11 @@ func (c *Cache) storeGossipUpdate(_ string, content roachpb.Value, _ int64) {
 // registered callbacks if the node became live in the process.
 func (c *Cache) maybeUpdate(ctx context.Context, newLivenessRec Record) {
 	if newLivenessRec.Liveness == (livenesspb.Liveness{}) {
-		log.Dev.Fatal(ctx, "invalid new liveness record; found to be empty")
+		log.KvExec.Fatal(ctx, "invalid new liveness record; found to be empty")
 	}
 
 	if newLivenessRec.NodeID == 0 {
-		log.Dev.Fatal(ctx, "attempt to cache liveness record with nid 0")
+		log.KvExec.Fatal(ctx, "attempt to cache liveness record with nid 0")
 	}
 
 	shouldReplace := true

--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -156,46 +156,46 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 
 	ctx = logtags.AddTag(ctx, "in test", nil)
 
-	log.Dev.Infof(ctx, "setting zone config to disable replication")
+	log.KvExec.Infof(ctx, "setting zone config to disable replication")
 	if _, err := tc.Conns[0].Exec(`ALTER RANGE meta CONFIGURE ZONE using num_replicas = 1`); err != nil {
 		t.Fatal(err)
 	}
 
-	log.Dev.Infof(ctx, "starting 3 more nodes")
+	log.KvExec.Infof(ctx, "starting 3 more nodes")
 	tc.AddAndStartServer(t, serverArgs)
 	tc.AddAndStartServer(t, serverArgs)
 	tc.AddAndStartServer(t, serverArgs)
 
-	log.Dev.Infof(ctx, "waiting for node statuses")
+	log.KvExec.Infof(ctx, "waiting for node statuses")
 	tc.WaitForNodeStatuses(t)
 	tc.WaitForNodeLiveness(t)
-	log.Dev.Infof(ctx, "waiting done")
+	log.KvExec.Infof(ctx, "waiting done")
 
 	firstServer := tc.Server(0)
 
 	liveNodeID := firstServer.NodeID()
 
 	deadNodeID := tc.Server(1).NodeID()
-	log.Dev.Infof(ctx, "shutting down node %d", deadNodeID)
+	log.KvExec.Infof(ctx, "shutting down node %d", deadNodeID)
 	tc.StopServer(1)
-	log.Dev.Infof(ctx, "done shutting down node %d", deadNodeID)
+	log.KvExec.Infof(ctx, "done shutting down node %d", deadNodeID)
 
 	decommissioningNodeID := tc.Server(2).NodeID()
-	log.Dev.Infof(ctx, "marking node %d as decommissioning", decommissioningNodeID)
+	log.KvExec.Infof(ctx, "marking node %d as decommissioning", decommissioningNodeID)
 	if err := firstServer.Decommission(ctx, livenesspb.MembershipStatus_DECOMMISSIONING, []roachpb.NodeID{decommissioningNodeID}); err != nil {
 		t.Fatal(err)
 	}
-	log.Dev.Infof(ctx, "marked node %d as decommissioning", decommissioningNodeID)
+	log.KvExec.Infof(ctx, "marked node %d as decommissioning", decommissioningNodeID)
 
 	removedNodeID := tc.Server(3).NodeID()
-	log.Dev.Infof(ctx, "marking node %d as decommissioning and shutting it down", removedNodeID)
+	log.KvExec.Infof(ctx, "marking node %d as decommissioning and shutting it down", removedNodeID)
 	if err := firstServer.Decommission(ctx, livenesspb.MembershipStatus_DECOMMISSIONING, []roachpb.NodeID{removedNodeID}); err != nil {
 		t.Fatal(err)
 	}
 	tc.StopServer(3)
-	log.Dev.Infof(ctx, "done removing node %d", removedNodeID)
+	log.KvExec.Infof(ctx, "done removing node %d", removedNodeID)
 
-	log.Dev.Infof(ctx, "checking status map")
+	log.KvExec.Infof(ctx, "checking status map")
 
 	// See what comes up in the status.
 	admin := tc.GetAdminClient(t, 0)
@@ -228,7 +228,7 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 				// We do this in every SucceedsSoon attempt, so we'll be good.
 				liveness.TimeUntilNodeDead.Override(ctx, &firstServer.ClusterSettings().SV, liveness.TestTimeUntilNodeDead)
 
-				log.Dev.Infof(ctx, "checking expected status (%s) for node %d", expectedStatus, nodeID)
+				log.KvExec.Infof(ctx, "checking expected status (%s) for node %d", expectedStatus, nodeID)
 				resp, err := admin.Liveness(ctx, &serverpb.LivenessRequest{})
 				require.NoError(t, err)
 				nodeStatuses := resp.Statuses

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -395,7 +395,7 @@ func (nl *NodeLiveness) SetDraining(
 		}
 		if err := nl.setDrainingInternal(ctx, oldLivenessRec, drain, reporter); err != nil {
 			if log.V(1) {
-				log.Dev.Infof(ctx, "attempting to set liveness draining status to %v: %v", drain, err)
+				log.KvExec.Infof(ctx, "attempting to set liveness draining status to %v: %v", drain, err)
 			}
 			if grpcutil.IsConnectionRejected(err) {
 				return err
@@ -515,7 +515,7 @@ func (nl *NodeLiveness) setDrainingInternal(
 	})
 	if err != nil {
 		if log.V(1) {
-			log.Dev.Infof(ctx, "updating liveness record: %v", err)
+			log.KvExec.Infof(ctx, "updating liveness record: %v", err)
 		}
 		if errors.Is(err, errNodeDrainingSet) {
 			return nil
@@ -543,7 +543,7 @@ func (nl *NodeLiveness) cacheUpdated(old livenesspb.Liveness, new livenesspb.Liv
 		nl.onNodeDecommissioning(new.NodeID)
 	}
 	if log.V(2) {
-		log.Dev.Infof(nl.ambientCtx.AnnotateCtx(context.Background()), "received liveness update: %s", new)
+		log.KvExec.Infof(nl.ambientCtx.AnnotateCtx(context.Background()), "received liveness update: %s", new)
 	}
 }
 
@@ -612,7 +612,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 	log.VEventf(ctx, 1, "starting node liveness instance")
 	if nl.started.Load() {
 		// This is meant to prevent tests from calling start twice.
-		log.Dev.Fatal(ctx, "liveness already started")
+		log.KvExec.Fatal(ctx, "liveness already started")
 	}
 
 	retryOpts := base.DefaultRetryOptions()
@@ -650,7 +650,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 							nodeID := nl.cache.selfID()
 							liveness, err := nl.getLivenessRecordFromKV(ctx, nodeID)
 							if err != nil {
-								log.Dev.Infof(ctx, "unable to get liveness record from KV: %s", err)
+								log.KvExec.Infof(ctx, "unable to get liveness record from KV: %s", err)
 								if grpcutil.IsConnectionRejected(err) {
 									return err
 								}
@@ -660,7 +660,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 						}
 						if err := nl.heartbeatInternal(ctx, oldLiveness, incrementEpoch); err != nil {
 							if errors.Is(err, ErrEpochIncremented) {
-								log.Dev.Infof(ctx, "%s; retrying", err)
+								log.KvExec.Infof(ctx, "%s; retrying", err)
 								continue
 							}
 							return err
@@ -670,7 +670,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 					}
 					return nil
 				}); err != nil {
-				log.Dev.Warningf(ctx, heartbeatFailureLogFormat, err)
+				log.KvExec.Warningf(ctx, heartbeatFailureLogFormat, err)
 			} else if nl.onSelfHeartbeat != nil {
 				nl.onSelfHeartbeat(ctx)
 			}
@@ -756,7 +756,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 		dur := timeutil.Since(start)
 		nl.metrics.HeartbeatLatency.RecordValue(dur.Nanoseconds())
 		if dur > time.Second {
-			log.Dev.Warningf(ctx, "slow heartbeat took %s; err=%v", dur, err)
+			log.KvExec.Warningf(ctx, "slow heartbeat took %s; err=%v", dur, err)
 		}
 	}(timeutil.Now())
 
@@ -1018,7 +1018,7 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness livenesspb.
 		return err
 	}
 
-	log.Dev.Infof(ctx, "incremented n%d liveness epoch to %d", written.NodeID, written.Epoch)
+	log.KvExec.Infof(ctx, "incremented n%d liveness epoch to %d", written.NodeID, written.Epoch)
 	nl.cache.maybeUpdate(ctx, written)
 	nl.metrics.EpochIncrements.Inc()
 	return nil
@@ -1070,7 +1070,7 @@ func (nl *NodeLiveness) updateLiveness(
 		written, err := nl.updateLivenessAttempt(ctx, update, handleCondFailed)
 		if err != nil {
 			if errors.HasType(err, (*errRetryLiveness)(nil)) {
-				log.Dev.Infof(ctx, "retrying liveness update after %s", err)
+				log.KvExec.Infof(ctx, "retrying liveness update after %s", err)
 				continue
 			}
 			return Record{}, err

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -100,7 +100,7 @@ func (ls *storageImpl) Update(
 		b := txn.NewBatch()
 		key := keys.NodeLivenessKey(update.newLiveness.NodeID)
 		if err := v.SetProto(&update.newLiveness); err != nil {
-			log.Dev.Fatalf(ctx, "failed to marshall proto: %s", err)
+			log.KvExec.Fatalf(ctx, "failed to marshall proto: %s", err)
 		}
 		b.CPut(key, v, update.oldRaw)
 		// Use a trigger on EndTxn to indicate that node liveness should be
@@ -158,7 +158,7 @@ func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error 
 			b := txn.NewBatch()
 			key := keys.NodeLivenessKey(nodeID)
 			if err := v.SetProto(&liveness); err != nil {
-				log.Dev.Fatalf(ctx, "failed to marshall proto: %s", err)
+				log.KvExec.Fatalf(ctx, "failed to marshall proto: %s", err)
 			}
 			// Given we're looking to create a new liveness record here, we don't
 			// expect to find anything.
@@ -177,7 +177,7 @@ func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error 
 		if err == nil {
 			// We'll learn about this liveness record through gossip eventually, so we
 			// don't bother updating our in-memory view of node liveness.
-			log.Dev.Infof(ctx, "created liveness record for n%d", nodeID)
+			log.KvExec.Infof(ctx, "created liveness record for n%d", nodeID)
 			return nil
 		}
 		if !isErrRetryLiveness(ctx, err) {

--- a/pkg/kv/kvserver/load/node_capacity_provider.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider.go
@@ -146,7 +146,7 @@ func (m *runtimeLoadMonitor) recordCPUUsage(ctx context.Context) {
 			panic(err)
 		}
 		// TODO(wenyihu6): we should revisit error handling here for production.
-		log.Dev.Warningf(ctx, "failed to get cpu usage: %v", err)
+		log.KvDistribution.Warningf(ctx, "failed to get cpu usage: %v", err)
 	}
 	// Convert milliseconds to nanoseconds.
 	totalUsageNanos := float64(userTimeMillis*1e6 + sysTimeMillis*1e6)
@@ -168,7 +168,7 @@ func (m *runtimeLoadMonitor) recordCPUCapacity(ctx context.Context) {
 			panic("programming error: cpu capacity is 0")
 		}
 		// TODO(wenyihu6): we should pass in an actual context here.
-		log.Dev.Warningf(ctx, "failed to get cpu capacity")
+		log.KvDistribution.Warningf(ctx, "failed to get cpu capacity")
 	}
 }
 

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -102,7 +102,7 @@ func MaybeSideloadEntries(
 			// Still no AddSSTable; someone must've proposed a v2 command
 			// but not because it contains an inlined SSTable. Strange, but
 			// let's be future proof.
-			log.Dev.Warning(ctx, "encountered sideloaded Raft command without inlined payload")
+			log.KvExec.Warning(ctx, "encountered sideloaded Raft command without inlined payload")
 			continue
 		}
 
@@ -215,7 +215,7 @@ func MaybeInlineSideloadedRaftCommand(
 func AssertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) {
 	typ, _, err := raftlog.EncodingOf(*ent)
 	if err != nil {
-		log.Dev.Fatalf(ctx, "%v", err)
+		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 	if !typ.IsSideloaded() {
 		return
@@ -223,12 +223,12 @@ func AssertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) 
 
 	e, err := raftlog.NewEntry(*ent)
 	if err != nil {
-		log.Dev.Fatalf(ctx, "%v", err)
+		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 
 	if len(e.Cmd.ReplicatedEvalResult.AddSSTable.Data) == 0 {
 		// The entry is "thin", which is what this assertion is checking for.
-		log.Dev.Fatalf(ctx, "found thin sideloaded raft command: %+v", e.Cmd)
+		log.KvExec.Fatalf(ctx, "found thin sideloaded raft command: %+v", e.Cmd)
 	}
 }
 

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -211,7 +211,7 @@ func (ss *DiskSideloadStorage) TruncateTo(ctx context.Context, lastIndex kvpb.Ra
 		if err != nil && !oserror.IsNotExist(err) {
 			// TODO(pavelkalinnikov): this is possible because deletedAll can be left
 			// true despite existence of files with index < from which are skipped.
-			log.Dev.Infof(ctx, "unable to remove sideloaded dir %s: %v", ss.dir, err)
+			log.KvExec.Infof(ctx, "unable to remove sideloaded dir %s: %v", ss.dir, err)
 			err = nil // handled
 		}
 	}
@@ -266,7 +266,7 @@ func (ss *DiskSideloadStorage) forEach(
 		upToDot := strings.SplitN(base, ".", 2)
 		logIdx, err := strconv.ParseUint(upToDot[0], 10, 64)
 		if err != nil {
-			log.Dev.Infof(ctx, "unexpected file %s in sideloaded directory %s", match, ss.dir)
+			log.KvExec.Infof(ctx, "unexpected file %s in sideloaded directory %s", match, ss.dir)
 			continue
 		}
 		if keepGoing, err := visit(kvpb.RaftIndex(logIdx), match); err != nil {

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -76,21 +76,21 @@ func (sl StateLoader) LoadLastEntryID(
 	if ok, _ := iter.Valid(); ok {
 		key := iter.UnsafeKey().Key
 		if len(key) < len(prefix) {
-			log.Dev.Fatalf(ctx, "unable to decode Raft log index key: len(%s) < len(%s)", key.String(), prefix.String())
+			log.KvExec.Fatalf(ctx, "unable to decode Raft log index key: len(%s) < len(%s)", key.String(), prefix.String())
 		}
 		suffix := key[len(prefix):]
 		var err error
 		last.Index, err = keys.DecodeRaftLogKeyFromSuffix(suffix)
 		if err != nil {
-			log.Dev.Fatalf(ctx, "unable to decode Raft log index key: %s; %v", key.String(), err)
+			log.KvExec.Fatalf(ctx, "unable to decode Raft log index key: %s; %v", key.String(), err)
 		}
 		v, err := iter.UnsafeValue()
 		if err != nil {
-			log.Dev.Fatalf(ctx, "unable to read Raft log entry %d (%s): %v", last.Index, key.String(), err)
+			log.KvExec.Fatalf(ctx, "unable to read Raft log entry %d (%s): %v", last.Index, key.String(), err)
 		}
 		entry, err := raftlog.RaftEntryFromRawValue(v)
 		if err != nil {
-			log.Dev.Fatalf(ctx, "unable to decode Raft log entry %d (%s): %v", last.Index, key.String(), err)
+			log.KvExec.Fatalf(ctx, "unable to decode Raft log entry %d (%s): %v", last.Index, key.String(), err)
 		}
 		last.Term = kvpb.RaftTerm(entry.Term)
 	}

--- a/pkg/kv/kvserver/logstore/sync_waiter.go
+++ b/pkg/kv/kvserver/logstore/sync_waiter.go
@@ -88,7 +88,7 @@ func (w *SyncWaiterLoop) waitLoop(ctx context.Context, stopper *stop.Stopper) {
 		select {
 		case w := <-w.q:
 			if err := w.wg.SyncWait(); err != nil {
-				log.Dev.Fatalf(ctx, "SyncWait error: %+v", err)
+				log.KvExec.Fatalf(ctx, "SyncWait error: %+v", err)
 			}
 			w.cb.run()
 			w.wg.Close()
@@ -120,7 +120,7 @@ func (w *SyncWaiterLoop) enqueue(ctx context.Context, wg syncWaiter, cb syncWait
 			// with enough capacity to hold more in-progress sync operations than
 			// Pebble allows (pebble/record.SyncConcurrency). However, we can still
 			// see this in cases where consumption from the queue is delayed.
-			log.Dev.VWarningf(ctx, 1, "SyncWaiterLoop.enqueue blocking due to insufficient channel capacity")
+			log.KvExec.VWarningf(ctx, 1, "SyncWaiterLoop.enqueue blocking due to insufficient channel capacity")
 		}
 		select {
 		case w.q <- b:

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -380,7 +380,7 @@ func MaybeApplyPendingRecoveryPlan(
 			return errors.Wrap(err, "failed to check cluster version against storage")
 		}
 
-		log.Dev.Infof(ctx, "applying staged loss of quorum recovery plan %s", plan.PlanID)
+		log.KvExec.Infof(ctx, "applying staged loss of quorum recovery plan %s", plan.PlanID)
 		batches := make(map[roachpb.StoreID]storage.Batch)
 		for _, e := range engines {
 			ident, err := kvstorage.ReadStoreIdent(ctx, e)
@@ -396,7 +396,7 @@ func MaybeApplyPendingRecoveryPlan(
 			return err
 		}
 		if len(prepRep.MissingStores) > 0 {
-			log.Dev.Warningf(ctx, "loss of quorum recovery plan application expected stores on the node %s",
+			log.KvExec.Warningf(ctx, "loss of quorum recovery plan application expected stores on the node %s",
 				strutil.JoinIDs("s", prepRep.MissingStores))
 		}
 		_, err = CommitReplicaChanges(batches)
@@ -426,14 +426,14 @@ func MaybeApplyPendingRecoveryPlan(
 			// This is wrong, we must not have staged plans in a non-bootstrapped
 			// node. But we can't write an error here as store init might refuse to
 			// work if there are already some keys in store.
-			log.Dev.Errorf(ctx, "node is not bootstrapped but it already has a recovery plan staged: %s", err)
+			log.KvExec.Errorf(ctx, "node is not bootstrapped but it already has a recovery plan staged: %s", err)
 			return nil
 		}
 		return err
 	}
 
 	if err := planStore.RemovePlan(); err != nil {
-		log.Dev.Errorf(ctx, "failed to remove loss of quorum recovery plan: %s", err)
+		log.KvExec.Errorf(ctx, "failed to remove loss of quorum recovery plan: %s", err)
 	}
 
 	err = applyPlan(storeIdent.NodeID, plan)
@@ -443,11 +443,11 @@ func MaybeApplyPendingRecoveryPlan(
 	}
 	if err != nil {
 		r.Error = err.Error()
-		log.Dev.Errorf(ctx, "failed to apply staged loss of quorum recovery plan %s", err)
+		log.KvExec.Errorf(ctx, "failed to apply staged loss of quorum recovery plan %s", err)
 	}
 	if err = writeNodeRecoveryResults(ctx, engines[0], r,
 		loqrecoverypb.DeferredRecoveryActions{DecommissionedNodeIDs: plan.DecommissionedNodeIDs}); err != nil {
-		log.Dev.Errorf(ctx, "failed to write loss of quorum recovery results to store: %s", err)
+		log.KvExec.Errorf(ctx, "failed to write loss of quorum recovery results to store: %s", err)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -230,7 +230,7 @@ func planReplicasWithMeta(
 			}
 			problems = append(problems, checkDescriptor(rankedRangeReplicas)...)
 			updates = append(updates, u)
-			log.Dev.Infof(ctx, "replica has lost quorum, recovering: %s -> %s",
+			log.KvExec.Infof(ctx, "replica has lost quorum, recovering: %s -> %s",
 				rankedRangeReplicas.survivor().Desc, u.NewReplica)
 		}
 	}
@@ -557,7 +557,7 @@ func makeReplicaUpdateIfNeeded(
 		// out on earlier stages. This is covered by invalid input tests and if we
 		// ended up here that means tests are not run, or code changed sufficiently
 		// and both checks and tests were lost.
-		log.Dev.Fatalf(ctx, "unexpected invalid replica info while making recovery plan, "+
+		log.KvExec.Fatalf(ctx, "unexpected invalid replica info while making recovery plan, "+
 			"we should never have unvalidated descriptors at planning stage, they must be detected "+
 			"while performing keyspace coverage check: %s", err)
 	}

--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -195,7 +195,7 @@ func readNodeRecoveryStatusInfo(
 	ok, err := storage.MVCCGetProto(ctx, reader, keys.StoreLossOfQuorumRecoveryStatusKey(),
 		hlc.Timestamp{}, &result, storage.MVCCGetOptions{})
 	if err != nil {
-		log.Dev.Error(ctx, "failed to read loss of quorum recovery plan application status")
+		log.KvExec.Error(ctx, "failed to read loss of quorum recovery plan application status")
 		return loqrecoverypb.PlanApplicationResult{}, false, err
 	}
 	return result, ok, nil
@@ -210,7 +210,7 @@ func ReadCleanupActionsInfo(
 	exists, err := storage.MVCCGetProto(ctx, writer, keys.StoreLossOfQuorumRecoveryCleanupActionsKey(),
 		hlc.Timestamp{}, &result, storage.MVCCGetOptions{})
 	if err != nil {
-		log.Dev.Errorf(ctx, "failed to read loss of quorum cleanup actions key: %s", err)
+		log.KvExec.Errorf(ctx, "failed to read loss of quorum cleanup actions key: %s", err)
 		return loqrecoverypb.DeferredRecoveryActions{}, false, err
 	}
 	return result, exists, nil

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -159,7 +159,7 @@ func (s Server) ServeClusterReplicas(
 	var descriptors, nodes, replicas atomic.Int64
 	defer func() {
 		if err == nil {
-			log.Dev.Infof(ctx, "streamed info: range descriptors %d, nodes %d, replica infos %d",
+			log.KvExec.Infof(ctx, "streamed info: range descriptors %d, nodes %d, replica infos %d",
 				descriptors.Load(), nodes.Load(), replicas.Load())
 		}
 	}()
@@ -183,7 +183,7 @@ func (s Server) ServeClusterReplicas(
 				return err
 			}
 			defer func() { _ = txn.Rollback(txnCtx) }()
-			log.Dev.Infof(txnCtx, "serving recovery range descriptors for all ranges")
+			log.KvExec.Infof(txnCtx, "serving recovery range descriptors for all ranges")
 			return txn.Iterate(txnCtx, keys.Meta2Prefix, keys.MetaMax, rangeMetadataScanChunkSize,
 				func(kvs []kv.KeyValue) error {
 					for _, rangeDescKV := range kvs {
@@ -211,7 +211,7 @@ func (s Server) ServeClusterReplicas(
 		if outStream.Context().Err() != nil {
 			return err
 		}
-		log.Dev.Infof(ctx, "failed to iterate all descriptors: %s", err)
+		log.KvExec.Infof(ctx, "failed to iterate all descriptors: %s", err)
 	}
 
 	// Stream local replica info from all nodes wrapping them in response stream.
@@ -231,7 +231,7 @@ func serveClusterReplicasParallelFn(
 	replicas, nodes *atomic.Int64,
 ) visitNodeAdminFn {
 	return func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error {
-		log.Dev.Infof(ctx, "trying to get info from node n%d", nodeID)
+		log.KvExec.Infof(ctx, "trying to get info from node n%d", nodeID)
 		var nodeReplicas int64
 		inStream, err := client.RecoveryCollectLocalReplicaInfo(ctx,
 			&serverpb.RecoveryCollectLocalReplicaInfoRequest{})
@@ -363,7 +363,7 @@ func (s Server) StagePlan(
 		return &serverpb.RecoveryStagePlanResponse{Errors: nodeErrors.Clone()}, nil
 	}
 
-	log.Dev.Infof(ctx, "attempting to stage loss of quorum recovery plan")
+	log.KvExec.Infof(ctx, "attempting to stage loss of quorum recovery plan")
 
 	responseFromError := func(err error) (*serverpb.RecoveryStagePlanResponse, error) {
 		return &serverpb.RecoveryStagePlanResponse{
@@ -492,7 +492,7 @@ func (s Server) NodeStatus(
 		return nil
 	})
 	if err = iterutil.Map(err); err != nil {
-		log.Dev.Errorf(ctx, "failed to read loss of quorum recovery application status %s", err)
+		log.KvExec.Errorf(ctx, "failed to read loss of quorum recovery application status %s", err)
 		return nil, err
 	}
 
@@ -766,7 +766,7 @@ func visitNodeWithRetry(
 	var err error
 	var ac serverpb.RPCAdminClient
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-		log.Dev.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
+		log.KvExec.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
 		// Note that we use ConnectNoBreaker here to avoid any race with probe
 		// running on current node and target node restarting. Errors from circuit
 		// breaker probes could confuse us and present node as unavailable.
@@ -775,7 +775,7 @@ func visitNodeWithRetry(
 		// them and let caller handle incomplete info.
 		if err != nil {
 			if grpcutil.IsConnectionUnavailable(err) {
-				log.Dev.Infof(ctx, "rejecting node n%d because of suspected un-retryable error: %s",
+				log.KvExec.Infof(ctx, "rejecting node n%d because of suspected un-retryable error: %s",
 					node.NodeID, err)
 				return nil
 			}
@@ -787,7 +787,7 @@ func visitNodeWithRetry(
 		if err == nil {
 			return nil
 		}
-		log.Dev.Infof(ctx, "failed calling a visitor for node n%d: %s", node.NodeID, err)
+		log.KvExec.Infof(ctx, "failed calling a visitor for node n%d: %s", node.NodeID, err)
 		if !IsRetryableError(err) {
 			return err
 		}
@@ -815,14 +815,14 @@ func makeVisitNode(nd *nodedialer.Dialer) visitNodeStatusFn {
 		var client serverpb.RPCStatusClient
 
 		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-			log.Dev.Infof(ctx, "visiting node n%d, attempt %d", nodeID, r.CurrentAttempt())
+			log.KvExec.Infof(ctx, "visiting node n%d, attempt %d", nodeID, r.CurrentAttempt())
 			// Note that we use ConnectNoBreaker here to avoid any race with probe
 			// running on current node and target node restarting. Errors from circuit
 			// breaker probes could confuse us and present node as unavailable.
 			client, err = serverpb.DialStatusClientNoBreaker(nd, ctx, nodeID, rpcbase.DefaultClass)
 			if err != nil {
 				if grpcutil.IsClosedConnection(err) {
-					log.Dev.Infof(ctx, "can't dial node n%d because connection is permanently closed: %s",
+					log.KvExec.Infof(ctx, "can't dial node n%d because connection is permanently closed: %s",
 						nodeID, err)
 					return err
 				}
@@ -833,7 +833,7 @@ func makeVisitNode(nd *nodedialer.Dialer) visitNodeStatusFn {
 			if err == nil {
 				return nil
 			}
-			log.Dev.Infof(ctx, "failed calling a visitor for node n%d: %s", nodeID, err)
+			log.KvExec.Infof(ctx, "failed calling a visitor for node n%d: %s", nodeID, err)
 			if !IsRetryableError(err) {
 				return err
 			}

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -146,7 +146,7 @@ func (mq *mergeQueue) shouldQueue(
 
 	needsSplit, err := confReader.NeedsSplit(ctx, desc.StartKey, desc.EndKey.Next())
 	if err != nil {
-		log.Dev.Warningf(
+		log.KvDistribution.Warningf(
 			ctx,
 			"could not compute if extending range would result in a split (err=%v); skipping merge for range %s",
 			err,
@@ -381,7 +381,7 @@ func (mq *mergeQueue) process(
 	}
 	for i := range rightRepls {
 		if typ := rightRepls[i].Type; !(typ == roachpb.VOTER_FULL || typ == roachpb.NON_VOTER) {
-			log.Dev.Infof(ctx, "RHS Type: %s", typ)
+			log.KvDistribution.Infof(ctx, "RHS Type: %s", typ)
 			return false,
 				errors.AssertionFailedf(
 					`cannot merge because rhs is either in a joint state or has learner replicas: %v`,
@@ -406,7 +406,7 @@ func (mq *mergeQueue) process(
 		// attempts because merges can race with other descriptor modifications.
 		// On seeing a ConditionFailedError, don't return an error and enqueue
 		// this replica again in case it still needs to be merged.
-		log.Dev.Infof(ctx, "merge saw concurrent descriptor modification; maybe retrying")
+		log.KvDistribution.Infof(ctx, "merge saw concurrent descriptor modification; maybe retrying")
 		mq.MaybeAddAsync(ctx, lhsRepl, now)
 		return false, nil
 	} else if err != nil {
@@ -415,12 +415,12 @@ func (mq *mergeQueue) process(
 		//
 		// TODO(aayush): Merges are indeed stable now, we can be smarter here about
 		// which errors should be marked as purgatory-worthy.
-		log.Dev.Warningf(ctx, "%v", err)
+		log.KvDistribution.Warningf(ctx, "%v", err)
 		return false, rangeMergePurgatoryError{err}
 	}
 	if testingAggressiveConsistencyChecks {
 		if _, err := mq.store.consistencyQueue.process(ctx, lhsRepl, confReader, -1 /*priorityAtEnqueue*/); err != nil {
-			log.Dev.Warningf(ctx, "%v", err)
+			log.KvDistribution.Warningf(ctx, "%v", err)
 		}
 	}
 

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -485,7 +485,7 @@ func makeMVCCGCQueueScoreImpl(
 	isGCScoreMet := func(score float64, minThreshold, maxThreshold float64, cooldown time.Duration) bool {
 		if minThreshold > maxThreshold {
 			if util.RaceEnabled {
-				log.Dev.Fatalf(ctx,
+				log.KvDistribution.Fatalf(ctx,
 					"invalid cooldown score thresholds. min (%f) must be less or equal to max (%f)",
 					minThreshold, maxThreshold)
 			}
@@ -602,7 +602,7 @@ func (r *replicaGCer) send(ctx context.Context, req kvpb.GCRequest) error {
 	b.AdmissionHeader = gcAdmissionHeader(r.repl.ClusterSettings())
 
 	if err := r.repl.store.cfg.DB.Run(ctx, &b); err != nil {
-		log.Dev.Infof(ctx, "%s", err)
+		log.KvDistribution.Infof(ctx, "%s", err)
 		return err
 	}
 	return nil
@@ -789,9 +789,9 @@ func (mgcq *mvccGCQueue) process(
 		// prevents the GC threshold from advancing. In that case, not only did we
 		// run a GC cycle without improving anything, but we also pile up a stats
 		// recomputation. This is hopefully too rare to matter.
-		log.Dev.Infof(ctx, "GC still needed following GC, recomputing MVCC stats")
-		log.Dev.Infof(ctx, "old score %s", r)
-		log.Dev.Infof(ctx, "new score %s", scoreAfter)
+		log.KvDistribution.Infof(ctx, "GC still needed following GC, recomputing MVCC stats")
+		log.KvDistribution.Infof(ctx, "old score %s", r)
+		log.KvDistribution.Infof(ctx, "new score %s", scoreAfter)
 		req := kvpb.RecomputeStatsRequest{
 			RequestHeader: kvpb.RequestHeader{Key: desc.StartKey.AsRawKey()},
 		}
@@ -799,7 +799,7 @@ func (mgcq *mvccGCQueue) process(
 		b.AddRawRequest(&req)
 		err := repl.store.db.Run(ctx, &b)
 		if err != nil {
-			log.Dev.Errorf(ctx, "failed to recompute stats with error=%s", err)
+			log.KvDistribution.Errorf(ctx, "failed to recompute stats with error=%s", err)
 		}
 	}
 
@@ -841,7 +841,7 @@ func (mgcq *mvccGCQueue) postProcessScheduled(
 			mgcq.scanReplicasForHiPriGCHints(ctx, processedReplica.GetRangeID())
 			return ctx.Err()
 		}); err != nil {
-			log.Dev.Infof(ctx, "failed to start mvcc gc scan for range delete hints, error: %s", err)
+			log.KvDistribution.Infof(ctx, "failed to start mvcc gc scan for range delete hints, error: %s", err)
 		}
 		// Set flag indicating that we are already collecting high priority to avoid
 		// rescanning and re-enqueueing ranges multiple times.
@@ -893,7 +893,7 @@ func (mgcq *mvccGCQueue) scanReplicasForHiPriGCHints(
 		}
 		return true
 	})
-	log.Dev.Infof(ctx, "mvcc gc scan for range delete hints found %d replicas", foundReplicas)
+	log.KvDistribution.Infof(ctx, "mvcc gc scan for range delete hints found %d replicas", foundReplicas)
 }
 
 // timer returns a constant duration to space out GC processing

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -117,7 +117,7 @@ func TestMVCCGCQueueMakeGCScoreInvariantQuick(t *testing.T) {
 		wouldHaveToDeleteSomething := gcBytes*int64(ttlSec) < ms.GCByteAge(now.WallTime)
 		result := !r.ShouldQueue || wouldHaveToDeleteSomething
 		if !result {
-			log.Dev.Warningf(ctx, "failing on ttl=%d, timePassed=%s, gcBytes=%d, gcByteAge=%d:\n%s",
+			log.KvDistribution.Warningf(ctx, "failing on ttl=%d, timePassed=%s, gcBytes=%d, gcByteAge=%d:\n%s",
 				ttlSec, timePassed, gcBytes, gcByteAge, r)
 		}
 		return result

--- a/pkg/kv/kvserver/protectedts/ptcache/cache.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache.go
@@ -192,7 +192,7 @@ func (c *Cache) periodicallyRefreshProtectedtsCache(ctx context.Context) {
 				// We expect an error if the context was cancelled, we don't want to log
 				// in that case.
 				if ctx.Err() == nil {
-					log.Dev.Errorf(ctx, "failed to refresh protected timestamps: %v", res.Err)
+					log.KvDistribution.Errorf(ctx, "failed to refresh protected timestamps: %v", res.Err)
 				}
 			}
 			timer.Reset(protectedts.PollInterval.Get(&c.settings.SV))

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -118,7 +118,7 @@ func (r *Reconciler) reconcile(ctx context.Context) {
 		return err
 	}); err != nil {
 		r.metrics.ReconciliationErrors.Inc(1)
-		log.Dev.Errorf(ctx, "failed to load protected timestamp records: %+v", err)
+		log.KvDistribution.Errorf(ctx, "failed to load protected timestamp records: %+v", err)
 		return
 	}
 	for _, rec := range state.Records {
@@ -145,7 +145,7 @@ func (r *Reconciler) reconcile(ctx context.Context) {
 			return nil
 		}); err != nil {
 			r.metrics.ReconciliationErrors.Inc(1)
-			log.Dev.Errorf(ctx, "failed to reconcile protected timestamp with id %s: %v",
+			log.KvDistribution.Errorf(ctx, "failed to reconcile protected timestamp with id %s: %v",
 				rec.ID.String(), err)
 		} else {
 			r.metrics.RecordsProcessed.Inc(1)

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -116,7 +116,7 @@ func (p *storage) Protect(ctx context.Context, r *ptpb.Record) error {
 
 	defer func() {
 		if err := it.Close(); err != nil {
-			log.Dev.Infof(ctx, "encountered %v when writing record %v", err, r.ID)
+			log.KvDistribution.Infof(ctx, "encountered %v when writing record %v", err, r.ID)
 		}
 	}()
 
@@ -236,7 +236,7 @@ func (p *storage) getRecords(ctx context.Context) ([]ptpb.Record, error) {
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var record ptpb.Record
 		if err := rowToRecord(it.Cur(), &record, false /* isDeprecatedRow */); err != nil {
-			log.Dev.Errorf(ctx, "failed to parse row as record: %v", err)
+			log.KvDistribution.Errorf(ctx, "failed to parse row as record: %v", err)
 		}
 		records = append(records, record)
 	}
@@ -370,7 +370,7 @@ func (p *storage) deprecatedProtect(ctx context.Context, r *ptpb.Record, meta []
 	}
 	row := it.Cur()
 	if err := it.Close(); err != nil {
-		log.Dev.Infof(ctx, "encountered %v when writing record %v", err, r.ID)
+		log.KvDistribution.Infof(ctx, "encountered %v when writing record %v", err, r.ID)
 	}
 	if failed := *row[0].(*tree.DBool); failed {
 		curNumSpans := int64(*row[1].(*tree.DInt))
@@ -423,7 +423,7 @@ func (p *storage) deprecatedGetRecords(ctx context.Context) ([]ptpb.Record, erro
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var record ptpb.Record
 		if err := rowToRecord(it.Cur(), &record, true /* isDeprecatedRow */); err != nil {
-			log.Dev.Errorf(ctx, "failed to parse row as record: %v", err)
+			log.KvDistribution.Errorf(ctx, "failed to parse row as record: %v", err)
 		}
 		records = append(records, record)
 	}

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -648,7 +648,7 @@ func TestCorruptData(t *testing.T) {
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)
 		require.NoError(t, err)
-		require.GreaterOrEqual(t, 1, len(entries), "entries: %v", entries)
+		require.GreaterOrEqual(t, len(entries), 1, "entries: %v", entries)
 		for _, e := range entries {
 			require.Equal(t, severity.ERROR, e.Severity)
 		}
@@ -740,7 +740,7 @@ func TestCorruptData(t *testing.T) {
 			entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 				log.WithFlattenedSensitiveData)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, 1, len(entries), "entries: %v", entries)
+			require.GreaterOrEqual(t, len(entries), 1, "entries: %v", entries)
 			for _, e := range entries {
 				require.Equal(t, severity.ERROR, e.Severity)
 			}

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -198,7 +198,7 @@ type replicaItem struct {
 // setProcessing moves the item from an enqueued state to a processing state.
 func (i *replicaItem) setProcessing() {
 	if i.index >= 0 {
-		log.Dev.Fatalf(context.Background(),
+		log.KvDistribution.Fatalf(context.Background(),
 			"r%d marked as processing but appears in prioQ", i.rangeID,
 		)
 	}
@@ -265,7 +265,7 @@ func (pq *priorityQueue) Pop() interface{} {
 func (pq *priorityQueue) update(item *replicaItem, priority float64) {
 	item.priority = priority
 	if len(pq.sl) <= item.index || pq.sl[item.index] != item {
-		log.Dev.Fatalf(context.Background(), "updating item in heap that's not contained in it: %v", item)
+		log.KvDistribution.Fatalf(context.Background(), "updating item in heap that's not contained in it: %v", item)
 	}
 	heap.Fix(pq, item.index)
 }
@@ -560,7 +560,7 @@ func newBaseQueue(name string, impl queueImpl, store *Store, cfg queueConfig) *b
 	ambient.AddLogTag(name, nil)
 
 	if !cfg.acceptsUnsplitRanges && !cfg.needsSpanConfigs {
-		log.Dev.Fatalf(ambient.AnnotateCtx(context.Background()),
+		log.KvDistribution.Fatalf(ambient.AnnotateCtx(context.Background()),
 			"misconfigured queue: acceptsUnsplitRanges=false requires needsSpanConfigs=true; got %+v", cfg)
 	}
 
@@ -705,7 +705,7 @@ func (h baseQueueHelper) Add(
 ) {
 	_, err := h.bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), prio, cb)
 	if err != nil && log.V(1) {
-		log.Dev.Infof(ctx, "during Add: %s", err)
+		log.KvDistribution.Infof(ctx, "during Add: %s", err)
 	}
 }
 
@@ -732,7 +732,7 @@ func (bq *baseQueue) Async(
 	ctx context.Context, opName string, wait bool, fn func(ctx context.Context, h queueHelper),
 ) error {
 	if log.V(3) {
-		log.Dev.InfofDepth(ctx, 2, "%s", redact.Safe(opName))
+		log.KvDistribution.InfofDepth(ctx, 2, "%s", redact.Safe(opName))
 	}
 	opName += " (" + bq.name + ")"
 	bgCtx, hdl, err := bq.store.stopper.GetHandle(
@@ -743,7 +743,7 @@ func (bq *baseQueue) Async(
 		})
 	if err != nil {
 		if bq.addLogN.ShouldLog() {
-			log.Dev.Infof(ctx, "rate limited in %s: %s", redact.Safe(opName), err)
+			log.KvDistribution.Infof(ctx, "rate limited in %s: %s", redact.Safe(opName), err)
 		}
 		return baseQueueAsyncRateLimited
 	}
@@ -894,18 +894,18 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 		hasExternal, err := realRepl.HasExternalBytes()
 		if err != nil {
 			bq.updateMetricsOnEnqueueUnexpectedError()
-			log.Dev.Warningf(ctx, "could not determine if %s has external bytes: %s", realRepl, err)
+			log.KvDistribution.Warningf(ctx, "could not determine if %s has external bytes: %s", realRepl, err)
 			return
 		}
 		if hasExternal {
 			bq.updateMetricsOnEnqueueUnexpectedError()
-			log.Dev.VInfof(ctx, 1, "skipping %s for %s because it has external bytes", bq.name, realRepl)
+			log.KvDistribution.VInfof(ctx, 1, "skipping %s for %s because it has external bytes", bq.name, realRepl)
 			return
 		}
 	}
 	_, err = bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), priority, noopProcessCallback)
 	if !isExpectedQueueError(err) {
-		log.Dev.Errorf(ctx, "unable to add: %+v", err)
+		log.KvDistribution.Errorf(ctx, "unable to add: %+v", err)
 	}
 }
 
@@ -969,7 +969,7 @@ func (bq *baseQueue) addInternal(
 		bypassDisabled := bq.store.TestingKnobs().BaseQueueDisabledBypassFilter
 		if bypassDisabled == nil || !bypassDisabled(desc.RangeID) {
 			if log.V(3) {
-				log.Dev.Infof(ctx, "queue disabled")
+				log.KvDistribution.Infof(ctx, "queue disabled")
 			}
 			return false, errQueueDisabled
 		}
@@ -996,7 +996,7 @@ func (bq *baseQueue) addInternal(
 		// one does.
 		if priority > item.priority {
 			if log.V(1) {
-				log.Dev.Infof(ctx, "updating priority: %0.3f -> %0.3f", item.priority, priority)
+				log.KvDistribution.Infof(ctx, "updating priority: %0.3f -> %0.3f", item.priority, priority)
 			}
 			bq.mu.priorityQ.update(item, priority)
 			// item.index should be updated now based on heap property now.
@@ -1006,7 +1006,7 @@ func (bq *baseQueue) addInternal(
 	}
 
 	if log.V(3) {
-		log.Dev.Infof(ctx, "adding: priority=%0.3f", priority)
+		log.KvDistribution.Infof(ctx, "adding: priority=%0.3f", priority)
 	}
 	item = &replicaItem{rangeID: desc.RangeID, replicaID: replicaID, priority: priority}
 	item.registerCallback(cb)
@@ -1020,7 +1020,7 @@ func (bq *baseQueue) addInternal(
 	if pqLen := bq.mu.priorityQ.Len(); int64(pqLen) > bq.mu.maxSize {
 		replicaItemToDrop := bq.mu.priorityQ.sl[pqLen-1]
 		bq.updateMetricsOnDroppedDueToFullQueue()
-		log.Dev.VInfof(ctx, 1, "dropping due to exceeding queue max size: priority=%0.3f, replica=%v",
+		log.KvDistribution.VInfof(ctx, 1, "dropping due to exceeding queue max size: priority=%0.3f, replica=%v",
 			priority, replicaItemToDrop.replicaID)
 		// TODO(wenyihu6): when we introduce base queue max size cluster setting,
 		// remember to invoke this callback when shrinking the size
@@ -1101,7 +1101,7 @@ func (bq *baseQueue) MaybeRemove(rangeID roachpb.RangeID) {
 	if item, ok := bq.mu.replicas[rangeID]; ok {
 		ctx := bq.AnnotateCtx(context.TODO())
 		if log.V(3) {
-			log.Dev.Infof(ctx, "%s: removing", item.rangeID)
+			log.KvDistribution.Infof(ctx, "%s: removing", item.rangeID)
 		}
 		bq.removeLocked(item)
 	}
@@ -1201,7 +1201,7 @@ func (bq *baseQueue) processOneAsyncAndReleaseSem(
 		// happens during a system shutdown. If the func is started this will
 		// never return an error.
 		bq.finishProcessingReplica(ctx, stopper, repl, err)
-		log.Dev.Warningf(ctx, "%s: task did not start %v", taskName, err)
+		log.KvDistribution.Warningf(ctx, "%s: task did not start %v", taskName, err)
 		<-bq.processSem
 	}
 }
@@ -1214,7 +1214,7 @@ func (bq *baseQueue) lastProcessDuration() time.Duration {
 // recordProcessDuration records the duration of a processing run.
 func (bq *baseQueue) recordProcessDuration(ctx context.Context, dur time.Duration) {
 	if log.V(2) {
-		log.Dev.Infof(ctx, "done %s", dur)
+		log.KvDistribution.Infof(ctx, "done %s", dur)
 	}
 	bq.processingNanos.Inc(dur.Nanoseconds())
 	atomic.StoreInt64(&bq.processDur, int64(dur))
@@ -1304,7 +1304,7 @@ func (bq *baseQueue) replicaCanBeProcessed(
 		confReader, err = bq.store.GetConfReader(ctx)
 		if err != nil {
 			if log.V(1) || !errors.Is(err, errSpanConfigsUnavailable) {
-				log.Dev.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
+				log.KvDistribution.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
 			}
 			return nil, err
 		}
@@ -1314,7 +1314,7 @@ func (bq *baseQueue) replicaCanBeProcessed(
 			// be spilt because of a span config.
 			needsSplit, err := confReader.NeedsSplit(ctx, repl.Desc().StartKey, repl.Desc().EndKey)
 			if err != nil {
-				log.Dev.Warningf(ctx, "unable to compute NeedsSplit, skipping: %v", err)
+				log.KvDistribution.Warningf(ctx, "unable to compute NeedsSplit, skipping: %v", err)
 				return nil, err
 			}
 			if needsSplit {
@@ -1386,23 +1386,23 @@ func (bq *baseQueue) assertInvariants(assertOnReplicaItem func(item *replicaItem
 	for _, item := range bq.mu.priorityQ.sl {
 		assertOnReplicaItem(item)
 		if item.processing {
-			log.Dev.Fatalf(ctx, "processing item found in prioQ: %v", item)
+			log.KvDistribution.Fatalf(ctx, "processing item found in prioQ: %v", item)
 		}
 		if _, inReplicas := bq.mu.replicas[item.rangeID]; !inReplicas {
-			log.Dev.Fatalf(ctx, "item found in prioQ but not in mu.replicas: %v", item)
+			log.KvDistribution.Fatalf(ctx, "item found in prioQ but not in mu.replicas: %v", item)
 		}
 		if _, inPurg := bq.mu.purgatory[item.rangeID]; inPurg {
-			log.Dev.Fatalf(ctx, "item found in prioQ and purgatory: %v", item)
+			log.KvDistribution.Fatalf(ctx, "item found in prioQ and purgatory: %v", item)
 		}
 	}
 	for rangeID := range bq.mu.purgatory {
 		item, inReplicas := bq.mu.replicas[rangeID]
 		assertOnReplicaItem(item)
 		if !inReplicas {
-			log.Dev.Fatalf(ctx, "item found in purg but not in mu.replicas: %v", item)
+			log.KvDistribution.Fatalf(ctx, "item found in purg but not in mu.replicas: %v", item)
 		}
 		if item.processing {
-			log.Dev.Fatalf(ctx, "processing item found in purgatory: %v", item)
+			log.KvDistribution.Fatalf(ctx, "processing item found in purgatory: %v", item)
 		}
 		// NB: we already checked above that item not in prioQ.
 	}
@@ -1418,7 +1418,7 @@ func (bq *baseQueue) assertInvariants(assertOnReplicaItem func(item *replicaItem
 		}
 	}
 	if nNotProcessing != len(bq.mu.purgatory)+len(bq.mu.priorityQ.sl) {
-		log.Dev.Fatalf(ctx, "have %d non-processing replicas in mu.replicas, "+
+		log.KvDistribution.Fatalf(ctx, "have %d non-processing replicas in mu.replicas, "+
 			"but %d in purgatory and %d in prioQ; the latter two should add up"+
 			"to the former", nNotProcessing, len(bq.mu.purgatory), len(bq.mu.priorityQ.sl))
 	}
@@ -1444,7 +1444,7 @@ func (bq *baseQueue) finishProcessingReplica(
 	bq.mu.Unlock()
 
 	if !processing {
-		log.Dev.Fatalf(ctx, "%s: attempt to remove non-processing replica %v", bq.name, repl)
+		log.KvDistribution.Fatalf(ctx, "%s: attempt to remove non-processing replica %v", bq.name, repl)
 	}
 
 	// Call any registered callbacks.
@@ -1475,7 +1475,7 @@ func (bq *baseQueue) finishProcessingReplica(
 
 		// If not a benign or purgatory error, log.
 		if !benign {
-			log.Dev.Warningf(ctx, "queue processing resulted in non-benign error: %v", err)
+			log.KvDistribution.Warningf(ctx, "queue processing resulted in non-benign error: %v", err)
 		}
 	}
 
@@ -1500,12 +1500,12 @@ func (bq *baseQueue) addToPurgatoryLocked(
 	// Check whether the queue supports purgatory errors. If not then something
 	// went wrong because a purgatory error should not have ended up here.
 	if bq.impl.purgatoryChan() == nil {
-		log.Dev.Errorf(ctx, "queue does not support purgatory errors, but saw %v", purgErr)
+		log.KvDistribution.Errorf(ctx, "queue does not support purgatory errors, but saw %v", purgErr)
 		return
 	}
 
 	if log.V(1) {
-		log.Dev.Infof(ctx, "purgatory: %v", purgErr)
+		log.KvDistribution.Infof(ctx, "purgatory: %v", purgErr)
 	}
 
 	if _, found := bq.mu.replicas[repl.GetRangeID()]; found {
@@ -1565,7 +1565,7 @@ func (bq *baseQueue) addToPurgatoryLocked(
 				}
 				bq.mu.Unlock()
 				for errStr, count := range errMap {
-					log.Dev.Errorf(ctx, "%d replicas failing with %q", count, errStr)
+					log.KvDistribution.Errorf(ctx, "%d replicas failing with %q", count, errStr)
 				}
 			case <-stopper.ShouldQuiesce():
 				return
@@ -1591,7 +1591,7 @@ func (bq *baseQueue) processReplicasInPurgatory(
 		for rangeID := range bq.mu.purgatory {
 			item := bq.mu.replicas[rangeID]
 			if item == nil {
-				log.Dev.Fatalf(ctx, "r%d is in purgatory but not in replicas", rangeID)
+				log.KvDistribution.Fatalf(ctx, "r%d is in purgatory but not in replicas", rangeID)
 			}
 			item.setProcessing()
 			ranges = append(ranges, item)
@@ -1626,7 +1626,7 @@ func (bq *baseQueue) processReplicasInPurgatory(
 	// Clean up purgatory, if empty.
 	bq.mu.Lock()
 	if len(bq.mu.purgatory) == 0 {
-		log.Dev.Infof(ctx, "purgatory is now empty")
+		log.KvDistribution.Infof(ctx, "purgatory is now empty")
 		bq.mu.purgatory = nil
 		bq.mu.Unlock()
 		return true /* purgatoryCleared */
@@ -1648,7 +1648,7 @@ func (bq *baseQueue) pop() (replicaInQueue, float64) {
 		}
 		item := heap.Pop(&bq.mu.priorityQ).(*replicaItem)
 		if item.processing {
-			log.Dev.Fatalf(bq.AnnotateCtx(context.Background()), "%s pulled processing item from heap: %v", bq.name, item)
+			log.KvDistribution.Fatalf(bq.AnnotateCtx(context.Background()), "%s pulled processing item from heap: %v", bq.name, item)
 		}
 		// We are saving priority because the state is reset by setProcessing()
 		priority := item.priority
@@ -1688,7 +1688,7 @@ func (bq *baseQueue) removeLocked(item *replicaItem) {
 		} else if item.index >= 0 {
 			bq.removeFromQueueLocked(item)
 		} else {
-			log.Dev.Fatalf(bq.AnnotateCtx(context.Background()),
+			log.KvDistribution.Fatalf(bq.AnnotateCtx(context.Background()),
 				"item for r%d is only in replicas map, but is not processing",
 				item.rangeID,
 			)
@@ -1712,7 +1712,7 @@ func (bq *baseQueue) removeFromQueueLocked(item *replicaItem) {
 // Caller must hold mutex.
 func (bq *baseQueue) removeFromReplicaSetLocked(rangeID roachpb.RangeID) {
 	if _, found := bq.mu.replicas[rangeID]; !found {
-		log.Dev.Fatalf(bq.AnnotateCtx(context.Background()),
+		log.KvDistribution.Fatalf(bq.AnnotateCtx(context.Background()),
 			"attempted to remove r%d from queue, but it isn't in it",
 			rangeID,
 		)

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -50,7 +50,7 @@ func forceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) error {
 
 func mustForceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) {
 	if err := forceScanAndProcess(ctx, s, q); err != nil {
-		log.Dev.Fatalf(ctx, "%v", err)
+		log.KvDistribution.Fatalf(ctx, "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -280,7 +280,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 
 	if raftStatus == nil {
 		if log.V(6) {
-			log.Dev.Infof(ctx, "the raft group doesn't exist for r%d", rangeID)
+			log.KvDistribution.Infof(ctx, "the raft group doesn't exist for r%d", rangeID)
 		}
 		return truncateDecision{}, nil
 	}
@@ -620,7 +620,7 @@ func (rlq *raftLogQueue) shouldQueue(
 ) (shouldQueue bool, priority float64) {
 	decision, err := newTruncateDecision(ctx, r)
 	if err != nil {
-		log.Dev.Warningf(ctx, "%v", err)
+		log.KvDistribution.Warningf(ctx, "%v", err)
 		return false, 0
 	}
 
@@ -688,7 +688,7 @@ func (rlq *raftLogQueue) process(
 	}
 
 	if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
-		log.Dev.Infof(ctx, "%v", redact.Safe(decision.String()))
+		log.KvDistribution.Infof(ctx, "%v", redact.Safe(decision.String()))
 	} else {
 		log.VEventf(ctx, 1, "%v", redact.Safe(decision.String()))
 	}

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -68,7 +68,7 @@ func (rq *raftSnapshotQueue) shouldQueue(
 		for _, p := range status.Progress {
 			if p.State == tracker.StateSnapshot {
 				if log.V(2) {
-					log.Dev.Infof(ctx, "raft snapshot needed, enqueuing")
+					log.KvDistribution.Infof(ctx, "raft snapshot needed, enqueuing")
 				}
 				return true, raftSnapshotPriority
 			}
@@ -86,7 +86,7 @@ func (rq *raftSnapshotQueue) process(
 		for id, p := range status.Progress {
 			if p.State == tracker.StateSnapshot {
 				if log.V(1) {
-					log.Dev.Infof(ctx, "sending raft snapshot")
+					log.KvDistribution.Infof(ctx, "sending raft snapshot")
 				}
 				if processed, err := rq.processRaftSnapshot(ctx, repl, roachpb.ReplicaID(id)); err != nil {
 					return false, err

--- a/pkg/kv/kvserver/rafttrace/rafttrace.go
+++ b/pkg/kv/kvserver/rafttrace/rafttrace.go
@@ -87,7 +87,7 @@ type traceValue struct {
 // trace.
 func (t *traceValue) logf(depth int, format string, args ...interface{}) {
 	if t.ctx != nil {
-		log.Dev.InfofDepth(t.ctx, depth+1, format, args...)
+		log.KvExec.InfofDepth(t.ctx, depth+1, format, args...)
 	}
 
 	t.mu.Lock()
@@ -210,7 +210,7 @@ func (r *RaftTracer) reserveSpace() bool {
 	// traces and don't register this request. Note that when this happens we
 	// also wont't log this request.
 	if numRegisteredReplica > numAllowed {
-		log.Dev.Infof(r.ctx, "flushing all traces due to setting change")
+		log.KvExec.Infof(r.ctx, "flushing all traces due to setting change")
 		r.m.Range(func(index kvpb.RaftIndex, t *traceValue) bool {
 			r.removeEntry(index)
 			return true

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -248,7 +248,7 @@ type SharedBudgetAllocation struct {
 func (a *SharedBudgetAllocation) Use(ctx context.Context) {
 	if a != nil {
 		if atomic.AddInt32(&a.refCount, 1) == 1 {
-			log.Dev.Fatalf(ctx, "unexpected shared memory allocation usage increase after free")
+			log.KvDistribution.Fatalf(ctx, "unexpected shared memory allocation usage increase after free")
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -197,7 +197,7 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 	// If the registration has a catch-up scan, run it.
 	if err := br.maybeRunCatchUpScan(ctx); err != nil {
 		err = errors.Wrap(err, "catch-up scan failed")
-		log.Dev.Errorf(ctx, "%v", err)
+		log.KvDistribution.Errorf(ctx, "%v", err)
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 
 		if overflowed {
 			if wasOverflowedOnFirstIteration && br.shouldLogOverflow(oneCheckpointWithTimestampSent) {
-				log.Dev.Warningf(ctx, "rangefeed %s overflowed during catch up scan from %s (useful checkpoint sent: %v)",
+				log.KvDistribution.Warningf(ctx, "rangefeed %s overflowed during catch up scan from %s (useful checkpoint sent: %v)",
 					br.span, br.catchUpTimestamp, oneCheckpointWithTimestampSent)
 			}
 

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -255,13 +255,13 @@ func setupData(
 		absPath = loc
 	}
 	if exists {
-		log.Dev.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
+		log.KvDistribution.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
 		testutils.ReadAllFiles(filepath.Join(loc, "*"))
 		return emk(b, loc, opts.lBaseMaxBytes, opts.rwMode), loc
 	}
 
 	eng := emk(b, loc, opts.lBaseMaxBytes, fs.ReadWrite)
-	log.Dev.Infof(ctx, "creating rangefeed benchmark data: %s", absPath)
+	log.KvDistribution.Infof(ctx, "creating rangefeed benchmark data: %s", absPath)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))
@@ -322,7 +322,7 @@ func setupData(
 		// optimizations which change the data size result in the same number of
 		// sstables.
 		if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
-			log.Dev.Infof(ctx, "committing (%d/~%d) (%d/%d)", i/scaled, 20, i, len(order))
+			log.KvDistribution.Infof(ctx, "committing (%d/~%d) (%d/%d)", i/scaled, 20, i, len(order))
 			if err := batch.Commit(false /* sync */); err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/kv/kvserver/rangefeed/event_size.go
+++ b/pkg/kv/kvserver/rangefeed/event_size.go
@@ -205,7 +205,7 @@ func opsCurrMemUsage(ops opsEvent) int64 {
 		case *enginepb.MVCCAbortTxnOp:
 			currMemUsage += abortTxnOpMemUsage(t.TxnID)
 		default:
-			log.Dev.Fatalf(context.Background(), "unknown logical op %T", t)
+			log.KvDistribution.Fatalf(context.Background(), "unknown logical op %T", t)
 		}
 	}
 	// For each op, a checkpoint may or may not be published depending on whether
@@ -276,7 +276,7 @@ func MemUsage(e event) int64 {
 		// For sync event, no rangefeed events will be published.
 		return eventOverhead + syncEventOverhead
 	default:
-		log.Dev.Fatalf(context.Background(), "missing event variant: %+v", e)
+		log.KvDistribution.Fatalf(context.Background(), "missing event variant: %+v", e)
 	}
 	// For empty event, only eventOverhead is accounted.
 	return eventOverhead

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -224,7 +224,7 @@ func (rts *resolvedTimestamp) consumeLogicalOp(
 		return rts.intentQ.Del(t.TxnID)
 
 	default:
-		log.Dev.Fatalf(ctx, "unknown logical op %T", t)
+		log.KvDistribution.Fatalf(ctx, "unknown logical op %T", t)
 		return false
 	}
 }
@@ -237,7 +237,7 @@ func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 		return false
 	}
 	if rts.closedTS.Less(rts.resolvedTS) {
-		log.Dev.Fatalf(ctx, "closed timestamp below resolved timestamp: %s < %s",
+		log.KvDistribution.Fatalf(ctx, "closed timestamp below resolved timestamp: %s < %s",
 			rts.closedTS, rts.resolvedTS)
 	}
 	newTS := rts.closedTS
@@ -246,7 +246,7 @@ func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 	// timestamps cannot be resolved yet.
 	if txn := rts.intentQ.Oldest(); txn != nil {
 		if txn.timestamp.LessEq(rts.resolvedTS) {
-			log.Dev.Fatalf(ctx, "unresolved txn equal to or below resolved timestamp: %s <= %s",
+			log.KvDistribution.Fatalf(ctx, "unresolved txn equal to or below resolved timestamp: %s <= %s",
 				txn.timestamp, rts.resolvedTS)
 		}
 		// txn.timestamp cannot be resolved, so the resolved timestamp must be Prev.
@@ -258,7 +258,7 @@ func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 	newTS.Logical = 0
 
 	if newTS.Less(rts.resolvedTS) {
-		log.Dev.Fatalf(ctx, "resolved timestamp regression, was %s, recomputed as %s",
+		log.KvDistribution.Fatalf(ctx, "resolved timestamp regression, was %s, recomputed as %s",
 			rts.resolvedTS, newTS)
 	}
 	return rts.resolvedTS.Forward(newTS)
@@ -271,7 +271,7 @@ func (rts *resolvedTimestamp) assertNoChange(ctx context.Context) {
 	before := rts.resolvedTS
 	changed := rts.recompute(ctx)
 	if changed || before != rts.resolvedTS {
-		log.Dev.Fatalf(ctx, "unexpected resolved timestamp change on recomputation, "+
+		log.KvDistribution.Fatalf(ctx, "unexpected resolved timestamp change on recomputation, "+
 			"was %s, recomputed as %s", before, rts.resolvedTS)
 	}
 }
@@ -289,9 +289,9 @@ func (rts *resolvedTimestamp) assertOpAboveRTS(
 		err := errors.AssertionFailedf(
 			"resolved timestamp %s equal to or above timestamp of operation %v", rts.resolvedTS, &op)
 		if fatal {
-			log.Dev.Fatalf(ctx, "%v", err)
+			log.KvDistribution.Fatalf(ctx, "%v", err)
 		} else {
-			log.Dev.Errorf(ctx, "%v", err)
+			log.KvDistribution.Errorf(ctx, "%v", err)
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -365,7 +365,7 @@ func (p *ScheduledProcessor) Register(
 			return nil
 		}
 		if !p.Span.AsRawSpanWithNoLocals().Contains(r.getSpan()) {
-			log.Dev.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
+			log.KvDistribution.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
 		}
 
 		// Add the new registration to the registry.
@@ -631,7 +631,7 @@ func runRequest[T interface{}](
 		if buildutil.CrdbTestBuild {
 			select {
 			case <-p.stoppedC:
-				log.Dev.Fatalf(ctx, "processing request on stopped processor")
+				log.KvDistribution.Fatalf(ctx, "processing request on stopped processor")
 			default:
 			}
 		}
@@ -695,7 +695,7 @@ func (p *ScheduledProcessor) consumeEvent(ctx context.Context, e *event) {
 	case e.sync != nil:
 		if e.sync.testRegCatchupSpan != nil {
 			if err := p.reg.waitForCaughtUp(ctx, *e.sync.testRegCatchupSpan); err != nil {
-				log.Dev.Errorf(
+				log.KvDistribution.Errorf(
 					ctx,
 					"error waiting for registries to catch up during test, results might be impacted: %s",
 					err,
@@ -704,7 +704,7 @@ func (p *ScheduledProcessor) consumeEvent(ctx context.Context, e *event) {
 		}
 		close(e.sync.c)
 	default:
-		log.Dev.Fatalf(ctx, "missing event variant: %+v", e)
+		log.KvDistribution.Fatalf(ctx, "missing event variant: %+v", e)
 	}
 }
 
@@ -742,7 +742,7 @@ func (p *ScheduledProcessor) consumeLogicalOps(
 			// No updates to publish.
 
 		default:
-			log.Dev.Fatalf(ctx, "unknown logical op %T", t)
+			log.KvDistribution.Fatalf(ctx, "unknown logical op %T", t)
 		}
 
 		// Determine whether the operation caused the resolved timestamp to
@@ -786,7 +786,7 @@ func (p *ScheduledProcessor) publishValue(
 	alloc *SharedBudgetAllocation,
 ) {
 	if !p.Span.ContainsKey(roachpb.RKey(key)) {
-		log.Dev.Fatalf(ctx, "key %v not in Processor's key range %v", key, p.Span)
+		log.KvDistribution.Fatalf(ctx, "key %v not in Processor's key range %v", key, p.Span)
 	}
 
 	var prevVal roachpb.Value
@@ -813,7 +813,7 @@ func (p *ScheduledProcessor) publishDeleteRange(
 ) {
 	span := roachpb.Span{Key: startKey, EndKey: endKey}
 	if !p.Span.ContainsKeyRange(roachpb.RKey(startKey), roachpb.RKey(endKey)) {
-		log.Dev.Fatalf(ctx, "span %s not in Processor's key range %v", span, p.Span)
+		log.KvDistribution.Fatalf(ctx, "span %s not in Processor's key range %v", span, p.Span)
 	}
 
 	var event kvpb.RangeFeedEvent
@@ -832,10 +832,10 @@ func (p *ScheduledProcessor) publishSSTable(
 	alloc *SharedBudgetAllocation,
 ) {
 	if sstSpan.Equal(roachpb.Span{}) {
-		log.Dev.Fatalf(ctx, "received SSTable without span")
+		log.KvDistribution.Fatalf(ctx, "received SSTable without span")
 	}
 	if sstWTS.IsEmpty() {
-		log.Dev.Fatalf(ctx, "received SSTable without write timestamp")
+		log.KvDistribution.Fatalf(ctx, "received SSTable without write timestamp")
 	}
 	p.reg.PublishToOverlapping(ctx, sstSpan, &kvpb.RangeFeedEvent{
 		SST: &kvpb.RangeFeedSSTable{

--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -493,7 +493,7 @@ func (ss *schedulerShard) processEvents(ctx context.Context) {
 
 		if remaining != 0 && buildutil.CrdbTestBuild {
 			if (remaining^procEventType)&remaining != 0 {
-				log.Dev.Fatalf(ctx,
+				log.KvDistribution.Fatalf(ctx,
 					"rangefeed processor attempted to reschedule event type %s that was not present in original event set %s",
 					procEventType, remaining)
 			}
@@ -501,7 +501,7 @@ func (ss *schedulerShard) processEvents(ctx context.Context) {
 
 		if e&Stopped != 0 {
 			if remaining != 0 {
-				log.Dev.VWarningf(ctx, 5,
+				log.KvDistribution.VWarningf(ctx, 5,
 					"rangefeed processor %d didn't process all events on close", entry.id)
 			}
 			// We'll keep Stopped state to avoid calling stopped processor again

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -86,11 +86,11 @@ func (s *PerRangeEventSink) SendError(err *kvpb.Error) {
 		Error: *transformRangefeedErrToClientError(err),
 	})
 	if ev.Error == nil {
-		log.Dev.Fatalf(context.Background(),
+		log.KvDistribution.Fatalf(context.Background(),
 			"unexpected: SendWithoutBlocking called with non-error event")
 	}
 	if err := s.wrapped.sendBuffered(ev, nil); err != nil {
-		log.Dev.Infof(context.Background(),
+		log.KvDistribution.Infof(context.Background(),
 			"failed to send rangefeed error to client: %v", err)
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/stream_manager.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager.go
@@ -98,7 +98,7 @@ func (sm *StreamManager) NewStream(streamID int64, rangeID roachpb.RangeID) (sin
 	case *UnbufferedSender:
 		return NewPerRangeEventSink(rangeID, streamID, sender)
 	default:
-		log.Dev.Fatalf(context.Background(), "unexpected sender type %T", sm)
+		log.KvDistribution.Fatalf(context.Background(), "unexpected sender type %T", sm)
 		return nil
 	}
 }
@@ -119,7 +119,7 @@ func (sm *StreamManager) OnError(streamID int64) {
 // DisconnectStream disconnects the stream with the given streamID.
 func (sm *StreamManager) DisconnectStream(streamID int64, err *kvpb.Error) {
 	if err == nil {
-		log.Dev.Fatalf(context.Background(),
+		log.KvDistribution.Fatalf(context.Background(),
 			"unexpected: DisconnectStream called with nil error")
 		return
 	}
@@ -146,7 +146,7 @@ func (sm *StreamManager) AddStream(streamID int64, d Disconnector) {
 		return
 	}
 	if _, ok := sm.streams.m[streamID]; ok {
-		log.Dev.Fatalf(context.Background(), "stream %d already exists", streamID)
+		log.KvDistribution.Fatalf(context.Background(), "stream %d already exists", streamID)
 	}
 	sm.streams.m[streamID] = d
 	sm.metrics.ActiveMuxRangeFeed.Inc(1)
@@ -207,7 +207,7 @@ func (sm *StreamManager) Stop(ctx context.Context) {
 // sender.run may also finish without sending anything to the channel.
 func (sm *StreamManager) Error() <-chan error {
 	if sm.errCh == nil {
-		log.Dev.Fatalf(context.Background(), "StreamManager.Error called before StreamManager.Start")
+		log.KvDistribution.Fatalf(context.Background(), "StreamManager.Error called before StreamManager.Start")
 	}
 	return sm.errCh
 }

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -60,7 +60,7 @@ func (s *initResolvedTSScan) Run(ctx context.Context) {
 	if err := s.iterateAndConsume(ctx); err != nil {
 		err = errors.Wrap(err, "initial resolved timestamp scan failed")
 		if ctx.Err() == nil { // cancellation probably caused the error
-			log.Dev.Errorf(ctx, "%v", err)
+			log.KvDistribution.Errorf(ctx, "%v", err)
 		}
 		s.p.StopWithErr(kvpb.NewError(err))
 	} else {
@@ -249,7 +249,7 @@ func (a *txnPushAttempt) Run(ctx context.Context) {
 	defer a.Cancel()
 	if err := a.pushOldTxns(ctx); err != nil {
 		if ctx.Err() == nil { // cancellation probably caused the error
-			log.Dev.Errorf(ctx, "pushing old intents failed: %v", err)
+			log.KvDistribution.Errorf(ctx, "pushing old intents failed: %v", err)
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -127,7 +127,7 @@ func (ubs *UnbufferedSender) sendBuffered(
 // Important to be thread-safe.
 func (ubs *UnbufferedSender) sendUnbuffered(event *kvpb.MuxRangeFeedEvent) error {
 	if event.Error != nil {
-		log.Dev.Fatalf(context.Background(), "unexpected: SendUnbuffered called with error event")
+		log.KvDistribution.Fatalf(context.Background(), "unexpected: SendUnbuffered called with error event")
 	}
 	return ubs.sender.Send(event)
 }
@@ -147,7 +147,7 @@ func (ubs *UnbufferedSender) run(
 			for _, clientErr := range toSend {
 				onError(clientErr.StreamID)
 				if err := ubs.sender.Send(clientErr); err != nil {
-					log.Dev.Infof(ctx, "failed to send rangefeed error to client: %v", err)
+					log.KvDistribution.Infof(ctx, "failed to send rangefeed error to client: %v", err)
 					return err
 				}
 			}

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -123,7 +123,7 @@ func (rgcq *replicaGCQueue) shouldQueue(
 	}
 	lastCheck, err := repl.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
-		log.Dev.Errorf(ctx, "could not read last replica GC timestamp: %+v", err)
+		log.KvDistribution.Errorf(ctx, "could not read last replica GC timestamp: %+v", err)
 		return false, 0
 	}
 	isSuspect := replicaIsSuspect(repl)
@@ -299,7 +299,7 @@ func (rgcq *replicaGCQueue) process(
 			// snapshot for *each* of them. This typically happens for the last
 			// range:
 			// [n1,replicaGC,s1,r33/1:/{Table/53/1/3…-Max}] removing replica [...]
-			log.Dev.Infof(ctx, "removing replica with pending split; will incur Raft snapshot for right hand side")
+			log.KvDistribution.Infof(ctx, "removing replica with pending split; will incur Raft snapshot for right hand side")
 		}
 
 		rgcq.metrics.RemoveReplicaCount.Inc(1)

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -531,7 +531,7 @@ func (metrics *ReplicateQueueMetrics) trackSuccessByAllocatorAction(
 		allocatorimpl.AllocatorFinalizeAtomicReplicationChange:
 		// Nothing to do, not recorded here.
 	default:
-		log.Dev.Errorf(ctx, "AllocatorAction %v unsupported in metrics tracking", action)
+		log.KvDistribution.Errorf(ctx, "AllocatorAction %v unsupported in metrics tracking", action)
 	}
 }
 
@@ -559,7 +559,7 @@ func (metrics *ReplicateQueueMetrics) trackErrorByAllocatorAction(
 		allocatorimpl.AllocatorFinalizeAtomicReplicationChange:
 		// Nothing to do, not recorded here.
 	default:
-		log.Dev.Errorf(ctx, "AllocatorAction %v unsupported in metrics tracking", action)
+		log.KvDistribution.Errorf(ctx, "AllocatorAction %v unsupported in metrics tracking", action)
 	}
 
 }

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -149,7 +149,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 			if c < minReplicas {
 				err := errors.Errorf(
 					"not balanced (want at least %d replicas on all stores): %d", minReplicas, counts)
-				log.Dev.Infof(ctx, "%v", err)
+				log.KvDistribution.Infof(ctx, "%v", err)
 				return err
 			}
 		}
@@ -343,7 +343,7 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 					if c < minReplicas {
 						err := errors.Errorf(
 							"not balanced (want at least %d replicas on all stores): %d", minReplicas, replicasPerStore)
-						log.Dev.Infof(ctx, "%v", err)
+						log.KvDistribution.Infof(ctx, "%v", err)
 						return err
 					}
 				}
@@ -354,7 +354,7 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 					if c < minLeases {
 						err := errors.Errorf(
 							"not balanced (want at least %d leases on all stores): %d", minLeases, leasesPerStore)
-						log.Dev.Infof(ctx, "%v", err)
+						log.KvDistribution.Infof(ctx, "%v", err)
 						return err
 					}
 				}
@@ -619,7 +619,7 @@ func checkReplicaCount(
 ) (bool, error) {
 	err := forceScanOnAllReplicationQueues(tc)
 	if err != nil {
-		log.Dev.Infof(ctx, "store.ForceReplicationScanAndProcess() failed with: %s", err)
+		log.KvDistribution.Infof(ctx, "store.ForceReplicationScanAndProcess() failed with: %s", err)
 		return false, err
 	}
 	*rangeDesc, err = tc.LookupRange(rangeDesc.StartKey.AsRawKey())
@@ -679,7 +679,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			return ok
@@ -716,7 +716,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			if !ok {
@@ -839,7 +839,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			return ok
@@ -1124,7 +1124,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			return ok
@@ -1170,7 +1170,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			if !ok {
@@ -1265,7 +1265,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			return ok
@@ -1327,7 +1327,7 @@ func TestReplicateQueueMetrics(t *testing.T) {
 			&scratchRange, 3 /* voterCount */, 0, /* nonVoterCount */
 		)
 		if err != nil {
-			log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+			log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 			return false
 		}
 		return ok
@@ -1353,7 +1353,7 @@ func TestReplicateQueueMetrics(t *testing.T) {
 				ctx, tc.(*testcluster.TestCluster), &scratchRange, 1, 0,
 			)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+				log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 				return false
 			}
 			return ok
@@ -1399,7 +1399,7 @@ func TestReplicateQueueMetrics(t *testing.T) {
 			ctx, tc.(*testcluster.TestCluster), &scratchRange, 3, 0,
 		)
 		if err != nil {
-			log.Dev.Errorf(ctx, "error checking replica count: %s", err)
+			log.KvDistribution.Errorf(ctx, "error checking replica count: %s", err)
 			return false
 		}
 		return ok
@@ -1448,7 +1448,7 @@ func getAggregateMetricCounts(
 		if storeId, exists := voterMap[s.NodeID()]; exists {
 			store, err := s.GetStores().(*kvserver.Stores).GetStore(storeId)
 			if err != nil {
-				log.Dev.Errorf(ctx, "error finding store: %s", err)
+				log.KvDistribution.Errorf(ctx, "error finding store: %s", err)
 				continue
 			}
 			if add {
@@ -1610,7 +1610,7 @@ func TestReplicateQueueSwapVotersWithNonVoters(t *testing.T) {
 		// any given point, any change in the configuration of these 5 replicas
 		// _must_ go through atomic non-voter promotions and voter demotions.
 		alterStatement, voterStores, nonVoterStores := synthesizeRandomConstraints()
-		log.Dev.Infof(ctx, "applying: %s", alterStatement)
+		log.KvDistribution.Infof(ctx, "applying: %s", alterStatement)
 		_, err := tc.ServerConn(0).Exec(alterStatement)
 		require.NoError(t, err)
 		checkRelocated(t, voterStores, nonVoterStores)
@@ -1665,7 +1665,7 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 	// above.
 	require.Eventually(t, func() bool {
 		if err := forceScanOnAllReplicationQueues(tc); err != nil {
-			log.Dev.Warningf(ctx, "received error while forcing a replicateQueue scan: %s", err)
+			log.KvDistribution.Warningf(ctx, "received error while forcing a replicateQueue scan: %s", err)
 			return false
 		}
 		scratchRange := tc.LookupRangeOrFatal(t, scratchStartKey)
@@ -1708,16 +1708,16 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 		)
 		recording := rec()
 		if err != nil {
-			log.Dev.Errorf(ctx, "err: %s", err.Error())
+			log.KvDistribution.Errorf(ctx, "err: %s", err.Error())
 			return false
 		}
 		if processErr != nil {
-			log.Dev.Errorf(ctx, "processErr: %s", processErr.Error())
+			log.KvDistribution.Errorf(ctx, "processErr: %s", processErr.Error())
 			return false
 		}
 		if matched, err := regexp.Match(matchString,
 			[]byte(recording.String())); !matched {
-			log.Dev.Infof(ctx, "didn't find matching string '%s' in trace %s",
+			log.KvDistribution.Infof(ctx, "didn't find matching string '%s' in trace %s",
 				matchString, recording.String())
 			require.NoError(t, err)
 			return false
@@ -1947,7 +1947,7 @@ func (h delayingRaftMessageHandler) HandleRaftRequest(
 		time.Sleep(raftDelay)
 		err := h.IncomingRaftMessageHandler.HandleRaftRequest(context.Background(), req, respStream)
 		if err != nil {
-			log.Dev.Infof(ctx, "HandleRaftRequest returned err %s", err)
+			log.KvDistribution.Infof(ctx, "HandleRaftRequest returned err %s", err)
 		}
 	}()
 
@@ -2006,7 +2006,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 	if leaseHolderNodeID == 1 {
 		remoteNodeID = 2
 	}
-	log.Dev.Infof(ctx, "RangeID %d, RemoteNodeID %d, LeaseHolderNodeID %d",
+	log.KvDistribution.Infof(ctx, "RangeID %d, RemoteNodeID %d, LeaseHolderNodeID %d",
 		rangeID, remoteNodeID, leaseHolderNodeID)
 	leaseHolderSrv := tc.Servers[leaseHolderNodeID-1]
 	leaseHolderStoreID := leaseHolderSrv.GetFirstStoreID()
@@ -2098,10 +2098,10 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 	// By now the lease holder may have changed.
 	testutils.SucceedsSoon(t, func() error {
 		leaseBefore, _ := leaseHolderRepl.GetLease()
-		log.Dev.Infof(ctx, "Lease before transfer %+v\n", leaseBefore)
+		log.KvDistribution.Infof(ctx, "Lease before transfer %+v\n", leaseBefore)
 
 		if uint64(leaseBefore.Replica.NodeID) == remoteNodeID {
-			log.Dev.Infof(
+			log.KvDistribution.Infof(
 				ctx,
 				"Lease successfully transferred to desired node %d\n",
 				remoteNodeID,
@@ -2252,7 +2252,7 @@ SELECT * FROM (
 	_, err := db.Exec("CREATE TABLE t (i INT PRIMARY KEY, s STRING)")
 	require.NoError(t, err)
 
-	log.Dev.Infof(ctx, "test setting ZONE survival configuration")
+	log.KvDistribution.Infof(ctx, "test setting ZONE survival configuration")
 	// ZONE survival configuration.
 	setConstraintFn("TABLE t", 5, 3,
 		", constraints = '{\"+region=2\": 1, \"+region=3\": 1}', voter_constraints = '{\"+region=1\": 3}'")
@@ -2297,7 +2297,7 @@ SELECT * FROM (
 	})
 
 	// REGION survival configuration.
-	log.Dev.Infof(ctx, "test setting REGION survival configuration")
+	log.KvDistribution.Infof(ctx, "test setting REGION survival configuration")
 	// Clear the rangelog so that we can rest assured to only pick up events
 	// resulting from the zone config change.
 	_, err = tc.Conns[0].ExecContext(ctx, `DELETE FROM system.rangelog WHERE TRUE`)

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -387,12 +387,12 @@ func (v *constraintConformanceVisitor) init(ctx context.Context) {
 	maxObjectID, err := v.cfg.GetLargestObjectID(
 		0 /* maxReservedDescID - return the largest ID in the config */, keys.PseudoTableIDs)
 	if err != nil {
-		log.Dev.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
+		log.KvDistribution.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
 	}
 	for i := config.ObjectID(1); i <= maxObjectID; i++ {
 		zone, err := getZoneByID(i, v.cfg)
 		if err != nil {
-			log.Dev.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
+			log.KvDistribution.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
 		}
 		if zone == nil {
 			continue

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -286,12 +286,12 @@ func (v *replicationStatsVisitor) init(ctx context.Context) {
 		0 /* maxReservedDescID - return the largest ID in the config */, keys.PseudoTableIDs,
 	)
 	if err != nil {
-		log.Dev.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
+		log.KvDistribution.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
 	}
 	for i := config.ObjectID(1); i <= maxObjectID; i++ {
 		zone, err := getZoneByID(i, v.cfg)
 		if err != nil {
-			log.Dev.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
+			log.KvDistribution.Fatalf(ctx, "unexpected failure to compute max object id: %s", err)
 		}
 		if zone == nil {
 			continue

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -151,7 +151,7 @@ func (stats *Reporter) Start(ctx context.Context, stopper *stop.Stopper) {
 					if err := stats.update(
 						ctx, &constraintsSaver, &replStatsSaver, &criticalLocSaver,
 					); err != nil {
-						log.Dev.Errorf(ctx, "failed to generate replication reports: %s", err)
+						log.KvDistribution.Errorf(ctx, "failed to generate replication reports: %s", err)
 					}
 				}
 				timer.Reset(interval)
@@ -230,7 +230,7 @@ func (stats *Reporter) update(
 		&constraintConfVisitor, &localityStatsVisitor, &replicationStatsVisitor,
 	); err != nil {
 		if errors.HasType(err, (*visitorError)(nil)) {
-			log.Dev.Errorf(ctx, "some reports have not been generated: %s", err)
+			log.KvDistribution.Errorf(ctx, "some reports have not been generated: %s", err)
 		} else {
 			return errors.Wrap(err, "failed to compute constraint conformance report")
 		}
@@ -270,7 +270,7 @@ func (stats *Reporter) meta1LeaseHolderStore(ctx context.Context) *kvserver.Stor
 		return nil
 	}
 	if err != nil {
-		log.Dev.Fatalf(ctx, "unexpected error when visiting stores: %s", err)
+		log.KvDistribution.Fatalf(ctx, "unexpected error when visiting stores: %s", err)
 	}
 	if repl.OwnsValidLease(ctx, store.Clock().NowAsClockTimestamp()) {
 		return store
@@ -707,7 +707,7 @@ func (r *meta2RangeIter) readBatch(ctx context.Context) (retErr error) {
 	defer func() { r.handleErr(ctx, retErr) }()
 
 	if len(r.buffer) > 0 {
-		log.Dev.Fatalf(ctx, "buffer not exhausted: %d keys remaining", len(r.buffer))
+		log.KvDistribution.Fatalf(ctx, "buffer not exhausted: %d keys remaining", len(r.buffer))
 	}
 	if r.txn == nil {
 		r.txn = r.db.NewTxn(ctx, "rangeStoreImpl")
@@ -755,7 +755,7 @@ func (r *meta2RangeIter) handleErr(ctx context.Context, err error) {
 		return
 	}
 	if errors.HasType(err, (*kvpb.TransactionRetryWithProtoRefreshError)(nil)) {
-		log.Dev.Warningf(ctx, "unexpected retryable error from "+
+		log.KvDistribution.Warningf(ctx, "unexpected retryable error from "+
 			"read-only transaction with fixed read timestamp: %s", err)
 	}
 	if r.txn != nil {

--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -607,7 +607,7 @@ func (m *Manager) waitForSignal(
 				return errors.Errorf("unsupported poison.Policy %d", pp)
 			}
 		case <-t.C:
-			log.Dev.Warningf(ctx, "have been waiting %s to acquire %s latch %s, held by %s latch %s",
+			log.KvExec.Warningf(ctx, "have been waiting %s to acquire %s latch %s, held by %s latch %s",
 				base.SlowRequestThreshold, waitType, wait, heldType, held)
 			if m.slowReqs != nil {
 				m.slowReqs.Inc(1)
@@ -674,7 +674,7 @@ func (m *Manager) Release(ctx context.Context, lg *Guard) {
 		const msg = "%s has held latch for %s. Some possible causes are " +
 			"slow disk reads, slow raft replication, and expensive request processing."
 		if m.everySecondLogger.ShouldLog() {
-			log.Dev.Warningf(ctx, msg, lg.ba, humanizeutil.Duration(held))
+			log.KvExec.Warningf(ctx, msg, lg.ba, humanizeutil.Duration(held))
 		} else {
 			log.VEventf(ctx, 2, msg, lg.ba, humanizeutil.Duration(held))
 		}

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -265,7 +265,7 @@ func (s *SpanSet) Intersects(other *SpanSet) bool {
 // only the span boundaries are checked.
 func (s *SpanSet) AssertAllowed(access SpanAccess, span roachpb.Span) {
 	if err := s.CheckAllowed(access, span); err != nil {
-		log.Dev.Fatalf(context.TODO(), "%v", err)
+		log.KvExec.Fatalf(context.TODO(), "%v", err)
 	}
 }
 

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -153,7 +153,7 @@ func shouldSplitRange(
 ) (shouldQ bool, priority float64) {
 	needsSplit, err := confReader.NeedsSplit(ctx, desc.StartKey, desc.EndKey)
 	if err != nil {
-		log.Dev.Warningf(ctx, "unable to compute NeedsSpilt (%v); skipping range %s", err, desc.RangeID)
+		log.KvDistribution.Warningf(ctx, "unable to compute NeedsSpilt (%v); skipping range %s", err, desc.RangeID)
 		return false, 0
 	}
 	if needsSplit {
@@ -226,7 +226,7 @@ func (sq *splitQueue) process(
 		// attempts because splits can race with other descriptor modifications.
 		// On seeing a ConditionFailedError, don't return an error and enqueue
 		// this replica again in case it still needs to be split.
-		log.Dev.Infof(ctx, "split saw concurrent descriptor modification; maybe retrying; err: %v", err)
+		log.KvDistribution.Infof(ctx, "split saw concurrent descriptor modification; maybe retrying; err: %v", err)
 		sq.MaybeAddAsync(ctx, r, sq.store.Clock().NowAsClockTimestamp())
 		return false, nil
 	}
@@ -266,9 +266,9 @@ func (sq *splitQueue) processAttemptWithTracing(
 		}
 	}
 	if err != nil {
-		log.Dev.Infof(ctx, "error during range split: %v%s", err, traceOutput)
+		log.KvDistribution.Infof(ctx, "error during range split: %v%s", err, traceOutput)
 	} else if exceededDuration {
-		log.Dev.Infof(ctx, "range split took %s, exceeding threshold of %s%s",
+		log.KvDistribution.Infof(ctx, "range split took %s, exceeding threshold of %s%s",
 			processDuration, sq.logTracesThreshold, traceOutput)
 	}
 

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -78,13 +78,13 @@ func WriteInitialReplicaState(
 	if existingLease, err := rsl.LoadLease(ctx, readWriter); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading lease")
 	} else if (existingLease != roachpb.Lease{}) {
-		log.Dev.Fatalf(ctx, "expected trivial lease, but found %+v", existingLease)
+		log.KvExec.Fatalf(ctx, "expected trivial lease, but found %+v", existingLease)
 	}
 
 	if existingGCThreshold, err := rsl.LoadGCThreshold(ctx, readWriter); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading GCThreshold")
 	} else if !existingGCThreshold.IsEmpty() {
-		log.Dev.Fatalf(ctx, "expected trivial GCthreshold, but found %+v", existingGCThreshold)
+		log.KvExec.Fatalf(ctx, "expected trivial GCthreshold, but found %+v", existingGCThreshold)
 	}
 
 	if existingGCHint, err := rsl.LoadGCHint(ctx, readWriter); err != nil {
@@ -96,7 +96,7 @@ func WriteInitialReplicaState(
 	if existingVersion, err := rsl.LoadVersion(ctx, readWriter); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading Version")
 	} else if (existingVersion != roachpb.Version{}) {
-		log.Dev.Fatalf(ctx, "expected trivial version, but found %+v", existingVersion)
+		log.KvExec.Fatalf(ctx, "expected trivial version, but found %+v", existingVersion)
 	}
 
 	newMS, err := rsl.Save(ctx, readWriter, s)

--- a/pkg/kv/kvserver/storeliveness/requester_state.go
+++ b/pkg/kv/kvserver/storeliveness/requester_state.go
@@ -201,7 +201,7 @@ func (rsh *requesterStateHandler) markIdleStores(ctx context.Context) {
 	for _, rs := range rsh.requesterState.supportFrom {
 		if !rs.recentlyQueried.CompareAndSwap(active, inactive) {
 			if rs.recentlyQueried.CompareAndSwap(inactive, idle) {
-				log.Dev.Infof(ctx, "stopping heartbeats to idle store %+v", rs.state.Target)
+				log.KvExec.Infof(ctx, "stopping heartbeats to idle store %+v", rs.state.Target)
 			}
 		}
 	}
@@ -422,13 +422,13 @@ func handleHeartbeatResponse(
 func logSupportFromChange(ctx context.Context, ss slpb.SupportState, ssNew slpb.SupportState) {
 	if ss.Epoch == ssNew.Epoch {
 		if ss.Expiration.IsEmpty() {
-			log.Dev.Infof(ctx, "received support from %s", supportChangeStr(ss, ssNew))
+			log.KvExec.Infof(ctx, "received support from %s", supportChangeStr(ss, ssNew))
 		} else if log.ExpensiveLogEnabled(ctx, 3) {
-			log.Dev.VInfof(ctx, 3, "extended support from %s", supportChangeStr(ss, ssNew))
+			log.KvExec.VInfof(ctx, 3, "extended support from %s", supportChangeStr(ss, ssNew))
 		}
 	} else {
 		assert(ss.Epoch < ssNew.Epoch, "epoch regressed")
-		log.Dev.Infof(ctx, "lost support from %s", supportChangeStr(ss, ssNew))
+		log.KvExec.Infof(ctx, "lost support from %s", supportChangeStr(ss, ssNew))
 	}
 }
 

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -144,11 +144,11 @@ func (sm *SupportManager) SupportFrom(id slpb.StoreIdent) (slpb.Epoch, hlc.Times
 		// uses a map to avoid duplicates, and the requesterStateHandler's
 		// addStore checks if the store exists before adding it.
 		sm.storesToAdd.addStore(id)
-		log.Dev.VInfof(context.TODO(), 2, "store %+v is not heartbeating store %+v yet", sm.storeID, id)
+		log.KvExec.VInfof(context.TODO(), 2, "store %+v is not heartbeating store %+v yet", sm.storeID, id)
 		return 0, hlc.Timestamp{}
 	}
 	if wasIdle {
-		log.Dev.Infof(
+		log.KvExec.Infof(
 			context.TODO(), "store %+v is starting to heartbeat store %+v (after being idle)",
 			sm.storeID, id,
 		)
@@ -290,7 +290,7 @@ func (sm *SupportManager) maybeAddStores(ctx context.Context) {
 	sta := sm.storesToAdd.drainStoresToAdd()
 	for _, store := range sta {
 		if sm.requesterStateHandler.addStore(store) {
-			log.Dev.Infof(ctx, "starting to heartbeat store %+v", store)
+			log.KvExec.Infof(ctx, "starting to heartbeat store %+v", store)
 			sm.metrics.SupportFromStores.Inc(1)
 		}
 	}
@@ -314,7 +314,7 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	livenessInterval := sm.options.SupportDuration
 	heartbeats := rsfu.getHeartbeatsToSend(sm.storeID, sm.clock.Now(), livenessInterval)
 	if err := rsfu.write(ctx, sm.engine); err != nil {
-		log.Dev.Warningf(ctx, "failed to write requester meta: %v", err)
+		log.KvExec.Warningf(ctx, "failed to write requester meta: %v", err)
 		sm.metrics.HeartbeatFailures.Inc(int64(len(heartbeats)))
 		return
 	}
@@ -326,12 +326,12 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 		if sent := sm.sender.SendAsync(ctx, msg); sent {
 			successes++
 		} else {
-			log.Dev.Warningf(ctx, "failed to send heartbeat to store %+v", msg.To)
+			log.KvExec.Warningf(ctx, "failed to send heartbeat to store %+v", msg.To)
 		}
 	}
 	sm.metrics.HeartbeatSuccesses.Inc(int64(successes))
 	sm.metrics.HeartbeatFailures.Inc(int64(len(heartbeats) - successes))
-	log.Dev.VInfof(ctx, 2, "sent heartbeats to %d stores", successes)
+	log.KvExec.VInfof(ctx, 2, "sent heartbeats to %d stores", successes)
 }
 
 // withdrawSupport delegates support withdrawal to supporterStateHandler.
@@ -353,17 +353,17 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 	batch := sm.engine.NewBatch()
 	defer batch.Close()
 	if err := ssfu.write(ctx, batch); err != nil {
-		log.Dev.Warningf(ctx, "failed to write supporter meta and state: %v", err)
+		log.KvExec.Warningf(ctx, "failed to write supporter meta and state: %v", err)
 		sm.metrics.SupportWithdrawFailures.Inc(int64(numWithdrawn))
 		return
 	}
 	if err := batch.Commit(true /* sync */); err != nil {
-		log.Dev.Warningf(ctx, "failed to commit supporter meta and state: %v", err)
+		log.KvExec.Warningf(ctx, "failed to commit supporter meta and state: %v", err)
 		sm.metrics.SupportWithdrawFailures.Inc(int64(numWithdrawn))
 		return
 	}
 	sm.supporterStateHandler.checkInUpdate(ssfu)
-	log.Dev.Infof(ctx, "withdrew support from %d stores", numWithdrawn)
+	log.KvExec.Infof(ctx, "withdrew support from %d stores", numWithdrawn)
 	sm.metrics.SupportWithdrawSuccesses.Inc(int64(numWithdrawn))
 	if sm.withdrawalCallback != nil {
 		beforeProcess := timeutil.Now()
@@ -373,7 +373,7 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 		if processDur > minCallbackDurationToRecord {
 			sm.metrics.CallbacksProcessingDuration.RecordValue(processDur.Nanoseconds())
 		}
-		log.Dev.Infof(ctx, "invoked callback for %d stores", numWithdrawn)
+		log.KvExec.Infof(ctx, "invoked callback for %d stores", numWithdrawn)
 	}
 }
 
@@ -381,7 +381,7 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 // to either the requesterStateHandler or supporterStateHandler. It then writes
 // all updates to disk in a single batch, and sends any responses via Transport.
 func (sm *SupportManager) handleMessages(ctx context.Context, msgs []*slpb.Message) {
-	log.Dev.VInfof(ctx, 2, "drained receive queue of size %d", len(msgs))
+	log.KvExec.VInfof(ctx, 2, "drained receive queue of size %d", len(msgs))
 	rsfu := sm.requesterStateHandler.checkOutUpdate()
 	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	ssfu := sm.supporterStateHandler.checkOutUpdate()
@@ -396,24 +396,24 @@ func (sm *SupportManager) handleMessages(ctx context.Context, msgs []*slpb.Messa
 		case slpb.MsgHeartbeatResp:
 			rsfu.handleHeartbeatResponse(ctx, msg)
 		default:
-			log.Dev.Errorf(ctx, "unexpected message type: %v", msg.Type)
+			log.KvExec.Errorf(ctx, "unexpected message type: %v", msg.Type)
 		}
 	}
 
 	batch := sm.engine.NewBatch()
 	defer batch.Close()
 	if err := rsfu.write(ctx, batch); err != nil {
-		log.Dev.Warningf(ctx, "failed to write requester meta: %v", err)
+		log.KvExec.Warningf(ctx, "failed to write requester meta: %v", err)
 		sm.metrics.MessageHandleFailures.Inc(int64(len(msgs)))
 		return
 	}
 	if err := ssfu.write(ctx, batch); err != nil {
-		log.Dev.Warningf(ctx, "failed to write supporter meta: %v", err)
+		log.KvExec.Warningf(ctx, "failed to write supporter meta: %v", err)
 		sm.metrics.MessageHandleFailures.Inc(int64(len(msgs)))
 		return
 	}
 	if err := batch.Commit(true /* sync */); err != nil {
-		log.Dev.Warningf(ctx, "failed to sync supporter and requester state: %v", err)
+		log.KvExec.Warningf(ctx, "failed to sync supporter and requester state: %v", err)
 		sm.metrics.MessageHandleFailures.Inc(int64(len(msgs)))
 		return
 	}
@@ -426,7 +426,7 @@ func (sm *SupportManager) handleMessages(ctx context.Context, msgs []*slpb.Messa
 	for _, response := range responses {
 		_ = sm.sender.SendAsync(ctx, response)
 	}
-	log.Dev.VInfof(ctx, 2, "sent %d heartbeat responses", len(responses))
+	log.KvExec.VInfof(ctx, 2, "sent %d heartbeat responses", len(responses))
 }
 
 // maxReceiveQueueSize is the maximum number of messages the receive queue can

--- a/pkg/kv/kvserver/storeliveness/supporter_state.go
+++ b/pkg/kv/kvserver/storeliveness/supporter_state.go
@@ -292,10 +292,10 @@ func logSupportForChange(ctx context.Context, ss slpb.SupportState, ssNew slpb.S
 	assert(!ssNew.Expiration.IsEmpty(), "requested support with zero expiration")
 	if ss.Epoch == ssNew.Epoch && !ss.Expiration.IsEmpty() {
 		if log.ExpensiveLogEnabled(ctx, 3) {
-			log.Dev.VInfof(ctx, 3, "extended support for %s", supportChangeStr(ss, ssNew))
+			log.KvExec.VInfof(ctx, 3, "extended support for %s", supportChangeStr(ss, ssNew))
 		}
 	} else {
-		log.Dev.Infof(ctx, "provided support for %s", supportChangeStr(ss, ssNew))
+		log.KvExec.Infof(ctx, "provided support for %s", supportChangeStr(ss, ssNew))
 	}
 }
 
@@ -318,7 +318,7 @@ func (ssfu *supporterStateForUpdate) withdrawSupport(
 		ssNew := maybeWithdrawSupport(ss, now)
 		if ss != ssNew {
 			ssfu.inProgress.supportFor[id] = ssNew
-			log.Dev.Infof(ctx, "withdrew support for %s", supportChangeStr(ss, ssNew))
+			log.KvExec.Infof(ctx, "withdrew support for %s", supportChangeStr(ss, ssNew))
 			meta := ssfu.getMeta()
 			if meta.MaxWithdrawn.Forward(now) {
 				ssfu.inProgress.meta = meta

--- a/pkg/kv/kvserver/tenantrate/factory.go
+++ b/pkg/kv/kvserver/tenantrate/factory.go
@@ -97,7 +97,7 @@ func (rl *LimiterFactory) GetTenant(
 		rcLim = new(refCountedLimiter)
 		rcLim.lim.init(rl, tenantID, rl.mu.config, rl.metrics.tenantMetrics(tenantID), rl.authorizer, options...)
 		rl.mu.tenants[tenantID] = rcLim
-		log.Dev.Infof(
+		log.KvDistribution.Infof(
 			ctx, "tenant %s rate limiter initialized (rate: %g RU/s; burst: %g RU)",
 			tenantID, rl.mu.config.Rate, rl.mu.config.Burst,
 		)

--- a/pkg/kv/kvserver/tscache/interval_skl.go
+++ b/pkg/kv/kvserver/tscache/interval_skl.go
@@ -257,7 +257,7 @@ func (s *intervalSkl) AddRange(
 			}
 			msg := fmt.Sprintf("inverted range (issue #32149): key lens = [%d,%d), diff @ index %d",
 				len(from), len(to), d)
-			log.Dev.Errorf(context.Background(), "%s, [%s,%s)", msg, from, to)
+			log.KvExec.Errorf(context.Background(), "%s, [%s,%s)", msg, from, to)
 			panic(redact.Safe(msg))
 		case cmp == 0:
 			// Starting key is same as ending key, so just add single node.

--- a/pkg/kv/kvserver/tscache/skl_impl.go
+++ b/pkg/kv/kvserver/tscache/skl_impl.go
@@ -96,12 +96,12 @@ func (tc *sklImpl) boundKeyLengths(start, end roachpb.Key) (roachpb.Key, roachpb
 	// requests to interfere, but will never permit consistency anomalies.
 	if l := len(start); l > maxKeySize {
 		start = start[:maxKeySize]
-		log.Dev.Warningf(context.TODO(), "start key with length %d exceeds maximum key length of %d; "+
+		log.KvExec.Warningf(context.TODO(), "start key with length %d exceeds maximum key length of %d; "+
 			"losing precision in timestamp cache", l, maxKeySize)
 	}
 	if l := len(end); l > maxKeySize {
 		end = end[:maxKeySize].PrefixEnd() // PrefixEnd to grow range
-		log.Dev.Warningf(context.TODO(), "end key with length %d exceeds maximum key length of %d; "+
+		log.KvExec.Warningf(context.TODO(), "end key with length %d exceeds maximum key length of %d; "+
 			"losing precision in timestamp cache", l, maxKeySize)
 	}
 	return start, end

--- a/pkg/kv/kvserver/tscache/tree_impl.go
+++ b/pkg/kv/kvserver/tscache/tree_impl.go
@@ -77,7 +77,7 @@ var _ Cache = &treeImpl{}
 // newTreeImpl returns a new treeImpl with the supplied hybrid clock.
 func newTreeImpl(clock *hlc.Clock) *treeImpl {
 	tc := &treeImpl{
-		cache:    cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}, log.Dev.Errorf),
+		cache:    cache.NewIntervalCache(cache.Config{Policy: cache.CacheFIFO}, log.KvExec.Errorf),
 		maxBytes: uint64(defaultTreeImplSize),
 		metrics:  makeMetrics(),
 	}

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -343,7 +343,7 @@ func (q *Queue) Clear(disable bool) {
 	metrics.PusheeWaiting.Dec(int64(len(q.mu.txns)))
 
 	if log.V(1) {
-		log.Dev.Infof(
+		log.KvExec.Infof(
 			context.Background(),
 			"clearing %d push waiters and %d query waiters",
 			waitingPushesCount,
@@ -394,7 +394,7 @@ func (q *Queue) ClearGE(key roachpb.Key) []roachpb.LockAcquisition {
 	}
 
 	if log.V(1) {
-		log.Dev.Infof(
+		log.KvExec.Infof(
 			context.Background(),
 			"clearing %d push waiters and %d query waiters",
 			waitingPushesCount,
@@ -503,7 +503,7 @@ func (q *Queue) UpdateTxn(ctx context.Context, txn *roachpb.Transaction) {
 	metrics.PusheeWaiting.Dec(1)
 
 	if log.V(1) && waitingPushes.Len() > 0 {
-		log.Dev.Infof(ctx, "updating %d push waiters for %s", waitingPushes.Len(), txn.ID.Short())
+		log.KvExec.Infof(ctx, "updating %d push waiters for %s", waitingPushes.Len(), txn.ID.Short())
 	}
 	// Send on pending waiter channels outside of the mutex lock.
 	for e := waitingPushes.Front(); e != nil; e = e.Next() {
@@ -698,7 +698,7 @@ func (q *Queue) waitForPush(
 		select {
 		case <-slowTimer.C:
 			metrics.PusherSlow.Inc(1)
-			log.Dev.Warningf(ctx, "pusher %s: have been waiting %.2fs for pushee %s",
+			log.KvExec.Warningf(ctx, "pusher %s: have been waiting %.2fs for pushee %s",
 				req.PusherTxn.ID.Short(),
 				timeutil.Since(tBegin).Seconds(),
 				req.PusheeTxn.ID.Short(),
@@ -706,7 +706,7 @@ func (q *Queue) waitForPush(
 			//nolint:deferloop
 			defer func() {
 				metrics.PusherSlow.Dec(1)
-				log.Dev.Warningf(ctx, "pusher %s: finished waiting after %.2fs for pushee %s",
+				log.KvExec.Warningf(ctx, "pusher %s: finished waiting after %.2fs for pushee %s",
 					req.PusherTxn.ID.Short(),
 					timeutil.Since(tBegin).Seconds(),
 					req.PusheeTxn.ID.Short(),
@@ -840,7 +840,7 @@ func (q *Queue) waitForPush(
 					// in a deadlock, but we don't want these to be too spammy.
 					level := log.Level(1)
 					if q.every.ShouldLog() {
-						level = 0 // will behave like a log.Dev.Infof
+						level = 0 // will behave like a log.KvExec.Infof
 					}
 					log.VEventf(
 						ctx,


### PR DESCRIPTION
First two commits are from https://github.com/cockroachdb/cockroach/pull/153945.

----

Starting from `rg -l 'log.Dev' pkg/kv/kvserver/ | sed -E 's/[^/]+$//g' | sort | uniq -c | sort -r -n`, I went through each package and wholesale replaced `log.Dev.*` either with the KvDistribution or KvExec log channel.

As of this PR, the only `log.Dev` logging in the `kvserver` tree is in the `kvserver` package itself:

```
$ rg -l 'log.Dev' pkg/kv/kvserver/ | sed -E 's/[^/]+$//g' | sort | uniq -c | sort -r -n
  81 pkg/kv/kvserver/
```

This will be addressed separately.

Epic: none