### PR TITLE
sql/execbuilder: specify the column family with jsonb_path_query tests

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/jsonb_path_query
+++ b/pkg/sql/opt/exec/execbuilder/testdata/jsonb_path_query
@@ -4,7 +4,8 @@
 statement ok
 CREATE TABLE json_tab (
   a INT PRIMARY KEY,
-  b JSONB
+  b JSONB,
+  FAMILY f1 (a, b)
 )
 
 statement ok


### PR DESCRIPTION
Fixes: #154634

Previously we didn't specify the column family in the definition of the table, leading to inderterministic for Scan response from kvbatcher. This commit is to fix it with explicitly setting the column family.

Release note: None