### PR TITLE
catalog/lease: fix nil pointer dereference in purgeOldVersions

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1277,6 +1277,11 @@ func (m *Manager) purgeOldVersions(
 		}
 		// We encountered an error telling us to renew the lease.
 		newest := m.findNewest(id)
+		// It is possible that a concurrent drop / removal of this descriptor is
+		// occurring. If the newest version just doesn't exist, bail out.
+		if newest == nil {
+			break
+		}
 		// Assert this should never happen due to a fixed expiration, since the range
 		// feed is responsible for purging old versions and acquiring new versions.
 		if newest.hasFixedExpiration() {


### PR DESCRIPTION
Previously, we added logic that to handle errRenewLease due to session expiration with a debug assertion making sure the latest version of a descriptor was not historical. Sadly, the assertion did not take into account concurrent clean up of the version being retained. To address this, this patch adds an explicit nil check to handle this scenario.

Note: This scenario is only likely in tests  with the knob`removeOnceDereferenced`

Fixes: #154155

Release note: None