### PR TITLE
release-25.4: external connection: deflake privs test

### DIFF
--- a/pkg/ccl/cloudccl/externalconn/testdata/privileges_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/privileges_external_connection
@@ -63,11 +63,11 @@ GRANT DROP ON EXTERNAL CONNECTION "drop-privileged" TO testuser;
 
 # Verify that the privileges exist.
 query-sql
-SELECT * FROM system.privileges
+SELECT username, path, privileges  FROM system.privileges order by user_id
 ----
-root /externalconn/drop-privileged {ALL} {} 1
-root /externalconn/drop-privileged-dup {ALL} {} 1
-testuser /externalconn/drop-privileged {DROP} {} 100
+root /externalconn/drop-privileged {ALL}
+root /externalconn/drop-privileged-dup {ALL}
+testuser /externalconn/drop-privileged {DROP}
 
 exec-sql user=testuser
 DROP EXTERNAL CONNECTION "drop-privileged"
@@ -131,11 +131,11 @@ CREATE EXTERNAL CONNECTION 'not-root' AS 'userfile:///bar'
 
 # Verify that the privileges exist.
 query-sql
-SELECT * FROM system.privileges
+SELECT username, path, privileges FROM system.privileges order by user_id
 ----
-root /externalconn/root {ALL} {} 1
-testuser /externalconn/not-root {ALL} {} 101
-testuser /global/ {EXTERNALCONNECTION} {} 101
+root /externalconn/root {ALL}
+testuser /externalconn/not-root {ALL}
+testuser /global/ {EXTERNALCONNECTION}
 
 exec-sql user=testuser
 BACKUP TABLE foo INTO 'external://not-root'


### PR DESCRIPTION
Backport 1/1 commits from #154201.

/cc @cockroachdb/release

---

Informs #154141

Release note: none
