### PR TITLE
asim: further improve tracing

### DIFF
--- a/pkg/kv/kvserver/asim/config/settings.go
+++ b/pkg/kv/kvserver/asim/config/settings.go
@@ -119,7 +119,7 @@ type SimulationSettings struct {
 	ST *cluster.Settings
 	// OnRecording is called with trace spans obtained by recording the allocator.
 	// NB: we can't use state.StoreID here since that causes an import cycle.
-	OnRecording func(storeID int64, rec tracingpb.Recording)
+	OnRecording func(storeID int64, atDuration time.Duration, rec tracingpb.Recording)
 }
 
 // DefaultSimulationSettings returns a set of default settings for simulation.

--- a/pkg/kv/kvserver/asim/tests/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/tests/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "rand_framework.go",
         "rand_gen.go",
         "rand_util.go",
+        "tracer_helper.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/tests",
     visibility = ["//visibility:public"],
@@ -25,6 +26,9 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/multiregion",
+        "//pkg/util/tracing/tracingpb",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )
 
@@ -62,7 +66,6 @@ go_test(
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_logtags//:logtags",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/tests/tracer_helper.go
+++ b/pkg/kv/kvserver/asim/tests/tracer_helper.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type traceHelper struct {
+	enabled  bool
+	testName string
+	plotDir  string
+	sample   int
+
+	traceDirCreated  map[int64]struct{} // by storeID
+	atDurationFormat string
+}
+
+func (tr traceHelper) OnRecording(
+	t *testing.T, storeID int64, atDuration time.Duration, rec tracingpb.Recording,
+) {
+	if !tr.enabled || len(rec[0].Logs) == 0 {
+		return
+	}
+
+	traceDir := filepath.Join(tr.plotDir, "traces", fmt.Sprintf("s%d", storeID))
+	if _, ok := tr.traceDirCreated[storeID]; !ok {
+		tr.traceDirCreated[storeID] = struct{}{}
+		require.NoError(t, os.MkdirAll(traceDir, 0755))
+	}
+	re := regexp.MustCompile(`[^a-zA-Z0-9.]+`)
+
+	var sampleS string
+	if tr.sample > 0 {
+		sampleS = strconv.Itoa(tr.sample)
+	}
+	outName := fmt.Sprintf("%s%s_%s_%s_s%d", tr.testName, sampleS, fmt.Sprintf(tr.atDurationFormat, atDuration.Seconds()),
+		re.ReplaceAllString(rec[0].Operation, "_"), storeID)
+	assert.NoError(t, os.WriteFile(
+		filepath.Join(traceDir, outName),
+		[]byte(rec.String()), 0644))
+}
+
+func makeTraceHelper(
+	enabled bool, plotDir string, testName string, sample int, duration time.Duration,
+) traceHelper {
+	secondsSinceBeginningWidth := len(fmt.Sprintf("%d", int64(duration.Seconds()+1)))
+	return traceHelper{
+		enabled:         enabled,
+		testName:        testName,
+		plotDir:         plotDir,
+		sample:          sample,
+		traceDirCreated: map[int64]struct{}{},
+		// Print seconds with two decimal places. The decimal point and two decimal
+		// places need three more characters.
+		atDurationFormat: fmt.Sprintf("%%0%d.2fs", secondsSinceBeginningWidth+3),
+	}
+}


### PR DESCRIPTION
Declutter the main datadriven test by extracting out a tracing helper. Revamp the file format so that it includes the seconds elapsed since simulation start, which facilitates lining traces up with asimview.

We now also trace lease and replica count rebalancing decisions, as well as any constraint repair.

Epic: CRDB-49117