### PR TITLE
sidetransport: Prototype send threadpool

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/debug.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/debug.go
@@ -124,12 +124,13 @@ func (s *Sender) HTML() string {
 	header(fmt.Sprintf("Connections (%d)", len(s.connsMu.conns)))
 	nids := make([]roachpb.NodeID, 0, len(s.connsMu.conns))
 	for nid := range s.connsMu.conns {
-		nids = append(nids, nid)
+		nids = append(nids, nid.nodeID)
 	}
 	slices.Sort(nids)
 	now := timeutil.Now()
 	for _, nid := range nids {
-		state := s.connsMu.conns[nid].getState()
+		connKey := connKey{nodeID: nid, id: s.connsMu.conSeq[nid]}
+		state := s.connsMu.conns[connKey].getState()
 		fmt.Fprintf(sb, "n%d: ", nid)
 		if state.connected {
 			fmt.Fprintf(sb, "connected at: %s (%s ago)\n", state.connectedTime.Truncate(time.Millisecond), now.Sub(state.connectedTime).Truncate(time.Second))

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -37,6 +37,11 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+type connKey struct {
+	nodeID roachpb.NodeID
+	id     uint64
+}
+
 // Sender represents the sending-side of the closed timestamps "side-transport".
 // Its role is to periodically advance the closed timestamps of all the ranges
 // with leases on the current node and to communicate these closed timestamps to
@@ -88,8 +93,9 @@ type Sender struct {
 	// will continuously try to reconnect.
 	connsMu struct {
 		syncutil.Mutex
-		conns      map[roachpb.NodeID]conn
-		quarantine map[roachpb.NodeID]hlc.Timestamp
+		conSeq     map[roachpb.NodeID]uint64
+		conns      map[connKey]conn
+		quarantine map[connKey]hlc.Timestamp
 	}
 }
 
@@ -218,8 +224,9 @@ func newSenderWithConnFactory(
 	s.trackedMu.tracked = make(map[roachpb.RangeID]trackedRange)
 	s.trackedMu.lastClosed = make(map[ctpb.RangeClosedTimestampPolicy]hlc.Timestamp)
 	s.leaseholdersMu.leaseholders = make(map[roachpb.RangeID]leaseholder)
-	s.connsMu.conns = make(map[roachpb.NodeID]conn)
-	s.connsMu.quarantine = make(map[roachpb.NodeID]hlc.Timestamp)
+	s.connsMu.conSeq = make(map[roachpb.NodeID]uint64)
+	s.connsMu.conns = make(map[connKey]conn)
+	s.connsMu.quarantine = make(map[connKey]hlc.Timestamp)
 	return s
 }
 
@@ -250,8 +257,8 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 				defer workerWg.Done()
 
 				errSleepTime := sleepOnErr
-				conns := make(map[roachpb.NodeID]conn, 1000)
-				quarantine := make(map[roachpb.NodeID]hlc.Timestamp, 1000)
+				conns := make(map[connKey]conn, 1000)
+				quarantine := make(map[connKey]hlc.Timestamp, 1000)
 
 				for {
 					// wait until s.buf is signaled.
@@ -281,56 +288,62 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 						s.connsMu.Unlock()
 
 						// Process connections assigned to this worker using modulo distribution
-						for nodeID, c := range conns {
-							if int(nodeID)%nomWorkers != workerID {
+						for connKey, c := range conns {
+							if int(connKey.nodeID)%nomWorkers != workerID {
 								continue
 							}
 
 							// Check if nodeID is in quarantine without checking the time yet.
-							if quarantineUntil, ok := quarantine[nodeID]; ok {
+							if quarantineUntil, ok := quarantine[connKey]; ok {
 								if s.clock.Now().Less(quarantineUntil) {
 									continue
 								}
-								delete(quarantine, nodeID)
+								delete(quarantine, connKey)
 							}
 
 							// log.Dev.Infof(ctx, "side-transport sender worker %d processing connection to n%d", workerID, nodeID)
 
 							rpcConn := c.(*rpcConn)
 
-							if rpcConn.testingKnobs.sleepOnErrOverride > 0 {
-								errSleepTime = rpcConn.testingKnobs.sleepOnErrOverride
+							if rpcConn.mu.testingKnobs.sleepOnErrOverride > 0 {
+								errSleepTime = rpcConn.mu.testingKnobs.sleepOnErrOverride
 							}
 
 							for {
-								if atomic.LoadInt32(&rpcConn.closed) > 0 {
+								rpcConn.mu.Lock()
+								if atomic.LoadInt32(&rpcConn.mu.closed) > 0 {
 									// If the connection is closed, it will be removed from the map.
 									// We don't need to process it anymore.
+									rpcConn.mu.Unlock()
 									break
 								}
 
-								if err := rpcConn.maybeConnect(ctx, s.stopper); err != nil {
-									if !errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) && rpcConn.everyN.ShouldLog() {
+								if err := rpcConn.maybeConnectLocked(ctx, s.stopper); err != nil {
+									if !errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) && rpcConn.mu.everyN.ShouldLog() {
 										log.Dev.Infof(ctx, "side-transport failed to connect to n%d: %s", nodeID, err)
 									}
 
+									rpcConn.mu.Unlock()
+
 									s.connsMu.Lock()
-									s.connsMu.quarantine[nodeID] = s.clock.Now().AddDuration(errSleepTime)
+									s.connsMu.quarantine[connKey] = s.clock.Now().AddDuration(errSleepTime)
 									s.connsMu.Unlock()
 									break
 								}
 
-								msg, ok, future := rpcConn.producer.buf.MaybeGetBySeq(ctx, rpcConn.lastSent+1)
+								msg, ok, future := rpcConn.producer.buf.MaybeGetBySeq(ctx, rpcConn.mu.lastSent+1)
 								// log.Dev.Infof(ctx, "side-transport sender worker %d got message %+v from n%d", workerID, msg, rpcConn.nodeID)
 								// We can be signaled to stop in two ways: the buffer can be closed (in
 								// which case all connections must exit), or this connection was closed
 								// via close(). In either case, we quit.
 								if !ok {
+									rpcConn.mu.Unlock()
 									break
 								}
 
 								if future {
 									// No new messages to send.
+									rpcConn.mu.Unlock()
 									break
 								}
 
@@ -339,19 +352,21 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 									// need to generate a snapshot in order to re-initialize the stream.
 									// The snapshot will give us the sequence number to use for future
 									// incrementals.
+									rpcConn.mu.Unlock()
 									msg = rpcConn.producer.GetSnapshot()
+									rpcConn.mu.Lock()
 								}
 
-								rpcConn.lastSent = msg.SeqNum
+								rpcConn.mu.lastSent = msg.SeqNum
 
-								if fn := rpcConn.testingKnobs.beforeSend; fn != nil {
-									fn(rpcConn.nodeID, msg)
+								if fn := rpcConn.mu.testingKnobs.beforeSend; fn != nil {
+									fn(rpcConn.mu.nodeID, msg)
 								}
-								if err := rpcConn.stream.Send(msg); err != nil {
+								if err := rpcConn.mu.stream.Send(msg); err != nil {
 									// log.Dev.Infof(ctx, "side-transport failed to send message %+v to n%d: %s", msg, rpcConn.nodeID, err)
-									if err != io.EOF && rpcConn.everyN.ShouldLog() {
+									if err != io.EOF && rpcConn.mu.everyN.ShouldLog() {
 										log.Dev.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
-											rpcConn.lastSent, rpcConn.nodeID, err)
+											rpcConn.mu.lastSent, rpcConn.mu.nodeID, err)
 									}
 									// Keep track of the fact that we need a new connection.
 									//
@@ -360,13 +375,14 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 									// the circuit breaker if the remote node is still unreachable, we
 									// should have a blocking version of Dial() that we just leave hanging
 									// and get a notification when it succeeds.
-									rpcConn.cleanupStream(err)
+									rpcConn.cleanupStreamLocked(err)
+									rpcConn.mu.Unlock()
 									s.connsMu.Lock()
-									s.connsMu.quarantine[rpcConn.nodeID] = s.clock.Now().AddDuration(errSleepTime)
+									s.connsMu.quarantine[connKey] = s.clock.Now().AddDuration(errSleepTime)
 									s.connsMu.Unlock()
 									break
 								} else {
-									// log.Dev.Infof(ctx, "side-transport sent message %+v to n%d", msg, rpcConn.nodeID)
+									rpcConn.mu.Unlock()
 								}
 							}
 						}
@@ -408,7 +424,9 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 					// Then iterate over all the connections and close them.
 					s.connsMu.Lock()
 					for _, c := range s.connsMu.conns {
-						c.(*rpcConn).cleanupStream(nil /* err */)
+						if rpcConn, ok := c.(*rpcConn); ok {
+							rpcConn.cleanupStream(nil /* err */)
+						}
 					}
 					s.connsMu.Unlock()
 					return
@@ -603,11 +621,14 @@ func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	// node).
 	{
 		s.connsMu.Lock()
-		for nodeID, c := range s.connsMu.conns {
-			if !nodesWithFollowers.Contains(int(nodeID)) {
-				delete(s.connsMu.conns, nodeID)
+		for connKey, c := range s.connsMu.conns {
+			if !nodesWithFollowers.Contains(int(connKey.nodeID)) {
+				delete(s.connsMu.conns, connKey)
 				c.close()
-				c.(*rpcConn).cleanupStream(nil /* err */)
+				if rpcConn, ok := c.(*rpcConn); ok {
+					rpcConn.cleanupStream(nil /* err */)
+				}
+				s.connsMu.conSeq[connKey.nodeID]++
 			}
 		}
 
@@ -620,10 +641,11 @@ func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 			// At the same time we can have followers colocated on the same node in
 			// different stores (e.g. during store rebalancing) so we can create
 			// connection to ourselves if we find such replicas.
-			if _, ok := s.connsMu.conns[nodeID]; !ok {
+			connectionKey := connKey{nodeID: nodeID, id: s.connsMu.conSeq[nodeID]}
+			if _, ok := s.connsMu.conns[connectionKey]; !ok {
 				c := s.connFactory.new(s, nodeID)
 				// c.run(ctx, s.stopper)
-				s.connsMu.conns[nodeID] = c
+				s.connsMu.conns[connectionKey] = c
 			}
 		})
 		s.connsMu.Unlock()
@@ -798,7 +820,9 @@ func (b *updatesBuf) GetBySeq(ctx context.Context, seqNum ctpb.SeqNum) (*ctpb.Up
 	}
 }
 
-func (b *updatesBuf) MaybeGetBySeq(ctx context.Context, seqNum ctpb.SeqNum) (*ctpb.Update, bool, bool) {
+func (b *updatesBuf) MaybeGetBySeq(
+	ctx context.Context, seqNum ctpb.SeqNum,
+) (*ctpb.Update, bool, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -866,7 +890,7 @@ type connFactory interface {
 // conn is a side-transport connection to a node. A conn watches an updatesBuf
 // and streams all the messages to the respective node.
 type conn interface {
-	run(context.Context, *stop.Stopper)
+	// run(context.Context, *stop.Stopper)
 	close()
 	getState() connState
 }
@@ -900,22 +924,23 @@ const sleepOnErr = time.Second
 // (because this stream is disconnected for long enough), we'll have to send a
 // snapshot before we can resume sending regular messages.
 type rpcConn struct {
-	log.AmbientContext
-	dialer       rpcbase.NodeDialer
-	producer     *Sender
-	nodeID       roachpb.NodeID
-	testingKnobs connTestingKnobs
-
-	stream   ctpb.RPCSideTransport_PushUpdatesClient
-	lastSent ctpb.SeqNum
-	// cancelStreamCtx cleans up the resources (goroutine) associated with stream.
-	// It needs to be called whenever stream is discarded.
-	cancelStreamCtx context.CancelFunc
-	closed          int32 // atomic
-
-	everyN log.EveryN
+	producer *Sender
 
 	mu struct {
+		log.AmbientContext
+		dialer       rpcbase.NodeDialer
+		nodeID       roachpb.NodeID
+		testingKnobs connTestingKnobs
+
+		stream   ctpb.RPCSideTransport_PushUpdatesClient
+		lastSent ctpb.SeqNum
+		// cancelStreamCtx cleans up the resources (goroutine) associated with stream.
+		// It needs to be called whenever stream is discarded.
+		cancelStreamCtx context.CancelFunc
+		closed          int32 // atomic
+
+		everyN log.EveryN
+
 		syncutil.Mutex
 		state connState
 	}
@@ -925,14 +950,14 @@ func newRPCConn(
 	dialer rpcbase.NodeDialer, producer *Sender, nodeID roachpb.NodeID, testingKnobs connTestingKnobs,
 ) conn {
 	r := &rpcConn{
-		dialer:       dialer,
-		producer:     producer,
-		nodeID:       nodeID,
-		testingKnobs: testingKnobs,
-		everyN:       log.Every(10 * time.Second),
+		producer: producer,
 	}
+	r.mu.dialer = dialer
+	r.mu.nodeID = nodeID
+	r.mu.testingKnobs = testingKnobs
+	r.mu.everyN = log.Every(10 * time.Second)
 	r.mu.state.connected = false
-	r.AddLogTag("ctstream", nodeID)
+	r.mu.AddLogTag("ctstream", nodeID)
 	return r
 }
 
@@ -942,42 +967,52 @@ func newRPCConn(
 // err is the communication error that led to the stream being closed. Can be
 // nil if the stream was closed because we're shutting down.
 func (r *rpcConn) cleanupStream(err error) {
-	if r.stream == nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cleanupStreamLocked(err)
+}
+
+func (r *rpcConn) cleanupStreamLocked(err error) {
+	if r.mu.stream == nil {
 		return
 	}
-	_ /* err */ = r.stream.CloseSend()
-	r.stream = nil
-	r.cancelStreamCtx()
-	r.cancelStreamCtx = nil
+	_ /* err */ = r.mu.stream.CloseSend()
+	r.mu.stream = nil
+	r.mu.cancelStreamCtx()
+	r.mu.cancelStreamCtx = nil
 	// If we've been disconnected, reset the message sequence. If we ever
 	// reconnect, we'll ask the buffer for message 1, which was a snapshot.
 	// Generally, the buffer is not going to have that message any more and so
 	// we'll generate a new snapshot.
-	r.lastSent = 0
+	r.mu.lastSent = 0
 
-	r.mu.Lock()
 	r.mu.state.connected = false
 	r.mu.state.lastDisconnect = err
 	r.mu.state.lastDisconnectTime = timeutil.Now()
-	r.mu.Unlock()
 }
 
 // close makes the connection stop sending messages. The run() goroutine will
 // exit asynchronously. The parent Sender is expected to remove this connection
 // from its list.
 func (r *rpcConn) close() {
-	atomic.StoreInt32(&r.closed, 1)
+	atomic.StoreInt32(&r.mu.closed, 1)
 }
 
-func (r *rpcConn) maybeConnect(ctx context.Context, _ *stop.Stopper) error {
-	if r.stream != nil {
+func (r *rpcConn) maybeConnect(ctx context.Context, s *stop.Stopper) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.maybeConnectLocked(ctx, s)
+}
+
+func (r *rpcConn) maybeConnectLocked(ctx context.Context, _ *stop.Stopper) error {
+	if r.mu.stream != nil {
 		// Already connected.
 		return nil
 	}
 
-	log.Dev.Infof(ctx, "side-transport connecting to n%d", r.nodeID)
+	log.Dev.Infof(ctx, "side-transport connecting to n%d", r.mu.nodeID)
 
-	client, err := ctpb.DialSideTransportClient(r.dialer, ctx, r.nodeID, rpcbase.SystemClass, r.producer.st)
+	client, err := ctpb.DialSideTransportClient(r.mu.dialer, ctx, r.mu.nodeID, rpcbase.SystemClass, r.producer.st)
 	if err != nil {
 		return err
 	}
@@ -987,85 +1022,85 @@ func (r *rpcConn) maybeConnect(ctx context.Context, _ *stop.Stopper) error {
 		cancel()
 		return err
 	}
-	r.recordConnect()
-	r.stream = stream
+	r.recordConnectLocked()
+	r.mu.stream = stream
 	// This will need to be called when we're done with the stream.
-	r.cancelStreamCtx = cancel
+	r.mu.cancelStreamCtx = cancel
 	return nil
 }
 
 // run implements the conn interface.
-func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
-	_ /* err */ = stopper.RunAsyncTask(ctx, fmt.Sprintf("closedts publisher for n%d", r.nodeID),
-		func(ctx context.Context) {
-			// This WithCancelOnQuiesce serves to interrupt r.stream.Send() calls. The
-			// cancelation will be inherited by all the gRPC streams.
-			ctx, cancel := stopper.WithCancelOnQuiesce(r.AnnotateCtx(ctx))
-			defer cancel()
+// func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
+// 	_ /* err */ = stopper.RunAsyncTask(ctx, fmt.Sprintf("closedts publisher for n%d", r.nodeID),
+// 		func(ctx context.Context) {
+// 			// This WithCancelOnQuiesce serves to interrupt r.stream.Send() calls. The
+// 			// cancelation will be inherited by all the gRPC streams.
+// 			ctx, cancel := stopper.WithCancelOnQuiesce(r.AnnotateCtx(ctx))
+// 			defer cancel()
 
-			defer r.cleanupStream(nil /* err */)
-			everyN := log.Every(10 * time.Second)
+// 			defer r.cleanupStream(nil /* err */)
+// 			everyN := log.Every(10 * time.Second)
 
-			errSleepTime := sleepOnErr
-			if r.testingKnobs.sleepOnErrOverride > 0 {
-				errSleepTime = r.testingKnobs.sleepOnErrOverride
-			}
+// 			errSleepTime := sleepOnErr
+// 			if r.testingKnobs.sleepOnErrOverride > 0 {
+// 				errSleepTime = r.testingKnobs.sleepOnErrOverride
+// 			}
 
-			for {
-				if ctx.Err() != nil {
-					return
-				}
-				if atomic.LoadInt32(&r.closed) > 0 {
-					return
-				}
-				if err := r.maybeConnect(ctx, stopper); err != nil {
-					if !errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) && everyN.ShouldLog() {
-						log.KvDistribution.Infof(ctx, "side-transport failed to connect to n%d: %s", r.nodeID, err)
-					}
-					time.Sleep(errSleepTime)
-					continue
-				}
+// 			for {
+// 				if ctx.Err() != nil {
+// 					return
+// 				}
+// 				if atomic.LoadInt32(&r.closed) > 0 {
+// 					return
+// 				}
+// 				if err := r.maybeConnect(ctx, stopper); err != nil {
+// 					if !errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) && everyN.ShouldLog() {
+// 						log.Dev.Infof(ctx, "side-transport failed to connect to n%d: %s", r.nodeID, err)
+// 					}
+// 					time.Sleep(errSleepTime)
+// 					continue
+// 				}
 
-				var msg *ctpb.Update
-				var ok bool
-				msg, ok = r.producer.buf.GetBySeq(ctx, r.lastSent+1)
-				// We can be signaled to stop in two ways: the buffer can be closed (in
-				// which case all connections must exit), or this connection was closed
-				// via close(). In either case, we quit.
-				if !ok {
-					return
-				}
+// 				var msg *ctpb.Update
+// 				var ok bool
+// 				msg, ok = r.producer.buf.GetBySeq(ctx, r.lastSent+1)
+// 				// We can be signaled to stop in two ways: the buffer can be closed (in
+// 				// which case all connections must exit), or this connection was closed
+// 				// via close(). In either case, we quit.
+// 				if !ok {
+// 					return
+// 				}
 
-				if msg == nil {
-					// The sequence number we've requested is no longer in the buffer. We
-					// need to generate a snapshot in order to re-initialize the stream.
-					// The snapshot will give us the sequence number to use for future
-					// incrementals.
-					msg = r.producer.GetSnapshot()
-				}
-				r.lastSent = msg.SeqNum
+// 				if msg == nil {
+// 					// The sequence number we've requested is no longer in the buffer. We
+// 					// need to generate a snapshot in order to re-initialize the stream.
+// 					// The snapshot will give us the sequence number to use for future
+// 					// incrementals.
+// 					msg = r.producer.GetSnapshot()
+// 				}
+// 				r.lastSent = msg.SeqNum
 
-				if fn := r.testingKnobs.beforeSend; fn != nil {
-					fn(r.nodeID, msg)
-				}
-				if err := r.stream.Send(msg); err != nil {
-					if err != io.EOF && everyN.ShouldLog() {
-						log.KvDistribution.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
-							r.lastSent, r.nodeID, err)
-					}
-					// Keep track of the fact that we need a new connection.
-					//
-					// TODO(andrei): Instead of simply trying to establish a connection
-					// again when the next message needs to be sent and get rejected by
-					// the circuit breaker if the remote node is still unreachable, we
-					// should have a blocking version of Dial() that we just leave hanging
-					// and get a notification when it succeeds.
-					r.cleanupStream(err)
-					time.Sleep(errSleepTime)
-				}
-			}
-		})
-}
+// 				if fn := r.testingKnobs.beforeSend; fn != nil {
+// 					fn(r.nodeID, msg)
+// 				}
+// 				if err := r.stream.Send(msg); err != nil {
+// 					if err != io.EOF && everyN.ShouldLog() {
+// 						log.Dev.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
+// 							r.lastSent, r.nodeID, err)
+// 					}
+// 					// Keep track of the fact that we need a new connection.
+// 					//
+// 					// TODO(andrei): Instead of simply trying to establish a connection
+// 					// again when the next message needs to be sent and get rejected by
+// 					// the circuit breaker if the remote node is still unreachable, we
+// 					// should have a blocking version of Dial() that we just leave hanging
+// 					// and get a notification when it succeeds.
+// 					r.cleanupStream(err)
+// 					time.Sleep(errSleepTime)
+// 				}
+// 			}
+// 		})
+// }
 
 type connState struct {
 	connected          bool
@@ -1077,14 +1112,22 @@ type connState struct {
 func (r *rpcConn) getState() connState {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.getStateLocked()
+}
+
+func (r *rpcConn) getStateLocked() connState {
 	return r.mu.state
 }
 
 func (r *rpcConn) recordConnect() {
 	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recordConnectLocked()
+}
+
+func (r *rpcConn) recordConnectLocked() {
 	r.mu.state.connected = true
 	r.mu.state.connectedTime = timeutil.Now()
-	r.mu.Unlock()
 }
 
 func (s streamState) String() string {


### PR DESCRIPTION
This commit prototypes having just one goroutine responsible for sending closedTS for all nodes.

Future prototype commits will:

1) Extend this to be on multiple goroutines
2) Add LogEvery for each connection
3) Add the ability to quarantine connections