### PR TITLE
workflows: run `update_releases` on `release-25.4`

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -32,6 +32,7 @@ jobs:
           - "release-24.3"
           - "release-25.2"
           - "release-25.3"
+          - "release-25.4"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Epic: None
Release note: None