### PR TITLE
release-25.3: roachtest: disable create_table_with_schema_locked in ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -77,7 +77,6 @@ func alterZoneConfigAndClusterSettings(
 		`ALTER ROLE ALL SET statement_timeout = '60s'`,
 		`ALTER ROLE ALL SET default_transaction_isolation = 'read committed'`,
 		`ALTER ROLE ALL SET autocommit_before_ddl = 'true'`,
-		`ALTER ROLE ALL SET create_table_with_schema_locked='true'`,
 	} {
 		if _, err := db.ExecContext(ctx, cmd); err != nil {
 			return err


### PR DESCRIPTION
Previously, we enabled create_table_with_schema_locked by default in ORM tests in anticipation of this setting becoming the default. However, this change did not become the default in version 25.3. Additionally, we recently discovered that TRUNCATE support was incorrectly enabled when schema_locked is active. This combination led to failures in the ORM tests. To resolve these issues, this patch disables create_table_with_schema_locked when testing ORMs.

Fixes: #154438
Fixes: #154431
Fixes: #154422
Fixes: #154420

Release note: None
Release justification: test only change