### PR TITLE
changefeedccl: support INCLUDE TABLES filter for DB-level changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -637,15 +637,14 @@ func createChangefeedJobRecord(
 		if targetDatabaseDesc.GetID() == keys.SystemDatabaseID {
 			return nil, changefeedbase.Targets{}, errors.Errorf("changefeed cannot target the system database")
 		}
-		if changefeedStmt.FilterOption != nil {
-			fqTableNames, err := getFullyQualifiedTableNames(
-				targetDatabaseDesc.GetName(), changefeedStmt.FilterOption.Tables,
-			)
-			if err != nil {
-				return nil, changefeedbase.Targets{}, err
-			}
-			changefeedStmt.FilterOption.Tables = fqTableNames
+		fqTableNames, err := getFullyQualifiedTableNames(
+			targetDatabaseDesc.GetName(), changefeedStmt.FilterOption.Tables,
+		)
+		if err != nil {
+			return nil, changefeedbase.Targets{}, err
 		}
+		changefeedStmt.FilterOption.Tables = fqTableNames
+
 		targetSpec := getDatabaseTargetSpec(targetDatabaseDesc, changefeedStmt.FilterOption)
 		details = jobspb.ChangefeedDetails{
 			TargetSpecifications: []jobspb.ChangefeedTargetSpecification{targetSpec},
@@ -1158,22 +1157,20 @@ func getTargetsAndTables(
 }
 
 func getDatabaseTargetSpec(
-	targetDatabaseDesc catalog.DatabaseDescriptor, filterOpt *tree.ChangefeedFilterOption,
+	targetDatabaseDesc catalog.DatabaseDescriptor, filterOpt tree.ChangefeedFilterOption,
 ) jobspb.ChangefeedTargetSpecification {
 	target := jobspb.ChangefeedTargetSpecification{
 		DescID:            targetDatabaseDesc.GetID(),
 		Type:              jobspb.ChangefeedTargetSpecification_DATABASE,
 		StatementTimeName: targetDatabaseDesc.GetName(),
 	}
-	if filterOpt != nil {
-		filterTables := make(map[string]pbtypes.Empty)
-		for _, table := range filterOpt.Tables {
-			filterTables[table.FQString()] = pbtypes.Empty{}
-		}
-		target.FilterList = &jobspb.FilterList{
-			FilterType: jobspb.FilterList_FilterType(filterOpt.FilterType),
-			Tables:     filterTables,
-		}
+	filterTables := make(map[string]pbtypes.Empty)
+	for _, table := range filterOpt.Tables {
+		filterTables[table.FQString()] = pbtypes.Empty{}
+	}
+	target.FilterList = &jobspb.FilterList{
+		FilterType: filterOpt.FilterType,
+		Tables:     filterTables,
 	}
 	return target
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -229,26 +229,78 @@ func TestDatabaseLevelChangefeedWithIncludeFilter(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
-		expectSuccess := func(stmt string) {
-			successfulFeed := feed(t, f, stmt)
-			defer closeFeed(t, successfulFeed)
-			_, err := successfulFeed.Next()
-			require.NoError(t, err)
-		}
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
-		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
-		sqlDB.Exec(t, `CREATE TABLE foo2 (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `INSERT INTO foo2 VALUES (0, 'initial')`)
-		sqlDB.Exec(t, `UPSERT INTO foo2 VALUES (0, 'updated')`)
+		for i := range 4 {
+			name := fmt.Sprintf("foo%d", i+1)
+			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s (a INT PRIMARY KEY, b STRING)`, name))
+			sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO %s VALUES (0, 'initial')`, name))
+			sqlDB.Exec(t, fmt.Sprintf(`UPSERT INTO %s VALUES (0, 'updated')`, name))
+		}
 
-		expectSuccess(`CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo`)
-		expectSuccess(`CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo,foo2`)
-		expectSuccess(`CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES d.bar.fizz, foo.foo2, foo`)
+		sqlDB.Exec(t, `CREATE SCHEMA private`)
+		sqlDB.Exec(t, `CREATE TABLE private.foo1 (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `INSERT INTO private.foo1 VALUES (0, 'initial')`)
+		// Test that if there are multiple tables with the same name the correct
+		// one will still be found using the default schema of public.
+		feed1 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo1`)
+		defer closeFeed(t, feed1)
+		assertPayloads(t, feed1, []string{
+			`foo1: [0]->{"after": {"a": 0, "b": "updated"}}`,
+		})
+
+		// Test that we can include multiple tables.
+		feed2 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo1,foo2`)
+		defer closeFeed(t, feed2)
+		assertPayloads(t, feed2, []string{
+			`foo1: [0]->{"after": {"a": 0, "b": "updated"}}`,
+			`foo2: [0]->{"after": {"a": 0, "b": "updated"}}`,
+		})
+
+		// Test that we can handle fully qualified, partially qualified, and unqualified
+		// table names.
+		feed3 := feed(t, f,
+			`CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES d.public.foo2, public.foo3, foo4`)
+		defer closeFeed(t, feed3)
+		assertPayloads(t, feed3, []string{
+			`foo2: [0]->{"after": {"a": 0, "b": "updated"}}`,
+			`foo3: [0]->{"after": {"a": 0, "b": "updated"}}`,
+			`foo4: [0]->{"after": {"a": 0, "b": "updated"}}`,
+		})
+
+		// Test that we can handle tables that don't exist.
+		feed4 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo1,bob`)
+		defer closeFeed(t, feed4)
+		assertPayloads(t, feed4, []string{
+			`foo1: [0]->{"after": {"a": 0, "b": "updated"}}`,
+		})
+
+		// Test that fully qualified table names outside of the target database will
+		// cause an error.
+		expectErrCreatingFeed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES fizz.buzz.foo`,
+			`table "fizz.buzz.foo" must be in target database "d"`)
+
+		// Table patterns are not supported.
 		expectErrCreatingFeed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo.*`,
 			`at or near "*": syntax error`)
-		// TODO(#147421): Assert payload once the filter works
+
+		// Test that name resolution is not dependent on search_path() or current DB.
+		sqlDB.Exec(t, `CREATE DATABASE notd`)
+		sqlDB.Exec(t, `USE notd`)
+		sqlDB.Exec(t, `SET search_path TO notpublic`)
+		feed5 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES foo1, private.foo1`)
+		defer closeFeed(t, feed5)
+		assertPayloads(t, feed5, []string{
+			`foo1: [0]->{"after": {"a": 0, "b": "updated"}}`,
+			`foo1: [0]->{"after": {"a": 0, "b": "initial"}}`,
+		})
+
+		// Test that partially qualified table names are always assumed to be
+		// <schema>.<table>.
+		feed6 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d INCLUDE TABLES d.foo1, public.foo2`)
+		defer closeFeed(t, feed6)
+		assertPayloads(t, feed6, []string{
+			`foo2: [0]->{"after": {"a": 0, "b": "updated"}}`,
+		})
 	}
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }
@@ -298,8 +350,10 @@ func TestDatabaseLevelChangefeedWithExcludeFilter(t *testing.T) {
 			`foo4: [0]->{"after": {"a": 0, "b": "updated"}}`,
 		})
 
-		// Test that we can handle fully qualfied, partially qualified, and unqualified table names.
-		feed4 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d EXCLUDE TABLES d.public.foo2, public.foo3, foo4`)
+		// Test that we can handle fully qualified, partially qualified, and unqualified
+		// table names.
+		feed4 := feed(t, f,
+			`CREATE CHANGEFEED FOR DATABASE d EXCLUDE TABLES d.public.foo2, public.foo3, foo4`)
 		defer closeFeed(t, feed4)
 		assertPayloads(t, feed4, []string{
 			`foo1: [0]->{"after": {"a": 0, "b": "initial"}}`,

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1113,10 +1113,7 @@ message ChangefeedTargetSpecification {
 }
 
 message FilterList {
-  enum FilterType {
-    EXCLUDE_TABLES = 0;
-  }
-  FilterType filter_type = 1;
+  uint32 filter_type = 1 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree.FilterType"];
   map<string, google.protobuf.Empty> tables = 2 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -965,11 +965,8 @@ func (u *sqlSymUnion) doBlockOptions() tree.DoBlockOptions {
 func (u *sqlSymUnion) doBlockOption() tree.DoBlockOption {
     return u.val.(tree.DoBlockOption)
 }
-func (u *sqlSymUnion) changefeedFilterOption() *tree.ChangefeedFilterOption {
-    if filterOption, ok := u.val.(*tree.ChangefeedFilterOption); ok {
-        return filterOption
-    }
-    return nil
+func (u *sqlSymUnion) changefeedFilterOption() tree.ChangefeedFilterOption {
+    return u.val.(tree.ChangefeedFilterOption)
 } 
 
 %}
@@ -1610,7 +1607,7 @@ func (u *sqlSymUnion) changefeedFilterOption() *tree.ChangefeedFilterOption {
 %type <tree.ReturningClause> returning_clause
 %type <tree.TableExprs> opt_using_clause
 %type <tree.RefreshDataOption> opt_clear_data
-%type <*tree.ChangefeedFilterOption> db_level_changefeed_filter_option
+%type <tree.ChangefeedFilterOption> db_level_changefeed_filter_option
 
 %type <tree.BatchParam> batch_param
 %type <[]tree.BatchParam> batch_param_list
@@ -6510,15 +6507,15 @@ opt_using_clause:
 db_level_changefeed_filter_option:
   EXCLUDE TABLES table_name_list
   {
-    $$.val = &tree.ChangefeedFilterOption{Tables: $3.tableNames(), FilterType: tree.ExcludeFilter}
+    $$.val = tree.ChangefeedFilterOption{Tables: $3.tableNames(), FilterType: tree.ExcludeFilter}
   }
 | INCLUDE TABLES table_name_list
   {
-    $$.val = &tree.ChangefeedFilterOption{Tables: $3.tableNames(), FilterType: tree.IncludeFilter}
+    $$.val = tree.ChangefeedFilterOption{Tables: $3.tableNames(), FilterType: tree.IncludeFilter}
   }
 | /* EMPTY */ 
   {
-    $$.val = nil
+    $$.val = tree.ChangefeedFilterOption{}
   }
 
 

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -46,7 +46,7 @@ type CreateChangefeed struct {
 	TableTargets   ChangefeedTableTargets
 	DatabaseTarget ChangefeedDatabaseTarget
 	Level          ChangefeedLevel
-	FilterOption   *ChangefeedFilterOption
+	FilterOption   ChangefeedFilterOption
 	SinkURI        Expr
 	Options        KVOptions
 	Select         *SelectClause
@@ -73,7 +73,7 @@ func (node *CreateChangefeed) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&node.TableTargets)
 	} else {
 		ctx.FormatNode(&node.DatabaseTarget)
-		if node.FilterOption != nil {
+		if len(node.FilterOption.Tables) > 0 {
 			ctx.WriteString(" ")
 			ctx.WriteString(node.FilterOption.FilterType.String())
 			ctx.WriteString(" TABLES ")


### PR DESCRIPTION
Support the ability to watch specific tables in a database-level feed. 
An example usage is:
CREATE DATABASE FOR CHANGEFEED defaultdb INCLUDE TABLES 
foo,fizz.buzz,defaultdb.bar.tab,notdefaultdb.bar.tab;

The table names above in the INCLUDE TABLES list will be resolved as such:

Non-qualified table name foo:
- defaultdb.public.foo

Partially-qualified table name fizz.buzz:
- defaultdb.fizz.buzz

Fully-qualified table name defaultdb.bar.tab:
- defaultdb.bar.tab

Fully-qualified table name notdefaultdb.bar.tab:
- Statement error; changefeed job will not be created

Note that partially qualified table names in the form \<database\>.\<table\> are not supported. Partially qualfied table names are always assumed to be \<schema\>.\<table\>.

Resolves: #147422
Release note: none