### PR TITLE
opt: refactor cardinality calculation

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -741,8 +741,9 @@ func (b *Builder) buildDeleteRange(del *memo.DeleteExpr) (execPlan, error) {
 		//
 		// Mutations only allow auto-commit if there are no FK checks or cascades.
 
-		if maxRows, ok := b.indexConstraintMaxResults(&scan.ScanPrivate, scan.Relational()); ok {
-			if maxKeys := maxRows * uint64(tab.FamilyCount()); maxKeys <= uint64(row.DeleteRangeChunkSize(b.evalCtx.TestingKnobs.ForceProductionValues)) {
+		if card := scan.Relational().Cardinality; !card.IsUnbounded() {
+			deleteRangeChunkSize := row.DeleteRangeChunkSize(b.evalCtx.TestingKnobs.ForceProductionValues)
+			if maxKeys := int(card.Max) * tab.FamilyCount(); maxKeys <= deleteRangeChunkSize {
 				autoCommit = true
 			}
 		}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -637,29 +637,6 @@ func (b *Builder) getColumns(
 	return needed, output
 }
 
-// indexConstraintMaxResults returns the maximum number of results for a scan;
-// if successful (ok=true), the scan is guaranteed never to return more results
-// than maxRows.
-func (b *Builder) indexConstraintMaxResults(
-	scan *memo.ScanPrivate, relProps *props.Relational,
-) (maxRows uint64, ok bool) {
-	c := scan.Constraint
-	if c == nil || c.IsContradiction() || c.IsUnconstrained() {
-		return 0, false
-	}
-
-	numCols := c.Columns.Count()
-	var indexCols opt.ColSet
-	for i := 0; i < numCols; i++ {
-		indexCols.Add(c.Columns.Get(i).ID())
-	}
-	if !relProps.FuncDeps.ColsAreLaxKey(indexCols) {
-		return 0, false
-	}
-
-	return c.CalculateMaxResults(b.ctx, b.evalCtx, indexCols, relProps.NotNullCols)
-}
-
 // scanParams populates ScanParams and the output column mapping.
 func (b *Builder) scanParams(
 	tab cat.Table, scan *memo.ScanPrivate, relProps *props.Relational, reqProps *physical.Required,
@@ -739,7 +716,11 @@ func (b *Builder) scanParams(
 
 	softLimit := uint64(reqProps.LimitHintInt64())
 	hardLimit := scan.HardLimit.RowCount()
-	maxResults, maxResultsOk := b.indexConstraintMaxResults(scan, relProps)
+	var maxResults uint64
+	maxResultsOk := !relProps.Cardinality.IsUnbounded()
+	if maxResultsOk {
+		maxResults = uint64(relProps.Cardinality.Max)
+	}
 
 	// If the txn_rows_read_err guardrail is set, make sure that we never read
 	// more than txn_rows_read_err+1 rows on any single scan. Adding a hard limit
@@ -782,7 +763,7 @@ func (b *Builder) scanParams(
 			// row: it does nothing in this case except litter EXPLAINs.
 			// There are still cases where the flag doesn't do anything when the spans
 			// cover a single range, but there is nothing we can do about that.
-			if !(maxResults == 1 && scan.Constraint.Spans.Count() == 1) {
+			if !(maxResults == 1 && scan.Constraint != nil && scan.Constraint.Spans.Count() == 1) {
 				parallelize = true
 			}
 		} else if b.evalCtx != nil {

--- a/pkg/sql/opt/props/cardinality.go
+++ b/pkg/sql/opt/props/cardinality.go
@@ -58,20 +58,20 @@ func (c Cardinality) IsUnbounded() bool {
 }
 
 // AsLowAs ratchets the min bound downwards in order to ensure that it allows
-// values that are >= the min value.
-func (c Cardinality) AsLowAs(min uint32) Cardinality {
+// values that are >= the given value.
+func (c Cardinality) AsLowAs(v uint32) Cardinality {
 	return Cardinality{
-		Min: minVal(c.Min, min),
+		Min: min(c.Min, v),
 		Max: c.Max,
 	}
 }
 
 // Limit ratchets the bounds downwards so that they're no bigger than the given
-// max value.
-func (c Cardinality) Limit(max uint32) Cardinality {
+// value.
+func (c Cardinality) Limit(v uint32) Cardinality {
 	return Cardinality{
-		Min: minVal(c.Min, max),
-		Max: minVal(c.Max, max),
+		Min: min(c.Min, v),
+		Max: min(c.Max, v),
 	}
 }
 
@@ -79,8 +79,8 @@ func (c Cardinality) Limit(max uint32) Cardinality {
 // bounds in the given cardinality.
 func (c Cardinality) AtLeast(other Cardinality) Cardinality {
 	return Cardinality{
-		Min: maxVal(c.Min, other.Min),
-		Max: maxVal(c.Max, other.Max),
+		Min: max(c.Min, other.Min),
+		Max: max(c.Max, other.Max),
 	}
 }
 
@@ -134,8 +134,8 @@ func (c Cardinality) Skip(rows uint32) Cardinality {
 // Example: [0-1].Union([5-10]) = [0-10]
 func (c Cardinality) Union(other Cardinality) Cardinality {
 	return Cardinality{
-		Min: minVal(c.Min, other.Min),
-		Max: maxVal(c.Max, other.Max),
+		Min: min(c.Min, other.Min),
+		Max: max(c.Max, other.Max),
 	}
 }
 
@@ -144,18 +144,4 @@ func (c Cardinality) String() string {
 		return fmt.Sprintf("[%d - ]", c.Min)
 	}
 	return fmt.Sprintf("[%d - %d]", c.Min, c.Max)
-}
-
-func minVal(a, b uint32) uint32 {
-	if a <= b {
-		return a
-	}
-	return b
-}
-
-func maxVal(a, b uint32) uint32 {
-	if a >= b {
-		return a
-	}
-	return b
 }


### PR DESCRIPTION
#### opt: remove custom min/max functions in favor of built-ins

Release note: None

#### opt: remove indexConstraintMaxResults

The execbuilder method `indexConstraintMaxResults` has been removed in
favor of using the max cardinality in relational properties, which is
populated during optimization.

Release note: None

