### PR TITLE
release-25.4: restore: fix restore hanging on server stop

### DIFF
--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -367,6 +367,7 @@ func (gssp *generativeSplitAndScatterProcessor) Start(ctx context.Context) {
 	}); err != nil {
 		gssp.scatterErr = err
 		cancel()
+		close(gssp.doneScatterCh)
 		close(workerDone)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #154531.

/cc @cockroachdb/release

---

`RunTaskAsyncEx` returns an error if it is ran while the stopper is [stopping or
quiescing](https://github.com/cockroachdb/cockroach/blob/52aaf2e7ea3f20aced87d1dcc87a1873fb87ffbe/pkg/util/stop/stopper.go#L498-L500). In the generative split and scatterer processor, in the event that the task is run during stopping/quiesce, the `doneScatterCh` is never closed. That means that any follow up `Next` calls on the processor will hang on receiving from the channel.

Fixes: #153806

Release note: None

---

Release justification: Fix bug that results in deadlock during node stopping.