### PR TITLE
fix: TestRandomSyntaxFunctions issue fix

### DIFF
--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -106,6 +106,9 @@ func emitInternal(
 
 	if len(plan.Subqueries) == 0 && len(plan.Cascades) == 0 &&
 		len(plan.Checks) == 0 && len(plan.Triggers) == 0 {
+		if plan.Root == nil {
+			return errors.Errorf("cannot emit plan with nil root")
+		}
 		return walk(plan.Root)
 	}
 	ob.EnterNode("root", plan.Root.Columns(), plan.Root.Ordering())

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -238,6 +238,11 @@ func DecodePlanGistToPlan(s string, cat cat.Catalog) (plan *Plan, err error) {
 
 	plan.Root = d.popChild()
 
+	// Null check
+	if plan.Root == nil {
+		return nil, errors.Errorf("invalid plan gist: no root node found")
+	}
+
 	for _, n := range d.nodeStack {
 		subquery := exec.Subquery{
 			Root: n,


### PR DESCRIPTION
Closes: #154300 

The test sql/tests.TestRandomSyntaxFunctions failed with a panic: runtime error: index out of range [0] with length 0 when executing:
```
SELECT crdb_internal.decode_external_plan_gist('AgYd':::STRING);
```

 The error occurs in the SQL execution engine's plan gist decoding subsystem, specifically:

  - Component: /pkg/sql/opt/exec/explain/ - Plan gist factory and decoder
  - Files involved:
    - /pkg/sql/sem/builtins/generator_builtins.go:897 - The Values() method crashes
    - /pkg/sql/opt/exec/explain/plan_gist_factory.go:239 - Creates plan with nil Root
    - /pkg/sql/opt/exec/explain/emit.go:109,111 - Attempts to access nil plan.Root

## Why it occurs?

  1. Root Cause: The input 'AgYd' (which decodes to bytes 02 06 1d) represents a malformed/truncated
  plan gist
  2. Decode Process:
    - Decodes version correctly (first byte 02 = version 2, but current version is 1)
    - Fails version check but continues processing
    - The decoder loop doesn't create any nodes, leaving nodeStack empty
    - popChild() returns nil when called on empty stack
    - plan.Root becomes nil
  3. Panic Location: When the Emit function tries to call methods on plan.Root (which is nil), it
  causes a nil pointer dereference
  
## Fix:

1. Null check in DecodePlanGistToPlan (pkg/sql/opt/exec/explain/plan_gist_factory.go:239):
```golang
  plan.Root = d.popChild()
  if plan.Root == nil {
      return nil, errors.Errorf("invalid plan gist: no root node found")
  }
```
  3. Null check in emitInternal (pkg/sql/opt/exec/explain/emit.go:109):
  ```golang
  if plan.Root == nil {
      return errors.Errorf("cannot emit plan with nil root")
  }
  ```
  Note: This is an immediate fix. A better fix would be Enhancing input validation in the decoder to detect truncated/malformed gists earlier.