### PR TITLE
workload/schemachanger: add randomized testing for TRUNCATE

### DIFF
--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -89,7 +91,10 @@ func (t *truncateNode) startExec(params runParams) error {
 			}
 
 			if n.DropBehavior != tree.DropCascade {
-				return errors.Errorf("%q is %s table %q", tableDesc.Name, msg, other.Name)
+				// The error code returned here matches PGSQL, even though the CASCADE
+				// operation is supported there with TRUNCATE as well.
+				return errors.WithHintf(pgerror.Newf(pgcode.FeatureNotSupported, "%q is %s table %q", tableDesc.Name, msg, other.Name),
+					"truncate dependent tables at the same time or specify the CASCADE option")
 			}
 			if err := p.CheckPrivilege(ctx, other, privilege.DROP); err != nil {
 				return err

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -143,6 +143,7 @@ const (
 	dropTable    // DROP TABLE <table>
 	dropTrigger  // DROP TRIGGER <trigger> ON <table>
 	dropView     // DROP VIEW <view>
+	truncateTable
 
 	// Unimplemented operations. TODO(sql-foundations): Audit and/or implement these operations.
 	// alterDatabaseOwner
@@ -264,6 +265,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	renameSequence:                    (*operationGenerator).renameSequence,
 	renameTable:                       (*operationGenerator).renameTable,
 	renameView:                        (*operationGenerator).renameView,
+	truncateTable:                     (*operationGenerator).truncateTable,
 }
 
 var opWeights = []int{
@@ -321,6 +323,7 @@ var opWeights = []int{
 	renameSequence:                    1,
 	renameTable:                       1,
 	renameView:                        1,
+	truncateTable:                     1,
 }
 
 // This workload will maintain its own list of minimal supported versions for
@@ -358,4 +361,5 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	dropTable:                         clusterversion.MinSupported,
 	dropTrigger:                       clusterversion.MinSupported,
 	dropView:                          clusterversion.MinSupported,
+	truncateTable:                     clusterversion.V25_4,
 }

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -65,6 +65,7 @@ func _() {
 	_ = x[dropTable-49]
 	_ = x[dropTrigger-50]
 	_ = x[dropView-51]
+	_ = x[truncateTable-52]
 }
 
 func (i opType) String() string {
@@ -173,6 +174,8 @@ func (i opType) String() string {
 		return "dropTrigger"
 	case dropView:
 		return "dropView"
+	case truncateTable:
+		return "truncateTable"
 	default:
 		return "opType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
Previously, the randomized schema changer workload had no coverage for TRUNCATE. This patch adds support for testing TRUNCATE in the randomized workload with multiple tables and with / without CASSCADE.

Note: This patch also fixes the pgcode generated by TRUNCATE when foreign key refrences exist, since previously we returned an internal error. Postgres generates a FeatureNotSupported pgcode.

Fixes: #154045

Release note: None