### PR TITLE
log: sanitize log migration datadriven tests

### DIFF
--- a/pkg/util/log/migrator_test.go
+++ b/pkg/util/log/migrator_test.go
@@ -185,6 +185,7 @@ func cleanLogEntries(logs []logpb.Entry) []logpb.Entry {
 	for _, l := range logs {
 		l.Time = 0
 		l.Goroutine = 0
+		l.Line = 0
 		newLogs = append(newLogs, l)
 	}
 	return newLogs

--- a/pkg/util/log/testdata/log_migration
+++ b/pkg/util/log/testdata/log_migration
@@ -3,12 +3,12 @@ structured-event should_migrate=true new_channel=OPS
 DEV Channel: 
 []
 OPS Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:74 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:2 Redactable:true Channel:OPS StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:2 Redactable:true Channel:OPS StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
 
 structured-event should_migrate=false new_channel=OPS
 ----
 DEV Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:74 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:5 Redactable:true Channel:DEV StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:5 Redactable:true Channel:DEV StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
 OPS Channel: 
 []
 
@@ -17,12 +17,12 @@ structured-event should_migrate=true new_channel=OPS depth=0
 DEV Channel: 
 []
 OPS Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:72 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:8 Redactable:true Channel:OPS StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:8 Redactable:true Channel:OPS StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
 
 structured-event should_migrate=false new_channel=OPS depth=0
 ----
 DEV Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:72 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:11 Redactable:true Channel:DEV StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:11 Redactable:true Channel:DEV StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
 OPS Channel: 
 []
 
@@ -31,20 +31,20 @@ structured-event should_migrate=true new_channel=OPS depth=1
 DEV Channel: 
 []
 OPS Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:datadriven/datadriven.go Line:119 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:14 Redactable:true Channel:OPS StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:datadriven/datadriven.go Line:0 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:14 Redactable:true Channel:OPS StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
 
 structured-event should_migrate=false new_channel=OPS depth=1
 
 log should_migrate=true old_channel=TELEMETRY new_channel=SQL_EXEC
 ----
 DEV Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:datadriven/datadriven.go Line:119 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:17 Redactable:true Channel:DEV StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:datadriven/datadriven.go Line:0 Message:Structured entry: {"Timestamp":1735689600000000000,"EventType":"test_event"} Tags: Counter:17 Redactable:true Channel:DEV StructuredEnd:76 StructuredStart:18 StackTraceStart:0 TenantID: TenantName:}]
 OPS Channel: 
 []
 
 log should_migrate=false old_channel=TELEMETRY new_channel=SQL_EXEC
 ----
 TELEMETRY Channel: 
-[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:115 Message:‹migration log› Infof Tags: Counter:20 Redactable:true Channel:TELEMETRY StructuredEnd:0 StructuredStart:0 StackTraceStart:0 TenantID: TenantName:} {Severity:WARNING Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:116 Message:‹migration log› Warningf Tags: Counter:21 Redactable:true Channel:TELEMETRY StructuredEnd:0 StructuredStart:0 StackTraceStart:0 TenantID: TenantName:} {Severity:ERROR Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:117 Message:‹migration log› Errorf Tags: Counter:22 Redactable:true Channel:TELEMETRY StructuredEnd:0 StructuredStart:0 StackTraceStart:0 TenantID: TenantName:}]
+[{Severity:INFO Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:‹migration log› Infof Tags: Counter:20 Redactable:true Channel:TELEMETRY StructuredEnd:0 StructuredStart:0 StackTraceStart:0 TenantID: TenantName:} {Severity:WARNING Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:‹migration log› Warningf Tags: Counter:21 Redactable:true Channel:TELEMETRY StructuredEnd:0 StructuredStart:0 StackTraceStart:0 TenantID: TenantName:} {Severity:ERROR Time:0 Goroutine:0 File:util/log_test/migrator_test.go Line:0 Message:‹migration log› Errorf Tags: Counter:22 Redactable:true Channel:TELEMETRY StructuredEnd:0 StructuredStart:0 StackTraceStart:0 TenantID: TenantName:}]
 SQL_EXEC Channel: 
 []


### PR DESCRIPTION
The datadriven tests for log migration allow for an arbitrary depth to be provided, which is used to identify what file and line number a log is being logged from. For the sake of this test, the specific line number is not necessary and makes the test more brittle, especially since it may result in logging the log line from an external library.

To fix, `cleanLogEntries` has been updated to also set the line number in the structured event log output to be 0 for all logs.

Epic: None
Release note: None