### PR TITLE
sql/schemachanger: detect secondary and pk index name collisions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -694,3 +694,14 @@ tbl_with_collate  CREATE TABLE public.tbl_with_collate (
                   ) WITH (schema_locked = true);
 
 subtest end
+
+
+subtest index_name_conflicts_with_primary_key
+
+statement ok
+CREATE TABLE t_index_name_conflicts_with_primary_key (a INT PRIMARY KEY, b INT);
+
+statement error pgcode 42P07 index with name \"t_index_name_conflicts_with_primary_key_pkey\" already exists
+CREATE INDEX t_index_name_conflicts_with_primary_key_pkey ON t_index_name_conflicts_with_primary_key (a);
+
+subtest end


### PR DESCRIPTION
Previously, the declarative schema changer did not properly check if secondary index names and primary index names collided. This meant that instead of getting a query at statement time, one could be hit at runtime instead. To address this, this patch checks if either secondary or primary indexes with the same name exist when creating a new secondary index.

Fixes: #153702

Release note (bug fix): Addressed a runtime error that could be hit if a new secondary index had a name collision with a primary index.