### PR TITLE
changefeedccl: fix slow acquisition log message

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -523,13 +523,16 @@ func logSlowAcquisition(
 	return func(ctx context.Context, poolName string, r quotapool.Request, start time.Time) func() {
 		shouldLog := logSlowAcquire.ShouldLog()
 		if shouldLog {
-			log.Changefeed.Warningf(ctx, "have been waiting %s attempting to acquire changefeed quota (buffer=%s)", redact.SafeString(bufType),
-				timeutil.Since(start))
+			log.Changefeed.Warningf(ctx, "have been waiting %s attempting to acquire changefeed quota (buffer=%s)",
+				timeutil.Since(start),
+				redact.SafeString(bufType))
 		}
 
 		return func() {
 			if shouldLog {
-				log.Changefeed.Infof(ctx, "acquired changefeed quota after %s (buffer=%s)", timeutil.Since(start), redact.SafeString(bufType))
+				log.Changefeed.Infof(ctx, "acquired changefeed quota after %s (buffer=%s)",
+					timeutil.Since(start),
+					redact.SafeString(bufType))
 			}
 		}
 	}


### PR DESCRIPTION
Previously,

    have been waiting rangefeed attempting to acquire changefeed quota (buffer=5.000049088s)

Now,

    have been waiting 5.000049088s attempting to acquire changefeed quota (buffer=rangefeed)

It would be nice if the buffer name `rangefeed` was something that indicated that this a buffer that lives in the changefeed, but changing the name impacts the metrics which doesn't seem worth it.

Epic: none
Release note: None