### PR TITLE
release-25.4: changefeedccl: prevent panic in per-table PTS mixed-version

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1974,7 +1974,7 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		return cf.frontier.Frontier()
 	}()
 
-	if cf.spec.ProgressConfig.PerTableProtectedTimestamps {
+	if cf.spec.ProgressConfig != nil && cf.spec.ProgressConfig.PerTableProtectedTimestamps {
 		return cf.managePerTableProtectedTimestamps(ctx, txn, &ptsEntries, highwater)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #154863 on behalf of @aerfrei.

----

Fixes a panic that occurred when evaluating per-table protected timestamp settings. The fix adds a nil check on the change aggregator spec ProgressConfig before accessing the per-table PTS flag.

Fixes: #154830
Epic: CRDB-1421
Release note: None

----

Release justification: This issue was causing a panic in a mixed-version scenario which is a release blocker. See #154830