### PR TITLE
sql: move bufferable session var lookup to init-time

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2325,20 +2325,16 @@ func (ex *connExecutor) reportSessionDataChanges(fn func() error) error {
 	after := ex.sessionDataStack.Top()
 	if ex.dataMutatorIterator.paramStatusUpdater != nil {
 		for _, param := range bufferableParamStatusUpdates {
-			_, v, err := getSessionVar(param.lowerName, false /* missingOk */)
-			if err != nil {
-				return err
-			}
-			if v.Equal == nil {
+			if param.sv.Equal == nil {
 				return errors.AssertionFailedf("Equal for %s must be set", param.name)
 			}
-			if v.GetFromSessionData == nil {
+			if param.sv.GetFromSessionData == nil {
 				return errors.AssertionFailedf("GetFromSessionData for %s must be set", param.name)
 			}
-			if !v.Equal(before, after) {
+			if !param.sv.Equal(before, after) {
 				ex.dataMutatorIterator.paramStatusUpdater.BufferParamStatusUpdate(
 					param.name,
-					v.GetFromSessionData(after),
+					param.sv.GetFromSessionData(after),
 				)
 			}
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3387,8 +3387,8 @@ type paramStatusUpdater interface {
 }
 
 type bufferableParamStatusUpdate struct {
-	name      string
-	lowerName string
+	name string
+	sv   sessionVar
 }
 
 // bufferableParamStatusUpdates contains all vars which can be sent through
@@ -3403,9 +3403,14 @@ var bufferableParamStatusUpdates = func() []bufferableParamStatusUpdate {
 	}
 	ret := make([]bufferableParamStatusUpdate, len(params))
 	for i, param := range params {
+		svName := strings.ToLower(param)
+		_, sv, err := getSessionVar(svName, false /* missingOk */)
+		if err != nil {
+			panic(errors.Wrapf(err, "could not find session var %q", svName))
+		}
 		ret[i] = bufferableParamStatusUpdate{
-			name:      param,
-			lowerName: strings.ToLower(param),
+			name: param,
+			sv:   sv,
 		}
 	}
 	return ret


### PR DESCRIPTION
Lookups for bufferable session vars are now performed once at init-time
rather than every time `(*connExecutor).reportSessionDataChanges` is
called.

Release note: None
