### PR TITLE
sql/inspect: fix missing String() method for InspectDetails_Check_InspectCheckType

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1451,7 +1451,7 @@ message InspectDetails {
   message Check {
     enum InspectCheckType {
       option (gogoproto.goproto_enum_prefix) = false;
-      option (gogoproto.goproto_enum_stringer) = false;
+      option (gogoproto.goproto_enum_stringer) = true;
 
       // UNSPECIFIED indicates an unset check type. This is invalid.
       INSPECT_CHECK_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "InspectCheckUnspecified"];

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -27,6 +27,23 @@ SELECT description, status, finished IS NOT NULL AS finished FROM [SHOW JOBS] WH
 ----
 EXPERIMENTAL SCRUB TABLE t1 AS OF SYSTEM TIME '-1us'  succeeded  true
 
+# Verify the checks that were done.
+query TI
+SELECT
+  json_extract_path_text(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload),
+    'inspectDetails', 'checks', '0', 'type'
+  ) AS check_type,
+  jsonb_array_length(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload) -> 'inspectDetails' -> 'checks'
+  ) AS num_checks
+FROM crdb_internal.system_jobs
+WHERE job_type = 'INSPECT'
+ORDER BY created DESC
+LIMIT 1
+----
+INSPECT_CHECK_INDEX_CONSISTENCY  1
+
 subtest end
 
 subtest scrub_job_multi_stmt_txn


### PR DESCRIPTION
Changed `goproto_enum_stringer = false` to `true` in jobs.proto to generate the required String() method. This fixes panics when using pb_to_json() on INSPECT job payloads. Added logictest verification.

Release note: None

Epic: CRDB-30356