### PR TITLE
stmtdiagnostics: don't create statement dignostics request for txn di…

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -653,7 +653,7 @@ func (r *Registry) innerInsertStatementDiagnostics(
 		if err != nil {
 			return diagID, err
 		}
-	} else {
+	} else if txnDiagnosticId == 0 {
 		// Insert a completed request into system.statement_diagnostics_request.
 		// This is necessary because the UI uses this table to discover completed
 		// diagnostics.


### PR DESCRIPTION
…agnostics

Previously, `innerInsertStatementDiagnostics` was creating new statement diagnostics requests when a transaction diagnostics bundle was being created. Now, these new statement requests will no longer be created.

Epic: CRDB-53541
Release note: None