### PR TITLE
release-25.1: sql: enforce schema_locked for TRUNCATE

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -747,15 +747,16 @@ func TestLogicalReplicationWithPhantomDelete(t *testing.T) {
 	skip.UnderDeadlock(t)
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
-	tc, s, serverASQL, serverBSQL := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
-	defer tc.Stopper().Stop(ctx)
-
-	serverAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
-
 	for _, mode := range []string{"validated", "immediate"} {
 		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			tc, s, serverASQL, serverBSQL := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
+			defer tc.Stopper().Stop(ctx)
+
+			serverAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+			serverASQL.Exec(t, "ALTER TABLE tab SET (schema_locked = false)")
+			serverBSQL.Exec(t, "ALTER TABLE tab SET (schema_locked = false)")
+
 			serverASQL.Exec(t, "TRUNCATE tab")
 			serverBSQL.Exec(t, "TRUNCATE tab")
 			var jobBID jobspb.JobID

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -257,3 +257,13 @@ SELECT distinct(index_name), comment FROM [SHOW INDEXES FROM t WITH COMMENT]
 ----
 t_pkey  NULL
 i       hello2
+
+subtest truncate_with_schema_locked
+
+statement ok
+CREATE TABLE t_schema_locked(x int) WITH (schema_locked=true)
+
+statement error pgcode 57000  schema changes are disallowed on table \"t_schema_locked\" because it is locked
+TRUNCATE TABLE t_schema_locked
+
+subtest end

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -117,7 +117,7 @@ func (t *truncateNode) startExec(params runParams) error {
 	}
 
 	for id, name := range toTruncate {
-		if err := p.truncateTable(ctx, id, tree.AsStringWithFQNames(t.n, params.Ann())); err != nil {
+		if err := p.truncateTable(ctx, id, tree.AsStringWithFQNames(t.n, params.Ann()), t.n); err != nil {
 			return err
 		}
 
@@ -158,11 +158,18 @@ var PreservedSplitCountMultiple = settings.RegisterIntSetting(
 // so by dropping all existing indexes on the table and creating new ones without
 // backfilling any data into the new indexes. The old indexes are cleaned up
 // asynchronously by the SchemaChangeGCJob.
-func (p *planner) truncateTable(ctx context.Context, id descpb.ID, jobDesc string) error {
+func (p *planner) truncateTable(
+	ctx context.Context, id descpb.ID, jobDesc string, truncate *tree.Truncate,
+) error {
 	// Read the table descriptor because it might have changed
 	// while another table in the truncation list was truncated.
 	tableDesc, err := p.Descriptors().MutableByID(p.txn).Table(ctx, id)
 	if err != nil {
+		return err
+	}
+
+	// Check if this operation is blocked due to schema_locked.
+	if err := checkSchemaChangeIsAllowed(tableDesc, truncate); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #154048.

/cc @cockroachdb/release

---

Previously, we were completely ignoring schema_locked for the TRUNCATE command, which could changefeeds to break. To address this, this patch blocks TRUNCATE on schema_locked tables.

Fixes: #151941

Release note (bug fix): schema_locked was not enforced on the TRUNCATE command, which could cause changefeed jobs to fail.
Release justification: low risk fix for an issue that can break change feed if tables truncated
