### PR TITLE
security: disable DRPC for TestTLSCipherRestrict

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -94,7 +94,6 @@ go_test(
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -124,7 +123,6 @@ func verifyX509Cert(cert *x509.Certificate, dnsName string, roots *x509.CertPool
 func TestTLSCipherRestrict(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 153802)
 
 	tests := []struct {
 		name      string
@@ -164,7 +162,9 @@ func TestTLSCipherRestrict(t *testing.T) {
 			})()
 			ctx := context.Background()
 
-			s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+			s := serverutils.StartServerOnly(t, base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
+			})
 			defer s.Stopper().Stop(ctx)
 
 			// set the custom test ciphers


### PR DESCRIPTION
This test was failing continuously, and we skipped it to unblock others.
Since this occurs only for DRPC, we are disabling it only for that. We will
perform a root cause analysis and enable it back.

Fixes: #153802
Release note: none
Epic: none