### PR TITLE
release 25.4: roachtest: remove per-table PTS setting from frontier persistence tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3156,8 +3156,6 @@ CONFIGURE ZONE USING
 						// Disable span-level checkpointing since it's not necessary
 						// when frontier persistence is on.
 						"changefeed.span_checkpoint.interval": "'0'",
-						// Disable per-table PTS to avoid impact on results.
-						"changefeed.protect_timestamp.per_table.enabled": "false",
 					} {
 						stmt := fmt.Sprintf(`SET CLUSTER SETTING %s = %s`, name, value)
 						if _, err := db.ExecContext(ctx, stmt); err != nil {


### PR DESCRIPTION
The per-table PTS setting was removed in an earlier commit but
`cdc/frontier-persistence-benchmark/*` was not updated to reflect this.

Fixes #154812
Fixes #154813
Fixes #154814
Fixes #154815
Fixes #154816
Fixes #154817
Fixes #154818
Fixes #154819
Fixes #154820
Fixes #154821
Fixes #154822
Fixes #154823
Fixes #154824
Fixes #154825
Fixes #154829

Release note: None

---

Release justification: test fix