### PR TITLE
release-25.4: changefeedccl: remove shared PTS record for non-lagging tables

### DIFF
--- a/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
+++ b/pkg/ccl/changefeedccl/cdcprogresspb/progress.proto
@@ -13,6 +13,7 @@ import "gogoproto/gogo.proto";
 message ProtectedTimestampRecords {
   map<uint32, bytes> protected_timestamp_records = 1 [
     (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID",
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
+    (gogoproto.nullable) = false
   ];
 }

--- a/pkg/ccl/changefeedccl/changefeed_job_info.go
+++ b/pkg/ccl/changefeedccl/changefeed_job_info.go
@@ -45,6 +45,20 @@ func writeChangefeedJobInfo(
 	return jobs.WriteChunkedFileToJobInfo(ctx, filename, data, txn, jobID)
 }
 
+// deleteChangefeedJobInfo deletes a changefeed job info protobuf from the
+// job_info table. A changefeed-specific filename is required.
+func deleteChangefeedJobInfo(
+	ctx context.Context, filename string, txn isql.Txn, jobID jobspb.JobID,
+) error {
+	if !strings.HasPrefix(filename, jobInfoFilenamePrefix) {
+		return errors.AssertionFailedf("filename %q must start with prefix %q", filename, jobInfoFilenamePrefix)
+	}
+	if !strings.HasSuffix(filename, jobInfoFilenameExtension) {
+		return errors.AssertionFailedf("filename %q must end with extension %q", filename, jobInfoFilenameExtension)
+	}
+	return jobs.WriteChunkedFileToJobInfo(ctx, filename, nil, txn, jobID)
+}
+
 // readChangefeedJobInfo reads a changefeed job info protobuf from the
 // job_info table. A changefeed-specific filename is required.
 func readChangefeedJobInfo(

--- a/pkg/ccl/changefeedccl/changefeed_job_info_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_job_info_test.go
@@ -35,9 +35,9 @@ func TestChangefeedJobInfoRoundTrip(t *testing.T) {
 	uuid1 := uuid.MakeV4()
 	uuid2 := uuid.MakeV4()
 	ptsRecords := cdcprogresspb.ProtectedTimestampRecords{
-		ProtectedTimestampRecords: map[descpb.ID]*uuid.UUID{
-			descpb.ID(100): &uuid1,
-			descpb.ID(200): &uuid2,
+		ProtectedTimestampRecords: map[descpb.ID]uuid.UUID{
+			descpb.ID(100): uuid1,
+			descpb.ID(200): uuid2,
 		},
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1957,6 +1957,10 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		}
 	}()
 
+	if cf.knobs.ManagePTSError != nil {
+		return false, cf.knobs.ManagePTSError()
+	}
+
 	var ptsEntries cdcprogresspb.ProtectedTimestampRecords
 	if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, cf.spec.JobID); err != nil {
 		return false, err
@@ -1971,15 +1975,7 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 	}()
 
 	if cf.spec.ProgressConfig.PerTableProtectedTimestamps {
-		newPTS, updatedPerTablePTS, err := cf.managePerTableProtectedTimestamps(ctx, txn, &ptsEntries, highwater)
-		if err != nil {
-			return false, err
-		}
-		updatedMainPTS, err := cf.advanceProtectedTimestamp(ctx, progress, pts, newPTS)
-		if err != nil {
-			return false, err
-		}
-		return updatedMainPTS || updatedPerTablePTS, nil
+		return cf.managePerTableProtectedTimestamps(ctx, txn, &ptsEntries, highwater)
 	}
 
 	return cf.advanceProtectedTimestamp(ctx, progress, pts, highwater)
@@ -1990,28 +1986,8 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 	txn isql.Txn,
 	ptsEntries *cdcprogresspb.ProtectedTimestampRecords,
 	highwater hlc.Timestamp,
-) (newPTS hlc.Timestamp, updatedPerTablePTS bool, err error) {
-	var leastLaggingTimestamp hlc.Timestamp
-	for _, frontier := range cf.frontier.Frontiers() {
-		if frontier.Frontier().After(leastLaggingTimestamp) {
-			leastLaggingTimestamp = frontier.Frontier()
-		}
-	}
-
-	newPTS = func() hlc.Timestamp {
-		lagDuration := changefeedbase.ProtectTimestampBucketingInterval.Get(&cf.FlowCtx.Cfg.Settings.SV)
-		ptsLagCutoff := leastLaggingTimestamp.AddDuration(-lagDuration)
-		// If we are within the bucketing interval of having started the changefeed,
-		// we use the highwater as the PTS timestamp so as not to try to protect
-		// tables before the changefeed started.
-		if ptsLagCutoff.Less(highwater) {
-			return highwater
-		}
-		return ptsLagCutoff
-	}()
-
+) (updatedPerTablePTS bool, err error) {
 	pts := cf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
-	tableIDsToRelease := make([]descpb.ID, 0)
 	tableIDsToCreate := make(map[descpb.ID]hlc.Timestamp)
 	for tableID, frontier := range cf.frontier.Frontiers() {
 		tableHighWater := func() hlc.Timestamp {
@@ -2023,66 +1999,35 @@ func (cf *changeFrontier) managePerTableProtectedTimestamps(
 			return frontier.Frontier()
 		}()
 
-		isLagging := tableHighWater.Less(newPTS)
-
-		if cf.knobs.IsTableLagging != nil && cf.knobs.IsTableLagging(tableID) {
-			isLagging = true
-		}
-
-		if !isLagging {
-			if ptsEntries.ProtectedTimestampRecords[tableID] != nil {
-				tableIDsToRelease = append(tableIDsToRelease, tableID)
-			}
-			continue
-		}
-
-		if ptsEntries.ProtectedTimestampRecords[tableID] != nil {
+		if ptsEntries.ProtectedTimestampRecords[tableID] != uuid.Nil {
 			if updated, err := cf.advancePerTableProtectedTimestampRecord(ctx, ptsEntries, tableID, tableHighWater, pts); err != nil {
-				return hlc.Timestamp{}, false, err
+				return false, err
 			} else if updated {
 				updatedPerTablePTS = true
 			}
 		} else {
 			// TODO(#152448): Do not include system table protections in these records.
+			// TODO(#153894): Newly added/dropped tables should be caught and
+			// protected when starting the frontier, not here.
 			tableIDsToCreate[tableID] = tableHighWater
 		}
 	}
 
-	if len(tableIDsToRelease) > 0 {
-		if err := cf.releasePerTableProtectedTimestampRecords(ctx, ptsEntries, tableIDsToRelease, pts); err != nil {
-			return hlc.Timestamp{}, false, err
-		}
-	}
-
 	if len(tableIDsToCreate) > 0 {
-		if err := cf.createPerTableProtectedTimestampRecords(ctx, ptsEntries, tableIDsToCreate, pts); err != nil {
-			return hlc.Timestamp{}, false, err
+		if err := cf.createPerTableProtectedTimestampRecords(
+			ctx, ptsEntries, tableIDsToCreate, pts,
+		); err != nil {
+			return false, err
 		}
-	}
-
-	if len(tableIDsToRelease) > 0 || len(tableIDsToCreate) > 0 {
-		if err := writeChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, ptsEntries, txn, cf.spec.JobID); err != nil {
-			return hlc.Timestamp{}, false, err
+		if err := writeChangefeedJobInfo(
+			ctx, perTableProtectedTimestampsFilename, ptsEntries, txn, cf.spec.JobID,
+		); err != nil {
+			return false, err
 		}
 		updatedPerTablePTS = true
 	}
 
-	return newPTS, updatedPerTablePTS, nil
-}
-
-func (cf *changeFrontier) releasePerTableProtectedTimestampRecords(
-	ctx context.Context,
-	ptsEntries *cdcprogresspb.ProtectedTimestampRecords,
-	tableIDs []descpb.ID,
-	pts protectedts.Storage,
-) error {
-	for _, tableID := range tableIDs {
-		if err := pts.Release(ctx, *ptsEntries.ProtectedTimestampRecords[tableID]); err != nil {
-			return err
-		}
-		delete(ptsEntries.ProtectedTimestampRecords, tableID)
-	}
-	return nil
+	return updatedPerTablePTS, nil
 }
 
 func (cf *changeFrontier) advancePerTableProtectedTimestampRecord(
@@ -2092,7 +2037,7 @@ func (cf *changeFrontier) advancePerTableProtectedTimestampRecord(
 	tableHighWater hlc.Timestamp,
 	pts protectedts.Storage,
 ) (updated bool, err error) {
-	rec, err := pts.GetRecord(ctx, *ptsEntries.ProtectedTimestampRecords[tableID])
+	rec, err := pts.GetRecord(ctx, ptsEntries.ProtectedTimestampRecords[tableID])
 	if err != nil {
 		return false, err
 	}
@@ -2102,7 +2047,7 @@ func (cf *changeFrontier) advancePerTableProtectedTimestampRecord(
 		return false, nil
 	}
 
-	if err := pts.UpdateTimestamp(ctx, *ptsEntries.ProtectedTimestampRecords[tableID], tableHighWater); err != nil {
+	if err := pts.UpdateTimestamp(ctx, ptsEntries.ProtectedTimestampRecords[tableID], tableHighWater); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -2115,7 +2060,7 @@ func (cf *changeFrontier) createPerTableProtectedTimestampRecords(
 	pts protectedts.Storage,
 ) error {
 	if ptsEntries.ProtectedTimestampRecords == nil {
-		ptsEntries.ProtectedTimestampRecords = make(map[descpb.ID]*uuid.UUID)
+		ptsEntries.ProtectedTimestampRecords = make(map[descpb.ID]uuid.UUID)
 	}
 	for tableID, tableHighWater := range tableIDsToCreate {
 		targets, err := cf.createPerTablePTSTargets(tableID)
@@ -2126,7 +2071,7 @@ func (cf *changeFrontier) createPerTableProtectedTimestampRecords(
 			ctx, cf.FlowCtx.Codec(), cf.spec.JobID, targets, tableHighWater,
 		)
 		uuid := ptr.ID.GetUUID()
-		ptsEntries.ProtectedTimestampRecords[tableID] = &uuid
+		ptsEntries.ProtectedTimestampRecords[tableID] = uuid
 		if err := pts.Protect(ctx, ptr); err != nil {
 			return err
 		}
@@ -2208,10 +2153,6 @@ func (cf *changeFrontier) advanceProtectedTimestamp(
 	// on system tables.
 	if rec.Timestamp.AddDuration(ptsUpdateLag).After(timestamp) {
 		return false, nil
-	}
-
-	if cf.knobs.ManagePTSError != nil {
-		return false, cf.knobs.ManagePTSError()
 	}
 
 	log.VEventf(ctx, 2, "updating protected timestamp %v at %v", progress.ProtectedTimestampRecord, timestamp)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/backup/backupresolver"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/checkpoint"
@@ -326,21 +327,78 @@ func changefeedPlanHook(
 			}
 
 			recordPTSMetricsTime := sliMetrics.Timers.PTSCreate.Start()
-
+			// ptr is the feed-level protected timestamp record which exists when per-table protected
+			// timestamps are disabled.
 			var ptr *ptpb.Record
+			// perTablePTSRecords is the per-table protected timestamp records which exist when
+			// per-table protected timestamps are enabled.
+			var perTablePTSRecords []*ptpb.Record
+			// ptsRecords is the protected timestamp records object containing all per-table protected
+			// timestamp records. Its format matches what will be persisted to the job info table.
+			var ptsRecords *cdcprogresspb.ProtectedTimestampRecords
 			codec := p.ExecCfg().Codec
-			ptr = createProtectedTimestampRecord(
-				ctx,
-				codec,
-				jobID,
-				targets,
-				details.StatementTime,
-			)
-			progress.GetChangefeed().ProtectedTimestampRecord = ptr.ID.GetUUID()
 
+			// We do not yet have the progress config here, so we need to check the settings directly.
+			perTableTrackingEnabled := changefeedbase.TrackPerTableProgress.Get(&p.ExecCfg().Settings.SV)
+			perTableProtectedTimestampsEnabled := changefeedbase.PerTableProtectedTimestamps.Get(&p.ExecCfg().Settings.SV)
+			usingPerTablePTS := perTableTrackingEnabled && perTableProtectedTimestampsEnabled
+			if usingPerTablePTS {
+				protectedTimestampRecords := make(map[descpb.ID]uuid.UUID)
+				if err := targets.EachTarget(func(target changefeedbase.Target) error {
+					ptsTargets := changefeedbase.Targets{}
+					ptsTargets.Add(target)
+					ptsRecord := createProtectedTimestampRecord(
+						ctx,
+						codec,
+						jobID,
+						ptsTargets,
+						details.StatementTime,
+					)
+					perTablePTSRecords = append(perTablePTSRecords, ptsRecord)
+					uuid := ptsRecord.ID.GetUUID()
+					protectedTimestampRecords[target.DescID] = uuid
+					return nil
+				}); err != nil {
+					return err
+				}
+				ptsRecords = &cdcprogresspb.ProtectedTimestampRecords{
+					ProtectedTimestampRecords: protectedTimestampRecords,
+				}
+			} else {
+				ptr = createProtectedTimestampRecord(
+					ctx,
+					codec,
+					jobID,
+					targets,
+					details.StatementTime,
+				)
+				progress.GetChangefeed().ProtectedTimestampRecord = ptr.ID.GetUUID()
+			}
 			jr.Progress = *progress.GetChangefeed()
 
 			if changefeedStmt.CreatedByInfo != nil {
+				// We protect the PTS records that we created earlier. There should either be a
+				// feed-level PTS record or per-table PTS record, but not both.
+				if ptr != nil {
+					pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(p.InternalSQLTxn())
+					if err := pts.Protect(ctx, ptr); err != nil {
+						return err
+					}
+				}
+				if usingPerTablePTS {
+					for _, perTableRecord := range perTablePTSRecords {
+						pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(p.InternalSQLTxn())
+						if err := pts.Protect(ctx, perTableRecord); err != nil {
+							return err
+						}
+					}
+					if err := writeChangefeedJobInfo(
+						ctx, perTableProtectedTimestampsFilename, ptsRecords, p.InternalSQLTxn(), jobID,
+					); err != nil {
+						return err
+					}
+				}
+
 				// This changefeed statement invoked by the scheduler.  As such, the scheduler
 				// must have specified transaction to use, and is responsible for committing
 				// transaction.
@@ -348,13 +406,6 @@ func changefeedPlanHook(
 				_, err := p.ExecCfg().JobRegistry.CreateAdoptableJobWithTxn(ctx, *jr, jr.JobID, p.InternalSQLTxn())
 				if err != nil {
 					return err
-				}
-
-				if ptr != nil {
-					pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(p.InternalSQLTxn())
-					if err := pts.Protect(ctx, ptr); err != nil {
-						return err
-					}
 				}
 
 				select {
@@ -368,11 +419,29 @@ func changefeedPlanHook(
 			}
 
 			if err := p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				// We protect the PTS records that we created earlier. There should either be a
+				// feed-level PTS record or per-table PTS record, but not both.
+				if ptr != nil {
+					err := p.ExecCfg().ProtectedTimestampProvider.WithTxn(txn).Protect(ctx, ptr)
+					if err != nil {
+						return err
+					}
+				}
+				if usingPerTablePTS {
+					pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(txn)
+					for _, perTableRecord := range perTablePTSRecords {
+						if err := pts.Protect(ctx, perTableRecord); err != nil {
+							return err
+						}
+					}
+					if err := writeChangefeedJobInfo(
+						ctx, perTableProtectedTimestampsFilename, ptsRecords, txn, jobID,
+					); err != nil {
+						return err
+					}
+				}
 				if err := p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jr.JobID, txn, *jr); err != nil {
 					return err
-				}
-				if ptr != nil {
-					return p.ExecCfg().ProtectedTimestampProvider.WithTxn(txn).Protect(ctx, ptr)
 				}
 				return nil
 			}); err != nil {
@@ -1850,12 +1919,35 @@ func (b *changefeedResumer) OnFailOrCancel(
 	exec := jobExec.(sql.JobExecContext)
 	execCfg := exec.ExecCfg()
 	progress := b.job.Progress()
-	b.maybeCleanUpProtectedTimestamp(
-		ctx,
-		execCfg.InternalDB,
-		execCfg.ProtectedTimestampProvider,
-		progress.GetChangefeed().ProtectedTimestampRecord,
-	)
+
+	maybeCleanUpProtectedTimestamp := func(ptsID uuid.UUID) {
+		b.maybeCleanUpProtectedTimestamp(
+			ctx,
+			execCfg.InternalDB,
+			execCfg.ProtectedTimestampProvider,
+			ptsID,
+		)
+	}
+
+	maybeCleanUpProtectedTimestamp(progress.GetChangefeed().ProtectedTimestampRecord)
+	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		ptsEntries := cdcprogresspb.ProtectedTimestampRecords{}
+		if err := readChangefeedJobInfo(
+			ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, b.job.ID(),
+		); err != nil {
+			return err
+		}
+
+		if len(ptsEntries.ProtectedTimestampRecords) == 0 {
+			return nil
+		}
+		for _, record := range ptsEntries.ProtectedTimestampRecords {
+			maybeCleanUpProtectedTimestamp(record)
+		}
+		return deleteChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, txn, b.job.ID())
+	}); err != nil {
+		return err
+	}
 
 	var numTargets uint
 	if b.job != nil {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/checkpoint"
@@ -65,6 +66,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -12035,15 +12037,47 @@ WITH resolved='10ms', min_checkpoint_frequency='10ms', no_initial_scan`
 			return errors.New("waiting for high watermark to advance")
 		}
 		testutils.SucceedsSoon(t, checkHWM)
+		var tableID int
+		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'foo' AND database_name = 'd'`).Scan(&tableID)
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
 
-		// Get the PTS of this feed.
-		p, err := eFeed.Progress()
-		require.NoError(t, err)
+		getTimestampFromPTSRecord := func(ptsRecordID uuid.UUID) hlc.Timestamp {
+			ptsQry := fmt.Sprintf(`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`, ptsRecordID)
+			var tsStr string
+			sqlDB.QueryRow(t, ptsQry).Scan(&tsStr)
+			ts, err := hlc.ParseHLC(tsStr)
+			require.NoError(t, err)
+			return ts
+		}
+		getPerTablePTS := func() hlc.Timestamp {
+			var ts hlc.Timestamp
+			err := execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+				if err := readChangefeedJobInfo(
+					ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID(),
+				); err != nil {
+					return err
+				}
+				ptsRecordID := ptsEntries.ProtectedTimestampRecords[descpb.ID(tableID)]
+				ts = getTimestampFromPTSRecord(ptsRecordID)
+				return nil
+			})
+			require.NoError(t, err)
+			return ts
+		}
+		perTablePTSEnabled := changefeedbase.PerTableProtectedTimestamps.Get(&s.Server.ClusterSettings().SV)
+		perTableProgressEnabled := changefeedbase.TrackPerTableProgress.Get(&s.Server.ClusterSettings().SV)
+		getPTS := func() hlc.Timestamp {
+			if perTablePTSEnabled && perTableProgressEnabled {
+				return getPerTablePTS()
+			}
 
-		ptsQry := fmt.Sprintf(`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`, p.ProtectedTimestampRecord)
-		var ts, ts2 string
-		sqlDB.QueryRow(t, ptsQry).Scan(&ts)
-		require.NoError(t, err)
+			p, err := eFeed.Progress()
+			require.NoError(t, err)
+			return getTimestampFromPTSRecord(p.ProtectedTimestampRecord)
+		}
+
+		ts := getPTS()
 
 		// Force the changefeed to restart.
 		require.NoError(t, eFeed.Pause())
@@ -12053,8 +12087,7 @@ WITH resolved='10ms', min_checkpoint_frequency='10ms', no_initial_scan`
 		testutils.SucceedsSoon(t, checkHWM)
 
 		// Check that the PTS was not updated after the resume.
-		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)
-		require.NoError(t, err)
+		ts2 := getPTS()
 		require.Equal(t, ts, ts2)
 
 		// Lower the PTS lag and check that it has been updated.
@@ -12066,9 +12099,8 @@ WITH resolved='10ms', min_checkpoint_frequency='10ms', no_initial_scan`
 		testutils.SucceedsSoon(t, checkHWM)
 		testutils.SucceedsSoon(t, checkHWM)
 
-		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)
-		require.NoError(t, err)
-		require.Less(t, ts, ts2)
+		ts2 = getPTS()
+		require.True(t, ts.Less(ts2))
 
 		managePTSCount, _ = metrics.AggMetrics.Timers.PTSManage.WindowedSnapshot().Total()
 		managePTSErrorCount, _ = metrics.AggMetrics.Timers.PTSManageError.WindowedSnapshot().Total()

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -207,16 +207,6 @@ var ProtectTimestampInterval = settings.RegisterDurationSetting(
 	settings.PositiveDuration,
 	settings.WithPublic)
 
-// ProtectTimestampBucketingInterval controls the amount a table is allowed to lag behind the
-// most advanced table before a per-table protected timestamp record is created
-var ProtectTimestampBucketingInterval = settings.RegisterDurationSetting(
-	settings.ApplicationLevel,
-	"changefeed.protect_timestamp_bucketing_interval",
-	"controls the amount a table is allowed to lag behind the most advanced table before a per-table protected timestamp record is created; "+
-		"only used when changefeed.protect_timestamp.per_table.enabled is true",
-	2*time.Minute,
-	settings.PositiveDuration)
-
 // ProtectTimestampLag controls how much the protected timestamp record should lag behind the high watermark
 var ProtectTimestampLag = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -404,7 +404,21 @@ func TestChangefeedAlterPTS(t *testing.T) {
 
 		_, _ = expectResolvedTimestamp(t, f2)
 
-		require.Equal(t, 1, getNumPTSRecords())
+		perTablePTSEnabled :=
+			changefeedbase.PerTableProtectedTimestamps.Get(&s.Server.ClusterSettings().SV) &&
+				changefeedbase.TrackPerTableProgress.Get(&s.Server.ClusterSettings().SV)
+
+		if perTablePTSEnabled {
+			eFeed, ok := f2.(cdctest.EnterpriseTestFeed)
+			require.True(t, ok)
+			hwm, err := eFeed.HighWaterMark()
+			require.NoError(t, err)
+			require.NoError(t, eFeed.WaitForHighWaterMark(hwm))
+
+			require.Equal(t, 2, getNumPTSRecords())
+		} else {
+			require.Equal(t, 1, getNumPTSRecords())
+		}
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
@@ -737,6 +751,8 @@ func TestChangefeedMigratesProtectedTimestampTargets(t *testing.T) {
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
 		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
@@ -853,6 +869,12 @@ func TestChangefeedMigratesProtectedTimestamps(t *testing.T) {
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
 		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
+
+		// Since old style PTS records should not be created when per-table PTS records are enabled,
+		// we disable them for this test. Per-table PTS breaks assumptions about where we can find
+		// the PTS record uuids.
+		changefeedbase.PerTableProtectedTimestamps.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, false)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
@@ -1091,32 +1113,13 @@ func TestChangefeedPerTableProtectedTimestampProgression(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO table2 VALUES (1)`)
 		sqlDB.Exec(t, `INSERT INTO table3 VALUES (1)`)
 
-		// Get table IDs for controlling lagging behavior
 		var table1ID, table2ID, table3ID descpb.ID
 		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table1' AND database_name = current_database()`).Scan(&table1ID)
 		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table2' AND database_name = current_database()`).Scan(&table2ID)
 		sqlDB.QueryRow(t, `SELECT table_id FROM crdb_internal.tables WHERE name = 'table3' AND database_name = current_database()`).Scan(&table3ID)
 
-		knobs := s.TestingKnobs.
-			DistSQL.(*execinfra.TestingKnobs).
-			Changefeed.(*TestingKnobs)
-
-		var table1Lagging, table2Lagging, table3Lagging atomic.Bool
-		knobs.IsTableLagging = func(tableID descpb.ID) bool {
-			switch tableID {
-			case table1ID:
-				return table1Lagging.Load()
-			case table2ID:
-				return table2Lagging.Load()
-			case table3ID:
-				return table3Lagging.Load()
-			default:
-				return false
-			}
-		}
-
 		createStmt := `CREATE CHANGEFEED FOR table1, table2, table3
-WITH resolved='100ms', min_checkpoint_frequency='100ms'`
+		WITH resolved='100ms', min_checkpoint_frequency='100ms'`
 		testFeed := feed(t, f, createStmt)
 		defer closeFeed(t, testFeed)
 
@@ -1131,80 +1134,83 @@ WITH resolved='100ms', min_checkpoint_frequency='100ms'`
 
 		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
 
-		assertTablePTSRecords := func(expectedTables map[descpb.ID]struct{}) {
-			testutils.SucceedsSoon(t, func() error {
-				return execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
-					var ptsEntries cdcprogresspb.ProtectedTimestampRecords
-					if err := readChangefeedJobInfo(ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID()); err != nil {
-						return err
-					}
+		// Assert that the feed-level PTS record does not exist because per-table
+		// protected timestamps are enabled.
+		progress, err := eFeed.Progress()
+		require.NoError(t, err)
+		require.Equal(t, progress.ProtectedTimestampRecord, uuid.UUID{})
 
-					if len(ptsEntries.ProtectedTimestampRecords) != len(expectedTables) {
-						return errors.Newf("expected %d per-table PTS records, got %d", len(expectedTables), len(ptsEntries.ProtectedTimestampRecords))
-					}
-
-					for tableID := range expectedTables {
-						if ptsEntries.ProtectedTimestampRecords[tableID] == nil {
-							return errors.Newf("expected PTS record for table %d", tableID)
-						}
-					}
-					return nil
-				})
-			})
-		}
-
-		// Assert that the feed-level PTS record exists.
-		assertFeedLevelPTS := func() {
-			testutils.SucceedsSoon(t, func() error {
-				hwm, err := eFeed.HighWaterMark()
-				if err != nil {
-					return err
-				}
-				if hwm.IsEmpty() {
-					return errors.New("waiting for high watermark to be set")
-				}
-				return execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
-					progress, err := eFeed.Progress()
-					if err != nil {
-						return err
-					}
-					if progress.ProtectedTimestampRecord.Equal(uuid.UUID{}) {
-						return errors.New("expected feed-level PTS record to be set")
-					}
-					return nil
-				})
-			})
-		}
-
-		assertFeedLevelPTS()
-		// Since no tables are lagging, we should see 0 per-table records.
-		assertTablePTSRecords(map[descpb.ID]struct{}{})
-
-		// Make table1 start lagging. We should see 1 table-level record.
-		table1Lagging.Store(true)
-		assertTablePTSRecords(map[descpb.ID]struct{}{table1ID: {}})
-
-		// Make the rest of the tables lag. We should see 3 total table-level records.
-		table2Lagging.Store(true)
-		table3Lagging.Store(true)
-		assertTablePTSRecords(map[descpb.ID]struct{}{
+		tablePTS := make(map[descpb.ID]hlc.Timestamp)
+		expectedTables := map[descpb.ID]struct{}{
 			table1ID: {},
 			table2ID: {},
 			table3ID: {},
+		}
+		testutils.SucceedsSoon(t, func() error {
+			return execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+				if err := readChangefeedJobInfo(
+					ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID(),
+				); err != nil {
+					return err
+				}
+
+				if len(ptsEntries.ProtectedTimestampRecords) != len(expectedTables) {
+					return errors.Newf(
+						"expected %d per-table PTS records, got %d",
+						len(expectedTables), len(ptsEntries.ProtectedTimestampRecords),
+					)
+				}
+
+				// We save the protection timestamps for each table in tablePTS
+				// so that we can assert that they progress as expected later.
+				for tableID := range expectedTables {
+					if ptsEntries.ProtectedTimestampRecords[tableID] == uuid.Nil {
+						return errors.Newf("expected PTS record for table %d", tableID)
+					}
+					ptsQry := fmt.Sprintf(
+						`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`,
+						ptsEntries.ProtectedTimestampRecords[tableID],
+					)
+					var tsStr string
+					sqlDB.QueryRow(t, ptsQry).Scan(&tsStr)
+					ts, err := hlc.ParseHLC(tsStr)
+					require.NoError(t, err)
+					tablePTS[tableID] = ts
+				}
+				return nil
+			})
 		})
 
-		// Make table3 stop lagging. We should see only 2 table-level records.
-		table3Lagging.Store(false)
-		assertTablePTSRecords(map[descpb.ID]struct{}{
-			table1ID: {},
-			table2ID: {},
-		})
+		// Assert that each per table PTS record progresses as expected.
+		testutils.SucceedsSoon(t, func() error {
+			return execCfg.InternalDB.Txn(context.Background(), func(ctx context.Context, txn isql.Txn) error {
+				var ptsEntries cdcprogresspb.ProtectedTimestampRecords
+				if err := readChangefeedJobInfo(
+					ctx, perTableProtectedTimestampsFilename, &ptsEntries, txn, eFeed.JobID(),
+				); err != nil {
+					return err
+				}
 
-		// Make the remaining tables stop lagging. We should see 0 table-level records.
-		table1Lagging.Store(false)
-		table2Lagging.Store(false)
-		assertTablePTSRecords(map[descpb.ID]struct{}{})
-		assertFeedLevelPTS()
+				for tableID := range expectedTables {
+					ptsQry := fmt.Sprintf(
+						`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`,
+						ptsEntries.ProtectedTimestampRecords[tableID],
+					)
+					var tsStr string
+					sqlDB.QueryRow(t, ptsQry).Scan(&tsStr)
+					ts, err := hlc.ParseHLC(tsStr)
+					require.NoError(t, err)
+					if !ts.After(tablePTS[tableID]) {
+						return errors.Newf(
+							"expected PTS record for table %d to progress since %s, got %s",
+							tableID, tablePTS[tableID], ts,
+						)
+					}
+				}
+				return nil
+			})
+		})
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -93,10 +92,6 @@ type TestingKnobs struct {
 
 	// ManagePTSError is used to return an error when managing protected timestamps.
 	ManagePTSError func() error
-
-	// IsTableLagging is a callback that's invoked by manage protected timestamp
-	// to check if the table is lagging.
-	IsTableLagging func(tableID descpb.ID) bool
 
 	// PulsarClientSkipCreation skips creating the sink client when
 	// dialing.


### PR DESCRIPTION
Backport 1/1 commits from #153421 on behalf of @aerfrei.

----

Previously, per-table PTS changefeeds used a single protected
timestamp record for all non-lagging tables, while assigning
individual records only to lagging ones. This commit removes
that shared record; instead, all tables now receive their own
per-table PTS record at startup, each updated using the table's
highwater.

Fixes #153681

Epic: [CRDB-1421](https://cockroachlabs.atlassian.net/browse/CRDB-1421)
Release note: None

----

Release justification: fix for GA blocker