### PR TITLE
opt: move some assignment cast execbuilder logic to init-time

### DIFF
--- a/pkg/sql/catalog/descs/dist_sql_function_resolver.go
+++ b/pkg/sql/catalog/descs/dist_sql_function_resolver.go
@@ -46,10 +46,7 @@ func (d *DistSQLFunctionResolver) ResolveFunction(
 		return nil, err
 	}
 	// Get builtin and udf functions if there is any match.
-	builtinDef, err := tree.GetBuiltinFuncDefinition(fn, path)
-	if err != nil {
-		return nil, err
-	}
+	builtinDef := tree.GetBuiltinFuncDefinition(fn, path)
 	if builtinDef == nil {
 		return nil, errors.Mark(
 			pgerror.Newf(pgcode.UndefinedFunction, "function %s not found", fn.Object()),

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -370,6 +370,13 @@ func (b *Builder) buildCast(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Ty
 	return tree.NewTypedCastExpr(input, cast.Typ), nil
 }
 
+const assnCastFnName = "crdb_internal.assignment_cast"
+
+var (
+	assnCastFuncRef                  = tree.WrapFunction(assnCastFnName)
+	assnCastProps, assnCastOverloads = builtinsregistry.GetBuiltinProperties(assnCastFnName)
+)
+
 // buildAssignmentCast builds an AssignmentCastExpr with input i and type T into
 // a built-in function call crdb_internal.assignment_cast(i, NULL::T).
 func (b *Builder) buildAssignmentCast(
@@ -388,21 +395,15 @@ func (b *Builder) buildAssignmentCast(
 		return input, nil
 	}
 
-	const fnName = "crdb_internal.assignment_cast"
-	funcRef, err := b.wrapBuiltinFunction(fnName)
-	if err != nil {
-		return nil, err
-	}
-	props, overloads := builtinsregistry.GetBuiltinProperties(fnName)
 	return tree.NewTypedFuncExpr(
-		funcRef,
+		assnCastFuncRef,
 		0, /* aggQualifier */
 		tree.TypedExprs{input, tree.NewTypedCastExpr(tree.DNull, cast.Typ)},
 		nil, /* filter */
 		nil, /* windowDef */
 		cast.Typ,
-		props,
-		&overloads[0],
+		assnCastProps,
+		&assnCastOverloads[0],
 	), nil
 }
 

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -34,10 +34,7 @@ func (tc *Catalog) ResolveFunction(
 	}
 
 	// Attempt to resolve to a built-in function first.
-	def, err := tree.GetBuiltinFuncDefinition(fn, path)
-	if err != nil {
-		return nil, err
-	}
+	def := tree.GetBuiltinFuncDefinition(fn, path)
 	if def != nil {
 		return def, nil
 	}

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -457,10 +457,7 @@ func (sr *schemaResolver) ResolveFunction(
 	}
 
 	// Get builtin and udf functions if there is any match.
-	builtinDef, err := tree.GetBuiltinFuncDefinition(fn, path)
-	if err != nil {
-		return nil, err
-	}
+	builtinDef := tree.GetBuiltinFuncDefinition(fn, path)
 	routine, err := maybeLookupRoutine(ctx, sr, path, fn)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1393,10 +1393,7 @@ func (s *TestState) ResolveFunction(
 	if err != nil {
 		return nil, err
 	}
-	fd, err := tree.GetBuiltinFuncDefinition(fnName, path)
-	if err != nil {
-		return nil, err
-	}
+	fd := tree.GetBuiltinFuncDefinition(fnName, path)
 	if fd != nil {
 		return fd, nil
 	}

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -691,10 +691,7 @@ func containsUDF(expr tree.Expr) (bool, error) {
 			if err != nil {
 				return false, nil, err
 			}
-			fd, err := tree.GetBuiltinFuncDefinition(fn, &sessiondata.DefaultSearchPath)
-			if err != nil {
-				return false, nil, err
-			}
+			fd := tree.GetBuiltinFuncDefinition(fn, &sessiondata.DefaultSearchPath)
 			if fd == nil {
 				foundUDF = true
 			}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -599,10 +599,7 @@ func QualifyBuiltinFunctionDefinition(
 func GetBuiltinFuncDefinitionOrFail(
 	fName RoutineName, searchPath SearchPath,
 ) (*ResolvedFunctionDefinition, error) {
-	def, err := GetBuiltinFuncDefinition(fName, searchPath)
-	if err != nil {
-		return nil, err
-	}
+	def := GetBuiltinFuncDefinition(fName, searchPath)
 	if def == nil {
 		forError := fName // prevent fName from escaping
 		return nil, errors.Mark(
@@ -634,28 +631,23 @@ func GetBuiltinFunctionByOIDOrFail(oid oid.Oid) (*ResolvedFunctionDefinition, er
 // in the specific schema are searched. Otherwise, all schemas on the given
 // searchPath are searched. A nil is returned if no function is found. It's
 // caller's choice to error out if function not found.
-//
-// In theory, this function returns an error only when the search path iterator
-// errors which won't happen since the iterating function never errors out. But
-// error is still checked and return from the function signature just in case
-// we change the iterating function in the future.
 func GetBuiltinFuncDefinition(
 	fName RoutineName, searchPath SearchPath,
-) (*ResolvedFunctionDefinition, error) {
+) *ResolvedFunctionDefinition {
 	if fName.ExplicitSchema {
-		return ResolvedBuiltinFuncDefs[fName.Schema()+"."+fName.Object()], nil
+		return ResolvedBuiltinFuncDefs[fName.Schema()+"."+fName.Object()]
 	}
 
 	// First try that if we can get function directly with the function name.
 	// There is a case where the part[0] of the name is a qualified string when
-	// the qualified name is double quoted as a single name like "schema.fn".
+	// the qualified name is double-quoted as a single name like "schema.fn".
 	if def, ok := ResolvedBuiltinFuncDefs[fName.Object()]; ok {
-		return def, nil
+		return def
 	}
 
 	// Then try if it's in pg_catalog.
 	if def, ok := ResolvedBuiltinFuncDefs[catconstants.PgCatalogName+"."+fName.Object()]; ok {
-		return def, nil
+		return def
 	}
 
 	// If not in pg_catalog, go through search path.
@@ -669,5 +661,5 @@ func GetBuiltinFuncDefinition(
 		}
 	}
 
-	return resolvedDef, nil
+	return resolvedDef
 }

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -71,8 +71,7 @@ func TestBuiltinFunctionResolver(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			fnName, err := tc.fnName.ToRoutineName()
 			require.NoError(t, err)
-			funcDef, err := tree.GetBuiltinFuncDefinition(fnName, &path)
-			require.NoError(t, err)
+			funcDef := tree.GetBuiltinFuncDefinition(fnName, &path)
 			if tc.expectNoFound {
 				require.Nil(t, funcDef)
 				return


### PR DESCRIPTION
#### opt: move some assignment cast execbuilder logic to init-time

Lookups for the `crdb_internal.assignment_cast` function properties and
overload are now performed once at init-time instead of for every
assignment cast built at execbuild-time.

Release note: None

#### sql/sem/tree: remove always-nil error return from GetBuiltinFuncDefinition

Release note: None
