### PR TITLE
release-25.3: roachtest: verbose raft logging in follower reads tests

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -43,6 +43,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func followerReadsVerboseRaftStartOpts() option.StartOpts {
+	opts := option.DefaultStartOpts()
+	// This verbose logging can help us reason about failures that seem related
+	// to an unusually long failover process, such as #153245.
+	opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs,
+		"--vmodule=raft=2,support_manager=2,replica_range_lease=2,requester_state=3,supporter_state=3")
+	return opts
+}
+
 func registerFollowerReads(r registry.Registry) {
 	register := func(
 		survival survivalGoal, locality localitySetting, rc readConsistency, insufficientQuorum bool,
@@ -67,7 +76,7 @@ func registerFollowerReads(r registry.Registry) {
 				if c.Cloud() == spec.GCE && c.Spec().Arch == vm.ArchARM64 {
 					t.Skip("arm64 in GCE is available only in us-central1")
 				}
-				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+				c.Start(ctx, t.L(), followerReadsVerboseRaftStartOpts(), install.MakeClusterSettings())
 				topology := topologySpec{
 					multiRegion:       true,
 					locality:          locality,


### PR DESCRIPTION
Backport 1/1 commits from #153332 on behalf of @tbg.

----

In the linked failure below, the test fails due to what looks like a slow failover on a system range. Since I can only see that there was a >10s lag between proposing and applying a lease, naturally I'm curious what happened at the raft leadership and lease level. Hopefully this verbose logging will be helpful to diagnose future occurrences, should there be any (a lot changed on master and the failure is on an older branch).

Closes #153245.

Epic: none


----

Release justification: Testing only.