### PR TITLE
sql: give cluster time to upgrade under test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl
@@ -16,7 +16,7 @@ upgrade all
 # Verify that the cluster version upgrades have begun by asserting we're no
 # longer on the previous version. Note that the first cluster upgrade is the
 # one that repairs all descriptors.
-query B retry
+query B retry retry_duration 90s
 SELECT version != '$initial_version' FROM [SHOW CLUSTER SETTING version]
 ----
 true


### PR DESCRIPTION
In local 3-node testing the upgrade takes ~80s to get to the cluster
version bump so relaxing the retries helps the tests pass.

Epic: none
Fixes: #154550
Fixes: #154077
Fixes: #155046

Release note: None
