### PR TITLE
sql: skip a big test that ooms on the race detector

### DIFF
--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -227,6 +227,7 @@ func TestPrettyVerify(t *testing.T) {
 func TestPrettyBigStatement(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "excessive memory usage")
 
 	// Create a SELECT statement with a 1 million item IN expression. Without
 	// mitigation, this can cause stack overflows - see #91197.


### PR DESCRIPTION
The test still passes without the race detector and the smaller tests
still pass with the race detector.

Epic: none
Fixes: #154140
Fixes: #154243

Release note: None
