### PR TITLE
ci,ui: fix cluster-ui-release "check if published" step

### DIFF
--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         PACKAGE_VERSION=$(cat ./package.json | jq -r ".version");
         VERSIONS=$(npm view @cockroachlabs/cluster-ui versions)
-        if [[ $VERSIONS == *"$PACKAGE_VERSION"* ]]; then
+        if [[ $VERSIONS == *\'"$PACKAGE_VERSION"\'* ]]; then
           echo "published=yes" >> $GITHUB_OUTPUT
           echo
           echo "🛑 Cluster UI package version $PACKAGE_VERSION is already published"


### PR DESCRIPTION
The check for whether a version exists in npm is too liberal with its pattern matching, resulting in pre-release branches to cause other releases to fail to publish.

Now, a pre-release version will not cause a potential failure in publish a regular version release.

Epic: None
Release note: None

Updated script on the right, old on the left:
<img width="1715" height="471" alt="image" src="https://github.com/user-attachments/assets/f01c415d-d176-40d5-af83-ba169429813c" />
