### PR TITLE
rpc: avoid closing already closed DRPC connection

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -138,8 +138,13 @@ type closeEntirePoolConn struct {
 }
 
 func (c *closeEntirePoolConn) Close() error {
-	_ = c.Conn.Close()
-	return c.pool.Close()
+	select {
+	case <-c.Conn.Closed():
+		return nil // already closed
+	default:
+		_ = c.Conn.Close()
+		return c.pool.Close()
+	}
 }
 
 type DRPCConnection = Connection[drpc.Conn]


### PR DESCRIPTION
Previously, closing an already closed DRPC connection would lead to a panic.
`panic: close of closed channel`

This patch makes the closing of an already closed connection to be a no-op.

Epic: none
Release note: None