### PR TITLE
kv: make TestFollowerReadsWithStaleDescriptor work with multi-tenancy

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvtestutils",
+        "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/rpcbase",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -148,6 +148,11 @@ func (d DeploymentMode) IsExternal() bool {
 	return d == ExternalProcess
 }
 
+// IsSingleTenant returns whether the deployment mode is single tenant or not.
+func (d DeploymentMode) IsSingleTenant() bool {
+	return d == SingleTenant
+}
+
 // RPCConn defines a common interface for creating RPC clients. It hides the
 // underlying RPC connection (gRPC or DRPC), making it easy to swap
 // them without changing the caller code.


### PR DESCRIPTION
This previously didn't work for a slew of reasons, commented in-line.

References https://github.com/cockroachdb/cockroach/issues/142800
Release note: None