### PR TITLE
scbuild: implement RENAME CONSTRAINT in declarative schema changer

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -463,6 +463,13 @@ func TestBackupRollbacks_base_alter_table_rename_column(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1230,6 +1237,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_rename_column(t *testing.T
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2003,6 +2017,13 @@ func TestBackupSuccess_base_alter_table_rename_column(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2770,6 +2791,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_rename_column(t *testing.T) 
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_10_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_10_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -85,9 +84,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_11_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_11_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -85,9 +84,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_12_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_12_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -85,9 +84,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_13_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_13_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -81,13 +80,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_14_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_14_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -81,13 +80,14 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_15_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_15_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -85,9 +84,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_16_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_16_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -85,9 +84,10 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_17_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_17_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -116,7 +115,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_18_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_18_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_19_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_19_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_20_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_20_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_21_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_21_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -110,7 +109,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_22_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_22_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -110,7 +109,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_23_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_23_of_23.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
@@ -128,6 +127,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_9_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_9_of_23.explain
@@ -56,7 +56,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
       │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
@@ -84,10 +83,11 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_17_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_17_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -117,7 +116,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_18_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_18_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_19_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_19_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_20_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_20_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_21_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_21_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -113,7 +112,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_22_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_22_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -113,7 +112,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_23_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_23_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_24_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_24_of_24.explain
@@ -78,7 +78,6 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 5}
       │    └── 57 Mutation operations
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
-      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
@@ -118,7 +117,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── DiscardTableZoneConfig {"TableID":108}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
       │         ├── DiscardTableZoneConfig {"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
@@ -132,6 +131,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "alter_table_drop_column.go",
         "alter_table_drop_constraint.go",
         "alter_table_rename_column.go",
+        "alter_table_rename_constraint.go",
         "alter_table_set_rls_mode.go",
         "alter_table_validate_constraint.go",
         "comment_on.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -44,6 +44,7 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableSetOnUpdate)(nil)):        {fn: alterTableSetOnUpdate, on: true, checks: isV254Active},
 	reflect.TypeOf((*tree.AlterTableRenameColumn)(nil)):       {fn: alterTableRenameColumn, on: true, checks: isV254Active},
 	reflect.TypeOf((*tree.AlterTableDropStored)(nil)):         {fn: alterTableDropStored, on: true, checks: isV261Active},
+	reflect.TypeOf((*tree.AlterTableRenameConstraint)(nil)):   {fn: alterTableRenameConstraint, on: true, checks: isV261Active},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_rename_constraint.go
@@ -1,0 +1,159 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+)
+
+func alterTableRenameConstraint(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	n *tree.AlterTable,
+	t *tree.AlterTableRenameConstraint,
+) {
+	// Resolve the constraint by current name.
+	constraintElems := b.ResolveConstraint(tbl.TableID, t.Constraint, ResolveParams{
+		RequiredPrivilege: privilege.CREATE,
+	})
+
+	// Validate constraint exists.
+	if constraintElems == nil {
+		panic(sqlerrors.NewUndefinedConstraintError(tree.ErrString(&t.Constraint), tn.Table()))
+	}
+
+	// Short circuit if the name is unchanged.
+	if t.Constraint == t.NewName {
+		return
+	}
+
+	// Handle both index-backed and non-index constraints.
+	indexName := constraintElems.FilterIndexName().NotToAbsent().MustGetZeroOrOneElement()
+	constraintWithoutIndexName := constraintElems.FilterConstraintWithoutIndexName().NotToAbsent().MustGetZeroOrOneElement()
+
+	if indexName == nil && constraintWithoutIndexName == nil {
+		panic(pgerror.Newf(pgcode.UndefinedObject, "constraint %q does not exist", t.Constraint))
+	}
+
+	// Check for name conflicts across all constraint types.
+	// This must check both ConstraintWithoutIndexName (CHECK, FK, UNIQUE without
+	// index) and IndexName (UNIQUE with index, PRIMARY KEY) to prevent a CHECK
+	// constraint from being renamed to match a UNIQUE constraint name.
+	checkConstraintNameConflicts(b, tbl.TableID, t.NewName)
+
+	// For index-backed constraints, check for dependent views.
+	if indexName != nil {
+		checkForDependentViews(b, tbl.TableID, indexName.IndexID, t.Constraint)
+	}
+
+	// Rename based on constraint type.
+	if indexName != nil {
+		// Index-backed constraint (PRIMARY KEY, UNIQUE with index).
+		b.Drop(indexName)
+		b.Add(&scpb.IndexName{
+			TableID: tbl.TableID,
+			IndexID: indexName.IndexID,
+			Name:    string(t.NewName),
+		})
+	} else {
+		// Non-index constraint (CHECK, FK, UNIQUE without index).
+		b.Drop(constraintWithoutIndexName)
+		b.Add(&scpb.ConstraintWithoutIndexName{
+			TableID:      tbl.TableID,
+			ConstraintID: constraintWithoutIndexName.ConstraintID,
+			Name:         string(t.NewName),
+		})
+	}
+}
+
+// checkConstraintNameConflicts verifies that the new constraint name does
+// not conflict with any existing constraint in the table, across all constraint
+// types. This checks both ConstraintWithoutIndexName elements (CHECK, FK, UNIQUE
+// without index) and IndexName elements (UNIQUE with index, PRIMARY KEY).
+// This comprehensive check is necessary because constraint names must be unique
+// across all types - a CHECK constraint cannot have the same name as a UNIQUE
+// constraint.
+func checkConstraintNameConflicts(b BuildCtx, tableID catid.DescID, newName tree.Name) {
+	// Check ConstraintWithoutIndexName elements (CHECK, FK, UNIQUE without index).
+	tableElems := b.QueryByID(tableID)
+	conflictingConstraints := tableElems.FilterConstraintWithoutIndexName().Filter(func(
+		_ scpb.Status, target scpb.TargetStatus, e *scpb.ConstraintWithoutIndexName,
+	) bool {
+		return tree.Name(e.Name) == newName && target == scpb.ToPublic
+	})
+
+	if !conflictingConstraints.IsEmpty() {
+		panic(pgerror.Newf(pgcode.DuplicateObject, "duplicate constraint name: %q", newName))
+	}
+
+	// Check IndexName elements. These could be either index-backed constraints
+	// (UNIQUE with index, PRIMARY KEY) or regular indexes.
+	conflictingIndexNames := tableElems.FilterIndexName().Filter(func(
+		_ scpb.Status, target scpb.TargetStatus, e *scpb.IndexName,
+	) bool {
+		return e.Name == string(newName) && target == scpb.ToPublic
+	})
+
+	conflictingIndexNames.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, indexNameElem *scpb.IndexName) {
+		// Check if this index backs a constraint by looking for corresponding
+		// index elements with ConstraintID set.
+		secondaryIndex := tableElems.FilterSecondaryIndex().Filter(func(
+			_ scpb.Status, _ scpb.TargetStatus, idx *scpb.SecondaryIndex,
+		) bool {
+			return idx.IndexID == indexNameElem.IndexID && idx.ConstraintID != 0
+		})
+
+		primaryIndex := tableElems.FilterPrimaryIndex().Filter(func(
+			_ scpb.Status, _ scpb.TargetStatus, idx *scpb.PrimaryIndex,
+		) bool {
+			return idx.IndexID == indexNameElem.IndexID
+		})
+
+		isConstraintIndex := !secondaryIndex.IsEmpty() || !primaryIndex.IsEmpty()
+
+		if isConstraintIndex {
+			panic(pgerror.Newf(pgcode.DuplicateObject, "duplicate constraint name: %q", newName))
+		} else {
+			panic(pgerror.Newf(pgcode.DuplicateRelation, "relation %v already exists", newName))
+		}
+	})
+}
+
+// checkForDependentViews ensures that views don't depend on the index being
+// renamed. This follows the same logic as the legacy schema changer.
+func checkForDependentViews(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID, constraintName tree.Name,
+) {
+	// Check for views that depend on this index.
+	scpb.ForEachView(b.BackReferences(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.View,
+	) {
+		// Check if the view depends on this specific index.
+		for _, forwardRef := range e.ForwardReferences {
+			if forwardRef.IndexID != indexID {
+				continue
+			}
+
+			// This view depends on the index-backed constraint being renamed.
+			viewName := b.QueryByID(e.ViewID).FilterNamespace().MustGetOneElement()
+			tableName := b.QueryByID(tableID).FilterNamespace().MustGetOneElement()
+			// Check if view is in the same database and schema.
+			if viewName.DatabaseID != tableName.DatabaseID || viewName.SchemaID != tableName.SchemaID {
+				panic(sqlerrors.NewDependentBlocksOpError("rename", "constraint",
+					tree.ErrString(&constraintName), "view", qualifiedName(b, e.ViewID)))
+			}
+			panic(sqlerrors.NewDependentBlocksOpError("rename", "constraint",
+				tree.ErrString(&constraintName), "view", viewName.Name))
+		}
+	})
+}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_rename_constraint
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_rename_constraint
@@ -1,0 +1,70 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT, CONSTRAINT cc CHECK (i > 0));
+----
+
+build
+ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[ConstraintWithoutIndexName:{DescID: 104, Name: cc, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, name: cc, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[ConstraintWithoutIndexName:{DescID: 104, Name: cc_renamed, ConstraintID: 2}, PUBLIC], ABSENT]
+  {constraintId: 2, name: cc_renamed, tableId: 104}
+
+setup
+CREATE TABLE t2 (i INT PRIMARY KEY, CONSTRAINT u UNIQUE (i));
+----
+
+build
+ALTER TABLE t2 RENAME CONSTRAINT u TO u_renamed;
+----
+- [[IndexData:{DescID: 105, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 105}
+- [[IndexName:{DescID: 105, Name: u, IndexID: 2}, ABSENT], PUBLIC]
+  {indexId: 2, name: u, tableId: 105}
+- [[IndexData:{DescID: 105, IndexID: 2}, PUBLIC], PUBLIC]
+  {indexId: 2, tableId: 105}
+- [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 105}
+- [[IndexName:{DescID: 105, Name: u_renamed, IndexID: 2}, PUBLIC], ABSENT]
+  {indexId: 2, name: u_renamed, tableId: 105}
+
+setup
+CREATE TABLE t3 (i INT PRIMARY KEY);
+CREATE TABLE t4 (i INT REFERENCES t3(i));
+----
+
+build
+ALTER TABLE t4 RENAME CONSTRAINT t4_i_fkey TO fk_renamed;
+----
+- [[IndexData:{DescID: 107, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 107}
+- [[ConstraintWithoutIndexName:{DescID: 107, Name: t4_i_fkey, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, name: t4_i_fkey, tableId: 107}
+- [[TableData:{DescID: 107, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 107}
+- [[ConstraintWithoutIndexName:{DescID: 107, Name: fk_renamed, ConstraintID: 2}, PUBLIC], ABSENT]
+  {constraintId: 2, name: fk_renamed, tableId: 107}
+
+setup
+CREATE TABLE t5 (i INT PRIMARY KEY, j INT, CONSTRAINT con1 CHECK (i > 0), CONSTRAINT con2 CHECK (j > 0));
+----
+
+build
+ALTER TABLE t5 RENAME CONSTRAINT con1 TO con1_old, RENAME CONSTRAINT con2 TO con1;
+----
+- [[IndexData:{DescID: 108, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 108}
+- [[ConstraintWithoutIndexName:{DescID: 108, Name: con1, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, name: con1, tableId: 108}
+- [[ConstraintWithoutIndexName:{DescID: 108, Name: con2, ConstraintID: 3}, ABSENT], PUBLIC]
+  {constraintId: 3, name: con2, tableId: 108}
+- [[TableData:{DescID: 108, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 108}
+- [[ConstraintWithoutIndexName:{DescID: 108, Name: con1_old, ConstraintID: 2}, PUBLIC], ABSENT]
+  {constraintId: 2, name: con1_old, tableId: 108}
+- [[ConstraintWithoutIndexName:{DescID: 108, Name: con1, ConstraintID: 3}, PUBLIC], ABSENT]
+  {constraintId: 3, name: con1, tableId: 108}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -13,10 +13,6 @@ CREATE TABLE defaultdb.foo (
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo RENAME CONSTRAINT foobar TO baz
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo EXPERIMENTAL_AUDIT SET READ WRITE
 ----
 

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "dep_drop_trigger.go",
         "dep_garbage_collection.go",
         "dep_rename_column.go",
+        "dep_rename_constraint.go",
         "dep_rename_table.go",
         "dep_schema_locked.go",
         "dep_swap_index.go",

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_constraint.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package current
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	. "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+)
+
+// These rules ensure that when renaming a constraint, the old name element
+// is dropped before the new name element is added. This prevents conflicts
+// and ensures proper rollback behavior.
+
+func init() {
+	// Rule for index-backed constraints (UNIQUE with index, PRIMARY KEY).
+	registerDepRule(
+		"old index name is dropped before new index name is added",
+		scgraph.SameStagePrecedence,
+		"old-index-name", "new-index-name",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.IndexName)(nil)),
+				to.Type((*scpb.IndexName)(nil)),
+				JoinOnIndexID(from, to, "table-id", "index-id"),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
+
+	// Rule for non-index constraints (CHECK, FK, UNIQUE without index).
+	registerDepRule(
+		"old constraint name is dropped before new constraint name is added",
+		scgraph.SameStagePrecedence,
+		"old-constraint-name", "new-constraint-name",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.ConstraintWithoutIndexName)(nil)),
+				to.Type((*scpb.ConstraintWithoutIndexName)(nil)),
+				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_rename_constraint.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	. "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 )
 
 // These rules ensure that when renaming a constraint, the old name element
@@ -45,6 +46,69 @@ func init() {
 				from.Type((*scpb.ConstraintWithoutIndexName)(nil)),
 				to.Type((*scpb.ConstraintWithoutIndexName)(nil)),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
+
+	// Rule to handle cross-constraint name conflicts for index-backed constraints.
+	// This rule must NOT match during secondary index swaps (ALTER PRIMARY KEY),
+	// where an old index is replaced by a new one with the same name.
+	registerDepRule(
+		"old index name is dropped before conflicting new index name is added",
+		scgraph.Precedence,
+		"old-index-name", "new-index-name",
+		func(from, to NodeVars) rel.Clauses {
+			nameVar := rel.Var("name")
+			return rel.Clauses{
+				from.Type((*scpb.IndexName)(nil)),
+				to.Type((*scpb.IndexName)(nil)),
+				JoinOnDescID(from, to, "table-id"),
+				// Both have the same name (conflict).
+				from.El.AttrEqVar(screl.Name, nameVar),
+				to.El.AttrEqVar(screl.Name, nameVar),
+				to.El.AttrEqVar(screl.IndexID, "index-id"),
+				// Ensure the new index is not part of a secondary index swap.
+				// This check will succeed for rename-only operations because there
+				// won't be a matching secondary index swap pattern in the graph.
+				IsNotPotentialSecondaryIndexSwap("table-id", "index-id"),
+				from.TargetStatus(scpb.ToAbsent),
+				from.CurrentStatus(scpb.Status_ABSENT),
+				to.TargetStatus(scpb.ToPublic),
+				to.CurrentStatus(scpb.Status_PUBLIC),
+			}
+		},
+	)
+
+	// Rule to handle cross-constraint name conflicts for other constraint type
+	// combos that involve constraints without index names.
+	registerDepRule(
+		"old constraint name is dropped before conflicting new constraint name is added when at least one is non-index-backed",
+		scgraph.Precedence,
+		"old-index-name", "new-index-name",
+		func(from, to NodeVars) rel.Clauses {
+			nameVar := rel.Var("name")
+			return rel.Clauses{
+				// Accept IndexName and ConstraintWithoutIndexName elements.
+				from.Type((*scpb.IndexName)(nil), (*scpb.ConstraintWithoutIndexName)(nil)),
+				to.Type((*scpb.IndexName)(nil), (*scpb.ConstraintWithoutIndexName)(nil)),
+				JoinOnDescID(from, to, "table-id"),
+				// Both have the same name (conflict).
+				from.El.AttrEqVar(screl.Name, nameVar),
+				to.El.AttrEqVar(screl.Name, nameVar),
+				// But they must be different elements (handles both same-type and cross-type).
+				FilterElements("names-are-for-different-elements", from, to,
+					func(from, to scpb.Element) bool {
+						_, fromIsIndexName := from.(*scpb.IndexName)
+						_, toIsIndexName := to.(*scpb.IndexName)
+						// The case where both are IndexName elements is handled
+						// by a different rule.
+						return !(fromIsIndexName && toIsIndexName) && from != to
+					},
+				),
 				from.TargetStatus(scpb.ToAbsent),
 				from.CurrentStatus(scpb.Status_ABSENT),
 				to.TargetStatus(scpb.ToPublic),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4290,9 +4290,26 @@ deprules
     - $new-column-name-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-column-name, $old-column-name-Target, $old-column-name-Node)
     - joinTargetNode($new-column-name, $new-column-name-Target, $new-column-name-Node)
+- name: old constraint name is dropped before conflicting new constraint name is added when at least one is non-index-backed
+  from: old-index-name-Node
+  kind: Precedence
+  to: new-index-name-Node
+  query:
+    - $old-index-name[Type] IN ['*scpb.IndexName', '*scpb.ConstraintWithoutIndexName']
+    - $new-index-name[Type] IN ['*scpb.IndexName', '*scpb.ConstraintWithoutIndexName']
+    - joinOnDescID($old-index-name, $new-index-name, $table-id)
+    - $old-index-name[Name] = $name
+    - $new-index-name[Name] = $name
+    - names-are-for-different-elements(scpb.Element, scpb.Element)($old-index-name, $new-index-name)
+    - $old-index-name-Target[TargetStatus] = ABSENT
+    - $old-index-name-Node[CurrentStatus] = ABSENT
+    - $new-index-name-Target[TargetStatus] = PUBLIC
+    - $new-index-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-index-name, $old-index-name-Target, $old-index-name-Node)
+    - joinTargetNode($new-index-name, $new-index-name-Target, $new-index-name-Node)
 - name: old constraint name is dropped before new constraint name is added
   from: old-constraint-name-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: new-constraint-name-Node
   query:
     - $old-constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -4324,9 +4341,27 @@ deprules
     - $new-primary-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-primary-index, $old-primary-index-Target, $old-primary-index-Node)
     - joinTargetNode($new-primary-index, $new-primary-index-Target, $new-primary-index-Node)
-- name: old index name is dropped before new index name is added
+- name: old index name is dropped before conflicting new index name is added
   from: old-index-name-Node
   kind: Precedence
+  to: new-index-name-Node
+  query:
+    - $old-index-name[Type] = '*scpb.IndexName'
+    - $new-index-name[Type] = '*scpb.IndexName'
+    - joinOnDescID($old-index-name, $new-index-name, $table-id)
+    - $old-index-name[Name] = $name
+    - $new-index-name[Name] = $name
+    - $new-index-name[IndexID] = $index-id
+    - no secondary index swap is on going($table-id, $index-id)
+    - $old-index-name-Target[TargetStatus] = ABSENT
+    - $old-index-name-Node[CurrentStatus] = ABSENT
+    - $new-index-name-Target[TargetStatus] = PUBLIC
+    - $new-index-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-index-name, $old-index-name-Target, $old-index-name-Node)
+    - joinTargetNode($new-index-name, $new-index-name-Target, $new-index-name-Node)
+- name: old index name is dropped before new index name is added
+  from: old-index-name-Node
+  kind: SameStagePrecedence
   to: new-index-name-Node
   query:
     - $old-index-name[Type] = '*scpb.IndexName'
@@ -9492,9 +9527,26 @@ deprules
     - $new-column-name-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-column-name, $old-column-name-Target, $old-column-name-Node)
     - joinTargetNode($new-column-name, $new-column-name-Target, $new-column-name-Node)
+- name: old constraint name is dropped before conflicting new constraint name is added when at least one is non-index-backed
+  from: old-index-name-Node
+  kind: Precedence
+  to: new-index-name-Node
+  query:
+    - $old-index-name[Type] IN ['*scpb.IndexName', '*scpb.ConstraintWithoutIndexName']
+    - $new-index-name[Type] IN ['*scpb.IndexName', '*scpb.ConstraintWithoutIndexName']
+    - joinOnDescID($old-index-name, $new-index-name, $table-id)
+    - $old-index-name[Name] = $name
+    - $new-index-name[Name] = $name
+    - names-are-for-different-elements(scpb.Element, scpb.Element)($old-index-name, $new-index-name)
+    - $old-index-name-Target[TargetStatus] = ABSENT
+    - $old-index-name-Node[CurrentStatus] = ABSENT
+    - $new-index-name-Target[TargetStatus] = PUBLIC
+    - $new-index-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-index-name, $old-index-name-Target, $old-index-name-Node)
+    - joinTargetNode($new-index-name, $new-index-name-Target, $new-index-name-Node)
 - name: old constraint name is dropped before new constraint name is added
   from: old-constraint-name-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: new-constraint-name-Node
   query:
     - $old-constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -9526,9 +9578,27 @@ deprules
     - $new-primary-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-primary-index, $old-primary-index-Target, $old-primary-index-Node)
     - joinTargetNode($new-primary-index, $new-primary-index-Target, $new-primary-index-Node)
-- name: old index name is dropped before new index name is added
+- name: old index name is dropped before conflicting new index name is added
   from: old-index-name-Node
   kind: Precedence
+  to: new-index-name-Node
+  query:
+    - $old-index-name[Type] = '*scpb.IndexName'
+    - $new-index-name[Type] = '*scpb.IndexName'
+    - joinOnDescID($old-index-name, $new-index-name, $table-id)
+    - $old-index-name[Name] = $name
+    - $new-index-name[Name] = $name
+    - $new-index-name[IndexID] = $index-id
+    - no secondary index swap is on going($table-id, $index-id)
+    - $old-index-name-Target[TargetStatus] = ABSENT
+    - $old-index-name-Node[CurrentStatus] = ABSENT
+    - $new-index-name-Target[TargetStatus] = PUBLIC
+    - $new-index-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-index-name, $old-index-name-Target, $old-index-name-Node)
+    - joinTargetNode($new-index-name, $new-index-name-Target, $new-index-name-Node)
+- name: old index name is dropped before new index name is added
+  from: old-index-name-Node
+  kind: SameStagePrecedence
   to: new-index-name-Node
   query:
     - $old-index-name[Type] = '*scpb.IndexName'

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4290,6 +4290,20 @@ deprules
     - $new-column-name-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-column-name, $old-column-name-Target, $old-column-name-Node)
     - joinTargetNode($new-column-name, $new-column-name-Target, $new-column-name-Node)
+- name: old constraint name is dropped before new constraint name is added
+  from: old-constraint-name-Node
+  kind: Precedence
+  to: new-constraint-name-Node
+  query:
+    - $old-constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
+    - $new-constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
+    - joinOnConstraintID($old-constraint-name, $new-constraint-name, $table-id, $constraint-id)
+    - $old-constraint-name-Target[TargetStatus] = ABSENT
+    - $old-constraint-name-Node[CurrentStatus] = ABSENT
+    - $new-constraint-name-Target[TargetStatus] = PUBLIC
+    - $new-constraint-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-constraint-name, $old-constraint-name-Target, $old-constraint-name-Node)
+    - joinTargetNode($new-constraint-name, $new-constraint-name-Target, $new-constraint-name-Node)
 - name: old index absent before new index public when swapping with transient
   from: old-primary-index-Node
   kind: Precedence
@@ -4310,6 +4324,20 @@ deprules
     - $new-primary-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-primary-index, $old-primary-index-Target, $old-primary-index-Node)
     - joinTargetNode($new-primary-index, $new-primary-index-Target, $new-primary-index-Node)
+- name: old index name is dropped before new index name is added
+  from: old-index-name-Node
+  kind: Precedence
+  to: new-index-name-Node
+  query:
+    - $old-index-name[Type] = '*scpb.IndexName'
+    - $new-index-name[Type] = '*scpb.IndexName'
+    - joinOnIndexID($old-index-name, $new-index-name, $table-id, $index-id)
+    - $old-index-name-Target[TargetStatus] = ABSENT
+    - $old-index-name-Node[CurrentStatus] = ABSENT
+    - $new-index-name-Target[TargetStatus] = PUBLIC
+    - $new-index-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-index-name, $old-index-name-Target, $old-index-name-Node)
+    - joinTargetNode($new-index-name, $new-index-name-Target, $new-index-name-Node)
 - name: old secondary indexes that have been recreated should be removed when their replacement is usable.
   from: new-primary-index-Node
   kind: SameStagePrecedence
@@ -9464,6 +9492,20 @@ deprules
     - $new-column-name-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-column-name, $old-column-name-Target, $old-column-name-Node)
     - joinTargetNode($new-column-name, $new-column-name-Target, $new-column-name-Node)
+- name: old constraint name is dropped before new constraint name is added
+  from: old-constraint-name-Node
+  kind: Precedence
+  to: new-constraint-name-Node
+  query:
+    - $old-constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
+    - $new-constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
+    - joinOnConstraintID($old-constraint-name, $new-constraint-name, $table-id, $constraint-id)
+    - $old-constraint-name-Target[TargetStatus] = ABSENT
+    - $old-constraint-name-Node[CurrentStatus] = ABSENT
+    - $new-constraint-name-Target[TargetStatus] = PUBLIC
+    - $new-constraint-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-constraint-name, $old-constraint-name-Target, $old-constraint-name-Node)
+    - joinTargetNode($new-constraint-name, $new-constraint-name-Target, $new-constraint-name-Node)
 - name: old index absent before new index public when swapping with transient
   from: old-primary-index-Node
   kind: Precedence
@@ -9484,6 +9526,20 @@ deprules
     - $new-primary-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-primary-index, $old-primary-index-Target, $old-primary-index-Node)
     - joinTargetNode($new-primary-index, $new-primary-index-Target, $new-primary-index-Node)
+- name: old index name is dropped before new index name is added
+  from: old-index-name-Node
+  kind: Precedence
+  to: new-index-name-Node
+  query:
+    - $old-index-name[Type] = '*scpb.IndexName'
+    - $new-index-name[Type] = '*scpb.IndexName'
+    - joinOnIndexID($old-index-name, $new-index-name, $table-id, $index-id)
+    - $old-index-name-Target[TargetStatus] = ABSENT
+    - $old-index-name-Node[CurrentStatus] = ABSENT
+    - $new-index-name-Target[TargetStatus] = PUBLIC
+    - $new-index-name-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($old-index-name, $old-index-name-Target, $old-index-name-Node)
+    - joinTargetNode($new-index-name, $new-index-name-Target, $new-index-name-Node)
 - name: old secondary indexes that have been recreated should be removed when their replacement is usable.
   from: new-primary-index-Node
   kind: SameStagePrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -3142,6 +3142,10 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   kind: Precedence
   rule: secondary index named before validation (without index swap)
 - from: [IndexName:{DescID: 109, Name: baz_pkey, IndexID: 1}, ABSENT]
+  to:   [IndexName:{DescID: 109, Name: baz_pkey, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before conflicting new index name is added
+- from: [IndexName:{DescID: 109, Name: baz_pkey, IndexID: 1}, ABSENT]
   to:   [PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before index

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
@@ -3646,6 +3646,10 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   kind: Precedence
   rule: secondary index named before validation (without index swap)
 - from: [IndexName:{DescID: 108, Name: baz_pkey, IndexID: 1}, ABSENT]
+  to:   [IndexName:{DescID: 108, Name: baz_pkey, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before conflicting new index name is added
+- from: [IndexName:{DescID: 108, Name: baz_pkey, IndexID: 1}, ABSENT]
   to:   [PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before index

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -820,6 +820,10 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: SameStagePrecedence
   rule: schedule all GC jobs for a descriptor in the same stage
 - from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT]
+  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before conflicting new index name is added
+- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT]
   to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before index

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -1171,6 +1171,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: SameStagePrecedence
   rule: schedule all GC jobs for a descriptor in the same stage
 - from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
+  to:   [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before conflicting new index name is added
+- from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
@@ -2715,6 +2719,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: SameStagePrecedence
   rule: schedule all GC jobs for a descriptor in the same stage
 - from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
+  to:   [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before conflicting new index name is added
+- from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
@@ -3581,6 +3589,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN udfcol;
   to:   [IndexData:{DescID: 107, IndexID: 4}, TRANSIENT_DROPPED]
   kind: SameStagePrecedence
   rule: schedule all GC jobs for a descriptor in the same stage
+- from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
+  to:   [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before conflicting new index name is added
 - from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_rename_constraint
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_rename_constraint
@@ -1,0 +1,172 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT, CONSTRAINT cc CHECK (i > 0));
+----
+
+ops
+ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: cc, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: cc_renamed, ConstraintID: 2}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 104
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: cc_renamed
+      TableID: 104
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: cc, ConstraintID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: cc_renamed, ConstraintID: 2}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: cc, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: cc_renamed, ConstraintID: 2}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 104
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: cc_renamed
+      TableID: 104
+
+deps
+ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----
+- from: [ConstraintWithoutIndexName:{DescID: 104, Name: cc, ConstraintID: 2}, ABSENT]
+  to:   [ConstraintWithoutIndexName:{DescID: 104, Name: cc_renamed, ConstraintID: 2}, PUBLIC]
+  kind: Precedence
+  rule: old constraint name is dropped before new constraint name is added
+
+setup
+CREATE TABLE t2 (i INT PRIMARY KEY, CONSTRAINT u UNIQUE (i));
+----
+
+ops
+ALTER TABLE t2 RENAME CONSTRAINT u TO u_renamed;
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[IndexName:{DescID: 105, Name: u, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexName:{DescID: 105, Name: u_renamed, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetIndexName
+      IndexID: 2
+      Name: crdb_internal_index_2_name_placeholder
+      TableID: 105
+    *scop.SetIndexName
+      IndexID: 2
+      Name: u_renamed
+      TableID: 105
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[IndexName:{DescID: 105, Name: u, IndexID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[IndexName:{DescID: 105, Name: u_renamed, IndexID: 2}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[IndexName:{DescID: 105, Name: u, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexName:{DescID: 105, Name: u_renamed, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetIndexName
+      IndexID: 2
+      Name: crdb_internal_index_2_name_placeholder
+      TableID: 105
+    *scop.SetIndexName
+      IndexID: 2
+      Name: u_renamed
+      TableID: 105
+
+deps
+ALTER TABLE t2 RENAME CONSTRAINT u TO u_renamed;
+----
+- from: [IndexName:{DescID: 105, Name: u, IndexID: 2}, ABSENT]
+  to:   [IndexName:{DescID: 105, Name: u_renamed, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: old index name is dropped before new index name is added
+
+setup
+CREATE TABLE t3 (i INT PRIMARY KEY, j INT, CONSTRAINT con1 CHECK (i > 0), CONSTRAINT con2 CHECK (j > 0));
+----
+
+ops
+ALTER TABLE t3 RENAME CONSTRAINT con1 TO con1_old, RENAME CONSTRAINT con2 TO con1;
+----
+StatementPhase stage 1 of 1 with 4 MutationType ops
+  transitions:
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con2, ConstraintID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1_old, ConstraintID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 3}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 106
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: crdb_internal_constraint_3_name_placeholder
+      TableID: 106
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: con1_old
+      TableID: 106
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: con1
+      TableID: 106
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con2, ConstraintID: 3}, ABSENT], ABSENT] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1_old, ConstraintID: 2}, PUBLIC], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 3}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 4 MutationType ops
+  transitions:
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con2, ConstraintID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1_old, ConstraintID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 3}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 106
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: crdb_internal_constraint_3_name_placeholder
+      TableID: 106
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: con1_old
+      TableID: 106
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: con1
+      TableID: 106
+
+deps
+ALTER TABLE t3 RENAME CONSTRAINT con1 TO con1_old, RENAME CONSTRAINT con2 TO con1;
+----
+- from: [ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 2}, ABSENT]
+  to:   [ConstraintWithoutIndexName:{DescID: 106, Name: con1_old, ConstraintID: 2}, PUBLIC]
+  kind: Precedence
+  rule: old constraint name is dropped before new constraint name is added
+- from: [ConstraintWithoutIndexName:{DescID: 106, Name: con2, ConstraintID: 3}, ABSENT]
+  to:   [ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 3}, PUBLIC]
+  kind: Precedence
+  rule: old constraint name is dropped before new constraint name is added

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_rename_constraint
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_rename_constraint
@@ -44,7 +44,7 @@ ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
 ----
 - from: [ConstraintWithoutIndexName:{DescID: 104, Name: cc, ConstraintID: 2}, ABSENT]
   to:   [ConstraintWithoutIndexName:{DescID: 104, Name: cc_renamed, ConstraintID: 2}, PUBLIC]
-  kind: Precedence
+  kind: SameStagePrecedence
   rule: old constraint name is dropped before new constraint name is added
 
 setup
@@ -93,7 +93,7 @@ ALTER TABLE t2 RENAME CONSTRAINT u TO u_renamed;
 ----
 - from: [IndexName:{DescID: 105, Name: u, IndexID: 2}, ABSENT]
   to:   [IndexName:{DescID: 105, Name: u_renamed, IndexID: 2}, PUBLIC]
-  kind: Precedence
+  kind: SameStagePrecedence
   rule: old index name is dropped before new index name is added
 
 setup
@@ -163,10 +163,14 @@ deps
 ALTER TABLE t3 RENAME CONSTRAINT con1 TO con1_old, RENAME CONSTRAINT con2 TO con1;
 ----
 - from: [ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 2}, ABSENT]
-  to:   [ConstraintWithoutIndexName:{DescID: 106, Name: con1_old, ConstraintID: 2}, PUBLIC]
+  to:   [ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 3}, PUBLIC]
   kind: Precedence
+  rule: old constraint name is dropped before conflicting new constraint name is added when at least one is non-index-backed
+- from: [ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 2}, ABSENT]
+  to:   [ConstraintWithoutIndexName:{DescID: 106, Name: con1_old, ConstraintID: 2}, PUBLIC]
+  kind: SameStagePrecedence
   rule: old constraint name is dropped before new constraint name is added
 - from: [ConstraintWithoutIndexName:{DescID: 106, Name: con2, ConstraintID: 3}, ABSENT]
   to:   [ConstraintWithoutIndexName:{DescID: 106, Name: con1, ConstraintID: 3}, PUBLIC]
-  kind: Precedence
+  kind: SameStagePrecedence
   rule: old constraint name is dropped before new constraint name is added

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -463,6 +463,13 @@ func TestEndToEndSideEffects_alter_table_rename_column(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1230,6 +1237,13 @@ func TestExecuteWithDMLInjection_alter_table_rename_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2003,6 +2017,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_rename_column(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2770,6 +2791,13 @@ func TestPause_alter_table_rename_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3543,6 +3571,13 @@ func TestPauseMixedVersion_alter_table_rename_column(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4310,6 +4345,13 @@ func TestRollback_alter_table_rename_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_column"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_rename_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_10_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_11_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_12_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_13_of_15.explain
@@ -24,17 +24,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_14_of_15.explain
@@ -24,17 +24,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_15_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_9_of_15.explain
@@ -24,17 +24,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -77,12 +76,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -77,12 +76,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -77,12 +76,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -74,7 +73,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
@@ -83,6 +82,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -74,7 +73,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
@@ -83,6 +82,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -77,12 +76,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_16_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -77,12 +76,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_16.explain
@@ -48,7 +48,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
@@ -76,13 +75,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_10_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_11_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_12_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_13_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -39,11 +38,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_14_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -39,11 +38,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_15_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_9_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -40,10 +39,11 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_10_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_11_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_12_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_13_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -39,11 +38,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_14_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -39,11 +38,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_15_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -41,9 +40,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_9_of_15.explain
@@ -28,7 +28,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 4 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j-), IndexID: 5}
       │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -40,10 +39,11 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_10_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_11_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_12_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_13_of_15.explain
@@ -24,17 +24,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_14_of_15.explain
@@ -24,17 +24,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_15_of_15.explain
@@ -24,7 +24,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
@@ -32,9 +31,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_9_of_15.explain
@@ -24,17 +24,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    └── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_17_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_17_of_23.explain
@@ -49,7 +49,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -73,7 +72,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
@@ -84,6 +83,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_18_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_18_of_23.explain
@@ -50,7 +50,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -75,11 +74,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_19_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_19_of_23.explain
@@ -50,7 +50,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -75,11 +74,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_20_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_20_of_23.explain
@@ -50,7 +50,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -75,11 +74,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_21_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_21_of_23.explain
@@ -50,7 +50,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -72,7 +71,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
@@ -80,6 +79,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_22_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_22_of_23.explain
@@ -50,7 +50,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -72,7 +71,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
@@ -80,6 +79,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_23_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_23_of_23.explain
@@ -50,7 +50,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -75,11 +74,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_10_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -51,9 +50,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_11_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -51,9 +50,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_12_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -51,9 +50,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_13_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -48,12 +47,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_14_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -48,12 +47,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_15_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -51,9 +50,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands__rollback_9_of_15.explain
@@ -33,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (p-), IndexID: 5}
       │    └── 24 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
@@ -50,10 +49,11 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t DROP COLUMN k
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TABLE t (x INT PRIMARY KEY, y INT, CONSTRAINT cc CHECK (x > 10));
+----
+
+test
+ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.explain
@@ -1,0 +1,50 @@
+/* setup */
+CREATE TABLE t (x INT PRIMARY KEY, y INT, CONSTRAINT cc CHECK (x > 10));
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME CONSTRAINT ‹cc› TO ‹cc_renamed›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc_renamed", ConstraintID: 2 (cc-cc_renamed+)}
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc", ConstraintID: 2 (cc-cc_renamed+)}
+ │         └── 3 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              └── SetConstraintName {"ConstraintID":2,"Name":"cc_renamed","TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── PUBLIC → ABSENT ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc_renamed", ConstraintID: 2 (cc-cc_renamed+)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │    │    │    └── ABSENT → PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── ABSENT → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc", ConstraintID: 2 (cc-cc_renamed+)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc_renamed", ConstraintID: 2 (cc-cc_renamed+)}
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc", ConstraintID: 2 (cc-cc_renamed+)}
+ │         └── 5 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"cc_renamed","TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ └── PostCommitPhase
+      └── Stage 1 of 1 in PostCommitPhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE TABLE t (x INT PRIMARY KEY, y INT, CONSTRAINT cc CHECK (x > 10));
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME CONSTRAINT ‹cc› TO ‹cc_renamed›;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint.side_effects
@@ -1,0 +1,147 @@
+/* setup */
+CREATE TABLE t (x INT PRIMARY KEY, y INT, CONSTRAINT cc CHECK (x > 10));
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.rename_constraint
+## StatementPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+  ...
+       constraintId: 2
+       expr: x > 10:::INT8
+  -    name: cc
+  +    name: cc_renamed
+     columns:
+     - id: 1
+  ...
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 5 MutationType ops
+upsert descriptor #104
+  ...
+       constraintId: 2
+       expr: x > 10:::INT8
+  -    name: cc
+  +    name: cc_renamed
+     columns:
+     - id: 1
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": x
+  +        "2": "y"
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      constraints:
+  +        "2": cc_renamed
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "1": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME CONSTRAINT ‹cc› TO ‹cc_renamed›
+  +        statement: ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t RENAME CONSTRAINT cc TO cc_renamed"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": x
+  -        "2": "y"
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      constraints:
+  -        "2": cc_renamed
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "1": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› RENAME CONSTRAINT ‹cc› TO ‹cc_renamed›
+  -        statement: ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     replacementOf:
+       time: {}
+  +  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #3
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_constraint/alter_table_rename_constraint__rollback_1_of_1.explain
@@ -1,0 +1,26 @@
+/* setup */
+CREATE TABLE t (x INT PRIMARY KEY, y INT, CONSTRAINT cc CHECK (x > 10));
+
+/* test */
+ALTER TABLE t RENAME CONSTRAINT cc TO cc_renamed;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t RENAME CONSTRAINT cc TO cc_renamed;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── ABSENT → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc", ConstraintID: 2 (cc_renamed-cc+)}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── PUBLIC → ABSENT ConstraintWithoutIndexName:{DescID: 104 (t), Name: "cc_renamed", ConstraintID: 2 (cc_renamed-cc+)}
+      │    └── 4 Mutation operations
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"cc","TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint.explain
@@ -19,8 +19,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› VALIDATE
  │         └── 5 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── AddCheckConstraint {"CheckExpr":"i \u003e 0:::INT8","ConstraintID":3,"TableID":104,"Validity":2}
- │              ├── SetConstraintName {"ConstraintID":3,"Name":"check_i","TableID":104}
  │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":3,"Name":"check_i","TableID":104}
  │              └── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
@@ -46,8 +46,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› VALIDATE
  │         └── 7 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── AddCheckConstraint {"CheckExpr":"i \u003e 0:::INT8","ConstraintID":3,"TableID":104,"Validity":2}
- │              ├── SetConstraintName {"ConstraintID":3,"Name":"check_i","TableID":104}
  │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":3,"Name":"check_i","TableID":104}
  │              ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint__rollback_1_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint__rollback_1_of_3.explain
@@ -17,8 +17,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t VALIDATE CONS
       │    │    └── PUBLIC     → ABSENT ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_i", ConstraintID: 3 (check_i-)}
       │    └── 6 Mutation operations
       │         ├── AddCheckConstraint {"CheckExpr":"i \u003e 0:::INT8","ConstraintID":2,"TableID":104,"Validity":1}
-      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_i","TableID":104}
       │         ├── SetConstraintName {"ConstraintID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_i","TableID":104}
       │         ├── RemoveCheckConstraint {"ConstraintID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint__rollback_2_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint__rollback_2_of_3.explain
@@ -17,8 +17,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t VALIDATE CONS
       │    │    └── PUBLIC     → ABSENT ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_i", ConstraintID: 3 (check_i-)}
       │    └── 6 Mutation operations
       │         ├── AddCheckConstraint {"CheckExpr":"i \u003e 0:::INT8","ConstraintID":2,"TableID":104,"Validity":1}
-      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_i","TableID":104}
       │         ├── SetConstraintName {"ConstraintID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_i","TableID":104}
       │         ├── RemoveCheckConstraint {"ConstraintID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint__rollback_3_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_validate_constraint/alter_table_validate_constraint__rollback_3_of_3.explain
@@ -17,9 +17,9 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t VALIDATE CONS
       │    │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_i", ConstraintID: 3 (check_i-)}
       │    └── 6 Mutation operations
       │         ├── AddCheckConstraint {"CheckExpr":"i \u003e 0:::INT8","ConstraintID":2,"TableID":104,"Validity":1}
-      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_i","TableID":104}
       │         ├── MakePublicCheckConstraintValidated {"ConstraintID":3,"TableID":104}
       │         ├── SetConstraintName {"ConstraintID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_i","TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase


### PR DESCRIPTION
This patch implements full support for RENAME CONSTRAINT in the
declarative schema changer. The implementation handles two types of
constraints:

1. Index-backed constraints (PRIMARY KEY, UNIQUE with index): These
   rename by dropping the old IndexName element and adding a new one
   with the updated name.

2. Non-index constraints (CHECK, FK, UNIQUE without index): These
   rename by dropping the old ConstraintWithoutIndexName element and
   adding a new one with the updated name.

The implementation includes proper validation:
- Checks for constraint existence
- Validates the constraint is not being added/dropped concurrently
- Prevents name conflicts with existing constraints and indexes
- Ensures views don't depend on index-backed constraints being renamed

New dependency rules ensure the old name element reaches ABSENT before
the new name element becomes PUBLIC, preventing conflicts and ensuring
correct rollback behavior.

###  scplan: add dependency rules for cross-constraint name conflicts during rename

This commit enhances the RENAME CONSTRAINT implementation by adding
dependency rules to handle name conflicts that occur when multiple
constraints are renamed in the same schema change operation.

Previously, the dependency rules only handled simple single-constraint
renames (A → B). However, when multiple constraints are renamed such
that names are swapped or reused (e.g., C1: "old" → "new" while C2:
"new" → "other"), the original rules could allow conflicting names to
exist simultaneously during execution.

This adds two new Precedence rules:

1. For index-backed constraints: Ensures old IndexName elements reach
   ABSENT before new IndexName elements with the same name become PUBLIC.
   Includes special handling to exclude secondary index swaps during
   ALTER PRIMARY KEY operations.

2. For cross-type conflicts: Handles name conflicts between any
   combination of ConstraintWithoutIndexName and IndexName elements,
   preventing CHECK constraints from conflicting with UNIQUE constraint
   names, for example.

---

fixes #148341

Release note: None