### PR TITLE
sqlproxyccl: pass in ctx when transferring connections

### DIFF
--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -371,7 +371,7 @@ func (b *Balancer) processQueue(ctx context.Context) {
 
 			// Each request is retried up to maxTransferAttempts.
 			for i := 0; i < maxTransferAttempts && ctx.Err() == nil; i++ {
-				err := req.conn.TransferConnection()
+				err := req.conn.TransferConnection(ctx)
 				if err == nil || errors.Is(err, context.Canceled) {
 					break
 				}

--- a/pkg/ccl/sqlproxyccl/balancer/conn.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn.go
@@ -19,7 +19,7 @@ type ConnectionHandle interface {
 	// TransferConnection performs a connection migration on the connection
 	// handle. Invoking this blocks until the connection migration process has
 	// been completed.
-	TransferConnection() error
+	TransferConnection(context.Context) error
 
 	// IsIdle returns true if the connection is idle, and false otherwise.
 	IsIdle() bool

--- a/pkg/ccl/sqlproxyccl/balancer/conn_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_test.go
@@ -44,7 +44,7 @@ func (h *testConnHandle) Close() {
 }
 
 // TransferConnection implements the ConnectionHandle interface.
-func (h *testConnHandle) TransferConnection() error {
+func (h *testConnHandle) TransferConnection(ctx context.Context) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.mu.onTransferConnectionCount++

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -127,7 +127,7 @@ var errTransferCannotStart = errors.New("transfer cannot be started")
 // error).
 //
 // TransferConnection implements the balancer.ConnectionHandle interface.
-func (f *forwarder) TransferConnection() (retErr error) {
+func (f *forwarder) TransferConnection(ctx context.Context) (retErr error) {
 	// A previous non-recoverable transfer would have closed the forwarder, so
 	// return right away.
 	if f.ctx.Err() != nil {
@@ -146,18 +146,18 @@ func (f *forwarder) TransferConnection() (retErr error) {
 	// whenever the context expires. We have to close the forwarder because
 	// the transfer may be blocked on I/O, and the only way for now is to close
 	// the connections. This then allow TransferConnection to return and cleanup.
-	ctx, cancel := newTransferContext(f.ctx)
+	transferCtx, cancel := newTransferContext(ctx)
 	defer cancel()
 
 	// Use a separate handler for timeouts. This is the only way to handle
 	// blocked I/Os as described above.
 	go func() {
-		<-ctx.Done()
+		<-transferCtx.Done()
 		// This Close call here in addition to the one in the defer callback
 		// below is on purpose. This would help unblock situations where we're
 		// blocked on sending/reading messages from connections that couldn't
 		// be handled with context.Context.
-		if !ctx.isRecoverable() {
+		if !transferCtx.isRecoverable() {
 			f.Close()
 		}
 	}()
@@ -179,7 +179,7 @@ func (f *forwarder) TransferConnection() (retErr error) {
 
 		// When TransferConnection returns, it's either the forwarder has been
 		// closed, or the procesors have been resumed.
-		if !ctx.isRecoverable() {
+		if !transferCtx.isRecoverable() {
 			log.Dev.Infof(logCtx, "transfer failed: connection closed, latency=%v, err=%v", latencyDur, retErr)
 			f.metrics.ConnMigrationErrorFatalCount.Inc(1)
 			f.Close()
@@ -201,16 +201,16 @@ func (f *forwarder) TransferConnection() (retErr error) {
 
 	// Suspend both processors before starting the transfer.
 	request, response := f.getProcessors()
-	if err := request.suspend(ctx); err != nil {
+	if err := request.suspend(transferCtx); err != nil {
 		return errors.Wrap(err, "suspending request processor")
 	}
-	if err := response.suspend(ctx); err != nil {
+	if err := response.suspend(transferCtx); err != nil {
 		return errors.Wrap(err, "suspending response processor")
 	}
 
 	// Transfer the connection.
 	clientConn, serverConn := f.getConns()
-	newServerConn, err := transferConnection(ctx, f, f.connector, f.metrics, clientConn, serverConn)
+	newServerConn, err := transferConnection(transferCtx, f, f.connector, f.metrics, clientConn, serverConn)
 	if err != nil {
 		return errors.Wrap(err, "transferring connection")
 	}


### PR DESCRIPTION
Previously, the span used when transferring connections was reused from
the forwarder. However, transferring connections has async components,
so it's possible that the forwarder calls `Finish` on the span before
the connection transfer is done using the span. This leads to a panic:
`panic: use of Span after Finish`. To address this, this patch passes a
context in when transferring a connection, instead of using the
forwarder's context.

Fixes: https://github.com/cockroachdb/cockroach/issues/153569
Release note: None