### PR TITLE
roachprod: azure GetVMSpecs() implementation

### DIFF
--- a/pkg/cmd/roachtest/tests/roachtest.go
+++ b/pkg/cmd/roachtest/tests/roachtest.go
@@ -81,6 +81,18 @@ func registerRoachtest(r registry.Registry) {
 			monitorFatalTestGlobal(ctx, t, c)
 		},
 	})
+
+	// Manual test for verifying framework behavior in a test success scenario
+	r.Add(registry.TestSpec{
+		Name:             "roachtest/manual/success",
+		Owner:            registry.OwnerTestEng,
+		Cluster:          r.MakeClusterSpec(3),
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.ManualOnly,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			t.L().Printf("hello")
+		},
+	})
 }
 
 // monitorFatalTest will always fail with a node logging a fatal error in a

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -41,7 +41,10 @@ go_library(
 
 go_test(
     name = "azure_test",
-    srcs = ["utils_test.go"],
+    srcs = [
+        "ids_test.go",
+        "utils_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":azure"],
     deps = [

--- a/pkg/roachprod/vm/azure/ids.go
+++ b/pkg/roachprod/vm/azure/ids.go
@@ -20,9 +20,35 @@ import (
 // https://github.com/Azure/azure-sdk-for-go/issues/3080
 // is solved.
 
+// azureIDPattern matches
+// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{namespace}/{type}/{name}[/childType/childName ...]
+// If child resource type name pair(s) are not present, the last matching
+// group will be empty. Otherwise, the last matching group will contain all
+// additional pairs.
+//
+// Currently, we are not using any Azure Resource IDs that contain child
+// resource type name pairs, so we do not save them as a field in azureID. If
+// we need to use them in the future we can add a field to azureID and set
+// that field in parseAzureID.
+// Note: the number of child resource pairs is ambiguous and currently the
+// entire remainder of the string gets matched to the last group if a trailing
+// '/' is present after resourceName.
 var azureIDPattern = regexp.MustCompile(
-	"/subscriptions/(.+)/resourceGroups/(.+)/providers/(.+?)/(.+?)/(.+)")
+	`/subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/([^/]+)/([^/]+)/([^/]+)(?:/(.*))?`)
 
+// azureID defines a fully qualified Azure Resource ID which must contain a
+// subscription ID, a resourceGroup name, a provider namespace, and at least
+// one type and name pair. The first type name pair describes the resourceType
+// and resourceName. For examples, reference unit tests.
+//
+// Additional type name pairs are optional, and if they exist, this Resource ID
+// is describing a child resource or sometimes referred to as a subresource.
+// This struct does not contain a field for child resources. If a
+// child resource ID needs to be parsed, this struct must be extended.
+//
+// Template:
+//
+//	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{namespace}/{type}/{name}[/childType/childName ...]
 type azureID struct {
 	provider      string
 	resourceGroup string
@@ -31,14 +57,17 @@ type azureID struct {
 	subscription  string
 }
 
+// String does not account for child resources since they are not saved after
+// being parsed
 func (id azureID) String() string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s",
+	s := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s",
 		id.subscription, id.resourceGroup, id.provider, id.resourceType, id.resourceName)
+	return s
 }
 
 func parseAzureID(id string) (azureID, error) {
 	parts := azureIDPattern.FindStringSubmatch(id)
-	if len(parts) == 0 {
+	if len(parts) != 7 {
 		return azureID{}, errors.Errorf("could not parse Azure ID %q", id)
 	}
 	ret := azureID{

--- a/pkg/roachprod/vm/azure/ids_test.go
+++ b/pkg/roachprod/vm/azure/ids_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package azure
+
+import "testing"
+
+func TestParseAzureID(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedString string
+		expectErr      bool
+		expected       azureID
+	}{
+		{
+			name:           "Valid VM",
+			input:          "/subscriptions/1234-abcd/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/n01",
+			expectedString: "/subscriptions/1234-abcd/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/n01",
+			expected: azureID{
+				subscription:  "1234-abcd",
+				resourceGroup: "my-rg",
+				provider:      "Microsoft.Compute",
+				resourceType:  "virtualMachines",
+				resourceName:  "n01",
+			},
+		},
+		{
+			name:           "Valid NIC",
+			input:          "/subscriptions/1234-abcd/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/test-nic01",
+			expectedString: "/subscriptions/1234-abcd/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/test-nic01",
+			expected: azureID{
+				subscription:  "1234-abcd",
+				resourceGroup: "test-rg",
+				provider:      "Microsoft.Network",
+				resourceType:  "networkInterfaces",
+				resourceName:  "test-nic01",
+			},
+		},
+		{
+			// Since child resources are not implemented, all we are checking here is
+			// that the resourceName gets selected out properly
+			name:           "Valid with child resource",
+			input:          "/subscriptions/1111/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb01/frontendIPConfigurations/ipconfig1",
+			expectedString: "/subscriptions/1111/resourceGroups/rg1/providers/Microsoft.Network/loadBalancers/lb01",
+			expected: azureID{
+				subscription:  "1111",
+				resourceGroup: "rg1",
+				provider:      "Microsoft.Network",
+				resourceType:  "loadBalancers",
+				resourceName:  "lb01",
+			},
+		},
+		{
+			name:      "Invalid - missing fields",
+			input:     "/subscriptions/abcd/resourceGroups//providers/Microsoft.Compute/virtualMachines/vm1",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid - not an Azure ID",
+			input:     "/this/is/not/an/azure/id",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseAzureID(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			// Compare fields
+			if actual.subscription != tt.expected.subscription {
+				t.Errorf("subscription: actual %q, expected %q", actual.subscription, tt.expected.subscription)
+			}
+			if actual.resourceGroup != tt.expected.resourceGroup {
+				t.Errorf("resourceGroup: actual %q, expected %q", actual.resourceGroup, tt.expected.resourceGroup)
+			}
+			if actual.provider != tt.expected.provider {
+				t.Errorf("provider: actual %q, expected %q", actual.provider, tt.expected.provider)
+			}
+			if actual.resourceType != tt.expected.resourceType {
+				t.Errorf("resourceType: actual %q, expected %q", actual.resourceType, tt.expected.resourceType)
+			}
+			if actual.resourceName != tt.expected.resourceName {
+				t.Errorf("resourceName: actual %q, expected %q", actual.resourceName, tt.expected.resourceName)
+			}
+			// Ensure String() reconstructs the same input
+			if actual.String() != tt.expectedString {
+				t.Errorf("String(): actual %q, expected %q", actual.String(), tt.expectedString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/146202 

Implementation for previously unimplemented interface method `GetVMSpecs()` for Azure. This will allow for cluster information to be fetched in roachtest via `FetchVMSpecs`

Also changed `azureIDPattern` to match the optional type name pairs that may exist in a fully qualified azure resource id. See comments for more details.  Previously, if these optional type name pairs existed, they were just a part of the `resourceName` field. Currently, I didn't see any of these child resource ids being parsed, but if we were to ever parse those in the future the previous implementation wouldn't make sense.
* Note: Although the regex selects child resource type and names in the last matching group, they are not saved to AzureId struct because they are not being used

For Azure, `client.Get(...)` allows you to pass in an optional `expander` parameter which seems to provide additional information for `"instanceView"` and runs an optionally passed in user script (passed in on vm creation) when `"userData"` is passed in.
*  `"userData"` doesn't seem relevant for us "retrieves the UserData property as part of the VM model view that was provided by the user during the VM Create/Update operation" https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/get?view=rest-compute-2025-04-01&tabs=HTTP
  *  "The `instanceView` of an Azure Virtual Machine (VM) provides a snapshot of the runtime properties and status of the VM" https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/instance-view?view=rest-compute-2025-04-01&tabs=HTTP Seems nice, but there's no diff in the json returned by `"instanceView"` and the default when `expander` is not set (referred to `model view` in some places on thier docs) 
```go
InstanceViewTypesInstanceView InstanceViewTypes = "instanceView"  
InstanceViewTypesUserData InstanceViewTypes = "userData"
```


IBM PR: https://github.com/cockroachdb/cockroach/pull/155368
