### PR TITLE
WORKSPACE: update pgo profile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -641,8 +641,8 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "57414977040f9ed887a4e2b0434ca97f0047229928d8456a25acb3e08b4a71f2",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250616172238-909ceb6ada01354d34416f1087fc256a066daa17.pb.gz",
+    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
+    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
 )
 
 # Download and register the FIPS enabled Go toolchain at the end to avoid toolchain conflicts for gazelle.


### PR DESCRIPTION
Benchstat results:
```
                                                 │ benchstat_old.txt │           benchstat.txt            │
                                                 │    queries/sec    │ queries/sec  vs base               │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64         25.86k ± 3%   27.15k ± 1%  +5.00% (p=0.000 n=20)

                                                 │ benchstat_old.txt │           benchstat.txt            │
                                                 │     txns/sec      │  txns/sec    vs base               │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64         1.293k ± 3%   1.358k ± 1%  +5.00% (p=0.000 n=20)

                                                 │ benchstat_old.txt │           benchstat.txt           │
                                                 │      ms/min       │   ms/min    vs base               │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          13.00 ± 4%   12.13 ± 5%  -6.69% (p=0.000 n=20)

                                                 │ benchstat_old.txt │           benchstat.txt           │
                                                 │      ms/avg       │   ms/avg    vs base               │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          49.50 ± 3%   47.14 ± 1%  -4.77% (p=0.000 n=20)

                                                 │ benchstat_old.txt │           benchstat.txt           │
                                                 │      ms/p95       │   ms/p95    vs base               │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          77.89 ± 3%   71.83 ± 2%  -7.79% (p=0.000 n=20)

                                                 │ benchstat_old.txt │         benchstat.txt         │
                                                 │      ms/max       │   ms/max     vs base          │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          251.4 ± 6%   216.9 ± 12%  ~ (p=0.086 n=20)

```

Fixes: REL-3226
Release note: None