### PR TITLE
retry: deflake TestRetryWithMaxDurationAndMaxRetries

### DIFF
--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -566,7 +566,7 @@ func TestRetryWithMaxDurationAndMaxRetries(t *testing.T) {
 			InitialBackoff: time.Millisecond,
 			MaxBackoff:     time.Millisecond * 20,
 			Multiplier:     2,
-			MaxDuration:    time.Millisecond * 50,
+			MaxDuration:    time.Second,
 			MaxRetries:     3,
 		}
 


### PR DESCRIPTION
Previously, the time bound for the retry test was quite small. So an overloaded or slow test runner may hit the timeout before the goroutine was scheduled for max retries.

Fixes: #154160
Release note: none