### PR TITLE
ui: bump cluster-ui package.json to 26.1.0-prerelease-.0

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.4.0-prerelease.0",
+  "version": "26.1.0-prerelease.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Now that the release branch has been cut for 25.4, the cluster-ui package.json version can be bumped to 26.1.0-prerelease.0

Epic: None
Release note: None