### PR TITLE
release-25.4: kvnemesis: expect nil bytes in CPuts

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -349,11 +349,14 @@ func applyClientOp(
 		o.Result.OptionalTimestamp = ts
 	case *CPutOperation:
 		_, ts, err := dbRunWithResultAndTimestamp(ctx, db, func(b *kv.Batch) {
-			expVal := roachpb.MakeValueFromBytes(o.ExpVal)
+			var expBytes []byte
+			if o.ExpVal != nil {
+				expBytes = roachpb.MakeValueFromBytes(o.ExpVal).TagAndDataBytes()
+			}
 			if o.AllowIfDoesNotExist {
-				b.CPutAllowingIfNotExists(o.Key, o.Value(), expVal.TagAndDataBytes())
+				b.CPutAllowingIfNotExists(o.Key, o.Value(), expBytes)
 			} else {
-				b.CPut(o.Key, o.Value(), expVal.TagAndDataBytes())
+				b.CPut(o.Key, o.Value(), expBytes)
 			}
 			setLastReqSeq(b, o.Seq)
 		})


### PR DESCRIPTION
Backport 1/1 commits from #154021 on behalf of @stevendanna.

----

A CPut that expects a non-existent key needs to set a nil expected bytes. MakeValueFromBytes will return a non-nil byte slice (containing the BYTES type tag) if given a nil byte slice.

Epic: none
Release note: None

----

Release justification: Test-only change