### PR TITLE
batcheval: pass in split trigger information as a struct

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -2203,9 +2203,16 @@ func TestSplitTriggerWritesInitialReplicaState(t *testing.T) {
 	err = sl.SetVersion(ctx, batch, nil, &version)
 	require.NoError(t, err)
 
+	in := splitTriggerHelperInput{
+		leftLease:      lease,
+		gcThreshold:    &gcThreshold,
+		gcHint:         &gcHint,
+		replicaVersion: version,
+	}
+
 	// Run the split trigger, which is normally run as a subset of EndTxn request
 	// evaluation.
-	_, _, err = splitTrigger(ctx, rec, batch, enginepb.MVCCStats{}, split, hlc.Timestamp{})
+	_, _, err = splitTrigger(ctx, rec, batch, enginepb.MVCCStats{}, split, in, hlc.Timestamp{})
 	require.NoError(t, err)
 
 	// Verify that range state was migrated to the right-hand side properly.


### PR DESCRIPTION
Instead of creating a stateloader and reading information about the LHS's lease, gcThrehsold etc. in the splitTriggerHelper, this patch lifts that two levels up. In reference to @pav-kv's comment on #149714.

Epic: none

Release note: None