### PR TITLE
roachtest: add test selector logger

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -312,9 +312,12 @@ func testsToRun(
 		// the test categorization must be complete in 30 seconds
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		updateSpecForSelectiveTests(ctx, specs, func(format string, args ...interface{}) {
+		err := updateSpecForSelectiveTests(ctx, specs, func(format string, args ...interface{}) {
 			fmt.Fprintf(os.Stdout, format, args...)
 		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var notSkipped []registry.TestSpec
@@ -389,7 +392,7 @@ func updateSpecForSelectiveTests(
 	selectorLogger.Printf("This is the test selector logger")
 
 	selectedTestsCount := 0
-	allTests, err := testselector.CategoriseTests(ctx,
+	allTests, err := testselector.CategoriseTests(ctx, selectorLogger,
 		testselector.NewDefaultSelectTestsReq(roachtestflags.Cloud, roachtestflags.Suite))
 	if err != nil {
 		return errors.Wrap(err, "running all tests! error selecting tests: %v")

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"os"
 	"os/user"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/testselector"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq" // register postgres driver
@@ -377,13 +379,20 @@ func testsToRun(
 //  5. All tests that are marked "selected=true" are considered for the test run.
 func updateSpecForSelectiveTests(
 	ctx context.Context, specs []registry.TestSpec, logFunc func(format string, args ...interface{}),
-) {
+) error {
+	logPath := filepath.Join(roachtestflags.ArtifactsDir, "selector.log")
+	selectorLogger, err := logger.RootLogger(logPath, logger.NoTee)
+	if err != nil {
+		return err
+	}
+	defer selectorLogger.Close()
+	selectorLogger.Printf("This is the test selector logger")
+
 	selectedTestsCount := 0
 	allTests, err := testselector.CategoriseTests(ctx,
 		testselector.NewDefaultSelectTestsReq(roachtestflags.Cloud, roachtestflags.Suite))
 	if err != nil {
-		logFunc("running all tests! error selecting tests: %v\n", err)
-		return
+		return errors.Wrap(err, "running all tests! error selecting tests: %v")
 	}
 
 	// successfulTests are the tests considered by snowflake to not run, but, part of the testSpecs.
@@ -436,6 +445,7 @@ func updateSpecForSelectiveTests(
 		}
 	}
 	logFunc("%d out of %d tests selected for the run!\n", selectedTestsCount, len(specs))
+	return nil
 }
 
 // testShouldBeSkipped decides whether a test should be skipped based on test details and suite

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -395,7 +395,7 @@ func updateSpecForSelectiveTests(
 	allTests, err := testselector.CategoriseTests(ctx, selectorLogger,
 		testselector.NewDefaultSelectTestsReq(roachtestflags.Cloud, roachtestflags.Suite))
 	if err != nil {
-		return errors.Wrap(err, "running all tests! error selecting tests: %v")
+		return errors.Wrap(err, "running all tests! error selecting tests")
 	}
 
 	// successfulTests are the tests considered by snowflake to not run, but, part of the testSpecs.

--- a/pkg/cmd/roachtest/testselector/BUILD.bazel
+++ b/pkg/cmd/roachtest/testselector/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/roachtest/spec",
+        "//pkg/roachprod/logger",
         "@com_github_snowflakedb_gosnowflake//:gosnowflake",
     ],
 )

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -96,6 +95,24 @@ func NewDefaultSelectTestsReq(cloud spec.Cloud, suite string) *SelectTestsReq {
 func CategoriseTests(
 	ctx context.Context, logger *logger.Logger, req *SelectTestsReq,
 ) ([]*TestDetails, error) {
+	currentBranch := os.Getenv("TC_BUILD_BRANCH")
+	if currentBranch == "" {
+		currentBranch = "master"
+	}
+
+	// Can't do this because the literal `%V exists in the query bc `like `%VMs ....``
+	//debugQuery := strings.ReplaceAll(PreparedQuery, "?", "%v")
+	//logger.Printf(debugQuery)
+	//logger.Printf(debugQuery, req.ForPastDays*-1, currentBranch,
+	//	fmt.Sprintf("%%%s - %s%%", suites[req.Suite], req.Cloud),
+	//	req.FirstRunOn*-1, req.LastRunOn*-1)
+
+	// Print Query & Query Params
+
+	logger.Printf("Query Params:\n%d\n%s\n%s\n%d\n%d", req.ForPastDays*-1, currentBranch,
+		fmt.Sprintf("%%%s - %s%%", suites[req.Suite], req.Cloud),
+		req.FirstRunOn*-1, req.LastRunOn*-1)
+
 	db, err := getConnect(ctx)
 	if err != nil {
 		return nil, err
@@ -107,10 +124,10 @@ func CategoriseTests(
 	}
 	defer func() { _ = statement.Close() }()
 	// get the current branch from the teamcity environment
-	currentBranch := os.Getenv("TC_BUILD_BRANCH")
-	if currentBranch == "" {
-		currentBranch = "master"
-	}
+	//currentBranch := os.Getenv("TC_BUILD_BRANCH")
+	//if currentBranch == "" {
+	//	currentBranch = "master"
+	//}
 	// add the parameters in sequence
 	rows, err := statement.QueryContext(ctx, req.ForPastDays*-1, currentBranch,
 		fmt.Sprintf("%%%s - %s%%", suites[req.Suite], req.Cloud),
@@ -119,11 +136,10 @@ func CategoriseTests(
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-
-	debugQuery := strings.ReplaceAll(PreparedQuery, "?", "%v")
-	logger.Printf(debugQuery, req.ForPastDays*-1, currentBranch,
-		fmt.Sprintf("%%%s - %s%%", suites[req.Suite], req.Cloud),
-		req.FirstRunOn*-1, req.LastRunOn*-1)
+	//debugQuery := strings.ReplaceAll(PreparedQuery, "?", "%v")
+	//logger.Printf(debugQuery, req.ForPastDays*-1, currentBranch,
+	//	fmt.Sprintf("%%%s - %s%%", suites[req.Suite], req.Cloud),
+	//	req.FirstRunOn*-1, req.LastRunOn*-1)
 
 	// All the column headers
 	colHeaders, err := rows.Columns()


### PR DESCRIPTION
Putting this on hold for now. I feel like just adding the query doesn't really add all the insights i'd wanna see from test selection. I think the current selection model makes sense, I'd just like to at a glance more easily see what's going on.

Test selection is currently a black box. Adding logging to help see what's going on. i.e. test is timing out, we see that all tests got selected 
```
[06:05:28] :	 [Step 2/2] 0 selected out of 0 successful tests.
[06:05:28] :	 [Step 2/2] 673 out of 673 tests selected for the run!
```
In this case we know why, but it would be nice to see more details on selection for future issues