### PR TITLE
roachtest: disable network partitions in mixed version tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -543,7 +543,8 @@ type networkPartitionMutator struct{}
 func (m networkPartitionMutator) Name() string { return failures.IPTablesNetworkPartitionName }
 
 func (m networkPartitionMutator) Probability() float64 {
-	return 0.3
+	// TODO(#154547)
+	return 0.0
 }
 
 func (m networkPartitionMutator) Generate(


### PR DESCRIPTION
This mutator is currently causing test flakes and we need to revaluate our approach before re-enabling. See #154547.

Fixes: #153933
Fixes: #154501