### PR TITLE
kvserver: deflake TestProcessSplitAfterRightHandSideHasBeenRemoved

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5396,6 +5396,11 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 							// Newly-started stores (including the "rogue" one) should not GC
 							// their replicas. We'll turn this back on when needed.
 							DisableReplicaGCQueue: true,
+							// Some subtests, e.g. (4), expect that n1 catches up on the raft
+							// log after a partition, and runs the split trigger. Disable raft
+							// log truncation to make sure that it doesn't miss the split
+							// trigger by being caught up by a later snapshot. See #154313.
+							DisableRaftLogQueue:   true,
 							TestingProposalFilter: testingProposalFilter,
 						},
 					},

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	raft "github.com/cockroachdb/cockroach/pkg/raft"
@@ -5320,13 +5321,13 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			t *testing.T, store *kvserver.Store, rangeID roachpb.RangeID,
 		) raftpb.HardState {
 			t.Helper()
-			hs, err := stateloader.Make(rangeID).LoadHardState(ctx, store.TODOEngine())
+			hs, err := logstore.NewStateLoader(rangeID).LoadHardState(ctx, store.LogEngine())
 			require.NoError(t, err)
 			return hs
 		}
 		partitionReplicaOnSplit := func(t *testing.T, tc *testcluster.TestCluster, key roachpb.Key, basePartition *testClusterPartitionedRange, partRange **testClusterPartitionedRange) {
-			// Set up a hook to partition the RHS range at its initial range ID
-			// before proposing the split trigger.
+			// Set up a hook to partition away the first store of the RHS range at the
+			// first opportunity (when the split trigger is proposed).
 			var setupOnce sync.Once
 			f := kvserverbase.ReplicaProposalFilter(func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
 				req, ok := args.Req.GetArg(kvpb.EndTxn)
@@ -5357,9 +5358,10 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			proposalFilter.Store(f)
 		}
 
-		// The basic setup for all of these tests are that we have a LHS range on 3
-		// nodes and we've partitioned store 0 for the LHS range. The tests will now
-		// perform a split, remove the RHS, add it back and validate assumptions.
+		// The basic setup for all of these tests are that we have an LHS range on 3
+		// nodes (lease on the last one), and we've partitioned store 0 for the LHS
+		// range. The tests will now perform a split, remove the RHS, add it back
+		// and validate assumptions.
 		//
 		// Different outcomes will occur depending on whether and how the RHS is
 		// partitioned and whether the server is killed. In all cases we want the
@@ -5480,9 +5482,9 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			target := tc.Target(0)
 			log.KvExec.Infof(ctx, "removing voter: %v", target)
 			tc.RemoveVotersOrFatal(t, keyB, target)
-			// Unsuccessful because the RHS will not accept the learner snapshot
-			// and will be rolled back. Nevertheless it will have learned that it
-			// has been removed at the old replica ID.
+			// Unsuccessful because the RHS will not accept the learner snapshot and
+			// will be rolled back. Nevertheless, it will have learned that it has
+			// been removed at the old replica ID.
 			_, err = tc.Servers[0].DB().AdminChangeReplicas(
 				ctx, keyB, tc.LookupRangeOrFatal(t, keyB),
 				kvpb.MakeReplicationChanges(roachpb.ADD_VOTER, target),
@@ -5695,8 +5697,8 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			target := tc.Target(0)
 			log.KvExec.Infof(ctx, "removing voter: %v", target)
 			tc.RemoveVotersOrFatal(t, keyB, target)
-			// Unsuccessfuly because the RHS will not accept the learner snapshot
-			// and will be rolled back. Nevertheless it will have learned that it
+			// Unsuccessful because the RHS will not accept the learner snapshot
+			// and will be rolled back. Nevertheless, it will have learned that it
 			// has been removed at the old replica ID.
 			//
 			// Not using tc.AddVoters because we expect an error, but that error
@@ -5716,7 +5718,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			log.KvExec.Infof(ctx, "added %d to RHS partition: %s", rhsInfo.Desc.NextReplicaID, rhsPartition)
 
 			// We do all of this incrementing to ensure that nobody will ever
-			// succeed in sending a message the new RHS replica after we restart
+			// succeed in sending a message to the new RHS replica after we restart
 			// the store. Previously there were races which could happen if we
 			// stopped the store immediately. Sleeps worked but this feels somehow
 			// more principled.


### PR DESCRIPTION
The test relies on the fact that the LHS replica will be caught up via log, and run the split trigger. In the flake, the replica has been caught up by a snapshot. Likely cause is that the leader's log has been truncated while the replica has been partitioned away. The PR disables log truncation for this test, so that the catch up via log is guaranteed.

Fixes #154313