### PR TITLE
cmd/roachtest: prevent macOS host from idle-sleeping during test

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -497,6 +497,14 @@ var (
 						Always collect artifacts during test teardown, even if the test did not
 						time out or fail.`,
 	})
+
+	Caffeinate bool = true
+	_               = registerRunFlag(&Caffeinate, FlagInfo{
+		Name: "caffeinate",
+		Usage: `
+						On Darwin, prevent the system from sleeping while roachtest is running
+						by invoking caffeinate -i -w <pid>. Default is true.`,
+	})
 )
 
 // The flags below override the final cluster configuration. They have no


### PR DESCRIPTION
These tests run for 20mins+ so it is common to step away to make coffee or something while they are running. Unfortunately this can mean the host goes to sleep, failing the test. To avoid this we can invoke the macOS utility 'caffeinate' with '-i' to prevent only machine idle sleep (but not display sleep/lock), and with the roachtest process, so it will inhibit sleep until the roachtest process exits.

Release note: none.
Epic: none.