### PR TITLE
roachest: ensure reader tenant accepts connections before restart

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1051,6 +1051,16 @@ func (rd *replicationDriver) maybeRestartReaderTenantService(ctx context.Context
 		return nil
 	})
 
+	// Now wait for the reader tenant to be accepting connections
+	readerTenantConn := rd.c.Conn(ctx, rd.t.L(), rd.setup.dst.gatewayNodes[0],
+		option.VirtualClusterName(readerTenantName),
+		option.DBName("system"),
+		option.User("root"),
+		option.AuthMode(install.AuthRootCert))
+
+	defer readerTenantConn.Close()
+	testutils.SucceedsSoon(rd.t, func() error { return readerTenantConn.Ping() })
+
 	rd.t.Status("restarting reader tenant service")
 
 	// Stop the reader tenant service


### PR DESCRIPTION
Previously, the roachtest would restart the tenant before the tenant could accept connections, which means the tenant could still be bootstrapping. Restarting the tenant service during bootstrap could lead to sadness, as outlined in #154356.

Informs #154356
Informs #154311
Informs #153131

Release note: none