### PR TITLE
sql/inspect: remove obsolete TODO

### DIFF
--- a/pkg/sql/inspect/inspect_job.go
+++ b/pkg/sql/inspect/inspect_job.go
@@ -60,7 +60,6 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 		return err
 	}
 
-	// TODO(149460): add a goroutine that will replan the job on topology changes
 	plan, planCtx, err := c.planInspectProcessors(ctx, jobExecCtx, pkSpans)
 	if err != nil {
 		return err


### PR DESCRIPTION
We have no plans to add a replanner to INSPECT for topology changes. See #149460 for rationale. Removing the TODO that was previously added for it.

Closes #149460

Epic: CRDB-30356
Release note: none