### PR TITLE
changefeedccl: clean up blocking buffer metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1245,32 +1245,9 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
-    - name: changefeed.buffer_entries.allocated_mem.aggregator
-      exported_name: changefeed_buffer_entries_allocated_mem_aggregator
-      description: Current quota pool memory allocation - between the kvfeed and the sink
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.buffer_entries.allocated_mem.rangefeed
-      exported_name: changefeed_buffer_entries_allocated_mem_rangefeed
-      description: Current quota pool memory allocation - between the rangefeed and the kvfeed
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.buffer_entries.flush
-      exported_name: changefeed_buffer_entries_flush
-      description: Number of flush elements added to the buffer
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.flush.aggregator
       exported_name: changefeed_buffer_entries_flush_aggregator
+      labeled_name: 'changefeed.buffer_entries.flush{buffer_type: aggregator}'
       description: Number of flush elements added to the buffer - between the kvfeed and the sink
       y_axis_label: Events
       type: COUNTER
@@ -1279,22 +1256,16 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.flush.rangefeed
       exported_name: changefeed_buffer_entries_flush_rangefeed
+      labeled_name: 'changefeed.buffer_entries.flush{buffer_type: rangefeed}'
       description: Number of flush elements added to the buffer - between the rangefeed and the kvfeed
       y_axis_label: Events
       type: COUNTER
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.in
-      exported_name: changefeed_buffer_entries_in
-      description: Total entries entering the buffer between raft and changefeed sinks
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.in.aggregator
       exported_name: changefeed_buffer_entries_in_aggregator
+      labeled_name: 'changefeed.buffer_entries.in{buffer_type: aggregator}'
       description: Total entries entering the buffer between raft and changefeed sinks - between the kvfeed and the sink
       y_axis_label: Entries
       type: COUNTER
@@ -1303,22 +1274,16 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.in.rangefeed
       exported_name: changefeed_buffer_entries_in_rangefeed
+      labeled_name: 'changefeed.buffer_entries.in{buffer_type: rangefeed}'
       description: Total entries entering the buffer between raft and changefeed sinks - between the rangefeed and the kvfeed
       y_axis_label: Entries
       type: COUNTER
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.kv
-      exported_name: changefeed_buffer_entries_kv
-      description: Number of kv elements added to the buffer
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.kv.aggregator
       exported_name: changefeed_buffer_entries_kv_aggregator
+      labeled_name: 'changefeed.buffer_entries.kv{buffer_type: aggregator}'
       description: Number of kv elements added to the buffer - between the kvfeed and the sink
       y_axis_label: Events
       type: COUNTER
@@ -1327,22 +1292,16 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.kv.rangefeed
       exported_name: changefeed_buffer_entries_kv_rangefeed
+      labeled_name: 'changefeed.buffer_entries.kv{buffer_type: rangefeed}'
       description: Number of kv elements added to the buffer - between the rangefeed and the kvfeed
       y_axis_label: Events
       type: COUNTER
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.out
-      exported_name: changefeed_buffer_entries_out
-      description: Total entries leaving the buffer between raft and changefeed sinks
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.out.aggregator
       exported_name: changefeed_buffer_entries_out_aggregator
+      labeled_name: 'changefeed.buffer_entries.out{buffer_type: aggregator}'
       description: Total entries leaving the buffer between raft and changefeed sinks - between the kvfeed and the sink
       y_axis_label: Entries
       type: COUNTER
@@ -1351,15 +1310,8 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.out.rangefeed
       exported_name: changefeed_buffer_entries_out_rangefeed
+      labeled_name: 'changefeed.buffer_entries.out{buffer_type: rangefeed}'
       description: Total entries leaving the buffer between raft and changefeed sinks - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.released
-      exported_name: changefeed_buffer_entries_released
-      description: Total entries processed, emitted and acknowledged by the sinks
       y_axis_label: Entries
       type: COUNTER
       unit: COUNT
@@ -1367,6 +1319,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.released.aggregator
       exported_name: changefeed_buffer_entries_released_aggregator
+      labeled_name: 'changefeed.buffer_entries.released{buffer_type: aggregator}'
       description: Total entries processed, emitted and acknowledged by the sinks - between the kvfeed and the sink
       y_axis_label: Entries
       type: COUNTER
@@ -1375,22 +1328,16 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.released.rangefeed
       exported_name: changefeed_buffer_entries_released_rangefeed
+      labeled_name: 'changefeed.buffer_entries.released{buffer_type: rangefeed}'
       description: Total entries processed, emitted and acknowledged by the sinks - between the rangefeed and the kvfeed
       y_axis_label: Entries
       type: COUNTER
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.resolved
-      exported_name: changefeed_buffer_entries_resolved
-      description: Number of resolved elements added to the buffer
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.resolved.aggregator
       exported_name: changefeed_buffer_entries_resolved_aggregator
+      labeled_name: 'changefeed.buffer_entries.resolved{buffer_type: aggregator}'
       description: Number of resolved elements added to the buffer - between the kvfeed and the sink
       y_axis_label: Events
       type: COUNTER
@@ -1399,6 +1346,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries.resolved.rangefeed
       exported_name: changefeed_buffer_entries_resolved_rangefeed
+      labeled_name: 'changefeed.buffer_entries.resolved{buffer_type: rangefeed}'
       description: Number of resolved elements added to the buffer - between the rangefeed and the kvfeed
       y_axis_label: Events
       type: COUNTER
@@ -1413,22 +1361,6 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.acquired.aggregator
-      exported_name: changefeed_buffer_entries_mem_acquired_aggregator
-      description: Total amount of memory acquired for entries as they enter the system - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.acquired.rangefeed
-      exported_name: changefeed_buffer_entries_mem_acquired_rangefeed
-      description: Total amount of memory acquired for entries as they enter the system - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_entries_mem.released
       exported_name: changefeed_buffer_entries_mem_released
       description: Total amount of memory released by the entries after they have been emitted
@@ -1437,32 +1369,9 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.released.aggregator
-      exported_name: changefeed_buffer_entries_mem_released_aggregator
-      description: Total amount of memory released by the entries after they have been emitted - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.released.rangefeed
-      exported_name: changefeed_buffer_entries_mem_released_rangefeed
-      description: Total amount of memory released by the entries after they have been emitted - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_pushback_nanos
-      exported_name: changefeed_buffer_pushback_nanos
-      description: Total time spent waiting while the buffer was full
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_pushback_nanos.aggregator
       exported_name: changefeed_buffer_pushback_nanos_aggregator
+      labeled_name: 'changefeed.buffer_pushback_nanos{buffer_type: aggregator}'
       description: Total time spent waiting while the buffer was full - between the kvfeed and the sink
       y_axis_label: Nanoseconds
       type: COUNTER
@@ -1471,6 +1380,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.buffer_pushback_nanos.rangefeed
       exported_name: changefeed_buffer_pushback_nanos_rangefeed
+      labeled_name: 'changefeed.buffer_pushback_nanos{buffer_type: rangefeed}'
       description: Total time spent waiting while the buffer was full - between the rangefeed and the kvfeed
       y_axis_label: Nanoseconds
       type: COUNTER

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -502,7 +502,7 @@ func (ca *changeAggregator) startKVFeed(
 	}
 	buf := kvevent.NewThrottlingBuffer(
 		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV,
-			&ca.metrics.KVFeedMetrics.AggregatorBufferMetricsWithCompat, options...),
+			&ca.metrics.KVFeedMetrics.AggregatorBufferMetrics, options...),
 		cdcutils.NodeLevelThrottler(&cfg.Settings.SV, &ca.metrics.ThrottleMetrics))
 
 	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6411,10 +6411,10 @@ func TestChangefeedMonitoring(t *testing.T) {
 			if c := s.Server.MustGetSQLCounter(`changefeed.max_behind_nanos`); c != 0 {
 				t.Errorf(`expected %d got %d`, 0, c)
 			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.in`); c != 0 {
+			if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.in.rangefeed`); c != 0 {
 				t.Errorf(`expected 0 got %d`, c)
 			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.out`); c != 0 {
+			if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.out.rangefeed`); c != 0 {
 				t.Errorf(`expected 0 got %d`, c)
 			}
 			if c := s.Server.MustGetSQLCounter(`changefeed.schemafeed.table_metadata_nanos`); c != 0 {
@@ -6447,10 +6447,10 @@ func TestChangefeedMonitoring(t *testing.T) {
 				if c := s.Server.MustGetSQLCounter(`changefeed.max_behind_nanos`); c <= 0 {
 					return errors.Errorf(`expected > 0 got %d`, c)
 				}
-				if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.in`); c <= 0 {
+				if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.in.rangefeed`); c <= 0 {
 					return errors.Errorf(`expected > 0 got %d`, c)
 				}
-				if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.out`); c <= 0 {
+				if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.out.rangefeed`); c <= 0 {
 					return errors.Errorf(`expected > 0 got %d`, c)
 				}
 				switch c := s.Server.MustGetSQLCounter(`changefeed.schemafeed.table_history_scans`); {

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",

--- a/pkg/ccl/changefeedccl/kvevent/bench_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkMemBuffer(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetricsWithCompat
+	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetrics
 	st := cluster.MakeTestingClusterSettings()
 
 	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics)

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -25,7 +25,7 @@ import (
 // from a mon.BoundAccount and blocks if no resources are available.
 type blockingBuffer struct {
 	sv       *settings.Values
-	metrics  *PerBufferMetricsWithCompat
+	metrics  *PerBufferMetrics
 	qp       allocPool     // Pool for memory allocations.
 	signalCh chan struct{} // Signal when new events are available.
 
@@ -54,7 +54,7 @@ type blockingBuffer struct {
 func NewMemBuffer(
 	acc mon.BoundAccount,
 	sv *settings.Values,
-	metrics *PerBufferMetricsWithCompat,
+	metrics *PerBufferMetrics,
 	options ...BlockingBufferOption,
 ) Buffer {
 	return newMemBuffer(acc, sv, metrics, nil, options...)
@@ -65,7 +65,7 @@ func NewMemBuffer(
 func TestingNewMemBuffer(
 	acc mon.BoundAccount,
 	sv *settings.Values,
-	metrics *PerBufferMetricsWithCompat,
+	metrics *PerBufferMetrics,
 	onWaitStart quotapool.OnWaitStartFunc,
 ) Buffer {
 	return newMemBuffer(acc, sv, metrics, onWaitStart)
@@ -74,7 +74,7 @@ func TestingNewMemBuffer(
 func newMemBuffer(
 	acc mon.BoundAccount,
 	sv *settings.Values,
-	metrics *PerBufferMetricsWithCompat,
+	metrics *PerBufferMetrics,
 	onWaitStart quotapool.OnWaitStartFunc,
 	options ...BlockingBufferOption,
 ) Buffer {
@@ -488,7 +488,7 @@ func (r *memRequest) ShouldWait() bool {
 
 type allocPool struct {
 	*quotapool.AbstractPool
-	metrics *PerBufferMetricsWithCompat
+	metrics *PerBufferMetrics
 	sv      *settings.Values
 }
 

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -81,7 +82,7 @@ func TestBlockingBuffer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetricsWithCompat
+	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetrics
 	ba, release := getBoundAccountWithBudget(4096)
 	defer release()
 
@@ -178,11 +179,60 @@ func TestBlockingBuffer(t *testing.T) {
 	require.EqualValues(t, 0, metrics.AllocatedMem.Value())
 }
 
+func TestMultipleBlockingBufferMemoryMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	rnd, _ := randutil.NewTestRand()
+	metrics := kvevent.MakeMetrics(time.Minute)
+
+	// Ensure that the metrics struct is valid for registration.
+	require.NotPanics(t, func() {
+		reg := metric.NewRegistry()
+		reg.AddMetricStruct(metrics)
+	})
+
+	ba, release := getBoundAccountWithBudget(4096)
+	defer release()
+
+	st := cluster.MakeTestingClusterSettings()
+	bufRangefeed := kvevent.TestingNewMemBuffer(ba, &st.SV, &metrics.RangefeedBufferMetrics, nil)
+	bufAggregator := kvevent.TestingNewMemBuffer(ba, &st.SV, &metrics.AggregatorBufferMetrics, nil)
+	defer func() {
+		require.NoError(t, bufRangefeed.CloseWithReason(ctx, nil))
+		require.NoError(t, bufAggregator.CloseWithReason(ctx, nil))
+	}()
+
+	// Make an event and add it to one buffer, then the next.
+	evt := kvevent.MakeKVEvent(makeRangeFeedEvent(rnd, 256, 0))
+	require.NoError(t, bufRangefeed.Add(ctx, evt))
+	evt, err := bufRangefeed.Get(ctx)
+	require.NoError(t, err)
+
+	// The event is in neither buffer, but it's memory allocation is still tracked.
+	require.GreaterOrEqual(t, metrics.CommonBufferMetrics.AllocatedMem.Value(), int64(100))
+
+	require.NoError(t, bufAggregator.Add(ctx, evt))
+	_, err = bufAggregator.Get(ctx)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, metrics.CommonBufferMetrics.BufferEntriesMemAcquired.Count(), int64(100))
+
+	// Release the event's allocation.
+	a := evt.DetachAlloc()
+	a.Release(ctx)
+
+	require.Equal(t, metrics.CommonBufferMetrics.BufferEntriesMemAcquired.Count(), metrics.CommonBufferMetrics.BufferEntriesMemReleased.Count())
+
+}
+
 func TestBlockingBufferNotifiesConsumerWhenOutOfMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetricsWithCompat
+	metrics := kvevent.MakeMetrics(time.Minute).AggregatorBufferMetrics
 	ba, release := getBoundAccountWithBudget(4096)
 	defer release()
 

--- a/pkg/ccl/changefeedccl/kvevent/metrics.go
+++ b/pkg/ccl/changefeedccl/kvevent/metrics.go
@@ -60,100 +60,36 @@ var (
 // Metrics is a metric.Struct for kvfeed metrics.
 type Metrics struct {
 	// RangefeedBufferMetrics tracks metrics for the buffer between the rangefeed and the kvfeed.
-	// It's exposed to get registered as a metric.Struct.
 	RangefeedBufferMetrics PerBufferMetrics
 	// AggregatorBufferMetrics tracks metrics for the buffer between the kvfeed and the sink.
-	// It's exposed to get registered as a metric.Struct.
 	AggregatorBufferMetrics PerBufferMetrics
-
-	// RangefeedBufferMetricsWithCompat tracks metrics for the buffer between
-	// the rangefeed and the kvfeed, while forwarding the old metrics for compatibility.
-	// This should be the version used by the kvfeed, and it's exposed for that purpose.
-	RangefeedBufferMetricsWithCompat PerBufferMetricsWithCompat
-	// AggregatorBufferMetricsWithCompat tracks metrics for the buffer between
-	// the kvfeed and the sink, while forwarding the old metrics for compatibility.
-	// This should be the version used by the kvfeed, and it's exposed for that purpose.
-	AggregatorBufferMetricsWithCompat PerBufferMetricsWithCompat
-
-	// CombinedBufferMetrics tracks the combined metrics for both buffers, for
-	// historical reasons. It's exposed to get registered as a metric.Struct.
-	CombinedBufferMetrics PerBufferMetrics
+	// CommonBufferMetrics tracks metrics that are common to both the rangefeed and aggregator buffers.
+	CommonBufferMetrics CommonBufferMetrics
 }
 
-// PerBufferMetricsWithCompat is a compatibility layer between the new
-// per-buffer metrics and the old metrics. Note that it is not a metric.Struct.
-type PerBufferMetricsWithCompat struct {
-	BufferType               bufferType
-	BufferEntriesIn          *forwardingCounter
-	BufferEntriesOut         *forwardingCounter
-	BufferEntriesReleased    *forwardingCounter
-	BufferPushbackNanos      *forwardingCounter
-	BufferEntriesMemAcquired *forwardingCounter
-	BufferEntriesMemReleased *forwardingCounter
-	AllocatedMem             *forwardingGauge
-	BufferEntriesByType      [numEventTypes]*forwardingCounter
-}
-
-// forwardingCounter is a wrapper around multiple `*metric.Counter`s that
-// forwards Inc/Dec calls to all of them. It's used here to implement the
-// compatibility layer between the new and old metrics.
-type forwardingCounter struct {
-	sinks []*metric.Counter
-}
-
-func (fc *forwardingCounter) Inc(n int64) {
-	for _, c := range fc.sinks {
-		c.Inc(n)
-	}
-}
-
-func (fc *forwardingCounter) Count() int64 {
-	if len(fc.sinks) == 0 {
-		return 0
-	}
-	// This method is only used in tests, so just return data from an arbitrary
-	// sink.
-	return fc.sinks[0].Count()
-}
-
-// forwardingGauge is a wrapper around multiple `*metric.Gauge`s that
-// forwards Inc/Dec calls to all of them. It's used here to implement the
-// compatibility layer between the new and old metrics.
-type forwardingGauge struct {
-	sinks []*metric.Gauge
-}
-
-func (fc *forwardingGauge) Inc(n int64) {
-	for _, c := range fc.sinks {
-		c.Inc(n)
-	}
-}
-
-func (fc *forwardingGauge) Dec(n int64) {
-	for _, c := range fc.sinks {
-		c.Dec(n)
-	}
-}
-
-func (fc *forwardingGauge) Value() int64 {
-	if len(fc.sinks) == 0 {
-		return 0
-	}
-	// This method is only used in tests, so just return data from an arbitrary
-	// sink.
-	return fc.sinks[0].Value()
-}
-
-type PerBufferMetrics struct {
-	BufferType               bufferType
-	BufferEntriesIn          *metric.Counter
-	BufferEntriesOut         *metric.Counter
-	BufferEntriesReleased    *metric.Counter
-	BufferPushbackNanos      *metric.Counter
+// CommonBufferMetrics tracks metrics that are common to both the rangefeed and aggregator buffers.
+type CommonBufferMetrics struct {
 	BufferEntriesMemAcquired *metric.Counter
 	BufferEntriesMemReleased *metric.Counter
 	AllocatedMem             *metric.Gauge
-	BufferEntriesByType      [numEventTypes]*metric.Counter
+}
+
+func (CommonBufferMetrics) MetricStruct() {}
+
+var _ metric.Struct = (*CommonBufferMetrics)(nil)
+
+// PerBufferMetrics tracks metrics for a single buffer.
+type PerBufferMetrics struct {
+	BufferType            bufferType
+	BufferEntriesIn       *metric.Counter
+	BufferEntriesOut      *metric.Counter
+	BufferEntriesReleased *metric.Counter
+	BufferPushbackNanos   *metric.Counter
+	BufferEntriesByType   [numEventTypes]*metric.Counter
+	// CommonBufferMetrics tracks metrics that are common to both the rangefeed
+	// and aggregator buffers. This is a pointer to the common metrics field of
+	// the Metrics struct.
+	*CommonBufferMetrics
 }
 
 var _ metric.Struct = (*PerBufferMetrics)(nil)
@@ -169,7 +105,9 @@ const (
 
 // We don't want to rely on labels for this since tsdb doesn't support them, So make separate metrics for each buffer type.
 func (bt bufferType) alterMeta(meta metric.Metadata) metric.Metadata {
+	meta.LabeledName = meta.Name
 	meta.Name = fmt.Sprintf("%s.%s", meta.Name, bt)
+	meta.StaticLabels = metric.MakeLabelPairs("buffer_type", string(bt))
 	switch bt {
 	case rangefeedBuffer:
 		meta.Help = fmt.Sprintf("%s - between the rangefeed and the kvfeed", meta.Help)
@@ -199,82 +137,38 @@ func MakeMetrics(histogramWindow time.Duration) Metrics {
 			Unit:        metric.Unit_COUNT,
 		}
 	}
+	commonBufferMetrics := CommonBufferMetrics{
+		BufferEntriesMemAcquired: metric.NewCounter(metaChangefeedBufferMemAcquired),
+		BufferEntriesMemReleased: metric.NewCounter(metaChangefeedBufferMemReleased),
+		AllocatedMem:             metric.NewGauge(metaChangefeedAllocatedMemory),
+	}
 	m := Metrics{
+		CommonBufferMetrics: commonBufferMetrics,
 		RangefeedBufferMetrics: PerBufferMetrics{
-			BufferType:               rangefeedBuffer,
-			BufferEntriesIn:          metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferEntriesIn)),
-			BufferEntriesOut:         metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferEntriesOut)),
-			BufferEntriesReleased:    metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferEntriesReleased)),
-			BufferEntriesMemAcquired: metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferMemAcquired)),
-			BufferEntriesMemReleased: metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferMemReleased)),
-			BufferPushbackNanos:      metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferPushbackNanos)),
-			AllocatedMem:             metric.NewGauge(rangefeedBuffer.alterMeta(metaChangefeedAllocatedMemory)),
+			BufferType:            rangefeedBuffer,
+			BufferEntriesIn:       metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferEntriesIn)),
+			BufferEntriesOut:      metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferEntriesOut)),
+			BufferEntriesReleased: metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferEntriesReleased)),
+			BufferPushbackNanos:   metric.NewCounter(rangefeedBuffer.alterMeta(metaChangefeedBufferPushbackNanos)),
 			BufferEntriesByType: [numEventTypes]*metric.Counter{
 				metric.NewCounter(rangefeedBuffer.alterMeta(eventTypeMeta(TypeFlush))),
 				metric.NewCounter(rangefeedBuffer.alterMeta(eventTypeMeta(TypeKV))),
 				metric.NewCounter(rangefeedBuffer.alterMeta(eventTypeMeta(TypeResolved))),
 			},
+			CommonBufferMetrics: &commonBufferMetrics,
 		},
 		AggregatorBufferMetrics: PerBufferMetrics{
-			BufferType:               aggregatorBuffer,
-			BufferEntriesIn:          metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferEntriesIn)),
-			BufferEntriesOut:         metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferEntriesOut)),
-			BufferEntriesReleased:    metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferEntriesReleased)),
-			BufferEntriesMemAcquired: metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferMemAcquired)),
-			BufferEntriesMemReleased: metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferMemReleased)),
-			BufferPushbackNanos:      metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferPushbackNanos)),
-			AllocatedMem:             metric.NewGauge(aggregatorBuffer.alterMeta(metaChangefeedAllocatedMemory)),
+			BufferType:            aggregatorBuffer,
+			BufferEntriesIn:       metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferEntriesIn)),
+			BufferEntriesOut:      metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferEntriesOut)),
+			BufferEntriesReleased: metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferEntriesReleased)),
+			BufferPushbackNanos:   metric.NewCounter(aggregatorBuffer.alterMeta(metaChangefeedBufferPushbackNanos)),
 			BufferEntriesByType: [numEventTypes]*metric.Counter{
 				metric.NewCounter(aggregatorBuffer.alterMeta(eventTypeMeta(TypeFlush))),
 				metric.NewCounter(aggregatorBuffer.alterMeta(eventTypeMeta(TypeKV))),
 				metric.NewCounter(aggregatorBuffer.alterMeta(eventTypeMeta(TypeResolved))),
 			},
-		},
-		CombinedBufferMetrics: PerBufferMetrics{
-			BufferType:               aggregatorBuffer,
-			BufferEntriesIn:          metric.NewCounter(metaChangefeedBufferEntriesIn),
-			BufferEntriesOut:         metric.NewCounter(metaChangefeedBufferEntriesOut),
-			BufferEntriesReleased:    metric.NewCounter(metaChangefeedBufferEntriesReleased),
-			BufferEntriesMemAcquired: metric.NewCounter(metaChangefeedBufferMemAcquired),
-			BufferEntriesMemReleased: metric.NewCounter(metaChangefeedBufferMemReleased),
-			BufferPushbackNanos:      metric.NewCounter(metaChangefeedBufferPushbackNanos),
-			AllocatedMem:             metric.NewGauge(metaChangefeedAllocatedMemory),
-			BufferEntriesByType: [numEventTypes]*metric.Counter{
-				metric.NewCounter(eventTypeMeta(TypeFlush)),
-				metric.NewCounter(eventTypeMeta(TypeKV)),
-				metric.NewCounter(eventTypeMeta(TypeResolved)),
-			},
-		},
-	}
-
-	m.AggregatorBufferMetricsWithCompat = PerBufferMetricsWithCompat{
-		BufferType:               aggregatorBuffer,
-		BufferEntriesIn:          &forwardingCounter{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesIn, m.CombinedBufferMetrics.BufferEntriesIn}},
-		BufferEntriesOut:         &forwardingCounter{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesOut, m.CombinedBufferMetrics.BufferEntriesOut}},
-		BufferEntriesReleased:    &forwardingCounter{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesReleased, m.CombinedBufferMetrics.BufferEntriesReleased}},
-		BufferEntriesMemAcquired: &forwardingCounter{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesMemAcquired, m.CombinedBufferMetrics.BufferEntriesMemAcquired}},
-		BufferEntriesMemReleased: &forwardingCounter{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesMemReleased, m.CombinedBufferMetrics.BufferEntriesMemReleased}},
-		BufferPushbackNanos:      &forwardingCounter{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferPushbackNanos, m.CombinedBufferMetrics.BufferPushbackNanos}},
-		AllocatedMem:             &forwardingGauge{sinks: []*metric.Gauge{m.AggregatorBufferMetrics.AllocatedMem, m.CombinedBufferMetrics.AllocatedMem}},
-		BufferEntriesByType: [numEventTypes]*forwardingCounter{
-			{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesByType[0], m.CombinedBufferMetrics.BufferEntriesByType[0]}},
-			{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesByType[1], m.CombinedBufferMetrics.BufferEntriesByType[1]}},
-			{sinks: []*metric.Counter{m.AggregatorBufferMetrics.BufferEntriesByType[2], m.CombinedBufferMetrics.BufferEntriesByType[2]}},
-		},
-	}
-	m.RangefeedBufferMetricsWithCompat = PerBufferMetricsWithCompat{
-		BufferType:               rangefeedBuffer,
-		BufferEntriesIn:          &forwardingCounter{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesIn, m.CombinedBufferMetrics.BufferEntriesIn}},
-		BufferEntriesOut:         &forwardingCounter{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesOut, m.CombinedBufferMetrics.BufferEntriesOut}},
-		BufferEntriesReleased:    &forwardingCounter{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesReleased, m.CombinedBufferMetrics.BufferEntriesReleased}},
-		BufferEntriesMemAcquired: &forwardingCounter{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesMemAcquired, m.CombinedBufferMetrics.BufferEntriesMemAcquired}},
-		BufferEntriesMemReleased: &forwardingCounter{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesMemReleased, m.CombinedBufferMetrics.BufferEntriesMemReleased}},
-		BufferPushbackNanos:      &forwardingCounter{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferPushbackNanos, m.CombinedBufferMetrics.BufferPushbackNanos}},
-		AllocatedMem:             &forwardingGauge{sinks: []*metric.Gauge{m.RangefeedBufferMetrics.AllocatedMem, m.CombinedBufferMetrics.AllocatedMem}},
-		BufferEntriesByType: [numEventTypes]*forwardingCounter{
-			{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesByType[0], m.CombinedBufferMetrics.BufferEntriesByType[0]}},
-			{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesByType[1], m.CombinedBufferMetrics.BufferEntriesByType[1]}},
-			{sinks: []*metric.Counter{m.RangefeedBufferMetrics.BufferEntriesByType[2], m.CombinedBufferMetrics.BufferEntriesByType[2]}},
+			CommonBufferMetrics: &commonBufferMetrics,
 		},
 	}
 	return m

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -128,7 +128,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	bf := func() kvevent.Buffer {
-		return kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), &cfg.Settings.SV, &cfg.Metrics.RangefeedBufferMetricsWithCompat)
+		return kvevent.NewMemBuffer(cfg.MM.MakeBoundAccount(), &cfg.Settings.SV, &cfg.Metrics.RangefeedBufferMetrics)
 	}
 
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -125,12 +125,12 @@ func TestKVFeed(t *testing.T) {
 			Settings: settings,
 		})
 		metrics := kvevent.MakeMetrics(time.Minute)
-		buf := kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.AggregatorBufferMetricsWithCompat)
+		buf := kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.AggregatorBufferMetrics)
 
 		// bufferFactory, when called, gives you a memory-monitored
 		// in-memory "buffer" to write to and read from.
 		bufferFactory := func() kvevent.Buffer {
-			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.RangefeedBufferMetricsWithCompat)
+			return kvevent.NewMemBuffer(mm.MakeBoundAccount(), &st.SV, &metrics.RangefeedBufferMetrics)
 		}
 		scans := make(chan scanConfig)
 


### PR DESCRIPTION
This commit removes the blocking buffer metrics
that were not broken down by buffer type
(rangefeed and aggregator), with the exception of
the memory accounting metrics, which have had the
broken down versions removed because the
breakdown was incorrect in their case.

Fixes #147624

Removed because the buffer type breakdown was inappropriate:
- changefeed.buffer_entries.allocated_mem.aggregator
- changefeed.buffer_entries.allocated_mem.rangefeed
- changefeed.buffer_entries_mem.acquired.aggregator
- changefeed.buffer_entries_mem.acquired.rangefeed
- changefeed.buffer_entries_mem.released.aggregator
- changefeed.buffer_entries_mem.released.rangefeed

Removed because the buffer type breakdown (eg
changefeed.buffer_entries.flush.rangefeed) is
sufficient:
- changefeed.buffer_entries.flush
- changefeed.buffer_entries.in
- changefeed.buffer_entries.out
- changefeed.buffer_entries.kv
- changefeed.buffer_entries.released
- changefeed.buffer_pushback_nanos


Release note (ops change): Cleaned up several
redundant and misleading metrics.
