### PR TITLE
rangefeed: make TestUnrecoverableErrors work with multi-tenancy

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -952,7 +952,6 @@ func TestUnrecoverableErrors(t *testing.T) {
 		// handle duplicated events.
 		kvserver.RangefeedUseBufferedSender.Override(ctx, &settings.SV, rt.useBufferedSender)
 		srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109472),
 			Knobs: base.TestingKnobs{
 				SpanConfig: &spanconfig.TestingKnobs{
 					ConfigureScratchRange: true,


### PR DESCRIPTION
This test wants to see errors because of strict GC enforcement policies. To do so, it creates a scratch range and tries to trigger an error there. Strict GC enforcement policies don't apply to the scratch range out of the box, so to sidestep this, the test would explicitly configure the scratch range's span config. This explicit configuration only worked for the system tenant previously; this patch extends it to secondary tenants.

Closes https://github.com/cockroachdb/cockroach/issues/109472

Release note: None