### PR TITLE
dbconsole: custom metrics update when units change

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -316,7 +316,7 @@ export class CustomChart extends React.Component<
     return (
       <MetricsDataProvider
         id={`debug-custom-chart.${index}`}
-        key={index}
+        key={`${index}-${units}`}
         setMetricsFixedWindow={this.props.setMetricsFixedWindow}
         setTimeScale={this.props.setTimeScale}
         history={this.props.history}


### PR DESCRIPTION
This fixes a long-standing bug in which changing the axis units fails to update the graph unless you also make some other change.

This PR was generated by Claude Code.

I asked it to write a test and it produced something with enough mocks that I wasn't sure on the value.

I have manually tested this and have confirmed it does result in custom graphs being updated immediately when the axis units are changed.

Epic: none
Release note: None