### PR TITLE
kvnemesis: disable DRPC for tests

### DIFF
--- a/pkg/kv/kvnemesis/main_test.go
+++ b/pkg/kv/kvnemesis/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	)()
 
 	defer serverutils.TestingGlobalDRPCOption(
-		base.TestDRPCEnabledRandomly,
+		base.TestDRPCDisabled,
 	)()
 
 	os.Exit(m.Run())


### PR DESCRIPTION
The 'TestKVNemesisMultiNode*' tests are showing flakiness when DRPC is enabled, and this can be reproduced under stress. Until the root cause is found, it's best to disable DRPC for these tests.

Release note: none
Epic: none
Informs: #154847