### PR TITLE
sql/inspect: fix progress tracking bugs causing over 100% completion

### DIFF
--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -114,7 +114,7 @@ func (p *inspectProcessor) Run(ctx context.Context, output execinfra.RowReceiver
 // Each span is read from a buffered channel and passed to processSpan.
 // The function blocks until all spans are processed or an error occurs.
 func (p *inspectProcessor) runInspect(ctx context.Context, output execinfra.RowReceiver) error {
-	log.Dev.Infof(ctx, "INSPECT processor started processorID=%d concurrency=%d", p.processorID, p.concurrency)
+	log.Dev.Infof(ctx, "INSPECT processor started processorID=%d concurrency=%d spans=%d", p.processorID, p.concurrency, len(p.spec.Spans))
 
 	group := ctxgroup.WithContext(ctx)
 
@@ -262,9 +262,6 @@ func (p *inspectProcessor) processSpan(
 		if stepErr != nil {
 			return stepErr
 		}
-		if !ok {
-			break
-		}
 
 		// Check if any inspections have completed (when the count decreases).
 		currentCheckCount := runner.CheckCount()
@@ -274,6 +271,10 @@ func (p *inspectProcessor) processSpan(
 			if err := p.sendInspectProgress(ctx, output, int64(checksCompleted), false /* finished */); err != nil {
 				return err
 			}
+		}
+
+		if !ok {
+			break
 		}
 	}
 


### PR DESCRIPTION
Fix two bugs in INSPECT job progress tracking that caused inaccurate completion percentages, sometimes exceeding 100%.

The first issue was in inspect_processor.go, where processSpan() checked the loop termination condition (!ok) before accounting for the final completed check. When the last check finished we would exit the loop before reporting the final check as complete.

The second issue was in inspect_job.go, where initProgressFromPlan() calculated total checks using PK spans rather than the partitioned spans actually used by processors. The number of total checks that we think need to be complete were much lower than the partitioned spans. This caused us to report completion rates in excess of 100%.

Epic: CRDB-30356

Informs: #154457

Release note: none