### PR TITLE
catalog/lease: update locked timestamps when updates are received

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -6687,7 +6687,6 @@ INSERT INTO baz.bar VALUES (110, 'a'), (210, 'b'), (310, 'c'), (410, 'd'), (510,
 	tenant10.Exec(t, `BACKUP DATABASE baz INTO 'userfile://defaultdb.myfililes/test4' with revision_history`)
 	expected = nil
 	for _, resume := range []exportResumePoint{
-		{mkSpan(id2, "/Tenant/10/Table/3", "/Tenant/10/Table/4"), withoutTS},
 		{mkSpan(id2, "/Tenant/10/Table/:id/1", "/Tenant/10/Table/:id/2"), withoutTS},
 		{mkSpan(id2, "/Tenant/10/Table/:id/1/210", "/Tenant/10/Table/:id/2"), withoutTS},
 		// We have two entries for 210 because of history and super small table

--- a/pkg/backup/targets.go
+++ b/pkg/backup/targets.go
@@ -185,7 +185,7 @@ func getAllDescChanges(
 	startTime, endTime hlc.Timestamp,
 	priorIDs map[descpb.ID]descpb.ID,
 ) ([]backuppb.BackupManifest_DescriptorRevision, error) {
-	startKey := codec.TablePrefix(keys.DescriptorTableID)
+	startKey := codec.IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	endKey := startKey.PrefixEnd()
 
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -831,7 +831,7 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 	}
 	codec := tf.leaseMgr.Codec()
 	start := crtime.NowMono()
-	span := roachpb.Span{Key: codec.TablePrefix(keys.DescriptorTableID)}
+	span := roachpb.Span{Key: codec.IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)}
 	span.EndKey = span.Key.PrefixEnd()
 
 	tf.mu.Lock()

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -148,7 +148,7 @@ func FetchDescVersionModificationTime(
 	db := serverutils.OpenDBConn(
 		t, s.SQLAddr(), dbName, false, s.AppStopper())
 
-	tblKey := s.Codec().TablePrefix(keys.DescriptorTableID)
+	tblKey := s.Codec().IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	header := kvpb.RequestHeader{
 		Key:    tblKey,
 		EndKey: tblKey.PrefixEnd(),

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -211,9 +211,9 @@ func (s *SystemConfig) GetLargestObjectID(
 	// Search for the descriptor table entries within the SystemConfig. lowIndex
 	// (in s.Values) is the first and highIndex one past the last KV pair in the
 	// descriptor table.
-	lowBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID)
+	lowBound := keys.SystemSQLCodec.IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	lowIndex := s.getIndexBound(lowBound)
-	highBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID + 1)
+	highBound := keys.SystemSQLCodec.IndexPrefix(keys.DescriptorTableID+1, keys.DescriptorTablePrimaryKeyIndexID)
 	highIndex := s.getIndexBound(highBound)
 	if lowIndex == highIndex {
 		return 0, fmt.Errorf("descriptor table not found in system config of %d values", len(s.Values))

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -426,9 +426,14 @@ const (
 	ZonesTableConfigColumnID = 2
 	ZonesTableConfigColFamID = 2
 
-	DescriptorTablePrimaryKeyIndexID         = 1
-	DescriptorTableDescriptorColID           = 2
-	DescriptorTableDescriptorColFamID        = 2
+	DescriptorTablePrimaryKeyIndexID  = 1
+	DescriptorTableDescriptorColID    = 2
+	DescriptorTableDescriptorColFamID = 2
+	// DescriptorTableDescriptorUpdateIndexID is not a real index. It is a special
+	// ID used to construct index entries that inform the lease subsystem of
+	// descriptor updates within a transaction. The value for such an entry is a
+	// descpb.DescriptorUpdates message.
+	DescriptorTableDescriptorUpdateIndexID   = 2
 	TenantsTablePrimaryKeyIndexID            = 1
 	SpanConfigurationsTablePrimaryKeyIndexID = 1
 	CommentsTablePrimaryKeyIndexID           = 1

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -449,7 +449,7 @@ func (r *Reporter) populateSQLInfo(uptime int64, sql *diagnosticspb.SQLInstanceI
 // type fields. Check out `schematelemetry` package for a better data source for
 // collecting redacted schema information.
 func (r *Reporter) collectSchemaInfo(ctx context.Context) ([]descpb.TableDescriptor, error) {
-	startKey := keys.MakeSQLCodec(r.TenantID).TablePrefix(keys.DescriptorTableID)
+	startKey := keys.MakeSQLCodec(r.TenantID).IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	endKey := startKey.PrefixEnd()
 	kvs, err := r.DB.Scan(ctx, startKey, endKey, 0)
 	if err != nil {

--- a/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
@@ -195,6 +195,15 @@ func (s *SQLWatcher) watchForDescriptorUpdates(
 			// Event for a tombstone on a tombstone -- nothing for us to do here.
 			return
 		}
+		// Skip over any modifications to the descriptor update tracking key, this
+		// is transaction information for the lease manager only.
+		if isUpdateKey, err := s.codec.DecodeDescUpdateKey(ev.Key); isUpdateKey || err != nil {
+			if err != nil {
+				log.Dev.Warningf(ctx, "failed to decode descriptor update key: %v", err)
+			}
+			return
+		}
+
 		value := ev.Value
 		if !ev.Value.IsPresent() {
 			// The descriptor was deleted.

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -287,6 +287,11 @@ func MakeDescMetadataKey(codec keys.SQLCodec, descID descpb.ID) roachpb.Key {
 	return codec.DescMetadataKey(uint32(descID))
 }
 
+// MakeDescUpdateKey returns the key for the descriptor.
+func MakeDescUpdateKey(codec keys.SQLCodec, id descpb.ID) roachpb.Key {
+	return codec.DescMetadataUpdateKey(uint32(id))
+}
+
 // CommentsMetadataPrefix returns the key prefix for all comments in the
 // system.comments table.
 func CommentsMetadataPrefix(codec keys.SQLCodec) roachpb.Key {

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1937,3 +1937,14 @@ message Descriptor {
     FunctionDescriptor function = 5;
   }
 }
+
+// DescriptorUpdates tracks updates to descriptors within a transaction, which
+// will be written to a special key.
+message DescriptorUpdates {
+  option (gogoproto.equal) = true;
+  // Needed for the descriptorProto interface.
+  option (gogoproto.goproto_getters) = true;
+
+  repeated uint32 descriptor_ids = 1 [(gogoproto.customname) = "DescriptorIDs", (gogoproto.casttype) = "ID"];
+  repeated uint32 descriptor_versions = 2  [(gogoproto.customname) = "DescriptorVersions", (gogoproto.casttype) = "DescriptorVersion"];
+}

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_google_btree//:btree",
     ],
 )
 

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -68,9 +68,9 @@ type ManagerTestingKnobs struct {
 	// has been reset.
 	RangeFeedResetChannel chan struct{}
 
-	// TestingOnRangeFeedCheckPoint is invoked when a range feed checkpoint is
+	// TestingOnUpdateReadTimestamp is invoked when a range feed checkpoint is
 	// hit.
-	TestingOnRangeFeedCheckPoint func()
+	TestingOnUpdateReadTimestamp func(timestamp hlc.Timestamp)
 
 	LeaseStoreTestingKnobs StorageTestingKnobs
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2418,6 +2418,10 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retEr
 		}
 	}
 
+	if err := ex.extraTxnState.descCollection.EmitDescriptorUpdatesKey(ctx, ex.state.mu.txn); err != nil {
+		return err
+	}
+
 	if err := ex.state.mu.txn.Commit(ctx); err != nil {
 		return err
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -2049,6 +2049,9 @@ func (ief *InternalDB) txn(
 			if err != nil {
 				return err
 			}
+			if err := descsCol.EmitDescriptorUpdatesKey(ctx, kvTxn); err != nil {
+				return err
+			}
 			// We check this testing condition here since a retry cannot be generated
 			// after a successful commit. Since we commit below, this is our last
 			// chance to generate a retry for users of (*InternalDB).Txn.

--- a/pkg/sql/vecindex/manager_test.go
+++ b/pkg/sql/vecindex/manager_test.go
@@ -117,11 +117,6 @@ func TestVectorManager(t *testing.T) {
 	}).BuildCreatedMutable()
 
 	err := internalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) (err error) {
-		defer func() {
-			if err == nil {
-				err = txn.KV().Commit(ctx)
-			}
-		}()
 		b := txn.KV().NewBatch()
 
 		err = txn.Descriptors().WriteDescToBatch(ctx, false, newDB, b)


### PR DESCRIPTION
Previously, the lease manager would increase its locked read time stamp was when a check point occurred on the range feed. This was not adequate because this could cause schema changes could be slowed down if the old version of descriptors was held. While the current design does not intentionally reserve, previous versions, a later update will start holding old versions intentionally to serve queries. To address this, this patch has schema changes write the list of descriptors modified to a special key `/Table/Descriptors/2/<First ID in Schema Change`, which will be used by the lease manager range feed to to update timestamps. Additionally, this patch also deflakes and fixes
`TestLeaseManagerLockedTimestampBasic`, which was not setup correctly.

Informs: #153618
Fixes: #153826
Fixes: https://github.com/cockroachdb/cockroach/issues/154075

Release note: None