### PR TITLE
startup: allow test to run in nightly stress jobs

### DIFF
--- a/pkg/util/startup/startup_test.go
+++ b/pkg/util/startup/startup_test.go
@@ -89,7 +89,7 @@ func TestStartupFailureRandomRange(t *testing.T) {
 	// CI. We also skip race builds as the test uses multiple nodes, which can
 	// cause the test to grind to a halt and flake out.
 	skip.UnderRace(t, "6 nodes with replication is too slow for race")
-	if !skip.Stress() {
+	if !skip.NightlyStress() {
 		skip.IgnoreLint(t, "test takes 30s to run due to circuit breakers and timeouts")
 	}
 


### PR DESCRIPTION
The change in #154071 incorrectly marked the test as skippable in nightly runs. Fix by allowing the test to run by checking the status of `skip.NightlyStress`.

Fix #123908.

Release note: None.

Epic: None.