### PR TITLE
build: use docker image mirror

### DIFF
--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -35,6 +35,10 @@ if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
   git status >&2 || true
   git diff -a >&2 || true
   echo "Nuking build cruft. Please teach this build to clean up after itself." >&2
-  run docker run --volume="$root:/nuke" --workdir="/nuke" golang:stretch /bin/bash -c "git clean -ffdx ; git submodule foreach --recursive git clean -xffd" >&2
+	# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+	# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+  run docker run --volume="$root:/nuke" --workdir="/nuke" \
+    us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/golang:stretch \
+    /bin/bash -c "git clean -ffdx ; git submodule foreach --recursive git clean -xffd" >&2
   exit 1
 fi

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,5 +1,7 @@
 # Build the test binary in a multistage build.
-FROM golang:1.23 AS builder
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/golang:1.23 AS builder
 WORKDIR /workspace
 COPY . .
 RUN go test -v -c -tags gss_compose -o gss.test

--- a/pkg/cmd/roachprod/docker/Dockerfile
+++ b/pkg/cmd/roachprod/docker/Dockerfile
@@ -12,7 +12,9 @@ RUN bazel build --config=crosslinux //pkg/cmd/roachprod:roachprod
 # Copy the roachprod binary to a stable location
 RUN cp $(bazel info bazel-bin --config=crosslinux)/pkg/cmd/roachprod/roachprod_/roachprod ./
 
-FROM golang:1.23
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/golang:1.23
 COPY entrypoint.sh build.sh /build/
 RUN ["/build/build.sh"]
 COPY --from=builder /build/roachprod /usr/local/bin/roachprod


### PR DESCRIPTION
Previously, some of our build steps pulled docker images from 3rd party repos (e.g. Docker Hub). These repos sometimes have reliability issues, which can cause our builds to fail. This commit updates our build steps to use a docker image mirror hosted in GCP Artifact Registry instead.

Epic: none
Release note: none