### PR TITLE
ui: fix diagnostics expires after input validation

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
@@ -293,8 +293,11 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef<
               disabled={!expires}
               value={expiresAfter}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                if (parseInt(e.target.value) > 0) {
-                  setExpiresAfter(parseInt(e.target.value));
+                const expires = parseInt(e.target.value);
+                if (!isNaN(expires) && expires > -1) {
+                  setExpiresAfter(expires);
+                } else {
+                  setExpiresAfter(0);
                 }
               }}
               rootClassName={cx("compact")}


### PR DESCRIPTION
currently the field for expires_after does not allow full deletion of the inputted number, leading to a poor experience

this is changed by allowing full deletions, while maintaining sanitation for integrity of integer outputs

demo: https://github.com/user-attachments/assets/3a98554b-6d02-44ce-8019-796f3c7a7339

Epic: None
Release note: None