### PR TITLE
dev-inf: Use GITHUB_TOKEN for Claude Code review action

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -29,6 +29,7 @@ jobs:
         id: stage1
         uses: cockroachdb/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: "true"
           claude_args: |
             --model claude-sonnet-4-5-20250929
@@ -63,6 +64,7 @@ jobs:
         if: contains(steps.stage1.outputs.result, 'STAGE1_RESULT - POTENTIAL_BUG_DETECTED')
         uses: cockroachdb/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: "true"
           claude_args: |
             --model claude-4-5-sonnet-20250929
@@ -98,6 +100,7 @@ jobs:
         if: contains(steps.stage2.outputs.result, 'STAGE2_RESULT - POTENTIAL_BUG_DETECTED')
         uses: cockroachdb/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: "true"
           claude_args: |
             --model claude-4-5-sonnet-20250929
@@ -147,6 +150,7 @@ jobs:
         if: always()
         uses: cockroachdb/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: "true"
           claude_args: |
             --model claude-4-5-sonnet-20250929


### PR DESCRIPTION
The action's OIDC token exchange is failing, likely because the GitHub
app isn't configured to accept OIDC tokens from this workflow. By
explicitly providing the built-in GITHUB_TOKEN, we bypass the OIDC
exchange entirely.

The built-in token has sufficient permissions for PR analysis and
commenting, which is all this workflow needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)