### PR TITLE
dev-inf: Use pull_request_target for Claude Code review action

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -1,7 +1,7 @@
 name: Claude Code PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize, ready_for_review, reopened, labeled]
 
 jobs:


### PR DESCRIPTION
Previously, the Claude Code PR Review GitHub Action used the pull_request trigger, which runs in the context of the PR branch. This prevents GitHub from injecting OIDC tokens when the PR comes from a forked repository, causing authentication failures with Google Cloud's Workload Identity Federation.

This change updates the workflow to use pull_request_target instead, which runs in the context of the base repository. This allows OIDC tokens to be injected even for fork PRs, enabling authentication with Google Cloud for Vertex AI access.

Our standard git flow requires developers to create PRs from forks, so this change is necessary for the action to function in our development workflow. The workflow is safe to run with pull_request_target because it does not check out the PR branch - all PR content is fetched safely via the GitHub API using 'gh pr diff' and 'gh pr view'.

Release note: None

Epic: None