### PR TITLE
security: skip flaky TestTLSCipherRestrict

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -123,6 +124,7 @@ func verifyX509Cert(cert *x509.Certificate, dnsName string, roots *x509.CertPool
 func TestTLSCipherRestrict(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 153802)
 
 	tests := []struct {
 		name      string


### PR DESCRIPTION
This commit skips flaky test TestTLSCipherRestrict for CI.

Informs: https://github.com/cockroachdb/cockroach/issues/153802
Release note: none