### PR TITLE
changefeedccl: fix changefeed.parallel_io_pending_rows metric

### DIFF
--- a/pkg/ccl/changefeedccl/parallel_io.go
+++ b/pkg/ccl/changefeedccl/parallel_io.go
@@ -332,7 +332,10 @@ func (p *ParallelIO) processIO(ctx context.Context, numEmitWorkers int) error {
 					inflight.UnionWith(req.r.Keys())
 					metricsRec.setInFlightKeys(int64(inflight.Len()))
 					pending = append(pending[:i], pending[i+1:]...)
-					metricsRec.recordPendingQueuePop(int64(req.r.NumMessages()), timeutil.Since(req.pendingQueueAdmitTime))
+					metricsRec.recordPendingQueuePop(
+						int64(req.r.Keys().Len()),
+						timeutil.Since(req.pendingQueueAdmitTime),
+					)
 					if err := submitIO(req); err != nil {
 						return err
 					}
@@ -391,7 +394,7 @@ func (p *ParallelIO) processIO(ctx context.Context, numEmitWorkers int) error {
 				// to the pending queue to be rechecked for validity later.
 				req.pendingQueueAdmitTime = timeutil.Now()
 				pending = append(pending, req)
-				metricsRec.recordPendingQueuePush(int64(req.r.NumMessages()))
+				metricsRec.recordPendingQueuePush(int64(req.r.Keys().Len()))
 			} else {
 				newInFlightKeys := req.r.Keys()
 				inflight.UnionWith(newInFlightKeys)


### PR DESCRIPTION
Based on clues from the existing code, we should be keeping track of the
number of keys, not the number of messages.

Exhibit A: The y-axis for metaChangefeedParallelIOPendingRows is defined
to be the number of keys, not the number of messages.

Exhibit B: The function signatures for recordPendingQueuePush and
recordPendingQueuePop are defined to take the number of keys, not the
number of messages.

Exhibit C: The number of keys is less than or equal to the number of
messages, and the reported issue is that this metric was being
over-reported.

Release note(ops change): Fix over-reporting of
changefeed.parallel_io_pending_rows metric by tracking the number of
pending keys instead of the number of messages.

Fixes: #147625