### PR TITLE
allocatorimpl: remove alwaysAllowDecisionWithoutStats

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2389,7 +2389,6 @@ func (a *Allocator) TransferLeaseTarget(
 		SendStreamStats(*rac2.RangeSendStreamStats)
 	},
 	usageInfo allocator.RangeUsageInfo,
-	forceDecisionWithoutStats bool,
 	opts allocator.TransferLeaseOptions,
 ) roachpb.ReplicaDescriptor {
 	if a.knobs != nil {
@@ -2443,10 +2442,7 @@ func (a *Allocator) TransferLeaseTarget(
 		if !excludeLeaseRepl {
 			switch transferDec {
 			case shouldNotTransfer:
-				if !forceDecisionWithoutStats {
-					return roachpb.ReplicaDescriptor{}
-				}
-				fallthrough
+				return roachpb.ReplicaDescriptor{}
 			case decideWithoutStats:
 				if !a.shouldTransferLeaseForLeaseCountConvergence(ctx, storePool, sl, source, validTargets) {
 					return roachpb.ReplicaDescriptor{}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -2052,7 +2052,6 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{}, /* stats */
-				false,                      /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       c.excludeLeaseRepl,
 					CheckCandidateFullness: true,
@@ -2184,7 +2183,6 @@ func TestAllocatorTransferLeaseTargetIOOverloadCheck(t *testing.T) {
 					storeID:           tc.leaseholder,
 				},
 				allocator.RangeUsageInfo{}, /* stats */
-				false,                      /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					CheckCandidateFullness: true,
 				},
@@ -2297,7 +2295,6 @@ func TestAllocatorTransferLeaseToReplicasNeedingSnapshot(t *testing.T) {
 				c.existing,
 				repl,
 				allocator.RangeUsageInfo{},
-				false, /* alwaysAllowDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       c.excludeLeaseRepl,
 					CheckCandidateFullness: true,
@@ -2441,7 +2438,6 @@ func TestAllocatorTransferLeaseToReplicasNeedingCatchup(t *testing.T) {
 				c.existing,
 				repl,
 				allocator.RangeUsageInfo{},
-				false, /* alwaysAllowDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       c.excludeLeaseRepl,
 					CheckCandidateFullness: true,
@@ -2537,7 +2533,6 @@ func TestAllocatorTransferLeaseTargetConstraints(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{},
-				false, /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       false,
 					CheckCandidateFullness: true,
@@ -2650,7 +2645,6 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{},
-				false, /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       c.excludeLeaseRepl,
 					CheckCandidateFullness: true,
@@ -3312,7 +3306,6 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{},
-				false, /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       false,
 					CheckCandidateFullness: true,
@@ -3332,7 +3325,6 @@ func TestAllocatorLeasePreferences(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{},
-				false, /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       true,
 					CheckCandidateFullness: true,
@@ -3426,7 +3418,6 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{},
-				false, /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       false,
 					CheckCandidateFullness: true,
@@ -3447,7 +3438,6 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				allocator.RangeUsageInfo{},
-				false, /* forceDecisionWithoutStats */
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       true,
 					CheckCandidateFullness: true,
@@ -6084,7 +6074,6 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 					storeID:           c.leaseholder,
 				},
 				usage,
-				false,
 				allocator.TransferLeaseOptions{
 					ExcludeLeaseRepl:       c.excludeLeaseRepl,
 					CheckCandidateFullness: true,

--- a/pkg/kv/kvserver/allocator/plan/lease.go
+++ b/pkg/kv/kvserver/allocator/plan/lease.go
@@ -142,7 +142,6 @@ func (lp LeasePlanner) PlanOneChange(
 		existingVoters,
 		repl,
 		usage,
-		false, /* forceDecisionWithoutStats */
 		allocator.TransferLeaseOptions{
 			Goal:                   allocator.FollowTheWorkload,
 			ExcludeLeaseRepl:       false,

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -900,7 +900,6 @@ func (rp ReplicaPlanner) maybeTransferLeaseAwayTarget(
 		desc.Replicas().VoterDescriptors(),
 		repl,
 		usageInfo,
-		false, /* forceDecisionWithoutStats */
 		allocator.TransferLeaseOptions{
 			Goal: allocator.LeaseCountConvergence,
 			// NB: This option means that the allocator is asked to not consider the

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1051,7 +1051,6 @@ func (rq *replicateQueue) shedLease(
 		desc.Replicas().VoterDescriptors(),
 		repl,
 		rangeUsageInfo,
-		false, /* forceDecisionWithoutStats */
 		opts,
 	)
 	if targetDesc == (roachpb.ReplicaDescriptor{}) {

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -814,7 +814,6 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			candidates,
 			candidateReplica,
 			candidateReplica.RangeUsageInfo(),
-			true, /* forceDecisionWithoutStats */
 			allocator.TransferLeaseOptions{
 				Goal:             allocator.LoadConvergence,
 				ExcludeLeaseRepl: false,


### PR DESCRIPTION
Previously, we called TransferLeaseTarget with alwaysAllowDecisionWithoutStats,
but it was only relevant when the lease transfer goal was
allocator.FollowTheWorkload. The only case where we passed true for
alwaysAllowDecisionWithoutStats was from storeRebalancer.chooseLeaseToTransfer,
where opt.Goal was set to allocator.LoadConvergence. This commit removes it
since it is unclear whether flag was useful.

Epic: none 
Release note: none 