### PR TITLE
release-25.3.3-rc: roachtest: deflake drop/tpcc/w=100,nodes=9

### DIFF
--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -98,6 +98,7 @@ func registerDrop(r registry.Registry) {
 			}
 
 			const stmtTruncate = "TRUNCATE TABLE tpcc.stock"
+			run(false, "ALTER TABLE tpcc.stock SET (schema_locked=false)")
 			run(false, stmtTruncate)
 
 			const stmtDrop = "DROP DATABASE tpcc"


### PR DESCRIPTION
Backport 1/1 commits from #153273 on behalf of @tbg.

----

As of https://github.com/cockroachdb/cockroach/issues/151941, TRUNCATE won't work on locked tables.

Fixes #153236.

Epic: none


----

Fixes #154721
Release justification: test deflake