### PR TITLE
concurrency: add optional lock table flushing

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_flush_lock_table.go
+++ b/pkg/kv/kvserver/batcheval/cmd_flush_lock_table.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func init() {
@@ -74,6 +75,7 @@ func FlushLockTable(
 		return true
 	})
 
+	log.KvExec.Infof(ctx, "flushing %d locks; latched: %s", len(locksToFlush), cArgs.Concurrency.LatchSpans())
 	for i, l := range locksToFlush {
 		locksToFlush[i].Durability = lock.Replicated
 		if err := storage.MVCCAcquireLock(ctx, rw,

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "concurrency_manager.go",
         "latch_manager.go",
         "lock_table.go",
+        "lock_table_flusher.go",
         "lock_table_waiter.go",
         "metrics.go",
         "verifiable_lock_table.go",
@@ -33,6 +34,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/container/list",
         "//pkg/util/debugutil",
@@ -58,6 +60,7 @@ go_test(
     srcs = [
         "concurrency_manager_test.go",
         "datadriven_util_test.go",
+        "lock_table_flusher_test.go",
         "lock_table_test.go",
         "lock_table_waiter_test.go",
         ":keylocks_interval_btree_test.go",  # keep

--- a/pkg/kv/kvserver/concurrency/lock_table_flusher.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_flusher.go
@@ -1,0 +1,383 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package concurrency
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// TODO(review): Decide how much configurability we want here.
+var (
+	maxWorkerCount            = 16
+	maxFlushBytes       int64 = 16 << 20 // 16 MiB
+	workerQuiescePeriod       = 30 * time.Second
+)
+
+// LockTableFlusher is responsible for sending FlushLockTableRequests for ranges
+// whose lock table has grown too large. Ranges are enqueued by their respective
+// lock tables and the lock table flusher maintains a set of workers.
+type LockTableFlusher struct {
+	sender  sender
+	stopper *stop.Stopper
+
+	mu struct {
+		syncutil.Mutex
+
+		queue       flushQueue
+		workerCount int
+	}
+	workReady chan struct{}
+}
+
+type sender interface {
+	SendWrappedWithAdmission(context.Context, kvpb.Header, kvpb.AdmissionHeader, kvpb.Request) (kvpb.Response, *kvpb.Error)
+	AnnotateCtx(context.Context) context.Context
+}
+
+type kvSender struct {
+	*kv.DB
+}
+
+func (s kvSender) SendWrappedWithAdmission(
+	ctx context.Context, h kvpb.Header, ah kvpb.AdmissionHeader, r kvpb.Request,
+) (kvpb.Response, *kvpb.Error) {
+	return kv.SendWrappedWithAdmission(ctx, s.DB.NonTransactionalSender(), h, ah, r)
+}
+
+func (s kvSender) AnnotateCtx(ctx context.Context) context.Context {
+	return s.DB.AmbientContext.AnnotateCtx(ctx)
+}
+
+func NewLockTableFlusher(db *kv.DB, stopper *stop.Stopper) *LockTableFlusher {
+	return newLockTableFlusherForSender(kvSender{db}, stopper)
+}
+
+func newLockTableFlusherForSender(s sender, stopper *stop.Stopper) *LockTableFlusher {
+	ltf := &LockTableFlusher{
+		sender:    s,
+		stopper:   stopper,
+		workReady: make(chan struct{}),
+	}
+	ltf.mu.queue = makeFlushQueue()
+	return ltf
+}
+
+func (f *LockTableFlusher) sendFlush(ctx context.Context, r *lockFlushRequest) error {
+	ctx, span := tracing.ChildSpan(ctx, "LockTableFlusher.sendFlush")
+	defer span.Finish()
+
+	header := kvpb.Header{
+		TargetBytes: maxFlushBytes,
+	}
+	admissionHeader := kvpb.AdmissionHeader{
+		Priority:   int32(admissionpb.LockingNormalPri),
+		CreateTime: timeutil.Now().UnixNano(),
+		Source:     kvpb.AdmissionHeader_ROOT_KV,
+	}
+	req := kvpb.FlushLockTableRequest{
+		RequestHeader: kvpb.RequestHeaderFromSpan(r.span),
+	}
+
+	log.KvExec.Infof(ctx, "flushing locks for range %d (%s) (expectedNumToFlush: %d)", r.rangeID, r.span, r.numToFlush)
+	resp, pErr := f.sender.SendWrappedWithAdmission(ctx, header, admissionHeader, &req)
+	if pErr != nil {
+		return pErr.GoError()
+	}
+	flushResp := resp.(*kvpb.FlushLockTableResponse)
+	log.KvExec.Infof(ctx, "flushed %d unreplicated locks as replicated (resume reason: %s)", flushResp.LocksWritten, flushResp.ResumeReason)
+
+	return nil
+}
+
+// MaybeEnqueueFlush add a request to flush the given range to the queue. If the
+// range is already in the queue, it adjusts the priority of the existing
+// request. If a request for the range is already in flight, this call is a
+// no-op.
+//
+// NB: numKeys is only used for request ordering. An in-flight flush request
+// will always attempt to flush up to maxFlushBytes.
+func (f *LockTableFlusher) MaybeEnqueueFlush(id roachpb.RangeID, span roachpb.Span, numKeys int64) {
+	added := f.enqueue(&lockFlushRequest{
+		span:       span,
+		rangeID:    id,
+		numToFlush: numKeys,
+	})
+	if !added {
+		return
+	}
+	// Notify worker that we've added something to the queue.
+	select {
+	case f.workReady <- struct{}{}:
+	default:
+	}
+}
+
+func (f *LockTableFlusher) Inflight() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.mu.queue.inflight)
+}
+
+func (f *LockTableFlusher) QueueLength() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mu.queue.Len()
+}
+
+func (f *LockTableFlusher) WorkerCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mu.workerCount
+}
+
+func (f *LockTableFlusher) enqueue(req *lockFlushRequest) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	added := f.mu.queue.maybeEnqueue(req)
+	if f.mu.workerCount == 0 {
+		f.maybeStartWorkerLocked()
+	}
+	return added
+}
+
+func (f *LockTableFlusher) maybeStartWorker() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.maybeStartWorkerLocked()
+}
+
+func (f *LockTableFlusher) maybeStartWorkerLocked() {
+	if f.mu.workerCount >= maxWorkerCount {
+		return
+	}
+	f.mu.workerCount++
+
+	ctx := f.sender.AnnotateCtx(context.Background())
+	if err := f.stopper.RunAsyncTask(ctx, "lock-table-flusher", func(ctx context.Context) {
+		ctx, cancel := f.stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+		f.worker(ctx)
+	}); err != nil {
+		f.mu.workerCount--
+		log.KvExec.Errorf(ctx, "could not start lock table flush worker: %s", err.Error())
+	}
+}
+
+func (f *LockTableFlusher) worker(ctx context.Context) {
+	log.KvExec.Infof(ctx, "starting lock table flush worker")
+	defer func() { log.KvExec.Infof(ctx, "stopping lock table flush worker") }()
+
+	var lastWorkItem *lockFlushRequest
+	var currentWorkItem *lockFlushRequest
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		lastWorkItem = currentWorkItem
+		var remaining int
+		currentWorkItem, remaining = f.nextWorkItem(lastWorkItem)
+		if currentWorkItem != nil {
+			if remaining > 0 {
+				// If the queue has work remaining, try to start another worker.
+				f.maybeStartWorker()
+			}
+			if err := f.sendFlush(ctx, currentWorkItem); err != nil {
+				log.KvExec.Errorf(ctx, "lock table flush failed: %s", err.Error())
+			}
+
+			// If we had work this time, look for work again.
+			continue
+		}
+
+		// No work in the queue twice in a row, exit if able.
+		if lastWorkItem == nil && f.workerShouldExit() {
+			return
+		}
+
+		// No work in the queue, let's wait a bit for work and shut ourselves down
+		// if no work shows up.
+		select {
+		case <-f.workReady:
+		case <-ctx.Done():
+			return
+		case <-time.After(workerQuiescePeriod):
+			if f.workerShouldExit() {
+				return
+			}
+		}
+	}
+}
+
+// workerShouldExit returns true if the given worker should exit. When true is
+// returned, the worker must exit as the worker count has been decreased.
+//
+// We never allow the last worker to exit once it is started.
+func (f *LockTableFlusher) workerShouldExit() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.mu.workerCount > 1 {
+		f.mu.workerCount--
+		return true
+	}
+	return false
+}
+
+func (f *LockTableFlusher) nextWorkItem(lastWorkItem *lockFlushRequest) (*lockFlushRequest, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mu.queue.dequeue(lastWorkItem), f.mu.queue.Len()
+}
+
+type lockFlushRequest struct {
+	idx int
+
+	span       roachpb.Span
+	rangeID    roachpb.RangeID
+	numToFlush int64
+}
+
+func (l *lockFlushRequest) Combine(o *lockFlushRequest) {
+	l.numToFlush = max(l.numToFlush, o.numToFlush)
+	if o.span.Key.Less(l.span.Key) {
+		l.span.Key = o.span.Key
+	}
+	if l.span.EndKey.Less(o.span.EndKey) {
+		l.span.EndKey = o.span.EndKey
+	}
+}
+
+func (l *lockFlushRequest) String() string {
+	return fmt.Sprintf("lock flush request for %s (%s)", l.rangeID, l.span)
+}
+
+// flushQueue maintains a heap ordered by the number of keys we need to flush
+// for the given range. It keeps track of dequeued ranges until the worker
+// indicates it has finished that work by dequeue-ing another item.
+//
+// This implementation is not thread-safe and should be wrapped in a Mutex if
+// called from more than 1 thread.
+//
+// This implementation was based on the batchQueue in the request batcher.
+//
+// TODO(review): If we don't think that ordering by locksToFlush is really
+// necessary, we could get rid of the heap business all together and just have
+// this be a simple queue.
+type flushQueue struct {
+	reqs    []*lockFlushRequest
+	byRange map[roachpb.RangeID]*lockFlushRequest
+
+	// inflight ranges currently in-flight by users of the queue.
+	inflight map[roachpb.RangeID]struct{}
+}
+
+var _ heap.Interface = (*flushQueue)(nil)
+
+func makeFlushQueue() flushQueue {
+	return flushQueue{
+		byRange:  make(map[roachpb.RangeID]*lockFlushRequest),
+		inflight: make(map[roachpb.RangeID]struct{}),
+	}
+}
+
+// maybeEnqueue adds a request to the queue if it is not already in-flight. If a
+// request for this range is already in the queue, its priority is updated based
+// on the new request.
+func (q *flushQueue) maybeEnqueue(req *lockFlushRequest) bool {
+	queuedReq, inFlight, queued := q.get(req.rangeID)
+	if inFlight {
+		return false
+	}
+
+	if queued {
+		queuedReq.Combine(req)
+		heap.Fix(q, queuedReq.idx)
+		return false
+	}
+
+	heap.Push(q, req)
+	return true
+}
+
+func (q *flushQueue) dequeue(lastRequest *lockFlushRequest) *lockFlushRequest {
+	if lastRequest != nil {
+		delete(q.inflight, lastRequest.rangeID)
+	}
+	item := q.popFront()
+	if item == nil {
+		return nil
+	}
+	q.inflight[item.rangeID] = struct{}{}
+	return item
+}
+
+func (q *flushQueue) popFront() *lockFlushRequest {
+	if q.Len() == 0 {
+		return nil
+	}
+	return heap.Pop(q).(*lockFlushRequest)
+}
+
+func (q *flushQueue) get(id roachpb.RangeID) (_ *lockFlushRequest, inflight bool, queued bool) {
+	if _, ok := q.inflight[id]; ok {
+		return nil, true, false
+	}
+	b, exists := q.byRange[id]
+	return b, false, exists
+}
+
+func (q *flushQueue) Len() int {
+	return len(q.reqs)
+}
+
+func (q *flushQueue) Swap(i, j int) {
+	q.reqs[i], q.reqs[j] = q.reqs[j], q.reqs[i]
+	q.reqs[i].idx = i
+	q.reqs[j].idx = j
+}
+
+func (q *flushQueue) Less(i, j int) bool {
+	iNum, jNum := q.reqs[i].numToFlush, q.reqs[j].numToFlush
+	if iNum != jNum {
+		// The heap library provides a min heap, so we reverse this conditional so
+		// that the largest number of keys to flush is the first to be popped.
+		return iNum > jNum
+	}
+	return q.reqs[i].rangeID < q.reqs[j].rangeID
+}
+
+func (q *flushQueue) Push(v interface{}) {
+	r := v.(*lockFlushRequest)
+	r.idx = len(q.reqs)
+	q.byRange[r.rangeID] = r
+	q.reqs = append(q.reqs, r)
+}
+
+func (q *flushQueue) Pop() interface{} {
+	r := q.reqs[len(q.reqs)-1]
+	q.reqs[len(q.reqs)-1] = nil
+	q.reqs = q.reqs[:len(q.reqs)-1]
+	delete(q.byRange, r.rangeID)
+	r.idx = -1
+	return r
+}

--- a/pkg/kv/kvserver/concurrency/lock_table_flusher_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_flusher_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+)
+
+type sendFunc func(context.Context, kvpb.Header, kvpb.AdmissionHeader, kvpb.Request) (kvpb.Response, *kvpb.Error)
+type testSender struct {
+	onSend sendFunc
+}
+
+func (s *testSender) SendWrappedWithAdmission(
+	ctx context.Context, h kvpb.Header, ah kvpb.AdmissionHeader, r kvpb.Request,
+) (kvpb.Response, *kvpb.Error) {
+	return s.onSend(ctx, h, ah, r)
+}
+
+func (s *testSender) AnnotateCtx(ctx context.Context) context.Context {
+	return ctx
+}
+
+func TestLockTableFlusher(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	workerQuiescePeriod = 10 * time.Millisecond
+	s := &testSender{}
+	ltf := newLockTableFlusherForSender(s, stopper)
+
+	validateHeader := func(h kvpb.Header) {
+		require.True(t, h.TargetBytes > 0, "target bytes should be sent")
+	}
+
+	blocker := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(blocker) })
+	defer unblock()
+	started := make(chan struct{}, maxWorkerCount*4)
+
+	s.onSend = func(ctx context.Context, h kvpb.Header, ah kvpb.AdmissionHeader, r kvpb.Request) (kvpb.Response, *kvpb.Error) {
+		started <- struct{}{}
+		<-blocker
+		validateHeader(h)
+		return &kvpb.FlushLockTableResponse{}, nil
+	}
+
+	// Enqueue twice the maxWorkerCount.
+	for i := range maxWorkerCount * 2 {
+		span := roachpb.Span{Key: roachpb.Key{byte(i)}, EndKey: roachpb.Key{byte(i + 1)}}
+		ltf.MaybeEnqueueFlush(roachpb.RangeID(i+1), span, 5)
+	}
+
+	// maxWorkerCount requests should be able to start in parallel. Note, this
+	// test doesn't guaranteed that we don't go over the max, but in practice it
+	// does catch such bugs relatively quickly.
+	startedRequests := 0
+	for startedRequests < maxWorkerCount {
+		select {
+		case <-started:
+			startedRequests++
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for %d tasks to start", maxWorkerCount)
+		}
+	}
+
+	require.Equal(t, maxWorkerCount, ltf.Inflight())
+	require.Equal(t, maxWorkerCount, ltf.WorkerCount())
+	require.Equal(t, maxWorkerCount, stopper.NumTasks())
+	require.Equal(t, maxWorkerCount, ltf.QueueLength())
+
+	// Re-enqueue all ranges.
+	for i := range maxWorkerCount * 2 {
+		span := roachpb.Span{Key: roachpb.Key{byte(i)}, EndKey: roachpb.Key{byte(i + 1)}}
+		ltf.MaybeEnqueueFlush(roachpb.RangeID(i+1), span, 5)
+	}
+
+	// Nothing should change.
+	require.Equal(t, maxWorkerCount, ltf.Inflight())
+	require.Equal(t, maxWorkerCount, ltf.WorkerCount())
+	require.Equal(t, maxWorkerCount, ltf.QueueLength())
+
+	unblock()
+
+	// Count the rest of the requests, we should get to the 2*maxWorkerCount we
+	// enqueued.
+	for startedRequests < 2*maxWorkerCount {
+		select {
+		case <-started:
+			startedRequests++
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for %d tasks to start", maxWorkerCount)
+		}
+	}
+
+	// That should be all of the requests.
+	testutils.SucceedsSoon(t, func() error {
+		if ltf.Inflight() != 0 {
+			return errors.New("inflight requests")
+		} else if ltf.QueueLength() != 0 {
+			return errors.New("queue non-empty")
+		}
+		return nil
+	})
+
+	// The worker count should decrease back to 1 over time.
+	testutils.SucceedsSoon(t, func() error {
+		if ltf.WorkerCount() > 1 {
+			return errors.New("too many workers")
+		}
+		return nil
+	})
+}
+
+func TestFlushQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var (
+		r1     = roachpb.RangeID(1)
+		r1Span = roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}
+		r2     = roachpb.RangeID(2)
+		r2Span = roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}
+		r3     = roachpb.RangeID(3)
+		r3Span = roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}
+	)
+
+	t.Run("enqueue duplicate range updates range", func(t *testing.T) {
+		q := makeFlushQueue()
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r1, span: r1Span, numToFlush: 10}))
+		require.False(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r1, span: r1Span, numToFlush: 100}))
+		require.Equal(t, 1, q.Len())
+		item := q.dequeue(nil)
+		require.NotNil(t, item)
+		require.Equal(t, int64(100), item.numToFlush)
+	})
+
+	t.Run("enqueue doesn't add inflight range", func(t *testing.T) {
+		q := makeFlushQueue()
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r1, span: r1Span, numToFlush: 10}))
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r2, span: r2Span, numToFlush: 1}))
+
+		item := q.dequeue(nil)
+		require.NotNil(t, item)
+		require.Equal(t, r1, item.rangeID)
+		require.Equal(t, int64(10), item.numToFlush)
+
+		// We still can't enqueue this because it is "inflight"
+		require.False(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r1, span: r1Span, numToFlush: 100}))
+
+		item = q.dequeue(item)
+		require.NotNil(t, item)
+		require.Equal(t, r2, item.rangeID)
+		require.Equal(t, int64(1), item.numToFlush)
+
+		// Now we can enqueue r1 again because it is no longer "inflight"
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r1, span: r1Span, numToFlush: 43}))
+	})
+
+	t.Run("dequeue is ordered by numToFlush", func(t *testing.T) {
+		q := makeFlushQueue()
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r1, span: r1Span, numToFlush: 10}))
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r2, span: r2Span, numToFlush: 100}))
+		require.True(t, q.maybeEnqueue(&lockFlushRequest{rangeID: r3, span: r3Span, numToFlush: 42}))
+		require.Equal(t, 3, q.Len())
+
+		item := q.dequeue(nil)
+		require.NotNil(t, item)
+		require.Equal(t, r2, item.rangeID)
+		require.Equal(t, int64(100), item.numToFlush)
+
+		item = q.dequeue(item)
+		require.NotNil(t, item)
+		require.Equal(t, r3, item.rangeID)
+		require.Equal(t, int64(42), item.numToFlush)
+
+		item = q.dequeue(item)
+		require.NotNil(t, item)
+		require.Equal(t, r1, item.rangeID)
+		require.Equal(t, int64(10), item.numToFlush)
+
+		item = q.dequeue(item)
+		require.Nil(t, item)
+	})
+}

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -197,7 +197,7 @@ func TestLockTableBasic(t *testing.T) {
 				var maxLocks int
 				d.ScanArgs(t, "maxlocks", &maxLocks)
 				ltImpl := newLockTable(
-					int64(maxLocks), roachpb.RangeID(3), clock, cluster.MakeTestingClusterSettings(),
+					int64(maxLocks), roachpb.RangeID(3), clock, cluster.MakeTestingClusterSettings(), nil,
 				)
 				ltImpl.enabled = true
 				ltImpl.enabledSeq = 1
@@ -889,7 +889,7 @@ func newLock(txn *enginepb.TxnMeta, key roachpb.Key, str lock.Strength) *roachpb
 
 func TestLockTableMaxLocks(t *testing.T) {
 	lt := newLockTable(
-		5, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
+		5, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(), nil,
 	)
 	lt.minKeysLocked = 0
 	lt.enabled = true
@@ -1031,7 +1031,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 // ref counting.
 func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
 	lt := newLockTable(
-		2, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
+		2, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(), nil,
 	)
 	lt.minKeysLocked = 0
 	lt.enabled = true
@@ -1316,7 +1316,7 @@ func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecuto
 		nil, /* latchWaitDurations */
 		clock,
 	)
-	ltImpl := newLockTable(maxLocks, roachpb.RangeID(3), clock, settings)
+	ltImpl := newLockTable(maxLocks, roachpb.RangeID(3), clock, settings, nil)
 	ltImpl.enabled = true
 	lt := maybeWrapInVerifyingLockTable(ltImpl)
 	ex := &workloadExecutor{
@@ -2018,7 +2018,7 @@ func BenchmarkLockTable(b *testing.B) {
 						lm := spanlatch.Make(
 							nil /* stopper */, nil /* slowReqs */, settings, nil /* latchWaitDurations */, clock,
 						)
-						lt := newLockTable(maxLocks, roachpb.RangeID(3), clock, settings)
+						lt := newLockTable(maxLocks, roachpb.RangeID(3), clock, settings, nil)
 						lt.enabled = true
 						env := benchEnv{
 							lm:                &lm,
@@ -2063,6 +2063,7 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 				roachpb.RangeID(3),
 				hlc.NewClockForTesting(nil),
 				cluster.MakeTestingClusterSettings(),
+				nil,
 			)
 			lt.enabled = true
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -133,6 +133,7 @@ func newUninitializedReplicaWithoutRaftGroup(store *Store, id roachpb.FullReplic
 			Clock:              store.Clock(),
 			Stopper:            store.Stopper(),
 			IntentResolver:     store.intentResolver,
+			LockTableFlusher:   store.lockTableFlusher,
 			TxnWaitMetrics:     store.txnWaitMetrics,
 			SlowLatchGauge:     store.metrics.SlowLatchRequests,
 			LatchWaitDurations: store.metrics.LatchWaitDurations,


### PR DESCRIPTION
This adds a new LockTableFlusher which can optionally be used by the lock table to move unreplicated locks into the replicated lock table when under memory pressure.

The LockTableFlusher is held at the store level, limiting the total number of in-flight lock requests.

Right now, we start sending flush requests when we are 80% of the maximum size.

Epic: none
Release note: None