### PR TITLE
roachtest: remove global-seed flag

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestflags/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/cmd/roachtest/spec",
         "//pkg/roachprod/vm",
-        "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
     ],

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/spf13/pflag"
 )
 
@@ -474,12 +473,6 @@ var (
 	_                         = registerRunFlag(&AutoKillThreshold, FlagInfo{
 		Name:  "auto-kill-threshold",
 		Usage: `Percentage of failed tests before all remaining tests are automatically terminated.`,
-	})
-
-	GlobalSeed int64 = randutil.NewPseudoSeed()
-	_                = registerRunFlag(&GlobalSeed, FlagInfo{
-		Name:  "global-seed",
-		Usage: `The global random seed used for all tests.`,
 	})
 
 	ClearClusterCache bool = true


### PR DESCRIPTION
This flag allows the user to seed the global rng instance for the entire test suite run. This flag is rarely (never) used and adds confusion for test writers as they are unsure if they should use the global seed or the test scoped COCKROACH_RANDOM_SEED.

This changes the flag to be a ROACHTEST_GLOBAL_SEED env var which still allows it to be set, but unexposes it from being used directly in roachtests themselves.

Fixes: none
Epic: none
Release note: none