### PR TITLE
sql: remove canModifySchema interface

### DIFF
--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -118,9 +118,6 @@ func (node *SetZoneConfig) Format(ctx *FmtCtx) {
 	node.ZoneConfigSettings.Format(ctx)
 }
 
-// modifiesSchema implements the canModifySchema interface.
-func (*SetZoneConfig) modifiesSchema() bool { return true }
-
 // ZoneConfigSettings represents info needed for zone config setting.
 type ZoneConfigSettings struct {
 	Discard    bool      // True for `CONFIGURE ZONE DISCARD` stmt


### PR DESCRIPTION
The `canModifySchema` interface has been removed. The `CanModifySchema`
function now has special logic for the two non-DDL statements that
modify the schema: `DISCARD` and `SET ZONE CONFIG`. Additionally,
`CanModifySchema` now returns early for DML statements—a very minor
optimization to avoid an unnecessary invocation of the
`StatementReturnType` method which can chase additional pointers for
`RETURNING` nodes of `INSERT` and `UPDATE` statements.

Release note: None
