### PR TITLE
ui: bump cluster-ui version to 25.4.1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.4.0",
+  "version": "25.4.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
the bump to 25.4.0 failed due a to bug in
cluster-ui-release.yml that has been fixed as part of https://github.com/cockroachdb/cockroach/pull/154169.

This commit is needed in order to get this version published to npm

Epic: None
Release note: None
Release justification: The previous PR to release cluster-ui v25.4.0 failed due to a bug in cluster-ui-release.yml. Now that this has been fixed we need to bump the the version again for it to publish