### PR TITLE
changefeedccl: skip legacy schema changer in TestChangefeedSchemaChangeBackfillCheckpoint

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1323,7 +1323,7 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		usingLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
+		usingLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, rnd, sqlDB)
 		// NB: For the `ALTER TABLE foo ADD COLUMN ... DEFAULT` schema change,
 		// the expected boundary is different depending on if we are using the
 		// legacy schema changer or not.


### PR DESCRIPTION
This test fails regularly when the legacy schema changer is randomly chosen. This skips such configurations while the root cause is investigated. It also threads a random source into the maybeDisableDeclarativeSchemaChangesForTest.

Informs #151279
Release note: None