### PR TITLE
schematelemetry: update object count gauge using table stats

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -273,21 +273,17 @@ func (tc *Collection) IsVersionBumpOfUncommittedDescriptor(id descpb.ID) bool {
 	return tc.uncommitted.versionBumpOnly[id]
 }
 
-// HasUncommittedNewOrDroppedDescriptors returns true if the collection contains
-// any uncommitted descriptors that are newly created or dropped.
-func (tc *Collection) HasUncommittedNewOrDroppedDescriptors() bool {
-	isNewDescriptor := false
-	err := tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
+// CountUncommittedNewOrDroppedDescriptors returns the number of uncommitted
+// descriptors that are newly created or dropped.
+func (tc *Collection) CountUncommittedNewOrDroppedDescriptors() int {
+	count := 0
+	_ = tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
 		if desc.GetVersion() == 1 || desc.Dropped() {
-			isNewDescriptor = true
-			return iterutil.StopIteration()
+			count++
 		}
 		return nil
 	})
-	if err != nil {
-		return false
-	}
-	return isNewDescriptor
+	return count
 }
 
 // HasUncommittedTypes returns true if the Collection contains uncommitted

--- a/pkg/sql/catalog/schematelemetry/BUILD.bazel
+++ b/pkg/sql/catalog/schematelemetry/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/keys",
         "//pkg/scheduledjobs",
         "//pkg/security/username",
         "//pkg/server/telemetry",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4175,11 +4175,10 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			if err := ex.waitForInitialVersionForNewDescriptors(cachedRegions); err != nil {
 				return advanceInfo{}, err
 			}
-		}
-		if ex.extraTxnState.descCollection.CountUncommittedNewOrDroppedDescriptors() > 0 {
+
 			execCfg := ex.planner.ExecCfg()
 			if err := UpdateDescriptorCount(ex.Ctx(), execCfg, execCfg.SchemaChangerMetrics); err != nil {
-				log.Dev.Warningf(ex.Ctx(), "failed to scan descriptor table: %v", err)
+				log.Dev.Warningf(ex.Ctx(), "failed to update descriptor count metric: %v", err)
 			}
 		}
 		fallthrough

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4176,7 +4176,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 				return advanceInfo{}, err
 			}
 		}
-		if ex.extraTxnState.descCollection.HasUncommittedNewOrDroppedDescriptors() {
+		if ex.extraTxnState.descCollection.CountUncommittedNewOrDroppedDescriptors() > 0 {
 			execCfg := ex.planner.ExecCfg()
 			if err := UpdateDescriptorCount(ex.Ctx(), execCfg, execCfg.SchemaChangerMetrics); err != nil {
 				log.Dev.Warningf(ex.Ctx(), "failed to scan descriptor table: %v", err)
@@ -4577,6 +4577,15 @@ func (ex *connExecutor) notifyStatsRefresherOfNewTables(ctx context.Context) {
 			// created/refreshed here.
 			ex.planner.execCfg.StatsRefresher.NotifyMutation(desc, math.MaxInt32 /* rowsAffected */)
 		}
+	}
+	if cnt := ex.extraTxnState.descCollection.CountUncommittedNewOrDroppedDescriptors(); cnt > 0 {
+		// Notify the refresher of a mutation on the system.descriptor table.
+		// We conservatively assume that any transaction which creates or
+		desc, err := ex.extraTxnState.descCollection.ByIDWithLeased(ex.planner.txn).Get().Table(ctx, keys.DescriptorTableID)
+		if err != nil {
+			log.Dev.Warningf(ctx, "failed to fetch descriptor table to refresh stats: %v", err)
+		}
+		ex.planner.execCfg.StatsRefresher.NotifyMutation(desc, cnt)
 	}
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3574,20 +3574,3 @@ func (p *planner) CanCreateCrossDBSequenceRef() error {
 	}
 	return nil
 }
-
-// UpdateDescriptorCount updates our sql.schema_changer.object_count gauge with
-// a fresh count of objects in the system.descriptor table.
-func UpdateDescriptorCount(
-	ctx context.Context, execCfg *ExecutorConfig, metric *SchemaChangerMetrics,
-) error {
-	return DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		row, err := txn.QueryRow(ctx, "sql-schema-changer-object-count", txn.KV(),
-			`SELECT count(*) FROM system.descriptor`)
-		if err != nil {
-			return err
-		}
-		count := *row[0].(*tree.DInt)
-		metric.ObjectCount.Update(int64(count))
-		return nil
-	})
-}

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -1165,6 +1165,9 @@ func TestApproxMaxSchemaObjects(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuress(t, "slow test, requires polling to wait for auto stats job")
+	skip.UnderShort(t, "slow test, requires polling to wait for auto stats job")
+
 	ctx := context.Background()
 
 	// Test with both declarative schema changer modes.
@@ -1177,37 +1180,37 @@ func TestApproxMaxSchemaObjects(t *testing.T) {
 
 			// Configure the declarative schema changer mode.
 			if useDeclarative {
+				tdb.Exec(t, `SET sql.defaults.use_declarative_schema_changer = 'on'`)
 				tdb.Exec(t, `SET use_declarative_schema_changer = 'on'`)
 			} else {
+				tdb.Exec(t, `SET sql.defaults.use_declarative_schema_changer = 'off'`)
 				tdb.Exec(t, `SET use_declarative_schema_changer = 'off'`)
 			}
 
-			// Get the current count of descriptors to set a realistic limit.
-			var currentCount int
-			tdb.QueryRow(t, `SELECT count(*) FROM system.descriptor`).Scan(&currentCount)
+			var maxObjects int
+			updateMaxObjects := func() {
+				// Manually refresh stats.
+				tdb.Exec(t, "ANALYZE system.public.descriptor")
 
-			// Set the limit to be slightly more than current count.
-			maxObjects := currentCount + 5
-			tdb.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING sql.schema.approx_max_object_count = %d`, maxObjects))
+				// Get the current count of descriptors to set a realistic limit.
+				var currentCount int
+				tdb.QueryRow(t, `SELECT count(*) FROM system.descriptor`).Scan(&currentCount)
 
-			// Create a test database and use it.
-			tdb.Exec(t, `CREATE DATABASE testdb`)
-			tdb.Exec(t, `USE testdb`)
+				// Set the limit to be slightly more than current count.
+				maxObjects = currentCount + 1
+				tdb.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING sql.schema.approx_max_object_count = %d`, maxObjects))
+			}
+			updateMaxObjects()
 
 			// Test that different object types are subject to the limit.
 			objectTypes := []string{"table", "database", "schema", "type", "function"}
 			for _, objectType := range objectTypes {
 				t.Run(objectType, func(t *testing.T) {
 					// Increase the limit before each subtest to avoid interference.
-					maxObjects += 10
-					tdb.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING sql.schema.approx_max_object_count = %d`, maxObjects))
-
-					// Try to create objects until we hit the limit.
-					// ANALYZE before starting to ensure stats are fresh.
-					tdb.Exec(t, `ANALYZE system.descriptor`)
+					updateMaxObjects()
 
 					objNum := 0
-					for {
+					testutils.SucceedsWithin(t, func() error {
 						var createStmt string
 						switch objectType {
 						case "table":
@@ -1224,30 +1227,22 @@ func TestApproxMaxSchemaObjects(t *testing.T) {
 
 						_, err := sqlDB.Exec(createStmt)
 						if err != nil {
-							// Check if we got the expected error.
+							// Check if we got the expected error and message.
 							if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
 								if string(pqErr.Code) == pgcode.ConfigurationLimitExceeded.String() {
-									// Verify the error message mentions "approximate maximum".
-									testutils.IsError(err, "would exceed approximate maximum")
-									break
+									if testutils.IsError(err, "would exceed approximate maximum") {
+										return nil
+									}
 								}
 							}
 							// Some other error occurred.
-							t.Fatal(err)
+							return err
 						}
 						objNum++
 
-						// Re-analyze periodically to update stats.
-						if objNum%2 == 0 {
-							tdb.Exec(t, `ANALYZE system.descriptor`)
-						}
-
-						// Safety check: if we created way more objects than expected,
-						// something is wrong.
-						if objNum > 30 {
-							t.Fatalf("created %d %ss without hitting limit (max=%d)", objNum, objectType, maxObjects)
-						}
-					}
+						// Haven't hit the limit yet, keep trying.
+						return errors.Errorf("created %d %ss without hitting limit (max=%d)", objNum, objectType, maxObjects)
+					}, 5*time.Minute)
 				})
 			}
 		})


### PR DESCRIPTION
In order to support larger scales of object counts, we switch away from
using a full table scan on system.descriptors in order to update the
object count gauge.

Instead, we use table stats on system.descriptor now. The
schematelemetry job is updated so it notifies the stats refresher to
keep the stats up to date. Note that the stats refresher is also
notified with a partial count already.

Epic CRDB-48806
Release note: None