### PR TITLE
 ui: add transaction diagnostics api client and page 

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -699,6 +699,9 @@ importers:
       reselect:
         specifier: ^4.0.0
         version: 4.0.0
+      swr:
+        specifier: 2.2.5
+        version: 2.2.5(react@16.12.0)
       uplot:
         specifier: ^1.6.19
         version: 1.6.19

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./fetchData";
 export * from "./statementDiagnosticsApi";
+export * from "./transactionDiagnosticsApi";
 export * from "./statementsApi";
 export * from "./basePath";
 export * from "./nodesApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/transactionDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/transactionDiagnosticsApi.ts
@@ -1,0 +1,133 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import Long from "long";
+import moment from "moment-timezone";
+
+import { fetchData } from "src/api";
+
+import { DurationToMomentDuration, NumberToDuration } from "../util";
+
+const TRANSACTION_DIAGNOSTICS_PATH = "_status/txndiagreports";
+const CANCEL_TRANSACTION_DIAGNOSTICS_PATH =
+  TRANSACTION_DIAGNOSTICS_PATH + "/cancel";
+
+export type TransactionDiagnosticsReport = {
+  id: string;
+  transaction_fingerprint: string;
+  transaction_fingerprint_id: bigint;
+  statement_fingerprint_ids: Uint8Array[];
+  completed: boolean;
+  transaction_diagnostics_id?: string;
+  requested_at: moment.Moment;
+  min_execution_latency?: moment.Duration;
+  expires_at?: moment.Moment;
+  sampling_probability?: number;
+  redacted: boolean;
+  username: string;
+};
+
+export type TransactionDiagnosticsResponse = TransactionDiagnosticsReport[];
+
+export async function getTransactionDiagnosticsReports(): Promise<TransactionDiagnosticsResponse> {
+  const response = await fetchData(
+    cockroach.server.serverpb.TransactionDiagnosticsReportsResponse,
+    TRANSACTION_DIAGNOSTICS_PATH,
+  );
+  return response.reports.map(report => {
+    const minExecutionLatency = report.min_execution_latency
+      ? DurationToMomentDuration(report.min_execution_latency)
+      : null;
+    let txnId = BigInt(0);
+    if (
+      report.transaction_fingerprint_id &&
+      report.transaction_fingerprint_id.length >= 8
+    ) {
+      // Note: the probuf code constructs the Uint8Array fingeprint
+      // using a shared underlying buffer so we need to use its
+      // specific offset when decoding the Uint64 within.
+      const dv = new DataView(report.transaction_fingerprint_id.buffer);
+      txnId = dv.getBigUint64(report.transaction_fingerprint_id.byteOffset);
+    }
+    return {
+      id: report.id.toString(),
+      transaction_fingerprint: report.transaction_fingerprint,
+      transaction_fingerprint_id: txnId,
+      statement_fingerprint_ids: report.statement_fingerprint_ids,
+      completed: report.completed,
+      transaction_diagnostics_id: report.transaction_diagnostics_id?.toString(),
+      requested_at: moment.unix(report.requested_at?.seconds.toNumber()),
+      min_execution_latency: minExecutionLatency,
+      expires_at: moment.unix(report.expires_at?.seconds.toNumber()),
+      sampling_probability: report.sampling_probability,
+      redacted: report.redacted,
+      username: report.username,
+    };
+  });
+}
+
+export type InsertTxnDiagnosticRequest = {
+  transactionFingerprintId: Uint8Array;
+  statementFingerprintIds: Uint8Array[];
+  samplingProbability?: number;
+  minExecutionLatencySeconds?: number;
+  expiresAfterSeconds?: number;
+  redacted: boolean;
+};
+
+export type InsertTxnDiagnosticResponse = {
+  req_resp: boolean;
+};
+
+export async function createTransactionDiagnosticsReport(
+  req: InsertTxnDiagnosticRequest,
+): Promise<InsertTxnDiagnosticResponse> {
+  return fetchData(
+    cockroach.server.serverpb.CreateTransactionDiagnosticsReportResponse,
+    TRANSACTION_DIAGNOSTICS_PATH,
+    cockroach.server.serverpb.CreateTransactionDiagnosticsReportRequest,
+    new cockroach.server.serverpb.CreateTransactionDiagnosticsReportRequest({
+      transaction_fingerprint_id: req.transactionFingerprintId,
+      statement_fingerprint_ids: req.statementFingerprintIds,
+      sampling_probability: req.samplingProbability,
+      min_execution_latency: NumberToDuration(req.minExecutionLatencySeconds),
+      expires_at: NumberToDuration(req.expiresAfterSeconds),
+      redacted: req.redacted,
+    }),
+  ).then(response => {
+    return {
+      req_resp: response.report !== null,
+    };
+  });
+}
+
+export type CancelTxnDiagnosticRequest = {
+  requestId: string;
+};
+
+export type CancelTxnDiagnosticResponse = {
+  txn_diag_req_id: string;
+};
+
+export async function cancelTransactionDiagnosticsReport(
+  req: CancelTxnDiagnosticRequest,
+): Promise<CancelTxnDiagnosticResponse> {
+  return fetchData(
+    cockroach.server.serverpb.CancelTransactionDiagnosticsReportResponse,
+    CANCEL_TRANSACTION_DIAGNOSTICS_PATH,
+    cockroach.server.serverpb.CancelTransactionDiagnosticsReportRequest,
+    new cockroach.server.serverpb.CancelTransactionDiagnosticsReportRequest({
+      request_id: Long.fromString(req.requestId),
+    }),
+  ).then(response => {
+    if (response.error) {
+      throw new Error(response.error);
+    }
+    return {
+      txn_diag_req_id: req.requestId,
+    };
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsUtils.ts
@@ -10,9 +10,9 @@ import { TimeScale, toDateRange } from "src/timeScaleDropdown";
 
 import { StatementDiagnosticsReport } from "../../api";
 
-export function getDiagnosticsStatus(
-  diagnosticsRequest: StatementDiagnosticsReport,
-): DiagnosticStatuses {
+export function getDiagnosticsStatus(diagnosticsRequest: {
+  completed: boolean;
+}): DiagnosticStatuses {
   if (diagnosticsRequest.completed) {
     return "READY";
   }

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -72,6 +72,7 @@
     "redux-saga": "^1.1.3",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
+    "swr": "2.2.5",
     "uplot": "^1.6.19",
     "whatwg-fetch": "^2.0.3"
   },

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -66,6 +66,7 @@ import { ConnectedDecommissionedNodeHistory } from "src/views/reports";
 import Certificates from "src/views/reports/containers/certificates";
 import CustomChart from "src/views/reports/containers/customChart";
 import Debug from "src/views/reports/containers/debug";
+import DiagnosticsHistoryPage from "src/views/reports/containers/diagnosticsHistoryPage";
 import EnqueueRange from "src/views/reports/containers/enqueueRange";
 import HotRanges from "src/views/reports/containers/hotranges";
 import Localities from "src/views/reports/containers/localities";
@@ -75,7 +76,6 @@ import ProblemRanges from "src/views/reports/containers/problemRanges";
 import Range from "src/views/reports/containers/range";
 import ReduxDebug from "src/views/reports/containers/redux";
 import Settings from "src/views/reports/containers/settings";
-import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import Stores from "src/views/reports/containers/stores";
 import ScheduleDetails from "src/views/schedules/scheduleDetails";
 import SchedulesPage from "src/views/schedules/schedulesPage";
@@ -467,8 +467,14 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                         />
                         <Route
                           exact
-                          path={`/reports/statements/diagnosticshistory`}
-                          component={StatementsDiagnosticsHistoryView}
+                          path={`/reports/diagnosticshistory`}
+                          component={DiagnosticsHistoryPage}
+                        />
+                        {/* Redirect old statement diagnostics route to new tabbed page */}
+                        <Redirect
+                          exact
+                          from={`/reports/statements/diagnosticshistory`}
+                          to={`/reports/diagnosticshistory?tab=Statements`}
                         />
                         {/* hot ranges */}
                         <Route

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -229,9 +229,9 @@ function StatementDiagnosticsSelector(props: {
   return (
     canSeeDebugPanelLink && (
       <DebugPanelLink
-        name="Statement Diagnostics History"
-        url="#/reports/statements/diagnosticshistory"
-        note="View the history of statement diagnostics requests"
+        name="Diagnostics History"
+        url="#/reports/diagnosticshistory"
+        note="View the history of statement and transaction diagnostics requests"
       />
     )
   );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/diagnosticsHistoryPage/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/diagnosticsHistoryPage/index.spec.tsx
@@ -1,0 +1,265 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import React from "react";
+import { Router } from "react-router-dom";
+
+import DiagnosticsHistoryPage, { DiagnosticsHistoryTabType } from "./index";
+
+// Mock the child components since we're testing the page wrapper
+jest.mock("src/views/reports/containers/statementDiagnosticsHistory", () => {
+  return function MockStatementDiagnosticsHistory() {
+    return (
+      <div data-testid="statement-diagnostics-history">
+        Statement Diagnostics History View
+      </div>
+    );
+  };
+});
+
+jest.mock("src/views/reports/containers/transactionDiagnosticsHistory", () => {
+  return function MockTransactionDiagnosticsHistory() {
+    return (
+      <div data-testid="transaction-diagnostics-history">
+        Transaction Diagnostics History View
+      </div>
+    );
+  };
+});
+
+describe("DiagnosticsHistoryPage", () => {
+  const createHistory = (search = "") => {
+    return createMemoryHistory({
+      initialEntries: [`/diagnostics-history${search}`],
+    });
+  };
+
+  const renderComponent = (history = createHistory()) => {
+    const mockProps = {
+      match: {
+        params: {},
+        isExact: true,
+        path: "/diagnostics-history",
+        url: "/diagnostics-history",
+      },
+      location: history.location,
+      history,
+    };
+
+    return render(
+      <Router history={history}>
+        <DiagnosticsHistoryPage {...mockProps} />
+      </Router>,
+    );
+  };
+
+  it("renders the page with correct heading", () => {
+    renderComponent();
+
+    expect(screen.getByText("Diagnostics History")).toBeTruthy();
+  });
+
+  it("defaults to Statements tab when no tab parameter is provided", () => {
+    renderComponent();
+
+    expect(screen.getByTestId("statement-diagnostics-history")).toBeTruthy();
+    expect(screen.queryByTestId("transaction-diagnostics-history")).toBeNull();
+  });
+
+  it("shows Statements tab when tab=Statements in URL", () => {
+    const history = createHistory("?tab=Statements");
+    renderComponent(history);
+
+    expect(screen.getByTestId("statement-diagnostics-history")).toBeTruthy();
+    expect(screen.queryByTestId("transaction-diagnostics-history")).toBeNull();
+  });
+
+  it("shows Transactions tab when tab=Transactions in URL", () => {
+    const history = createHistory("?tab=Transactions");
+    renderComponent(history);
+
+    expect(screen.getByTestId("transaction-diagnostics-history")).toBeTruthy();
+    expect(screen.queryByTestId("statement-diagnostics-history")).toBeNull();
+  });
+
+  it("has both tab options available", () => {
+    renderComponent();
+
+    expect(screen.getByRole("tab", { name: "Statements" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Transactions" })).toBeTruthy();
+  });
+
+  it("updates URL when tab is clicked", () => {
+    const history = createHistory();
+    renderComponent(history);
+
+    const transactionsTab = screen.getByRole("tab", { name: "Transactions" });
+    fireEvent.click(transactionsTab);
+
+    expect(history.location.search).toBe("?tab=Transactions");
+  });
+
+  it("switches content when changing tabs", async () => {
+    const history = createHistory();
+    const { rerender } = renderComponent(history);
+
+    // Initially shows Statements tab
+    expect(screen.getByTestId("statement-diagnostics-history")).toBeTruthy();
+
+    // Click Transactions tab
+    const transactionsTab = screen.getByRole("tab", { name: "Transactions" });
+    fireEvent.click(transactionsTab);
+
+    // Wait for URL to update
+    await waitFor(() => {
+      expect(history.location.search).toBe("?tab=Transactions");
+    });
+
+    // Re-render component with updated history to reflect URL change
+    const mockProps = {
+      match: {
+        params: {},
+        isExact: true,
+        path: "/diagnostics-history",
+        url: "/diagnostics-history",
+      },
+      location: history.location,
+      history,
+    };
+
+    rerender(
+      <Router history={history}>
+        <DiagnosticsHistoryPage {...mockProps} />
+      </Router>,
+    );
+
+    // Now check that the transaction tab content is visible
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("transaction-diagnostics-history"),
+      ).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("statement-diagnostics-history")).toBeNull();
+  });
+
+  it("switches back to Statements tab", async () => {
+    const history = createHistory("?tab=Transactions");
+    const { rerender } = renderComponent(history);
+
+    // Initially shows Transactions tab
+    expect(screen.getByTestId("transaction-diagnostics-history")).toBeTruthy();
+
+    // Click Statements tab
+    const statementsTab = screen.getByRole("tab", { name: "Statements" });
+    fireEvent.click(statementsTab);
+
+    // Wait for URL to update
+    await waitFor(() => {
+      expect(history.location.search).toBe("?tab=Statements");
+    });
+
+    // Re-render component with updated history
+    const mockProps = {
+      match: {
+        params: {},
+        isExact: true,
+        path: "/diagnostics-history",
+        url: "/diagnostics-history",
+      },
+      location: history.location,
+      history,
+    };
+
+    rerender(
+      <Router history={history}>
+        <DiagnosticsHistoryPage {...mockProps} />
+      </Router>,
+    );
+
+    // Now check that the statements tab content is visible
+    await waitFor(() => {
+      expect(screen.getByTestId("statement-diagnostics-history")).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("transaction-diagnostics-history")).toBeNull();
+  });
+
+  it("handles unknown tab parameter gracefully", () => {
+    const history = createHistory("?tab=UnknownTab");
+    renderComponent(history);
+
+    // Should default to Statements tab for unknown tab values
+    expect(screen.getByTestId("statement-diagnostics-history")).toBeTruthy();
+  });
+
+  it("preserves other URL parameters when changing tabs", () => {
+    const history = createHistory("?tab=Statements&other=value");
+    renderComponent(history);
+
+    const transactionsTab = screen.getByRole("tab", { name: "Transactions" });
+    fireEvent.click(transactionsTab);
+
+    expect(history.location.search).toBe("?tab=Transactions");
+  });
+
+  it("uses correct default tab constant", () => {
+    expect(DiagnosticsHistoryPage.defaultProps).toBeUndefined();
+    // The default is defined in the component logic, not as defaultProps
+    renderComponent();
+
+    // Verify the default behavior
+    expect(screen.getByTestId("statement-diagnostics-history")).toBeTruthy();
+  });
+
+  it("tab types are correctly defined", () => {
+    expect(DiagnosticsHistoryTabType.Statements).toBe("Statements");
+    expect(DiagnosticsHistoryTabType.Transactions).toBe("Transactions");
+  });
+
+  it("has destroyInactiveTabPane enabled", async () => {
+    const history = createHistory();
+    const { rerender } = renderComponent(history);
+
+    // Switch to Transactions tab
+    const transactionsTab = screen.getByRole("tab", { name: "Transactions" });
+    fireEvent.click(transactionsTab);
+
+    // Wait for URL to update
+    await waitFor(() => {
+      expect(history.location.search).toBe("?tab=Transactions");
+    });
+
+    // Re-render component with updated history
+    const mockProps = {
+      match: {
+        params: {},
+        isExact: true,
+        path: "/diagnostics-history",
+        url: "/diagnostics-history",
+      },
+      location: history.location,
+      history,
+    };
+
+    rerender(
+      <Router history={history}>
+        <DiagnosticsHistoryPage {...mockProps} />
+      </Router>,
+    );
+
+    // Wait for the tab content to update
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("transaction-diagnostics-history"),
+      ).toBeTruthy();
+    });
+
+    // Statements tab content should not be in DOM (due to destroyInactiveTabPane)
+    expect(screen.queryByTestId("statement-diagnostics-history")).toBeNull();
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/diagnosticsHistoryPage/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/diagnosticsHistoryPage/index.tsx
@@ -1,0 +1,70 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { commonStyles, util } from "@cockroachlabs/cluster-ui";
+import { Tabs } from "antd";
+import React from "react";
+import Helmet from "react-helmet";
+import { RouteComponentProps } from "react-router-dom";
+
+import { tabAttr } from "src/util/constants";
+import StatementDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
+import TransactionDiagnosticsHistoryView from "src/views/reports/containers/transactionDiagnosticsHistory";
+
+import type { TabsProps } from "antd";
+
+export enum DiagnosticsHistoryTabType {
+  Statements = "Statements",
+  Transactions = "Transactions",
+}
+
+export const DIAGNOSTICS_HISTORY_DEFAULT_TAB: DiagnosticsHistoryTabType =
+  DiagnosticsHistoryTabType.Statements;
+
+const DiagnosticsHistoryPage: React.FC<RouteComponentProps> = props => {
+  const tabFromUrl = util.queryByName(props.location, tabAttr);
+  const currentTab = Object.values(DiagnosticsHistoryTabType).includes(
+    tabFromUrl as DiagnosticsHistoryTabType,
+  )
+    ? (tabFromUrl as DiagnosticsHistoryTabType)
+    : DiagnosticsHistoryTabType.Statements;
+
+  const onTabChange = (tabId: string): void => {
+    const params = new URLSearchParams({ tab: tabId });
+    props.history.replace({
+      search: params.toString(),
+    });
+  };
+
+  const tabItems: TabsProps["items"] = [
+    {
+      key: DiagnosticsHistoryTabType.Statements,
+      label: "Statements",
+      children: <StatementDiagnosticsHistoryView />,
+    },
+    {
+      key: DiagnosticsHistoryTabType.Transactions,
+      label: "Transactions",
+      children: <TransactionDiagnosticsHistoryView />,
+    },
+  ];
+
+  return (
+    <div>
+      <Helmet title="Diagnostics history | Debug" />
+      <h3 className={commonStyles("base-heading")}>Diagnostics History</h3>
+      <Tabs
+        defaultActiveKey={DIAGNOSTICS_HISTORY_DEFAULT_TAB}
+        className={commonStyles("cockroach--tabs")}
+        onChange={onTabChange}
+        activeKey={currentTab}
+        destroyInactiveTabPane
+        items={tabItems}
+      />
+    </div>
+  );
+};
+
+export default DiagnosticsHistoryPage;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.spec.tsx
@@ -1,0 +1,172 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
+import { render, screen } from "@testing-library/react";
+import Long from "long";
+import moment from "moment-timezone";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import { StatementDiagnosticsHistoryView } from "./index";
+
+describe("StatementDiagnosticsHistoryView", () => {
+  const createMockReport = (
+    overrides: Partial<clusterUiApi.StatementDiagnosticsReport> = {},
+  ): clusterUiApi.StatementDiagnosticsReport => ({
+    id: "1",
+    statement_fingerprint: "SELECT * FROM table",
+    completed: false,
+    statement_diagnostics_id: "diag-1",
+    requested_at: moment("2023-01-01T10:00:00Z"),
+    min_execution_latency: moment.duration(100, "milliseconds"),
+    expires_at: moment("2023-01-02T10:00:00Z"),
+    ...overrides,
+  });
+
+  const defaultProps = {
+    loading: false,
+    diagnosticsReports: [createMockReport()],
+    getStatementByFingerprint: jest.fn(() => ({
+      id: Long.fromString("123"),
+      key: {
+        key_data: {
+          query: "SELECT * FROM table",
+          implicit_txn: true,
+        },
+      },
+    })),
+    onCancelRequest: jest.fn(),
+    refresh: jest.fn(),
+  };
+
+  const renderComponent = (props = defaultProps) => {
+    return render(
+      <MemoryRouter>
+        <StatementDiagnosticsHistoryView {...props} />
+      </MemoryRouter>,
+    );
+  };
+
+  it("renders the component with diagnostics reports", () => {
+    renderComponent();
+
+    expect(screen.getByText("1 diagnostics bundles")).toBeTruthy();
+    expect(screen.getByText("SELECT FROM table")).toBeTruthy();
+    expect(screen.getByText("Cancel request")).toBeTruthy();
+  });
+
+  it("displays empty state when no reports", () => {
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [],
+    });
+
+    expect(screen.getByText("0 diagnostics bundles")).toBeTruthy();
+    expect(screen.getByText("No statement diagnostics to show")).toBeTruthy();
+  });
+
+  it("shows download button for completed reports", () => {
+    const completedReport = createMockReport({
+      completed: true,
+      statement_diagnostics_id: "completed-diag-1",
+    });
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [completedReport],
+    });
+
+    expect(screen.getByText("Bundle (.zip)")).toBeTruthy();
+    expect(screen.queryByText("Cancel request")).not.toBeTruthy();
+  });
+
+  it("shows cancel button for pending reports", () => {
+    const pendingReport = createMockReport({
+      completed: false,
+    });
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [pendingReport],
+    });
+
+    expect(screen.getByText("Cancel request")).toBeTruthy();
+    expect(screen.queryByText("Bundle (.zip)")).not.toBeTruthy();
+  });
+
+  it("displays proper table count for multiple reports", () => {
+    const reports = Array.from({ length: 5 }, (_, i) =>
+      createMockReport({ id: i.toString() }),
+    );
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: reports,
+    });
+
+    expect(screen.getByText("5 diagnostics bundles")).toBeTruthy();
+  });
+
+  it("renders statement as link when statement data is available", () => {
+    const mockStatement = {
+      id: Long.fromString("123"),
+      key: {
+        key_data: {
+          query: "SELECT * FROM table",
+          implicit_txn: true,
+        },
+      },
+    };
+
+    renderComponent({
+      ...defaultProps,
+      getStatementByFingerprint: jest.fn(() => mockStatement),
+    });
+
+    const linkElement = screen.getByRole("link");
+    expect(linkElement.getAttribute("href")).toBe("/statement/true/123");
+  });
+
+  it("calls onCancelRequest when cancel button is clicked", async () => {
+    const pendingReport = createMockReport({
+      completed: false,
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [pendingReport],
+    });
+
+    const cancelButton = screen.getByText("Cancel request");
+    cancelButton.click();
+
+    expect(defaultProps.onCancelRequest).toHaveBeenCalledWith({
+      ...pendingReport,
+      key: 0,
+    });
+  });
+
+  it("renders statement as text when statement data is not available", () => {
+    renderComponent({
+      ...defaultProps,
+      getStatementByFingerprint: jest.fn(() => undefined),
+    });
+
+    expect(screen.getByText("SELECT FROM table")).toBeTruthy();
+    expect(screen.queryByRole("link")).not.toBeTruthy();
+  });
+
+  it("displays proper pagination info for large datasets", () => {
+    const reports = Array.from({ length: 20 }, (_, i) =>
+      createMockReport({ id: i.toString() }),
+    );
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: reports,
+    });
+
+    expect(screen.getByText("16 of 20 diagnostics bundles")).toBeTruthy();
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -17,45 +17,71 @@ import {
   util,
   Timestamp,
 } from "@cockroachlabs/cluster-ui";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import isUndefined from "lodash/isUndefined";
 import moment from "moment-timezone";
-import React from "react";
-import { Helmet } from "react-helmet";
-import { connect } from "react-redux";
+import React, { useRef, useState, useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
+import useSWR from "swr";
 
 import { Anchor, Button, Text, TextTypes, Tooltip } from "src/components";
+import {
+  createStatementDiagnosticsAlertLocalSetting,
+  cancelStatementDiagnosticsAlertLocalSetting,
+} from "src/redux/alerts";
 import { trackCancelDiagnosticsBundleAction } from "src/redux/analyticsActions";
-import {
-  invalidateStatementDiagnosticsRequests,
-  refreshStatementDiagnosticsRequests,
-} from "src/redux/apiReducers";
-import { AdminUIState, AppDispatch } from "src/redux/state";
-import { cancelStatementDiagnosticsReportAction } from "src/redux/statements";
-import {
-  selectStatementDiagnosticsReports,
-  selectStatementByFingerprint,
-  statementDiagnosticsReportsInFlight,
-} from "src/redux/statements/statementsSelectors";
+import { AdminUIState } from "src/redux/state";
 import { trackDownloadDiagnosticsBundle } from "src/util/analytics";
 import { statementDiagnostics } from "src/util/docs";
 import { summarize } from "src/util/sql/summarize";
 import { trustIcon } from "src/util/trust";
-import HeaderSection from "src/views/shared/components/headerSection";
 
 import "./statementDiagnosticsHistoryView.styl";
 
 import DownloadIcon from "!!raw-loader!assets/download.svg";
 import EmptyTableIcon from "!!url-loader!assets/emptyState/empty-table-results.svg";
 
-type StatementDiagnosticsHistoryViewProps = MapStateToProps &
-  MapDispatchToProps;
+export type Stmt =
+  cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
-interface StatementDiagnosticsHistoryViewState {
-  sortSetting: {
-    columnTitle?: string;
-    ascending: boolean;
+const DIAGNOSTICS_REPORTS_KEY = "statement-diagnostics-reports";
+
+function useStatementDiagnosticsReports() {
+  const {
+    data,
+    error,
+    isLoading,
+    mutate: mutateDiagnostics,
+  } = useSWR(
+    DIAGNOSTICS_REPORTS_KEY,
+    () => clusterUiApi.getStatementDiagnosticsReports(),
+    {
+      // Poll every 30 seconds if there are active (non-completed) reports
+      refreshInterval: latestData => {
+        if (!latestData) return 0;
+        const hasActiveRequests = latestData.some(report => !report.completed);
+        return hasActiveRequests ? 30000 : 0;
+      },
+      revalidateOnFocus: true,
+    },
+  );
+
+  return {
+    data: data || [],
+    loading: isLoading,
+    error,
+    refresh: mutateDiagnostics,
   };
+}
+
+interface StatementDiagnosticsHistoryViewProps {
+  diagnosticsReports: clusterUiApi.StatementDiagnosticsReport[];
+  loading: boolean;
+  getStatementByFingerprint: (fingerprint: string) => Stmt | undefined;
+  onCancelRequest: (
+    report: clusterUiApi.StatementDiagnosticsReport,
+  ) => Promise<void>;
 }
 
 class StatementDiagnosticsHistoryTable extends SortedTable<clusterUiApi.StatementDiagnosticsReport> {}
@@ -85,11 +111,23 @@ const StatementColumn: React.FC<{ fingerprint: string }> = ({
   return <Text textType={TextTypes.Code}>{shortenedStatement}</Text>;
 };
 
-class StatementDiagnosticsHistoryView extends React.Component<
-  StatementDiagnosticsHistoryViewProps,
-  StatementDiagnosticsHistoryViewState
-> {
-  columns: ColumnDescriptor<clusterUiApi.StatementDiagnosticsReport>[] = [
+export const StatementDiagnosticsHistoryView: React.FC<
+  StatementDiagnosticsHistoryViewProps
+> = ({
+  diagnosticsReports,
+  loading,
+  getStatementByFingerprint,
+  onCancelRequest,
+}) => {
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    columnTitle: "activated_on",
+    ascending: false,
+  });
+
+  const downloadRef = useRef<DownloadFileRef>();
+  const tablePageSize = 16;
+
+  const columns: ColumnDescriptor<clusterUiApi.StatementDiagnosticsReport>[] = [
     {
       title: "Activated on",
       name: "activated_on",
@@ -104,7 +142,6 @@ class StatementDiagnosticsHistoryView extends React.Component<
       title: "Statement",
       name: "statement",
       cell: record => {
-        const { getStatementByFingerprint } = this.props;
         const fingerprint = record.statement_fingerprint;
         const statement = getStatementByFingerprint(fingerprint);
         const { implicit_txn: implicitTxn = "true", query } =
@@ -175,7 +212,7 @@ class StatementDiagnosticsHistoryView extends React.Component<
               size="small"
               type="secondary"
               onClick={() => {
-                this.props.onDiagnosticCancelRequest(record);
+                onCancelRequest(record);
               }}
             >
               Cancel request
@@ -186,26 +223,10 @@ class StatementDiagnosticsHistoryView extends React.Component<
     },
   ];
 
-  tablePageSize = 16;
-
-  downloadRef = React.createRef<DownloadFileRef>();
-
-  constructor(props: StatementDiagnosticsHistoryViewProps) {
-    super(props);
-    (this.state = {
-      sortSetting: {
-        columnTitle: "activated_on",
-        ascending: false,
-      },
-    }),
-      props.refresh();
-  }
-
-  renderTableTitle = () => {
-    const { diagnosticsReports } = this.props;
+  const renderTableTitle = () => {
     const totalCount = diagnosticsReports.length;
 
-    if (totalCount <= this.tablePageSize) {
+    if (totalCount <= tablePageSize) {
       return (
         <div className="diagnostics-history-view__table-header">
           <Text>{`${totalCount} diagnostics bundles`}</Text>
@@ -215,107 +236,123 @@ class StatementDiagnosticsHistoryView extends React.Component<
 
     return (
       <div className="diagnostics-history-view__table-header">
-        <Text>{`${this.tablePageSize} of ${totalCount} diagnostics bundles`}</Text>
+        <Text>{`${tablePageSize} of ${totalCount} diagnostics bundles`}</Text>
       </div>
     );
   };
 
-  changeSortSetting = (ss: SortSetting) => {
-    this.setState({
-      sortSetting: ss,
-    });
+  const changeSortSetting = (ss: SortSetting) => {
+    setSortSetting(ss);
   };
 
-  render() {
-    const { diagnosticsReports, loading } = this.props;
-    const dataSource = diagnosticsReports.map((diagnosticsReport, idx) => ({
-      ...diagnosticsReport,
-      key: idx,
-    }));
+  const dataSource = diagnosticsReports.map((diagnosticsReport, idx) => ({
+    ...diagnosticsReport,
+    key: idx,
+  }));
 
-    return (
-      <section className="section">
-        <Helmet title="Statement diagnostics history | Debug" />
-        <HeaderSection
-          title="Statement diagnostics history"
-          navigationBackConfig={{
-            text: "Advanced Debug",
-            path: "/debug",
-          }}
-        />
-        {this.renderTableTitle()}
-        <StatementDiagnosticsHistoryTable
-          className="statements-table"
-          tableWrapperClassName="sorted-table"
-          data={dataSource}
-          columns={this.columns}
-          loading={loading}
-          renderNoResult={
-            <EmptyTable
-              title="No statement diagnostics to show"
-              icon={EmptyTableIcon}
-              message={
-                "Statement diagnostics  can help when troubleshooting issues with specific queries. " +
-                "The diagnostic bundle can be activated from individual statement pages and will include EXPLAIN" +
-                " plans, table statistics, and traces."
-              }
-              footer={
-                <Anchor href={statementDiagnostics} target="_blank">
-                  Learn more about statement diagnostics
-                </Anchor>
-              }
-            />
-          }
-          sortSetting={this.state.sortSetting}
-          onChangeSortSetting={this.changeSortSetting}
-        />
-        <DownloadFile ref={this.downloadRef} />
-      </section>
-    );
-  }
-}
+  return (
+    <>
+      {renderTableTitle()}
+      <StatementDiagnosticsHistoryTable
+        className="statements-table"
+        tableWrapperClassName="sorted-table"
+        data={dataSource}
+        columns={columns}
+        loading={loading}
+        renderNoResult={
+          <EmptyTable
+            title="No statement diagnostics to show"
+            icon={EmptyTableIcon}
+            message={
+              "Statement diagnostics can help when troubleshooting issues with specific queries. " +
+              "The diagnostic bundle can be activated from individual statement pages and will include EXPLAIN" +
+              " plans, table statistics, and traces."
+            }
+            footer={
+              <Anchor href={statementDiagnostics} target="_blank">
+                Learn more about statement diagnostics
+              </Anchor>
+            }
+          />
+        }
+        sortSetting={sortSetting}
+        onChangeSortSetting={changeSortSetting}
+      />
+      <DownloadFile ref={downloadRef} />
+    </>
+  );
+};
 
-interface MapStateToProps {
-  loading: boolean;
-  diagnosticsReports: clusterUiApi.StatementDiagnosticsReport[];
-  getStatementByFingerprint: (
-    fingerprint: string,
-  ) => ReturnType<typeof selectStatementByFingerprint>;
-}
+const StatementDiagnosticsHistoryContainer: React.FC = () => {
+  const dispatch = useDispatch();
+  const {
+    data: diagnosticsReports,
+    loading,
+    refresh,
+  } = useStatementDiagnosticsReports();
 
-interface MapDispatchToProps {
-  onDiagnosticCancelRequest: (
-    report: clusterUiApi.StatementDiagnosticsReport,
-  ) => void;
-  refresh: () => void;
-}
+  const statements = useSelector(
+    (state: AdminUIState) => state.cachedData.statements.data?.statements,
+  );
 
-const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
-  loading: statementDiagnosticsReportsInFlight(state),
-  diagnosticsReports: selectStatementDiagnosticsReports(state) || [],
-  getStatementByFingerprint: (fingerprint: string) =>
-    selectStatementByFingerprint(state, fingerprint),
-});
+  const getStatementByFingerprint = useCallback(
+    (fingerprint: string): Stmt | undefined => {
+      return (statements || []).find(
+        statement => statement.key.key_data.query === fingerprint,
+      );
+    },
+    [statements],
+  );
 
-const mapDispatchToProps = (dispatch: AppDispatch): MapDispatchToProps => ({
-  onDiagnosticCancelRequest: (
-    report: clusterUiApi.StatementDiagnosticsReport,
-  ) => {
-    dispatch(cancelStatementDiagnosticsReportAction({ requestId: report.id }));
-    dispatch(trackCancelDiagnosticsBundleAction(report.statement_fingerprint));
-  },
-  refresh: () => {
-    dispatch(invalidateStatementDiagnosticsRequests());
-    dispatch(refreshStatementDiagnosticsRequests());
-  },
-});
+  const handleCancelRequest = useCallback(
+    async (report: clusterUiApi.StatementDiagnosticsReport) => {
+      try {
+        await clusterUiApi.cancelStatementDiagnosticsReport({
+          requestId: report.id,
+        });
 
-export default connect<
-  MapStateToProps,
-  MapDispatchToProps,
-  StatementDiagnosticsHistoryViewProps,
-  AdminUIState
->(
-  mapStateToProps,
-  mapDispatchToProps,
-)(StatementDiagnosticsHistoryView);
+        dispatch(
+          trackCancelDiagnosticsBundleAction(report.statement_fingerprint),
+        );
+
+        dispatch(
+          createStatementDiagnosticsAlertLocalSetting.set({
+            show: false,
+          }),
+        );
+        dispatch(
+          cancelStatementDiagnosticsAlertLocalSetting.set({
+            show: true,
+            status: "SUCCESS",
+          }),
+        );
+
+        await refresh();
+      } catch (error) {
+        dispatch(
+          createStatementDiagnosticsAlertLocalSetting.set({
+            show: false,
+          }),
+        );
+        dispatch(
+          cancelStatementDiagnosticsAlertLocalSetting.set({
+            show: true,
+            status: "FAILED",
+          }),
+        );
+      }
+    },
+    [dispatch, refresh],
+  );
+
+  return (
+    <StatementDiagnosticsHistoryView
+      diagnosticsReports={diagnosticsReports}
+      loading={loading}
+      getStatementByFingerprint={getStatementByFingerprint}
+      onCancelRequest={handleCancelRequest}
+    />
+  );
+};
+
+export default StatementDiagnosticsHistoryContainer;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/index.spec.tsx
@@ -1,0 +1,194 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
+import { render, screen } from "@testing-library/react";
+import moment from "moment-timezone";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import { TransactionDiagnosticsHistoryView } from "./index";
+
+describe("TransactionDiagnosticsHistoryView", () => {
+  const createMockReport = (
+    overrides: Partial<clusterUiApi.TransactionDiagnosticsReport> = {},
+  ): clusterUiApi.TransactionDiagnosticsReport => ({
+    id: "1",
+    transaction_fingerprint: "Transaction fingerprint",
+    transaction_fingerprint_id: BigInt("72623859790382856"),
+    statement_fingerprint_ids: [new Uint8Array([1, 2, 3])],
+    completed: false,
+    transaction_diagnostics_id: "txn-diag-1",
+    requested_at: moment("2023-01-01T10:00:00Z"),
+    min_execution_latency: moment.duration(200, "milliseconds"),
+    expires_at: moment("2023-01-02T10:00:00Z"),
+    sampling_probability: 0.1,
+    redacted: false,
+    username: "testuser",
+    ...overrides,
+  });
+
+  const defaultProps = {
+    loading: false,
+    diagnosticsReports: [createMockReport()],
+    onCancelRequest: jest.fn(),
+  };
+
+  const renderComponent = (props = defaultProps) => {
+    return render(
+      <MemoryRouter>
+        <TransactionDiagnosticsHistoryView {...props} />
+      </MemoryRouter>,
+    );
+  };
+
+  it("renders the component with diagnostics reports", () => {
+    renderComponent();
+
+    expect(screen.getByText("1 diagnostics bundles")).toBeTruthy();
+    expect(screen.getByText("Transaction fingerprint")).toBeTruthy();
+    expect(screen.getByText("Cancel request")).toBeTruthy();
+  });
+
+  it("shows loading state when loading", () => {
+    renderComponent({
+      ...defaultProps,
+      loading: true,
+    });
+
+    expect(screen.getByText("1 diagnostics bundles")).toBeTruthy();
+  });
+
+  it("displays empty state when no reports", () => {
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [],
+    });
+
+    expect(screen.getByText("0 diagnostics bundles")).toBeTruthy();
+    expect(screen.getByText("No transaction diagnostics to show")).toBeTruthy();
+    expect(
+      screen.getByText(/Transaction diagnostics can help when troubleshooting/),
+    ).toBeTruthy();
+  });
+
+  it("shows download button for completed reports", () => {
+    const completedReport = createMockReport({
+      completed: true,
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [completedReport],
+    });
+
+    expect(screen.getByText("Bundle (.zip)")).toBeTruthy();
+    expect(screen.queryByText("Cancel request")).not.toBeTruthy();
+  });
+
+  it("shows cancel button for pending reports", () => {
+    const pendingReport = createMockReport({
+      completed: false,
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [pendingReport],
+    });
+
+    expect(screen.getByText("Cancel request")).toBeTruthy();
+    expect(screen.queryByText("Bundle (.zip)")).not.toBeTruthy();
+  });
+
+  it("displays proper table count for multiple reports", () => {
+    const reports = Array.from({ length: 5 }, (_, i) =>
+      createMockReport({ id: i.toString() }),
+    );
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: reports,
+    });
+
+    expect(screen.getByText("5 diagnostics bundles")).toBeTruthy();
+  });
+
+  it("renders transaction as link when fingerprint ID is available", () => {
+    const report = createMockReport({
+      transaction_fingerprint_id: BigInt("72623859790382856"),
+      transaction_fingerprint: "Test transaction",
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [report],
+    });
+
+    const linkElement = screen.getByRole("link");
+    expect(linkElement.getAttribute("href")).toBe(
+      "/transaction/72623859790382856",
+    );
+  });
+
+  it("handles missing transaction fingerprint gracefully", () => {
+    const reportWithoutFingerprint = createMockReport({
+      transaction_fingerprint: "",
+      transaction_fingerprint_id: BigInt("72623859790382856"),
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [reportWithoutFingerprint],
+    });
+
+    expect(screen.getByText("Transaction 72623859790382856")).toBeTruthy();
+  });
+
+  it("handles missing transaction fingerprint ID gracefully", () => {
+    const reportWithoutFingerprintId = createMockReport({
+      transaction_fingerprint: "Test transaction",
+      transaction_fingerprint_id: BigInt(0),
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [reportWithoutFingerprintId],
+    });
+
+    expect(screen.getByText("Test transaction")).toBeTruthy();
+  });
+
+  it("calls onCancelRequest when cancel button is clicked", () => {
+    const pendingReport = createMockReport({
+      completed: false,
+    });
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: [pendingReport],
+    });
+
+    const cancelButton = screen.getByText("Cancel request");
+    cancelButton.click();
+
+    expect(defaultProps.onCancelRequest).toHaveBeenCalledWith({
+      ...pendingReport,
+      key: 0,
+    });
+  });
+
+  it("displays proper pagination info for large datasets", () => {
+    const reports = Array.from({ length: 20 }, (_, i) =>
+      createMockReport({ id: i.toString() }),
+    );
+
+    renderComponent({
+      ...defaultProps,
+      diagnosticsReports: reports,
+    });
+
+    expect(screen.getByText("16 of 20 diagnostics bundles")).toBeTruthy();
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/index.tsx
@@ -1,0 +1,331 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import {
+  api as clusterUiApi,
+  DownloadFile,
+  DownloadFileRef,
+  EmptyTable,
+  getDiagnosticsStatus,
+  DiagnosticStatusBadge,
+  SortedTable,
+  SortSetting,
+  ColumnDescriptor,
+  util,
+  Timestamp,
+} from "@cockroachlabs/cluster-ui";
+import moment from "moment-timezone";
+import React, { useRef, useState, useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
+import useSWR from "swr";
+
+import { Anchor, Button, Text, TextTypes, Tooltip } from "src/components";
+import {
+  createStatementDiagnosticsAlertLocalSetting,
+  cancelStatementDiagnosticsAlertLocalSetting,
+} from "src/redux/alerts";
+import { trackCancelDiagnosticsBundleAction } from "src/redux/analyticsActions";
+import { trackDownloadDiagnosticsBundle } from "src/util/analytics";
+import { statementDiagnostics } from "src/util/docs";
+import { trustIcon } from "src/util/trust";
+
+import "./transactionDiagnosticsHistoryView.styl";
+
+import DownloadIcon from "!!raw-loader!assets/download.svg";
+import EmptyTableIcon from "!!url-loader!assets/emptyState/empty-table-results.svg";
+
+const TRANSACTION_DIAGNOSTICS_REPORTS_KEY = "transaction-diagnostics-reports";
+
+function useTransactionDiagnosticsReports() {
+  const {
+    data,
+    error,
+    isLoading,
+    mutate: mutateDiagnostics,
+  } = useSWR(
+    TRANSACTION_DIAGNOSTICS_REPORTS_KEY,
+    () => clusterUiApi.getTransactionDiagnosticsReports(),
+    {
+      // Poll every 30 seconds if there are active (non-completed) reports
+      refreshInterval: latestData => {
+        if (!latestData) return 0;
+        const hasActiveRequests = latestData.some(report => !report.completed);
+        return hasActiveRequests ? 30000 : 0;
+      },
+      revalidateOnFocus: true,
+    },
+  );
+
+  return {
+    data: data || [],
+    loading: isLoading,
+    error,
+    refresh: mutateDiagnostics,
+  };
+}
+
+interface TransactionDiagnosticsHistoryViewProps {
+  diagnosticsReports: clusterUiApi.TransactionDiagnosticsReport[];
+  loading: boolean;
+  onCancelRequest: (
+    report: clusterUiApi.TransactionDiagnosticsReport,
+  ) => Promise<void>;
+}
+
+class TransactionDiagnosticsHistoryTable extends SortedTable<clusterUiApi.TransactionDiagnosticsReport> {}
+
+const TransactionColumn: React.FC<{ fingerprint: string }> = ({
+  fingerprint,
+}) => {
+  const shortenedFingerprint =
+    fingerprint.length > 50
+      ? `${fingerprint.substring(0, 47)}...`
+      : fingerprint;
+  const showTooltip = fingerprint !== shortenedFingerprint;
+
+  if (showTooltip) {
+    return (
+      <Text textType={TextTypes.Code}>
+        <Tooltip
+          placement="bottom"
+          title={
+            <pre className="cl-table-link__description">{fingerprint}</pre>
+          }
+          overlayClassName="cl-table-link__statement-tooltip--fixed-width"
+        >
+          {shortenedFingerprint}
+        </Tooltip>
+      </Text>
+    );
+  }
+  return <Text textType={TextTypes.Code}>{shortenedFingerprint}</Text>;
+};
+
+export const TransactionDiagnosticsHistoryView: React.FC<
+  TransactionDiagnosticsHistoryViewProps
+> = ({ diagnosticsReports, loading, onCancelRequest }) => {
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    columnTitle: "activated_on",
+    ascending: false,
+  });
+
+  const downloadRef = useRef<DownloadFileRef>();
+  const tablePageSize = 16;
+
+  const columns: ColumnDescriptor<clusterUiApi.TransactionDiagnosticsReport>[] =
+    [
+      {
+        title: "Activated on",
+        name: "activated_on",
+        cell: record => (
+          <Timestamp
+            time={record.requested_at}
+            format={util.DATE_FORMAT_24_TZ}
+          />
+        ),
+        sort: record => {
+          return moment.utc(record.requested_at).unix();
+        },
+      },
+      {
+        title: "Transaction",
+        name: "transaction",
+        cell: record => {
+          const displayText =
+            record.transaction_fingerprint ||
+            `Transaction ${record.transaction_fingerprint_id}`;
+
+          const transactionLink = `/transaction/${record.transaction_fingerprint_id}`;
+
+          return (
+            <Link
+              to={transactionLink}
+              className="crl-statements-diagnostics-view__statements-link"
+            >
+              <TransactionColumn fingerprint={displayText} />
+            </Link>
+          );
+        },
+        sort: record => record.transaction_fingerprint_id.toString(),
+      },
+      {
+        title: "Status",
+        name: "status",
+        sort: record => `${record.completed}`,
+        cell: record => (
+          <Text>
+            <DiagnosticStatusBadge status={getDiagnosticsStatus(record)} />
+          </Text>
+        ),
+      },
+      {
+        title: "",
+        name: "actions",
+        cell: record => {
+          if (record.completed) {
+            return (
+              <div className="crl-statements-diagnostics-view__actions-column cell--show-on-hover nodes-table__link">
+                <a
+                  href={`_admin/v1/txnbundle/${record.transaction_diagnostics_id}`}
+                  onClick={() =>
+                    trackDownloadDiagnosticsBundle(
+                      record.transaction_fingerprint,
+                    )
+                  }
+                >
+                  <Button
+                    size="small"
+                    type="flat"
+                    iconPosition="left"
+                    icon={() => (
+                      <span
+                        className="crl-statements-diagnostics-view__icon"
+                        dangerouslySetInnerHTML={trustIcon(DownloadIcon)}
+                      />
+                    )}
+                  >
+                    Bundle (.zip)
+                  </Button>
+                </a>
+              </div>
+            );
+          }
+          return (
+            <div className="crl-statements-diagnostics-view__actions-column cell--show-on-hover nodes-table__link">
+              <Button
+                size="small"
+                type="secondary"
+                onClick={() => {
+                  onCancelRequest(record);
+                }}
+              >
+                Cancel request
+              </Button>
+            </div>
+          );
+        },
+      },
+    ];
+
+  const renderTableTitle = () => {
+    const totalCount = diagnosticsReports.length;
+
+    if (totalCount <= tablePageSize) {
+      return (
+        <div className="diagnostics-history-view__table-header">
+          <Text>{`${totalCount} diagnostics bundles`}</Text>
+        </div>
+      );
+    }
+
+    return (
+      <div className="diagnostics-history-view__table-header">
+        <Text>{`${tablePageSize} of ${totalCount} diagnostics bundles`}</Text>
+      </div>
+    );
+  };
+
+  const changeSortSetting = (ss: SortSetting) => {
+    setSortSetting(ss);
+  };
+
+  const dataSource = diagnosticsReports.map((diagnosticsReport, idx) => ({
+    ...diagnosticsReport,
+    key: idx,
+  }));
+
+  return (
+    <>
+      {renderTableTitle()}
+      <TransactionDiagnosticsHistoryTable
+        className="statements-table"
+        tableWrapperClassName="sorted-table"
+        data={dataSource}
+        columns={columns}
+        loading={loading}
+        renderNoResult={
+          <EmptyTable
+            title="No transaction diagnostics to show"
+            icon={EmptyTableIcon}
+            message={
+              "Transaction diagnostics can help when troubleshooting issues with specific transactions. " +
+              "The diagnostic bundle can be activated from individual transaction pages and will include EXPLAIN" +
+              " plans, table statistics, and traces for all statements in the transaction."
+            }
+            footer={
+              <Anchor href={statementDiagnostics} target="_blank">
+                Learn more about transaction diagnostics
+              </Anchor>
+            }
+          />
+        }
+        sortSetting={sortSetting}
+        onChangeSortSetting={changeSortSetting}
+      />
+      <DownloadFile ref={downloadRef} />
+    </>
+  );
+};
+
+const TransactionDiagnosticsHistoryContainer: React.FC = () => {
+  const dispatch = useDispatch();
+  const {
+    data: diagnosticsReports,
+    loading,
+    refresh,
+  } = useTransactionDiagnosticsReports();
+
+  const handleCancelRequest = useCallback(
+    async (report: clusterUiApi.TransactionDiagnosticsReport) => {
+      try {
+        await clusterUiApi.cancelTransactionDiagnosticsReport({
+          requestId: report.id,
+        });
+
+        dispatch(
+          trackCancelDiagnosticsBundleAction(report.transaction_fingerprint),
+        );
+
+        dispatch(
+          createStatementDiagnosticsAlertLocalSetting.set({
+            show: false,
+          }),
+        );
+        dispatch(
+          cancelStatementDiagnosticsAlertLocalSetting.set({
+            show: true,
+            status: "SUCCESS",
+          }),
+        );
+
+        await refresh();
+      } catch (error) {
+        dispatch(
+          createStatementDiagnosticsAlertLocalSetting.set({
+            show: false,
+          }),
+        );
+        dispatch(
+          cancelStatementDiagnosticsAlertLocalSetting.set({
+            show: true,
+            status: "FAILED",
+          }),
+        );
+      }
+    },
+    [dispatch, refresh],
+  );
+
+  return (
+    <TransactionDiagnosticsHistoryView
+      diagnosticsReports={diagnosticsReports}
+      loading={loading}
+      onCancelRequest={handleCancelRequest}
+    />
+  );
+};
+
+export default TransactionDiagnosticsHistoryContainer;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/transactionDiagnosticsHistoryView.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/transactionDiagnosticsHistory/transactionDiagnosticsHistoryView.styl
@@ -1,0 +1,22 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+@require '~src/components/core/index.styl'
+
+.diagnostics-history-view
+  &__table-container
+    background $colors--white
+    padding $spacing-medium-small
+
+  & .crl-table-wrapper .sort-table__row:hover .nodes-table__link
+    color $colors--primary-blue-3
+    text-decoration underline
+
+  &__table-header
+    margin-top: $spacing-medium-small
+    margin-bottom $spacing-x-small
+
+.sorted-table
+  width 100%


### PR DESCRIPTION
This change introduces a transaction diagnostics request page that
lists oustanding and completed requests along with the transaction IDs
or fingerprints. If the bundle has not yet been captured, we can only
show the transactionId, otherwise we'll have the fingeprint available
to display as well. In both cases, the ID or fingerprint will link to
the corresponding SQL Activity page for that Transaction.

Resolves: [CRDB-53543](https://cockroachlabs.atlassian.net/browse/CRDB-53543)
Epic: [CRDB-53541](https://cockroachlabs.atlassian.net/browse/CRDB-53541)
Release note (db console change): The statement diagnostics page in
Advanced Debug now also displays any active transaction diagnostics
requests in a separate tab