### PR TITLE
release-25.4: sql: update stats for descriptor table

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -273,21 +273,17 @@ func (tc *Collection) IsVersionBumpOfUncommittedDescriptor(id descpb.ID) bool {
 	return tc.uncommitted.versionBumpOnly[id]
 }
 
-// HasUncommittedNewOrDroppedDescriptors returns true if the collection contains
-// any uncommitted descriptors that are newly created or dropped.
-func (tc *Collection) HasUncommittedNewOrDroppedDescriptors() bool {
-	isNewDescriptor := false
-	err := tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
+// CountUncommittedNewOrDroppedDescriptors returns the number of uncommitted
+// descriptors that are newly created or dropped.
+func (tc *Collection) CountUncommittedNewOrDroppedDescriptors() int {
+	count := 0
+	_ = tc.uncommitted.iterateUncommittedByID(func(desc catalog.Descriptor) error {
 		if desc.GetVersion() == 1 || desc.Dropped() {
-			isNewDescriptor = true
-			return iterutil.StopIteration()
+			count++
 		}
 		return nil
 	})
-	if err != nil {
-		return false
-	}
-	return isNewDescriptor
+	return count
 }
 
 // HasUncommittedTypes returns true if the Collection contains uncommitted

--- a/pkg/sql/catalog/schematelemetry/BUILD.bazel
+++ b/pkg/sql/catalog/schematelemetry/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/keys",
         "//pkg/scheduledjobs",
         "//pkg/security/username",
         "//pkg/server/telemetry",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4167,7 +4167,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 				return advanceInfo{}, err
 			}
 		}
-		if ex.extraTxnState.descCollection.HasUncommittedNewOrDroppedDescriptors() {
+		if ex.extraTxnState.descCollection.CountUncommittedNewOrDroppedDescriptors() > 0 {
 			execCfg := ex.planner.ExecCfg()
 			if err := UpdateDescriptorCount(ex.Ctx(), execCfg, execCfg.SchemaChangerMetrics); err != nil {
 				log.Dev.Warningf(ex.Ctx(), "failed to scan descriptor table: %v", err)
@@ -4568,6 +4568,16 @@ func (ex *connExecutor) notifyStatsRefresherOfNewTables(ctx context.Context) {
 			// created/refreshed here.
 			ex.planner.execCfg.StatsRefresher.NotifyMutation(desc, math.MaxInt32 /* rowsAffected */)
 		}
+	}
+	if cnt := ex.extraTxnState.descCollection.CountUncommittedNewOrDroppedDescriptors(); cnt > 0 {
+		// Notify the refresher of a mutation on the system.descriptor table.
+		// We conservatively assume that any transaction which creates or
+		desc, err := ex.extraTxnState.descCollection.ByIDWithLeased(ex.planner.txn).Get().Table(ctx, keys.DescriptorTableID)
+		if err != nil {
+			log.Dev.Warningf(ctx, "failed to fetch descriptor table to refresh stats: %v", err)
+			return
+		}
+		ex.planner.execCfg.StatsRefresher.NotifyMutation(desc, cnt)
 	}
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4166,11 +4166,10 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			if err := ex.waitForInitialVersionForNewDescriptors(cachedRegions); err != nil {
 				return advanceInfo{}, err
 			}
-		}
-		if ex.extraTxnState.descCollection.CountUncommittedNewOrDroppedDescriptors() > 0 {
+
 			execCfg := ex.planner.ExecCfg()
 			if err := UpdateDescriptorCount(ex.Ctx(), execCfg, execCfg.SchemaChangerMetrics); err != nil {
-				log.Dev.Warningf(ex.Ctx(), "failed to scan descriptor table: %v", err)
+				log.Dev.Warningf(ex.Ctx(), "failed to update descriptor count metric: %v", err)
 			}
 		}
 		fallthrough

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3574,20 +3574,3 @@ func (p *planner) CanCreateCrossDBSequenceRef() error {
 	}
 	return nil
 }
-
-// UpdateDescriptorCount updates our sql.schema_changer.object_count gauge with
-// a fresh count of objects in the system.descriptor table.
-func UpdateDescriptorCount(
-	ctx context.Context, execCfg *ExecutorConfig, metric *SchemaChangerMetrics,
-) error {
-	return DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		row, err := txn.QueryRow(ctx, "sql-schema-changer-object-count", txn.KV(),
-			`SELECT count(*) FROM system.descriptor`)
-		if err != nil {
-			return err
-		}
-		count := *row[0].(*tree.DInt)
-		metric.ObjectCount.Update(int64(count))
-		return nil
-	})
-}


### PR DESCRIPTION
Backport 2/2 commits from #154711 on behalf of @rafiss.

----

This is needed in order to enforce the
sql.schema.approx_max_object_count cluster setting, which relies on optimizer table statistics to find the count.

Since the schemachanger uses the KV API to write to the descriptor table, we need to explicitly notify the stats refresher when it should compute new stats for the table.

informs: https://github.com/cockroachdb/cockroach/issues/148286
Release note: None

###  schematelemetry: update object count gauge using table stats

In order to support larger scales of object counts, we switch away from
using a full table scan on system.descriptors in order to update the
object count gauge.

Instead, we use table stats on system.descriptor now. The
schematelemetry job is updated so it notifies the stats refresher to
keep the stats up to date. Note that the stats refresher is also
notified with a partial count already.

Epic CRDB-48806
Release note: None

----

Release justification: resolve GA blocker