### PR TITLE
release-25.4: sql/inspect: add checkpointing tracking to INSPECT

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/jobs",
+        "//pkg/jobs/jobfrontier",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv/kvserver/protectedts/ptpb",
@@ -47,7 +48,8 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/log",
-        "//pkg/util/stop",
+        "//pkg/util/protoutil",
+        "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
@@ -77,6 +79,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/jobs",
+        "//pkg/jobs/jobfrontier",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/inspect/inspect_job.go
+++ b/pkg/sql/inspect/inspect_job.go
@@ -60,17 +60,22 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 		return err
 	}
 
-	// TODO(149460): add a goroutine that will replan the job on topology changes
-	plan, planCtx, err := c.planInspectProcessors(ctx, jobExecCtx, pkSpans)
-	if err != nil {
-		return err
-	}
-
-	progressTracker, cleanupProgress, err := c.setupProgressTracking(ctx, execCfg, pkSpans)
+	progressTracker, cleanupProgress, remainingSpans, err := c.setupProgressTrackingAndFilter(ctx, execCfg, pkSpans)
 	if err != nil {
 		return err
 	}
 	defer cleanupProgress()
+
+	// If all spans are completed, job is done.
+	if len(remainingSpans) == 0 {
+		log.Dev.Infof(ctx, "all spans already completed, INSPECT job finished")
+		return nil
+	}
+
+	plan, planCtx, err := c.planInspectProcessors(ctx, jobExecCtx, remainingSpans)
+	if err != nil {
+		return err
+	}
 
 	if err := c.runInspectPlan(ctx, jobExecCtx, planCtx, plan, progressTracker); err != nil {
 		return err
@@ -202,7 +207,7 @@ func (c *inspectResumer) runInspectPlan(
 	metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter(
 		func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
 			if meta.BulkProcessorProgress != nil {
-				return progressTracker.handleProcessorProgress(ctx, meta)
+				return progressTracker.handleProgressUpdate(ctx, meta)
 			}
 			return nil
 		})
@@ -228,43 +233,71 @@ func (c *inspectResumer) runInspectPlan(
 	return metadataCallbackWriter.Err()
 }
 
-// setupProgressTracking initializes and starts progress tracking for the INSPECT job.
-// It calculates the total number of applicable checks, initializes progress to 0%, and starts
-// the background update goroutine. Returns the progress tracker and cleanup function.
-func (c *inspectResumer) setupProgressTracking(
+// setupProgressTrackingAndFilter initializes progress tracking and returns
+// it, along with a cleanup function and the remaining spans to process.
+func (c *inspectResumer) setupProgressTrackingAndFilter(
 	ctx context.Context, execCfg *sql.ExecutorConfig, pkSpans []roachpb.Span,
-) (*inspectProgressTracker, func(), error) {
-	fractionInterval := fractionUpdateInterval.Get(&execCfg.Settings.SV)
-	details := c.job.Details().(jobspb.InspectDetails)
-
-	// Build applicability checkers for progress tracking
-	applicabilityCheckers, err := buildApplicabilityCheckers(details)
+) (*inspectProgressTracker, func(), []roachpb.Span, error) {
+	// Create and initialize the tracker. We use the completed spans from the job
+	// (if any) to filter out the spans we need to process in this run of the job.
+	progressTracker := newInspectProgressTracker(
+		c.job,
+		&execCfg.Settings.SV,
+		execCfg.InternalDB,
+	)
+	completedSpans, err := progressTracker.initTracker(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+	remainingSpans := c.filterCompletedSpans(pkSpans, completedSpans)
+
+	applicabilityCheckers, err := buildApplicabilityCheckers(c.job.Details().(jobspb.InspectDetails))
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
-	// Calculate total applicable checks: only count checks that will actually run
+	// Calculate total applicable checks on ALL spans (not just remaining ones)
+	// This ensures consistent progress calculation across job restarts.
 	totalCheckCount, err := countApplicableChecks(pkSpans, applicabilityCheckers, execCfg.Codec)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+	completedCheckCount, err := countApplicableChecks(completedSpans, applicabilityCheckers, execCfg.Codec)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
-	// Create and initialize progress tracker
-	progressTracker := newInspectProgressTracker(c.job, fractionInterval)
-	if err := progressTracker.initJobProgress(ctx, totalCheckCount); err != nil {
-		progressTracker.terminateTracker(ctx)
-		return nil, nil, err
+	if err := progressTracker.initJobProgress(ctx, totalCheckCount, completedCheckCount); err != nil {
+		return nil, nil, nil, err
 	}
-
-	// Start background progress updates
-	progressTracker.startBackgroundUpdates(ctx)
-
-	// Return cleanup function
 	cleanup := func() {
-		progressTracker.terminateTracker(ctx)
+		progressTracker.terminateTracker()
 	}
 
-	return progressTracker, cleanup, nil
+	return progressTracker, cleanup, remainingSpans, nil
+}
+
+// filterCompletedSpans removes spans that are already completed from the list to process.
+func (c *inspectResumer) filterCompletedSpans(
+	allSpans []roachpb.Span, completedSpans []roachpb.Span,
+) []roachpb.Span {
+	if len(completedSpans) == 0 {
+		return allSpans
+	}
+
+	completedGroup := roachpb.SpanGroup{}
+	completedGroup.Add(completedSpans...)
+
+	var remainingSpans []roachpb.Span
+	for _, span := range allSpans {
+		// Check if this span is fully contained in completed spans.
+		// We need to check if the entire span is covered by completed spans.
+		if !completedGroup.Encloses(span) {
+			remainingSpans = append(remainingSpans, span)
+		}
+	}
+
+	return remainingSpans
 }
 
 // buildApplicabilityCheckers creates lightweight applicability checkers from InspectDetails.

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -45,6 +45,14 @@ var (
 		10*time.Second,
 		settings.DurationWithMinimum(1*time.Millisecond),
 	)
+
+	checkpointInterval = settings.RegisterDurationSetting(
+		settings.ApplicationLevel,
+		"sql.inspect.checkpoint_interval",
+		"the amount of time between INSPECT job checkpoint updates",
+		30*time.Second,
+		settings.DurationWithMinimum(1*time.Millisecond),
+	)
 )
 
 type inspectCheckFactory func(asOf hlc.Timestamp) inspectCheck
@@ -211,7 +219,7 @@ func (p *inspectProcessor) processSpan(
 ) (err error) {
 	asOfToUse := p.getTimestampForSpan()
 
-	// Only create checks that apply to this span
+	// Only create checks that apply to this span.
 	var checks []inspectCheck
 	for _, factory := range p.checkFactories {
 		check := factory(asOfToUse)
@@ -222,11 +230,6 @@ func (p *inspectProcessor) processSpan(
 		if applies {
 			checks = append(checks, check)
 		}
-	}
-
-	// If no checks apply to this span, there's nothing to do
-	if len(checks) == 0 {
-		return nil
 	}
 
 	runner := inspectRunner{
@@ -262,6 +265,11 @@ func (p *inspectProcessor) processSpan(
 				return err
 			}
 		}
+	}
+
+	// Report span completion for checkpointing.
+	if err := p.sendSpanCompletionProgress(ctx, output, span, false /* finished */); err != nil {
+		return err
 	}
 
 	return nil
@@ -303,6 +311,36 @@ func (p *inspectProcessor) getTimestampForSpan() hlc.Timestamp {
 		return p.clock.Now()
 	}
 	return p.spec.InspectDetails.AsOf
+}
+
+// sendSpanCompletionProgress sends progress indicating a span has been completed.
+// This is used for checkpointing to track which spans are done.
+func (p *inspectProcessor) sendSpanCompletionProgress(
+	ctx context.Context, output execinfra.RowReceiver, completedSpan roachpb.Span, finished bool,
+) error {
+	progressMsg := &jobspb.InspectProcessorProgress{
+		ChecksCompleted: 0, // No additional checks completed, just marking span done
+		Finished:        finished,
+	}
+
+	progressAny, err := pbtypes.MarshalAny(progressMsg)
+	if err != nil {
+		return errors.Wrapf(err, "unable to marshal inspect processor progress")
+	}
+
+	meta := &execinfrapb.ProducerMetadata{
+		BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
+			CompletedSpans:  []roachpb.Span{completedSpan}, // Mark this span as completed
+			ProgressDetails: *progressAny,
+			NodeID:          p.flowCtx.NodeID.SQLInstanceID(),
+			FlowID:          p.flowCtx.ID,
+			ProcessorID:     p.processorID,
+			Drained:         finished,
+		},
+	}
+
+	output.Push(nil, meta)
+	return nil
 }
 
 // newInspectProcessor constructs a new inspectProcessor from the given InspectSpec.

--- a/pkg/sql/inspect/progress.go
+++ b/pkg/sql/inspect/progress.go
@@ -7,176 +7,360 @@ package inspect
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobfrontier"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	pbtypes "github.com/gogo/protobuf/types"
 )
 
+// Name for the INSPECT completed spans frontier in jobfrontier.
+const inspectCompletedSpansKey = "inspect_completed_spans"
+
+// inspectProgressTracker tracks INSPECT job progress with span checkpointing.
+// It maintains completed spans to enable job restarts without reprocessing.
+// Progress updates occur at two frequencies: fraction complete updates happen
+// more frequently than full checkpoint updates to minimize writes.
 type inspectProgressTracker struct {
-	job             *jobs.Job
-	totalChecks     int64
-	completedChecks atomic.Int64
+	job                *jobs.Job
+	jobID              jobspb.JobID
+	clock              timeutil.TimeSource
+	checkpointInterval func() time.Duration
+	fractionInterval   func() time.Duration
+	internalDB         isql.DB
 
-	// Update timing
-	fractionInterval time.Duration
-	lastUpdateTime   time.Time
-
-	// Background goroutine management
-	stopper *stop.Stopper
-	mu      struct {
+	mu struct {
 		syncutil.Mutex
-		stopped bool
+		// cachedProgress holds the latest progress update from processors.
+		cachedProgress *jobspb.Progress
+		// completedSpans tracks all completed spans with automatic deduplication.
+		completedSpans roachpb.SpanGroup
+	}
+
+	// Goroutine management.
+	stopFunc func()
+}
+
+func newInspectProgressTracker(
+	job *jobs.Job, sv *settings.Values, internalDB isql.DB,
+) *inspectProgressTracker {
+	return &inspectProgressTracker{
+		job:                job,
+		jobID:              job.ID(),
+		clock:              timeutil.DefaultTimeSource{},
+		fractionInterval:   func() time.Duration { return fractionUpdateInterval.Get(sv) },
+		checkpointInterval: func() time.Duration { return checkpointInterval.Get(sv) },
+		internalDB:         internalDB,
 	}
 }
 
-// initJobProgress initializes the job progress to 0% completed.
-func (p *inspectProgressTracker) initJobProgress(ctx context.Context, totalCheckCount int64) error {
-	p.totalChecks = totalCheckCount
-	// TODO(148297): when we have checkpointing, we should load existing progress here
-	// and not reset it to 0 if the job is resuming.
-	p.completedChecks.Store(0)
+// loadCompletedSpansFromStorage loads completed spans from jobfrontier.
+func (t *inspectProgressTracker) loadCompletedSpansFromStorage(
+	ctx context.Context,
+) ([]roachpb.Span, error) {
+	var completedSpans []roachpb.Span
 
-	return p.job.NoTxn().Update(ctx,
-		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-			progress := md.Progress
-			progress.Progress = &jobspb.Progress_FractionCompleted{
-				FractionCompleted: 0,
-			}
-			progress.Details = &jobspb.Progress_Inspect{
-				Inspect: &jobspb.InspectProgress{
-					JobTotalCheckCount:     totalCheckCount,
-					JobCompletedCheckCount: 0,
-				},
-			}
-			ju.UpdateProgress(progress)
-			return nil
-		},
-	)
+	err := t.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		resolvedSpans, found, err := jobfrontier.GetResolvedSpans(ctx, txn, t.jobID, inspectCompletedSpansKey)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return nil // No completed spans stored yet
+		}
+
+		// Extract just the spans (we don't care about timestamps for INSPECT).
+		completedSpans = make([]roachpb.Span, len(resolvedSpans))
+		for i, rs := range resolvedSpans {
+			completedSpans[i] = rs.Span
+		}
+		return nil
+	})
+
+	return completedSpans, err
 }
 
-// handleProcessorProgress processes processor progress metadata and updates the job progress.
-func (p *inspectProgressTracker) handleProcessorProgress(
+// initTracker sets up the progress tracker and returns completed spans from any previous
+// job execution. This should be called before planning to enable span optimization.
+func (t *inspectProgressTracker) initTracker(ctx context.Context) ([]roachpb.Span, error) {
+	completedSpans, err := t.loadCompletedSpansFromStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add loaded spans to our cached SpanGroup.
+	if len(completedSpans) > 0 {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		t.mu.completedSpans.Add(completedSpans...)
+		log.Dev.Infof(ctx, "INSPECT job restarting with %d existing completed spans", len(completedSpans))
+	}
+
+	return completedSpans, nil
+}
+
+// initJobProgress writes the initial job progress to the job record with the correct
+// check counts determined after planning. This should be called after planning.
+func (t *inspectProgressTracker) initJobProgress(
+	ctx context.Context, totalCheckCount int64, completedCheckCount int64,
+) error {
+	inspectProgress := &jobspb.InspectProgress{
+		JobTotalCheckCount:     totalCheckCount,
+		JobCompletedCheckCount: completedCheckCount,
+	}
+
+	// Calculate initial fraction complete based on check counts.
+	var fractionComplete float32
+	if totalCheckCount > 0 {
+		fractionComplete = float32(completedCheckCount) / float32(totalCheckCount)
+	}
+
+	progress := &jobspb.Progress{
+		Details: &jobspb.Progress_Inspect{Inspect: inspectProgress},
+		Progress: &jobspb.Progress_FractionCompleted{
+			FractionCompleted: fractionComplete,
+		},
+	}
+
+	func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		t.mu.cachedProgress = progress
+	}()
+	if err := t.flushProgress(ctx); err != nil {
+		return err
+	}
+
+	// Start the progress update goroutines.
+	t.stopFunc = t.startPeriodicUpdates(ctx)
+	return nil
+}
+
+// handleProgressUpdate handles incoming processor metadata and performs any necessary
+// job updates. Determines how to handle the update (immediate vs deferred).
+func (t *inspectProgressTracker) handleProgressUpdate(
 	ctx context.Context, meta *execinfrapb.ProducerMetadata,
 ) error {
+	needsImmediatePersistence, err := t.updateProgressCache(meta)
+	if err != nil {
+		return err
+	}
+
+	// If updateProgressCache returned true (indicating immediate persistence needed),
+	// flush the progress to storage. This happens when a processor signals completion (Drained=true).
+	if needsImmediatePersistence {
+		// Checkpoints are stored separately from general progress, so we need to
+		// flush them separately.
+		if err := t.flushCheckpointUpdate(ctx); err != nil {
+			return err
+		}
+		if err := t.flushProgress(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Otherwise, the background goroutines will handle the persistence
+	return nil
+}
+
+// updateProgressCache computes updated job progress from processor metadata and updates
+// the internal cache. Returns true when immediate persistence is needed.
+func (t *inspectProgressTracker) updateProgressCache(
+	meta *execinfrapb.ProducerMetadata,
+) (bool, error) {
 	if meta.BulkProcessorProgress == nil {
-		return nil
+		return false, nil
 	}
 
 	var incomingProcProgress jobspb.InspectProcessorProgress
 	if err := pbtypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &incomingProcProgress); err != nil {
-		return errors.Wrapf(err, "unable to unmarshal inspect progress details")
+		return false, errors.Wrapf(err, "unable to unmarshal inspect progress details")
 	}
 
-	// Update completed checks count
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.mu.cachedProgress == nil {
+		return false, errors.AssertionFailedf("progress not initialized")
+	}
+
+	orig := t.mu.cachedProgress.GetInspect()
+	if orig == nil {
+		return false, errors.AssertionFailedf("cached progress does not contain Inspect details")
+	}
+	inspectProgress := protoutil.Clone(orig).(*jobspb.InspectProgress)
+
+	// The CompletedSpans in the progress message is the delta of spans
+	// completed since the last progress update. Add them to our SpanGroup for
+	// automatic deduplication and merging.
+	if len(meta.BulkProcessorProgress.CompletedSpans) > 0 {
+		t.mu.completedSpans.Add(meta.BulkProcessorProgress.CompletedSpans...)
+	}
+
+	// Update check count.
 	if incomingProcProgress.ChecksCompleted > 0 {
-		newCompleted := p.completedChecks.Add(incomingProcProgress.ChecksCompleted)
-		log.Dev.Infof(ctx, "INSPECT progress: %d/%d checks completed", newCompleted, p.totalChecks)
+		inspectProgress.JobCompletedCheckCount += incomingProcProgress.ChecksCompleted
 	}
 
-	// If processor is finished, update job progress immediately
-	if incomingProcProgress.Finished {
-		return p.updateJobProgress(ctx)
-	}
-
-	return nil
-}
-
-// updateJobProgress writes the current progress fraction to the job table.
-func (p *inspectProgressTracker) updateJobProgress(ctx context.Context) error {
-	completed := p.completedChecks.Load()
-	var fraction float32 = 0
-	if p.totalChecks > 0 {
-		fraction = float32(completed) / float32(p.totalChecks)
-	}
-
-	if fraction > 1.0 {
-		return errors.AssertionFailedf("progress fraction %.2f exceeds 1.0 (completed=%d, total=%d)",
-			fraction, completed, p.totalChecks)
-	}
-
-	err := p.job.NoTxn().Update(ctx,
-		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-			progress := md.Progress
-			progress.Progress = &jobspb.Progress_FractionCompleted{
-				FractionCompleted: fraction,
-			}
-			if inspectDetails, ok := progress.Details.(*jobspb.Progress_Inspect); ok {
-				inspectDetails.Inspect.JobCompletedCheckCount = completed
-			}
-			ju.UpdateProgress(progress)
-			return nil
+	// Update cached progress - the goroutine will handle actual persistence.
+	t.mu.cachedProgress = &jobspb.Progress{
+		Details: &jobspb.Progress_Inspect{
+			Inspect: inspectProgress,
 		},
-	)
-
-	if err == nil {
-		p.lastUpdateTime = timeutil.Now()
-		log.Dev.Infof(ctx, "INSPECT progress updated: %.2f%% (%d/%d checks)",
-			fraction*100, completed, p.totalChecks)
 	}
 
-	return err
+	// If the incoming progress indicates the processor is drained, we tell the
+	// caller that progress needs to be written immediately. This ensures we
+	// capture the final state when a processor completes its work, rather than
+	// waiting for the next periodic checkpoint update.
+	return meta.BulkProcessorProgress.Drained, nil
 }
 
-// startBackgroundUpdates launches a background goroutine that periodically updates job progress.
-func (p *inspectProgressTracker) startBackgroundUpdates(ctx context.Context) {
-	_ = p.stopper.RunAsyncTask(ctx, "inspect-progress-updater", func(ctx context.Context) {
-		ticker := time.NewTicker(p.fractionInterval)
-		defer ticker.Stop()
+// terminateTracker performs any necessary cleanup when the job completes or fails.
+func (t *inspectProgressTracker) terminateTracker() {
+	if t.stopFunc != nil {
+		t.stopFunc()
+		t.stopFunc = nil
+	}
+}
 
+// startPeriodicUpdates launches background goroutines to periodically flush
+// progress updates at different intervals. Returns a stop function to terminate
+// the goroutines and wait for their completion.
+func (t *inspectProgressTracker) startPeriodicUpdates(ctx context.Context) (stop func()) {
+	stopCh := make(chan struct{})
+	runPeriodicWrite := func(
+		ctx context.Context,
+		write func(context.Context) error,
+		interval func() time.Duration,
+	) error {
+		timer := t.clock.NewTimer()
+		defer timer.Stop()
 		for {
+			timer.Reset(interval())
 			select {
+			case <-stopCh:
+				return nil
 			case <-ctx.Done():
-				return
-			case <-p.stopper.ShouldQuiesce():
-				return
-			case <-ticker.C:
-				p.mu.Lock()
-				stopped := p.mu.stopped
-				p.mu.Unlock()
-
-				if stopped {
-					return
-				}
-
-				if err := p.updateJobProgress(ctx); err != nil {
-					log.Dev.Warningf(ctx, "failed to update INSPECT progress: %v", err)
+				return ctx.Err()
+			case <-timer.Ch():
+				if err := write(ctx); err != nil {
+					log.Dev.Warningf(ctx, "could not flush progress: %v", err)
 				}
 			}
 		}
+	}
+
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		return runPeriodicWrite(
+			ctx, t.flushProgress, t.fractionInterval)
+	})
+	g.GoCtx(func(ctx context.Context) error {
+		return runPeriodicWrite(
+			ctx, t.flushCheckpointUpdate, t.checkpointInterval)
+	})
+
+	toClose := stopCh // make the returned function idempotent
+	return func() {
+		if toClose != nil {
+			close(toClose)
+			toClose = nil
+		}
+		if err := g.Wait(); err != nil {
+			log.Dev.Warningf(ctx, "waiting for progress flushing goroutines: %v", err)
+		}
+	}
+}
+
+// flushProgress updates the complete progress including processor details and fraction complete.
+func (t *inspectProgressTracker) flushProgress(ctx context.Context) error {
+	if t.job == nil { // Job can be nil for tests.
+		return nil
+	}
+
+	var cachedInspectProgress *jobspb.InspectProgress
+	func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		cachedInspectProgress = t.mu.cachedProgress.GetInspect()
+	}()
+
+	// Calculate fraction complete based on check counts from cached progress.
+	var fractionComplete float32
+	if cachedInspectProgress.JobTotalCheckCount > 0 {
+		fractionComplete = float32(cachedInspectProgress.JobCompletedCheckCount) / float32(cachedInspectProgress.JobTotalCheckCount)
+	}
+
+	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		newProgress := &jobspb.Progress{
+			Details: &jobspb.Progress_Inspect{
+				Inspect: cachedInspectProgress,
+			},
+			Progress: &jobspb.Progress_FractionCompleted{
+				FractionCompleted: fractionComplete,
+			},
+		}
+		ju.UpdateProgress(newProgress)
+		return nil
 	})
 }
 
-// terminateTracker stops the background progress update goroutine.
-func (p *inspectProgressTracker) terminateTracker(ctx context.Context) {
-	p.mu.Lock()
-	p.mu.stopped = true
-	p.mu.Unlock()
+// flushCheckpointUpdate performs a progress update to include completed spans.
+// The completed spans are stored via jobfrontier.
+func (t *inspectProgressTracker) flushCheckpointUpdate(ctx context.Context) error {
+	var completedSpans []roachpb.Span
+	func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		completedSpans = t.mu.completedSpans.Slice()
+	}()
 
-	p.stopper.Stop(ctx)
+	// If no completed spans, nothing to store.
+	if len(completedSpans) == 0 {
+		return nil
+	}
+
+	return t.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		// Create a frontier for the spans (using zero timestamps since INSPECT doesn't need timing).
+		frontier, err := span.MakeFrontier(completedSpans...)
+		if err != nil {
+			return err
+		}
+		defer frontier.Release()
+		return jobfrontier.Store(ctx, txn, t.jobID, inspectCompletedSpansKey, frontier)
+	})
 }
 
-// newInspectProgressTracker creates a new progress tracker for the given job.
-func newInspectProgressTracker(
-	job *jobs.Job, fractionInterval time.Duration,
-) *inspectProgressTracker {
-	return &inspectProgressTracker{
-		job:              job,
-		fractionInterval: fractionInterval,
-		lastUpdateTime:   timeutil.Now(),
-		stopper:          stop.NewStopper(),
+// getCachedCheckCounts returns the current cached check counts (total and completed).
+// This is useful for testing to verify progress state without accessing the mutex directly.
+func (t *inspectProgressTracker) getCachedCheckCounts() (totalChecks int64, completedChecks int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.mu.cachedProgress == nil {
+		return 0, 0
 	}
+
+	inspectProgress := t.mu.cachedProgress.GetInspect()
+	if inspectProgress == nil {
+		return 0, 0
+	}
+
+	return inspectProgress.JobTotalCheckCount, inspectProgress.JobCompletedCheckCount
 }
 
 // countApplicableChecks determines how many checks will actually run across all spans.

--- a/pkg/sql/inspect/progress_test.go
+++ b/pkg/sql/inspect/progress_test.go
@@ -8,27 +8,31 @@ package inspect
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobfrontier"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 )
 
-func TestInspectProgressTracker(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
+// setupProgressTestInfra creates common test infrastructure for progress tracking tests.
+func setupProgressTestInfra(
+	t *testing.T,
+) (context.Context, serverutils.TestServerInterface, *jobs.Registry, *jobs.Job, func()) {
+	t.Helper()
 
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
 
 	registry := s.JobRegistry().(*jobs.Registry)
 
@@ -40,7 +44,24 @@ func TestInspectProgressTracker(t *testing.T) {
 	}
 
 	job, err := registry.CreateJobWithTxn(ctx, record, registry.MakeJobID(), nil /* txn */)
-	require.NoError(t, err)
+	if err != nil {
+		s.Stopper().Stop(ctx)   // Clean up server if job creation fails
+		require.NoError(t, err) // This will fail the test
+	}
+
+	cleanup := func() {
+		s.Stopper().Stop(ctx)
+	}
+
+	return ctx, s, registry, job, cleanup
+}
+
+func TestInspectProgressTracker_CheckCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, s, _, job, cleanup := setupProgressTestInfra(t)
+	defer cleanup()
 
 	testCases := []struct {
 		name                      string
@@ -89,46 +110,36 @@ func TestInspectProgressTracker(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create progress tracker
-			tracker := newInspectProgressTracker(job, time.Minute)
-			defer tracker.terminateTracker(ctx)
+			tracker := newInspectProgressTracker(job, &s.ClusterSettings().SV, s.InternalDB().(isql.DB))
+			defer tracker.terminateTracker()
 
 			// Initialize job progress
-			err := tracker.initJobProgress(ctx, tc.totalCheckCount)
+			err := tracker.initJobProgress(ctx, tc.totalCheckCount, 0 /* completedCheckCount */)
 			require.NoError(t, err)
 
 			// Verify initial internal state
-			require.Equal(t, tc.totalCheckCount, tracker.totalChecks)
-			require.Equal(t, int64(0), tracker.completedChecks.Load())
+			totalChecks, completedChecks := tracker.getCachedCheckCounts()
+			require.Equal(t, tc.totalCheckCount, totalChecks)
+			require.Equal(t, int64(0), completedChecks)
 
 			// Simulate processor progress updates
 			for i, checksCompleted := range tc.progressUpdates {
-				// Create processor progress metadata like the real processor does
-				progressMsg := &jobspb.InspectProcessorProgress{
-					ChecksCompleted: checksCompleted,
-					Finished:        i == len(tc.progressUpdates)-1, // Last update is finished
-				}
-
-				progressAny, err := pbtypes.MarshalAny(progressMsg)
+				meta, err := createProcessorProgressUpdate(
+					checksCompleted,
+					i == len(tc.progressUpdates)-1, // Last update is finished
+					nil,                            // No completed spans for this test
+				)
 				require.NoError(t, err)
 
-				meta := &execinfrapb.ProducerMetadata{
-					BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
-						ProgressDetails: *progressAny,
-						NodeID:          1, // Test node ID
-						FlowID:          execinfrapb.FlowID{},
-						ProcessorID:     int32(i),
-						Drained:         i == len(tc.progressUpdates)-1,
-					},
-				}
-
 				// Handle the processor progress update
-				err = tracker.handleProcessorProgress(ctx, meta)
+				err = tracker.handleProgressUpdate(ctx, meta)
 				require.NoError(t, err)
 			}
 
 			// Verify final internal state
-			require.Equal(t, tc.totalCheckCount, tracker.totalChecks)
-			require.Equal(t, tc.expectedCompletedChecks, tracker.completedChecks.Load())
+			totalChecks, completedChecks = tracker.getCachedCheckCounts()
+			require.Equal(t, tc.totalCheckCount, totalChecks)
+			require.Equal(t, tc.expectedCompletedChecks, completedChecks)
 
 			// Verify job progress was updated correctly
 			progress := job.Progress()
@@ -147,4 +158,282 @@ func TestInspectProgressTracker(t *testing.T) {
 			require.Equal(t, tc.expectedCompletedChecks, inspectProgress.Inspect.JobCompletedCheckCount)
 		})
 	}
+}
+
+// progressUpdate represents a processor progress update for testing.
+type progressUpdate struct {
+	checksCompleted int64
+	finished        bool
+	completedSpans  []roachpb.Span
+}
+
+func TestInspectProgressTracker_SpanCheckpointing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, s, registry, _, cleanup := setupProgressTestInfra(t)
+	defer cleanup()
+
+	testCases := []struct {
+		name            string
+		progressUpdates []progressUpdate
+		expectStored    bool
+		expectFullCover bool // whether spans should cover the full table span
+		expectSpanCount int  // exact number of spans we expect stored
+	}{
+		{
+			name: "no completed spans",
+			progressUpdates: []progressUpdate{
+				{0, false, nil},
+			},
+			expectStored:    false,
+			expectFullCover: false,
+			expectSpanCount: 0,
+		},
+		{
+			name: "single span completion",
+			progressUpdates: []progressUpdate{
+				{5, true, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")}}},
+			},
+			expectStored:    true,
+			expectFullCover: false,
+			expectSpanCount: 1,
+		},
+		{
+			name: "adjacent spans that merge",
+			progressUpdates: []progressUpdate{
+				{5, false, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")}}},
+				{5, true, []roachpb.Span{{Key: roachpb.Key("m"), EndKey: roachpb.Key("z")}}},
+			},
+			expectStored:    true,
+			expectFullCover: true,
+			expectSpanCount: 1, // Should merge into 1 span
+		},
+		{
+			name: "non-adjacent spans",
+			progressUpdates: []progressUpdate{
+				{3, false, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")}}},
+				{3, true, []roachpb.Span{{Key: roachpb.Key("x"), EndKey: roachpb.Key("z")}}},
+			},
+			expectStored:    true,
+			expectFullCover: false,
+			expectSpanCount: 2, // Should remain separate
+		},
+		{
+			name: "overlapping spans",
+			progressUpdates: []progressUpdate{
+				{4, false, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("n")}}},
+				{4, true, []roachpb.Span{{Key: roachpb.Key("j"), EndKey: roachpb.Key("z")}}},
+			},
+			expectStored:    true,
+			expectFullCover: true,
+			expectSpanCount: 1, // Should merge due to overlap
+		},
+		{
+			name: "duplicate spans",
+			progressUpdates: []progressUpdate{
+				{3, false, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")}}},
+				{3, true, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")}}},
+			},
+			expectStored:    true,
+			expectFullCover: false,
+			expectSpanCount: 1, // Should deduplicate
+		},
+		{
+			name: "many small adjacent spans",
+			progressUpdates: []progressUpdate{
+				{1, false, []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")}}},
+				{1, false, []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}},
+				{1, false, []roachpb.Span{{Key: roachpb.Key("e"), EndKey: roachpb.Key("g")}}},
+				{1, true, []roachpb.Span{{Key: roachpb.Key("g"), EndKey: roachpb.Key("z")}}},
+			},
+			expectStored:    true,
+			expectFullCover: true,
+			expectSpanCount: 1, // Should all merge into one span
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			record := jobs.Record{
+				Details:  jobspb.InspectDetails{},
+				Progress: jobspb.InspectProgress{},
+				Username: username.TestUserName(),
+			}
+
+			job, err := registry.CreateJobWithTxn(ctx, record, registry.MakeJobID(), nil /* txn */)
+			require.NoError(t, err)
+
+			// Phase 1: Store spans and verify storage.
+			tracker1 := newInspectProgressTracker(job, &s.ClusterSettings().SV, s.InternalDB().(isql.DB))
+			defer tracker1.terminateTracker()
+
+			// Initialize job progress.
+			err = tracker1.initJobProgress(ctx, 100 /* totalCheckCount */, 0 /* completedCheckCount */)
+			require.NoError(t, err)
+
+			// Send progress updates.
+			for _, update := range tc.progressUpdates {
+				meta, err := createProcessorProgressUpdate(
+					update.checksCompleted,
+					update.finished,
+					update.completedSpans,
+				)
+				require.NoError(t, err)
+
+				err = tracker1.handleProgressUpdate(ctx, meta)
+				require.NoError(t, err)
+			}
+
+			// Verify completed spans are stored (or not) as expected.
+			storedCompletedSpans := verifyStoredSpans(t, ctx, s.InternalDB().(isql.DB), job.ID(), tc.expectStored, tc.expectSpanCount)
+
+			if tc.expectStored && tc.expectFullCover {
+				// Check if completed spans cover the entire table span [a, z).
+				tableSpan := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
+				var spanGroup roachpb.SpanGroup
+				spanGroup.Add(storedCompletedSpans...)
+				mergedSpans := spanGroup.Slice()
+				require.Greater(t, len(mergedSpans), 0)
+
+				// Find the overall span covered by completed spans.
+				overallStart := mergedSpans[0].Key
+				overallEnd := mergedSpans[len(mergedSpans)-1].EndKey
+				actualCoverage := roachpb.Span{Key: overallStart, EndKey: overallEnd}
+
+				require.True(t, actualCoverage.Contains(tableSpan),
+					"completed spans should cover entire table span. Expected: %s, Actual coverage: %s", tableSpan, actualCoverage)
+			}
+
+			// Phase 2: Test restart behavior.
+			// Terminate the first tracker to simulate job interruption.
+			tracker1.terminateTracker()
+
+			// Create new tracker and verify it loads completed spans.
+			tracker2 := newInspectProgressTracker(job, &s.ClusterSettings().SV, s.InternalDB().(isql.DB))
+			defer tracker2.terminateTracker()
+
+			// This simulates what would happen during job restart.
+			loadedSpans, err := tracker2.initTracker(ctx)
+			require.NoError(t, err)
+
+			if !tc.expectStored {
+				// For cases with no stored spans, restart should load empty span set.
+				require.Equal(t, 0, len(loadedSpans), "should have loaded no spans when none were stored")
+				return
+			}
+
+			require.Greater(t, len(loadedSpans), 0, "should have loaded completed spans on restart")
+
+			// Verify the loaded spans match what we stored.
+			var loadedSpanGroup roachpb.SpanGroup
+			loadedSpanGroup.Add(loadedSpans...)
+			loadedSpanSlice := loadedSpanGroup.Slice()
+
+			var storedSpanGroup roachpb.SpanGroup
+			storedSpanGroup.Add(storedCompletedSpans...)
+			storedSpanSlice := storedSpanGroup.Slice()
+
+			require.Equal(t, len(storedSpanSlice), len(loadedSpanSlice),
+				"loaded spans should have same coverage as stored spans")
+
+			for i, storedSpan := range storedSpanSlice {
+				require.True(t, loadedSpanSlice[i].Equal(storedSpan),
+					"loaded span %d should match stored span: loaded=%s, stored=%s",
+					i, loadedSpanSlice[i], storedSpan)
+			}
+
+			// Test that these loaded spans would actually filter work.
+			testSpans := []roachpb.Span{
+				{Key: roachpb.Key("a"), EndKey: roachpb.Key("d")}, // May overlap with completed spans
+				{Key: roachpb.Key("x"), EndKey: roachpb.Key("z")}, // May not overlap
+			}
+
+			for _, testSpan := range testSpans {
+				isCompleted := false
+				for _, completedSpan := range loadedSpans {
+					if completedSpan.Contains(testSpan) {
+						isCompleted = true
+						break
+					}
+				}
+
+				if tc.expectFullCover {
+					require.True(t, isCompleted, "span %s should be contained in completed spans for full coverage case", testSpan)
+				}
+			}
+		})
+	}
+}
+
+// verifyStoredSpans verifies that completed spans are stored correctly in jobfrontier
+// and returns the stored spans for further verification.
+func verifyStoredSpans(
+	t *testing.T,
+	ctx context.Context,
+	db isql.DB,
+	jobID jobspb.JobID,
+	expectStored bool,
+	expectSpanCount int,
+) []roachpb.Span {
+	var storedCompletedSpans []roachpb.Span
+	err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		resolvedSpans, found, err := jobfrontier.GetResolvedSpans(ctx, txn, jobID, inspectCompletedSpansKey)
+		if err != nil {
+			return err
+		}
+		if !found {
+			if expectStored {
+				return errors.New("expected to find inspect spans key")
+			}
+			return nil // No spans expected
+		}
+
+		// Extract just the spans (we don't care about timestamps for INSPECT).
+		storedCompletedSpans = make([]roachpb.Span, len(resolvedSpans))
+		for i, rs := range resolvedSpans {
+			storedCompletedSpans[i] = rs.Span
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	if expectStored {
+		require.Equal(t, expectSpanCount, len(storedCompletedSpans),
+			"expected exactly %d stored spans, got %d", expectSpanCount, len(storedCompletedSpans))
+	} else {
+		require.Equal(t, 0, len(storedCompletedSpans), "expected no stored spans")
+	}
+
+	return storedCompletedSpans
+}
+
+// createProcessorProgressUpdate creates a processor progress update message.
+func createProcessorProgressUpdate(
+	checksCompleted int64, finished bool, completedSpans []roachpb.Span,
+) (*execinfrapb.ProducerMetadata, error) {
+	progressMsg := &jobspb.InspectProcessorProgress{
+		ChecksCompleted: checksCompleted,
+		Finished:        finished,
+	}
+
+	progressAny, err := pbtypes.MarshalAny(progressMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	const testNodeID = 1
+	const testProcessorID = 1
+	meta := &execinfrapb.ProducerMetadata{
+		BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
+			CompletedSpans:  completedSpans,
+			ProgressDetails: *progressAny,
+			NodeID:          testNodeID,
+			FlowID:          execinfrapb.FlowID{},
+			ProcessorID:     testProcessorID,
+			Drained:         finished,
+		},
+	}
+
+	return meta, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #154276.

/cc @cockroachdb/release

---

Previously, INSPECT jobs did not support checkpointing, meaning job restarts would reprocess all data from the beginning. This change adds span based checkpointing to allow jobs to resume from their last completed spans.

Progress is tracked using jobfrontier to store completed spans. On job restart, the resumer loads completed spans and filters them from the work to be done.

Closes #148297

Release note: None

Epic: CRDB-30356

Release justification: required for MVP of INSPECT in 25.4