### PR TITLE
release-25.2: workflows: update names of GitHub Action runner groups

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -53,7 +53,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   acceptance:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   check_generated_code:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   docker_image_amd64:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -110,7 +110,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   examples_orms:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
         run: ./cockroach/build/github/cleanup-engflow-keys.sh
         if: always()
   lint:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   local_roachtest:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   local_roachtest_fips:
-    runs-on: [self-hosted, basic_runner_group_fips]
+    runs-on: [self-hosted, ubuntu_2004_fips]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -205,7 +205,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   linux_amd64_build:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -226,7 +226,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   linux_amd64_fips_build:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -247,7 +247,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   unit_tests:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   base:
     name: build merge base
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     outputs:
       merge_base: ${{ steps.build.outputs.merge_base }}
@@ -32,7 +32,7 @@ jobs:
           pkg: ${{ env.PACKAGE }}
   head:
     name: build head
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
           ref: head
           pkg: ${{ env.PACKAGE }}
   run-group-1:
-    runs-on: [self-hosted, basic_microbench_runner_group]
+    runs-on: [self-hosted, ubuntu_2004_microbench]
     timeout-minutes: 60
     needs: [base, head]
     steps:
@@ -57,7 +57,7 @@ jobs:
           pkg: ${{ env.PACKAGE }}
           group: 1
   run-group-2:
-    runs-on: [self-hosted, basic_microbench_runner_group]
+    runs-on: [self-hosted, ubuntu_2004_microbench]
     timeout-minutes: 60
     needs: [base, head]
     steps:
@@ -70,7 +70,7 @@ jobs:
           pkg: ${{ env.PACKAGE }}
           group: 2
   compare:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     needs: [base, run-group-1, run-group-2]
     steps:


### PR DESCRIPTION
Backport 1/1 commits from #154698 on behalf of @rickystewart.

----

These are the new-style names that will make it easier to migrate to Ubuntu 22.04+ when the time comes.

----

Release justification: Non-production code changes