### PR TITLE
kvserver: use Pebble snapshot for catchup scans

### DIFF
--- a/pkg/backup/backupsink/file_sst_sink.go
+++ b/pkg/backup/backupsink/file_sst_sink.go
@@ -361,7 +361,7 @@ func (s *FileSSTSink) copyPointKeys(ctx context.Context, dataSST []byte) (roachp
 
 	empty := true
 	for iter.SeekGE(storage.MVCCKey{Key: keys.MinKey}); ; iter.Next() {
-		if err := s.pacer.Pace(ctx); err != nil {
+		if _, err := s.pacer.Pace(ctx); err != nil {
 			return nil, err
 		}
 		if valid, err := iter.Valid(); !valid || err != nil {

--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -422,7 +422,7 @@ func compactSpanEntry(
 	scratch = append(scratch, prefix...)
 	iter := sstIter.iter
 	for iter.SeekGE(trimmedStart); ; iter.NextKey() {
-		if err := pacer.Pace(ctx); err != nil {
+		if _, err := pacer.Pace(ctx); err != nil {
 			return err
 		}
 		var key storage.MVCCKey

--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -476,7 +476,7 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 			// TODO(yevgeniy): rework this function: this function should simply
 			// return an error, and not rely on "handleError".
 			// It's hard to reason about this functions correctness otherwise.
-			_ = s.pacer.Pace(ctx)
+			_, _ = s.pacer.Pace(ctx)
 
 			switch r := req.(type) {
 			case *rowEvent:

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -343,7 +343,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 	// Request CPU time to use for event consumption, block if this time is
 	// unavailable. If there is unused CPU time left from the last call to
 	// Pace, then use that time instead of blocking.
-	if err := c.pacer.Pace(ctx); err != nil {
+	if _, err := c.pacer.Pace(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -445,7 +445,7 @@ func (b *SSTBatcher) AddMVCCKeyLDR(ctx context.Context, key storage.MVCCKey, val
 // Keys must be added in order.
 func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key storage.MVCCKey, value []byte) error {
 	// Pace based on admission control before adding the key.
-	if err := b.pacer.Pace(ctx); err != nil {
+	if _, err := b.pacer.Pace(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/bufalloc",
         "//pkg/util/buildutil",

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -56,11 +56,12 @@ type bufferedRegistration struct {
 		outputLoopCancelFn func()
 		disconnected       bool
 
-		// catchUpIter is created by replcia under raftMu lock when registration is
-		// created. It is detached by output loop for processing and closed.
-		// If output loop was not started and catchUpIter is non-nil at the time
-		// that disconnect is called, it is closed by disconnect.
-		catchUpIter *CatchUpIterator
+		// catchUpSnap is created by a replica under the raftMu lock when a
+		// registration is created. It is detached by the output loop for
+		// processing and closed. If the output loop was not started and
+		// catchUpSnap is non-nil at the time that disconnect is called, it is
+		// closed by disconnect.
+		catchUpSnap *CatchUpSnapshot
 	}
 
 	// Number of events that have been written to the buffer but
@@ -74,7 +75,7 @@ func newBufferedRegistration(
 	streamCtx context.Context,
 	span roachpb.Span,
 	startTS hlc.Timestamp,
-	catchUpIter *CatchUpIterator,
+	catchUpSnap *CatchUpSnapshot,
 	withDiff bool,
 	withFiltering bool,
 	withOmitRemote bool,
@@ -101,7 +102,7 @@ func newBufferedRegistration(
 		buf:           make(chan *sharedEvent, bufferSz),
 		blockWhenFull: blockWhenFull,
 	}
-	br.mu.catchUpIter = catchUpIter
+	br.mu.catchUpSnap = catchUpSnap
 	return br
 }
 
@@ -166,9 +167,9 @@ func (br *bufferedRegistration) Disconnect(pErr *kvpb.Error) {
 	br.mu.Lock()
 	defer br.mu.Unlock()
 	if !br.mu.disconnected {
-		if br.mu.catchUpIter != nil {
-			br.mu.catchUpIter.Close()
-			br.mu.catchUpIter = nil
+		if br.mu.catchUpSnap != nil {
+			br.mu.catchUpSnap.Close()
+			br.mu.catchUpSnap = nil
 		}
 		if br.mu.outputLoopCancelFn != nil {
 			br.mu.outputLoopCancelFn()
@@ -297,20 +298,19 @@ func (br *bufferedRegistration) drainAllocations(ctx context.Context) {
 // This uses the iterator provided when the registration was originally created;
 // after the scan completes, the iterator will be closed.
 //
-// If the registration does not have a catchUpIteratorConstructor, this method
-// is a no-op.
+// If the registration does not have a catchUpSnap, this method is a no-op.
 func (br *bufferedRegistration) maybeRunCatchUpScan(ctx context.Context) error {
-	catchUpIter := br.detachCatchUpIter()
-	if catchUpIter == nil {
+	catchUpSnap := br.detachCatchUpSnap()
+	if catchUpSnap == nil {
 		return nil
 	}
 	start := crtime.NowMono()
 	defer func() {
-		catchUpIter.Close()
+		catchUpSnap.Close()
 		br.metrics.RangeFeedCatchUpScanNanos.Inc(start.Elapsed().Nanoseconds())
 	}()
 
-	return catchUpIter.CatchUpScan(ctx, br.stream.SendUnbuffered, br.withDiff, br.withFiltering, br.withOmitRemote, br.bulkDelivery)
+	return catchUpSnap.CatchUpScan(ctx, br.stream.SendUnbuffered, br.withDiff, br.withFiltering, br.withOmitRemote, br.bulkDelivery)
 }
 
 // Wait for this registration to completely process its internal
@@ -335,13 +335,13 @@ func (br *bufferedRegistration) waitForCaughtUp(ctx context.Context) error {
 	return errors.Errorf("bufferedRegistration %v failed to empty in time", br.Range())
 }
 
-// detachCatchUpIter detaches the catchUpIter that was previously attached.
-func (br *bufferedRegistration) detachCatchUpIter() *CatchUpIterator {
+// detachCatchUpSnap detaches the catchUpSnap that was previously attached.
+func (br *bufferedRegistration) detachCatchUpSnap() *CatchUpSnapshot {
 	br.mu.Lock()
 	defer br.mu.Unlock()
-	catchUpIter := br.mu.catchUpIter
-	br.mu.catchUpIter = nil
-	return catchUpIter
+	catchUpSnap := br.mu.catchUpSnap
+	br.mu.catchUpSnap = nil
+	return catchUpSnap
 }
 
 var overflowLogEvery = log.Every(5 * time.Second)

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -258,7 +258,7 @@ func TestBufferedSenderOnStreamShutdown(t *testing.T) {
 	}
 
 	// Add our stream to the stream manager.
-	registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+	registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 		sm.NewStream(streamID, 1 /*rangeID*/))
 	require.True(t, registered)

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -8,20 +8,23 @@ package rangefeed
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 )
 
-// simpleCatchupIter is an extension of SimpleMVCCIterator that allows for the
+// SimpleCatchupIter is an extension of SimpleMVCCIterator that allows for the
 // primary iterator to be implemented using a regular MVCCIterator or a
 // (often) more efficient MVCCIncrementalIterator. When the caller wants to
 // iterate to see older versions of a key, the desire of the caller needs to
@@ -30,84 +33,101 @@ import (
 //     bounds.
 //   - NextIgnoringTime: when it wants to see the next older version even if it
 //     is not within the time bounds.
-type simpleCatchupIter interface {
+type SimpleCatchupIter interface {
 	storage.SimpleMVCCIterator
 	NextIgnoringTime()
 	RangeKeyChangedIgnoringTime() bool
 	RangeKeysIgnoringTime() storage.MVCCRangeKeyStack
 }
 
-type simpleCatchupIterAdapter struct {
-	storage.SimpleMVCCIterator
+// EngSnapshot abstracts an engine snapshot for testing.
+type EngSnapshot interface {
+	Close()
+	NewMVCCIncrementalIterator(
+		context.Context, storage.MVCCIncrementalIterOptions) (SimpleCatchupIter, error)
 }
 
-func (i simpleCatchupIterAdapter) NextIgnoringTime() {
-	i.SimpleMVCCIterator.Next()
+type EngSnapshotAdapter struct {
+	snap storage.Reader
 }
 
-func (i simpleCatchupIterAdapter) RangeKeyChangedIgnoringTime() bool {
-	return i.SimpleMVCCIterator.RangeKeyChanged()
+var _ EngSnapshot = EngSnapshotAdapter{}
+
+func (s EngSnapshotAdapter) Close() {
+	s.snap.Close()
 }
 
-func (i simpleCatchupIterAdapter) RangeKeysIgnoringTime() storage.MVCCRangeKeyStack {
-	return i.SimpleMVCCIterator.RangeKeys()
+func (s EngSnapshotAdapter) NewMVCCIncrementalIterator(
+	ctx context.Context, opts storage.MVCCIncrementalIterOptions,
+) (SimpleCatchupIter, error) {
+	iter, err := storage.NewMVCCIncrementalIterator(ctx, s.snap, opts)
+	if err != nil {
+		return nil, err
+	}
+	return iter, nil
 }
 
-var _ simpleCatchupIter = simpleCatchupIterAdapter{}
-
-// CatchUpIterator is an iterator for catchup-scans.
-type CatchUpIterator struct {
-	simpleCatchupIter
-	close     func()
-	span      roachpb.Span
-	startTime hlc.Timestamp // exclusive
-	pacer     *admission.Pacer
-	OnEmit    func(key, endKey roachpb.Key, ts hlc.Timestamp, vh enginepb.MVCCValueHeader)
+// CatchUpSnapshot is an engine snapshot for catchup-scans.
+type CatchUpSnapshot struct {
+	snap                 EngSnapshot
+	iterOpts             storage.MVCCIncrementalIterOptions
+	close                func()
+	span                 roachpb.Span
+	startTime            hlc.Timestamp // exclusive
+	pacer                *admission.Pacer
+	OnEmit               func(key, endKey roachpb.Key, ts hlc.Timestamp, vh enginepb.MVCCValueHeader)
+	iterRecreateDuration time.Duration
 }
 
-// NewCatchUpIterator returns a CatchUpIterator for the given Reader over the
-// given key/time span. startTime is exclusive.
+// NewCatchUpSnapshot returns a CatchUpSnapshot for the given Engine over the
+// given key/time span, where span represents a global key range. startTime is
+// exclusive.
 //
 // NB: startTime is exclusive, i.e. the first possible event will be emitted at
 // Timestamp.Next().
-func NewCatchUpIterator(
-	ctx context.Context,
-	reader storage.Reader,
+//
+// iterRecreateDuration, if > 0, is the duration after which the
+// MVCCIncrementalIterator should be closed and reopened (see the
+// storage.snapshot.recreate_iter_duration cluster setting for details).
+func NewCatchUpSnapshot(
+	eng storage.Engine,
 	span roachpb.Span,
 	startTime hlc.Timestamp,
 	closer func(),
 	pacer *admission.Pacer,
-) (*CatchUpIterator, error) {
-	iter, err := storage.NewMVCCIncrementalIterator(ctx, reader,
-		storage.MVCCIncrementalIterOptions{
-			KeyTypes:  storage.IterKeyTypePointsAndRanges,
-			StartKey:  span.Key,
-			EndKey:    span.EndKey,
-			StartTime: startTime,
-			EndTime:   hlc.MaxTimestamp,
-			// We want to emit intents rather than error
-			// (the default behavior) so that we can skip
-			// over the provisional values during
-			// iteration.
-			IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
-			ReadCategory: fs.RangefeedReadCategory,
-		})
-	if err != nil {
-		return nil, err
+	iterRecreateDuration time.Duration,
+) *CatchUpSnapshot {
+	iterOpts := storage.MVCCIncrementalIterOptions{
+		KeyTypes:  storage.IterKeyTypePointsAndRanges,
+		StartKey:  span.Key,
+		EndKey:    span.EndKey,
+		StartTime: startTime,
+		EndTime:   hlc.MaxTimestamp,
+		// We want to emit intents rather than error
+		// (the default behavior) so that we can skip
+		// over the provisional values during
+		// iteration.
+		IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
+		ReadCategory: fs.RangefeedReadCategory,
 	}
-	return &CatchUpIterator{
-		simpleCatchupIter: iter,
-		close:             closer,
-		span:              span,
-		startTime:         startTime,
-		pacer:             pacer,
-	}, nil
+	// TODO(sumeer): create a snapshot over span and the lock table spans
+	// derived from it.
+	snap := eng.NewSnapshot()
+	return &CatchUpSnapshot{
+		snap:                 EngSnapshotAdapter{snap},
+		iterOpts:             iterOpts,
+		close:                closer,
+		span:                 span,
+		startTime:            startTime,
+		pacer:                pacer,
+		iterRecreateDuration: iterRecreateDuration,
+	}
 }
 
 // Close closes the iterator and calls the instantiator-supplied close
 // callback.
-func (i *CatchUpIterator) Close() {
-	i.simpleCatchupIter.Close()
+func (i *CatchUpSnapshot) Close() {
+	i.snap.Close()
 	i.pacer.Close()
 	if i.close != nil {
 		i.close()
@@ -132,10 +152,7 @@ type outputEventFn func(e *kvpb.RangeFeedEvent) error
 // For example, with MVCC range tombstones [a-f)@5 and [a-f)@3 overlapping point
 // keys a@6, a@4, and b@2, the emitted order is [a-f)@3,[a-f)@5,a@4,a@6,b@2 because
 // the start key "a" is ordered before all of the timestamped point keys.
-//
-// TODO(sumeer): ctx is not used for SeekGE and Next. Fix by adding a method
-// to SimpleMVCCIterator to replace the context.
-func (i *CatchUpIterator) CatchUpScan(
+func (i *CatchUpSnapshot) CatchUpScan(
 	ctx context.Context,
 	emitFn outputEventFn,
 	withDiff bool,
@@ -182,23 +199,101 @@ func (i *CatchUpIterator) CatchUpScan(
 		reorderBuf = reorderBuf[:0]
 		return nil
 	}
+	iter, err := i.snap.NewMVCCIncrementalIterator(ctx, i.iterOpts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
+	lastIterCreateTime := crtime.NowMono()
 	// Iterate though all keys using Next. We want to publish all committed
 	// versions of each key that are after the registration's startTS, so we
 	// can't use NextKey.
 	var lastKey roachpb.Key
 	var meta enginepb.MVCCMetadata
-	i.SeekGE(storage.MVCCKey{Key: i.span.Key})
+	iter.SeekGE(storage.MVCCKey{Key: i.span.Key})
 
 	for {
-		if ok, err := i.Valid(); err != nil {
+		if ok, err := iter.Valid(); err != nil {
 			return err
 		} else if !ok {
 			break
 		}
 
-		if err := i.pacer.Pace(ctx); err != nil {
+		readmitted, err := i.pacer.Pace(ctx)
+		if err != nil {
 			return err
 		}
+		// Determine whether the iterator moved to a new key.
+		unsafeKey := iter.UnsafeKey()
+		sameKey := bytes.Equal(unsafeKey.Key, lastKey)
+		if !sameKey {
+			// If so, output events for the last key encountered.
+			if err := outputEvents(); err != nil {
+				return err
+			}
+			a, lastKey = a.Copy(unsafeKey.Key)
+			// NB: we only recreate the iterator when we have moved to a new
+			// roachpb.Key. This is because we will need to reposition the new
+			// iterator using a seek, and the seek respects the time bounds.
+			// Repositioning the iterator using a seek within the different versions
+			// of a roachpb.Key is not desirable since we sometimes want to observe
+			// a version that is outside the time bounds (see the calls to
+			// NextIgnoringTime).
+			recreateIter := false
+			// recreateIter => now is initialized.
+			var now crtime.Mono
+			// We sample the current time only when readmitted is true, to avoid
+			// doing it in every iteration of the loop. In practice, readmitted is
+			// true after every 100ms of cpu time, and there is no wall time limit
+			// on how long one can wait in Pace. So there is a risk that the
+			// iterator recreation is arbitrarily delayed. But we accept that risk
+			// for now. The alternative would be to pass a context with a timeout to
+			// Pace. We also need to consider the CPU cost of recreating the
+			// iterator, and using the cpu time to amortize that cost seems
+			// reasonable.
+			if (readmitted && i.iterRecreateDuration > 0) || util.RaceEnabled {
+				// If enough walltime has elapsed, close iter and reopen. This
+				// prevents the iter from holding on to Pebble memtables for too long,
+				// which can cause OOMs.
+				now = crtime.NowMono()
+				recreateIter = now.Sub(lastIterCreateTime) > i.iterRecreateDuration || util.RaceEnabled
+			}
+			if recreateIter {
+				lastIterCreateTime = now
+				iter.Close()
+				iter = nil
+				iter, err = i.snap.NewMVCCIncrementalIterator(ctx, i.iterOpts)
+				if err != nil {
+					return err
+				}
+				// Resume from the same position. NB: we may have arrived at lastKey
+				// using NextIgnoringTime() in the previous iteration of this loop,
+				// and so lastKey may have a MVCC timestamp that is outside the time
+				// window. So the following seek (which does respect the time window)
+				// may land on a key > lastKey. Which is why we need to potentially
+				// replace lastKey below and to consider the case that the iterator is
+				// exhausted.
+				iter.SeekGE(storage.MVCCKey{Key: lastKey})
+				if ok, err := iter.Valid(); err != nil {
+					return err
+				} else if !ok {
+					break
+				}
+				unsafeKey = iter.UnsafeKey()
+				if !bytes.Equal(unsafeKey.Key, lastKey) {
+					// The seek moved past lastKey, so replace lastKey with the new key.
+					a, lastKey = a.Copy(unsafeKey.Key)
+				}
+			}
+		}
+		// Any stepping of the iterator below will immediately continue, i.e., key
+		// is what we will be processing in this iteration of the loop, and is a
+		// stable roachpb.Key.
+		key := lastKey
 
 		// Emit any new MVCC range tombstones when their start key is encountered.
 		// Range keys can currently only be MVCC range tombstones.
@@ -207,11 +302,11 @@ func (i *CatchUpIterator) CatchUpScan(
 		// NextIgnoringTime() call moved onto an MVCC range tombstone outside of the
 		// time bounds. In this case, HasPointAndRange() will return false,false and
 		// we step forward.
-		if i.RangeKeyChangedIgnoringTime() {
-			hasPoint, hasRange := i.HasPointAndRange()
+		if iter.RangeKeyChangedIgnoringTime() {
+			hasPoint, hasRange := iter.HasPointAndRange()
 			if hasRange {
 				// Emit events for these MVCC range tombstones, in chronological order.
-				rangeKeys := i.RangeKeys()
+				rangeKeys := iter.RangeKeys()
 				for j := rangeKeys.Len() - 1; j >= 0; j-- {
 					var span roachpb.Span
 					a, span.Key = a.Copy(rangeKeys.Bounds.Key)
@@ -239,13 +334,20 @@ func (i *CatchUpIterator) CatchUpScan(
 			// step onto the next key. This may be a point key version at the same key
 			// as the range key's start bound, or a later point/range key.
 			if !hasPoint {
-				i.Next()
+				iter.Next()
 				continue
 			}
 		}
+		// Else since !iter.RangekeyChangedIgnoringTime, we must have stepped to a
+		// new point key.
 
-		unsafeKey := i.UnsafeKey()
-		unsafeValRaw, err := i.UnsafeValue()
+		if util.RaceEnabled {
+			hasPoint, _ := iter.HasPointAndRange()
+			if !hasPoint {
+				return errors.AssertionFailedf("expected point key: %s", iter.UnsafeKey())
+			}
+		}
+		unsafeValRaw, err := iter.UnsafeValue()
 		if err != nil {
 			return err
 		}
@@ -270,23 +372,27 @@ func (i *CatchUpIterator) CatchUpScan(
 			// the time bounds. Using `NextIgnoringTime` on the next line makes sure
 			// that we are guaranteed to validate the version that belongs to the
 			// intent.
-			i.NextIgnoringTime()
+			iter.NextIgnoringTime()
 
-			if ok, err := i.Valid(); err != nil {
+			if ok, err := iter.Valid(); err != nil {
 				return errors.Wrap(err, "iterating to provisional value for intent")
 			} else if !ok {
 				return errors.Errorf("expected provisional value for intent")
 			}
-			if meta.Timestamp.ToTimestamp() != i.UnsafeKey().Timestamp {
+			if meta.Timestamp.ToTimestamp() != iter.UnsafeKey().Timestamp {
 				return errors.Errorf("expected provisional value for intent with ts %s, found %s",
-					meta.Timestamp, i.UnsafeKey().Timestamp)
+					meta.Timestamp, iter.UnsafeKey().Timestamp)
+			}
+			if util.RaceEnabled && !bytes.Equal(key, iter.UnsafeKey().Key) {
+				return errors.AssertionFailedf("expected key %s, and found %s",
+					key, iter.UnsafeKey().Key)
 			}
 			// Now move to the next key of interest. Note that if in the last
 			// iteration of the loop we called `NextIgnoringTime`, the fact that we
 			// hit an intent proves that there wasn't a previous value, so we can
 			// (in fact, have to, to avoid surfacing unwanted keys) unconditionally
 			// enforce time bounds.
-			i.Next()
+			iter.Next()
 			continue
 		}
 
@@ -303,20 +409,9 @@ func (i *CatchUpIterator) CatchUpScan(
 		if ignore && !withDiff {
 			// Skip all the way to the next key.
 			// NB: fast-path to avoid value copy when !r.withDiff.
-			i.NextKey()
+			iter.NextKey()
 			continue
 		}
-
-		// Determine whether the iterator moved to a new key.
-		sameKey := bytes.Equal(unsafeKey.Key, lastKey)
-		if !sameKey {
-			// If so, output events for the last key encountered.
-			if err := outputEvents(); err != nil {
-				return err
-			}
-			a, lastKey = a.Copy(unsafeKey.Key)
-		}
-		key := lastKey
 
 		// INVARIANT: !ignore || withDiff
 		//
@@ -345,7 +440,7 @@ func (i *CatchUpIterator) CatchUpScan(
 						// However, don't emit a value if an MVCC range tombstone existed
 						// between this value and the next one. The RangeKeysIgnoringTime()
 						// call is cheap, no need for caching.
-						rangeKeys := i.RangeKeysIgnoringTime()
+						rangeKeys := iter.RangeKeysIgnoringTime()
 						if rangeKeys.IsEmpty() || !rangeKeys.HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
 							// TODO(sumeer): find out if it is deliberate that we are not populating
 							// PrevValue.Timestamp.
@@ -361,7 +456,7 @@ func (i *CatchUpIterator) CatchUpScan(
 			// remote cluster (non zero originID), and the iterator has opted into
 			// omitting remote values.
 			if (mvccVal.OmitInRangefeeds && withFiltering) || (mvccVal.OriginID != 0 && withOmitRemote) {
-				i.Next()
+				iter.Next()
 				continue
 			}
 
@@ -384,16 +479,16 @@ func (i *CatchUpIterator) CatchUpScan(
 
 		if ignore {
 			// Skip all the way to the next key.
-			i.NextKey()
+			iter.NextKey()
 		} else {
 			// Move to the next version of this key (there may not be one, in which
 			// case it will move to the next key).
 			if withDiff {
 				// Need to see the next version even if it is older than the time
 				// bounds.
-				i.NextIgnoringTime()
+				iter.NextIgnoringTime()
 			} else {
-				i.Next()
+				iter.Next()
 			}
 		}
 	}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -47,13 +47,10 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		func() {
-			iter, err := rangefeed.NewCatchUpIterator(ctx, eng, span, opts.ts, nil, nil)
-			if err != nil {
-				b.Fatal(err)
-			}
-			defer iter.Close()
+			snap := rangefeed.NewCatchUpSnapshot(eng, span, opts.ts, nil, nil, 0)
+			defer snap.Close()
 			counter := 0
-			err = iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
+			err := snap.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
 				counter++
 				return nil
 			}, opts.withDiff, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery)

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -154,12 +154,11 @@ func TestCatchupScan(t *testing.T) {
 		testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
 			testutils.RunTrueAndFalse(t, "withFiltering", func(t *testing.T, withFiltering bool) {
 				span := roachpb.Span{Key: testKey1, EndKey: roachpb.KeyMax}
-				iter, err := NewCatchUpIterator(ctx, eng, span, ts1, nil, nil)
-				require.NoError(t, err)
-				defer iter.Close()
+				snap := NewCatchUpSnapshot(eng, span, ts1, nil, nil, 0)
+				defer snap.Close()
 				var events []kvpb.RangeFeedValue
 				// ts1 here is exclusive, so we do not want the versions at ts1.
-				require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+				require.NoError(t, snap.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 					events = append(events, *e.Val)
 					return nil
 				}, withDiff, withFiltering, false /* withOmitRemote */, noBulkDelivery))
@@ -232,12 +231,12 @@ func TestCatchupScanOriginID(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "withOmitRmote", func(t *testing.T, omitRemote bool) {
 		span := roachpb.Span{Key: a1.Key.Key, EndKey: roachpb.KeyMax}
-		iter, err := NewCatchUpIterator(ctx, eng, span, exclusiveStartTime, nil, nil)
+		snap := NewCatchUpSnapshot(eng, span, exclusiveStartTime, nil, nil, 0)
 		require.NoError(t, err)
-		defer iter.Close()
+		defer snap.Close()
 		var events []kvpb.RangeFeedValue
 		// ts1 here is exclusive, so we do not want the versions at ts1.
-		require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+		require.NoError(t, snap.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 			events = append(events, *e.Val)
 			return nil
 		}, false /* withDiff */, false /* withFiltering */, omitRemote, noBulkDelivery))
@@ -267,11 +266,11 @@ func TestCatchupScanInlineError(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it error.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter, err := NewCatchUpIterator(ctx, eng, span, hlc.Timestamp{}, nil, nil)
+	snap := NewCatchUpSnapshot(eng, span, hlc.Timestamp{}, nil, nil, 0)
 	require.NoError(t, err)
-	defer iter.Close()
+	defer snap.Close()
 
-	err = iter.CatchUpScan(ctx, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery)
+	err = snap.CatchUpScan(ctx, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected inline value")
 }
@@ -311,12 +310,12 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it succeed.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter, err := NewCatchUpIterator(ctx, eng, span, tsCutoff, nil, nil)
+	snap := NewCatchUpSnapshot(eng, span, tsCutoff, nil, nil, 0)
 	require.NoError(t, err)
-	defer iter.Close()
+	defer snap.Close()
 
 	keys := map[string]struct{}{}
-	require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+	require.NoError(t, snap.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 		keys[string(e.Val.Key)] = struct{}{}
 		return nil
 	}, true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery))

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -173,10 +173,10 @@ type Processor interface {
 	// events that are consumed concurrently with this call. The channel will be
 	// provided an error when the registration closes.
 	//
-	// The optionally provided "catch-up" iterator is used to read changes from the
+	// The optionally provided "catch-up" snapshot is used to read changes from the
 	// engine which occurred after the provided start timestamp (exclusive). If
-	// this method succeeds, registration must take ownership of iterator and
-	// subsequently close it. If method fails, iterator must be kept intact and
+	// this method succeeds, registration must take ownership of snapshot and
+	// subsequently close it. If method fails, snapshot must be kept intact and
 	// would be closed by caller.
 	//
 	// If the method returns false, the processor will have been stopped, so calling
@@ -189,7 +189,7 @@ type Processor interface {
 		streamCtx context.Context,
 		span roachpb.RSpan,
 		startTS hlc.Timestamp, // exclusive
-		catchUpIter *CatchUpIterator,
+		catchUpSnap *CatchUpSnapshot,
 		withDiff bool,
 		withFiltering bool,
 		withOmitRemote bool,

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -65,7 +65,7 @@ func TestProcessorBasic(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -200,7 +200,7 @@ func TestProcessorBasic(t *testing.T) {
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			true,  /* withDiff */
 			true,  /* withFiltering */
 			false, /* withOmitRemote */
@@ -313,7 +313,7 @@ func TestProcessorBasic(t *testing.T) {
 			r3Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -335,7 +335,7 @@ func TestProcessorBasic(t *testing.T) {
 			r4Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -361,7 +361,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -387,7 +387,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			true,  /* withOmitRemote */
@@ -445,7 +445,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 				r1Stream.ctx,
 				roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 				hlc.Timestamp{WallTime: 1},
-				nil,   /* catchUpIter */
+				nil,   /* catchUpSnap */
 				false, /* withDiff */
 				false, /* withFiltering */
 				false, /* withOmitRemote */
@@ -457,7 +457,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 				r2Stream.ctx,
 				roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 				hlc.Timestamp{WallTime: 1},
-				nil,   /* catchUpIter */
+				nil,   /* catchUpSnap */
 				false, /* withDiff */
 				false, /* withFiltering */
 				false, /* withOmitRemote */
@@ -553,7 +553,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -609,7 +609,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -691,7 +691,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1002,7 +1002,7 @@ func TestProcessorConcurrentStop(t *testing.T) {
 				defer wg.Done()
 				runtime.Gosched()
 				s := newTestStream()
-				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 					noBulkDelivery,
 					h.toBufferedStreamIfNeeded(s))
@@ -1076,7 +1076,7 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 				// operation is should see is firstIdx.
 				s := newTestStream()
 				regs[s] = firstIdx
-				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 					noBulkDelivery,
 					h.toBufferedStreamIfNeeded(s))
@@ -1135,7 +1135,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 			rStream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1216,7 +1216,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 			rStream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1287,7 +1287,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1301,7 +1301,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false /* withOmitRemote */, noBulkDelivery,
@@ -1472,7 +1472,7 @@ func TestProcessorBackpressure(t *testing.T) {
 
 		// Add a registration.
 		stream := newTestStream()
-		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpIter */
+		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpSnap */
 			false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(stream))

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -314,27 +314,12 @@ func (p *ScheduledProcessor) stopInternal(ctx context.Context, pErr *kvpb.Error)
 	p.scheduler.StopProcessor()
 }
 
-// Register registers the stream over the specified span of keys.
-//
-// The registration will not observe any events that were consumed before this
-// method was called. It is undefined whether the registration will observe
-// events that are consumed concurrently with this call. The channel will be
-// provided an error when the registration closes.
-//
-// The optionally provided "catch-up" iterator is used to read changes from the
-// engine which occurred after the provided start timestamp (exclusive).
-//
-// If the method returns false, the processor will have been stopped, so calling
-// Stop is not necessary. If the method returns true, it will also return an
-// updated operation filter that includes the operations required by the new
-// registration.
-//
-// NB: startTS is exclusive; the first possible event will be at startTS.Next().
+// Register implements rangefeed.Processor.
 func (p *ScheduledProcessor) Register(
 	streamCtx context.Context,
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
-	catchUpIter *CatchUpIterator,
+	catchUpSnap *CatchUpSnapshot,
 	withDiff bool,
 	withFiltering bool,
 	withOmitRemote bool,
@@ -352,11 +337,11 @@ func (p *ScheduledProcessor) Register(
 	bufferedStream, isBufferedStream := stream.(BufferedStream)
 	if isBufferedStream {
 		r = newUnbufferedRegistration(
-			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
+			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpSnap, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
 			p.Config.EventChanCap, p.Metrics, bufferedStream, p.unregisterClientAsync)
 	} else {
 		r = newBufferedRegistration(
-			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
+			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpSnap, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
 			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, p.unregisterClientAsync)
 	}
 

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -223,7 +223,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 				p, h, stopper := newTestProcessor(t, withRangefeedTestType(rt))
 				defer stopper.Stop(ctx)
 				stream := sm.NewStream(sID, rID)
-				registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 					stream)
 				require.True(t, registered)
@@ -237,7 +237,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			stream := sm.NewStream(sID, rID)
 			p, h, stopper := newTestProcessor(t, withRangefeedTestType(rt))
 			defer stopper.Stop(ctx)
-			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 				stream)
 			require.True(t, registered)
@@ -252,7 +252,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			stream := sm.NewStream(sID, rID)
 			p, h, stopper := newTestProcessor(t, withRangefeedTestType(rt))
 			defer stopper.Stop(ctx)
-			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 				stream)
 			require.True(t, registered)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -76,10 +76,10 @@ type unbufferedRegistration struct {
 		// via publish() are ignored.
 		disconnected bool
 
-		// catchUpIter is created by replica under raftMu lock when registration is
-		// created. It is set to nil by output loop for processing and closed when
-		// done.
-		catchUpIter *CatchUpIterator
+		// catchUpSnap is created by a replica under the raftMu lock when a
+		// registration is created. It is set to nil by the output loop for
+		// processing and closed when done.
+		catchUpSnap *CatchUpSnapshot
 
 		// Used for testing only. Indicates that all events in catchUpBuf have been
 		// sent to BufferedStream.
@@ -93,7 +93,7 @@ func newUnbufferedRegistration(
 	streamCtx context.Context,
 	span roachpb.Span,
 	startTS hlc.Timestamp,
-	catchUpIter *CatchUpIterator,
+	catchUpSnap *CatchUpSnapshot,
 	withDiff bool,
 	withFiltering bool,
 	withOmitRemote bool,
@@ -117,10 +117,10 @@ func newUnbufferedRegistration(
 		metrics: metrics,
 		stream:  stream,
 	}
-	br.mu.catchUpIter = catchUpIter
+	br.mu.catchUpSnap = catchUpSnap
 	br.mu.caughtUp = true
-	if br.mu.catchUpIter != nil {
-		// A nil catchUpIter indicates we don't need a catch-up scan. We avoid
+	if br.mu.catchUpSnap != nil {
+		// A nil catchUpSnap indicates we don't need a catch-up scan. We avoid
 		// initializing catchUpBuf in this case, which will result in publish()
 		// sending all events to the underlying stream immediately.
 		br.mu.catchUpBuf = make(chan *sharedEvent, bufferSz)
@@ -187,10 +187,10 @@ func (ubr *unbufferedRegistration) disconnectLocked(pErr *kvpb.Error) {
 	if ubr.mu.disconnected {
 		return
 	}
-	if ubr.mu.catchUpIter != nil {
+	if ubr.mu.catchUpSnap != nil {
 		// Catch-up scan hasn't started yet.
-		ubr.mu.catchUpIter.Close()
-		ubr.mu.catchUpIter = nil
+		ubr.mu.catchUpSnap.Close()
+		ubr.mu.catchUpSnap = nil
 	}
 	if ubr.mu.catchUpScanCancelFn != nil {
 		ubr.mu.catchUpScanCancelFn()
@@ -340,31 +340,31 @@ func (ubr *unbufferedRegistration) publishCatchUpBuffer(ctx context.Context) err
 	return nil
 }
 
-// detachCatchUpIter detaches the catchUpIter that was previously attached.
-func (ubr *unbufferedRegistration) detachCatchUpIter() *CatchUpIterator {
+// detachCatchUpSnap detaches the catchUpSnap that was previously attached.
+func (ubr *unbufferedRegistration) detachCatchUpSnap() *CatchUpSnapshot {
 	ubr.mu.Lock()
 	defer ubr.mu.Unlock()
-	catchUpIter := ubr.mu.catchUpIter
-	ubr.mu.catchUpIter = nil
-	return catchUpIter
+	catchUpSnap := ubr.mu.catchUpSnap
+	ubr.mu.catchUpSnap = nil
+	return catchUpSnap
 }
 
-// maybeRunCatchUpScan runs the catch-up scan if catchUpIter is not nil. It
-// promises to close catchUpIter once detached. It returns an error if catch-up
+// maybeRunCatchUpScan runs the catch-up scan if catchUpSnap is not nil. It
+// promises to close catchUpSnap once detached. It returns an error if catch-up
 // scan fails. Note that catch up scan bypasses BufferedStream and are sent to
 // the underlying stream directly.
 func (ubr *unbufferedRegistration) maybeRunCatchUpScan(ctx context.Context) error {
-	catchUpIter := ubr.detachCatchUpIter()
-	if catchUpIter == nil {
+	catchUpSnap := ubr.detachCatchUpSnap()
+	if catchUpSnap == nil {
 		return nil
 	}
 	start := crtime.NowMono()
 	defer func() {
-		catchUpIter.Close()
+		catchUpSnap.Close()
 		ubr.metrics.RangeFeedCatchUpScanNanos.Inc(start.Elapsed().Nanoseconds())
 	}()
 
-	return catchUpIter.CatchUpScan(ctx, ubr.stream.SendUnbuffered, ubr.withDiff, ubr.withFiltering,
+	return catchUpSnap.CatchUpScan(ctx, ubr.stream.SendUnbuffered, ubr.withDiff, ubr.withFiltering,
 		ubr.withOmitRemote, ubr.bulkDelivery)
 
 }

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -260,12 +260,12 @@ func (r *Replica) RangeFeed(
 		checkTS = r.Clock().Now()
 	}
 
-	// If we will be using a catch-up iterator, wait for the limiter here before
+	// If we will be using a catch-up snapshot, wait for the limiter here before
 	// locking raftMu.
-	usingCatchUpIter := false
+	usingCatchUpSnap := false
 	iterSemRelease := func() {}
 	if !args.Timestamp.IsEmpty() {
-		usingCatchUpIter = true
+		usingCatchUpSnap = true
 		perConsumerRelease := func() {}
 		if perConsumerCatchupLimiter != nil {
 			perConsumerAlloc, err := perConsumerCatchupLimiter.Begin(streamCtx)
@@ -310,21 +310,15 @@ func (r *Replica) RangeFeed(
 		return nil, err
 	}
 
-	// Register the stream with a catch-up iterator.
-	var catchUpIter *rangefeed.CatchUpIterator
-	if usingCatchUpIter {
-		// Pass context.Background() since the context where the iter will be used
-		// is different.
-		catchUpIter, err = rangefeed.NewCatchUpIterator(
-			context.Background(), r.store.TODOEngine(), rSpan.AsRawSpanWithNoLocals(),
-			args.Timestamp, iterSemRelease, pacer)
-		if err != nil {
-			r.raftMu.Unlock()
-			iterSemRelease()
-			return nil, err
-		}
+	// Register the stream with a catch-up snapshot.
+	var catchUpSnap *rangefeed.CatchUpSnapshot
+	if usingCatchUpSnap {
+		catchUpSnap = rangefeed.NewCatchUpSnapshot(
+			r.store.StateEngine(), rSpan.AsRawSpanWithNoLocals(),
+			args.Timestamp, iterSemRelease, pacer,
+			storage.SnapshotRecreateIterDuration.Get(&r.store.ClusterSettings().SV))
 		if f := r.store.TestingKnobs().RangefeedValueHeaderFilter; f != nil {
-			catchUpIter.OnEmit = f
+			catchUpSnap.OnEmit = f
 		}
 	}
 
@@ -333,7 +327,7 @@ func (r *Replica) RangeFeed(
 		bulkDeliverySize = int(rangeFeedBulkDeliverySize.Get(&r.store.ClusterSettings().SV))
 	}
 	p, disconnector, err := r.registerWithRangefeedRaftMuLocked(
-		streamCtx, rSpan, args.Timestamp, catchUpIter, args.WithDiff, args.WithFiltering, omitRemote, bulkDeliverySize, stream,
+		streamCtx, rSpan, args.Timestamp, catchUpSnap, args.WithDiff, args.WithFiltering, omitRemote, bulkDeliverySize, stream,
 	)
 	r.raftMu.Unlock()
 
@@ -429,15 +423,15 @@ func logSlowRangefeedRegistration(ctx context.Context) func() {
 // already running. Requires raftMu be locked.
 // Returns Future[*roachpb.Error] which will return an error once rangefeed
 // completes.
-// Note that caller delegates lifecycle of catchUpIter to this method in both
-// success and failure cases. So it is important that this method closes
-// iterator in case registration fails. Successful registration takes iterator
+// Note that caller delegates lifecycle of catchUpSnap to this method in both
+// success and failure cases. So it is important that this method closes the
+// snap in case registration fails. Successful registration takes snap
 // ownership and ensures it is closed when catch up is complete or aborted.
 func (r *Replica) registerWithRangefeedRaftMuLocked(
 	streamCtx context.Context,
 	span roachpb.RSpan,
 	startTS hlc.Timestamp, // exclusive
-	catchUpIter *rangefeed.CatchUpIterator,
+	catchUpSnap *rangefeed.CatchUpSnapshot,
 	withDiff bool,
 	withFiltering bool,
 	withOmitRemote bool,
@@ -446,12 +440,12 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 ) (rangefeed.Processor, rangefeed.Disconnector, error) {
 	defer logSlowRangefeedRegistration(streamCtx)()
 
-	// Always defer closing iterator to cover old and new failure cases.
-	// On successful path where registration succeeds reset catchUpIter to prevent
+	// Always defer closing snapshot to cover old and new failure cases.
+	// On successful path where registration succeeds reset catchUpSnap to prevent
 	// closing it.
 	defer func() {
-		if catchUpIter != nil {
-			catchUpIter.Close()
+		if catchUpSnap != nil {
+			catchUpSnap.Close()
 		}
 	}()
 
@@ -462,7 +456,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	p := r.rangefeedMu.proc
 
 	if p != nil {
-		reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
+		reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpSnap, withDiff, withFiltering, withOmitRemote, bulkDeliverySize,
 			stream)
 		if reg {
 			// Registered successfully with an existing processor.
@@ -470,7 +464,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 			// that this new registration might be interested in.
 			r.setRangefeedFilterLocked(filter)
 			r.rangefeedMu.Unlock()
-			catchUpIter = nil
+			catchUpSnap = nil
 			return p, disconnector, nil
 		}
 		// If the registration failed, the processor was already being shut
@@ -543,7 +537,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// any other goroutines are able to stop the processor. In other words,
 	// this ensures that the only time the registration fails is during
 	// server shutdown.
-	reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff,
+	reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpSnap, withDiff,
 		withFiltering, withOmitRemote, bulkDeliverySize, stream)
 	if !reg {
 		select {
@@ -553,7 +547,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 			panic("unexpected Stopped processor")
 		}
 	}
-	catchUpIter = nil
+	catchUpSnap = nil
 
 	// Set the rangefeed processor and filter reference.
 	r.setRangefeedProcessor(p)

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -751,7 +751,7 @@ func (cf *cFetcher) setNextKV(kv roachpb.KeyValue) {
 // rows, the Batch.Length is 0.
 func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 	for {
-		if err := cf.pacer.Pace(ctx); err != nil {
+		if _, err := cf.pacer.Pace(ctx); err != nil {
 			return nil, err
 		}
 		if debugState {

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -594,7 +594,7 @@ func runParallelImport(
 		var numSkipped int64
 		var count int64
 		for producer.Scan() {
-			if err := pacer.Pace(ctx); err != nil {
+			if _, err := pacer.Pace(ctx); err != nil {
 				return err
 			}
 			// Skip rows if needed.
@@ -712,7 +712,7 @@ func (p *parallelImporter) importWorker(
 		for batchIdx, record := range batch.data {
 			rowNum = batch.startPos + int64(batchIdx)
 			// Pace the admission control before processing each row.
-			if err := pacer.Pace(ctx); err != nil {
+			if _, err := pacer.Pace(ctx); err != nil {
 				return err
 			}
 

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -275,7 +275,7 @@ func (w *WorkloadKVConverter) Worker(
 		a = a.Truncate()
 		w.rows.FillBatch(batchIdx, cb, &a)
 		for rowIdx, numRows := 0, cb.Length(); rowIdx < numRows; rowIdx++ {
-			if err := pacer.Pace(ctx); err != nil {
+			if _, err := pacer.Pace(ctx); err != nil {
 				return err
 			}
 			for colIdx, col := range cb.ColVecs() {

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -751,7 +751,7 @@ func (f *txnKVFetcher) maybeAdmitBatchResponse(ctx context.Context, br *kvpb.Bat
 		// TODO(irfansharif): Add tests for the SELECT queries issued by the TTL
 		// to ensure that they have local plans with a single TableReader
 		// processor in multi-node clusters.
-		if err := f.admissionPacer.Pace(ctx); err != nil {
+		if _, err := f.admissionPacer.Pace(ctx); err != nil {
 			return err
 		}
 	} else if f.responseAdmissionQ != nil {

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -345,7 +345,7 @@ func (ib *indexBackfiller) ingestIndexEntries(
 			addedToVectorIndex := false
 			for _, indexEntry := range indexBatch.indexEntries {
 				// Pace the admission control before processing each index entry.
-				if err := pacer.Pace(ctx); err != nil {
+				if _, err := pacer.Pace(ctx); err != nil {
 					return err
 				}
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -198,6 +198,32 @@ var UnhealthyWriteDuration = settings.RegisterDurationSetting(
 	20*time.Second,
 	settings.WithPublic)
 
+const defaultRecreateDuration = int(20 * time.Second)
+
+// SnapshotRecreateIterDuration controls how often a storage iterator over a
+// snapshot should be recreated. An iterator pins the memtables it references,
+// and if those memtables are subsequently flushed, but the iterator is still
+// open, they cannot be discarded and are considered zombie memtables. Memory
+// usage via zombie memtables steals capacity from the block cache, and in
+// extreme cases can cause OOMs (see
+// https://github.com/cockroachdb/cockroach/issues/133851). Closing and
+// creating a new iterator over the snapshot prevents accumulation of zombie
+// memtable memory. There is a small cost to recreating the iterator, which
+// should be amortized over the duration (default 20s).
+//
+// An alternative to using a duration would be to query the zombie memtable
+// bytes pinned by the iterator, and recreate when it exceeds some byte
+// threshold. However, the local knowledge of zombie bytes due to an iterator
+// is insufficient, since there can be 100s of iterators each only pinning
+// disjoint sets of 2 memtables each, but resulting in a high aggregate
+// memory. The simpler duration based approach does not have this limitation.
+var SnapshotRecreateIterDuration = settings.RegisterDurationSetting(settings.SystemOnly,
+	"storage.snapshot.recreate_iter_duration",
+	"the interval after which a storage iterator over a snapshot should be recreated, "+
+		"to reduce memory usage caused by zombie memtables",
+	time.Duration(metamorphic.ConstantWithTestRange("storage.snapshot.recreate_iter_duration",
+		defaultRecreateDuration, 1, defaultRecreateDuration)))
+
 // SSTableCompressionProfile is an enumeration of compression algorithms
 // available for compressing SSTables (e.g. for backup or transport).
 type SSTableCompressionProfile int64

--- a/pkg/util/admission/pacer.go
+++ b/pkg/util/admission/pacer.go
@@ -24,11 +24,14 @@ type Pacer struct {
 }
 
 // Pace will block as needed to pace work that calls it as configured. It is
-// intended to be called in a tight loop, and will attempt to minimize per-call
-// overhead. Non-nil errors are returned only if the context is canceled.
-func (p *Pacer) Pace(ctx context.Context) error {
+// intended to be called in a tight loop, and will attempt to minimize
+// per-call overhead. Non-nil errors are returned only if the context is
+// canceled. The readmitted value is set to true if the call involved the
+// heavier weight work of asking for admission -- this will be true whenever
+// the granted CPU time runs out.
+func (p *Pacer) Pace(ctx context.Context) (readmitted bool, err error) {
 	if p == nil {
-		return nil
+		return false, nil
 	}
 
 	if overLimit, _ := p.cur.OverLimit(); overLimit {
@@ -39,11 +42,11 @@ func (p *Pacer) Pace(ctx context.Context) error {
 	if p.cur == nil {
 		handle, err := p.wq.Admit(ctx, p.unit, p.wi)
 		if err != nil {
-			return err
+			return false, err
 		}
 		p.cur = handle
 	}
-	return nil
+	return true, nil
 }
 
 // Close is part of the Pacer interface.


### PR DESCRIPTION
The snapshot is used to create an iterator, which is recreated based on the storage.snapshot.recreate_iter_duration cluster setting, which defaults to 20s.

This is mostly plumbing changes, except for catchup_scan.go.

Fixes #133851

Epic: none

Release note (ops change): The cluster setting
storage.snapshot.recreate_iter_duration (default 20s) controls how frequently a long-lived engine iterator, backed by an engine snapshot, will be closed and recreated. Currently, it is only used for iterators used in rangefeed catchup scans.