### PR TITLE
util/ctxgroup: print recovered panic stacks during crash

### DIFF
--- a/pkg/util/ctxgroup/ctxgroup_test.go
+++ b/pkg/util/ctxgroup/ctxgroup_test.go
@@ -44,6 +44,13 @@ func funcThatPanics(x interface{}) {
 	panic(x)
 }
 
+func deferThatPanics() {
+	defer func() {
+		panic("in deferred panic")
+	}()
+	funcThatPanics("in func panic")
+}
+
 func TestPanic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -64,4 +71,52 @@ func TestPanic(t *testing.T) {
 			t.Fatal(g.Wait(), "unreachable if we hit expected panic in Wait")
 		}()
 	})
+}
+
+func TestPanicInDefer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected panic from Wait")
+		err := r.(error)
+		require.Contains(t, err.Error(), "in deferred panic", "expected deferred panic message")
+		require.Contains(t, err.Error(), "deferThatPanics", "expected deferThatPanics in stack")
+		require.Contains(t, err.Error(), "funcThatPanics", "expected deferThatPanics in stack")
+		t.Log("recovered: ", err.Error())
+	}()
+
+	g := WithContext(context.Background())
+	g.GoCtx(func(_ context.Context) error { deferThatPanics(); return errors.New("unseen") })
+	t.Fatal(g.Wait(), "unreachable if we hit expected panic in Wait")
+}
+
+func innerGroup() error {
+	g := WithContext(context.Background())
+	g.GoCtx(func(_ context.Context) error { funcThatPanics("inner"); return nil })
+	return g.Wait()
+}
+
+func outerGroup() error {
+	g := WithContext(context.Background())
+	g.GoCtx(func(_ context.Context) error { return innerGroup() })
+	return g.Wait()
+}
+
+func TestNestedContextGroup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "expected panic from Wait")
+		err := r.(error)
+		require.Contains(t, err.Error(), "inner", "expected inner panic message")
+		require.Contains(t, err.Error(), "innerGroup", "expected innerGroup in stack")
+		require.Contains(t, err.Error(), "outerGroup", "expected outerGroup in stack")
+		t.Log("recovered: ", err.Error())
+	}()
+
+	g := WithContext(context.Background())
+	g.GoCtx(func(_ context.Context) error { return outerGroup() })
+	t.Fatal(g.Wait(), "unreachable if we hit expected panic in Wait")
 }


### PR DESCRIPTION
When ctxgroup recovers a panic in a worker to be rethrown in Wait(), it uses errors.WithStack to try to capture the stack to the original panic, and subsequent recover, in the error that is stored to be rethrown on the Wait goroutine. And indeed, WithStack captures it... but only to have it ignored and not printed by the runtime crash handler, which just invokes Error(), if/when the rethrown panic bubbles up if unrecovered.

This makes such panics _very_ hard to debug: all information about where they were actually raised is gone, making this rethrow-on-Wait actually much worse than just not recovering at all.

This changes the capture-and-rethrow to wrap the captured error in a thin wrapper that overrides .Error() to incldue the stack, so that it is printed by the runtime crash handler if a rethrown panic makes it there.

Release note: none.
Epic: none.
Informs: #153347