### PR TITLE
release-25.4: sql/importer: updates under single table assumption

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -690,9 +690,10 @@ message ImportDetails {
   message Type {
     sqlbase.TypeDescriptor desc = 1;
   }
-  // TODO(yuzefovich): we now can only support importing into a single table via
-  // a single IMPORT job, so we could change this field.
-  repeated Table tables = 1 [(gogoproto.nullable) = false];
+  Table table = 28 [(gogoproto.nullable) = false];
+  // TODO(yuzefovich): remove Tables field once compatibility with 25.3 is no
+  // longer needed.
+  repeated Table tables = 1 [(gogoproto.nullable) = false, deprecated = true];
   repeated Type types = 26 [(gogoproto.nullable) = false];
 
   repeated string uris = 2 [(gogoproto.customname) = "URIs"];
@@ -716,7 +717,7 @@ message ImportDetails {
 
   reserved 4, 7, 8, 9, 10, 11, 14, 22, 23, 24, 25;
 
-  // next val: 28
+  // next val: 29
 }
 
 // SequenceValChunks represents a single chunk of sequence values allocated

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -707,7 +707,7 @@ message ImportDetails {
   ];
 
   bool prepare_complete = 12;
-  bool tables_published = 13;
+  bool table_published = 13;
 
   // If the database being imported into is a multi-region database, then this
   // field stores the databases' primary region.

--- a/pkg/server/application_api/jobs_test.go
+++ b/pkg/server/application_api/jobs_test.go
@@ -407,16 +407,9 @@ func TestJobStatusResponse(t *testing.T) {
 			Statements:  []string{"SELECT 1"},
 			Username:    username.RootUserName(),
 			Details: jobspb.ImportDetails{
-				Tables: []jobspb.ImportDetails_Table{
-					{
-						Desc: &descpb.TableDescriptor{
-							ID: 1,
-						},
-					},
-					{
-						Desc: &descpb.TableDescriptor{
-							ID: 2,
-						},
+				Table: jobspb.ImportDetails_Table{
+					Desc: &descpb.TableDescriptor{
+						ID: 1,
 					},
 				},
 				URIs: []string{"a", "b"},

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -120,6 +120,9 @@ message ReadImportDataSpec {
     repeated string targetCols = 2 [(gogoproto.nullable) = true];
   }
 
+  optional ImportTable table = 20;
+  // TODO(yuzefovich): remove Tables field once compatibility with 25.3 is no
+  // longer needed.
   // tables supports input formats that can read multiple tables. If it is
   // non-empty, the keys specify the names of tables for which the processor
   // should read and emit data (ignoring data for any other tables that is
@@ -131,7 +134,7 @@ message ReadImportDataSpec {
   // TableDescriptor with the corresponding descriptor ID key. If tables is
   // empty (and table_desc above is not specified), the processor should read
   // all tables in the input, determining their schemas on the fly.
-  map<string, ImportTable> tables = 9 [(gogoproto.nullable) = true];
+  map<string, ImportTable> tables = 9 [(gogoproto.nullable) = true, deprecated = true];
 
   // uri is a cloud.ExternalStorage URI pointing to the CSV files to be
   // read. The map key must be unique across the entire IMPORT job.
@@ -172,7 +175,7 @@ message ReadImportDataSpec {
 
   optional int32 initial_splits = 18 [(gogoproto.nullable) = false];
 
-  // NEXTID: 20.
+  // NEXTID: 21.
 }
 
 message IngestStoppedSpec {

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -349,53 +349,24 @@ func (r *importResumer) prepareTablesForIngestion(
 	importDetails := details
 	importDetails.Tables = make([]jobspb.ImportDetails_Table, len(details.Tables))
 
-	var err error
-	var desc *descpb.TableDescriptor
-
-	useImportEpochs := importEpochs.Get(&p.ExecCfg().Settings.SV)
-	for i, table := range details.Tables {
-		desc, err = prepareExistingTablesForIngestion(ctx, txn, descsCol, table.Desc, useImportEpochs)
-		if err != nil {
-			return importDetails, err
-		}
-		importDetails.Tables[i] = jobspb.ImportDetails_Table{
-			Desc:       desc,
-			Name:       table.Name,
-			SeqVal:     table.SeqVal,
-			TargetCols: table.TargetCols,
-		}
+	if len(details.Tables) != 1 {
+		return jobspb.ImportDetails{}, errors.AssertionFailedf("expected exactly one table, got %d", len(details.Tables))
 	}
-
-	importDetails.PrepareComplete = true
-
-	// We have to wait for all nodes to see the same descriptor version before
-	// choosing our Walltime.
-	importDetails.Walltime = 0
-	return importDetails, nil
-}
-
-// prepareExistingTablesForIngestion prepares descriptors for existing tables
-// being imported into.
-func prepareExistingTablesForIngestion(
-	ctx context.Context,
-	txn *kv.Txn,
-	descsCol *descs.Collection,
-	desc *descpb.TableDescriptor,
-	useImportEpochs bool,
-) (*descpb.TableDescriptor, error) {
+	table := details.Tables[0]
+	desc := table.Desc
 	if len(desc.Mutations) > 0 {
-		return nil, errors.Errorf("cannot IMPORT INTO a table with schema changes in progress -- try again later (pending mutation %s)", desc.Mutations[0].String())
+		return jobspb.ImportDetails{}, errors.Errorf("cannot IMPORT INTO a table with schema changes in progress -- try again later (pending mutation %s)", desc.Mutations[0].String())
 	}
 
 	// Note that desc is just used to verify that the version matches.
 	importing, err := descsCol.MutableByID(txn).Table(ctx, desc.ID)
 	if err != nil {
-		return nil, err
+		return jobspb.ImportDetails{}, err
 	}
 	// Ensure that the version of the table has not been modified since this
 	// job was created.
 	if got, exp := importing.Version, desc.Version; got != exp {
-		return nil, errors.Errorf("another operation is currently operating on the table")
+		return jobspb.ImportDetails{}, errors.Errorf("another operation is currently operating on the table")
 	}
 
 	// Take the table offline for import.
@@ -404,7 +375,7 @@ func prepareExistingTablesForIngestion(
 
 	// We only use the new OfflineForImport on 24.1, which bumps
 	// the ImportEpoch, if we are completely on 24.1.
-	if useImportEpochs {
+	if importEpochs.Get(&p.ExecCfg().Settings.SV) {
 		importing.OfflineForImport()
 	} else {
 		importing.SetOffline(tabledesc.OfflineReasonImporting)
@@ -414,10 +385,22 @@ func prepareExistingTablesForIngestion(
 	if err := descsCol.WriteDesc(
 		ctx, false /* kvTrace */, importing, txn,
 	); err != nil {
-		return nil, err
+		return jobspb.ImportDetails{}, err
 	}
 
-	return importing.TableDesc(), nil
+	importDetails.Tables[0] = jobspb.ImportDetails_Table{
+		Desc:       importing.TableDesc(),
+		Name:       table.Name,
+		SeqVal:     table.SeqVal,
+		TargetCols: table.TargetCols,
+	}
+
+	importDetails.PrepareComplete = true
+
+	// We have to wait for all nodes to see the same descriptor version before
+	// choosing our Walltime.
+	importDetails.Walltime = 0
+	return importDetails, nil
 }
 
 // bindTableDescImportProperties updates the table descriptor at the start of an

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -118,6 +118,16 @@ var importRowCountValidation = settings.RegisterBoolSetting(
 	settings.WithUnsafe,
 )
 
+func getTable(details jobspb.ImportDetails) (jobspb.ImportDetails_Table, error) {
+	if len(details.Tables) > 0 {
+		if len(details.Tables) != 1 {
+			return jobspb.ImportDetails_Table{}, errors.AssertionFailedf("expected exactly one table, got %d", len(details.Tables))
+		}
+		return details.Tables[0], nil
+	}
+	return details.Table, nil
+}
+
 // Resume is part of the jobs.Resumer interface.
 func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	p := execCtx.(sql.JobExecContext)
@@ -126,78 +136,65 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	files := details.URIs
 	format := details.Format
 
-	tables := make(map[string]*execinfrapb.ReadImportDataSpec_ImportTable, len(details.Tables))
-	if details.Tables != nil {
-		// Skip prepare stage on job resumption, if it has already been completed.
-		if !details.PrepareComplete {
-			if err := sql.DescsTxn(ctx, p.ExecCfg(), func(
-				ctx context.Context, txn isql.Txn, descsCol *descs.Collection,
-			) error {
-				var preparedDetails jobspb.ImportDetails
-				var err error
-				curDetails := details
-
-				preparedDetails, err = r.prepareTablesForIngestion(ctx, p, curDetails, txn.KV(), descsCol)
-				if err != nil {
-					return err
-				}
-
-				// Telemetry for multi-region.
-				for _, table := range preparedDetails.Tables {
-					dbDesc, err := descsCol.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, table.Desc.GetParentID())
-					if err != nil {
-						return err
-					}
-					if dbDesc.IsMultiRegion() {
-						telemetry.Inc(sqltelemetry.ImportIntoMultiRegionDatabaseCounter)
-					}
-				}
-
-				// Update the job details now that the schemas and table descs have
-				// been "prepared".
-				return r.job.WithTxn(txn).Update(ctx, func(
-					txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
-				) error {
-					pl := md.Payload
-					*pl.GetImport() = preparedDetails
-
-					// Update the set of descriptors for later observability.
-					// TODO(ajwerner): Do we need this idempotence test?
-					prev := md.Payload.DescriptorIDs
-					if prev == nil {
-						var descriptorIDs []descpb.ID
-						for _, table := range preparedDetails.Tables {
-							descriptorIDs = append(descriptorIDs, table.Desc.GetID())
-						}
-						pl.DescriptorIDs = descriptorIDs
-					}
-					ju.UpdatePayload(pl)
-					return nil
-				})
-			}); err != nil {
+	// Skip prepare stage on job resumption, if it has already been completed.
+	if !details.PrepareComplete {
+		if err := sql.DescsTxn(ctx, p.ExecCfg(), func(
+			ctx context.Context, txn isql.Txn, descsCol *descs.Collection,
+		) error {
+			preparedDetails, err := r.prepareTablesForIngestion(ctx, p, details, txn.KV(), descsCol)
+			if err != nil {
 				return err
 			}
 
-			// Re-initialize details after prepare step.
-			details = r.job.Details().(jobspb.ImportDetails)
-			emitImportJobEvent(ctx, p, jobs.StateRunning, r.job)
-		}
-
-		for _, i := range details.Tables {
-			var tableName string
-			if i.Name != "" {
-				tableName = i.Name
-			} else if i.Desc != nil {
-				tableName = i.Desc.Name
-			} else {
-				return errors.New("invalid table specification")
+			// Telemetry for multi-region.
+			table, err := getTable(details)
+			if err != nil {
+				return err
+			}
+			dbDesc, err := descsCol.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, table.Desc.GetParentID())
+			if err != nil {
+				return err
+			}
+			if dbDesc.IsMultiRegion() {
+				telemetry.Inc(sqltelemetry.ImportIntoMultiRegionDatabaseCounter)
 			}
 
-			tables[tableName] = &execinfrapb.ReadImportDataSpec_ImportTable{
-				Desc:       i.Desc,
-				TargetCols: i.TargetCols,
-			}
+			// Update the job details now that the schemas and table descs have
+			// been "prepared".
+			return r.job.WithTxn(txn).Update(ctx, func(
+				txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+			) error {
+				pl := md.Payload
+				*pl.GetImport() = preparedDetails
+
+				// Update the set of descriptors for later observability.
+				// TODO(ajwerner): Do we need this idempotence test?
+				prev := md.Payload.DescriptorIDs
+				if prev == nil {
+					pl.DescriptorIDs = []descpb.ID{table.Desc.GetID()}
+				}
+				ju.UpdatePayload(pl)
+				return nil
+			})
+		}); err != nil {
+			return err
 		}
+
+		// Re-initialize details after prepare step.
+		details = r.job.Details().(jobspb.ImportDetails)
+		emitImportJobEvent(ctx, p, jobs.StateRunning, r.job)
+	}
+
+	// Note that this getTable call has to be separate from the one we did for
+	// multi-region telemetry above since we've just updated the details after
+	// the prepare step.
+	table, err := getTable(details)
+	if err != nil {
+		return err
+	}
+	importTable := &execinfrapb.ReadImportDataSpec_ImportTable{
+		Desc:       table.Desc,
+		TargetCols: table.TargetCols,
 	}
 
 	typeDescs := make([]*descpb.TypeDescriptor, len(details.Types))
@@ -221,21 +218,21 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		// we can cheaply clear-range instead of revert-range to cleanup (or if the
 		// cluster has finalized to 22.1, use DeleteRange without predicate
 		// filtering).
-		for i := range details.Tables {
-			tblDesc := tabledesc.NewBuilder(details.Tables[i].Desc).BuildImmutableTable()
-			tblSpan := tblDesc.TableSpan(p.ExecCfg().Codec)
-			res, err := p.ExecCfg().DB.Scan(ctx, tblSpan.Key, tblSpan.EndKey, 1 /* maxRows */)
-			if err != nil {
-				return errors.Wrap(err, "checking if existing table is empty")
-			}
-			details.Tables[i].WasEmpty = len(res) == 0
+		tblDesc := tabledesc.NewBuilder(table.Desc).BuildImmutableTable()
+		tblSpan := tblDesc.TableSpan(p.ExecCfg().Codec)
+		res, err := p.ExecCfg().DB.Scan(ctx, tblSpan.Key, tblSpan.EndKey, 1 /* maxRows */)
+		if err != nil {
+			return errors.Wrap(err, "checking if existing table is empty")
+		}
+		details.Table.WasEmpty = len(res) == 0
+		details.Tables[0].WasEmpty = len(res) == 0
 
-			// Update the descriptor in the job record and in the database
-			details.Tables[i].Desc.ImportStartWallTime = details.Walltime
+		// Update the descriptor in the job record and in the database
+		details.Table.Desc.ImportStartWallTime = details.Walltime
+		details.Tables[0].Desc.ImportStartWallTime = details.Walltime
 
-			if err := bindTableDescImportProperties(ctx, p, tblDesc.GetID(), details.Walltime); err != nil {
-				return err
-			}
+		if err := bindTableDescImportProperties(ctx, p, tblDesc.GetID(), details.Walltime); err != nil {
+			return err
 		}
 
 		if err := r.job.NoTxn().SetDetails(ctx, details); err != nil {
@@ -247,20 +244,17 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	initialSplitsPerProc := int(initialSplitsPerProcessor.Get(&p.ExecCfg().Settings.SV))
 
 	res, err := ingestWithRetry(
-		ctx, p, r.job, tables, typeDescs, files, format, details.Walltime,
+		ctx, p, r.job, importTable, typeDescs, files, format, details.Walltime,
 		r.testingKnobs, procsPerNode, initialSplitsPerProc,
 	)
 	if err != nil {
 		return err
 	}
 
-	pkIDs := make(map[uint64]struct{}, len(details.Tables))
-	for _, t := range details.Tables {
-		pkIDs[kvpb.BulkOpSummaryID(uint64(t.Desc.ID), uint64(t.Desc.PrimaryIndex.ID))] = struct{}{}
-	}
+	pkID := kvpb.BulkOpSummaryID(uint64(table.Desc.ID), uint64(table.Desc.PrimaryIndex.ID))
 	r.res.DataSize = res.DataSize
 	for id, count := range res.EntryCounts {
-		if _, ok := pkIDs[id]; ok {
+		if id == pkID {
 			r.res.Rows += count
 		} else {
 			r.res.IndexEntries += count
@@ -296,7 +290,11 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	}
 
 	if importRowCountValidation.Get(&p.ExecCfg().Settings.SV) {
-		tblDesc := tabledesc.NewBuilder(details.Tables[0].Desc).BuildImmutableTable()
+		table, err := getTable(details)
+		if err != nil {
+			return err
+		}
+		tblDesc := tabledesc.NewBuilder(table.Desc).BuildImmutableTable()
 		if len(tblDesc.PublicNonPrimaryIndexes()) > 0 {
 			_, err := sql.TriggerInspectJob(
 				ctx,
@@ -347,12 +345,11 @@ func (r *importResumer) prepareTablesForIngestion(
 	descsCol *descs.Collection,
 ) (jobspb.ImportDetails, error) {
 	importDetails := details
-	importDetails.Tables = make([]jobspb.ImportDetails_Table, len(details.Tables))
-
-	if len(details.Tables) != 1 {
-		return jobspb.ImportDetails{}, errors.AssertionFailedf("expected exactly one table, got %d", len(details.Tables))
+	table, err := getTable(details)
+	if err != nil {
+		return jobspb.ImportDetails{}, err
 	}
-	table := details.Tables[0]
+
 	desc := table.Desc
 	if len(desc.Mutations) > 0 {
 		return jobspb.ImportDetails{}, errors.Errorf("cannot IMPORT INTO a table with schema changes in progress -- try again later (pending mutation %s)", desc.Mutations[0].String())
@@ -388,12 +385,13 @@ func (r *importResumer) prepareTablesForIngestion(
 		return jobspb.ImportDetails{}, err
 	}
 
-	importDetails.Tables[0] = jobspb.ImportDetails_Table{
+	importDetails.Table = jobspb.ImportDetails_Table{
 		Desc:       importing.TableDesc(),
 		Name:       table.Name,
 		SeqVal:     table.SeqVal,
 		TargetCols: table.TargetCols,
 	}
+	importDetails.Tables = []jobspb.ImportDetails_Table{importDetails.Table}
 
 	importDetails.PrepareComplete = true
 
@@ -440,66 +438,67 @@ func (r *importResumer) publishTables(
 	if details.TablesPublished {
 		return setPublicTimestamp, nil
 	}
+	tbl, err := getTable(details)
+	if err != nil {
+		return setPublicTimestamp, err
+	}
 
 	log.Event(ctx, "making tables live")
 
 	var kvTxn *kv.Txn
-	err := sql.DescsTxn(ctx, execCfg, func(
+	if err := sql.DescsTxn(ctx, execCfg, func(
 		ctx context.Context, txn isql.Txn, descsCol *descs.Collection,
 	) error {
 		kvTxn = txn.KV()
 		b := kvTxn.NewBatch()
-		for _, tbl := range details.Tables {
-			newTableDesc, err := descsCol.MutableByID(kvTxn).Table(ctx, tbl.Desc.ID)
-			if err != nil {
-				return err
-			}
-			newTableDesc.SetPublic()
+		newTableDesc, err := descsCol.MutableByID(kvTxn).Table(ctx, tbl.Desc.ID)
+		if err != nil {
+			return err
+		}
+		newTableDesc.SetPublic()
 
-			// NB: This is not using AllNonDropIndexes or directly mutating the
-			// constraints returned by the other usual helpers because we need to
-			// replace the `OutboundFKs` and `Checks` slices of newTableDesc with copies
-			// that we can mutate. We need to do that because newTableDesc is a shallow
-			// copy of tbl.Desc that we'll be asserting is the current version when we
-			// CPut below.
-			//
-			// Set FK constraints to unvalidated before publishing the table imported
-			// into.
-			newTableDesc.OutboundFKs = make([]descpb.ForeignKeyConstraint, len(newTableDesc.OutboundFKs))
-			copy(newTableDesc.OutboundFKs, tbl.Desc.OutboundFKs)
-			for i := range newTableDesc.OutboundFKs {
-				newTableDesc.OutboundFKs[i].Validity = descpb.ConstraintValidity_Unvalidated
-			}
+		// NB: This is not using AllNonDropIndexes or directly mutating the
+		// constraints returned by the other usual helpers because we need to
+		// replace the `OutboundFKs` and `Checks` slices of newTableDesc with copies
+		// that we can mutate. We need to do that because newTableDesc is a shallow
+		// copy of tbl.Desc that we'll be asserting is the current version when we
+		// CPut below.
+		//
+		// Set FK constraints to unvalidated before publishing the table imported
+		// into.
+		newTableDesc.OutboundFKs = make([]descpb.ForeignKeyConstraint, len(newTableDesc.OutboundFKs))
+		copy(newTableDesc.OutboundFKs, tbl.Desc.OutboundFKs)
+		for i := range newTableDesc.OutboundFKs {
+			newTableDesc.OutboundFKs[i].Validity = descpb.ConstraintValidity_Unvalidated
+		}
 
-			// Set CHECK constraints to unvalidated before publishing the table imported into.
-			for _, c := range newTableDesc.CheckConstraints() {
-				// We only "unvalidate" constraints that are not hash-sharded column
-				// check constraints.
-				if !c.IsHashShardingConstraint() {
-					c.CheckDesc().Validity = descpb.ConstraintValidity_Unvalidated
-				}
+		// Set CHECK constraints to unvalidated before publishing the table imported into.
+		for _, c := range newTableDesc.CheckConstraints() {
+			// We only "unvalidate" constraints that are not hash-sharded column
+			// check constraints.
+			if !c.IsHashShardingConstraint() {
+				c.CheckDesc().Validity = descpb.ConstraintValidity_Unvalidated
 			}
-			newTableDesc.FinalizeImport()
-			// TODO(dt): re-validate any FKs?
-			if err := descsCol.WriteDescToBatch(
-				ctx, false /* kvTrace */, newTableDesc, b,
-			); err != nil {
-				return errors.Wrapf(err, "publishing table %d", newTableDesc.ID)
-			}
+		}
+		newTableDesc.FinalizeImport()
+		// TODO(dt): re-validate any FKs?
+		if err := descsCol.WriteDescToBatch(
+			ctx, false /* kvTrace */, newTableDesc, b,
+		); err != nil {
+			return errors.Wrapf(err, "publishing table %d", newTableDesc.ID)
 		}
 		if err := kvTxn.Run(ctx, b); err != nil {
 			return errors.Wrap(err, "publishing tables")
 		}
 
-		// Update job record to mark tables published state as complete.
-		details.TablesPublished = true
-		err := r.job.WithTxn(txn).SetDetails(ctx, details)
+		// Update job record to mark table published state as complete.
+		details.TablePublished = true
+		err = r.job.WithTxn(txn).SetDetails(ctx, details)
 		if err != nil {
 			return errors.Wrap(err, "updating job details after publishing tables")
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return setPublicTimestamp, err
 	}
 
@@ -515,10 +514,8 @@ func (r *importResumer) publishTables(
 	// Initiate a run of CREATE STATISTICS. We don't know the actual number of
 	// rows affected per table, so we use a large number because we want to make
 	// sure that stats always get created/refreshed here.
-	for i := range details.Tables {
-		desc := tabledesc.NewBuilder(details.Tables[i].Desc).BuildImmutableTable()
-		execCfg.StatsRefresher.NotifyMutation(desc, math.MaxInt32 /* rowsAffected */)
-	}
+	desc := tabledesc.NewBuilder(tbl.Desc).BuildImmutableTable()
+	execCfg.StatsRefresher.NotifyMutation(desc, math.MaxInt32 /* rowsAffected */)
 
 	return setPublicTimestamp, nil
 }
@@ -528,23 +525,25 @@ func (r *importResumer) publishTables(
 func (r *importResumer) checkVirtualConstraints(
 	ctx context.Context, execCfg *sql.ExecutorConfig, job *jobs.Job, user username.SQLUsername,
 ) error {
-	for _, tbl := range job.Details().(jobspb.ImportDetails).Tables {
-		desc := tabledesc.NewBuilder(tbl.Desc).BuildExistingMutableTable()
-		desc.SetPublic()
+	tbl, err := getTable(job.Details().(jobspb.ImportDetails))
+	if err != nil {
+		return err
+	}
+	desc := tabledesc.NewBuilder(tbl.Desc).BuildExistingMutableTable()
+	desc.SetPublic()
 
-		if sql.HasVirtualUniqueConstraints(desc) {
-			status := jobs.StatusMessage(fmt.Sprintf("re-validating %s", desc.GetName()))
-			if err := job.NoTxn().UpdateStatusMessage(ctx, status); err != nil {
-				return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(job.ID()))
-			}
+	if sql.HasVirtualUniqueConstraints(desc) {
+		status := jobs.StatusMessage(fmt.Sprintf("re-validating %s", desc.GetName()))
+		if err := job.NoTxn().UpdateStatusMessage(ctx, status); err != nil {
+			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(job.ID()))
 		}
+	}
 
-		if err := execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
-			txn.Descriptors().AddSyntheticDescriptor(desc)
-			return sql.RevalidateUniqueConstraintsInTable(ctx, txn, user, desc)
-		}); err != nil {
-			return err
-		}
+	if err := execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		txn.Descriptors().AddSyntheticDescriptor(desc)
+		return sql.RevalidateUniqueConstraintsInTable(ctx, txn, user, desc)
+	}); err != nil {
+		return err
 	}
 	return nil
 }
@@ -667,7 +666,7 @@ func ingestWithRetry(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
 	job *jobs.Job,
-	tables map[string]*execinfrapb.ReadImportDataSpec_ImportTable,
+	table *execinfrapb.ReadImportDataSpec_ImportTable,
 	typeDescs []*descpb.TypeDescriptor,
 	from []string,
 	format roachpb.IOFileFormat,
@@ -696,7 +695,7 @@ func ingestWithRetry(
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		for {
 			res, err = distImport(
-				ctx, execCtx, job, tables, typeDescs, from, format, walltime, testingKnobs, procsPerNode, initialSplitsPerProc,
+				ctx, execCtx, job, table, typeDescs, from, format, walltime, testingKnobs, procsPerNode, initialSplitsPerProc,
 			)
 			// If we got a re-planning error, then do at least one more attempt
 			// regardless of the retry duration.
@@ -845,16 +844,15 @@ func (r *importResumer) dropTables(
 		return nil
 	}
 
-	var tableWasEmpty bool
-	var intoTable catalog.TableDescriptor
-	for _, tbl := range details.Tables {
-		desc, err := descsCol.MutableByID(txn.KV()).Table(ctx, tbl.Desc.ID)
-		if err != nil {
-			return err
-		}
-		intoTable = desc.ImmutableCopy().(catalog.TableDescriptor)
-		tableWasEmpty = tbl.WasEmpty
+	tbl, err := getTable(details)
+	if err != nil {
+		return err
 	}
+	desc, err := descsCol.MutableByID(txn.KV()).Table(ctx, tbl.Desc.ID)
+	if err != nil {
+		return err
+	}
+	intoTable := desc.ImmutableCopy().(catalog.TableDescriptor)
 	// Clear table data from a rolling back IMPORT INTO cmd
 	//
 	// The walltime can be 0 if there is a failure between publishing the tables
@@ -864,7 +862,7 @@ func (r *importResumer) dropTables(
 	//
 	// In this case, we don't want to rollback the data since data ingestion has
 	// not yet begun (since we have not chosen a timestamp at which to ingest.)
-	if details.Walltime != 0 && !tableWasEmpty {
+	if details.Walltime != 0 && !tbl.WasEmpty {
 		// NB: if a revert fails it will abort the rest of this failure txn, which is
 		// also what brings tables back online. We _could_ change the error handling
 		// or just move the revert into Resume()'s error return path, however it isn't
@@ -885,7 +883,7 @@ func (r *importResumer) dropTables(
 			predicates, sql.RevertTableDefaultBatchSize); err != nil {
 			return errors.Wrap(err, "rolling back IMPORT INTO in non empty table via DeleteRange")
 		}
-	} else if tableWasEmpty {
+	} else if tbl.WasEmpty {
 		if err := gcjob.DeleteAllTableData(
 			ctx, execCfg.DB, execCfg.DistSender, execCfg.Codec, intoTable,
 		); err != nil {

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -626,7 +626,7 @@ func importPlanHook(
 			}
 		}
 
-		var tableDetails []jobspb.ImportDetails_Table
+		var tableDetails jobspb.ImportDetails_Table
 		var typeDetails []jobspb.ImportDetails_Type
 		jobDesc, err := importJobDescription(ctx, p, importStmt, filenamePatterns, opts)
 		if err != nil {
@@ -712,13 +712,13 @@ func importPlanHook(
 			}
 			if len(typeDescs) > 0 {
 				typeDetails = make([]jobspb.ImportDetails_Type, 0, len(typeDescs))
-			}
-			for _, typeDesc := range typeDescs {
-				typeDetails = append(typeDetails, jobspb.ImportDetails_Type{Desc: typeDesc.TypeDesc()})
+				for _, typeDesc := range typeDescs {
+					typeDetails = append(typeDetails, jobspb.ImportDetails_Type{Desc: typeDesc.TypeDesc()})
+				}
 			}
 		}
 
-		tableDetails = []jobspb.ImportDetails_Table{{Desc: &found.TableDescriptor, TargetCols: intoCols}}
+		tableDetails = jobspb.ImportDetails_Table{Desc: &found.TableDescriptor, TargetCols: intoCols}
 
 		// Store the primary region of the database being imported into. This is
 		// used during job execution to evaluate certain default expressions and
@@ -768,7 +768,8 @@ func importPlanHook(
 			URIs:                  files,
 			Format:                format,
 			ParentID:              db.GetID(),
-			Tables:                tableDetails,
+			Table:                 tableDetails,
+			Tables:                []jobspb.ImportDetails_Table{tableDetails},
 			Types:                 typeDetails,
 			DatabasePrimaryRegion: databasePrimaryRegion,
 		}

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -246,21 +245,16 @@ func makeInputConverter(
 	seqChunkProvider *row.SeqChunkProvider,
 	db *kv.DB,
 ) (inputConverter, error) {
-	injectTimeIntoEvalCtx(evalCtx, spec.WalltimeNanos)
-	var singleTable catalog.TableDescriptor
-	var singleTableTargetCols tree.NameList
-	if len(spec.Tables) == 1 {
-		for _, table := range spec.Tables {
-			singleTable = tabledesc.NewBuilder(table.Desc).BuildImmutableTable()
-			singleTableTargetCols = make(tree.NameList, len(table.TargetCols))
-			for i, colName := range table.TargetCols {
-				singleTableTargetCols[i] = tree.Name(colName)
-			}
-		}
+	if len(spec.Tables) > 1 {
+		return nil, errors.AssertionFailedf("%s only supports reading a single, pre-specified table", spec.Format.Format.String())
 	}
 
-	if singleTable == nil {
-		return nil, errors.Errorf("%s only supports reading a single, pre-specified table", spec.Format.Format.String())
+	injectTimeIntoEvalCtx(evalCtx, spec.WalltimeNanos)
+	table := getTableFromSpec(spec)
+	desc := tabledesc.NewBuilder(table.Desc).BuildImmutableTable()
+	targetCols := make(tree.NameList, len(table.TargetCols))
+	for i, colName := range table.TargetCols {
+		targetCols[i] = tree.Name(colName)
 	}
 
 	// If we're using a format like CSV where data columns are not "named", and
@@ -270,8 +264,8 @@ func makeInputConverter(
 	// We could potentially do something smarter here and check that only a
 	// suffix of the columns are computed, and then expect the data file to have
 	// #(visible columns) - #(computed columns).
-	if len(singleTableTargetCols) == 0 && !formatHasNamedColumns(spec.Format.Format) {
-		for _, col := range singleTable.VisibleColumns() {
+	if len(targetCols) == 0 && !formatHasNamedColumns(spec.Format.Format) {
+		for _, col := range desc.VisibleColumns() {
 			if col.IsComputed() {
 				return nil, unimplemented.NewWithIssueDetail(56002, "import.computed",
 					"to use computed columns, use IMPORT INTO")
@@ -297,31 +291,26 @@ func makeInputConverter(
 			}
 		}
 		if isWorkload {
-			return newWorkloadReader(semaCtx, evalCtx, singleTable, kvCh, readerParallelism, db), nil
+			return newWorkloadReader(semaCtx, evalCtx, desc, kvCh, readerParallelism, db), nil
 		}
 		return newCSVInputReader(
 			semaCtx, kvCh, spec.Format.Csv, spec.WalltimeNanos, readerParallelism,
-			singleTable, singleTableTargetCols, evalCtx, seqChunkProvider, db), nil
+			desc, targetCols, evalCtx, seqChunkProvider, db), nil
 	case roachpb.IOFileFormat_MysqlOutfile:
 		return newMysqloutfileReader(
 			semaCtx, spec.Format.MysqlOut, kvCh, spec.WalltimeNanos,
-			readerParallelism, singleTable, singleTableTargetCols, evalCtx, db)
+			readerParallelism, desc, targetCols, evalCtx, db)
 	case roachpb.IOFileFormat_PgCopy:
 		return newPgCopyReader(semaCtx, spec.Format.PgCopy, kvCh, spec.WalltimeNanos,
-			readerParallelism, singleTable, singleTableTargetCols, evalCtx, db)
+			readerParallelism, desc, targetCols, evalCtx, db)
 	case roachpb.IOFileFormat_Avro:
 		return newAvroInputReader(
-			semaCtx, kvCh, singleTable, spec.Format.Avro, spec.WalltimeNanos,
+			semaCtx, kvCh, desc, spec.Format.Avro, spec.WalltimeNanos,
 			readerParallelism, evalCtx, db)
 	default:
 		return nil, errors.Errorf(
 			"Requested IMPORT format (%d) not supported by this node", spec.Format.Format)
 	}
-}
-
-type tableAndIndex struct {
-	tableID catid.DescID
-	indexID catid.IndexID
 }
 
 // ingestKvs drains kvs from the channel until it closes, ingesting them using
@@ -330,6 +319,7 @@ func ingestKvs(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	spec *execinfrapb.ReadImportDataSpec,
+	tableName string,
 	progCh chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
 	kvCh <-chan row.KVBatch,
 ) (*kvpb.BulkOpSummary, error) {
@@ -339,19 +329,8 @@ func ingestKvs(
 	defer flowCtx.Cfg.JobRegistry.MarkAsIngesting(spec.Progress.JobID)()
 
 	writeTS := hlc.Timestamp{WallTime: spec.WalltimeNanos}
-
-	var pkAdderName, indexAdderName = "rows", "indexes"
-	if len(spec.Tables) == 1 {
-		for k := range spec.Tables {
-			pkAdderName = fmt.Sprintf("%s rows", k)
-			indexAdderName = fmt.Sprintf("%s indexes", k)
-		}
-	}
-
-	isPK := make(map[tableAndIndex]bool, len(spec.Tables))
-	for _, t := range spec.Tables {
-		isPK[tableAndIndex{tableID: t.Desc.ID, indexID: t.Desc.PrimaryIndex.ID}] = true
-	}
+	pkAdderName := fmt.Sprintf("%s rows", tableName)
+	indexAdderName := fmt.Sprintf("%s indexes", tableName)
 
 	// We create two bulk adders so as to combat the excessive flushing of small
 	// SSTs which was observed when using a single adder for both primary and
@@ -362,17 +341,11 @@ func ingestKvs(
 	// of the pkIndexAdder buffer be set below that of the indexAdder buffer.
 	// Otherwise, as a consequence of filling up faster the pkIndexAdder buffer
 	// will hog memory as it tries to grow more aggressively.
-	minBufferSize, maxBufferSize := importBufferConfigSizes(flowCtx.Cfg.Settings,
-		true /* isPKAdder */)
+	minBufferSize, maxBufferSize := importBufferConfigSizes(flowCtx.Cfg.Settings, true /* isPKAdder */)
 
-	var bulkAdderImportEpoch uint32
-	for _, v := range spec.Tables {
-		if bulkAdderImportEpoch == 0 {
-			bulkAdderImportEpoch = v.Desc.ImportEpoch
-		} else if bulkAdderImportEpoch != v.Desc.ImportEpoch {
-			return nil, errors.AssertionFailedf("inconsistent import epoch on multi-table import")
-		}
-	}
+	table := getTableFromSpec(spec)
+	bulkAdderImportEpoch := table.Desc.ImportEpoch
+	pkID := table.Desc.PrimaryIndex.ID
 
 	pkIndexAdder, err := flowCtx.Cfg.BulkAdder(ctx, flowCtx.Cfg.DB.KV(), writeTS, kvserverbase.BulkAdderOptions{
 		Name:                     pkAdderName,
@@ -389,8 +362,7 @@ func ingestKvs(
 	}
 	defer pkIndexAdder.Close(ctx)
 
-	minBufferSize, maxBufferSize = importBufferConfigSizes(flowCtx.Cfg.Settings,
-		false /* isPKAdder */)
+	minBufferSize, maxBufferSize = importBufferConfigSizes(flowCtx.Cfg.Settings, false /* isPKAdder */)
 	indexAdder, err := flowCtx.Cfg.BulkAdder(ctx, flowCtx.Cfg.DB.KV(), writeTS, kvserverbase.BulkAdderOptions{
 		Name:                     indexAdderName,
 		DisallowShadowingBelow:   writeTS,
@@ -530,7 +502,7 @@ func ingestKvs(
 		// number of L0 (and total) files, but with a lower memory usage.
 		for kvBatch := range kvCh {
 			for _, kv := range kvBatch.KVs {
-				_, tableID, indexID, indexErr := flowCtx.Codec().DecodeIndexPrefix(kv.Key)
+				_, _, indexID, indexErr := flowCtx.Codec().DecodeIndexPrefix(kv.Key)
 				if indexErr != nil {
 					return indexErr
 				}
@@ -540,7 +512,7 @@ func ingestKvs(
 				// TODO(adityamaru): There is a potential optimization of plumbing the
 				// different putters, and differentiating based on their type. It might be
 				// more efficient than parsing every kv.
-				if isPK[tableAndIndex{tableID: catid.DescID(tableID), indexID: catid.IndexID(indexID)}] {
+				if catid.IndexID(indexID) == pkID {
 					if err := pkIndexAdder.Add(ctx, kv.Key, kv.Value.RawBytes); err != nil {
 						if errors.HasType(err, (*kvserverbase.DuplicateKeyError)(nil)) {
 							return errors.Wrap(err, "duplicate key in primary index")

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -57,14 +57,14 @@ import (
 type testSpec struct {
 	format roachpb.IOFileFormat
 	inputs map[int32]string
-	tables map[string]*execinfrapb.ReadImportDataSpec_ImportTable
+	table  *execinfrapb.ReadImportDataSpec_ImportTable
 }
 
 // Given test spec returns ReadImportDataSpec suitable creating input converter.
 func (spec *testSpec) getConverterSpec() *execinfrapb.ReadImportDataSpec {
 	return &execinfrapb.ReadImportDataSpec{
 		Format:            spec.format,
-		Tables:            spec.tables,
+		Table:             spec.table,
 		Uri:               spec.inputs,
 		ReaderParallelism: 1, // Make tests deterministic
 	}
@@ -953,8 +953,9 @@ func newTestSpec(
 	}
 	assert.True(t, numCols > 0)
 
-	spec.tables = map[string]*execinfrapb.ReadImportDataSpec_ImportTable{
-		"simple": {Desc: descr.TableDesc(), TargetCols: targetCols[0:numCols]},
+	spec.table = &execinfrapb.ReadImportDataSpec_ImportTable{
+		Desc:       descr.TableDesc(),
+		TargetCols: targetCols[0:numCols],
 	}
 
 	for id, path := range inputs {

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -74,7 +74,7 @@ func runImport(
 	// Used to send ingested import rows to the KV layer.
 	kvCh := make(chan row.KVBatch, 10)
 
-	// Install type metadata in all of the import tables.
+	// Install type metadata in the import table.
 	spec = protoutil.Clone(spec).(*execinfrapb.ReadImportDataSpec)
 	importResolver := crosscluster.MakeCrossClusterTypeResolver(spec.Types)
 	table := getTableFromSpec(spec)


### PR DESCRIPTION
Backport 4/4 commits from #153959 on behalf of @yuzefovich.

----

This PR contains several commits that clean up the import code under a single table assumption. See each commit for details.

Epic: None
Release note: None

----

Release justification: low-risk refactor that allows faster removal of deprecated code.