### PR TITLE
rangefeed: move to per-registration limit in buffered sender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -149,10 +149,6 @@ func (ubr *unbufferedRegistration) publish(
 	// is nil. Safe to send to underlying stream.
 	if ubr.mu.catchUpBuf == nil {
 		if err := ubr.stream.SendBuffered(strippedEvent, alloc); err != nil {
-			// Disconnect here for testing purposes only: there are test stream
-			// implementations that inject errors without calling disconnect. For
-			// production code, we expect buffered sender to shut down all
-			// registrations.
 			ubr.disconnectLocked(kvpb.NewError(err))
 		}
 	} else {

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -132,6 +132,12 @@ func (ubs *UnbufferedSender) sendUnbuffered(event *kvpb.MuxRangeFeedEvent) error
 	return ubs.sender.Send(event)
 }
 
+// removeStream implements sender.
+func (ubs *UnbufferedSender) removeStream(int64) {}
+
+// cleanup implements sender.
+func (ubs *UnbufferedSender) cleanup(context.Context) {}
+
 // run forwards rangefeed completion errors back to the client. run is expected
 // to be called in a goroutine and will block until the context is done or the
 // stopper is quiesced. UnbufferedSender will stop forward rangefeed completion
@@ -185,7 +191,3 @@ func (ubs *UnbufferedSender) detachMuxErrors() []*kvpb.MuxRangeFeedEvent {
 	ubs.mu.muxErrors = nil
 	return toSend
 }
-
-// The following methods are no-op implementations to satisfy the sender
-// interface.
-func (ubs *UnbufferedSender) cleanup(context.Context) {}


### PR DESCRIPTION
This move the overall queue limit to a per-registration limit, more similar to the behaviour we had in the old unbuffered sender world. One potential advantage here is that it doesn't punish all connected registrations because of one high-traffic registrations, reducing the rate of catch-up scans needed.

Epic: none
Release note: None