### PR TITLE
ui: bump cluster-ui package.json to 25.4.0

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.4.0-prerelease.0",
+  "version": "25.4.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Epic: None
Release note: None
Release justification: Now that we have an official 25.4 release branch, the cluster-ui npm package is no longer a "pre-release" version and should be bumped to 25.4.0