### PR TITLE
drpc, server: implement filtering rules for server initialization state

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -68,24 +68,6 @@ func (s *grpcServer) health(ctx context.Context) error {
 	}
 }
 
-var rpcsAllowedWhileBootstrapping = map[string]struct{}{
-	"/cockroach.rpc.Heartbeat/Ping":             {},
-	"/cockroach.gossip.Gossip/Gossip":           {},
-	"/cockroach.server.serverpb.Init/Bootstrap": {},
-	"/cockroach.server.serverpb.Admin/Health":   {},
-}
-
-// intercept implements filtering rules for each server state.
-func (s *grpcServer) intercept(fullName string) error {
-	if s.operational() {
-		return nil
-	}
-	if _, allowed := rpcsAllowedWhileBootstrapping[fullName]; !allowed {
-		return NewWaitingForInitError(fullName)
-	}
-	return nil
-}
-
 // NewWaitingForInitError creates an error indicating that the server cannot run
 // the specified method until the node has been initialized.
 func NewWaitingForInitError(methodName string) error {


### PR DESCRIPTION
Previously, in DRPC, the `batch` RPC was able to access `node.Descriptor` which was yet to be initialized. This led to a data race, described in #153948.

This wasn't the case for gRPC, because of an interceptor that could filter RPCs during different server states. Particularly, it allows only bootstrap, heartbeat, health and gossip methods during initialization to prevent calls to potentially uninitialized services.

This patch adds this interceptor support into drpc as well. In-depth discussion on this: https://github.com/cockroachdb/cockroach/issues/153948#issuecomment-3332458390

Epic: None
Fixes: #153948
Release note: None