### PR TITLE
release-25.4: sql: fix transaction diagnostics for implicit txns

### DIFF
--- a/pkg/sql/txn_instrumentation.go
+++ b/pkg/sql/txn_instrumentation.go
@@ -280,6 +280,9 @@ func (h *txnInstrumentationHelper) ShouldRedact() bool {
 func (h *txnInstrumentationHelper) Finalize(ctx context.Context, executionDuration time.Duration) {
 	defer h.Reset()
 	collector := h.diagnosticsCollector
+	if collector.InProgress() {
+		collector.UpdateState(txnDiagnosticsReadyToFinalize)
+	}
 	if collector.ShouldCollect(executionDuration) {
 		collector.collectTrace()
 		buf, err := collector.z.Finalize()


### PR DESCRIPTION
Backport 1/1 commits from #154662 on behalf of @kyle-a-wong.

----

Fixes transaction diagnostic collection to work for implicit transactions

Epic: [CRDB-53541](https://cockroachlabs.atlassian.net/browse/CRDB-53541)
Release note: None

----

Release justification: This is a low risk bug fix for a feature released in 25.4