### PR TITLE
sql: TestTelemetryLoggingDataDriven ignore retries

### DIFF
--- a/pkg/sql/telemetry_datadriven_test.go
+++ b/pkg/sql/telemetry_datadriven_test.go
@@ -69,7 +69,7 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 		[]string{"sampled_query"},
 		logtestutils.FormatEntryAsJSON,
 		func(_ logpb.Entry, logStr string) bool {
-			return !strings.Contains(logStr, ignoredAppname)
+			return !strings.Contains(logStr, ignoredAppname) && !strings.Contains(logStr, "NumRetries")
 		},
 	)
 


### PR DESCRIPTION
The current setup compares all outputs, and during retries the output fails to match. This change ignores retry logs

closes: cockroachdb#153768
Epic: None
Release note: None