### PR TITLE
release-25.4: sql/inspect: skip INSPECT checks for non-applicable spans earlier

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/keys",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/security/username",

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -190,10 +190,24 @@ func getInspectLogger(flowCtx *execinfra.FlowCtx, jobID jobspb.JobID) inspectLog
 func (p *inspectProcessor) processSpan(
 	ctx context.Context, span roachpb.Span, workerIndex int,
 ) (err error) {
-	checks := make([]inspectCheck, len(p.checkFactories))
-	for i, factory := range p.checkFactories {
-		checks[i] = factory()
+	// Only create checks that apply to this span
+	var checks []inspectCheck
+	for _, factory := range p.checkFactories {
+		check := factory()
+		applies, err := check.AppliesTo(p.cfg.Codec, span)
+		if err != nil {
+			return err
+		}
+		if applies {
+			checks = append(checks, check)
+		}
 	}
+
+	// If no checks apply to this span, there's nothing to do
+	if len(checks) == 0 {
+		return nil
+	}
+
 	runner := inspectRunner{
 		checks: checks,
 		logger: p.logger,
@@ -263,8 +277,10 @@ func buildInspectCheckFactories(
 		case jobspb.InspectCheckIndexConsistency:
 			checkFactories = append(checkFactories, func() inspectCheck {
 				return &indexConsistencyCheck{
+					indexConsistencyCheckApplicability: indexConsistencyCheckApplicability{
+						tableID: tableID,
+					},
 					flowCtx: flowCtx,
-					tableID: tableID,
 					indexID: indexID,
 					asOf:    spec.InspectDetails.AsOf,
 				}

--- a/pkg/sql/inspect/inspect_processor_test.go
+++ b/pkg/sql/inspect/inspect_processor_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -112,6 +113,13 @@ type testingInspectCheck struct {
 }
 
 var _ inspectCheck = (*testingInspectCheck)(nil)
+var _ inspectCheckApplicability = (*testingInspectCheck)(nil)
+
+// AppliesTo implements the inspectCheckApplicability interface.
+func (t *testingInspectCheck) AppliesTo(codec keys.SQLCodec, span roachpb.Span) (bool, error) {
+	// For testing, assume all checks apply to all spans
+	return true, nil
+}
 
 // Started implements the inspectCheck interface.
 func (t *testingInspectCheck) Started() bool {

--- a/pkg/sql/inspect/runner.go
+++ b/pkg/sql/inspect/runner.go
@@ -8,10 +8,34 @@ package inspect
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/errors"
 )
+
+// inspectCheckApplicability defines the interface for determining if a check
+// applies to a span.
+type inspectCheckApplicability interface {
+	// AppliesTo reports whether this check applies to the given span.
+	AppliesTo(codec keys.SQLCodec, span roachpb.Span) (bool, error)
+}
+
+// assertCheckApplies is a helper that calls AppliesTo and asserts the check applies.
+func assertCheckApplies(
+	check inspectCheckApplicability, codec keys.SQLCodec, span roachpb.Span,
+) error {
+	applies, err := check.AppliesTo(codec, span)
+	if err != nil {
+		return err
+	}
+	if !applies {
+		return errors.AssertionFailedf(
+			"check does not apply to this span: span=%s", span.String())
+	}
+	return nil
+}
 
 // inspectCheck defines a single validation operation used by the INSPECT system.
 // Each check represents a specific type of data validation, such as index consistency.
@@ -25,6 +49,8 @@ import (
 // under the hood to detect inconsistencies. All results are surfaced through the
 // inspectIssue type.
 type inspectCheck interface {
+	inspectCheckApplicability
+
 	// Started reports whether the check has been initialized.
 	Started() bool
 
@@ -116,4 +142,13 @@ func (c *inspectRunner) Close(ctx context.Context) error {
 		}
 	}
 	return retErr
+}
+
+// spanContainsTable checks if the given span contains data for the specified table.
+func spanContainsTable(tableID descpb.ID, codec keys.SQLCodec, span roachpb.Span) (bool, error) {
+	_, spanTableID, err := codec.DecodeTablePrefix(span.Key)
+	if err != nil {
+		return false, err
+	}
+	return descpb.ID(spanTableID) == tableID, nil
 }

--- a/pkg/sql/inspect/runner_test.go
+++ b/pkg/sql/inspect/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -28,6 +29,13 @@ type mockInspectCheck struct {
 }
 
 var _ inspectCheck = &mockInspectCheck{}
+var _ inspectCheckApplicability = &mockInspectCheck{}
+
+// AppliesTo implements the inspectCheckApplicability interface.
+func (m *mockInspectCheck) AppliesTo(codec keys.SQLCodec, span roachpb.Span) (bool, error) {
+	// For testing, assume all checks apply to all spans
+	return true, nil
+}
 
 func (m *mockInspectCheck) Started() bool {
 	return m.started


### PR DESCRIPTION
Backport 1/1 commits from #154135 on behalf of @spilchen.

----

INSPECT jobs generate a set of checks along with a separate list of spans, which only apply to some of the checks. Previously, filtering to ensure a span applied to a check happened late in the process.

This commit moves that filtering earlier, so checks immediately skip spans that are not relevant. This improves efficiency and prepares the system for upcoming progress tracking logic, which will be added in a separate PR.

Informs: #148297
Epic: CRDB-30356

Release note: none

----

Release justification: required for MVP of new INSPECT feature