### PR TITLE
release-24.3: crosscluster/physical: skip TestAlterTenantAddReader under deadlock

### DIFF
--- a/pkg/ccl/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/ccl/crosscluster/physical/alter_replication_job_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -115,6 +116,8 @@ func TestAlterTenantCompleteToLatest(t *testing.T) {
 func TestAlterTenantAddReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t, "flakes with deadlock detector")
 
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs


### PR DESCRIPTION
Backport 1/1 commits from #147548.

/cc @cockroachdb/release

---

Informs #146788

Epic: none
