### PR TITLE
release-25.4: build: update release branch for Pebble scripts

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -39,10 +39,10 @@ cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
 # Pull in the version of Pebble from upstream. If none is specified, the
-# benchmarks run against the tip of the 'master' branch. We do this by `go
+# benchmarks run against the tip of the 'crl-release-25.4' branch. We do this by `go
 # get`ting the SHA of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-pebble_go_get_version="${PEBBLE_SHA:-master}"
+pebble_go_get_version="${PEBBLE_SHA:-crl-release-25.4}"
 echo "Benchmarking against: ${pebble_go_get_version}"
 
 bazel run @go_sdk//:bin/go get "github.com/cockroachdb/pebble@${pebble_go_get_version}"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -19,10 +19,10 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 mkdir -p artifacts
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-25.4' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-25.4
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
@@ -19,10 +19,10 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 mkdir -p artifacts
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-25.4' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-25.4
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
@@ -19,10 +19,10 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 mkdir -p artifacts
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-25.4' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-25.4
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -39,10 +39,10 @@ cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
 # Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# against the tip of the 'crl-release-25.4' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-25.4
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race -c opt


### PR DESCRIPTION
Informs: #149116

Epic: none
Release note: None

---

Release justification: dev infra change only