### PR TITLE
release-25.4: sql: Fix idle latency tracking

### DIFF
--- a/pkg/sql/sessionphase/session_phase.go
+++ b/pkg/sql/sessionphase/session_phase.go
@@ -114,6 +114,9 @@ func NewTimes() *Times {
 }
 
 // SetSessionPhaseTime sets the time for a given SessionPhase.
+// TODO(alyshan): Session Phase Times are set throughout the conn executor, it is
+// a tedious process to track when and where these times are set.
+// Found a bug again? Consider refactoring.
 func (t *Times) SetSessionPhaseTime(sp SessionPhase, time crtime.Mono) {
 	t.times[sp] = time
 }

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -113,6 +113,9 @@ func (s *StatsCollector) PreviousPhaseTimes() *sessionphase.Times {
 
 // Reset resets the StatsCollector with a new flushTarget (the session's current
 // application stats), and a new copy of the sessionphase.Times.
+// TODO(alyshan): Session Phase Times are set throughout the conn executor, it is
+// a tedious process to track when and where these times are set.
+// Found a bug again? Consider refactoring.
 func (s *StatsCollector) Reset(appStats *ssmemstorage.Container, phaseTime *sessionphase.Times) {
 	s.flushTarget = appStats
 	s.stmtFingerprintID = 0


### PR DESCRIPTION
Backport 1/1 commits from #154028.

/cc @cockroachdb/release

Release justification: Bug fix

---

Previously idle latencies were not being tracked accurately in two situations.

First, there was massive over counting of idle latencies in transactions that had INSERTs with placeholders (more generally statement that executed a prepare/bind before running). See issue #146116.

In these situations we had missed setting the QueryServiced time for the statements within the transaction, resulting in all the intermediate idle latencies calulating their `waitingSince` from the transaction start time.

The control flow of the conn executor can be difficult to track and through adding print statements, the difference between a transaction with `INSERT INTO ... VALUES (1)` vs `INSERT INTO ... VALUES ($1)` highlighted that setting QueryServiced at the end of the `ExecStmt` case in `execCmd` meant that for the prepare/bind version of the INSERT statements, we never set QueryServiced.

Simple statements:
```
execCmd ExecStmt
execStmtInOpenState INSERT INTO test_idle VALUES (1)
execCmd Setting QueryServiced
execCmd ExecStmt
execStmtInOpenState INSERT INTO test_idle VALUES (1)
execCmd Setting QueryServiced
execCmd ExecStmt
execStmtInOpenState INSERT INTO test_idle VALUES (1)
execCmd Setting QueryServiced
```

Notice how after every `execStmtInOpenState`, the flow returns to `execCmd`. Whereas in the case below, we just flow back into `execStmtInOpenState`.

Prepare/bind statements:
```
prepare statsCollector.Reset
bind statsCollector.Reset
execStmtInOpenState INSERT INTO test_idle VALUES ($1)
prepare statsCollector.Reset
bind statsCollector.Reset
execStmtInOpenState INSERT INTO test_idle VALUES ($1)
prepare statsCollector.Reset
bind statsCollector.Reset
execStmtInOpenState INSERT INTO test_idle VALUES ($1)
```

The second situation in which idle latencies were not tracked correctly was when observer statements were run in between statements in the transaction. This is a situation that occurs when using the `cockroach sql` cli. In this case, idle latencies were severely undercounted because we'd reset the stats collector before running the observer statement, and then when the non observer statement ran and we recorded the statement summary, the idle latency would be calculated from the previous observer statement time.

This commit fixes the first situation by additionally setting QueryServiced after `execStmt`.

This commit fixes the second situation by accumulating idle latencies in between observer statements.

Lastly this commit removes the existing TestSQLStatsIdleLatencies as it evidently had poor coverage and replaces it with TestTransactionLatencies which enforces invariants like:
totalTxnTime >= txnServiceLatency >= txnIdleLatency

p.s debugging session phase times is really tedious and we should consider refactoring.

Fixes: #146116
Release note (bug fix): Fixes discrepencies between idle and service latencies.
