### PR TITLE
explain: harden gist decoding logic for invalid gists

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -288,3 +288,21 @@ SELECT crdb_internal.decode_plan_gist('AgHk+v//3xoEAKAFAgAABQQGBA==');
 • virtual table
   table: @?
   spans: 1+ spans
+
+# Regression tests for #154300. Gracefully handle invalid gists.
+query T nosort
+SELECT crdb_internal.decode_external_plan_gist('AgYd':::STRING);
+----
+
+query T nosort
+SELECT crdb_internal.decode_external_plan_gist('Agwc':::STRING);
+----
+• root
+│
+├── • explain
+│
+└── • subquery
+    │ id: @S1
+    │ exec mode: exists
+    │
+    └── • group (scalar)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -77,11 +77,17 @@ func emitInternal(
 	e := makeEmitter(ob, spanFormatFn)
 	var walk func(n *Node) error
 	walk = func(n *Node) error {
+		if n == nil {
+			return nil
+		}
 		// In non-verbose mode, we skip all projections.
 		// In verbose mode, we only skip trivial projections (which just rearrange
 		// or rename the columns).
 		if !ob.flags.Verbose {
 			if n.op == serializingProjectOp || n.op == simpleProjectOp {
+				if len(n.children) == 0 {
+					return nil
+				}
 				return walk(n.children[0])
 			}
 		}
@@ -233,6 +239,9 @@ func omitTrivialProjections(n *Node) (*Node, colinfo.ResultColumns, colinfo.Colu
 		return n, n.Columns(), n.Ordering()
 	}
 
+	if len(n.children) == 0 {
+		return n, n.Columns(), n.Ordering()
+	}
 	input, inputColumns, inputOrdering := omitTrivialProjections(n.children[0])
 
 	// Check if the projection is a bijection (i.e. permutation of all input

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -64,6 +64,9 @@ func (n *Node) Child(idx int) *Node {
 
 // Columns returns the ResultColumns for this node.
 func (n *Node) Columns() colinfo.ResultColumns {
+	if n == nil {
+		return nil
+	}
 	return n.columns
 }
 

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -167,6 +167,9 @@ func getResultColumns(
 		return tableColumns(a.Table, a.OutCols), nil
 
 	case vectorMutationSearchOp:
+		if len(inputs) == 0 {
+			return nil, nil
+		}
 		a := args.(*vectorMutationSearchArgs)
 		cols := appendColumns(inputs[0], colinfo.ResultColumn{Name: "partition-key", Typ: types.Int})
 		if a.IsIndexPut {


### PR DESCRIPTION
Our randomized test just encountered a couple of cases when an invalid gist resulted in an internal error when being decoded. The problem is that in such case we can have different fields of `Node`s left unset, leading to nil pointers or index-out-of-bounds. This commit hardens the code against such scenarios.

We did something similar in a56120147b41151308822a77ca61dda3f72038cf.

Fixes: #154300.
Release note: None