### PR TITLE
release-25.3.3-rc: roachtest: disable create_table_with_schema_locked for ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -77,6 +77,7 @@ func alterZoneConfigAndClusterSettings(
 		`ALTER ROLE ALL SET statement_timeout = '60s'`,
 		`ALTER ROLE ALL SET default_transaction_isolation = 'read committed'`,
 		`ALTER ROLE ALL SET autocommit_before_ddl = 'true'`,
+		`ALTER ROLE ALL SET create_table_with_schema_locked = 'false'`,
 	} {
 		if _, err := db.ExecContext(ctx, cmd); err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #154731 on behalf of @fqazi.

----

Previously, create_table_with_schema_locked was implicitly disabled in
the ORM tests by unsetting it. Unfortunately, the CI environment uses
builds with assertions enabled, which enables this setting by default.
To address this, this patch explicitly disables
create_table_with_schema_locked for ORM tests.

Fixes: #154626
Release note: None
Release justification: test only change

----

Release justification: test only change