### PR TITLE
metric: permit counter resets in update assertion

### DIFF
--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -825,7 +825,7 @@ func (c *Counter) Inc(v int64) {
 // maintained elsewhere.
 func (c *Counter) Update(val int64) {
 	if buildutil.CrdbTestBuild {
-		if prev := c.count.Load(); val < prev {
+		if prev := c.count.Load(); val < prev && val != 0 {
 			panic(fmt.Sprintf("Counters should not decrease, prev: %d, new: %d.", prev, val))
 		}
 	}
@@ -1446,7 +1446,7 @@ func (cv *CounterVec) Update(labels map[string]string, v int64) {
 	}
 
 	currentValue := cv.Count(labels)
-	if currentValue > v {
+	if currentValue > v && v != 0 {
 		panic(fmt.Sprintf("Counters should not decrease, prev: %d, new: %d.", currentValue, v))
 	}
 


### PR DESCRIPTION
When we call `Update` on counter metrics, we have an assertion that panics in tests if the counter is set to a lower value than the prior update. In practice, counters are permitted to reset and 3rd party metric systems expect this to happen occasionally. The assertion logic is adjusted to permit a setting of zero when the value is lower.

Resolves: #154364
Resolves: #154365
Resolves: #154366
Resolves: #154367
Resolves: #154368

Epic: None
Release note: None