### PR TITLE
stmtdiagnostics: add 25.4 version gate to txn diagnostics polling

### DIFF
--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/multitenant",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/stmtdiagnostics/txn_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/txn_diagnostics.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -541,6 +542,10 @@ func (r *TxnRegistry) findTxnRequestLocked(requestID RequestID) bool {
 // pollTxnRequests reads the pending rows from system.transaction_diagnostics_requests and
 // updates r.mu.requests accordingly.
 func (r *TxnRegistry) pollTxnRequests(ctx context.Context) error {
+	if !r.st.Version.IsActive(ctx, clusterversion.V25_4) {
+		return nil
+	}
+
 	var rows []tree.Datums
 
 	// Loop until we run the query without straddling an epoch increment.


### PR DESCRIPTION
Adds a version gate to the TxnRegistry.pollTxnRequests to return early if v25.4 is not active. This will ensure that the `system.transaction_diagnostics_requests` table exists before try to query it.

Epic: None
Release note: None