### PR TITLE
unsafesql: avoid panicking during query formatting

### DIFF
--- a/pkg/sql/unsafesql/BUILD.bazel
+++ b/pkg/sql/unsafesql/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/severity",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -26,7 +27,9 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings",
         "//pkg/sql/isql",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",


### PR DESCRIPTION
Part of the effort to guard access to the crdb_internal and system namespaces includes auditing override access (and denied access) to these unsafe internals. Included in this audit is the offending query which attempted to pry into these namespaces.

In multiple locations however, this auditing caused the system to panic, for different reasons. In one case, an incorrect number of annotations on the query caused a panic. Another included a plan builder which had no associated statement.

We see the process of going from plan -> query as a difficult one, and thus guard this attempt to audit these accesses in a blanket panic catcher, as it's not common that this will happen, and when it does we don't want the system to wholesale fail the query.

Fixes: #153590 Epic: CRDB-24527

Release note: none