### PR TITLE
sql: deflake TestReadCommittedImplicitPartitionUpsert

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2017,7 +2017,7 @@ type ExecutorTestingKnobs struct {
 
 	// AfterArbiterRead, if set, will be called after each row read from an arbiter index
 	// for an UPSERT or INSERT.
-	AfterArbiterRead func()
+	AfterArbiterRead func(query string)
 
 	// BeforeIndexSplitAndScatter is invoked with the split and scatter of an index
 	// occurs.

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -326,7 +326,7 @@ func (n *insertNode) BatchedNext(params runParams) (bool, error) {
 		if buildutil.CrdbTestBuild {
 			// This testing knob allows us to suspend execution to force a race condition.
 			if fn := params.ExecCfg().TestingKnobs.AfterArbiterRead; fn != nil {
-				fn()
+				fn(params.p.stmt.SQL)
 			}
 		}
 

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -476,7 +476,7 @@ func (n *insertFastPathNode) BatchedNext(params runParams) (bool, error) {
 		if buildutil.CrdbTestBuild {
 			// This testing knob allows us to suspend execution to force a race condition.
 			if fn := params.ExecCfg().TestingKnobs.AfterArbiterRead; fn != nil {
-				fn()
+				fn(params.p.stmt.SQL)
 			}
 		}
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -207,7 +207,7 @@ func (r *upsertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	if buildutil.CrdbTestBuild {
 		// This testing knob allows us to suspend execution to force a race condition.
 		if fn := params.ExecCfg().TestingKnobs.AfterArbiterRead; fn != nil {
-			fn()
+			fn(params.p.stmt.SQL)
 		}
 	}
 


### PR DESCRIPTION
The test TestReadCommittedImplicitPartitionUpsert started flaking after we switched the implementation of TRUNCATE to the declarative schema changer. This happened because the testing knobs were incorrectly picking up internal queries. To address this, this patch modifies the testing knobs to include the SQL statement, so they can skip unrelated queries.

Fixes: #153644

Release note: None