### PR TITLE
colcontainer: harden ctx capture in diskQueueWriter

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -597,6 +597,12 @@ func (d *diskQueue) writeFooterAndFlush(ctx context.Context) (err error) {
 			d.serializer = nil
 		}
 	}()
+	if d.writer != nil {
+		// The context that we captured when we created the diskQueueWriter
+		// might have a tracing span that has already been finished. To go
+		// around this, we capture the fresh context.
+		d.writer.ctx = ctx
+	}
 	if err := d.serializer.Finish(); err != nil {
 		return err
 	}


### PR DESCRIPTION
In ffb46661c673afd4283d2d14b61a4efb077cfcf6 we added more memory accounting to the disk queue. This required capturing the context inside the `diskQueueWriter` in order to preserve the `io.Writer` signature. We just saw a test failure where this capture was problematic - it's possible that when we close the disk queue as a whole (which happens _after_ closing all operators) that the captured context contains the tracing span that has been finished (since the relevant operator has already been closed). To go around this issue we now update the captured context before finishing each file.

An alternative solution could've been to use `context.Background` since we only need the context object for memory accounting purposes (in a single `Resize` call) so losing some contextual information there doesn't seem like a big deal.

Fixes: #154347.
Release note: None