### PR TITLE
changefeedccl: improve parallel io metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1780,7 +1780,7 @@ layers:
     - name: changefeed.parallel_io_pending_rows
       exported_name: changefeed_parallel_io_pending_rows
       description: Number of rows which are blocked from being sent due to conflicting in-flight keys
-      y_axis_label: Keys
+      y_axis_label: Messages
       type: GAUGE
       unit: COUNT
       aggregation: AVG
@@ -1799,6 +1799,14 @@ layers:
       y_axis_label: Nanoseconds
       type: HISTOGRAM
       unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.parallel_io_workers
+      exported_name: changefeed_parallel_io_workers
+      description: The number of workers in the ParallelIO
+      y_axis_label: Workers
+      type: GAUGE
+      unit: COUNT
       aggregation: AVG
       derivative: NONE
     - name: changefeed.progress_skew.span

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -554,8 +554,8 @@ func (k *kafkaHistogramAdapter) Variance() (_ float64) {
 }
 
 type parallelIOMetricsRecorder interface {
-	recordPendingQueuePush(numKeys int64)
-	recordPendingQueuePop(numKeys int64, latency time.Duration)
+	recordPendingQueuePush(numMessages int64)
+	recordPendingQueuePop(numMessages int64, latency time.Duration)
 	recordResultQueueLatency(latency time.Duration)
 	setInFlightKeys(n int64)
 }
@@ -976,7 +976,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 	metaChangefeedParallelIOPendingRows := metric.Metadata{
 		Name:        "changefeed.parallel_io_pending_rows",
 		Help:        "Number of rows which are blocked from being sent due to conflicting in-flight keys",
-		Measurement: "Keys",
+		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaChangefeedParallelIOResultQueueNanos := metric.Metadata{

--- a/pkg/ccl/changefeedccl/parallel_io.go
+++ b/pkg/ccl/changefeedccl/parallel_io.go
@@ -100,7 +100,7 @@ func NewParallelIO(
 	wg.GoCtx(func(ctx context.Context) error {
 		return io.processIO(ctx, numWorkers)
 	})
-
+	io.metrics.recordParallelIOWorkers(int64(numWorkers))
 	return io
 }
 


### PR DESCRIPTION
**changefeedccl: improve parallel io metrics**

Rename function parameter used to update pending rows metric and y-axis
label for that metric to be more accurate.

Release note(ops change): Fix changefeed.parallel_io_pending_rows metric
y-axis label to match the metric's definition.

Fixes: #147625

---
**changefeedccl: add parallel io workers metric** 

Add a gauge metric to track the number of workers in ParallelIO.

Release note(ops change): Add metric changefeed.parallel_io_workers to
track the number of workers in ParallelIO.

Resolves: #147625