### PR TITLE
release-25.4: scripts: update bump-pebble.sh

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -11,8 +11,8 @@
 # branch name (e.g. crl-release-23.2, etc.). Also update pebble nightly scripts
 # in build/teamcity/cockroach/nightlies to use `@crl-release-xy.z` instead of
 # `@master`.
-BRANCH=master
-PEBBLE_BRANCH=master
+BRANCH=release-25.4
+PEBBLE_BRANCH=crl-release-25.4
 
 # This script may be used to produce a branch bumping the Pebble version. The
 # storage team bumps CockroachDB's Pebble dependency frequently, and this script


### PR DESCRIPTION
Update the bump-pebble script to bump the Pebble SHA from the crl-release-25.4 branch.

Epic: none
Release note: none
Release justification: non-production code changes.