### PR TITLE
roachtest: allow specifying a set of valid architectures

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -3177,31 +3177,20 @@ func (c *clusterImpl) MaybeExtendCluster(
 // archForTest determines the CPU architecture to use for a test. If the test
 // doesn't specify it, one is chosen randomly depending on flags.
 func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSpec) vm.CPUArch {
-	if testSpec.Cluster.Arch != "" {
-		l.PrintfCtx(ctx, "Using specified arch=%q, %s", testSpec.Cluster.Arch, testSpec.Name)
-		return testSpec.Cluster.Arch
-	}
-
 	if roachtestflags.Cloud == spec.IBM {
 		// N.B. IBM only supports S390x on the "s390x" architecture.
 		l.PrintfCtx(ctx, "IBM Cloud: forcing arch=%q (only supported), %s", vm.ArchS390x, testSpec.Name)
 		return vm.ArchS390x
 	}
 
-	// CPU architecture is unspecified, choose one according to the
-	// probability distribution.
-	var arch vm.CPUArch
-	if prng.Float64() < roachtestflags.ARM64Probability {
-		arch = vm.ArchARM64
-	} else if prng.Float64() < roachtestflags.FIPSProbability {
-		// N.B. branch is taken with probability
-		//   (1 - arm64Probability) * fipsProbability
-		// which is P(fips & amd64).
-		// N.B. FIPS is only supported on 'amd64' at this time.
-		arch = vm.ArchFIPS
-	} else {
-		arch = vm.ArchAMD64
+	validArchs := spec.AllArchs
+	if !testSpec.Cluster.CompatibleArchs.IsEmpty() {
+		l.PrintfCtx(ctx, "Selecting from architectures=%q, %s", testSpec.Cluster.CompatibleArchs.String(), testSpec.Name)
+		validArchs = testSpec.Cluster.CompatibleArchs
 	}
+
+	arch := randomArch(ctx, l, validArchs, prng)
+
 	if roachtestflags.Cloud == spec.GCE && arch == vm.ArchARM64 {
 		// N.B. T2A support is rather limited, both in terms of supported
 		// regions and no local SSDs. Thus, we must fall back to AMD64 in
@@ -3219,6 +3208,58 @@ func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSp
 	l.PrintfCtx(ctx, "Using randomly chosen arch=%q, %s", arch, testSpec.Name)
 
 	return arch
+}
+
+// randomArch chooses a random architecture, respecting the set of valid architectures
+// specified by the test as well as the global architecture probability flags for the
+// entire run.
+func randomArch(
+	ctx context.Context, l *logger.Logger, validArchs spec.ArchSet, prng *rand.Rand,
+) vm.CPUArch {
+	baseProbabilities := map[vm.CPUArch]float64{
+		vm.ArchAMD64: (1.0 - roachtestflags.ARM64Probability) * (1.0 - roachtestflags.FIPSProbability),
+		vm.ArchARM64: roachtestflags.ARM64Probability,
+		// N.B. FIPS is only supported on 'amd64' at this time:
+		// FIPS is taken with probability
+		//   (1 - arm64Probability) * fipsProbability
+		// 	 which is P(fips & amd64)
+		vm.ArchFIPS: (1.0 - roachtestflags.ARM64Probability) * roachtestflags.FIPSProbability,
+	}
+
+	// Calculate total weight for valid architectures only.
+	totalValidWeight := 0.0
+	validArchsList := validArchs.List()
+	for _, arch := range validArchsList {
+		totalValidWeight += baseProbabilities[arch]
+	}
+
+	// This would happen if the set of valid compatible arches (set by cluster spec) is disjoint with the set of
+	// enabled arches (set by roachtest flags).
+	if totalValidWeight == 0.0 {
+		l.PrintfCtx(ctx, "Defaulting to %s; CompatibleArches %s yields no architectures after applying roachtest arch probability flags", vm.ArchAMD64, validArchs.String())
+		return vm.ArchAMD64
+	}
+
+	// Since we allow only a subset of architectures, our total probability
+	// may not add up to 1. We normalize the weights amongst the valid architectures
+	// and track cumulative weights that give us "probability buckets" for each
+	// architecture.
+	cumulativeWeights := make([]float64, 0, len(validArchsList))
+	runningTotal := 0.0
+	for _, arch := range validArchsList {
+		normalizedWeight := baseProbabilities[arch] / totalValidWeight
+		runningTotal += normalizedWeight
+		cumulativeWeights = append(cumulativeWeights, runningTotal)
+	}
+	x := prng.Float64()
+	for i, weight := range cumulativeWeights {
+		if x < weight {
+			return validArchsList[i]
+		}
+	}
+	// Since we are adding floating point numbers, it's possible that we
+	// don't quite add up to 1.0. In that case, return the last architecture.
+	return validArchsList[len(validArchsList)-1]
 }
 
 // bucketVMsByProvider buckets cachedCluster.VMs by provider.

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -57,6 +57,11 @@ var AllArchs = Archs(ArchAMD64, ArchARM64, ArchFIPS)
 // OnlyAMD64 contains only the AMD64 architecture.
 var OnlyAMD64 = Archs(ArchAMD64)
 
+var OnlyARM64 = Archs(ArchARM64)
+
+// OnlyFIPS contains only the FIPS architecture.
+var OnlyFIPS = Archs(ArchFIPS)
+
 var AllExceptFIPS = AllArchs.remove(ArchFIPS)
 
 // Archs creates an ArchSet for the given architectures.

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -37,6 +37,92 @@ const (
 	RoachtestBranch = "roachtest-branch"
 )
 
+// ArchSet represents a set of CPU architectures using bitmasking.
+//
+// N.B. We call this a set to mirror how we represent other sets (e.g. clouds, suites),
+// but we cannot use a map directly since we compare cluster specs for reusability.
+type ArchSet uint8
+
+const (
+	ArchAMD64 ArchSet = 1 << iota
+	ArchARM64
+	ArchFIPS
+)
+
+// AllArchs contains all supported architectures.
+//
+// We omit s390x here as it is only supported iff the cloud is IBM.
+var AllArchs = Archs(ArchAMD64, ArchARM64, ArchFIPS)
+
+// OnlyAMD64 contains only the AMD64 architecture.
+var OnlyAMD64 = Archs(ArchAMD64)
+
+var AllExceptFIPS = AllArchs.remove(ArchFIPS)
+
+// Archs creates an ArchSet for the given architectures.
+func Archs(archs ...ArchSet) ArchSet {
+	var as ArchSet
+	for _, arch := range archs {
+		as |= arch
+	}
+	return as
+}
+
+// NoAMD64 removes the AMD64 architecture and returns the new set.
+func (as ArchSet) NoAMD64() ArchSet {
+	return as.remove(ArchAMD64)
+}
+
+// NoARM64 removes the ARM64 architecture and returns the new set.
+func (as ArchSet) NoARM64() ArchSet {
+	return as.remove(ArchARM64)
+}
+
+// NoFIPS removes the FIPS architecture and returns the new set.
+func (as ArchSet) NoFIPS() ArchSet {
+	return as.remove(ArchFIPS)
+}
+
+// remove returns a new ArchSet with the specified architecture removed.
+func (as ArchSet) remove(arch ArchSet) ArchSet {
+	return as &^ arch
+}
+
+// Contains returns true if the set contains the given architecture.
+func (as ArchSet) Contains(arch ArchSet) bool {
+	return as&arch != 0
+}
+
+func (as ArchSet) List() []vm.CPUArch {
+	var archs []vm.CPUArch
+	if as.Contains(ArchAMD64) {
+		archs = append(archs, vm.ArchAMD64)
+	}
+	if as.Contains(ArchARM64) {
+		archs = append(archs, vm.ArchARM64)
+	}
+	if as.Contains(ArchFIPS) {
+		archs = append(archs, vm.ArchFIPS)
+	}
+	return archs
+}
+
+func (as ArchSet) String() string {
+	var elems []string
+	for _, arch := range as.List() {
+		elems = append(elems, string(arch))
+	}
+	if len(elems) == 0 {
+		return "<none>"
+	}
+	return strings.Join(elems, ",")
+}
+
+// IsEmpty returns true if the set contains no architectures.
+func (as ArchSet) IsEmpty() bool {
+	return as == 0
+}
+
 type MemPerCPU int
 
 const (
@@ -97,8 +183,8 @@ const (
 // ClusterSpec represents a test's description of what its cluster needs to
 // look like. It becomes part of a clusterConfig when the cluster is created.
 type ClusterSpec struct {
-	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
-	NodeCount int
+	CompatibleArchs ArchSet // The set of all valid architectures to choose from.
+	NodeCount       int
 	// WorkloadNode indicates if we are using workload nodes.
 	// WorkloadNodeCount indicates count of the last few node of the cluster
 	// treated as workload node. Defaults to a VM with 4 CPUs if not specified

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -5,24 +5,20 @@
 
 package spec
 
-import (
-	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-)
+import "time"
 
 // Option for MakeClusterSpec.
 type Option func(spec *ClusterSpec)
 
-// Arch requests a specific CPU architecture.
+// Arch requests specific CPU architecture(s).
 //
 // Note that it is not guaranteed that this architecture will be used (e.g. if
 // the requested machine size isn't available in this architecture).
 //
 // TODO(radu): add a flag to indicate whether it's a preference or a requirement.
-func Arch(arch vm.CPUArch) Option {
+func Arch(as ArchSet) Option {
 	return func(spec *ClusterSpec) {
-		spec.Arch = arch
+		spec.CompatibleArchs = as
 	}
 }
 

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -37,7 +37,7 @@ func TestMakeTestRegistry(t *testing.T) {
 	require.EqualValues(t, 4, s.CPUs)
 	require.True(t, s.TerminateOnMigration)
 
-	s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(vm.ArchARM64))
+	s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(registry.OnlyARM64))
 	require.EqualValues(t, 10, s.NodeCount)
 	require.EqualValues(t, 16, s.CPUs)
 	require.EqualValues(t, vm.ArchARM64, s.Arch)

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
@@ -37,10 +36,10 @@ func TestMakeTestRegistry(t *testing.T) {
 	require.EqualValues(t, 4, s.CPUs)
 	require.True(t, s.TerminateOnMigration)
 
-	s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(registry.OnlyARM64))
+	s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(spec.OnlyARM64))
 	require.EqualValues(t, 10, s.NodeCount)
 	require.EqualValues(t, 16, s.CPUs)
-	require.EqualValues(t, vm.ArchARM64, s.Arch)
+	require.EqualValues(t, spec.OnlyARM64, s.CompatibleArchs)
 }
 
 // TestPrometheusMetricParser tests that the registry.PromSub()

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2413,10 +2413,6 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 		"coverageBuild":          fmt.Sprintf("%t", t.goCoverEnabled),
 	}
 
-	// Emit CPU architecture only if it was specified; otherwise, it's captured below, assuming cluster was created.
-	if spec.Cluster.Arch != "" {
-		clusterParams["arch"] = string(spec.Cluster.Arch)
-	}
 	// These params can be probabilistically set, so we pass them here to
 	// show what their actual values are in the posted issue.
 	if createOpts != nil {
@@ -2426,11 +2422,7 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 
 	if c != nil {
 		clusterParams["encrypted"] = fmt.Sprintf("%v", c.encAtRest)
-		if spec.Cluster.Arch == "" {
-			// N.B. when Arch is specified, it cannot differ from cluster's arch.
-			// Hence, we only emit when arch was unspecified.
-			clusterParams["arch"] = string(c.arch)
-		}
+		clusterParams["arch"] = string(c.arch)
 
 		c.destroyState.mu.Lock()
 		saved, savedMsg := c.destroyState.mu.saved, c.destroyState.mu.savedMsg

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -40,8 +40,9 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		// for IBM tests, and this test was disabled on Azure as of 05/2025.
 		CompatibleClouds: registry.AllExceptAzure,
 		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites:  registry.Suites(registry.Nightly),
-		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone()),
+		Suites: registry.Suites(registry.Nightly),
+		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
+		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone(), spec.Arch(spec.AllExceptFIPS)),
 		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount != 2 {

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -42,8 +42,9 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 		Monitor:          true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8),
-			spec.WorkloadNode(), spec.ReuseNone()),
+			spec.WorkloadNode(), spec.ReuseNone(), spec.Arch(spec.AllExceptFIPS)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			require.Equal(t, 4, c.Spec().NodeCount)
 

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -47,6 +47,8 @@ func registerSnapshotOverloadIO(r registry.Registry) {
 				spec.VolumeSize(cfg.volumeSize),
 				spec.ReuseNone(),
 				spec.DisableLocalSSD(),
+				// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
+				spec.Arch(spec.AllExceptFIPS),
 			),
 			Leases:  registry.MetamorphicLeases,
 			Timeout: 12 * time.Hour,

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -57,7 +57,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	roachprodaws "github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -2102,7 +2101,7 @@ func registerCDC(r registry.Registry) {
 		Name:      "cdc/initial-scan-only",
 		Owner:     registry.OwnerCDC,
 		Benchmark: true,
-		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),
 		// This test uses google cloudStorageSink because it is the fastest,
 		// but it is not a requirement for this test. The sink could be
 		// chosen on a per cloud basis if we want to run this on other clouds.
@@ -2283,7 +2282,7 @@ func registerCDC(r registry.Registry) {
 		Name:      "cdc/initial-scan-only/parquet",
 		Owner:     registry.OwnerCDC,
 		Benchmark: true,
-		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),
 		// This test uses google cloudStorageSink because it is the fastest,
 		// but it is not a requirement for this test. The sink could be
 		// chosen on a per cloud basis if we want to run this on other clouds.
@@ -2312,7 +2311,7 @@ func registerCDC(r registry.Registry) {
 		Skip:             "#119295",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -2774,7 +2773,7 @@ func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/kafka-auth-msk",
 		Owner:            registry.OwnerCDC,
-		Cluster:          r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.OnlyAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyAWS,
 		Suites:           registry.Suites(registry.Nightly),
@@ -2809,7 +2808,7 @@ func registerCDC(r registry.Registry) {
 		Owner:     `cdc`,
 		Benchmark: true,
 		// Only Kafka 3 supports Arm64, but the broker setup for Oauth used only works with Kafka 2
-		Cluster: r.MakeClusterSpec(4, spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Cluster: r.MakeClusterSpec(4, spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),
 		Leases:  registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
 		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
@@ -2856,7 +2855,7 @@ func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "cdc/kafka-topics",
 		Owner:   `cdc`,
-		Cluster: r.MakeClusterSpec(4, spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Cluster: r.MakeClusterSpec(4, spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),
 		Leases:  registry.MetamorphicLeases,
 		// Disabled on IBM due to lack of Kafka support on s390x.
 		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
@@ -2986,7 +2985,7 @@ func registerCDC(r registry.Registry) {
 		Owner:            `cdc`,
 		CompatibleClouds: registry.OnlyAzure,
 		// The Azure CLI only packages AMD64 binaries in its deb installer, so lock to AMD64.
-		Cluster: r.MakeClusterSpec(2, spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Cluster: r.MakeClusterSpec(2, spec.WorkloadNode(), spec.Arch(spec.OnlyAMD64)),
 		Leases:  registry.MetamorphicLeases,
 		Suites:  registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -33,9 +33,10 @@ import (
 // survives a temporary disk stall through failing over to a secondary disk.
 func registerDiskStalledWALFailover(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:                "disk-stalled/wal-failover/among-stores",
-		Owner:               registry.OwnerStorage,
-		Cluster:             r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.ReuseNone(), spec.SSD(2)),
+		Name:  "disk-stalled/wal-failover/among-stores",
+		Owner: registry.OwnerStorage,
+		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and lsblk outputs in the same format.
+		Cluster:             r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.ReuseNone(), spec.SSD(2), spec.Arch(spec.AllExceptFIPS)),
 		CompatibleClouds:    registry.OnlyGCE,
 		Suites:              registry.Suites(registry.Nightly),
 		Timeout:             3 * time.Hour,
@@ -209,7 +210,8 @@ func registerDiskStalledDetection(r registry.Registry) {
 			Owner: registry.OwnerStorage,
 			// Use PDs in an attempt to work around flakes encountered when using SSDs.
 			// See #97968.
-			Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode(), spec.ReuseNone(), spec.DisableLocalSSD()),
+			// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
+			Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode(), spec.ReuseNone(), spec.DisableLocalSSD(), spec.Arch(spec.AllExceptFIPS)),
 			CompatibleClouds:    registry.OnlyGCE,
 			Suites:              registry.Suites(registry.Nightly),
 			Timeout:             30 * time.Minute,
@@ -437,6 +439,8 @@ func registerDiskStalledWALFailoverWithProgress(r registry.Registry) {
 			spec.GCEVolumeCount(2),
 			spec.GCEVolumeType("pd-ssd"),
 			spec.VolumeSize(100),
+			// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
+			spec.Arch(spec.AllExceptFIPS),
 		),
 		CompatibleClouds:    registry.OnlyGCE,
 		Suites:              registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -104,12 +104,13 @@ func registerFailover(r registry.Registry) {
 			}
 
 			r.Add(registry.TestSpec{
-				Name:                   "failover/chaos" + readOnlyStr + leasesStr,
-				Owner:                  registry.OwnerKV,
-				Benchmark:              true,
-				Timeout:                90 * time.Minute,
-				Cluster:                r.MakeClusterSpec(10, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2), spec.DisableLocalSSD(), spec.ReuseNone()), // uses disk stalls
-				CompatibleClouds:       registry.OnlyGCE,                                                                                                           // dmsetup only configured for gce
+				Name:      "failover/chaos" + readOnlyStr + leasesStr,
+				Owner:     registry.OwnerKV,
+				Benchmark: true,
+				Timeout:   90 * time.Minute,
+				// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and lsblk outputs in the same format.
+				Cluster:                r.MakeClusterSpec(10, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2), spec.DisableLocalSSD(), spec.ReuseNone(), spec.Arch(spec.AllExceptFIPS)), // uses disk stalls
+				CompatibleClouds:       registry.OnlyGCE,                                                                                                                                          // dmsetup only configured for gce
 				Suites:                 registry.Suites(registry.Nightly),
 				Leases:                 leases,
 				SkipPostValidations:    registry.PostValidationNoDeadNodes, // cleanup kills nodes
@@ -172,6 +173,8 @@ func registerFailover(r registry.Registry) {
 				// Don't reuse the cluster for tests that call dmsetup to avoid
 				// spurious flakes from previous runs. See #107865
 				clusterOpts = append(clusterOpts, spec.ReuseNone())
+				// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and lsblk outputs in the same format.
+				clusterOpts = append(clusterOpts, spec.Arch(spec.AllExceptFIPS))
 				postValidation = registry.PostValidationNoDeadNodes
 				// dmsetup is currently only configured for gce.
 				clouds = registry.OnlyGCE

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -73,7 +73,7 @@ func registerFollowerReads(r registry.Registry) {
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Cloud() == spec.GCE && c.Spec().Arch == vm.ArchARM64 {
+				if c.Cloud() == spec.GCE && c.Architecture() == vm.ArchARM64 {
 					t.Skip("arm64 in GCE is available only in us-central1")
 				}
 				c.Start(ctx, t.L(), followerReadsVerboseRaftStartOpts(), install.MakeClusterSettings())

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -131,7 +130,7 @@ func registerKnex(r registry.Registry) {
 		Name:  "knex",
 		Owner: registry.OwnerSQLFoundations,
 		// Requires a pre-built node-oracledb binary for linux arm64.
-		Cluster:          r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.OnlyAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -73,7 +72,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/mixed-versions",
 		Owner:            registry.OwnerCDC,
-		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode(), spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode(), spec.GCEZones(teamcityAgentZone), spec.Arch(spec.OnlyAMD64)),
 		Timeout:          3 * time.Hour,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
@@ -86,7 +85,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/mixed-version/checkpointing",
 		Owner:            registry.OwnerCDC,
-		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode(), spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode(), spec.GCEZones(teamcityAgentZone), spec.Arch(spec.OnlyAMD64)),
 		Timeout:          3 * time.Hour,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 )
 
 var npgsqlReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -172,7 +171,7 @@ echo '%s' | git apply --ignore-whitespace -`, fmt.Sprintf(npgsqlPatch, result.St
 		Name:  "npgsql",
 		Owner: registry.OwnerSQLFoundations,
 		// .NET only supports AMD64 arch for 7.0.
-		Cluster:          r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.OnlyAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.Driver),

--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -304,6 +304,8 @@ func (v variations) makeClusterSpec() spec.ClusterSpec {
 	// Disable cluster reuse to avoid potential cgroup side effects.
 	if v.perturbationName() == "slowDisk" {
 		opts = append(opts, spec.ReuseNone())
+		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
+		opts = append(opts, spec.Arch(spec.AllExceptFIPS))
 	}
 	return spec.MakeClusterSpec(v.numNodes+v.numWorkloadNodes, opts...)
 }

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -226,7 +225,7 @@ func registerRebalanceLoad(r registry.Registry) {
 				// When using ssd > 1, only local SSDs on AMD64 arch are compatible
 				// currently. See #121951.
 				spec.SSD(2),
-				spec.Arch(vm.ArchAMD64),
+				spec.Arch(spec.OnlyAMD64),
 				spec.PreferLocalSSD(),
 			), // the last node is just used to generate load
 			CompatibleClouds: registry.OnlyGCE,

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/blobfixture"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
@@ -531,7 +530,7 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry) spec.ClusterSpec {
 			panic("cannot set stores per node and not use local SSD")
 		}
 		clusterOpts = append(clusterOpts, spec.SSD(hw.storesPerNode))
-		clusterOpts = append(clusterOpts, spec.Arch(vm.ArchAMD64))
+		clusterOpts = append(clusterOpts, spec.Arch(spec.OnlyAMD64))
 	}
 
 	if hw.mem != spec.Auto {


### PR DESCRIPTION
Previously, tests could only specify one valid architecture or enable all of them to be metamorphically chosen. This changes the cluster spec to allow multiple architectures to be specified.

This is now needed because we recently started running FIPS metamorphically on our nightlies. Some tests are not compatible with ARM or FIPS, and we want to only disable execution on those architectures.

Fixes: #153833
Fixes: #154110
Informs: #152781