### PR TITLE
release-25.4: sql: disable create_table_with_schema_locked by default

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -793,7 +793,7 @@ var CreateTableWithSchemaLocked = settings.RegisterBoolSetting(
 	"default value for create_table_with_schema_locked; "+
 		"default value for the create_table_with_schema_locked session setting; controls "+
 		"if new created tables will have schema_locked set",
-	true)
+	buildutil.CrdbTestBuild || buildutil.CrdbBenchBuild)
 
 // createTableWithSchemaLockedDefault override for the schema_locked
 var createTableWithSchemaLockedDefault = true


### PR DESCRIPTION
Previously, create_table_with_schema_locked was enabled by default in both tests and builds of CRDB. This patch disables it by default outside of tests.

Fixes: #152991

Release note: None
Release justification: low risk change reverting behaviour for create table to match 25.3