### PR TITLE
roachtest: plumb AOST used in backup fixture fingerprint to restore

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -825,6 +825,11 @@ func (rd *restoreDriver) prepareCluster(ctx context.Context) {
 
 // getAOST gets the AOST to use in the restore cmd.
 func (rd *restoreDriver) getAOST(ctx context.Context) {
+	if rd.fixtureMetadata.FingerprintTime != "" {
+		rd.aost = rd.fixtureMetadata.FingerprintTime
+		rd.t.L().Printf("using AOST from fixture metadata: %s", rd.aost)
+		return
+	}
 	if !rd.sp.fullBackupOnly {
 		rd.aost = ""
 		return

--- a/pkg/roachprod/blobfixture/metadata.go
+++ b/pkg/roachprod/blobfixture/metadata.go
@@ -40,6 +40,9 @@ type FixtureMetadata struct {
 	// Note: this may not be present if the fixture was too large to be
 	// fingerprinted.
 	Fingerprint map[string]string `json:"fingerprint,omitempty"`
+
+	// FingerprintTime is the aost used by the fingerprint command.
+	FingerprintTime string `json:"fingerprint_time,omitempty"`
 }
 
 func (f *FixtureMetadata) MarshalJson() ([]byte, error) {

--- a/pkg/roachprod/blobfixture/registry.go
+++ b/pkg/roachprod/blobfixture/registry.go
@@ -333,11 +333,14 @@ func (s *ScratchHandle) SetReadyAt(ctx context.Context) error {
 }
 
 // SetFingerprint sets the fingerprint for the fixture.
-func (s *ScratchHandle) SetFingerprint(ctx context.Context, fingerprint map[string]string) error {
+func (s *ScratchHandle) SetFingerprint(
+	ctx context.Context, fingerprint map[string]string, asOf string,
+) error {
 	s.metadata.Fingerprint = fingerprint
+	s.metadata.FingerprintTime = asOf
 	if err := s.registry.upsertMetadata(s.metadata); err != nil {
 		return err
 	}
-	s.logger.Printf("fixture '%s' fingerprint set to '%s'", s.metadata.DataPath, s.metadata.Fingerprint)
+	s.logger.Printf("fixture '%s' fingerprint set to '%s' with asOf time %s ", s.metadata.DataPath, s.metadata.Fingerprint, s.metadata.FingerprintTime)
 	return nil
 }


### PR DESCRIPTION
In the backup fixture roachtest, an incremental backup can be taken after the fingerprint aost is chosen. In this case, the restore roachtest should restore at that system time, instead of from LATEST, else the restore roachtest could mistakenly fail on a fingerprint violation.

This patch plumbs the backup fixture aost to the restore roachtest to avoid this test flake.

Informs #152721
Informs #152724

Release note: none