### PR TITLE
partitionccl: skip TestAlterPrimaryKeyCorrectZoneConfigBeforeBackfill under deadlock

### DIFF
--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "//pkg/sql/types",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/encoding",

--- a/pkg/ccl/partitionccl/alter_primary_key_test.go
+++ b/pkg/ccl/partitionccl/alter_primary_key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -16,6 +17,9 @@ import (
 func TestAlterPrimaryKeyCorrectZoneConfigBeforeBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t)
+	skip.UnderRace(t)
 
 	testCases := []testutilsccl.AlterPrimaryKeyCorrectZoneConfigTestCase{
 		{


### PR DESCRIPTION

fixes https://github.com/cockroachdb/cockroach/issues/154000
Release note: None