### PR TITLE
roachtest: update liquibase test harness

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -5,16 +5,10 @@
 
 package tests
 
-var liquibaseBlocklist = blocklist{
-	"liquibase.harness.change.ChangeObjectTests.apply addAutoIncrement against cockroachdb 20.2":            "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 20.2":          "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2": "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply alterSequence against cockroachdb 20.2":               "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 20.2":               "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply createSequence against cockroachdb 20.2":              "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 20.2":         "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply dropSequence against cockroachdb 20.2":                "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply renameSequence against cockroachdb 20.2":              "unknown",
-}
+var liquibaseBlocklist = blocklist{}
 
-var liquibaseIgnorelist = blocklist{}
+var liquibaseIgnorelist = blocklist{
+	`liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 24.1`:  "requires enterprise version of liquibase",
+	`liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 24.1`:       "requires enterprise version of liquibase",
+	`liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 24.1`: "requires enterprise version of liquibase",
+}


### PR DESCRIPTION
This resolves an issue where the test started failing because of an outdated java version.

fixes https://github.com/cockroachdb/cockroach/issues/154519
fixes https://github.com/cockroachdb/cockroach/issues/154606
fixes https://github.com/cockroachdb/cockroach/issues/154516
fixes https://github.com/cockroachdb/cockroach/issues/154508
fixes https://github.com/cockroachdb/cockroach/issues/154504
fixes https://github.com/cockroachdb/cockroach/issues/154511

Release note: None