### PR TITLE
release-25.4: backfill: skip TestVectorIndexMergingDuringBackfillWithPrefix under duress

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -350,6 +351,8 @@ func TestVectorIndexMergingDuringBackfill(t *testing.T) {
 func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDuress(t, "too slow")
 
 	// Channel to block the backfill process
 	blockBackfill := make(chan struct{})


### PR DESCRIPTION
Backport 1/1 commits from #154868 on behalf of @yuzefovich.

----

We've seen this recently added test time out twice under race with no clear signs of anything going wrong. The test seems just rather intense to be run under any heavy configs, so skip it under duress.

Fixes: #154844.
Release note: None

----

Release justification: test-only change.