### PR TITLE
kvserver: more logging for TestReplicaCircuitBreaker_Partial_Retry

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -793,6 +793,11 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 	skip.UnderRace(t)
 	skip.UnderDeadlock(t)
 
+	// To help debug issues like #154179.
+	prevVModule := log.GetVModule()
+	defer func() { _ = log.SetVModule(prevVModule) }()
+	require.NoError(t, log.SetVModule("dist_sender=3"))
+
 	testutils.RunValues(t, "lease-type", roachpb.ExpirationAndLeaderLeaseType(),
 		func(t *testing.T, leaseType roachpb.LeaseType) {
 			// Use a context timeout, to prevent test hangs on failures.


### PR DESCRIPTION
This test verifies the value of the `InLeaseTransferBackoffs` metric, but without more verbose `DistSender` logging, it's hard to investigate failures where the metric has unexpected values.

Fixes: #154179

Release note: None