### PR TITLE
dev-inf: Remove track_progress from Claude Code review action

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -33,7 +33,6 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-5-20250929
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
-          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -67,7 +66,6 @@ jobs:
           claude_args: |
             --model claude-4-5-sonnet-20250929
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
-          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -102,7 +100,6 @@ jobs:
           claude_args: |
             --model claude-4-5-sonnet-20250929
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*)"
-          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
The track_progress parameter doesn't support the 'labeled' event type,
and we don't want to spam PR comments with progress updates anyway.
The final results will still be posted as comments, and all progress
is visible in the GitHub Actions logs.


Release note: None
Epic: None