### PR TITLE
rangefeed: explicitly initialize stream status

### DIFF
--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -48,6 +48,7 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 	})
 	t.Run("register 50 streams", func(t *testing.T) {
 		for id := int64(0); id < 50; id++ {
+			sm.RegisteringStream(id)
 			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 				sm.NewStream(id, r1))
@@ -142,6 +143,7 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	evErr.MustSetValue(&kvpb.RangeFeedError{Error: *discErr})
 
 	// Register one stream.
+	sm.RegisteringStream(s1)
 	registered, d, _ := p.Register(ctx, h.span, startTs,
 		makeCatchUpIterator(catchUpIter, span, startTs), /* catchUpIter */
 		true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -132,6 +132,9 @@ func (ubs *UnbufferedSender) sendUnbuffered(event *kvpb.MuxRangeFeedEvent) error
 	return ubs.sender.Send(event)
 }
 
+// addStream implements sender.
+func (ubs *UnbufferedSender) addStream(int64) {}
+
 // removeStream implements sender.
 func (ubs *UnbufferedSender) removeStream(int64) {}
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2307,6 +2307,7 @@ func (n *Node) muxRangeFeed(muxStream kvpb.RPCInternal_MuxRangeFeedStream) error
 			// Disconnector returned can be used to shut down rangefeed from the
 			// stream manager. If rangefeed disconnects with an error after being
 			// successfully registered, it calls streamSink.SendError.
+			sm.RegisteringStream(req.StreamID)
 			if disconnector, err := n.stores.RangeFeed(streamCtx, req, streamSink, limiter); err != nil {
 				// The rangefeed was not registered, so it should be safe to send this
 				// error directly to the stream rather than via the registration.


### PR DESCRIPTION
Since we do have a window after an error where the unbufferedRegistration may send events, here we move to explicit initialization of the stream status to avoid leaking any streamStatus structs.

Epic: none
Release note: None