### PR TITLE
vecbench: add flag to control index creation timing

### DIFF
--- a/pkg/cmd/vecbench/mem_provider.go
+++ b/pkg/cmd/vecbench/mem_provider.go
@@ -110,7 +110,7 @@ func (m *MemProvider) Load(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// New implements the VectorProvider interface
+// New implements the VectorProvider interface.
 func (m *MemProvider) New(ctx context.Context) error {
 	// Clear any existing state.
 	m.Close()
@@ -147,6 +147,18 @@ func (m *MemProvider) InsertVectors(
 		}
 		return nil
 	})
+}
+
+// CreateIndex implements the VectorProvider interface.
+func (m *MemProvider) CreateIndex(ctx context.Context) error {
+	// No-op for in-memory provider as index is built incrementally during insertion.
+	return nil
+}
+
+// CheckIndexCreationStatus implements the VectorProvider interface.
+func (m *MemProvider) CheckIndexCreationStatus(ctx context.Context) (float64, error) {
+	// Always return 100% complete for in-memory provider since index is built incrementally.
+	return 1.0, nil
 }
 
 // SetupSearch implements the VectorProvider interface.

--- a/pkg/cmd/vecbench/vector_provider.go
+++ b/pkg/cmd/vecbench/vector_provider.go
@@ -54,6 +54,15 @@ type VectorProvider interface {
 	// identified by a key.
 	InsertVectors(ctx context.Context, keys []cspann.KeyBytes, vectors vector.Set) error
 
+	// CreateIndex creates a vector index on the data. This is called after
+	// table/store creation when the index should be created before data import.
+	CreateIndex(ctx context.Context) error
+
+	// CheckIndexCreationStatus returns the percentage complete (0.0-1.0) of index
+	// creation and any error. For providers that don't support async index creation,
+	// this should return 1.0, nil.
+	CheckIndexCreationStatus(ctx context.Context) (float64, error)
+
 	// SetupSearch allows the provider to perform expensive up-front steps in
 	// preparation for many calls to Search. It returns provider-specific state
 	// that will be passed to Search.


### PR DESCRIPTION
Previously, the vecbench SQL provider would create its test table with a
vector index. This patch gives us the option to retain that behavior
(the default) or to import into an empty table without a vector index
and then use CREATE INDEX to build the index after data is inserted.

Add the --index-after flag to provide choice between two index creation
workflows:
- Default: Create table with index, then import data
- Flag set: Create table, import data, then create index

Flag validation prevents use with --memstore since this only applies
to the SQL provider.

Also adds progress monitoring interface with CheckIndexCreationStatus()
method for tracking async index creation progress.

Informs: https://github.com/cockroachdb/cockroach/issues/146691
Release note: none