### PR TITLE
changefeedccl: add progress skew metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1725,6 +1725,22 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+    - name: changefeed.progress_skew.span
+      exported_name: changefeed_progress_skew_span
+      description: The time difference between the fastest and slowest span's resolved timestamp
+      y_axis_label: Nanoseconds
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.progress_skew.table
+      exported_name: changefeed_progress_skew_table
+      description: The time difference between the fastest and slowest table's resolved timestamp
+      y_axis_label: Nanoseconds
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
     - name: changefeed.queue_time_nanos
       exported_name: changefeed_queue_time_nanos
       description: Time KV event spent waiting to be processed

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -354,6 +354,11 @@ func (f *resolvedSpanFrontier) HasLaggingSpans(sv *settings.Values) bool {
 	return frontier.Add(lagThresholdNanos, 0).Less(f.latestTS)
 }
 
+// LatestTS returns the latest timestamp in the frontier.
+func (f *resolvedSpanFrontier) LatestTS() hlc.Timestamp {
+	return f.latestTS
+}
+
 // All returns an iterator over the resolved spans in the frontier.
 func (f *resolvedSpanFrontier) All() iter.Seq[jobspb.ResolvedSpan] {
 	return func(yield func(jobspb.ResolvedSpan) bool) {


### PR DESCRIPTION
This patch adds two new changefeed metrics for tracking the max skew
between a changefeed's slowest and fastest span/table. The metrics are
gauge metrics with the names `changefeed.progress_skew.{span,table}`.

Fixes #153170

Release note (ops change): Two new changefeed metrics for tracking
the max skew between a changefeed's slowest and fastest span/table
have been added. The metrics are gauge metrics with the names
`changefeed.progress_skew.{span,table}`.

---

Some example graphs from running `cdc/frontier-persistence-benchmark/interval=5s/tables=10000/ranges=1`:

**Per-table tracking off**
<img width="2450" height="556" alt="image" src="https://github.com/user-attachments/assets/ac7b6a86-d154-4e15-b37f-b88398185341" />

**Per-table tracking on**
<img width="2438" height="564" alt="image" src="https://github.com/user-attachments/assets/cebd5f18-0fcd-43d4-849d-bf42b7256db8" />