### PR TITLE
errorutil: add benchmark for errors.Is

### DIFF
--- a/pkg/util/errorutil/error_test.go
+++ b/pkg/util/errorutil/error_test.go
@@ -6,9 +6,13 @@
 package errorutil
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
+
+	"github.com/cockroachdb/errors"
 )
 
 // Renumber lines so they're stable no matter what changes above. (We
@@ -38,4 +42,168 @@ func TestUnexpectedWithIssueErrorf(t *testing.T) {
 	if !strings.Contains(safeMsg, exp) {
 		t.Errorf("expected substring in error\n%s\ngot:\n%s", exp, safeMsg)
 	}
+}
+
+func BenchmarkErrorsIs(b *testing.B) {
+	b.Run("SimpleError", func(b *testing.B) {
+		err := errors.New("test")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("WrappedError", func(b *testing.B) {
+		baseErr := errors.New("test")
+		err := errors.Wrap(baseErr, "wrapped error")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("WrappedWithStack", func(b *testing.B) {
+		baseErr := errors.New("test")
+		err := errors.WithStack(baseErr)
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("NetworkError", func(b *testing.B) {
+		netErr := &net.OpError{
+			Op:   "dial",
+			Net:  "tcp",
+			Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 26257},
+			Err:  fmt.Errorf("connection refused"),
+		}
+		err := errors.Wrap(netErr, "network connection failed")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("DeeplyWrappedNetworkError", func(b *testing.B) {
+		netErr := &net.OpError{
+			Op:   "dial",
+			Net:  "tcp",
+			Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 26257},
+			Err:  fmt.Errorf("connection refused"),
+		}
+		err := errors.WithStack(netErr)
+		err = errors.Wrap(err, "failed to connect to database")
+		err = errors.Wrap(err, "unable to establish connection")
+		err = errors.WithStack(err)
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("MultipleWrappedErrors", func(b *testing.B) {
+		baseErr := errors.New("internal error")
+		err := errors.WithStack(baseErr)
+		err = errors.Wrap(err, "operation failed")
+		err = errors.WithStack(err)
+		err = errors.Wrap(err, "transaction failed")
+		err = errors.WithStack(err)
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("NetworkErrorWithLongAddress", func(b *testing.B) {
+		netErr := &net.OpError{
+			Op:  "read",
+			Net: "tcp",
+			Addr: &net.TCPAddr{
+				IP:   net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+				Port: 26257,
+			},
+			Err: fmt.Errorf("i/o timeout"),
+		}
+		err := errors.WithStack(netErr)
+		err = errors.Wrap(err, "failed to read from connection")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("WithMessage", func(b *testing.B) {
+		baseErr := errors.New("test")
+		err := errors.WithMessage(baseErr, "additional context")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("MultipleWithMessage", func(b *testing.B) {
+		baseErr := errors.New("internal error")
+		err := errors.WithMessage(baseErr, "first message")
+		err = errors.WithMessage(err, "second message")
+		err = errors.WithMessage(err, "third message")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("WithMessageAndStack", func(b *testing.B) {
+		baseErr := errors.New("test")
+		err := errors.WithStack(baseErr)
+		err = errors.WithMessage(err, "operation context")
+		err = errors.WithStack(err)
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("NetworkErrorWithMessage", func(b *testing.B) {
+		netErr := &net.OpError{
+			Op:   "dial",
+			Net:  "tcp",
+			Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 26257},
+			Err:  fmt.Errorf("connection refused"),
+		}
+		err := errors.WithMessage(netErr, "database connection failed")
+		err = errors.WithMessage(err, "unable to reach server")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("NetworkErrorWithEverything", func(b *testing.B) {
+		netErr := &net.OpError{
+			Op:   "dial",
+			Net:  "tcp",
+			Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 26257},
+			Err:  fmt.Errorf("connection refused"),
+		}
+		err := errors.WithStack(netErr)
+		err = errors.WithMessage(err, "database connection failed")
+		err = errors.Wrap(err, "failed to establish TCP connection")
+		err = errors.WithStack(err)
+		err = errors.WithMessage(err, "unable to reach CockroachDB server")
+		err = errors.Wrap(err, "connection attempt failed")
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
+
+	b.Run("DeeplyNested100Levels", func(b *testing.B) {
+		baseErr := errors.New("base error")
+		err := baseErr
+
+		// Create a 100-level deep error chain
+		for i := 0; i < 100; i++ {
+			switch i % 3 {
+			case 0:
+				err = errors.Wrap(err, fmt.Sprintf("wrap level %d", i))
+			case 1:
+				err = errors.WithMessage(err, fmt.Sprintf("message level %d", i))
+			case 2:
+				err = errors.WithStack(err)
+			}
+		}
+
+		for range b.N {
+			errors.Is(err, context.Canceled)
+		}
+	})
 }


### PR DESCRIPTION
This is to help debug an expensive error handling call path that was seen in a profile.

```
goos: darwin
goarch: arm64
cpu: Apple M1 Pro
=== RUN   BenchmarkErrorsIs
BenchmarkErrorsIs
=== RUN   BenchmarkErrorsIs/SimpleError
BenchmarkErrorsIs/SimpleError
BenchmarkErrorsIs/SimpleError         	 1618170	       716.0 ns/op	     448 B/op	      14 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/WrappedError
BenchmarkErrorsIs/WrappedError
BenchmarkErrorsIs/WrappedError        	  300048	      4009 ns/op	    3344 B/op	      67 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/WrappedWithStack
BenchmarkErrorsIs/WrappedWithStack
BenchmarkErrorsIs/WrappedWithStack    	  941736	      1179 ns/op	     896 B/op	      23 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/NetworkError
BenchmarkErrorsIs/NetworkError
BenchmarkErrorsIs/NetworkError        	  414190	      2790 ns/op	    1768 B/op	      52 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/DeeplyWrappedNetworkError
BenchmarkErrorsIs/DeeplyWrappedNetworkError
BenchmarkErrorsIs/DeeplyWrappedNetworkError         	   44353	     27774 ns/op	   23419 B/op	     381 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/MultipleWrappedErrors
BenchmarkErrorsIs/MultipleWrappedErrors
BenchmarkErrorsIs/MultipleWrappedErrors             	   65017	     18352 ns/op	   20259 B/op	     275 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/NetworkErrorWithLongAddress
BenchmarkErrorsIs/NetworkErrorWithLongAddress
BenchmarkErrorsIs/NetworkErrorWithLongAddress       	  111456	     10746 ns/op	    8145 B/op	     150 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/WithMessage
BenchmarkErrorsIs/WithMessage
BenchmarkErrorsIs/WithMessage                       	  520652	      2595 ns/op	    1880 B/op	      40 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/MultipleWithMessage
BenchmarkErrorsIs/MultipleWithMessage
BenchmarkErrorsIs/MultipleWithMessage               	  107244	      9438 ns/op	    6929 B/op	     122 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/WithMessageAndStack
BenchmarkErrorsIs/WithMessageAndStack
BenchmarkErrorsIs/WithMessageAndStack               	  215155	      5640 ns/op	    5296 B/op	      87 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/NetworkErrorWithMessage
BenchmarkErrorsIs/NetworkErrorWithMessage
BenchmarkErrorsIs/NetworkErrorWithMessage           	  184285	      6572 ns/op	    4648 B/op	      99 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/NetworkErrorWithEverything
BenchmarkErrorsIs/NetworkErrorWithEverything
BenchmarkErrorsIs/NetworkErrorWithEverything        	   25274	     46921 ns/op	   35885 B/op	     594 allocs/op
=== NAME
=== RUN   BenchmarkErrorsIs/DeeplyNested100Levels
BenchmarkErrorsIs/DeeplyNested100Levels
BenchmarkErrorsIs/DeeplyNested100Levels             	     256	   4702923 ns/op	 5931739 B/op	   62712 allocs/op
=== NAME
```

informs: #153772
Release note: None