### PR TITLE
sql: audit production callers of `rowenc.DatumToEncDatum`

### DIFF
--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -253,8 +253,8 @@ func routingDatumsForSQLInstance(
 	sqlInstanceID base.SQLInstanceID,
 ) (rowenc.EncDatum, rowenc.EncDatum) {
 	routingBytes := roachpb.Key(fmt.Sprintf("node%d", sqlInstanceID))
-	startDatum := rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes)))
-	endDatum := rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes.Next())))
+	startDatum := rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes)))
+	endDatum := rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(routingBytes.Next())))
 	return startDatum, endDatum
 }
 
@@ -399,7 +399,7 @@ func (gssp *generativeSplitAndScatterProcessor) Next() (
 
 		row := rowenc.EncDatumRow{
 			routingDatum,
-			rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(entryBytes))),
+			rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(entryBytes))),
 		}
 		return row, nil
 	}

--- a/pkg/ccl/changefeedccl/avro/avro.go
+++ b/pkg/ccl/changefeedccl/avro/avro.go
@@ -995,7 +995,10 @@ func (r *DataRecord) rowFromNative(native interface{}) (rowenc.EncDatumRow, erro
 		if err != nil {
 			return nil, err
 		}
-		row[r.colIdxByFieldIdx[fieldIdx]] = rowenc.DatumToEncDatum(field.typ, decoded)
+		row[r.colIdxByFieldIdx[fieldIdx]], err = rowenc.DatumToEncDatumEx(field.typ, decoded)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return row, nil
 }

--- a/pkg/ccl/changefeedccl/avro/avro.go
+++ b/pkg/ccl/changefeedccl/avro/avro.go
@@ -995,7 +995,7 @@ func (r *DataRecord) rowFromNative(native interface{}) (rowenc.EncDatumRow, erro
 		if err != nil {
 			return nil, err
 		}
-		row[r.colIdxByFieldIdx[fieldIdx]], err = rowenc.DatumToEncDatumEx(field.typ, decoded)
+		row[r.colIdxByFieldIdx[fieldIdx]], err = rowenc.DatumToEncDatum(field.typ, decoded)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/avro/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro/avro_test.go
@@ -119,7 +119,7 @@ func parseValues(tableDesc catalog.TableDescriptor, values string) ([]rowenc.Enc
 			if err != nil {
 				return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 			}
-			row = append(row, rowenc.DatumToEncDatum(col.GetType(), datum))
+			row = append(row, rowenc.DatumToEncDatumUnsafe(col.GetType(), datum))
 		}
 		rows = append(rows, row)
 	}
@@ -951,8 +951,8 @@ func randEncDatumRow(typ *types.T) rowenc.EncDatumRow {
 	const notNull = false
 	rnd, _ := randutil.NewTestRand()
 	return rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(typ, randgen.RandDatum(rnd, typ, allowNull)),
-		rowenc.DatumToEncDatum(types.Int, randgen.RandDatum(rnd, types.Int, notNull)),
+		rowenc.DatumToEncDatumUnsafe(typ, randgen.RandDatum(rnd, typ, allowNull)),
+		rowenc.DatumToEncDatumUnsafe(types.Int, randgen.RandDatum(rnd, types.Int, notNull)),
 	}
 }
 
@@ -1059,7 +1059,7 @@ func BenchmarkEncodeDecimal(b *testing.B) {
 	d := &tree.DDecimal{}
 	coeff := int64(rand.Uint64()) % 10000
 	d.Decimal.SetFinite(coeff, 2)
-	encRow[0] = rowenc.DatumToEncDatum(typ, d)
+	encRow[0] = rowenc.DatumToEncDatumUnsafe(typ, d)
 	benchmarkEncodeType(b, typ, encRow)
 }
 

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -810,7 +810,7 @@ func TestingMakeEventRowFromDatums(datums tree.Datums) Row {
 	for i, d := range datums {
 		desc.cols = append(desc.cols, ResultColumn{ord: i})
 		desc.valueCols = append(desc.valueCols, i)
-		encRow = append(encRow, rowenc.DatumToEncDatum(d.ResolvedType(), d))
+		encRow = append(encRow, rowenc.DatumToEncDatumUnsafe(d.ResolvedType(), d))
 	}
 	return Row{
 		EventDescriptor: &desc,

--- a/pkg/ccl/changefeedccl/encoder_protobuf_test.go
+++ b/pkg/ccl/changefeedccl/encoder_protobuf_test.go
@@ -158,8 +158,8 @@ func Test_ProtoEncoderAllTypes(t *testing.T) {
 
 			targets := mkTargets(tableDesc)
 			row := cdcevent.TestingMakeEventRow(tableDesc, 0, rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1)),
-				rowenc.DatumToEncDatum(tc.typ, tc.datum),
+				rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(1)),
+				rowenc.DatumToEncDatumUnsafe(tc.typ, tc.datum),
 			}, false)
 
 			opts := changefeedbase.EncodingOptions{Envelope: changefeedbase.OptEnvelopeBare}
@@ -442,7 +442,7 @@ func Test_ProtoEncoder_Escaping(t *testing.T) {
 
 	targets := mkTargets(tableDesc)
 	row := cdcevent.TestingMakeEventRow(tableDesc, 0, rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(types.Int, tree.NewDInt(123)),
+		rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(123)),
 	}, false)
 
 	opts := changefeedbase.EncodingOptions{Envelope: changefeedbase.OptEnvelopeBare}
@@ -470,8 +470,8 @@ func TestProtoEncoder_BareEnvelope_WithMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	encRow := rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1)),
-		rowenc.DatumToEncDatum(types.String, tree.NewDString("Alice")),
+		rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(1)),
+		rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString("Alice")),
 	}
 	row := cdcevent.TestingMakeEventRow(tableDesc, 0, encRow, false)
 

--- a/pkg/ccl/changefeedccl/kcjsonschema/kafka_connect_json_schema_test.go
+++ b/pkg/ccl/changefeedccl/kcjsonschema/kafka_connect_json_schema_test.go
@@ -239,7 +239,7 @@ func parseValues(tableDesc catalog.TableDescriptor, values string) ([]rowenc.Enc
 			if err != nil {
 				return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 			}
-			row = append(row, rowenc.DatumToEncDatum(col.GetType(), datum))
+			row = append(row, rowenc.DatumToEncDatumUnsafe(col.GetType(), datum))
 		}
 		rows = append(rows, row)
 	}

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -376,7 +376,7 @@ func (lrw *logicalReplicationWriterProcessor) Next() (
 				return nil, lrw.DrainHelper()
 			}
 			row := rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(progressBytes))),
+				rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(progressBytes))),
 			}
 			return row, nil
 		} else {

--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -269,7 +269,7 @@ func (o *offlineInitialScanProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.P
 				return nil, o.DrainHelper()
 			}
 			row := rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(progressBytes))),
+				rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(progressBytes))),
 			}
 			return row, nil
 		}

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -532,7 +532,7 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 				return nil, sip.DrainHelper()
 			}
 			row := rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(progressBytes))),
+				rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(progressBytes))),
 			}
 			return row, nil
 		}

--- a/pkg/sql/cloud_check_processor.go
+++ b/pkg/sql/cloud_check_processor.go
@@ -257,15 +257,15 @@ func (p *proc) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 			return nil, p.DrainHelper()
 		}
 		return rowenc.EncDatumRow{
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(p.FlowCtx.EvalCtx.NodeID.SQLInstanceID()))),
-			rowenc.DatumToEncDatum(types.String, tree.NewDString(p.FlowCtx.EvalCtx.Locality.String())),
-			rowenc.DatumToEncDatum(types.Bool, tree.MakeDBool(tree.DBool(res.ok))),
-			rowenc.DatumToEncDatum(types.String, tree.NewDString(res.error)),
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(res.readBytes))),
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(res.readTime))),
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(res.wroteBytes))),
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(res.wroteTime))),
-			rowenc.DatumToEncDatum(types.Bool, tree.MakeDBool(tree.DBool(res.canDelete))),
+			rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(p.FlowCtx.EvalCtx.NodeID.SQLInstanceID()))),
+			rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString(p.FlowCtx.EvalCtx.Locality.String())),
+			rowenc.DatumToEncDatumUnsafe(types.Bool, tree.MakeDBool(tree.DBool(res.ok))),
+			rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString(res.error)),
+			rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(res.readBytes))),
+			rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(res.readTime))),
+			rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(res.wroteBytes))),
+			rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(res.wroteTime))),
+			rowenc.DatumToEncDatumUnsafe(types.Bool, tree.MakeDBool(tree.DBool(res.canDelete))),
 		}, nil
 	}
 }

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -144,11 +144,11 @@ func TestCaseOpRandomized(t *testing.T) {
 		partitionIdx := rng.Intn(numPartitions)
 		inputRow[0].Datum = tree.NewDInt(tree.DInt(partitionIdx))
 		for j := 1; j < numInputCols; j++ {
-			inputRow[j] = rowenc.DatumToEncDatum(outputType, randgen.RandDatum(rng, outputType, true /* nullOk */))
+			inputRow[j] = rowenc.DatumToEncDatumUnsafe(outputType, randgen.RandDatum(rng, outputType, true /* nullOk */))
 		}
 		inputRows[i] = inputRow
 		if !hasElseArm && partitionIdx == numWhenArms {
-			expectedOutput[i] = rowenc.DatumToEncDatum(outputType, tree.DNull)
+			expectedOutput[i] = rowenc.DatumToEncDatumUnsafe(outputType, tree.DNull)
 		} else {
 			expectedOutput[i] = inputRow[partitionIdx+1]
 		}

--- a/pkg/sql/colexec/coalesce_test.go
+++ b/pkg/sql/colexec/coalesce_test.go
@@ -141,11 +141,11 @@ func TestCoalesceRandomized(t *testing.T) {
 		partitionIdx := rng.Intn(numPartitions)
 		inputRow[0].Datum = tree.NewDInt(tree.DInt(partitionIdx))
 		for j := 1; j < numInputCols; j++ {
-			inputRow[j] = rowenc.DatumToEncDatum(outputType, randgen.RandDatum(rng, outputType, true /* nullOk */))
+			inputRow[j] = rowenc.DatumToEncDatumUnsafe(outputType, randgen.RandDatum(rng, outputType, true /* nullOk */))
 		}
 		inputRows[i] = inputRow
 		if partitionIdx == numExprs {
-			expectedOutput[i] = rowenc.DatumToEncDatum(outputType, tree.DNull)
+			expectedOutput[i] = rowenc.DatumToEncDatumUnsafe(outputType, tree.DNull)
 		} else {
 			expectedOutput[i] = inputRow[partitionIdx+1]
 		}

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -160,7 +160,7 @@ func TestSpanAssembler(t *testing.T) {
 											row := make(rowenc.EncDatumRow, len(typs))
 											for j := range typs {
 												datum := converter.GetDatumColumn(j)[i]
-												row[j] = rowenc.DatumToEncDatum(typs[j], datum)
+												row[j] = rowenc.DatumToEncDatumUnsafe(typs[j], datum)
 											}
 											rows[i] = row
 										}

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -69,7 +69,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 			rows := make(rowenc.EncDatumRows, numRows)
 			for i := 0; i < numRows; i++ {
 				rows[i] = make(rowenc.EncDatumRow, 1)
-				rows[i][0] = rowenc.DatumToEncDatum(typ, randgen.RandDatum(rng, typ, true /* nullOk */))
+				rows[i][0] = rowenc.DatumToEncDatumUnsafe(typ, randgen.RandDatum(rng, typ, true /* nullOk */))
 			}
 			typs := []*types.T{typ}
 			source := execinfra.NewRepeatableRowSource(typs, rows)

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -74,7 +74,7 @@ func TestValues(t *testing.T) {
 					} else {
 						expected[i][j] = convFns[j](val)
 					}
-					rows[i][j] = rowenc.DatumToEncDatum(typ, val)
+					rows[i][j] = rowenc.DatumToEncDatumUnsafe(typ, val)
 				}
 			}
 

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -126,7 +126,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// below.
 	consumer.ConsumerDone()
 
-	row := rowenc.EncDatumRow{rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(0)))}
+	row := rowenc.EncDatumRow{rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(0)))}
 
 	// Now push a row to the outbox's RowChannel and expect the consumer status
 	// returned to be DrainRequested. This is wrapped in a SucceedsSoon because

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4478,7 +4478,7 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 			if err != nil {
 				return nil, err
 			}
-			encDatum, err := rowenc.DatumToEncDatumEx(resultTypes[colIdx], datum)
+			encDatum, err := rowenc.DatumToEncDatum(resultTypes[colIdx], datum)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4478,7 +4478,10 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 			if err != nil {
 				return nil, err
 			}
-			encDatum := rowenc.DatumToEncDatum(resultTypes[colIdx], datum)
+			encDatum, err := rowenc.DatumToEncDatumEx(resultTypes[colIdx], datum)
+			if err != nil {
+				return nil, err
+			}
 			buf, err = encDatum.Encode(resultTypes[colIdx], &a, catenumpb.DatumEncoding_VALUE, buf)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/distsql_plan_window.go
+++ b/pkg/sql/distsql_plan_window.go
@@ -180,7 +180,10 @@ func initBoundsFromAST(
 			spec.Start.OffsetType = execinfrapb.DatumInfo{Encoding: catenumpb.DatumEncoding_VALUE, Type: typ}
 			var buf []byte
 			var a tree.DatumAlloc
-			datum := rowenc.DatumToEncDatum(typ, dStartOffset)
+			datum, err := rowenc.DatumToEncDatumEx(typ, dStartOffset)
+			if err != nil {
+				return err
+			}
 			buf, err = datum.Encode(typ, &a, catenumpb.DatumEncoding_VALUE, buf)
 			if err != nil {
 				return err
@@ -226,7 +229,10 @@ func initBoundsFromAST(
 				spec.End.OffsetType = execinfrapb.DatumInfo{Encoding: catenumpb.DatumEncoding_VALUE, Type: typ}
 				var buf []byte
 				var a tree.DatumAlloc
-				datum := rowenc.DatumToEncDatum(typ, dEndOffset)
+				datum, err := rowenc.DatumToEncDatumEx(typ, dEndOffset)
+				if err != nil {
+					return err
+				}
 				buf, err = datum.Encode(typ, &a, catenumpb.DatumEncoding_VALUE, buf)
 				if err != nil {
 					return err

--- a/pkg/sql/distsql_plan_window.go
+++ b/pkg/sql/distsql_plan_window.go
@@ -180,7 +180,7 @@ func initBoundsFromAST(
 			spec.Start.OffsetType = execinfrapb.DatumInfo{Encoding: catenumpb.DatumEncoding_VALUE, Type: typ}
 			var buf []byte
 			var a tree.DatumAlloc
-			datum, err := rowenc.DatumToEncDatumEx(typ, dStartOffset)
+			datum, err := rowenc.DatumToEncDatum(typ, dStartOffset)
 			if err != nil {
 				return err
 			}
@@ -229,7 +229,7 @@ func initBoundsFromAST(
 				spec.End.OffsetType = execinfrapb.DatumInfo{Encoding: catenumpb.DatumEncoding_VALUE, Type: typ}
 				var buf []byte
 				var a tree.DatumAlloc
-				datum, err := rowenc.DatumToEncDatumEx(typ, dEndOffset)
+				datum, err := rowenc.DatumToEncDatum(typ, dEndOffset)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/execinfra/base_test.go
+++ b/pkg/sql/execinfra/base_test.go
@@ -80,7 +80,7 @@ func BenchmarkRowChannelPipeline(b *testing.B) {
 			}
 
 			row := rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(1))),
+				rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(1))),
 			}
 			b.SetBytes(int64(8 * 1 * 1))
 			for i := 0; i < b.N; i++ {

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -295,7 +295,10 @@ func (h *ProcOutputHelper) ProcessRow(
 			if err != nil {
 				return nil, false, err
 			}
-			h.outputRow[i] = rowenc.DatumToEncDatum(h.OutputTypes[i], datum)
+			h.outputRow[i], err = rowenc.DatumToEncDatumEx(h.OutputTypes[i], datum)
+			if err != nil {
+				return nil, false, err
+			}
 		}
 	} else if h.outputCols != nil {
 		// Projection.

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -295,7 +295,7 @@ func (h *ProcOutputHelper) ProcessRow(
 			if err != nil {
 				return nil, false, err
 			}
-			h.outputRow[i], err = rowenc.DatumToEncDatumEx(h.OutputTypes[i], datum)
+			h.outputRow[i], err = rowenc.DatumToEncDatum(h.OutputTypes[i], datum)
 			if err != nil {
 				return nil, false, err
 			}

--- a/pkg/sql/export/exportcsv.go
+++ b/pkg/sql/export/exportcsv.go
@@ -329,9 +329,9 @@ func (sp *csvWriter) exportFile() (rowenc.EncDatumRow, error) {
 		return nil, err
 	}
 	return rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(types.String, tree.NewDString(filename)),
-		rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(sp.rows))),
-		rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(size))),
+		rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString(filename)),
+		rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(sp.rows))),
+		rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(size))),
 	}, nil
 }
 

--- a/pkg/sql/export/exportparquet.go
+++ b/pkg/sql/export/exportparquet.go
@@ -255,9 +255,9 @@ func (sp *parquetWriterProcessor) exportFile() (rowenc.EncDatumRow, error) {
 		return nil, err
 	}
 	return rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(types.String, tree.NewDString(filename)),
-		rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(sp.rows))),
-		rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(size))),
+		rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString(filename)),
+		rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(sp.rows))),
+		rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(size))),
 	}, nil
 }
 

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -366,7 +366,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	leftRows := make(rowenc.EncDatumRows, 20)
 	for i := range leftRows {
 		leftRows[i] = rowenc.EncDatumRow{
-			rowenc.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i))),
+			rowenc.DatumToEncDatumUnsafe(typs[0], tree.NewDInt(tree.DInt(i))),
 		}
 	}
 	leftValuesSpec, err := execinfra.GenerateValuesSpec(typs, leftRows)
@@ -380,7 +380,7 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		for j := 1; j <= 4*execinfra.RowChannelBufSize; j++ {
 			rightRows = append(rightRows, rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(typs[0], tree.NewDInt(tree.DInt(i))),
+				rowenc.DatumToEncDatumUnsafe(typs[0], tree.NewDInt(tree.DInt(i))),
 			})
 		}
 	}
@@ -665,9 +665,9 @@ func BenchmarkInfrastructure(b *testing.B) {
 						for j := 0; j < numRows; j++ {
 							row := make(rowenc.EncDatumRow, 3)
 							lastVal += rng.Intn(10)
-							row[0] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(lastVal)))
-							row[1] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
-							row[2] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							row[0] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(lastVal)))
+							row[1] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
+							row[2] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(rng.Intn(100000))))
 							rows[j] = row
 						}
 						valSpec, err := execinfra.GenerateValuesSpec(types.ThreeIntCols, rows)

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -93,7 +93,7 @@ func TestOutbox(t *testing.T) {
 	go func() {
 		producerC <- func() error {
 			row := rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(0))),
+				rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(0))),
 			}
 			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != execinfra.NeedMoreRows {
 				return errors.Errorf("expected status: %d, got: %d", execinfra.NeedMoreRows, consumerStatus)
@@ -102,7 +102,7 @@ func TestOutbox(t *testing.T) {
 			// Send rows until the drain request is observed.
 			for {
 				row = rowenc.EncDatumRow{
-					rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(-1))),
+					rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(-1))),
 				}
 				consumerStatus := outbox.Push(row, nil /* meta */)
 				if consumerStatus == execinfra.DrainRequested {
@@ -114,7 +114,7 @@ func TestOutbox(t *testing.T) {
 			}
 
 			// Now send another row that the outbox will discard.
-			row = rowenc.EncDatumRow{rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(2)))}
+			row = rowenc.EncDatumRow{rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(2)))}
 			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != execinfra.DrainRequested {
 				return errors.Errorf("expected status: %d, got: %d", execinfra.DrainRequested, consumerStatus)
 			}
@@ -504,7 +504,7 @@ func BenchmarkOutbox(b *testing.B) {
 	for _, numCols := range []int{1, 2, 4, 8} {
 		row := rowenc.EncDatumRow{}
 		for i := 0; i < numCols; i++ {
-			row = append(row, rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(2))))
+			row = append(row, rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(2))))
 		}
 		b.Run(fmt.Sprintf("numCols=%d", numCols), func(b *testing.B) {
 			streamID := execinfrapb.StreamID(42)

--- a/pkg/sql/flowinfra/stream_data_test.go
+++ b/pkg/sql/flowinfra/stream_data_test.go
@@ -117,7 +117,7 @@ func TestStreamEncodeDecode(t *testing.T) {
 			if rng.Intn(10) != 0 {
 				rows[i].row = make(rowenc.EncDatumRow, rowLen)
 				for j := range rows[i].row {
-					rows[i].row[j] = rowenc.DatumToEncDatum(info[j].Type,
+					rows[i].row[j] = rowenc.DatumToEncDatumUnsafe(info[j].Type,
 						randgen.RandDatum(rng, info[j].Type, true))
 				}
 			} else {

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -205,8 +205,8 @@ func (idp *readImportDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pro
 	}
 
 	return rowenc.EncDatumRow{
-		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
-		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes([]byte{}))),
+		rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
+		rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes([]byte{}))),
 	}, nil
 }
 

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -199,7 +199,7 @@ func (p *planNodeToRowSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 
 		for i, datum := range p.node.Values() {
 			if datum != nil {
-				p.row[i], err = rowenc.DatumToEncDatumEx(p.outputTypes[i], datum)
+				p.row[i], err = rowenc.DatumToEncDatum(p.outputTypes[i], datum)
 				if err != nil {
 					p.MoveToDraining(err)
 					return nil, p.DrainHelper()

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -199,7 +199,11 @@ func (p *planNodeToRowSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 
 		for i, datum := range p.node.Values() {
 			if datum != nil {
-				p.row[i] = rowenc.DatumToEncDatum(p.outputTypes[i], datum)
+				p.row[i], err = rowenc.DatumToEncDatumEx(p.outputTypes[i], datum)
+				if err != nil {
+					p.MoveToDraining(err)
+					return nil, p.DrainHelper()
+				}
 			}
 		}
 		// ProcessRow here is required to deal with projections, which won't be

--- a/pkg/sql/randgen/encdatum.go
+++ b/pkg/sql/randgen/encdatum.go
@@ -24,7 +24,7 @@ func RandDatumEncoding(rng *rand.Rand) catenumpb.DatumEncoding {
 func RandEncDatum(rng *rand.Rand) (rowenc.EncDatum, *types.T) {
 	typ := RandType(rng)
 	datum := RandDatum(rng, typ, true /* nullOk */)
-	return rowenc.DatumToEncDatum(typ, datum), typ
+	return rowenc.DatumToEncDatumUnsafe(typ, datum), typ
 }
 
 // RandSortingEncDatumSlice generates a slice of random EncDatum values of the
@@ -33,7 +33,7 @@ func RandSortingEncDatumSlice(rng *rand.Rand, numVals int) ([]rowenc.EncDatum, *
 	typ := RandSortingType(rng)
 	vals := make([]rowenc.EncDatum, numVals)
 	for i := range vals {
-		vals[i] = rowenc.DatumToEncDatum(typ, RandDatum(rng, typ, true))
+		vals[i] = rowenc.DatumToEncDatumUnsafe(typ, RandDatum(rng, typ, true))
 	}
 	return vals, typ
 }
@@ -57,7 +57,7 @@ func RandSortingEncDatumSlices(
 func RandEncDatumRowOfTypes(rng *rand.Rand, types []*types.T) rowenc.EncDatumRow {
 	vals := make([]rowenc.EncDatum, len(types))
 	for i := range types {
-		vals[i] = rowenc.DatumToEncDatum(types[i], RandDatum(rng, types[i], true))
+		vals[i] = rowenc.DatumToEncDatumUnsafe(types[i], RandDatum(rng, types[i], true))
 	}
 	return vals
 }

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1131,7 +1131,10 @@ func (rf *Fetcher) processValueSingle(
 	if rf.args.TraceKV {
 		prettyValue = value.String()
 	}
-	table.row[idx] = rowenc.DatumToEncDatum(typ, value)
+	table.row[idx], err = rowenc.DatumToEncDatumEx(typ, value)
+	if err != nil {
+		return "", "", err
+	}
 	return prettyKey, prettyValue, nil
 }
 

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1131,7 +1131,7 @@ func (rf *Fetcher) processValueSingle(
 	if rf.args.TraceKV {
 		prettyValue = value.String()
 	}
-	table.row[idx], err = rowenc.DatumToEncDatumEx(typ, value)
+	table.row[idx], err = rowenc.DatumToEncDatum(typ, value)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -459,7 +459,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	)
 	defer d.Close(ctx)
 
-	row := rowenc.EncDatumRow{rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(1)))}
+	row := rowenc.EncDatumRow{rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(1)))}
 	err = d.AddRow(ctx, row)
 	if code := pgerror.GetPGCode(err); code != pgcode.DiskFull {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -281,17 +281,21 @@ func TestDiskRowContainer(t *testing.T) {
 					}
 
 					// Check sorted order.
-					sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
+					err = sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
+					if err != nil {
+						t.Fatal(err)
+					}
 					if cmp, err := compareEncRows(
 						ctx, types, sortedRows.scratchEncRow, row, &evalCtx, d.datumAlloc, ordering,
 					); err != nil {
 						t.Fatal(err)
 					} else if cmp != 0 {
-						sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
+						err = sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
 						t.Fatalf(
-							"expected %s to be equal to %s",
+							"expected %s to be equal to %s (err=%v)",
 							row.String(types),
 							sortedRows.scratchEncRow.String(types),
+							err,
 						)
 					}
 					numKeysRead++

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -362,8 +362,7 @@ func (i *hashMemRowBucketIterator) Next() {
 
 // EncRow implements the RowIterator interface.
 func (i *hashMemRowBucketIterator) EncRow() (rowenc.EncDatumRow, error) {
-	i.container.getEncRow(i.scratchEncRow, i.rowIdxs[i.curIdx])
-	return i.scratchEncRow, nil
+	return i.scratchEncRow, i.container.getEncRow(i.scratchEncRow, i.rowIdxs[i.curIdx])
 }
 
 // Row implements the RowIterator interface.
@@ -452,7 +451,7 @@ func (i *hashMemRowIterator) computeKey() error {
 	}
 
 	if valid {
-		i.container.getEncRow(i.scratchEncRow, i.curIdx)
+		err = i.container.getEncRow(i.scratchEncRow, i.curIdx)
 	} else {
 		if i.curIdx == 0 {
 			// There are no rows in the container, so the key corresponding to the
@@ -464,7 +463,10 @@ func (i *hashMemRowIterator) computeKey() error {
 		// will "simulate" the key corresponding to the non-existent row as the key
 		// to the last existing row plus one (plus one part is done below where we
 		// append the index of the row to curKey).
-		i.container.getEncRow(i.scratchEncRow, i.curIdx-1)
+		err = i.container.getEncRow(i.scratchEncRow, i.curIdx-1)
+	}
+	if err != nil {
+		return err
 	}
 
 	i.curKey = i.curKey[:0]
@@ -496,8 +498,7 @@ func (i *hashMemRowIterator) Next() {
 
 // EncRow implements the RowIterator interface.
 func (i *hashMemRowIterator) EncRow() (rowenc.EncDatumRow, error) {
-	i.container.getEncRow(i.scratchEncRow, i.curIdx)
-	return i.scratchEncRow, nil
+	return i.scratchEncRow, i.container.getEncRow(i.scratchEncRow, i.curIdx)
 }
 
 // Row implements the RowIterator interface.

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -559,7 +559,7 @@ func (h *HashDiskRowContainer) Init(
 		h.scratchEncRow = make(rowenc.EncDatumRow, len(storedTypes))
 		// Initialize the last column of the scratch row we use in AddRow() to
 		// be unmarked.
-		h.scratchEncRow[len(h.scratchEncRow)-1] = rowenc.DatumToEncDatum(
+		h.scratchEncRow[len(h.scratchEncRow)-1] = rowenc.DatumToEncDatumUnsafe(
 			types.Bool,
 			tree.MakeDBool(false),
 		)

--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -186,8 +186,7 @@ func (d *DiskBackedNumberedRowContainer) GetRow(
 			return nil, nil
 		}
 		mrc := d.rc.mrc
-		mrc.getEncRow(mrc.scratchEncRow, idx)
-		return mrc.scratchEncRow, nil
+		return mrc.scratchEncRow, mrc.getEncRow(mrc.scratchEncRow, idx)
 	}
 	return d.rowIter.getRow(ctx, idx, skip)
 }

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -552,7 +552,7 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 	for i := 0; i < numRows; i++ {
 		rows[i] = make([]rowenc.EncDatum, len(typs))
 		for j := range typs {
-			rows[i][j] = rowenc.DatumToEncDatum(typs[j], randgen.RandDatum(rng, typs[j], false))
+			rows[i][j] = rowenc.DatumToEncDatumUnsafe(typs[j], randgen.RandDatum(rng, typs[j], false))
 		}
 	}
 

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -231,11 +231,16 @@ func (mc *MemRowContainer) Less(i, j int) bool {
 // getEncRow populates the given EncDatumRow with the values of the idx-th row.
 // The behavior is undefined if the given row is of a different width than the
 // rows stored in the container.
-func (mc *MemRowContainer) getEncRow(encRow rowenc.EncDatumRow, idx int) {
+func (mc *MemRowContainer) getEncRow(encRow rowenc.EncDatumRow, idx int) error {
 	datums := mc.At(idx)
 	for i, d := range datums {
-		encRow[i] = rowenc.DatumToEncDatum(mc.types[i], d)
+		var err error
+		encRow[i], err = rowenc.DatumToEncDatumEx(mc.types[i], d)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // AddRow adds a row to the container.
@@ -344,7 +349,11 @@ func (i *memRowIterator) Next() {
 func (i *memRowIterator) EncRow() (rowenc.EncDatumRow, error) {
 	datums := i.container.At(i.curIdx)
 	for colidx, d := range datums {
-		i.scratchEncRow[colidx] = rowenc.DatumToEncDatum(i.container.types[colidx], d)
+		var err error
+		i.scratchEncRow[colidx], err = rowenc.DatumToEncDatumEx(i.container.types[colidx], d)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return i.scratchEncRow, nil
 }
@@ -377,8 +386,7 @@ func (mc *MemRowContainer) NewFinalIterator(ctx context.Context) RowIterator {
 
 // GetRow implements IndexedRowContainer.
 func (mc *MemRowContainer) GetRow(ctx context.Context, pos int) (eval.IndexedRow, error) {
-	mc.getEncRow(mc.scratchEncRow, pos)
-	return IndexedRow{Idx: pos, Row: mc.scratchEncRow}, nil
+	return IndexedRow{Idx: pos, Row: mc.scratchEncRow}, mc.getEncRow(mc.scratchEncRow, pos)
 }
 
 var _ RowIterator = &memRowFinalIterator{}
@@ -398,8 +406,7 @@ func (i *memRowFinalIterator) Next() {
 
 // EncRow implements the RowIterator interface.
 func (i *memRowFinalIterator) EncRow() (rowenc.EncDatumRow, error) {
-	i.container.getEncRow(i.scratchEncRow, 0)
-	return i.scratchEncRow, nil
+	return i.scratchEncRow, i.container.getEncRow(i.scratchEncRow, 0)
 }
 
 // Row implements the RowIterator interface.
@@ -942,7 +949,10 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 		}
 	}
 	mrc := f.DiskBackedRowContainer.mrc
-	mrc.getEncRow(mrc.scratchEncRow, pos)
+	err = mrc.getEncRow(mrc.scratchEncRow, pos)
+	if err != nil {
+		return nil, err
+	}
 	rowWithIdx = mrc.scratchEncRow
 	row, rowIdx := rowWithIdx[:len(rowWithIdx)-1], rowWithIdx[len(rowWithIdx)-1].Datum
 	if idx, ok := rowIdx.(*tree.DInt); ok {

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -235,7 +235,7 @@ func (mc *MemRowContainer) getEncRow(encRow rowenc.EncDatumRow, idx int) error {
 	datums := mc.At(idx)
 	for i, d := range datums {
 		var err error
-		encRow[i], err = rowenc.DatumToEncDatumEx(mc.types[i], d)
+		encRow[i], err = rowenc.DatumToEncDatum(mc.types[i], d)
 		if err != nil {
 			return err
 		}
@@ -350,7 +350,7 @@ func (i *memRowIterator) EncRow() (rowenc.EncDatumRow, error) {
 	datums := i.container.At(i.curIdx)
 	for colidx, d := range datums {
 		var err error
-		i.scratchEncRow[colidx], err = rowenc.DatumToEncDatumEx(i.container.types[colidx], d)
+		i.scratchEncRow[colidx], err = rowenc.DatumToEncDatum(i.container.types[colidx], d)
 		if err != nil {
 			return nil, err
 		}
@@ -785,7 +785,7 @@ func NewDiskBackedIndexedRowContainer(
 // AddRow implements SortableRowContainer.
 func (f *DiskBackedIndexedRowContainer) AddRow(ctx context.Context, row rowenc.EncDatumRow) error {
 	copy(f.scratchEncRow, row)
-	f.scratchEncRow[len(f.scratchEncRow)-1] = rowenc.DatumToEncDatum(
+	f.scratchEncRow[len(f.scratchEncRow)-1] = rowenc.DatumToEncDatumUnsafe(
 		types.Int,
 		tree.NewDInt(tree.DInt(f.idx)),
 	)

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -97,8 +97,8 @@ func TestRowContainerReplaceMax(t *testing.T) {
 			b = append(b, 'a')
 		}
 		return rowenc.EncDatumRow{
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(intVal))),
-			rowenc.DatumToEncDatum(types.String, tree.NewDString(string(b))),
+			rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(intVal))),
+			rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString(string(b))),
 		}
 	}
 

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -180,20 +180,7 @@ func EncDatumValueFromBufferWithOffsetsAndType(
 }
 
 // DatumToEncDatum initializes an EncDatum with the given Datum.
-//
-// NB: the method will panic if the datum's resolved type is not equivalent to
-// the passed-in type. Consider using safer DatumToEncDatumEx.
-func DatumToEncDatum(ctyp *types.T, d tree.Datum) EncDatum {
-	ed, err := DatumToEncDatumEx(ctyp, d)
-	if err != nil {
-		panic(err)
-	}
-	return ed
-}
-
-// DatumToEncDatumEx is the same as DatumToEncDatum that returns an error
-// instead of panicking under unexpected circumstances.
-func DatumToEncDatumEx(ctyp *types.T, d tree.Datum) (EncDatum, error) {
+func DatumToEncDatum(ctyp *types.T, d tree.Datum) (EncDatum, error) {
 	if d == nil {
 		return EncDatum{}, errors.AssertionFailedf("cannot convert nil datum to EncDatum")
 	}
@@ -203,6 +190,21 @@ func DatumToEncDatumEx(ctyp *types.T, d tree.Datum) (EncDatum, error) {
 		return EncDatum{}, errors.AssertionFailedf("invalid datum type given: %s, expected %s", dTyp.SQLStringForError(), ctyp.SQLStringForError())
 	}
 	return EncDatum{Datum: d}, nil
+}
+
+// DatumToEncDatumUnsafe initializes an EncDatum with the given Datum.
+//
+// NB: the method will panic if the datum's resolved type is not equivalent to
+// the passed-in type. Consider using safer DatumToEncDatum.
+//
+// An example valid use case of this method is when the datum is explicitly
+// constructed by the caller, so the types are guaranteed to match.
+func DatumToEncDatumUnsafe(ctyp *types.T, d tree.Datum) EncDatum {
+	ed, err := DatumToEncDatum(ctyp, d)
+	if err != nil {
+		panic(err)
+	}
+	return ed
 }
 
 // NullEncDatum initializes an EncDatum with the NULL value.
@@ -217,7 +219,7 @@ func (ed *EncDatum) UnsetDatum() {
 	ed.encoding = 0
 }
 
-// IsUnset returns true if EncDatumFromEncoded or DatumToEncDatum were not called.
+// IsUnset returns true if EncDatumFromEncoded or DatumToEncDatumUnsafe were not called.
 func (ed *EncDatum) IsUnset() bool {
 	return ed.encoded == nil && ed.Datum == nil
 }

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -180,6 +180,9 @@ func EncDatumValueFromBufferWithOffsetsAndType(
 }
 
 // DatumToEncDatum initializes an EncDatum with the given Datum.
+//
+// NB: the method will panic if the datum's resolved type is not equivalent to
+// the passed-in type. Consider using safer DatumToEncDatumEx.
 func DatumToEncDatum(ctyp *types.T, d tree.Datum) EncDatum {
 	ed, err := DatumToEncDatumEx(ctyp, d)
 	if err != nil {
@@ -190,8 +193,6 @@ func DatumToEncDatum(ctyp *types.T, d tree.Datum) EncDatum {
 
 // DatumToEncDatumEx is the same as DatumToEncDatum that returns an error
 // instead of panicking under unexpected circumstances.
-// TODO(yuzefovich): we should probably get rid of DatumToEncDatum in favor of
-// this method altogether.
 func DatumToEncDatumEx(ctyp *types.T, d tree.Datum) (EncDatum, error) {
 	if d == nil {
 		return EncDatum{}, errors.AssertionFailedf("cannot convert nil datum to EncDatum")

--- a/pkg/sql/rowenc/encoded_datum_test.go
+++ b/pkg/sql/rowenc/encoded_datum_test.go
@@ -42,14 +42,14 @@ func TestEncDatum(t *testing.T) {
 		t.Errorf("empty rowenc.EncDatum has an encoding")
 	}
 
-	x := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(5))
+	x := rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(5))
 
 	check := func(x rowenc.EncDatum) {
 		if x.IsUnset() {
-			t.Errorf("unset after DatumToEncDatum()")
+			t.Errorf("unset after DatumToEncDatumUnsafe()")
 		}
 		if x.IsNull() {
-			t.Errorf("null after DatumToEncDatum()")
+			t.Errorf("null after DatumToEncDatumUnsafe()")
 		}
 		if val, err := x.GetInt(); err != nil {
 			t.Fatal(err)
@@ -123,7 +123,7 @@ func TestEncDatumNull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Verify DNull is null.
-	n := rowenc.DatumToEncDatum(types.Int, tree.DNull)
+	n := rowenc.DatumToEncDatumUnsafe(types.Int, tree.DNull)
 	if !n.IsNull() {
 		t.Error("DNull not null")
 	}
@@ -239,8 +239,8 @@ func TestEncDatumCompare(t *testing.T) {
 				break
 			}
 		}
-		v1 := rowenc.DatumToEncDatum(typ, d1)
-		v2 := rowenc.DatumToEncDatum(typ, d2)
+		v1 := rowenc.DatumToEncDatumUnsafe(typ, d1)
+		v2 := rowenc.DatumToEncDatumUnsafe(typ, d2)
 
 		if val, err := v1.Compare(context.Background(), typ, a, evalCtx, &v2); err != nil {
 			t.Fatal(err)
@@ -341,7 +341,7 @@ func TestEncDatumRowCompare(t *testing.T) {
 
 	v := [5]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	asc := encoding.Ascending
@@ -495,7 +495,7 @@ func TestEncDatumRowAlloc(t *testing.T) {
 				in[i] = make(rowenc.EncDatumRow, cols)
 				for j := 0; j < cols; j++ {
 					datum := randgen.RandDatum(rng, colTypes[j], true /* nullOk */)
-					in[i][j] = rowenc.DatumToEncDatum(colTypes[j], datum)
+					in[i][j] = rowenc.DatumToEncDatumUnsafe(colTypes[j], datum)
 				}
 			}
 			var alloc rowenc.EncDatumRowAlloc
@@ -614,7 +614,7 @@ func TestEncDatumSize(t *testing.T) {
 			expectedSize: rowenc.EncDatumOverhead + 3, // 12345 is encoded with length 3 byte array
 		},
 		{
-			encDatum:     rowenc.DatumToEncDatum(types.Int, tree.NewDInt(123)),
+			encDatum:     rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(123)),
 			expectedSize: rowenc.EncDatumOverhead + DIntSize,
 		},
 		{
@@ -634,7 +634,7 @@ func TestEncDatumSize(t *testing.T) {
 			expectedSize: rowenc.EncDatumOverhead + 9, // 123.0 is encoded with length 9 byte array
 		},
 		{
-			encDatum:     rowenc.DatumToEncDatum(types.Float, tree.NewDFloat(123)),
+			encDatum:     rowenc.DatumToEncDatumUnsafe(types.Float, tree.NewDFloat(123)),
 			expectedSize: rowenc.EncDatumOverhead + DFloatSize,
 		},
 		{
@@ -654,7 +654,7 @@ func TestEncDatumSize(t *testing.T) {
 			expectedSize: rowenc.EncDatumOverhead + 4, // 123.0 is encoded with length 4 byte array
 		},
 		{
-			encDatum:     rowenc.DatumToEncDatum(types.Decimal, dec12300),
+			encDatum:     rowenc.DatumToEncDatumUnsafe(types.Decimal, dec12300),
 			expectedSize: rowenc.EncDatumOverhead + decimalSize,
 		},
 		{
@@ -674,7 +674,7 @@ func TestEncDatumSize(t *testing.T) {
 			expectedSize: rowenc.EncDatumOverhead + 9, // "123⌘" is encoded with length 9 byte array
 		},
 		{
-			encDatum:     rowenc.DatumToEncDatum(types.String, tree.NewDString("12")),
+			encDatum:     rowenc.DatumToEncDatumUnsafe(types.String, tree.NewDString("12")),
 			expectedSize: rowenc.EncDatumOverhead + DStringSize + 2,
 		},
 		{

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -543,7 +543,7 @@ func (ag *aggregatorBase) getAggResults(
 			// We can't encode nil into an EncDatum, so we represent it with DNull.
 			result = tree.DNull
 		}
-		ag.row[i], err = rowenc.DatumToEncDatumEx(ag.outputTypes[i], result)
+		ag.row[i], err = rowenc.DatumToEncDatum(ag.outputTypes[i], result)
 		if err != nil {
 			ag.MoveToDraining(err)
 			return aggStateUnknown, nil, nil

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -543,7 +543,11 @@ func (ag *aggregatorBase) getAggResults(
 			// We can't encode nil into an EncDatum, so we represent it with DNull.
 			result = tree.DNull
 		}
-		ag.row[i] = rowenc.DatumToEncDatum(ag.outputTypes[i], result)
+		ag.row[i], err = rowenc.DatumToEncDatumEx(ag.outputTypes[i], result)
+		if err != nil {
+			ag.MoveToDraining(err)
+			return aggStateUnknown, nil, nil
+		}
 	}
 
 	if outRow := ag.ProcessRowHelper(ag.row); outRow != nil {

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -647,10 +647,10 @@ func makeGroupedIntRows(groupSize, numCols int, groupedCols []int) rowenc.EncDat
 		rows[i] = make(rowenc.EncDatumRow, numCols)
 		for j := 0; j < numCols; j++ {
 			if groupColSet.Contains(j) {
-				rows[i][j] = rowenc.DatumToEncDatum(
+				rows[i][j] = rowenc.DatumToEncDatumUnsafe(
 					types.Int, tree.NewDInt(tree.DInt(getGroupedColVal(i, j))))
 			} else {
-				rows[i][j] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i+j)))
+				rows[i][j] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i+j)))
 			}
 		}
 	}

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -86,7 +86,7 @@ func (sp *bulkRowWriter) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 		if marshalErr == nil {
 			// Output the summary.
 			return rowenc.EncDatumRow{
-				rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
+				rowenc.DatumToEncDatumUnsafe(types.Bytes, tree.NewDBytes(tree.DBytes(countsBytes))),
 			}, nil
 		}
 	}

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -29,9 +29,9 @@ func TestDistinct(t *testing.T) {
 
 	v := [15]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
-	vNull := rowenc.DatumToEncDatum(types.Unknown, tree.DNull)
+	vNull := rowenc.DatumToEncDatumUnsafe(types.Unknown, tree.DNull)
 
 	testCases := []struct {
 		spec     execinfrapb.DistinctSpec

--- a/pkg/sql/rowexec/filterer_test.go
+++ b/pkg/sql/rowexec/filterer_test.go
@@ -29,7 +29,7 @@ func TestFilterer(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	// We run the same input rows through various PostProcessSpecs.

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -46,7 +46,7 @@ type hashJoinerTestCase struct {
 func hashJoinerTestCases() []hashJoinerTestCase {
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 	null := rowenc.EncDatum{Datum: tree.DNull}
 
@@ -844,7 +844,7 @@ type hashJoinerErrorTestCase struct {
 func hashJoinerErrorTestCases() []hashJoinerErrorTestCase {
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	testCases := []hashJoinerErrorTestCase{
@@ -1101,7 +1101,7 @@ func TestHashJoinerError(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	testCases := hashJoinerErrorTestCases()
@@ -1212,7 +1212,7 @@ func TestHashJoinerDrain(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 	spec := execinfrapb.HashJoinerSpec{
 		LeftEqColumns:  []uint32{0},
@@ -1322,7 +1322,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 	spec := execinfrapb.HashJoinerSpec{
 		LeftEqColumns:  []uint32{0},

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -585,8 +585,8 @@ func (ij *invertedJoiner) performScan() (invertedJoinerState, *execinfrapb.Produ
 	return ijEmittingRows, nil
 }
 
-var trueEncDatum = rowenc.DatumToEncDatum(types.Bool, tree.DBoolTrue)
-var falseEncDatum = rowenc.DatumToEncDatum(types.Bool, tree.DBoolFalse)
+var trueEncDatum = rowenc.DatumToEncDatumUnsafe(types.Bool, tree.DBoolTrue)
+var falseEncDatum = rowenc.DatumToEncDatumUnsafe(types.Bool, tree.DBoolFalse)
 
 // emitRow returns the next row from ij.emitCursor, if present. Otherwise it
 // prepares for another input batch.

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -654,7 +654,7 @@ func TestInvertedJoiner(t *testing.T) {
 				for rowIdx, row := range c.input {
 					encRow := make(rowenc.EncDatumRow, len(row))
 					for i, d := range row {
-						encRow[i] = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+						encRow[i] = rowenc.DatumToEncDatumUnsafe(c.inputTypes[i], d)
 					}
 					encRows[rowIdx] = encRow
 				}

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1095,7 +1095,7 @@ func TestJoinReader(t *testing.T) {
 							for rowIdx, row := range c.input {
 								encRow := make(rowenc.EncDatumRow, len(row))
 								for i, d := range row {
-									encRow[i] = rowenc.DatumToEncDatum(c.inputTypes[i], d)
+									encRow[i] = rowenc.DatumToEncDatumUnsafe(c.inputTypes[i], d)
 								}
 								encRows[rowIdx] = encRow
 							}
@@ -1381,7 +1381,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	}
 
 	encRow := make(rowenc.EncDatumRow, 1)
-	encRow[0] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(1))
+	encRow[0] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(1))
 
 	var fetchSpec fetchpb.IndexFetchSpec
 	if err := rowenc.InitIndexFetchSpec(

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -44,7 +44,7 @@ func TestMergeJoiner(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 	null := rowenc.EncDatum{Datum: tree.DNull}
 
@@ -761,7 +761,7 @@ func TestConsumerClosed(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	spec := execinfrapb.MergeJoinerSpec{

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -89,7 +89,7 @@ func (o *ordinalityProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 		}
 
 		// The ordinality should increment even if the row gets filtered out.
-		row = append(row, rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(o.curCnt))))
+		row = append(row, rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(o.curCnt))))
 		o.curCnt++
 		if outRow := o.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -29,7 +29,7 @@ func TestOrdinality(t *testing.T) {
 
 	v := [15]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	testCases := []struct {

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -54,7 +54,7 @@ func TestPostProcess(t *testing.T) {
 
 	v := [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	// We run the same input rows through various PostProcessSpecs.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -342,7 +342,7 @@ func (ps *projectSetProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) (rowenc.EncDatum, error) {
 	generatedColIdx := colIdx - len(ps.input.OutputTypes())
 	ctyp := ps.spec.GeneratedColumns[generatedColIdx]
-	return rowenc.DatumToEncDatumEx(ctyp, d)
+	return rowenc.DatumToEncDatum(ctyp, d)
 }
 
 func (ps *projectSetProcessor) close() {

--- a/pkg/sql/rowexec/set_op_test.go
+++ b/pkg/sql/rowexec/set_op_test.go
@@ -77,7 +77,7 @@ func intersectAllTestCases() []setOpTestCase {
 	null := rowenc.EncDatum{Datum: tree.DNull}
 	var v = [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	return []setOpTestCase{
@@ -210,7 +210,7 @@ func exceptAllTestCases() []setOpTestCase {
 	null := rowenc.EncDatum{Datum: tree.DNull}
 	var v = [10]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	return []setOpTestCase{

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -137,7 +137,7 @@ func (r *rowGeneratingSource) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 	}
 
 	for i := range r.scratchEncDatumRow {
-		r.scratchEncDatumRow[i] = rowenc.DatumToEncDatum(r.types[i], datumRow[i])
+		r.scratchEncDatumRow[i] = rowenc.DatumToEncDatumUnsafe(r.types[i], datumRow[i])
 	}
 	r.rowIdx++
 	return r.scratchEncDatumRow, nil

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -293,9 +293,9 @@ func (v *vectorMutationSearchProcessor) Next() (rowenc.EncDatumRow, *execinfrapb
 				}
 			}
 		}
-		row = append(row, rowenc.DatumToEncDatum(types.Int, partitionKey))
+		row = append(row, rowenc.DatumToEncDatumUnsafe(types.Int, partitionKey))
 		if v.isIndexPut {
-			row = append(row, rowenc.DatumToEncDatum(types.Bytes, quantizedVec))
+			row = append(row, rowenc.DatumToEncDatumUnsafe(types.Bytes, quantizedVec))
 		}
 		if outRow := v.ProcessRowHelper(row); outRow != nil {
 			return outRow, nil

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -722,7 +722,7 @@ func (w *windower) populateNextOutputRow() (bool, error) {
 		copy(w.outputRow, inputRow[:len(w.inputTypes)])
 		for windowFnIdx, windowFn := range w.windowFns {
 			windowFnRes := w.windowValues[w.partitionIdx][windowFnIdx][rowIdx]
-			encWindowFnRes, err := rowenc.DatumToEncDatumEx(w.outputTypes[windowFn.outputColIdx], windowFnRes)
+			encWindowFnRes, err := rowenc.DatumToEncDatum(w.outputTypes[windowFn.outputColIdx], windowFnRes)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -722,7 +722,10 @@ func (w *windower) populateNextOutputRow() (bool, error) {
 		copy(w.outputRow, inputRow[:len(w.inputTypes)])
 		for windowFnIdx, windowFn := range w.windowFns {
 			windowFnRes := w.windowValues[w.partitionIdx][windowFnIdx][rowIdx]
-			encWindowFnRes := rowenc.DatumToEncDatum(w.outputTypes[windowFn.outputColIdx], windowFnRes)
+			encWindowFnRes, err := rowenc.DatumToEncDatumEx(w.outputTypes[windowFn.outputColIdx], windowFnRes)
+			if err != nil {
+				return false, err
+			}
 			w.outputRow[windowFn.outputColIdx] = encWindowFnRes
 		}
 		w.rowsInBucketEmitted++

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -49,7 +49,7 @@ func intCols(numCols int) []*types.T {
 }
 
 func encInt(i int) rowenc.EncDatum {
-	return rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+	return rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 }
 
 func TestZigzagJoiner(t *testing.T) {
@@ -737,8 +737,8 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	for i := range v {
 		v[i] = tree.NewDInt(tree.DInt(i))
 	}
-	encThree := rowenc.DatumToEncDatum(types.Int, v[3])
-	encSeven := rowenc.DatumToEncDatum(types.Int, v[7])
+	encThree := rowenc.DatumToEncDatumUnsafe(types.Int, v[3])
+	encSeven := rowenc.DatumToEncDatumUnsafe(types.Int, v[7])
 
 	sqlutils.CreateTable(
 		t,

--- a/pkg/sql/rowflow/input_sync_test.go
+++ b/pkg/sql/rowflow/input_sync_test.go
@@ -29,7 +29,7 @@ func TestOrderedSync(t *testing.T) {
 
 	v := [6]rowenc.EncDatum{}
 	for i := range v {
-		v[i] = rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
+		v[i] = rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
 	}
 
 	asc := encoding.Ascending
@@ -193,8 +193,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
-				b := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(j)))
+				a := rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
+				b := rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(j)))
 				row := rowenc.EncDatumRow{a, b}
 				if status := mrc.Push(row, nil /* meta */); status != execinfra.NeedMoreRows {
 					producerErr <- errors.Errorf("producer error: unexpected response: %d", status)
@@ -241,8 +241,8 @@ func TestUnorderedSync(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {
-				a := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(i)))
-				b := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(j)))
+				a := rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(i)))
+				b := rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(j)))
 				row := rowenc.EncDatumRow{a, b}
 				if status := mrc.Push(row, nil /* meta */); status != execinfra.NeedMoreRows {
 					producerErr <- errors.Errorf("producer error: unexpected response: %d", status)

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -355,9 +355,9 @@ func TestConsumerStatus(t *testing.T) {
 			case *rangeRouter:
 				// Use 0 and MaxInt32 to route rows based on testRangeRouterSpec's spans.
 				d := tree.NewDInt(0)
-				row0 = rowenc.EncDatumRow{rowenc.DatumToEncDatum(colTypes[0], d)}
+				row0 = rowenc.EncDatumRow{rowenc.DatumToEncDatumUnsafe(colTypes[0], d)}
 				d = tree.NewDInt(math.MaxInt32)
-				row1 = rowenc.EncDatumRow{rowenc.DatumToEncDatum(colTypes[0], d)}
+				row1 = rowenc.EncDatumRow{rowenc.DatumToEncDatumUnsafe(colTypes[0], d)}
 			default:
 				rng, _ := randutil.NewTestRand()
 				vals := randgen.RandEncDatumRowsOfTypes(rng, 1 /* numRows */, colTypes)

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -437,7 +437,11 @@ func (s *Builder) SpansFromInvertedSpans(
 			scratchRows[i] = make(rowenc.EncDatumRow, keyLength+1)
 			for j := 0; j < keyLength; j++ {
 				val := span.StartKey().Value(j)
-				scratchRows[i][j] = rowenc.DatumToEncDatum(val.ResolvedType(), val)
+				var err error
+				scratchRows[i][j], err = rowenc.DatumToEncDatumEx(val.ResolvedType(), val)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	} else {

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -438,7 +438,7 @@ func (s *Builder) SpansFromInvertedSpans(
 			for j := 0; j < keyLength; j++ {
 				val := span.StartKey().Value(j)
 				var err error
-				scratchRows[i][j], err = rowenc.DatumToEncDatumEx(val.ResolvedType(), val)
+				scratchRows[i][j], err = rowenc.DatumToEncDatum(val.ResolvedType(), val)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -258,7 +258,11 @@ func (sr *SampleReservoir) copyRow(
 			return err
 		}
 		beforeRowSize += int64(dst[i].Size())
-		sr.scratch[i] = rowenc.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
+		var err error
+		sr.scratch[i], err = rowenc.DatumToEncDatumEx(sr.colTypes[i], src[i].Datum)
+		if err != nil {
+			return err
+		}
 		afterSize := sr.scratch[i].Size()
 
 		// If the datum is too large, truncate it.

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -259,7 +259,7 @@ func (sr *SampleReservoir) copyRow(
 		}
 		beforeRowSize += int64(dst[i].Size())
 		var err error
-		sr.scratch[i], err = rowenc.DatumToEncDatumEx(sr.colTypes[i], src[i].Datum)
+		sr.scratch[i], err = rowenc.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -39,7 +39,7 @@ func runSampleTest(
 	var sr SampleReservoir
 	sr.Init(numSamples, 1, []*types.T{types.Int}, memAcc, intsets.MakeFast(0))
 	for _, r := range ranks {
-		d := rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(r)))
+		d := rowenc.DatumToEncDatumUnsafe(types.Int, tree.NewDInt(tree.DInt(r)))
 		prevCapacity := sr.Cap()
 		if err := sr.SampleRow(ctx, evalCtx, rowenc.EncDatumRow{d}, uint64(r)); err != nil {
 			t.Fatal(err)
@@ -189,7 +189,7 @@ func TestSampleReservoirMemAccounting(t *testing.T) {
 
 	getStringDatum := func(l int) rowenc.EncDatum {
 		d := tree.DString(strings.Repeat("a", l))
-		return rowenc.DatumToEncDatum(types.String, &d)
+		return rowenc.DatumToEncDatumUnsafe(types.String, &d)
 	}
 	// First two rows need 152 bytes each. The third row has the smallest rank,
 	// so it wants to replace one of the other rows, but it has a large datum


### PR DESCRIPTION
**sql: audit production callers of `rowenc.DatumToEncDatum`**

This commit audits all callers of `rowenc.DatumToEncDatum` in order to replace possibly unsafe calls to `DatumToEncDatumEx` which requires explicit error handling (the former panics when the datum's resolved type is not equivalent to the passed-in type). I decided to not remove the former method altogether since it seems to be reasonable to use it when we're construcing the datum directly in the call site (and also in tests).

Fixes: #154607.

**rowenc: rename DatumToEncDatum methods**

This commit does the following renaming:
- `DatumToEncDatumEx` -> `DatumToEncDatum`
- `DatumToEncDatum` -> `DatumToEncDatumUnsafe`.

The goal is to encourage usage of safer version which requires explicit error handling (as opposed to panicking). The main use case (apart from tests) for the unsafe version has been documented.

Release note: None