### PR TITLE
release-25.4: cli: remove duplicate `stmt` column from `node_distsql_flows`

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -854,7 +854,6 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 		nonSensitiveCols: NonSensitiveColumns{
 			"flow_id",
 			"node_id",
-			"stmt",
 			"since",
 			"crdb_internal.hide_sql_constants(stmt) as stmt",
 		},


### PR DESCRIPTION
Backport 1/1 commits from #154443 on behalf of @dhartunian.

----

Resolves: #154442
Release note: None

----

Release justification: low-risk change to debug zip output clarity