### PR TITLE
changefeedccl: block db-level changefeed creation for non-empty tableset

### DIFF
--- a/pkg/backup/backupresolver/targets.go
+++ b/pkg/backup/backupresolver/targets.go
@@ -661,6 +661,7 @@ func LoadAllDescs(
 	ctx context.Context, execCfg *sql.ExecutorConfig, asOf hlc.Timestamp,
 ) (allDescs []catalog.Descriptor, _ error) {
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		fmt.Printf("LoadAllDescs: setting fixed timestamp to %s\n", asOf)
 		err := txn.KV().SetFixedTimestamp(ctx, asOf)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/changefeedccl/resolvedspan",
         "//pkg/ccl/changefeedccl/schemafeed",
+        "//pkg/ccl/changefeedccl/tableset",
         "//pkg/ccl/changefeedccl/timers",
         "//pkg/ccl/kvccl/kvfollowerreadsccl",
         "//pkg/ccl/utilccl",

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -109,6 +109,7 @@ func getTargetsFromDatabaseSpec(
 	ctx context.Context, ts jobspb.ChangefeedTargetSpecification, execCfg *sql.ExecutorConfig,
 ) (targets changefeedbase.Targets, err error) {
 	err = sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, descs *descs.Collection) error {
+		// TODO: Set fixed timestamp here.
 		databaseDescriptor, err := descs.ByIDWithLeased(txn.KV()).Get().Database(ctx, ts.DescID)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -53,12 +53,17 @@ func makeChangefeedConfigFromJobDetails(
 		Targets:  targets,
 	}, nil
 }
+func AllTargets(
+	ctx context.Context, cd jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig,
+) (changefeedbase.Targets, error) {
+	return AllTargetsWithTS(ctx, cd, execCfg, hlc.Timestamp{})
+}
 
 // AllTargets gets all the targets listed in a ChangefeedDetails,
 // from the statement time name map in old protos
 // or the TargetSpecifications in new ones.
-func AllTargets(
-	ctx context.Context, cd jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig,
+func AllTargetsWithTS(
+	ctx context.Context, cd jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig, timestamp hlc.Timestamp,
 ) (changefeedbase.Targets, error) {
 	targets := changefeedbase.Targets{}
 	var err error
@@ -72,7 +77,7 @@ func AllTargets(
 					if len(cd.TargetSpecifications) > 1 {
 						return changefeedbase.Targets{}, errors.AssertionFailedf("database-level changefeed is not supported with multiple targets")
 					}
-					targets, err = getTargetsFromDatabaseSpec(ctx, ts, execCfg)
+					targets, err = getTargetsFromDatabaseSpec(ctx, ts, execCfg, timestamp)
 					if err != nil {
 						return changefeedbase.Targets{}, err
 					}
@@ -106,10 +111,15 @@ func AllTargets(
 }
 
 func getTargetsFromDatabaseSpec(
-	ctx context.Context, ts jobspb.ChangefeedTargetSpecification, execCfg *sql.ExecutorConfig,
+	ctx context.Context, ts jobspb.ChangefeedTargetSpecification, execCfg *sql.ExecutorConfig, timestamp hlc.Timestamp,
 ) (targets changefeedbase.Targets, err error) {
 	err = sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, descs *descs.Collection) error {
 		// TODO: Set fixed timestamp here.
+		if timestamp != (hlc.Timestamp{}) {
+			if err := txn.KV().SetFixedTimestamp(ctx, timestamp); err != nil {
+				return errors.Wrapf(err, "setting timestamp for table descriptor fetch")
+			}
+		}
 		databaseDescriptor, err := descs.ByIDWithLeased(txn.KV()).Get().Database(ctx, ts.DescID)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -84,6 +84,7 @@ func distChangefeedFlow(
 	resultsCh chan<- tree.Datums,
 	onTracingEvent func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents),
 	targets changefeedbase.Targets,
+	schemaTSOverride hlc.Timestamp,
 ) error {
 	opts := changefeedbase.MakeStatementOptions(details.Opts)
 	progress := localState.progress
@@ -136,6 +137,14 @@ func distChangefeedFlow(
 			knobs.StartDistChangefeedInitialHighwater(ctx, initialHighWater)
 		}
 	}
+	// This isn't fixing current error (flowErr: fetching table descriptor 114: relation "[114]" does not exist)
+	// but I think it's necessary to have it.
+	if !schemaTSOverride.IsEmpty() {
+		schemaTS = schemaTSOverride
+		initialHighWater = schemaTSOverride
+		fmt.Printf("overriding schemaTS to %s from %s\n", schemaTSOverride, schemaTS)
+	}
+
 	return startDistChangefeed(
 		ctx, execCtx, jobID, schemaTS, details, description, initialHighWater, localState, resultsCh, onTracingEvent, targets)
 }
@@ -159,10 +168,12 @@ func fetchTableDescriptors(
 		// and lie within the primary index span. Deduplication is important
 		// here as requesting the same span twice will deadlock.
 		return targets.EachTableID(func(id catid.DescID) error {
+			fmt.Printf("fetching table descriptor %d at timestamp %s\n", id, ts)
 			tableDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, id)
 			if err != nil {
 				return errors.Wrapf(err, "fetching table descriptor %d", id)
 			}
+			fmt.Printf("fetched table descriptor %d at timestamp %s\n", id, ts)
 			targetDescs = append(targetDescs, tableDesc)
 			return nil
 		})
@@ -244,6 +255,7 @@ func startDistChangefeed(
 	if err != nil {
 		return err
 	}
+	fmt.Printf("fetched table descriptors\n")
 
 	if schemaTS.IsEmpty() {
 		schemaTS = details.StatementTime
@@ -269,11 +281,13 @@ func startDistChangefeed(
 			log.Changefeed.Infof(ctx, "span-level checkpoint: %s", spanLevelCheckpoint)
 		}
 	}
+	fmt.Printf("making plan\n")
 	p, planCtx, err := makePlan(execCtx, jobID, details, description, initialHighWater,
 		trackedSpans, spanLevelCheckpoint, localState.drainingNodes)(ctx, dsp)
 	if err != nil {
 		return err
 	}
+	fmt.Printf("made plan\n")
 
 	execPlan := func(ctx context.Context) error {
 		// Derive a separate context so that we can shut down the changefeed
@@ -339,6 +353,7 @@ func startDistChangefeed(
 		return resultRows.Err()
 	}
 
+	fmt.Printf("end of startDistChangefeed\n")
 	return ctxgroup.GoAndWait(ctx, execPlan)
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -205,6 +205,8 @@ func newChangeAggregatorProcessor(
 ) (_ execinfra.Processor, retErr error) {
 	// Setup monitoring for this node drain.
 	drainWatcher, drainDone := makeDrainWatcher(flowCtx)
+	fmt.Printf("newChangeAggregatorProcessor\n")
+
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("changeagg-mem"))
 	ca := &changeAggregator{
 		spec:              spec,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -378,7 +378,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	if ca.knobs.OverrideExecCfg != nil {
 		execCfg = ca.knobs.OverrideExecCfg(execCfg)
 	}
-	ca.targets, err = AllTargets(ctx, ca.spec.Feed, execCfg)
+	ca.targets, err = AllTargetsWithTS(ctx, ca.spec.Feed, execCfg, *ca.spec.InitialHighWater)
 	if err != nil {
 		log.Changefeed.Warningf(ca.Ctx(), "moving to draining due to error getting targets: %v", err)
 		ca.MoveToDraining(err)
@@ -452,6 +452,9 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	kvFeedHighWater := ca.frontier.Frontier()
 	if needsInitialScan {
 		kvFeedHighWater = ca.spec.Feed.StatementTime
+		fmt.Printf("Using statement time for kv feed high water: %s\n", kvFeedHighWater)
+	} else {
+		fmt.Printf("Using frontier for kv feed high water: %s\n", kvFeedHighWater)
 	}
 
 	// TODO(yevgeniy): Introduce separate changefeed monitor that's a parent
@@ -563,6 +566,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 	if schemaChange.Policy == changefeedbase.OptSchemaChangePolicyIgnore || initialScanOnly {
 		sf = schemafeed.DoNothingSchemaFeed
 	} else {
+		fmt.Printf("creating schema feed with initial frontier: %s\n", initialHighWater)
 		sf = schemafeed.New(ctx, cfg, schemaChange.EventClass, ca.targets,
 			initialHighWater, &ca.metrics.SchemaFeedMetrics, config.Opts.GetCanHandle())
 	}
@@ -1336,7 +1340,8 @@ func newChangeFrontierProcessor(
 	if cf.knobs.OverrideExecCfg != nil {
 		execCfg = cf.knobs.OverrideExecCfg(execCfg)
 	}
-	targets, err := AllTargets(ctx, spec.Feed, execCfg)
+	fmt.Printf("change frontier getting targets with initial high water: %s\n", spec.InitialHighWater)
+	targets, err := AllTargetsWithTS(ctx, spec.Feed, execCfg, *spec.InitialHighWater)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/checkpoint"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/tableset"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
@@ -57,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -445,7 +447,7 @@ func coreChangefeed(
 			knobs.BeforeDistChangefeed()
 		}
 
-		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh, nil, targets)
+		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh, nil, targets, hlc.Timestamp{})
 		if err == nil {
 			log.Changefeed.Infof(ctx, "core changefeed completed with no error")
 			return nil
@@ -1611,6 +1613,16 @@ func (b *changefeedResumer) resumeWithRetries(
 
 	maxBackoff := changefeedbase.MaxRetryBackoff.Get(&execCfg.Settings.SV)
 	backoffReset := changefeedbase.RetryBackoffReset.Get(&execCfg.Settings.SV)
+
+	mm := mon.NewMonitor(mon.Options{
+		Name:      mon.MakeName("test-mm"),
+		Limit:     1024 * 1024,
+		Increment: 128,
+		Settings:  cluster.MakeTestingClusterSettings(),
+	})
+	mm.Start(ctx, nil, mon.NewStandaloneBudget(1024*2024))
+	defer mm.Stop(ctx)
+
 	for r := getRetry(ctx, maxBackoff, backoffReset); r.Next(); {
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 
@@ -1624,24 +1636,114 @@ func (b *changefeedResumer) resumeWithRetries(
 				knobs.BeforeDistChangefeed()
 			}
 
-			confPoller := make(chan struct{})
+			runningChangefeedChan := make(chan struct{})
 			g := ctxgroup.WithContext(ctx)
+
+			// TODO: Get targets at the HWM, if it exists.
 			targets, err := AllTargets(ctx, details, execCfg)
 			if err != nil {
 				return err
 			}
+			var watcher *tableset.Watcher
+			watcherChan := make(chan []tableset.TableDiff)
+			if targets.NumUniqueTables() == 0 {
+				// If db-level changefeed with no watched tables.
+				if len(details.TargetSpecifications) == 0 {
+					return errors.New("no target specifications")
+				}
+
+				// Create watcher dependencies.
+				spec := details.TargetSpecifications[0]
+				if spec.Type != jobspb.ChangefeedTargetSpecification_DATABASE {
+					return errors.New("target specification is not a database, so no tables to watch")
+				}
+				dbID := spec.DescID
+				// TODO: Verify this. When would dbID be 0?
+				if dbID == 0 {
+					return errors.New("database ID is 0, so no tables to watch")
+				}
+				filter := tableset.Filter{
+					DatabaseID: dbID,
+				}
+				var initialWatcherTS hlc.Timestamp
+				if h := localState.progress.GetHighWater(); h != nil && !h.IsEmpty() {
+					initialWatcherTS = *h
+				} else {
+					initialWatcherTS = details.StatementTime
+				}
+
+				// Create a watcher for the database.
+				watcher = tableset.NewWatcher(filter, execCfg, mm, int64(jobID))
+				timestamp := initialWatcherTS
+				g.GoCtx(func(ctx context.Context) error {
+					err := watcher.Start(ctx, timestamp)
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+				// TODO: Verify that the watcher closes when the context is done.
+				// Does that mean the watcher will continue to run even once
+				// the changefeed is planned and running?
+			} else {
+				close(watcherChan)
+			}
+
+			// Start the changefeed.
 			g.GoCtx(func(ctx context.Context) error {
-				defer close(confPoller)
-				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh, onTracingEvent, targets)
+				defer close(runningChangefeedChan)
+				var schemaTSOverride hlc.Timestamp
+				// for targets.NumUniqueTables() == 0 {
+				if targets.NumUniqueTables() == 0 {
+					fmt.Printf("no target tables, blocking on watcherChan\n")
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case diffs := <-watcherChan:
+						fmt.Printf("received diffs: %v\n", diffs)
+						fmt.Printf("watcherChan closed\n")
+						if len(diffs) == 0 {
+							return errors.New("no diffs")
+						}
+						fmt.Printf("received diffs: %v\n", diffs)
+						fmt.Printf("watcherChan closed\n")
+						// Get the diff with the earliest timestamp.
+						earliestDiff := diffs[0]
+						if earliestDiff.Added.ID == 0 {
+							return errors.New("no added table")
+						}
+						earliestTimestamp := earliestDiff.AsOf
+						schemaTSOverride = earliestTimestamp
+						fmt.Printf("schemaTSOverride: %s\n", schemaTSOverride)
+						for _, diff := range diffs {
+							if diff.AsOf.LessEq(earliestTimestamp) {
+								if diff.Dropped.ID != 0 {
+									return errors.New("dropping table while tableset should be empty")
+								}
+								targets.Add(changefeedbase.Target{
+									DescID:            diff.Added.ID,
+									FamilyName:        "",
+									StatementTimeName: changefeedbase.StatementTimeName(diff.Added.Name),
+								})
+							} else {
+								break
+							}
+						}
+					}
+				}
+				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh, onTracingEvent, targets, schemaTSOverride)
 			})
+
+			// Poll for updated configuration or new database tables if hibernating.
 			g.GoCtx(func(ctx context.Context) error {
-				t := time.NewTicker(15 * time.Second)
+				// todo: change back to 15 seconds. This just simplifies testing.
+				t := time.NewTicker(3 * time.Second)
 				defer t.Stop()
 				for {
 					select {
 					case <-ctx.Done():
 						return ctx.Err()
-					case <-confPoller:
+					case <-runningChangefeedChan:
 						return nil
 					case <-t.C:
 						newDest, err := reloadDest(ctx, jobID, execCfg)
@@ -1651,11 +1753,26 @@ func (b *changefeedResumer) resumeWithRetries(
 							resolvedDest = newDest
 							return replanErr
 						}
+						if watcher == nil {
+							continue
+						}
+						unchanged, diffs, err := watcher.PopUnchangedUpTo(ctx, execCfg.Clock.Now())
+						if err != nil {
+							return err
+						}
+						if !unchanged {
+							if len(diffs) == 0 {
+								return errors.New("no diffs")
+							}
+							fmt.Printf("sending diffs to watcherChan: %v\n", diffs)
+							watcherChan <- diffs
+						}
 					}
 				}
 			})
 
 			flowErr = g.Wait()
+			fmt.Printf("flowErr: %v\n", flowErr)
 
 			if flowErr == nil {
 				return nil // Changefeed completed -- e.g. due to initial_scan=only mode.

--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -7,6 +7,7 @@ package changefeedccl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 	"github.com/linkedin/goavro/v2"
@@ -54,13 +56,13 @@ type enrichedSourceProvider struct {
 }
 
 func GetTableSchemaInfo(
-	ctx context.Context, cfg *execinfra.ServerConfig, targets changefeedbase.Targets,
+	ctx context.Context, cfg *execinfra.ServerConfig, targets changefeedbase.Targets, initialHighWater hlc.Timestamp,
 ) (map[descpb.ID]tableSchemaInfo, error) {
 	schemaInfo := make(map[descpb.ID]tableSchemaInfo)
 	execCfg := cfg.ExecutorConfig.(*sql.ExecutorConfig)
 	err := targets.EachTarget(func(target changefeedbase.Target) error {
 		id := target.DescID
-		td, dbd, sd, err := getDescriptors(ctx, execCfg, id)
+		td, dbd, sd, err := getDescriptors(ctx, execCfg, id, initialHighWater)
 		if err != nil {
 			return err
 		}
@@ -548,13 +550,17 @@ func init() {
 const originCockroachDB = "cockroachdb"
 
 func getDescriptors(
-	ctx context.Context, execCfg *sql.ExecutorConfig, tableID descpb.ID,
+	ctx context.Context, execCfg *sql.ExecutorConfig, tableID descpb.ID, initialHighWater hlc.Timestamp,
 ) (catalog.TableDescriptor, catalog.DatabaseDescriptor, catalog.SchemaDescriptor, error) {
 	var tableDescriptor catalog.TableDescriptor
 	var dbDescriptor catalog.DatabaseDescriptor
 	var schemaDescriptor catalog.SchemaDescriptor
 	var err error
 	f := func(ctx context.Context, txn descs.Txn) error {
+		fmt.Printf("getDescriptors: setting fixed timestamp to %s\n", initialHighWater)
+		if err := txn.KV().SetFixedTimestamp(ctx, initialHighWater); err != nil {
+			return err
+		}
 		byIDGetter := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get()
 		tableDescriptor, err = byIDGetter.Table(ctx, tableID)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -108,7 +108,8 @@ func newEventConsumer(
 		if encodingOpts.Envelope == changefeedbase.OptEnvelopeEnriched {
 			var schemaInfo map[descpb.ID]tableSchemaInfo
 			if inSet(changefeedbase.EnrichedPropertySource, encodingOpts.EnrichedProperties) {
-				schemaInfo, err = GetTableSchemaInfo(ctx, cfg, feed.Targets)
+				// TODO(log-head): should cursor be used here instead of initialHighWater?
+				schemaInfo, err = GetTableSchemaInfo(ctx, cfg, feed.Targets, *spec.InitialHighWater)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -8,6 +8,7 @@ package changefeedccl
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/url"
 	"runtime"
@@ -384,6 +385,7 @@ func (s errorWrapperSink) EmitRow(
 	alloc kvevent.Alloc,
 	headers rowHeaders,
 ) error {
+	fmt.Printf("EmitRow key: %s, value: %s\n", key, value)
 	if err := s.wrapped.(EventSink).EmitRow(ctx, topic, key, value, updated, mvcc, alloc, headers); err != nil {
 		return changefeedbase.MarkRetryableError(err)
 	}

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -106,6 +106,10 @@ message ChangeFrontierSpec {
   // ResolvedSpans contains the resolved spans that should be restored
   // when the changefeed resumes.
   repeated cockroach.sql.jobs.jobspb.ResolvedSpan resolved_spans = 8 [(gogoproto.nullable) = false];
+
+  // InitialHighWater represents a point in time where all data is known to have
+  // been seen for this changefeed job.
+  optional util.hlc.Timestamp initial_high_water = 9;
 }
 
 // ChangefeedProgressConfig is the configuration for the changefeed's progress tracking.


### PR DESCRIPTION
On startup, the changefeed should not be started until there exist tables in the database to watch. If no tables exist at the time of startup, then a tableset watcher is created and polled; the changefeed will be started from where there is first a target table.

Fixes: #148833
Epic: CRDB-1421

Release note: none