### PR TITLE
release-25.4: sql,unsafesql,sessiondata: do not log unsafe access logs for internal app names

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -920,7 +920,7 @@ func (s *Server) SetupConn(
 	// to use the InternalMetrics. However, some external connections use the prefix as well, for example
 	// the debug zip cli tool.
 	metrics := &s.Metrics
-	if strings.HasPrefix(sd.ApplicationName, catconstants.InternalAppNamePrefix) {
+	if sd.IsInternalAppName() {
 		metrics = &s.InternalMetrics
 	}
 
@@ -1255,7 +1255,6 @@ func (s *Server) newConnExecutor(
 	}
 
 	ex.applicationName.Store(ex.sessionData().ApplicationName)
-
 	ex.applicationStats = applicationStats
 	// We ignore statements and transactions run by the internal executor by
 	// passing a nil writer.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -9,9 +9,11 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -152,6 +154,10 @@ func (s *SessionData) SessionUser() username.SQLUsername {
 		return s.User()
 	}
 	return s.SessionUserProto.Decode()
+}
+
+func (s *SessionData) IsInternalAppName() bool {
+	return strings.HasPrefix(s.ApplicationName, catconstants.InternalAppNamePrefix)
 }
 
 // LocalUnmigratableSessionData contains session parameters that cannot

--- a/pkg/sql/unsafesql/BUILD.bazel
+++ b/pkg/sql/unsafesql/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//pkg/sql/isql",
         "//pkg/sql/sqlerrors",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",

--- a/pkg/sql/unsafesql/unsafesql.go
+++ b/pkg/sql/unsafesql/unsafesql.go
@@ -49,7 +49,7 @@ func CheckInternalsAccess(
 	sv *settings.Values,
 ) error {
 	// If the querier is internal, we should allow it.
-	if sd.Internal {
+	if sd.Internal || sd.IsInternalAppName() {
 		return nil
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #154267 on behalf of @kyle-a-wong.

----

If the app name of a session is an internal app name, we won't do any checks
on internals access.  An app name is considered to be an internal app name
if it begins with "$ internal"

Resolves: https://github.com/cockroachdb/cockroach/issues/153803
Epic: None
Release note: None

----

Release justification: low-risk change to reduce the amount of log noise caused by debug zip from new unsafe internals logs