### PR TITLE
roachprod: fix parse int for grow

### DIFF
--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -166,7 +166,7 @@ be fairly distributed across the zones of the cluster).
 `,
 		Args: cobra.ExactArgs(2),
 		Run: Wrap(func(cmd *cobra.Command, args []string) error {
-			count, err := strconv.ParseInt(args[1], 10, 8)
+			count, err := strconv.ParseInt(args[1], 10, 16)
 			if err != nil || count < 1 {
 				return errors.Wrapf(err, "invalid num-nodes argument")
 			}


### PR DESCRIPTION
Previously, the number of nodes to grow a cluster by was limited to the max of a signed byte. This change increases the limit to a word.

Epic: None
Release note: None