### PR TITLE
sql/copy: deflake copy datadriven test

### DIFF
--- a/pkg/sql/copy/testdata/copy_from
+++ b/pkg/sql/copy/testdata/copy_from
@@ -800,8 +800,8 @@ CREATE POLICY p_sel ON rls_table FOR SELECT USING (true);
 # Deny some
 copy-from-error
 COPY rls_table FROM STDIN WITH CSV
-20,"twenty"
 4,"four (violates rls policy)"
+20,"twenty"
 ----
 ERROR: new row violates row-level security policy for table "rls_table" (SQLSTATE 42501)
 


### PR DESCRIPTION
One of the `copy_from` test cases for RLS could previously fail if the copy batch size was metamorphically set to 1 and the test was using nonatomic copy. This commit fixes the flake by re-ordering the copied rows so that the failing one is copied first.

Fixes #154418

Release note: None