### PR TITLE
changefeedccl: fix TestAlterChangefeedAddTargetsDuringSchemaChangeError

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1349,7 +1349,8 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 			return nil
 		}
 
-		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s', no_initial_scan`)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo
+WITH resolved = '1s', no_initial_scan, min_checkpoint_frequency='1ns'`)
 		jobFeed := testFeed.(cdctest.EnterpriseTestFeed)
 		jobRegistry := s.Server.JobRegistry().(*jobs.Registry)
 


### PR DESCRIPTION
This patch deflakes a unit test that started failing because the change
to checkpoint aggregators regularly meant that setting a low span-level
checkpoint interval wasn't enough to make sure a checkpoint happened
quickly enough during the test.

Fixes #153918

Release note: None