### PR TITLE
release-24.1: backup: re-apply SECONDARY zone config during RESTORE DATABASE

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1239,6 +1239,11 @@ func createImportingDescriptors(
 
 							return nil
 						})
+
+						var opts []multiregion.MakeRegionConfigOption
+						if desc.RegionConfig.SecondaryRegion != "" {
+							opts = append(opts, multiregion.WithSecondaryRegion(desc.RegionConfig.SecondaryRegion))
+						}
 						regionConfig := multiregion.MakeRegionConfig(
 							regionNames,
 							desc.RegionConfig.PrimaryRegion,
@@ -1247,6 +1252,7 @@ func createImportingDescriptors(
 							desc.RegionConfig.Placement,
 							regionTypeDesc.TypeDesc().RegionConfig.SuperRegions,
 							regionTypeDesc.TypeDesc().RegionConfig.ZoneConfigExtensions,
+							opts...,
 						)
 						if err := sql.ApplyZoneConfigFromDatabaseRegionConfig(
 							ctx,

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -7,7 +7,7 @@ new-cluster name=s1 allow-implicit-access disable-tenant localities=us-east-1,us
 ----
 
 exec-sql
-CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1" SURVIVE REGION FAILURE;
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1" SURVIVE REGION FAILURE SECONDARY REGION "us-west-1";
 CREATE TABLE d.t (x INT);
 INSERT INTO d.t VALUES (1), (2), (3);
 ----
@@ -18,6 +18,19 @@ SELECT region FROM [SHOW REGIONS FROM DATABASE d] ORDER BY 1;
 eu-central-1
 us-east-1
 us-west-1
+
+query-sql
+SHOW ZONE CONFIGURATION FROM DATABASE d;
+----
+DATABASE d ALTER DATABASE d CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 14400,
+	num_replicas = 5,
+	num_voters = 5,
+	constraints = '{+region=eu-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+	voter_constraints = '{+region=us-east-1: 2, +region=us-west-1: 2}',
+	lease_preferences = '[[+region=us-east-1], [+region=us-west-1]]'
 
 exec-sql
 BACKUP DATABASE d INTO 'nodelocal://1/database_backup/';
@@ -46,11 +59,24 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/';
 query-sql
 SHOW DATABASES;
 ----
-d root us-east-1  {eu-central-1,us-east-1,us-west-1} region
+d root us-east-1 us-west-1 {eu-central-1,us-east-1,us-west-1} region
 data root <nil> <nil> {} <nil>
 defaultdb root <nil> <nil> {} <nil>
 postgres root <nil> <nil> {} <nil>
 system node <nil> <nil> {} <nil>
+
+query-sql
+SHOW ZONE CONFIGURATION FROM DATABASE d;
+----
+DATABASE d ALTER DATABASE d CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 14400,
+	num_replicas = 5,
+	num_voters = 5,
+	constraints = '{+region=eu-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+	voter_constraints = '{+region=us-east-1: 2, +region=us-west-1: 2}',
+	lease_preferences = '[[+region=us-east-1], [+region=us-west-1]]'
 
 # A new cluster with different localities settings.
 new-cluster name=s3 share-io-dir=s1 allow-implicit-access disable-tenant localities=eu-central-1,eu-north-1
@@ -77,6 +103,7 @@ SET enable_multiregion_placement_policy='true';
 ALTER DATABASE d SURVIVE ZONE FAILURE;
 ALTER DATABASE d PLACEMENT RESTRICTED;
 ALTER DATABASE d SET PRIMARY REGION 'eu-central-1';
+ALTER DATABASE d DROP SECONDARY REGION;
 ALTER DATABASE d DROP REGION 'us-east-1';
 ALTER DATABASE d DROP REGION 'us-west-1';
 ALTER DATABASE d ADD REGION 'eu-north-1';
@@ -92,6 +119,7 @@ SET enable_multiregion_placement_policy='true';
 ALTER DATABASE d_new SURVIVE ZONE FAILURE;
 ALTER DATABASE d PLACEMENT RESTRICTED;
 ALTER DATABASE d_new SET PRIMARY REGION 'eu-central-1';
+ALTER DATABASE d_new DROP SECONDARY REGION;
 ALTER DATABASE d_new DROP REGION 'us-east-1';
 ALTER DATABASE d_new DROP REGION 'us-west-1';
 ALTER DATABASE d_new ADD REGION 'eu-north-1';


### PR DESCRIPTION
Backport 1/1 commits from #154522.

/cc @cockroachdb/release

---

Previously during restoration of a DATABASE with a SECONDARY REGION, the region was correctly configured on the database but its *zone config* was not updated to reflect the region, so the second lease preference was not set, at least until some other schema change or operation reconcilled the descriptors config to a zone config. This updates the creation of the DB during RESTORE to also trigger the zone configuration update.

Fixes #154523.

Release note (bug fix): RESTORE of a database with a SECONDARY REGION now applies the lease-preference for said region.
Epic: none.

Release justification:  customer requested backport to fix a bug. As a bug fix for inconsistent zone configs, there's no reason to gate it.
