### PR TITLE
sql/importer: make inspect after import validation a metamorphic setting

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -515,6 +515,9 @@ type TableDescriptor interface {
 	// keys, even if they're not defined by the user.
 	HasPrimaryKey() bool
 
+	// IsExpressionIndex returns if the given index is an expression index.
+	IsExpressionIndex(idx Index) bool
+
 	// AllColumns returns a slice of Column interfaces containing the
 	// table's public columns and column mutations, in the canonical order:
 	// - all public columns in the same order as in the underlying

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2236,6 +2236,18 @@ func (desc *wrapper) HasPrimaryKey() bool {
 	return !desc.PrimaryIndex.Disabled
 }
 
+// IsExpressionIndex implements the TableDescriptor interface.
+func (desc *wrapper) IsExpressionIndex(idx catalog.Index) bool {
+	for i := 0; i < idx.NumKeyColumns(); i++ {
+		colID := idx.GetKeyColumnID(i)
+		col := catalog.FindColumnByID(desc, colID)
+		if col != nil && col.IsExpressionIndexColumn() {
+			return true
+		}
+	}
+	return false
+}
+
 // HasColumnBackfillMutation implements the TableDescriptor interface.
 func (desc *wrapper) HasColumnBackfillMutation() bool {
 	for _, m := range desc.AllMutations() {

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logutil",
+        "//pkg/util/metamorphic",
         "//pkg/util/protoutil",
         "//pkg/util/retry",
         "//pkg/util/syncutil",

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -379,12 +379,26 @@ func (c *indexConsistencyCheck) loadCatalogInfo(ctx context.Context) error {
 			// We can only check a secondary index that has a 1-to-1 mapping between
 			// keys in the primary index. Unsupported indexes should be filtered out
 			// when the job is created.
+			// TODO(154862): support partial indexes
 			if idx.IsPartial() {
 				return errors.AssertionFailedf(
 					"unsupported index type for consistency check: partial index",
 				)
 			}
+			// TODO(154762): support hash sharded indexes
+			if idx.IsSharded() {
+				return errors.AssertionFailedf(
+					"unsupported index type for consistency check: hash-sharded index",
+				)
+			}
+			// TODO(154772): support expression indexes
+			if c.tableDesc.IsExpressionIndex(idx) {
+				return errors.AssertionFailedf(
+					"unsupported index type for consistency check: expression index",
+				)
+			}
 			switch idx.GetType() {
+			// TODO(154860): support inverted indexes
 			case idxtype.INVERTED, idxtype.VECTOR:
 				return errors.AssertionFailedf(
 					"unsupported index type for consistency check: %s", idx.GetType(),

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -137,3 +137,43 @@ statement ok
 INSPECT DATABASE test;
 
 subtest end
+
+subtest inspect_unsupported_indexes
+
+user root
+
+# Test that unsupported indexes (hash-sharded, expression) are skipped.
+# Table has both unsupported indexes and a regular index.
+statement ok
+CREATE TABLE t2 (x INT, y INT, z INT, INDEX hash_idx (x) USING HASH, INDEX expr_idx ((y + z)), INDEX regular_idx (z));
+
+statement ok
+INSERT INTO t2 (x, y, z) VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
+
+# Should succeed, checking only the regular index.
+skipif config local-mixed-25.2 local-mixed-25.3
+statement ok
+EXPERIMENTAL SCRUB TABLE t2 AS OF SYSTEM TIME '-1us';
+
+# Verify only one check was created (for the regular index).
+skipif config local-mixed-25.2 local-mixed-25.3
+query TI
+SELECT
+  json_extract_path_text(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload),
+    'inspectDetails', 'checks', '0', 'type'
+  ) AS check_type,
+  jsonb_array_length(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload) -> 'inspectDetails' -> 'checks'
+  ) AS num_checks
+FROM crdb_internal.system_jobs
+WHERE job_type = 'INSPECT'
+ORDER BY created DESC
+LIMIT 1
+----
+INSPECT_CHECK_INDEX_CONSISTENCY  1
+
+statement ok
+DROP TABLE t2;
+
+subtest end


### PR DESCRIPTION
Previously, the setting `bulkio.import.row_count_validation.unsafe.enabled` was a boolean that controlled whether an INSPECT job would be triggered after an IMPORT operation. This commit replaces that boolean with a metamorphic enum setting.

The new enum has three values:
- `off`: No validation (default; preserves current behavior)
- `async`: Run INSPECT asynchronously in the background (future production default)
- `sync`: Run INSPECT synchronously and wait for completion (testing only)

The prior `true` value now maps to `async`. The new `sync` option is added specifically for testing. If the INSPECT job fails, it causes the IMPORT to fail as well, enabling roachtests to detect issues more easily without manual validation.

The setting has been renamed to `bulkio.import.row_count_validation.unsafe.mode` to reflect the new setting.

Informs: #154049
Epic: CRDB-30356

Release note: none