### PR TITLE
roachtest: handle null fingerprint in backup/restore roundtrip

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -630,7 +630,7 @@ func (fc *fingerprintContents) Load(
 ) error {
 	l.Printf("computing fingerprints for table %s", fc.table)
 	query := fmt.Sprintf(
-		"SELECT index_name, fingerprint FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s]%s ORDER BY index_name",
+		"SELECT index_name, COALESCE(fingerprint, '') FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s]%s ORDER BY index_name",
 		fc.table, aostFor(timestamp),
 	)
 	rows, err := fc.db.QueryContext(ctx, query)


### PR DESCRIPTION
Currently, if a table is empty during our backup/restore roundtrip test fingerprint, `SHOW EXPERIMENTAL_FINGERPRINTS` returns `NULL`. This commit teaches our roundtrip tests to properly handle `NULL` fingerprints.

Fixes: #154502

Fixes: #154506

Fixes: #154507

Release note: None