### PR TITLE
sql/inspect: support checking multiple indexes in one INSPECT job

### DIFF
--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -257,13 +257,15 @@ func buildInspectCheckFactories(
 ) ([]inspectCheckFactory, error) {
 	checkFactories := make([]inspectCheckFactory, 0, len(spec.InspectDetails.Checks))
 	for _, specCheck := range spec.InspectDetails.Checks {
+		tableID := specCheck.TableID
+		indexID := specCheck.IndexID
 		switch specCheck.Type {
 		case jobspb.InspectCheckIndexConsistency:
 			checkFactories = append(checkFactories, func() inspectCheck {
 				return &indexConsistencyCheck{
 					flowCtx: flowCtx,
-					tableID: specCheck.TableID,
-					indexID: specCheck.IndexID,
+					tableID: tableID,
+					indexID: indexID,
 					asOf:    spec.InspectDetails.AsOf,
 				}
 			})


### PR DESCRIPTION
Previously, there was an assert that made sure when building the INSPECT job that we only had one check. This removes that assert so that we can have mulitple checks. When you run INSPECT against many indexes on a table or against a database, we will have multiple checks, so it was necessary for that case.

Closes #148300

Release note: none
Epic: none