### PR TITLE
release-24.1: stmtdiagnostics: fix bizarre flake in TestDiagnosticsRequest

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -166,8 +166,12 @@ func TestDiagnosticsRequest(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), sqlerrors.QueryTimeoutError.Error()))
 
 		// Reset the stmt timeout so that it doesn't affect the query in
-		// checkCompleted.
-		runner.Exec(t, "RESET statement_timeout;")
+		// checkCompleted. Wrap it in a SucceedsSoon in case RESET query itself
+		// times out.
+		testutils.SucceedsSoon(t, func() error {
+			_, err = db.Exec("RESET statement_timeout;")
+			return err
+		})
 		checkCompleted(reqID)
 	})
 


### PR DESCRIPTION
Backport 1/1 commits from #154492 on behalf of @yuzefovich.

----

We just saw a failure in `TestDiagnosticsRequest` where "RESET statement_timeout;" itself timed out. Prevent such a flake by wrapping with SucceedsSoon.

Fixes: #154490.
Release note: None

----

Release justification: test-only change.