### PR TITLE
tree: generate a random tuple type in TestStringConcat

### DIFF
--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -75,10 +75,13 @@ func TestStringConcat(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	rng, _ := randutil.NewTestRand()
+
+	tuple := randgen.RandTupleFromSlice(rng, types.Scalar)
+
 	ctx := context.Background()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	for _, typ := range append([]*types.T{types.AnyTuple}, types.Scalar...) {
+	for _, typ := range append([]*types.T{tuple}, types.Scalar...) {
 		// Strings and Bytes are handled specially.
 		if typ.Identical(types.String) || typ.Identical(types.Bytes) {
 			continue


### PR DESCRIPTION
Previously, TestStringConcat was using the AnyTuple type to generate a randum datum. `AnyTuple` is not a real type that can be assigned to a value. Rather its a sentinel type used to represent any type that is a tuple.

This worked before  PR #153789, because randgen would pick random datums and then generate a new tuple type that matches the datums. But that behavior was broken for `NULL` values and did not match the behavior of the value decoder.

Release note: none
Fixes: #153789