### PR TITLE
roachtest: fix log file in slow-drain test

### DIFF
--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -134,7 +134,7 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 	testutils.SucceedsWithin(t, func() error {
 		for nodeID := 2; nodeID <= numNodes; nodeID++ {
 			if err := c.RunE(ctx, option.WithNodes(c.Node(nodeID)),
-				fmt.Sprintf("grep -q '%s' logs/cockroach.log", verboseStoreLogRe),
+				fmt.Sprintf("grep -q '%s' logs/cockroach-kv-distribution.log", verboseStoreLogRe),
 			); err == nil {
 				return nil
 			}


### PR DESCRIPTION
The test was looking for a specific log message, which recently moved to the KV distribution channel. This commit points the test to the right log file.

Fixes: #154153
Fixes: #154138

Release note: None