### PR TITLE
util: prioritize cancellations in retry loop

### DIFF
--- a/pkg/util/retry/BUILD.bazel
+++ b/pkg/util/retry/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
     ],
     embed = [":retry"],
     deps = [
-        "//pkg/testutils/skip",
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -172,6 +172,15 @@ func (r *Retry) Next() bool {
 		return false
 	}
 
+	// Check for cancellation first to prioritize over timer.
+	select {
+	case <-r.opts.Closer:
+		return false
+	case <-r.ctx.Done():
+		return false
+	default:
+	}
+
 	backoff, actualWait, shouldAttempt := r.calcDurationScopedBackoff()
 
 	if !shouldAttempt && r.opts.PreemptivelyCancel {


### PR DESCRIPTION
This commit teaches `util.Retry` to prioritize context cancellations and stoppers over retry attempts. This ensures more consistent behaviors and reduces test flakes.

Fixes: #154764

Release note: None