### PR TITLE
changefeedccl: fix blocking buffer memory metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1245,22 +1245,6 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
-    - name: changefeed.buffer_entries.allocated_mem.aggregator
-      exported_name: changefeed_buffer_entries_allocated_mem_aggregator
-      description: Current quota pool memory allocation - between the kvfeed and the sink
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.buffer_entries.allocated_mem.rangefeed
-      exported_name: changefeed_buffer_entries_allocated_mem_rangefeed
-      description: Current quota pool memory allocation - between the rangefeed and the kvfeed
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
     - name: changefeed.buffer_entries.flush
       exported_name: changefeed_buffer_entries_flush
       description: Number of flush elements added to the buffer
@@ -1413,41 +1397,9 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.acquired.aggregator
-      exported_name: changefeed_buffer_entries_mem_acquired_aggregator
-      description: Total amount of memory acquired for entries as they enter the system - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.acquired.rangefeed
-      exported_name: changefeed_buffer_entries_mem_acquired_rangefeed
-      description: Total amount of memory acquired for entries as they enter the system - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries_mem.released
       exported_name: changefeed_buffer_entries_mem_released
       description: Total amount of memory released by the entries after they have been emitted
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.released.aggregator
-      exported_name: changefeed_buffer_entries_mem_released_aggregator
-      description: Total amount of memory released by the entries after they have been emitted - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.released.rangefeed
-      exported_name: changefeed_buffer_entries_mem_released_rangefeed
-      description: Total amount of memory released by the entries after they have been emitted - between the rangefeed and the kvfeed
       y_axis_label: Entries
       type: COUNTER
       unit: COUNT

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -502,7 +502,7 @@ func (ca *changeAggregator) startKVFeed(
 	}
 	buf := kvevent.NewThrottlingBuffer(
 		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV,
-			&ca.metrics.KVFeedMetrics.AggregatorBufferMetricsWithCompat, options...),
+			&ca.metrics.KVFeedMetrics.AggregatorBufferMetrics, options...),
 		cdcutils.NodeLevelThrottler(&cfg.Settings.SV, &ca.metrics.ThrottleMetrics))
 
 	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while

--- a/pkg/ccl/changefeedccl/kvevent/bench_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkMemBuffer(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetricsWithCompat
+	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetrics
 	st := cluster.MakeTestingClusterSettings()
 
 	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics)

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -25,7 +25,7 @@ import (
 // from a mon.BoundAccount and blocks if no resources are available.
 type blockingBuffer struct {
 	sv       *settings.Values
-	metrics  *PerBufferMetricsWithCompat
+	metrics  *BufferMetrics
 	qp       allocPool     // Pool for memory allocations.
 	signalCh chan struct{} // Signal when new events are available.
 
@@ -54,7 +54,7 @@ type blockingBuffer struct {
 func NewMemBuffer(
 	acc mon.BoundAccount,
 	sv *settings.Values,
-	metrics *PerBufferMetricsWithCompat,
+	metrics *BufferMetrics,
 	options ...BlockingBufferOption,
 ) Buffer {
 	return newMemBuffer(acc, sv, metrics, nil, options...)
@@ -65,7 +65,7 @@ func NewMemBuffer(
 func TestingNewMemBuffer(
 	acc mon.BoundAccount,
 	sv *settings.Values,
-	metrics *PerBufferMetricsWithCompat,
+	metrics *BufferMetrics,
 	onWaitStart quotapool.OnWaitStartFunc,
 ) Buffer {
 	return newMemBuffer(acc, sv, metrics, onWaitStart)
@@ -74,7 +74,7 @@ func TestingNewMemBuffer(
 func newMemBuffer(
 	acc mon.BoundAccount,
 	sv *settings.Values,
-	metrics *PerBufferMetricsWithCompat,
+	metrics *BufferMetrics,
 	onWaitStart quotapool.OnWaitStartFunc,
 	options ...BlockingBufferOption,
 ) Buffer {
@@ -488,7 +488,7 @@ func (r *memRequest) ShouldWait() bool {
 
 type allocPool struct {
 	*quotapool.AbstractPool
-	metrics *PerBufferMetricsWithCompat
+	metrics *BufferMetrics
 	sv      *settings.Values
 }
 

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -128,7 +128,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	bf := func() kvevent.Buffer {
-		return kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), &cfg.Settings.SV, &cfg.Metrics.RangefeedBufferMetricsWithCompat)
+		return kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), &cfg.Settings.SV, &cfg.Metrics.RangefeedBufferMetrics)
 	}
 
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -125,12 +125,12 @@ func TestKVFeed(t *testing.T) {
 			Settings: settings,
 		})
 		metrics := kvevent.MakeMetrics(time.Minute)
-		buf := kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.AggregatorBufferMetricsWithCompat)
+		buf := kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.AggregatorBufferMetrics)
 
 		// bufferFactory, when called, gives you a memory-monitored
 		// in-memory "buffer" to write to and read from.
 		bufferFactory := func() kvevent.Buffer {
-			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.RangefeedBufferMetricsWithCompat)
+			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.RangefeedBufferMetrics)
 		}
 		scans := make(chan scanConfig)
 


### PR DESCRIPTION
Previously, we had separated blocking buffer
metrics into one copy for each buffer. This was
incorrect in the case of the memory accounting
metrics, as we don't dealloc and realloc event
memory when it's going from one buffer to the
other.

Fixes #147624

Release note (ops change): Removed misleading
metrics:
`changefeed.buffer_entries.allocated_mem.rangefeed`,
`changefeed.buffer_entries.allocated_mem.aggregator`,
`changefeed.buffer_entries_mem.acquired.rangefeed`,
`changefeed.buffer_entries_mem.acquired.aggregator`,
`changefeed.buffer_entries_mem.released.rangefeed`,
`changefeed.buffer_entries_mem.released.aggregator`
