### PR TITLE
roachrest, roachprod: support no disks on workload machines

### DIFF
--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -57,6 +57,15 @@ func WorkloadNodeCPU(n int) Option {
 	}
 }
 
+// WorkloadRequiresDisk should be used if the workload nodes should have the
+// exact same disk configuration as the rest of the cluster. Otherwise, all
+// workload nodes only have a boot disk.
+func WorkloadRequiresDisk() Option {
+	return func(spec *ClusterSpec) {
+		spec.WorkloadRequiresDisk = true
+	}
+}
+
 // Mem requests nodes with low/standard/high ratio of memory per CPU.
 func Mem(level MemPerCPU) Option {
 	return func(spec *ClusterSpec) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1085,7 +1085,10 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 		func(ctx context.Context, node Node) (*RunResultDetails, error) {
 			res := &RunResultDetails{Node: node}
 			var err error
-			cmd := fmt.Sprintf("test -e %s -a -e %s", vm.DisksInitializedFile, vm.OSInitializedFile)
+			// Only the `vm.OSInitializedFile` file is checked and not the
+			// `vm.DisksInitializedFile`, because it's possible to create VMs without
+			// any attached disks other than the boot disk.
+			cmd := fmt.Sprintf("test -e %s", vm.OSInitializedFile)
 			// N.B. we disable ssh debug output capture, lest we end up with _thousands_ of useless .log files.
 			opts := cmdOptsWithDebugDisabled()
 			for j := 0; j < 600; j++ {

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -543,6 +543,8 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		false, "use AWS Spot VMs, which are significantly cheaper, but can be preempted by AWS.")
 	flags.StringVar(&o.IAMProfile, ProviderName+"-iam-profile", o.IAMProfile,
 		"the IAM instance profile to associate with created VMs if non-empty")
+	flags.BoolVar(&o.BootDiskOnly, ProviderName+"-boot-disk-only", o.BootDiskOnly,
+		"Only attach the boot disk. No additional volumes will be provisioned even if specified.")
 }
 
 // ConfigureClusterCleanupFlags implements ProviderOpts.

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -30,6 +30,11 @@ const awsStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
 function setup_disks() {
+{{ if .BootDiskOnly }}
+	echo "VM has no disk attached other than the boot disk."
+	return 0
+{{ end }}
+
 {{ if not .Zfs }}
 	mount_opts="defaults,nofail"
 	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
@@ -181,11 +186,13 @@ func writeStartupScript(
 	useMultiple bool,
 	enableFips bool,
 	remoteUser string,
+	bootDiskOnly bool,
 ) (string, error) {
 	type tmplParams struct {
 		vm.StartupArgs
 		ExtraMountOpts   string
 		UseMultipleDisks bool
+		BootDiskOnly     bool
 	}
 
 	args := tmplParams{
@@ -198,6 +205,7 @@ func writeStartupScript(
 		),
 		ExtraMountOpts:   extraMountOpts,
 		UseMultipleDisks: useMultiple,
+		BootDiskOnly:     bootDiskOnly,
 	}
 
 	tmpfile, err := os.CreateTemp("", "aws-startup-script")

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -31,6 +31,7 @@ const awsStartupScriptTemplate = `#!/usr/bin/env bash
 
 function setup_disks() {
 {{ if .BootDiskOnly }}
+	mkdir -p /mnt/data1 && chmod 777 /mnt/data1
 	echo "VM has no disk attached other than the boot disk."
 	return 0
 {{ end }}

--- a/pkg/roachprod/vm/aws/support_test.go
+++ b/pkg/roachprod/vm/aws/support_test.go
@@ -17,7 +17,8 @@ import (
 
 // TestWriteStartupScriptTemplate mainly tests the startup script tpl compiles.
 func TestWriteStartupScriptTemplate(t *testing.T) {
-	file, err := writeStartupScript("vm_name", "", vm.Zfs, false, false, "ubuntu")
+	file, err := writeStartupScript("vm_name", "", vm.Zfs, false,
+		false, "ubuntu", false)
 	require.NoError(t, err)
 
 	f, err := os.ReadFile(file)

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -7,6 +7,8 @@ echo
 function setup_disks() {
 
 
+
+
 	use_multiple_disks=''
 
 	mount_prefix="/mnt/data"

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -931,6 +931,9 @@ func (p *Provider) createVM(
 		startupArgs.AttachedDiskLun = &lun
 	}
 
+	// Check if we only require a boot disk (workload only machines).
+	startupArgs.BootDiskOnly = providerOpts.BootDiskOnly
+
 	startupScript, err := evalStartupTemplate(startupArgs)
 	if err != nil {
 		return machine, err
@@ -1058,7 +1061,7 @@ func (p *Provider) createVM(
 		machine.VirtualMachineProperties.StorageProfile.DiskControllerType = compute.NVMe
 	}
 
-	if !opts.SSDOpts.UseLocalSSD {
+	if !opts.SSDOpts.UseLocalSSD && !providerOpts.BootDiskOnly {
 		caching := compute.CachingTypesNone
 
 		switch providerOpts.DiskCaching {

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -91,4 +91,6 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Number of IOPS provisioned for ultra disk, only used if network-disk-type=ultra-disk")
 	flags.StringVar(&o.DiskCaching, ProviderName+"-disk-caching", "none",
 		"Disk caching behavior for attached storage.  Valid values are: none, read-only, read-write.  Not applicable to Ultra disks.")
+	flags.BoolVar(&o.BootDiskOnly, ProviderName+"-boot-disk-only", o.BootDiskOnly,
+		"Only attach the boot disk. No additional volumes will be provisioned even if specified.")
 }

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -26,6 +26,7 @@ type ProviderOpts struct {
 	NetworkDiskSize int32
 	UltraDiskIOPS   int64
 	DiskCaching     string
+	BootDiskOnly    bool
 }
 
 // These default locations support availability zones. At the time of

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -6,7 +6,9 @@ echo
 # Script for setting up a Azure machine for roachprod use.
 
 function setup_disks() {
-	mount_opts="defaults"
+
+
+mount_opts="defaults"
 
 	devices=()
 

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -23,6 +23,7 @@ type azureStartupArgs struct {
 	vm.StartupArgs
 	AttachedDiskLun    *int // Use attached disk, with specified LUN; Use local ssd if nil.
 	DiskControllerNVMe bool // Interface data disk via NVMe
+	BootDiskOnly       bool
 }
 
 const azureStartupTemplate = `#!/bin/bash
@@ -30,7 +31,12 @@ const azureStartupTemplate = `#!/bin/bash
 # Script for setting up a Azure machine for roachprod use.
 
 function setup_disks() {
-	mount_opts="defaults"
+{{ if .BootDiskOnly }}
+	echo "VM has no disk attached other than the boot disk."
+	return 0
+{{ end }}
+
+mount_opts="defaults"
 
 	devices=()
 {{if .DiskControllerNVMe}}

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -32,6 +32,7 @@ const azureStartupTemplate = `#!/bin/bash
 
 function setup_disks() {
 {{ if .BootDiskOnly }}
+	mkdir -p /mnt/data1 && chmod 777 /mnt/data1
 	echo "VM has no disk attached other than the boot disk."
 	return 0
 {{ end }}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1158,6 +1158,8 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"enable turbo mode for the instance (only supported on C4 VM families, valid value: 'ALL_CORE_MAX')")
 	flags.IntVar(&o.ThreadsPerCore, ProviderName+"-threads-per-core", 0,
 		"the number of visible threads per physical core (valid values: 1 or 2), default is 0 (auto)")
+	flags.BoolVar(&o.BootDiskOnly, ProviderName+"-boot-disk-only", o.BootDiskOnly,
+		"Only attach the boot disk. No additional volumes will be provisioned even if specified.")
 }
 
 // ConfigureProviderFlags implements Provider

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -374,6 +374,9 @@ type ProviderOpts struct {
 	ManagedSpotZones []string
 	// Enable the cron service. It is disabled by default.
 	EnableCron bool
+	// BootDiskOnly ensures that no additional disks will be attached, other than
+	// the boot disk.
+	BootDiskOnly bool
 
 	// GCE allows two availability policies in case of a maintenance event (see --maintenance-policy via gcloud),
 	// 'TERMINATE' or 'MIGRATE'. The default is 'MIGRATE' which we denote by 'TerminateOnMigration == false'.
@@ -1456,51 +1459,54 @@ func (p *Provider) computeInstanceArgs(
 		}
 	}
 
+	// Disk selection args.
 	extraMountOpts := ""
 	// Dynamic args.
-	if opts.SSDOpts.UseLocalSSD {
-		if counts, err := AllowedLocalSSDCount(providerOpts.MachineType); err != nil {
-			return nil, cleanUpFn, err
+	if !providerOpts.BootDiskOnly {
+		if opts.SSDOpts.UseLocalSSD {
+			if counts, err := AllowedLocalSSDCount(providerOpts.MachineType); err != nil {
+				return nil, cleanUpFn, err
+			} else {
+				// Make sure the minimum number of local SSDs is met.
+				minCount := counts[0]
+				if providerOpts.SSDCount < minCount {
+					l.Printf("WARNING: SSD count must be at least %d for %q. Setting --gce-local-ssd-count to %d", minCount, providerOpts.MachineType, minCount)
+					providerOpts.SSDCount = minCount
+				}
+			}
+			for i := 0; i < providerOpts.SSDCount; i++ {
+				args = append(args, "--local-ssd", "interface=NVME")
+			}
+			// Add `discard` for Local SSDs on NVMe, as is advised in:
+			// https://cloud.google.com/compute/docs/disks/add-local-ssd
+			extraMountOpts = "discard"
+			if opts.SSDOpts.NoExt4Barrier {
+				extraMountOpts = fmt.Sprintf("%s,nobarrier", extraMountOpts)
+			}
 		} else {
-			// Make sure the minimum number of local SSDs is met.
-			minCount := counts[0]
-			if providerOpts.SSDCount < minCount {
-				l.Printf("WARNING: SSD count must be at least %d for %q. Setting --gce-local-ssd-count to %d", minCount, providerOpts.MachineType, minCount)
-				providerOpts.SSDCount = minCount
+			// create the "PDVolumeCount" number of persistent disks with the same configuration
+			for i := 0; i < providerOpts.PDVolumeCount; i++ {
+				pdProps := []string{
+					fmt.Sprintf("type=%s", providerOpts.PDVolumeType),
+					fmt.Sprintf("size=%dGB", providerOpts.PDVolumeSize),
+					"auto-delete=yes",
+				}
+				// TODO(pavelkalinnikov): support disk types with "provisioned-throughput"
+				// option, such as Hyperdisk Throughput:
+				// https://cloud.google.com/compute/docs/disks/add-hyperdisk#hyperdisk-throughput.
+				args = append(args, "--create-disk", strings.Join(pdProps, ","))
 			}
+			// Enable DISCARD commands for persistent disks, as is advised in:
+			// https://cloud.google.com/compute/docs/disks/optimizing-pd-performance#formatting_parameters.
+			extraMountOpts = "discard"
 		}
-		for i := 0; i < providerOpts.SSDCount; i++ {
-			args = append(args, "--local-ssd", "interface=NVME")
-		}
-		// Add `discard` for Local SSDs on NVMe, as is advised in:
-		// https://cloud.google.com/compute/docs/disks/add-local-ssd
-		extraMountOpts = "discard"
-		if opts.SSDOpts.NoExt4Barrier {
-			extraMountOpts = fmt.Sprintf("%s,nobarrier", extraMountOpts)
-		}
-	} else {
-		// create the "PDVolumeCount" number of persistent disks with the same configuration
-		for i := 0; i < providerOpts.PDVolumeCount; i++ {
-			pdProps := []string{
-				fmt.Sprintf("type=%s", providerOpts.PDVolumeType),
-				fmt.Sprintf("size=%dGB", providerOpts.PDVolumeSize),
-				"auto-delete=yes",
-			}
-			// TODO(pavelkalinnikov): support disk types with "provisioned-throughput"
-			// option, such as Hyperdisk Throughput:
-			// https://cloud.google.com/compute/docs/disks/add-hyperdisk#hyperdisk-throughput.
-			args = append(args, "--create-disk", strings.Join(pdProps, ","))
-		}
-		// Enable DISCARD commands for persistent disks, as is advised in:
-		// https://cloud.google.com/compute/docs/disks/optimizing-pd-performance#formatting_parameters.
-		extraMountOpts = "discard"
 	}
 
 	// Create GCE startup script file.
 	filename, err := writeStartupScript(
 		extraMountOpts, opts.SSDOpts.FileSystem,
 		providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS),
-		providerOpts.EnableCron,
+		providerOpts.EnableCron, providerOpts.BootDiskOnly,
 	)
 	if err != nil {
 		return nil, cleanUpFn, errors.Wrapf(err, "could not write GCE startup script to temp file")
@@ -1579,10 +1585,14 @@ func createInstanceTemplates(
 
 // createInstanceGroups creates an instance group in each zone, for the cluster
 func createInstanceGroups(
-	l *logger.Logger, project, clusterName string, zones []string, opts vm.CreateOpts,
+	l *logger.Logger,
+	project, clusterName string,
+	zones []string,
+	providerOpts *ProviderOpts,
+	opts vm.CreateOpts,
 ) error {
 	groupName := instanceGroupName(clusterName)
-	// Note that we set the IP addresses to be stateful, so that they remain the
+	// Note that we set the IP addresses to be stateful so that they remain the
 	// same when instances are auto-healed, updated, or recreated.
 	createGroupArgs := []string{"compute", "instance-groups", "managed", "create",
 		"--size", "0",
@@ -1592,12 +1602,11 @@ func createInstanceGroups(
 		groupName}
 
 	// Determine the number of stateful disks the instance group should retain. If
-	// we don't use a local SSD, we use 2 stateful disks, a boot disk and a
-	// persistent disk. If we use a local SSD, we use 1 stateful disk, the boot
-	// disk.
+	// we don't use a local SSD, we have the number of persistent disks plus a
+	// boot disk. If we use a local SSD, we use 1 stateful disk, the boot disk.
 	numStatefulDisks := 1
-	if !opts.SSDOpts.UseLocalSSD {
-		numStatefulDisks = 2
+	if !opts.SSDOpts.UseLocalSSD && !providerOpts.BootDiskOnly {
+		numStatefulDisks += providerOpts.PDVolumeCount
 	}
 	statefulDiskArgs := make([]string, 0)
 	for i := 0; i < numStatefulDisks; i++ {
@@ -1740,7 +1749,7 @@ func (p *Provider) Create(
 		if err != nil {
 			return nil, err
 		}
-		err = createInstanceGroups(l, project, opts.ClusterName, usedZones, opts)
+		err = createInstanceGroups(l, project, opts.ClusterName, usedZones, providerOpts, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -9,6 +9,8 @@ function setup_disks() {
 
 
 
+
+
 	use_multiple_disks=''
 
 	mount_prefix="/mnt/data"

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -29,6 +29,7 @@ function setup_disks() {
 	first_setup=$1
 
 {{ if .BootDiskOnly }}
+	mkdir -p /mnt/data1 && chmod 777 /mnt/data1
 	echo "VM has no disk attached other than the boot disk."
 	return 0
 {{ end }}

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -28,6 +28,11 @@ const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 function setup_disks() {
 	first_setup=$1
 
+{{ if .BootDiskOnly }}
+	echo "VM has no disk attached other than the boot disk."
+	return 0
+{{ end }}
+
 {{ if not .Zfs }}
 	mount_opts="defaults,nofail"
 	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
@@ -183,13 +188,19 @@ sudo touch {{ .OSInitializedFile }}
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool, enableCron bool,
+	extraMountOpts string,
+	fileSystem string,
+	useMultiple bool,
+	enableFIPS bool,
+	enableCron bool,
+	bootDiskOnly bool,
 ) (string, error) {
 	type tmplParams struct {
 		vm.StartupArgs
 		ExtraMountOpts   string
 		UseMultipleDisks bool
 		PublicKey        string
+		BootDiskOnly     bool
 	}
 
 	publicKey, err := config.SSHPublicKey()
@@ -208,6 +219,7 @@ func writeStartupScript(
 		ExtraMountOpts:   extraMountOpts,
 		UseMultipleDisks: useMultiple,
 		PublicKey:        publicKey,
+		BootDiskOnly:     bootDiskOnly,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/gce/utils_test.go
+++ b/pkg/roachprod/vm/gce/utils_test.go
@@ -30,7 +30,7 @@ func TestWriteStartupScriptTemplate(t *testing.T) {
 	config.SSHDirectory = tempDir
 
 	// Actual test
-	file, err := writeStartupScript("", vm.Zfs, false, false, false)
+	file, err := writeStartupScript("", vm.Zfs, false, false, false, false)
 	require.NoError(t, err)
 
 	f, err := os.ReadFile(file)

--- a/pkg/roachprod/vm/ibm/helpers.go
+++ b/pkg/roachprod/vm/ibm/helpers.go
@@ -111,7 +111,6 @@ func (p *Provider) createInstance(
 		return nil, errors.Wrap(err, "failed to get VPC service for region")
 	}
 
-	// Create the startup script
 	startupScript, err := p.startupScript(startupArgs{
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithVMName(opts.vmName),
@@ -120,6 +119,7 @@ func (p *Provider) createInstance(
 			vm.WithZfs(opts.vmOpts.SSDOpts.FileSystem == vm.Zfs),
 		),
 		UseMultipleDisks: opts.providerOpts.UseMultipleDisks,
+		BootDiskOnly:     opts.providerOpts.BootDiskOnly,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create startup script for instance %s", opts.vmName)
@@ -137,16 +137,19 @@ func (p *Provider) createInstance(
 
 	// Build the attached volumes information.
 	// Let's start with the default data disk.
-	attachedVolumes := volumeAttachments{
-		&volumeAttachment{
-			Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, 0),
-			ResourceGroupID:        p.config.roachprodResourceGroupID,
-			Capacity:               opts.providerOpts.DefaultVolume.VolumeSize,
-			IOPS:                   opts.providerOpts.DefaultVolume.IOPS,
-			Profile:                opts.providerOpts.DefaultVolume.VolumeType,
-			UserTags:               opts.tags,
-			DeleteOnInstanceDelete: true,
-		},
+	attachedVolumes := volumeAttachments{}
+	if !opts.providerOpts.BootDiskOnly {
+		attachedVolumes = volumeAttachments{
+			&volumeAttachment{
+				Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, 0),
+				ResourceGroupID:        p.config.roachprodResourceGroupID,
+				Capacity:               opts.providerOpts.DefaultVolume.VolumeSize,
+				IOPS:                   opts.providerOpts.DefaultVolume.IOPS,
+				Profile:                opts.providerOpts.DefaultVolume.VolumeType,
+				UserTags:               opts.tags,
+				DeleteOnInstanceDelete: true,
+			},
+		}
 	}
 	// Then we add any additional attached volumes.
 	for i, attachedVolume := range opts.providerOpts.AttachedVolumes {

--- a/pkg/roachprod/vm/ibm/provider_flags.go
+++ b/pkg/roachprod/vm/ibm/provider_flags.go
@@ -152,6 +152,13 @@ If > 1 zone specified, the cluster will be spread out evenly by zone regardless 
 	)
 
 	flags.BoolVar(
+		&o.BootDiskOnly,
+		ProviderName+"-boot-disk-only",
+		o.BootDiskOnly,
+		"Only attach the boot disk. No additional volumes will be provisioned even if specified.",
+	)
+
+	flags.BoolVar(
 		&o.UseMultipleDisks,
 		ProviderName+"-enable-multiple-stores",
 		false,

--- a/pkg/roachprod/vm/ibm/provider_flags.go
+++ b/pkg/roachprod/vm/ibm/provider_flags.go
@@ -48,6 +48,10 @@ type ProviderOpts struct {
 	// or terminated in case of a host failure or maintenance event. The default
 	// is to migrate the instance, which is the same as setting this to false.
 	TerminateOnMigration bool
+
+	// BootDiskOnly ensures that no additional disks will be attached, other than
+	// the boot disk.
+	BootDiskOnly bool
 }
 
 // Volume represents a volume to be attached to an IBM instance.

--- a/pkg/roachprod/vm/ibm/startup.go
+++ b/pkg/roachprod/vm/ibm/startup.go
@@ -20,6 +20,7 @@ type startupArgs struct {
 	vm.StartupArgs
 	ExtraMountOpts   string
 	UseMultipleDisks bool
+	BootDiskOnly     bool
 }
 
 const startupTemplate = `#!/usr/bin/env bash
@@ -27,6 +28,11 @@ const startupTemplate = `#!/usr/bin/env bash
 # Script for setting up an IBM machine for roachprod use.
 
 function setup_disks() {
+{{ if .BootDiskOnly }}
+	echo "VM has no disk attached other than the boot disk."
+	return 0
+{{ end }}
+
 	mount_prefix="/mnt/data"
 	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
 

--- a/pkg/roachprod/vm/ibm/startup.go
+++ b/pkg/roachprod/vm/ibm/startup.go
@@ -29,6 +29,7 @@ const startupTemplate = `#!/usr/bin/env bash
 
 function setup_disks() {
 {{ if .BootDiskOnly }}
+	mkdir -p /mnt/data1 && chmod 777 /mnt/data1
 	echo "VM has no disk attached other than the boot disk."
 	return 0
 {{ end }}

--- a/pkg/roachprod/vm/ibm/testdata/startup_script
+++ b/pkg/roachprod/vm/ibm/testdata/startup_script
@@ -6,6 +6,8 @@ echo
 # Script for setting up an IBM machine for roachprod use.
 
 function setup_disks() {
+
+
 	mount_prefix="/mnt/data"
 	use_multiple_disks=''
 


### PR DESCRIPTION
Previously, workload machines automatically inherited the same disk setup as the rest of the cluster. To optimize for cost, we now allow workload machines to have only boot disks.

The default behavior, for providers, is to attach a standard data disk, or a number of local SSDs depending on the cluster spec. Thus in order to explicitly prevent any data disk from being configured , a new provider option "BootDiskOnly" has been added to prevent the default behavior, specifically for workload machines.

Epic: None
Release note: None