### PR TITLE
release-25.4: sql/schemachanger: fix incorrect filter for pk index swaps

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.definition
@@ -35,6 +35,16 @@ SELECT index_name FROM crdb_internal.table_indexes WHERE descriptor_name='table_
 idx_v
 table_regional_by_row_pkey
 
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM  multiregion_db.public.table_regional_by_row@idx_v
+----
+true
+
+
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM  multiregion_db.public.table_regional_by_row@idx_v
+----
+true
 
 stage-query phase=PostCommitNonRevertiblePhase stage=:
 SELECT index_name FROM crdb_internal.table_indexes WHERE descriptor_name='table_regional_by_row' ORDER BY index_name;

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
@@ -250,7 +250,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         └── ValidateIndex {"IndexID":8,"TableID":108}
  │    ├── Stage 8 of 24 in PostCommitPhase
  │    │    ├── 7 elements transitioning toward PUBLIC
- │    │    │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+)}
  │    │    │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v+)}
  │    │    │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v+)}
@@ -312,14 +312,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 10 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    └── 2 Backfill operations
  │    │         ├── BackfillIndex {"IndexID":10,"SourceIndexID":8,"TableID":108}
  │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":8,"TableID":108}
  │    ├── Stage 11 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":108}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":108}
@@ -328,7 +328,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 12 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":108}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":108}
@@ -337,14 +337,14 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 13 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    └── 2 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":10,"TableID":108,"TemporaryIndexID":11}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":108,"TemporaryIndexID":5}
  │    ├── Stage 14 of 24 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 11, ConstraintID: 10, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey~)}
@@ -359,7 +359,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │    ├── 3 elements transitioning toward PUBLIC
  │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey+), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey~)}
  │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    └── 3 Validation operations
  │    │         ├── ValidateIndex {"IndexID":10,"TableID":108}
  │    │         ├── ValidateColumnNotNull {"ColumnID":6,"IndexIDForValidation":10,"TableID":108}
@@ -367,7 +367,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    ├── Stage 16 of 24 in PostCommitPhase
  │    │    ├── 11 elements transitioning toward PUBLIC
  │    │    │    ├── VALIDATED → PUBLIC        ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16+), IndexID: 10 (table_regional_by_row_pkey+)}
- │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v+)}
  │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 10 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key+)}
@@ -412,7 +412,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
  │    │         ├── SetIndexName {"IndexID":6,"Name":"table_regional_b...","TableID":108}
  │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":108}
- │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":108,"TargetPrimaryIndexID":10}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":108,"TargetPrimaryIndexID":8}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":108}
  │    │         ├── RefreshStats {"TableID":108}
  │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_10_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_10_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_11_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_11_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_12_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_12_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_13_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_13_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -130,7 +130,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_14_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_14_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -130,7 +130,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_15_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_15_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -129,7 +129,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    └── 15 Mutation operations

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_16_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_16_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -129,7 +129,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    └── 15 Mutation operations

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_17_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_17_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -180,7 +180,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_18_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_18_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -182,7 +182,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_19_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_19_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -182,7 +182,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_20_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_20_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -182,7 +182,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_21_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_21_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -184,7 +184,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_22_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_22_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -184,7 +184,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_23_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_23_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -182,7 +182,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_24_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_24_of_24.explain
@@ -51,7 +51,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 4, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
@@ -144,7 +144,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 10 (table_regional_by_row_pkey-), ConstraintID: 9, TemporaryIndexID: 11, SourceIndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (m-), IndexID: 8 (table_regional_by_row_pkey-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "idx_v", IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}
@@ -182,7 +182,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (crdb_internal_k_shard_16-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_rowid_key-)}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_9_of_24.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr__rollback_9_of_24.explain
@@ -49,7 +49,7 @@ Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regi
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 10 (table_regional_by_row_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (crdb_internal_k_shard_16-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (idx_v-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 4 (idx_v-)}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1483,6 +1483,9 @@ func updateElementsToDependOnNewFromOld(
 			if e.SourceIndexID == old && !excludes.Contains(e.IndexID) {
 				e.SourceIndexID = new
 			}
+			if e.RecreateTargetIndexID == old {
+				e.RecreateTargetIndexID = new
+			}
 		case *scpb.CheckConstraint:
 			if e.IndexIDForValidation == old {
 				e.IndexIDForValidation = new

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_swap_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_swap_index.go
@@ -152,8 +152,8 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			newIndex := MkNodeVars("new-index")
 			return append(rel.Clauses{
-				to.Type((*scpb.PrimaryIndex)(nil)),
 				from.Type((*scpb.SecondaryIndex)(nil)),
+				to.Type((*scpb.PrimaryIndex)(nil)),
 				JoinOnDescID(from, to, "table-id"),
 				from.TargetStatus(scpb.ToAbsent),
 				from.CurrentStatus(scpb.Status_VALIDATED),
@@ -163,9 +163,9 @@ func init() {
 				to.El.AttrEqVar(screl.IndexID, "new-primary-index-id"),
 				// Only active this rule on secondary indexes created after 25.4
 				FilterElements("only apply to secondary indexes created after 25.4",
-					from, to,
-					func(from *scpb.PrimaryIndex, to *scpb.SecondaryIndex) bool {
-						return to.HideForPrimaryKeyRecreated
+					newIndex, to,
+					func(newIndex *scpb.SecondaryIndex, to *scpb.PrimaryIndex) bool {
+						return newIndex.HideForPrimaryKeyRecreated
 					}),
 			},
 				IsPotentialSecondaryIndexSwapWithNodeVars(from, newIndex, "index-id", "table-id")...)

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4339,8 +4339,8 @@ deprules
   kind: SameStagePrecedence
   to: old-secondary-index-Node
   query:
-    - $old-secondary-index[Type] = '*scpb.PrimaryIndex'
     - $new-primary-index[Type] = '*scpb.SecondaryIndex'
+    - $old-secondary-index[Type] = '*scpb.PrimaryIndex'
     - joinOnDescID($new-primary-index, $old-secondary-index, $table-id)
     - $new-primary-index-Target[TargetStatus] = ABSENT
     - $new-primary-index-Node[CurrentStatus] = VALIDATED
@@ -4348,7 +4348,7 @@ deprules
     - $old-secondary-index-Node[CurrentStatus] = PUBLIC
     - $new-index[RecreateTargetIndexID] = $new-primary-index-id
     - $old-secondary-index[IndexID] = $new-primary-index-id
-    - only apply to secondary indexes created after 25.4(*scpb.PrimaryIndex, *scpb.SecondaryIndex)($new-primary-index, $old-secondary-index)
+    - only apply to secondary indexes created after 25.4(*scpb.SecondaryIndex, *scpb.PrimaryIndex)($new-index, $old-secondary-index)
     - $new-primary-index[Type] = '*scpb.SecondaryIndex'
     - $new-index[Type] = '*scpb.SecondaryIndex'
     - $new-primary-index-Target[TargetStatus] = ABSENT
@@ -9421,8 +9421,8 @@ deprules
   kind: SameStagePrecedence
   to: old-secondary-index-Node
   query:
-    - $old-secondary-index[Type] = '*scpb.PrimaryIndex'
     - $new-primary-index[Type] = '*scpb.SecondaryIndex'
+    - $old-secondary-index[Type] = '*scpb.PrimaryIndex'
     - joinOnDescID($new-primary-index, $old-secondary-index, $table-id)
     - $new-primary-index-Target[TargetStatus] = ABSENT
     - $new-primary-index-Node[CurrentStatus] = VALIDATED
@@ -9430,7 +9430,7 @@ deprules
     - $old-secondary-index-Node[CurrentStatus] = PUBLIC
     - $new-index[RecreateTargetIndexID] = $new-primary-index-id
     - $old-secondary-index[IndexID] = $new-primary-index-id
-    - only apply to secondary indexes created after 25.4(*scpb.PrimaryIndex, *scpb.SecondaryIndex)($new-primary-index, $old-secondary-index)
+    - only apply to secondary indexes created after 25.4(*scpb.SecondaryIndex, *scpb.PrimaryIndex)($new-index, $old-secondary-index)
     - $new-primary-index[Type] = '*scpb.SecondaryIndex'
     - $new-index[Type] = '*scpb.SecondaryIndex'
     - $new-primary-index-Target[TargetStatus] = ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
@@ -9,7 +9,7 @@ EXPLAIN (DDL) alter table t add primary key (a) USING HASH WITH (bucket_count=10
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›);
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 9 elements transitioning toward PUBLIC
+ │         ├── 20 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 12 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 12 (t_pkey+)}
@@ -18,8 +18,19 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10+)}
  │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), ReferencedColumnIDs: [1], Usage: REGULAR}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
- │         ├── 11 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 8 (idx_c+)}
+ │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (idx_c+)}
+ │         ├── 20 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 10 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey~)}
@@ -30,17 +41,44 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 10 (t_pkey~)}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 7}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 9}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT        TableSchemaLocked:{DescID: 104 (t)}
  │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
- │         └── 20 Mutation operations
+ │         └── 38 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"IsHidden":true,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_a_...","TableID":104}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"IsVirtual":true,"TableID":104}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":5,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":10,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":11}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
@@ -58,7 +96,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              └── AddColumnToIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 9 elements transitioning toward PUBLIC
+ │    │    ├── 20 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 12 (t_pkey+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 12 (t_pkey+)}
@@ -67,8 +105,19 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10+)}
  │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10+), TypeName: "INT8"}
  │    │    │    ├── PUBLIC        → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), ReferencedColumnIDs: [1], Usage: REGULAR}
- │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
- │    │    ├── 11 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 6 (idx_b+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 8 (idx_c+)}
+ │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c+)}
+ │    │    ├── 20 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 10 (t_pkey~)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey~)}
@@ -79,7 +128,16 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 10 (t_pkey~)}
- │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 7}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 9}
  │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │    │    │    └── ABSENT        → PUBLIC TableSchemaLocked:{DescID: 104 (t)}
  │    │    ├── 1 element transitioning toward ABSENT
@@ -87,7 +145,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 9 elements transitioning toward PUBLIC
+ │         ├── 20 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 12 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 12 (t_pkey+)}
@@ -96,8 +154,19 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10+)}
  │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), ReferencedColumnIDs: [1], Usage: REGULAR}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
- │         ├── 11 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (idx_b+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 8 (idx_c+)}
+ │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (idx_c+)}
+ │         ├── 20 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 10 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey~)}
@@ -108,17 +177,48 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 10 (t_pkey~)}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 7}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 9}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT        TableSchemaLocked:{DescID: 104 (t)}
  │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
- │         └── 25 Mutation operations
+ │         └── 47 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"IsHidden":true,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_a_...","TableID":104}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"IsVirtual":true,"TableID":104}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":5,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":10,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":11}}
  │              ├── MaybeAddSplitForIndex {"IndexID":10,"TableID":104}
@@ -144,226 +244,189 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+)}
  │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 11}
- │    │    └── 5 Mutation operations
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 11}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 7}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
+ │    │    └── 7 Mutation operations
  │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":5,"TableID":104}
  │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":5,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":7,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":11,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
  │    ├── Stage 2 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
  │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 1 Backfill operation
- │    │         └── BackfillIndex {"IndexID":10,"SourceIndexID":1,"TableID":104}
+ │    │    └── 3 Backfill operations
+ │    │         ├── BackfillIndex {"IndexID":10,"SourceIndexID":1,"TableID":104}
+ │    │         ├── BackfillIndex {"IndexID":6,"SourceIndexID":1,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":8,"SourceIndexID":1,"TableID":104}
  │    ├── Stage 3 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
  │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 3 Mutation operations
+ │    │    └── 5 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 4 of 16 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
- │    ├── Stage 5 of 16 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 1 Backfill operation
- │    │         └── MergeIndex {"BackfilledIndexID":10,"TableID":104,"TemporaryIndexID":11}
- │    ├── Stage 6 of 16 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 4 Mutation operations
- │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":10,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
- │    ├── Stage 7 of 16 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 1 Validation operation
- │    │         └── ValidateIndex {"IndexID":10,"TableID":104}
- │    ├── Stage 8 of 16 in PostCommitPhase
- │    │    ├── 11 elements transitioning toward PUBLIC
- │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 6 (idx_b+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (idx_b+)}
- │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 8 (idx_c+)}
- │    │    │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (idx_c+)}
- │    │    ├── 13 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 13}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 13}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 13}
- │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 7}
- │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
- │    │    │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 9}
- │    │    └── 29 Mutation operations
- │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":11,"IndexID":13,"IsUnique":true,"SourceIndexID":10,"TableID":104}}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":13,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":13,"Kind":2,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":13,"TableID":104}
- │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
- │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
- │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
- │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":13,"Ordinal":1,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 9 of 16 in PostCommitPhase
- │    │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 13}
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 7}
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey~)}
- │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
- │    │    └── 5 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":13,"TableID":104}
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":7,"TableID":104}
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
- │    ├── Stage 10 of 16 in PostCommitPhase
- │    │    ├── 3 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
- │    │    └── 3 Backfill operations
- │    │         ├── BackfillIndex {"IndexID":12,"SourceIndexID":10,"TableID":104}
- │    │         ├── BackfillIndex {"IndexID":6,"SourceIndexID":10,"TableID":104}
- │    │         └── BackfillIndex {"IndexID":8,"SourceIndexID":10,"TableID":104}
- │    ├── Stage 11 of 16 in PostCommitPhase
- │    │    ├── 3 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
- │    │    └── 5 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":12,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":6,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 12 of 16 in PostCommitPhase
- │    │    ├── 3 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
+ │    ├── Stage 4 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 5 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":12,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":6,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
- │    ├── Stage 13 of 16 in PostCommitPhase
- │    │    ├── 3 elements transitioning toward PUBLIC
- │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
+ │    ├── Stage 5 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 3 Backfill operations
- │    │         ├── MergeIndex {"BackfilledIndexID":12,"TableID":104,"TemporaryIndexID":13}
+ │    │         ├── MergeIndex {"BackfilledIndexID":10,"TableID":104,"TemporaryIndexID":11}
  │    │         ├── MergeIndex {"BackfilledIndexID":6,"TableID":104,"TemporaryIndexID":7}
  │    │         └── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
- │    ├── Stage 14 of 16 in PostCommitPhase
- │    │    ├── 3 elements transitioning toward PUBLIC
- │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
- │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey~)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey~)}
+ │    ├── Stage 6 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 8 Mutation operations
- │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":12,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":10,"TableID":104}
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":6,"TableID":104}
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":8,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
- │    ├── Stage 15 of 16 in PostCommitPhase
- │    │    ├── 4 elements transitioning toward PUBLIC
- │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
- │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
- │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
- │    │    └── 4 Validation operations
- │    │         ├── ValidateIndex {"IndexID":12,"TableID":104}
- │    │         ├── ValidateColumnNotNull {"ColumnID":5,"IndexIDForValidation":12,"TableID":104}
+ │    ├── Stage 7 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Validation operations
+ │    │         ├── ValidateIndex {"IndexID":10,"TableID":104}
  │    │         ├── ValidateIndex {"IndexID":6,"TableID":104}
  │    │         └── ValidateIndex {"IndexID":8,"TableID":104}
+ │    ├── Stage 8 of 16 in PostCommitPhase
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── VALIDATED → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b+)}
+ │    │    │    ├── VALIDATED → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+ │    │    │    └── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c+)}
+ │    │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey~)}
+ │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey~)}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 13}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 13}
+ │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 13}
+ │    │    ├── 4 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+ │    │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC    → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    │    └── PUBLIC    → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    └── 23 Mutation operations
+ │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":10,"Name":"t_pkey","TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":11,"IndexID":13,"IsUnique":true,"SourceIndexID":10,"TableID":104}}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":13,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":13,"Kind":2,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":13,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":6,"Name":"idx_b","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":8,"Name":"idx_c","TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":10,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":13,"Ordinal":1,"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":6,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":10}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":8,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":10}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":6,"TableID":104}
+ │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":8,"TableID":104}
+ │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ │    ├── Stage 9 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey~)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 13}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":13,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
+ │    ├── Stage 10 of 16 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":12,"SourceIndexID":10,"TableID":104}
+ │    ├── Stage 11 of 16 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":12,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ │    ├── Stage 12 of 16 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":12,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
+ │    ├── Stage 13 of 16 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":12,"TableID":104,"TemporaryIndexID":13}
+ │    ├── Stage 14 of 16 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey~)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":12,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
+ │    ├── Stage 15 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey~)}
+ │    │    │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
+ │    │    └── 2 Validation operations
+ │    │         ├── ValidateIndex {"IndexID":12,"TableID":104}
+ │    │         └── ValidateColumnNotNull {"ColumnID":5,"IndexIDForValidation":12,"TableID":104}
  │    └── Stage 16 of 16 in PostCommitPhase
- │         ├── 5 elements transitioning toward PUBLIC
- │         │    ├── VALIDATED → PUBLIC    ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
- │         │    ├── VALIDATED → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b+), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
- │         │    ├── ABSENT    → PUBLIC    IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b+)}
- │         │    ├── VALIDATED → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey~), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
- │         │    └── ABSENT    → PUBLIC    IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c+)}
- │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── VALIDATED → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey~), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-)}
- │         │    └── ABSENT    → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey~)}
- │         ├── 4 elements transitioning toward ABSENT
- │         │    ├── PUBLIC    → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
- │         │    ├── PUBLIC    → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
- │         │    ├── PUBLIC    → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │         │    └── PUBLIC    → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │         └── 19 Mutation operations
- │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
- │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │              ├── SetIndexName {"IndexID":10,"Name":"t_pkey","TableID":104}
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── VALIDATED → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 12 (t_pkey+)}
+ │         └── 3 Mutation operations
  │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":5,"TableID":104}
- │              ├── SetIndexName {"IndexID":6,"Name":"idx_b","TableID":104}
- │              ├── SetIndexName {"IndexID":8,"Name":"idx_c","TableID":104}
- │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":10,"TableID":104}
- │              ├── MarkRecreatedIndexAsInvisible {"IndexID":6,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":12}
- │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
- │              ├── RefreshStats {"TableID":104}
- │              ├── MarkRecreatedIndexAsInvisible {"IndexID":8,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":12}
- │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
- │              ├── RefreshStats {"TableID":104}
- │              ├── MarkRecreatedIndexAsVisible {"IndexID":6,"TableID":104}
- │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
- │              ├── MarkRecreatedIndexAsVisible {"IndexID":8,"TableID":104}
- │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │              └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
  └── PostCommitNonRevertiblePhase
@@ -378,11 +441,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 13}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 11}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 13}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10+), IndexID: 7}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain_shape
@@ -9,27 +9,27 @@ EXPLAIN (DDL, SHAPE) alter table t add primary key (a) USING HASH WITH (bucket_c
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›);
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey- in relation t
- │    └── into t_pkey~ (a, crdb_internal_a_shard_10+; rowid-, b)
- ├── execute 2 system table mutations transactions
- ├── merge temporary indexes into backfilled indexes in relation t
- │    └── from t@[11] into t_pkey~
- ├── execute 1 system table mutations transaction
- ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
- ├── execute 2 system table mutations transactions
- ├── backfill using primary index t_pkey~ in relation t
  │    ├── into idx_b+ (b: a, crdb_internal_a_shard_10+)
  │    ├── into idx_c+ (b, crdb_internal_b_shard_16: a, crdb_internal_a_shard_10+)
- │    └── into t_pkey+ (crdb_internal_a_shard_10+, a; b)
+ │    └── into t_pkey~ (a, crdb_internal_a_shard_10+; rowid-, b)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
  │    ├── from t@[7] into idx_b+
  │    ├── from t@[9] into idx_c+
+ │    └── from t@[11] into t_pkey~
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
+ ├── validate UNIQUE constraint backed by index idx_b+ in relation t
+ ├── validate UNIQUE constraint backed by index idx_c+ in relation t
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index t_pkey~ in relation t
+ │    └── into t_pkey+ (crdb_internal_a_shard_10+, a; b)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation t
  │    └── from t@[13] into t_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
  ├── validate NOT NULL constraint on column crdb_internal_a_shard_10+ in index t_pkey+ in relation t
- ├── validate UNIQUE constraint backed by index idx_b+ in relation t
- ├── validate UNIQUE constraint backed by index idx_c+ in relation t
  ├── execute 3 system table mutations transactions
  ├── validate non-index-backed constraint check_crdb_internal_a_shard_10+ in relation t
  └── execute 3 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
@@ -22,7 +22,7 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 20 MutationType ops
+## StatementPhase stage 1 of 1 with 38 MutationType ops
 upsert descriptor #104
   ...
        - 4
@@ -61,6 +61,126 @@ upsert descriptor #104
   +        width: 64
   +      virtual: true
   +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      keyColumnNames:
+  +      - crdb_internal_b_shard_16
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - b
+  +        isSharded: true
+  +        name: crdb_internal_b_shard_16
+  +        shardBuckets: 16
+  +      storeColumnNames: []
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 9
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      keyColumnNames:
+  +      - crdb_internal_b_shard_16
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - b
+  +        isSharded: true
+  +        name: crdb_internal_b_shard_16
+  +        shardBuckets: 16
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
   +  - constraint:
@@ -211,7 +331,7 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 25 MutationType ops
+## PreCommitPhase stage 2 of 2 with 47 MutationType ops
 upsert descriptor #104
   ...
        - 4
@@ -289,6 +409,126 @@ upsert descriptor #104
   +        width: 64
   +      virtual: true
   +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      keyColumnNames:
+  +      - crdb_internal_b_shard_16
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - b
+  +        isSharded: true
+  +        name: crdb_internal_b_shard_16
+  +        shardBuckets: 16
+  +      storeColumnNames: []
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 9
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      keyColumnNames:
+  +      - crdb_internal_b_shard_16
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      - 5
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - b
+  +        isSharded: true
+  +        name: crdb_internal_b_shard_16
+  +        shardBuckets: 16
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
   +  - constraint:
@@ -444,7 +684,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitPhase stage 1 of 16 with 5 MutationType ops
+## PostCommitPhase stage 1 of 16 with 7 MutationType ops
 upsert descriptor #104
   ...
        name: rowid_auto_not_null
@@ -459,6 +699,20 @@ upsert descriptor #104
      - id: 1
   ...
        direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
@@ -498,15 +752,29 @@ upsert descriptor #104
   -  version: "18"
   +  version: "19"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Backfilling index (1 operation) — PostCommit phase (stage 2 of 16)."
+update progress of schema change job #1: "Pending: Backfilling index (3 operations) — PostCommit phase (stage 2 of 16)."
 commit transaction #3
 begin transaction #4
-## PostCommitPhase stage 2 of 16 with 1 BackfillType op
-backfill indexes [10] from index #1 in table #104
+## PostCommitPhase stage 2 of 16 with 3 BackfillType ops
+backfill indexes [6 8 10] from index #1 in table #104
 commit transaction #4
 begin transaction #5
-## PostCommitPhase stage 3 of 16 with 3 MutationType ops
+## PostCommitPhase stage 3 of 16 with 5 MutationType ops
 upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -520,11 +788,25 @@ upsert descriptor #104
   -  version: "19"
   +  version: "20"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 4 of 16)."
+update progress of schema change job #1: "Pending: Updating schema metadata (3 operations) — PostCommit phase (stage 4 of 16)."
 commit transaction #5
 begin transaction #6
-## PostCommitPhase stage 4 of 16 with 3 MutationType ops
+## PostCommitPhase stage 4 of 16 with 5 MutationType ops
 upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -538,350 +820,15 @@ upsert descriptor #104
   -  version: "20"
   +  version: "21"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Merging index (1 operation) — PostCommit phase (stage 5 of 16)."
+update progress of schema change job #1: "Pending: Merging index (3 operations) — PostCommit phase (stage 5 of 16)."
 commit transaction #6
 begin transaction #7
-## PostCommitPhase stage 5 of 16 with 1 BackfillType op
-merge temporary indexes [11] into backfilled indexes [10] in table #104
+## PostCommitPhase stage 5 of 16 with 3 BackfillType ops
+merge temporary indexes [7 9 11] into backfilled indexes [6 8 10] in table #104
 commit transaction #7
 begin transaction #8
-## PostCommitPhase stage 6 of 16 with 4 MutationType ops
+## PostCommitPhase stage 6 of 16 with 8 MutationType ops
 upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: MERGING
-  -  - direction: ADD
-  +    state: WRITE_ONLY
-  +  - direction: DROP
-       index:
-         constraintId: 9
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "21"
-  +  version: "22"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Validating index (1 operation) — PostCommit phase (stage 7 of 16)."
-commit transaction #8
-begin transaction #9
-## PostCommitPhase stage 7 of 16 with 1 ValidationType op
-validate forward indexes [10] in table #104
-commit transaction #9
-begin transaction #10
-## PostCommitPhase stage 8 of 16 with 29 MutationType ops
-upsert descriptor #104
-  ...
-       mutationId: 1
-       state: WRITE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 11
-  +      createdExplicitly: true
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 13
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      - ASC
-  +      keyColumnIds:
-  +      - 5
-  +      - 1
-  +      keyColumnNames:
-  +      - crdb_internal_a_shard_10
-  +      - a
-  +      name: crdb_internal_index_13_name_placeholder
-  +      partitioning: {}
-  +      sharded:
-  +        columnNames:
-  +        - a
-  +        isSharded: true
-  +        name: crdb_internal_a_shard_10
-  +        shardBuckets: 10
-  +      storeColumnIds:
-  +      - 2
-  +      storeColumnNames:
-  +      - b
-  +      unique: true
-  +      useDeletePreservingEncoding: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: DELETE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 4
-  +      createdAtNanos: "1640998800000000000"
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 6
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 2
-  +      keyColumnNames:
-  +      - b
-  +      keySuffixColumnIds:
-  +      - 1
-  +      - 5
-  +      name: crdb_internal_index_6_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnNames: []
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: BACKFILLING
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 5
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 7
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 2
-  +      keyColumnNames:
-  +      - b
-  +      keySuffixColumnIds:
-  +      - 1
-  +      - 5
-  +      name: crdb_internal_index_7_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnNames: []
-  +      useDeletePreservingEncoding: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: DELETE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 6
-  +      createdAtNanos: "1640998800000000000"
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 8
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      - ASC
-  +      keyColumnIds:
-  +      - 4
-  +      - 2
-  +      keyColumnNames:
-  +      - crdb_internal_b_shard_16
-  +      - b
-  +      keySuffixColumnIds:
-  +      - 1
-  +      - 5
-  +      name: crdb_internal_index_8_name_placeholder
-  +      partitioning: {}
-  +      sharded:
-  +        columnNames:
-  +        - b
-  +        isSharded: true
-  +        name: crdb_internal_b_shard_16
-  +        shardBuckets: 16
-  +      storeColumnNames: []
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: BACKFILLING
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 7
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 9
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      - ASC
-  +      keyColumnIds:
-  +      - 4
-  +      - 2
-  +      keyColumnNames:
-  +      - crdb_internal_b_shard_16
-  +      - b
-  +      keySuffixColumnIds:
-  +      - 1
-  +      - 5
-  +      name: crdb_internal_index_9_name_placeholder
-  +      partitioning: {}
-  +      sharded:
-  +        columnNames:
-  +        - b
-  +        isSharded: true
-  +        name: crdb_internal_b_shard_16
-  +        shardBuckets: 16
-  +      storeColumnNames: []
-  +      useDeletePreservingEncoding: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 6
-  -  nextConstraintId: 11
-  +  nextConstraintId: 12
-     nextFamilyId: 1
-  -  nextIndexId: 13
-  +  nextIndexId: 14
-     nextMutationId: 1
-     parentId: 100
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "22"
-  +  version: "23"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (3 operations) — PostCommit phase (stage 9 of 16)."
-commit transaction #10
-begin transaction #11
-## PostCommitPhase stage 9 of 16 with 5 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     - direction: ADD
-       index:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     - direction: ADD
-       index:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     name: t
-     nextColumnId: 6
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "23"
-  +  version: "24"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Backfilling index (3 operations) — PostCommit phase (stage 10 of 16)."
-commit transaction #11
-begin transaction #12
-## PostCommitPhase stage 10 of 16 with 3 BackfillType ops
-backfill indexes [6 8 12] from index #10 in table #104
-commit transaction #12
-begin transaction #13
-## PostCommitPhase stage 11 of 16 with 5 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: BACKFILLING
-  +    state: DELETE_ONLY
-     - constraint:
-         check:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: BACKFILLING
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: BACKFILLING
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "24"
-  +  version: "25"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (3 operations) — PostCommit phase (stage 12 of 16)."
-commit transaction #13
-begin transaction #14
-## PostCommitPhase stage 12 of 16 with 5 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: MERGING
-     - constraint:
-         check:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: MERGING
-     - direction: ADD
-       index:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: MERGING
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "25"
-  +  version: "26"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Merging index (3 operations) — PostCommit phase (stage 13 of 16)."
-commit transaction #14
-begin transaction #15
-## PostCommitPhase stage 13 of 16 with 3 BackfillType ops
-merge temporary indexes [7 9 13] into backfilled indexes [6 8 12] in table #104
-commit transaction #15
-begin transaction #16
-## PostCommitPhase stage 14 of 16 with 8 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: MERGING
-  +    state: WRITE_ONLY
-     - constraint:
-         check:
-  ...
-       mutationId: 1
-       state: WRITE_ONLY
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-         constraintId: 11
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
   ...
          version: 4
        mutationId: 1
@@ -912,43 +859,41 @@ upsert descriptor #104
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 6
+     - constraint:
+         check:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 9
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "26"
-  +  version: "27"
+  -  version: "21"
+  +  version: "22"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Validating NOT NULL constraint (1 operation); Validating index (3 operations) — PostCommit phase (stage 15 of 16)."
-commit transaction #16
-begin transaction #17
-## PostCommitPhase stage 15 of 16 with 4 ValidationType ops
-validate forward indexes [12] in table #104
-validate CHECK constraint crdb_internal_a_shard_10_auto_not_null in table #104
+update progress of schema change job #1: "Pending: Validating index (3 operations) — PostCommit phase (stage 7 of 16)."
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 16 with 3 ValidationType ops
+validate forward indexes [10] in table #104
 validate forward indexes [6] in table #104
 validate forward indexes [8] in table #104
-commit transaction #17
-begin transaction #18
-## PostCommitPhase stage 16 of 16 with 19 MutationType ops
+commit transaction #9
+begin transaction #10
+## PostCommitPhase stage 8 of 16 with 23 MutationType ops
 upsert descriptor #104
-  ...
-       name: rowid_auto_not_null
-       validity: Dropping
-  -  - columnIds:
-  -    - 5
-  -    expr: crdb_internal_a_shard_10 IS NOT NULL
-  -    isNonNullConstraint: true
-  -    name: crdb_internal_a_shard_10_auto_not_null
-  -    validity: Validating
-     columns:
-     - id: 1
-  ...
-           statement: ALTER TABLE t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)
-           statementTag: ALTER TABLE
-  -    revertible: true
-       targetRanks: <redacted>
-       targets: <redacted>
   ...
      id: 104
      indexes:
@@ -999,47 +944,69 @@ upsert descriptor #104
        vecConfig: {}
        version: 4
   ...
-         id: 5
-         name: crdb_internal_a_shard_10
-  -      nullable: true
-         type:
-           family: IntFamily
-  ...
        mutationId: 1
        state: WRITE_ONLY
   -  - direction: ADD
   -    index:
-  -      constraintId: 8
+  -      constraintId: 4
+  -      createdAtNanos: "1640998800000000000"
   -      createdExplicitly: true
-  -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 10
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      - 5
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 6
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 8
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 5
-  -      - 1
+  -      - 4
+  -      - 2
   -      keyColumnNames:
-  -      - crdb_internal_a_shard_10
-  -      - a
-  -      name: crdb_internal_index_10_name_placeholder
+  -      - crdb_internal_b_shard_16
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      - 5
+  -      name: crdb_internal_index_8_name_placeholder
   -      partitioning: {}
   -      sharded:
   -        columnNames:
-  -        - a
+  -        - b
   -        isSharded: true
-  -        name: crdb_internal_a_shard_10
-  -        shardBuckets: 10
-  -      storeColumnIds:
-  -      - 3
-  -      - 2
-  -      storeColumnNames:
-  -      - rowid
-  -      - b
-  -      unique: true
+  -        name: crdb_internal_b_shard_16
+  -        shardBuckets: 16
+  -      storeColumnNames: []
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
@@ -1049,96 +1016,85 @@ upsert descriptor #104
   ...
        mutationId: 1
        state: WRITE_ONLY
-  -  - constraint:
-  -      check:
-  -        columnIds:
-  -        - 5
-  -        expr: crdb_internal_a_shard_10 IS NOT NULL
-  -        isNonNullConstraint: true
-  -        name: crdb_internal_a_shard_10_auto_not_null
-  -        validity: Validating
-  -      constraintType: NOT_NULL
-  -      foreignKey: {}
-  -      name: crdb_internal_a_shard_10_auto_not_null
-  -      notNullColumn: 5
-  -      uniqueWithoutIndexConstraint: {}
-  -    direction: ADD
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-     - direction: DROP
-       index:
-  ...
-       mutationId: 1
-       state: DELETE_ONLY
   -  - direction: ADD
   +  - direction: DROP
        index:
-  -      constraintId: 4
-  -      createdAtNanos: "1640998800000000000"
-  +      constraintId: 5
+  -      constraintId: 8
+  +      constraintId: 9
          createdExplicitly: true
+         encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 6
-  +      id: 7
+  -      id: 10
+  +      id: 11
          interleave: {}
          keyColumnDirections:
   ...
-         - 1
-         - 5
-  -      name: crdb_internal_index_6_name_placeholder
-  +      name: crdb_internal_index_7_name_placeholder
+         - crdb_internal_a_shard_10
+         - a
+  -      name: crdb_internal_index_10_name_placeholder
+  +      name: crdb_internal_index_11_name_placeholder
          partitioning: {}
-         sharded: {}
-         storeColumnNames: []
+         sharded:
+  ...
+         - b
+         unique: true
   +      useDeletePreservingEncoding: true
          vecConfig: {}
          version: 4
        mutationId: 1
   -    state: WRITE_ONLY
+  -  - direction: DROP
   +    state: DELETE_ONLY
-     - direction: DROP
+  +  - direction: ADD
        index:
-  -      constraintId: 5
-  +      constraintId: 7
+  -      constraintId: 9
+  +      constraintId: 10
          createdExplicitly: true
+         encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 7
-  +      id: 9
+  -      id: 11
+  +      id: 12
          interleave: {}
          keyColumnDirections:
-         - ASC
-  +      - ASC
-         keyColumnIds:
-  +      - 4
-         - 2
-         keyColumnNames:
-  +      - crdb_internal_b_shard_16
-         - b
-         keySuffixColumnIds:
-         - 1
-         - 5
-  -      name: crdb_internal_index_7_name_placeholder
-  +      name: crdb_internal_index_9_name_placeholder
-         partitioning: {}
-  -      sharded: {}
-  +      sharded:
-  +        columnNames:
-  +        - b
-  +        isSharded: true
-  +        name: crdb_internal_b_shard_16
-  +        shardBuckets: 16
-         storeColumnNames: []
-         useDeletePreservingEncoding: true
   ...
-       mutationId: 1
-       state: DELETE_ONLY
-  -  - direction: ADD
+         - crdb_internal_a_shard_10
+         - a
+  -      name: crdb_internal_index_11_name_placeholder
+  +      name: crdb_internal_index_12_name_placeholder
+         partitioning: {}
+         sharded:
+  ...
+           shardBuckets: 10
+         storeColumnIds:
+  -      - 3
+         - 2
+         storeColumnNames:
+  +      - b
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 5
+  +        expr: crdb_internal_a_shard_10 IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: crdb_internal_a_shard_10_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: crdb_internal_a_shard_10_auto_not_null
+  +      notNullColumn: 5
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
   +  - direction: DROP
-       index:
-  -      constraintId: 6
-  -      createdAtNanos: "1640998800000000000"
+  +    index:
   +      constraintId: 1
   +      createdAtNanos: "1640995200000000000"
   +      encodingType: 1
@@ -1151,7 +1107,7 @@ upsert descriptor #104
   +      keyColumnIds:
   +      - 3
   +      keyColumnNames:
-  +      - rowid
+         - rowid
   +      name: crdb_internal_index_1_name_placeholder
   +      partitioning: {}
   +      sharded: {}
@@ -1160,82 +1116,117 @@ upsert descriptor #104
   +      - 2
   +      storeColumnNames:
   +      - a
-  +      - b
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - direction: DROP
-  +    index:
-  +      createdAtNanos: "1640995200000000000"
-         createdExplicitly: true
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 8
-  +      id: 2
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-  -      - ASC
-         keyColumnIds:
-  -      - 4
-         - 2
-         keyColumnNames:
-  -      - crdb_internal_b_shard_16
          - b
-         keySuffixColumnIds:
-  -      - 1
-  -      - 5
-  -      name: crdb_internal_index_8_name_placeholder
-  +      - 3
-  +      name: idx_b
-         partitioning: {}
-  -      sharded:
-  -        columnNames:
-  -        - b
-  -        isSharded: true
-  -        name: crdb_internal_b_shard_16
-  -        shardBuckets: 16
-  -      storeColumnNames: []
-  +      sharded: {}
-         vecConfig: {}
-         version: 4
-  ...
-     - direction: DROP
-       index:
-  -      constraintId: 7
-  +      createdAtNanos: "1640995200000000000"
-         createdExplicitly: true
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 9
-  +      id: 4
-         interleave: {}
-         keyColumnDirections:
-  ...
-         - b
-         keySuffixColumnIds:
-  -      - 1
-  -      - 5
-  -      name: crdb_internal_index_9_name_placeholder
-  +      - 3
-  +      name: idx_c
-         partitioning: {}
-         sharded:
-  ...
-           name: crdb_internal_b_shard_16
-           shardBuckets: 16
-  -      storeColumnNames: []
+         unique: true
   -      useDeletePreservingEncoding: true
          vecConfig: {}
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  -      constraintId: 10
+  +      constraintId: 11
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 12
+  +      id: 13
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_internal_a_shard_10
+         - a
+  -      name: crdb_internal_index_12_name_placeholder
+  +      name: crdb_internal_index_13_name_placeholder
+         partitioning: {}
+         sharded:
+  ...
+         - b
+         unique: true
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 5
+  -        expr: crdb_internal_a_shard_10 IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: crdb_internal_a_shard_10_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      createdAtNanos: "1640995200000000000"
+  +      createdExplicitly: true
+         foreignKey: {}
+  -      name: crdb_internal_a_shard_10_auto_not_null
+  -      notNullColumn: 5
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 3
+  +      name: idx_b
+  +      partitioning: {}
+  +      sharded: {}
+  +      vecConfig: {}
+  +      version: 4
+       mutationId: 1
+       state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      createdAtNanos: "1640995200000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 2
+  +      keyColumnNames:
+  +      - crdb_internal_b_shard_16
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 3
+  +      name: idx_c
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - b
+  +        isSharded: true
+  +        name: crdb_internal_b_shard_16
+  +        shardBuckets: 16
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: t
      nextColumnId: 6
-  ...
+  -  nextConstraintId: 11
+  +  nextConstraintId: 12
+     nextFamilyId: 1
+  -  nextIndexId: 13
+  +  nextIndexId: 14
+     nextMutationId: 1
      parentId: 100
      primaryIndex:
   -    constraintId: 1
@@ -1280,10 +1271,164 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
+  -  version: "22"
+  +  version: "23"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 9 of 16)."
+commit transaction #10
+begin transaction #11
+## PostCommitPhase stage 9 of 16 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "23"
+  +  version: "24"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Backfilling index (1 operation) — PostCommit phase (stage 10 of 16)."
+commit transaction #11
+begin transaction #12
+## PostCommitPhase stage 10 of 16 with 1 BackfillType op
+backfill indexes [12] from index #10 in table #104
+commit transaction #12
+begin transaction #13
+## PostCommitPhase stage 11 of 16 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - constraint:
+         check:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "24"
+  +  version: "25"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 12 of 16)."
+commit transaction #13
+begin transaction #14
+## PostCommitPhase stage 12 of 16 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - constraint:
+         check:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "25"
+  +  version: "26"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Merging index (1 operation) — PostCommit phase (stage 13 of 16)."
+commit transaction #14
+begin transaction #15
+## PostCommitPhase stage 13 of 16 with 1 BackfillType op
+merge temporary indexes [13] into backfilled indexes [12] in table #104
+commit transaction #15
+begin transaction #16
+## PostCommitPhase stage 14 of 16 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - constraint:
+         check:
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+         constraintId: 11
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "26"
+  +  version: "27"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Validating NOT NULL constraint (1 operation); Validating index (1 operation) — PostCommit phase (stage 15 of 16)."
+commit transaction #16
+begin transaction #17
+## PostCommitPhase stage 15 of 16 with 2 ValidationType ops
+validate forward indexes [12] in table #104
+validate CHECK constraint crdb_internal_a_shard_10_auto_not_null in table #104
+commit transaction #17
+begin transaction #18
+## PostCommitPhase stage 16 of 16 with 3 MutationType ops
+upsert descriptor #104
+  ...
+       name: rowid_auto_not_null
+       validity: Dropping
+  -  - columnIds:
+  -    - 5
+  -    expr: crdb_internal_a_shard_10 IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: crdb_internal_a_shard_10_auto_not_null
+  -    validity: Validating
+     columns:
+     - id: 1
+  ...
+           statement: ALTER TABLE t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+         id: 5
+         name: crdb_internal_a_shard_10
+  -      nullable: true
+         type:
+           family: IntFamily
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 5
+  -        expr: crdb_internal_a_shard_10 IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: crdb_internal_a_shard_10_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: crdb_internal_a_shard_10_auto_not_null
+  -      notNullColumn: 5
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
   -  version: "27"
   +  version: "28"
 persist all catalog changes to storage
-adding table for stats refresh: 104
 update progress of schema change job #1: "Pending: Updating schema metadata (34 operations) — PostCommitNonRevertible phase (stage 1 of 6)."
 set schema change job #1 to non-cancellable
 commit transaction #18
@@ -1325,6 +1470,66 @@ upsert descriptor #104
   ...
        mutationId: 1
        state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 7
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      - 5
+  -      name: crdb_internal_index_7_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 7
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 9
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 2
+  -      keyColumnNames:
+  -      - crdb_internal_b_shard_16
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      - 5
+  -      name: crdb_internal_index_9_name_placeholder
+  -      partitioning: {}
+  -      sharded:
+  -        columnNames:
+  -        - b
+  -        isSharded: true
+  -        name: crdb_internal_b_shard_16
+  -        shardBuckets: 16
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
   -  - constraint:
   -      check:
   -        columnIds:
@@ -1382,8 +1587,18 @@ upsert descriptor #104
      - direction: ADD
        index:
   ...
-     - direction: DROP
-       index:
+         - 3
+         keyColumnNames:
+  -      - rowid
+  +      - crdb_internal_column_3_name_placeholder
+         name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
   -      constraintId: 11
   -      createdExplicitly: true
   -      encodingType: 1
@@ -1417,85 +1632,8 @@ upsert descriptor #104
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      constraintId: 5
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 7
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 2
-  -      keyColumnNames:
-  -      - b
-  -      keySuffixColumnIds:
-  -      - 1
-  -      - 5
-  -      name: crdb_internal_index_7_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnNames: []
-  -      useDeletePreservingEncoding: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      constraintId: 7
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 9
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      - ASC
-  -      keyColumnIds:
-  -      - 4
-  -      - 2
-  -      keyColumnNames:
-  -      - crdb_internal_b_shard_16
-  -      - b
-  -      keySuffixColumnIds:
-  -      - 1
-  -      - 5
-  -      name: crdb_internal_index_9_name_placeholder
-  -      partitioning: {}
-  -      sharded:
-  -        columnNames:
-  -        - b
-  -        isSharded: true
-  -        name: crdb_internal_b_shard_16
-  -        shardBuckets: 16
-  -      storeColumnNames: []
-  -      useDeletePreservingEncoding: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-         constraintId: 1
-         createdAtNanos: "1640995200000000000"
-  ...
-         - 3
-         keyColumnNames:
-  -      - rowid
-  +      - crdb_internal_column_3_name_placeholder
-         name: crdb_internal_index_1_name_placeholder
-         partitioning: {}
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
+       state: DELETE_ONLY
      - direction: DROP
-       index:
   ...
          keySuffixColumnIds:
          - 3

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,60 +68,86 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 15 elements transitioning toward ABSENT
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 16 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
@@ -129,7 +156,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,60 +68,86 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 15 elements transitioning toward ABSENT
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 16 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
@@ -129,7 +156,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,60 +68,86 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 15 elements transitioning toward ABSENT
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 16 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
@@ -129,7 +156,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -64,69 +65,91 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":2,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 18 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 18 elements transitioning toward ABSENT
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 19 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
@@ -135,7 +158,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -64,69 +65,91 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":2,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 18 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 18 elements transitioning toward ABSENT
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 11, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
-      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 19 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
@@ -135,7 +158,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,54 +68,80 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 15 elements transitioning toward ABSENT
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 16 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
@@ -129,7 +156,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_16_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 16 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,54 +68,80 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 15 elements transitioning toward ABSENT
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 12 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 13, SourceIndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    └── 16 Mutation operations
+      │    └── 15 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
@@ -129,7 +156,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_1_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_1_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 20 elements transitioning toward ABSENT
+      │    ├── 40 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -32,8 +32,28 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── PUBLIC        → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 22 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 42 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
@@ -44,14 +64,34 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":2,"TableID":104}
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_2_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_2_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
@@ -46,26 +64,56 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 8 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_3_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_3_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
@@ -46,26 +64,56 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 8 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_4_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_4_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── DELETE_ONLY   → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── DELETE_ONLY   → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
@@ -46,26 +64,56 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 8 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_5_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_5_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
@@ -42,6 +60,15 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
@@ -49,10 +76,19 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
+      │    ├── 16 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
@@ -60,14 +96,30 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 9 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_6_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_6_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
@@ -42,6 +60,15 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
@@ -49,10 +76,19 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
+      │    ├── 16 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
@@ -60,14 +96,30 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 9 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 17 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_7_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_7_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
@@ -46,26 +64,56 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 8 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_8_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_8_of_16.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 35 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
@@ -29,8 +29,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
@@ -46,26 +64,56 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
-      │    │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
-      │    └── 8 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_16.explain
@@ -9,14 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    ├── 39 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_c+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
@@ -30,30 +32,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 12 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 13}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
-      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 7}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 10 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 12}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
-      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 9}
-      │    └── 42 Mutation operations
+      │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
@@ -66,37 +67,63 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":12,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":13,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 16 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 10 (t_pkey-)}
+      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (idx_b-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 6 (idx_b-)}
+      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "idx_c", IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_b_shard_16), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (idx_c-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), IndexID: 8 (idx_c-)}
+      │    └── 18 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
@@ -104,20 +131,28 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_a_shard_10-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_a_shard_10-), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 6 (idx_b-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (idx_b-)}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (idx_c-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (idx_c-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+      │    └── 14 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnComputeExpression {"ColumnID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain
@@ -219,96 +219,27 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":6,"TableID":104}
  │    ├── Stage 8 of 23 in PostCommitPhase
- │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
- │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
- │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 9}
- │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
- │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
- │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 9}
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
- │    │    └── 12 Mutation operations
- │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
- │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │    │         ├── SetIndexName {"IndexID":6,"Name":"t_pkey","TableID":104}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx+)}
+ │    │    │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx+)}
+ │    │    ├── 8 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 9}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 9}
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+ │    │    │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+ │    │    └── 16 Mutation operations
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 9 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
- │    ├── Stage 10 of 23 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    └── 1 Backfill operation
- │    │         └── BackfillIndex {"IndexID":8,"SourceIndexID":6,"TableID":104}
- │    ├── Stage 11 of 23 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 12 of 23 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
- │    ├── Stage 13 of 23 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    └── 1 Backfill operation
- │    │         └── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
- │    ├── Stage 14 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
- │    │    └── 4 Mutation operations
- │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":8,"TableID":104}
- │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
- │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
- │    ├── Stage 15 of 23 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    └── 1 Validation operation
- │    │         └── ValidateIndex {"IndexID":8,"TableID":104}
- │    ├── Stage 16 of 23 in PostCommitPhase
- │    │    ├── 4 elements transitioning toward PUBLIC
- │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx+)}
- │    │    │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx+)}
- │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 11}
- │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
- │    │    │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
- │    │    └── 15 Mutation operations
- │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":9,"IndexID":11,"IsUnique":true,"SourceIndexID":8,"TableID":104}}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":11,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
@@ -319,184 +250,249 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 17 of 23 in PostCommitPhase
+ │    ├── Stage 9 of 23 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
- │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 11}
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 5}
  │    │    └── 4 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
- │    ├── Stage 18 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    ├── Stage 10 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │    │    └── 2 Backfill operations
- │    │         ├── BackfillIndex {"IndexID":10,"SourceIndexID":8,"TableID":104}
- │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":8,"TableID":104}
- │    ├── Stage 19 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    │         ├── BackfillIndex {"IndexID":8,"SourceIndexID":6,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":6,"TableID":104}
+ │    ├── Stage 11 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │    │    └── 4 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
- │    ├── Stage 20 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    ├── Stage 12 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │    │    └── 4 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
- │    ├── Stage 21 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
+ │    ├── Stage 13 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │    │    └── 2 Backfill operations
- │    │         ├── MergeIndex {"BackfilledIndexID":10,"TableID":104,"TemporaryIndexID":11}
+ │    │         ├── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
- │    ├── Stage 22 of 23 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
+ │    ├── Stage 14 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
  │    │    └── 6 Mutation operations
- │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":8,"TableID":104}
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
+ │    ├── Stage 15 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 2 Validation operations
+ │    │         ├── ValidateIndex {"IndexID":8,"TableID":104}
+ │    │         └── ValidateIndex {"IndexID":4,"TableID":104}
+ │    ├── Stage 16 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── VALIDATED → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx+)}
+ │    │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+ │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 11}
+ │    │    ├── 3 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+ │    │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │    │    │    └── PUBLIC    → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+ │    │    └── 17 Mutation operations
+ │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":6,"Name":"t_pkey","TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":9,"IndexID":11,"IsUnique":true,"SourceIndexID":8,"TableID":104}}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":11,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":4,"Name":"t_a_idx","TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":8}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":104}
+ │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ │    ├── Stage 17 of 23 in PostCommitPhase
+ │    │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
+ │    │    │    ├── VALIDATED   → PUBLIC              PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT      → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey~)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY          TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── ABSENT      → PUBLIC              IndexData:{DescID: 104 (t), IndexID: 11}
+ │    │    └── 7 Mutation operations
+ │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":8,"Name":"t_pkey","TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Backfil..."}
+ │    ├── Stage 18 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":10,"SourceIndexID":8,"TableID":104}
+ │    ├── Stage 19 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ │    ├── Stage 20 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Merging..."}
+ │    ├── Stage 21 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":10,"TableID":104,"TemporaryIndexID":11}
+ │    ├── Stage 22 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"Pending: Validat..."}
  │    └── Stage 23 of 23 in PostCommitPhase
- │         ├── 2 elements transitioning toward PUBLIC
- │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
- │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
- │         └── 2 Validation operations
- │              ├── ValidateIndex {"IndexID":10,"TableID":104}
- │              └── ValidateIndex {"IndexID":4,"TableID":104}
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │         └── 1 Validation operation
+ │              └── ValidateIndex {"IndexID":10,"TableID":104}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 5 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC              SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    └── ABSENT                → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx+)}
-      │    ├── 21 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── PUBLIC                → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → PUBLIC              PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
-      │    │    ├── ABSENT                → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey~)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 9}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 9}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 11}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    │    └── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → WRITE_ONLY          Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
-      │    │    ├── PUBLIC                → ABSENT              ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 3 (rowid-)}
-      │    │    ├── VALIDATED             → ABSENT              ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
-      │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 1 (t_pkey-)}
-      │    │    ├── VALIDATED             → DELETE_ONLY         PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    │    └── PUBLIC                → VALIDATED           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    └── 36 Mutation operations
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC                Column:{DescID: 104 (t), ColumnID: 4 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC                PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+      │    │    └── ABSENT                → PUBLIC                IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey+)}
+      │    ├── 24 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_VALIDATED   → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 11}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → WRITE_ONLY            Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
+      │    │    ├── PUBLIC                → ABSENT                ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 3 (rowid-)}
+      │    │    ├── VALIDATED             → ABSENT                ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 1 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    ├── PUBLIC                → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 2 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (t_a_idx-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    │    └── PUBLIC                → ABSENT                IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 2 (t_a_idx-)}
+      │    └── 41 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":8,"Name":"t_pkey","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"t_pkey","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"t_a_idx","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":10}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":104}
-      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 5 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY          → PUBLIC                Column:{DescID: 104 (t), ColumnID: 4 (m+)}
-      │    │    ├── VALIDATED           → PUBLIC                PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
-      │    │    └── ABSENT              → PUBLIC                IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey+)}
-      │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
-      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey~)}
-      │    │    └── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 6 (t_pkey~)}
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY          → DELETE_ONLY           Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
-      │    │    ├── DELETE_ONLY         → ABSENT                PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 2 (t_a_idx-)}
-      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (t_a_idx-)}
-      │    │    ├── VALIDATED           → DELETE_ONLY           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    │    └── PUBLIC              → ABSENT                IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 2 (t_a_idx-)}
-      │    └── 19 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
-      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── SetIndexName {"IndexID":10,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 5 in PostCommitNonRevertiblePhase
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
       │    │    ├── TRANSIENT_VALIDATED   → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
@@ -504,9 +500,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey~)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey~)}
       │    │    └── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 8 (t_pkey~)}
-      │    ├── 1 element transitioning toward ABSENT
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY           Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
+      │    │    ├── DELETE_ONLY           → ABSENT                PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT                SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
-      │    └── 9 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
@@ -516,7 +516,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 4 of 5 in PostCommitNonRevertiblePhase
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
       │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
@@ -545,7 +545,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 5 of 5 in PostCommitNonRevertiblePhase
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain_shape
@@ -17,21 +17,21 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey~ in relation t
+ │    ├── into t_a_idx+ (a: b)
  │    └── into t_pkey~ (b; rowid-, a, m+)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
+ │    ├── from t@[5] into t_a_idx+
  │    └── from t@[9] into t_pkey~
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
+ ├── validate UNIQUE constraint backed by index t_a_idx+ in relation t
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey~ in relation t
- │    ├── into t_a_idx+ (a: b)
  │    └── into t_pkey+ (b; a, m+)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
- │    ├── from t@[5] into t_a_idx+
  │    └── from t@[11] into t_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
- ├── validate UNIQUE constraint backed by index t_a_idx+ in relation t
- └── execute 5 system table mutations transactions
+ └── execute 4 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.side_effects
@@ -584,76 +584,11 @@ begin transaction #9
 validate forward indexes [6] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 23 with 12 MutationType ops
+## PostCommitPhase stage 8 of 23 with 16 MutationType ops
 upsert descriptor #104
   ...
        mutationId: 1
        state: WRITE_ONLY
-  -  - direction: ADD
-  -    index:
-  -      constraintId: 4
-  -      createdExplicitly: true
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 6
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 3
-  -      keyColumnNames:
-  -      - rowid
-  -      name: crdb_internal_index_6_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnIds:
-  -      - 1
-  -      - 2
-  -      - 4
-  -      storeColumnNames:
-  -      - a
-  -      - b
-  -      - m
-  -      unique: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-     - direction: DROP
-       index:
-  ...
-       mutationId: 1
-       state: WRITE_ONLY
-  +  - direction: DROP
-  +    index:
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 1
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 3
-  +      keyColumnNames:
-  +      - rowid
-  +      name: crdb_internal_index_1_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 1
-  +      - 2
-  +      storeColumnNames:
-  +      - a
-  +      - b
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
   +  - direction: ADD
   +    index:
   +      constraintId: 7
@@ -678,174 +613,6 @@ upsert descriptor #104
   +      - 4
   +      storeColumnNames:
   +      - rowid
-  +      - a
-  +      - m
-  +      unique: true
-  +      useDeletePreservingEncoding: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 5
-  ...
-     parentId: 100
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 4
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 6
-       interleave: {}
-       keyColumnDirections:
-  ...
-       - 1
-       - 2
-  +    - 4
-       storeColumnNames:
-       - a
-       - b
-  +    - m
-       unique: true
-       vecConfig: {}
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "13"
-  +  version: "14"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 9 of 23)."
-commit transaction #10
-begin transaction #11
-## PostCommitPhase stage 9 of 23 with 3 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     name: t
-     nextColumnId: 5
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "14"
-  +  version: "15"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Backfilling index (1 operation) — PostCommit phase (stage 10 of 23)."
-commit transaction #11
-begin transaction #12
-## PostCommitPhase stage 10 of 23 with 1 BackfillType op
-backfill indexes [8] from index #6 in table #104
-commit transaction #12
-begin transaction #13
-## PostCommitPhase stage 11 of 23 with 3 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: BACKFILLING
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "15"
-  +  version: "16"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 12 of 23)."
-commit transaction #13
-begin transaction #14
-## PostCommitPhase stage 12 of 23 with 3 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: MERGING
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "16"
-  +  version: "17"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Merging index (1 operation) — PostCommit phase (stage 13 of 23)."
-commit transaction #14
-begin transaction #15
-## PostCommitPhase stage 13 of 23 with 1 BackfillType op
-merge temporary indexes [9] into backfilled indexes [8] in table #104
-commit transaction #15
-begin transaction #16
-## PostCommitPhase stage 14 of 23 with 4 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: MERGING
-  +    state: WRITE_ONLY
-     - direction: ADD
-       index:
-  ...
-       mutationId: 1
-       state: WRITE_ONLY
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-         constraintId: 7
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 5
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "17"
-  +  version: "18"
-persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Validating index (1 operation) — PostCommit phase (stage 15 of 23)."
-commit transaction #16
-begin transaction #17
-## PostCommitPhase stage 15 of 23 with 1 ValidationType op
-validate forward indexes [8] in table #104
-commit transaction #17
-begin transaction #18
-## PostCommitPhase stage 16 of 23 with 15 MutationType ops
-upsert descriptor #104
-  ...
-       mutationId: 1
-       state: DELETE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 9
-  +      createdExplicitly: true
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 11
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 2
-  +      keyColumnNames:
-  +      - b
-  +      name: crdb_internal_index_11_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 1
-  +      - 4
-  +      storeColumnNames:
   +      - a
   +      - m
   +      unique: true
@@ -906,23 +673,16 @@ upsert descriptor #104
   +    state: DELETE_ONLY
      name: t
      nextColumnId: 5
-  -  nextConstraintId: 9
-  +  nextConstraintId: 10
-     nextFamilyId: 1
-  -  nextIndexId: 11
-  +  nextIndexId: 12
-     nextMutationId: 1
-     parentId: 100
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "18"
-  +  version: "19"
+  -  version: "13"
+  +  version: "14"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (2 operations) — PostCommit phase (stage 17 of 23)."
-commit transaction #18
-begin transaction #19
-## PostCommitPhase stage 17 of 23 with 4 MutationType ops
+update progress of schema change job #1: "Pending: Updating schema metadata (2 operations) — PostCommit phase (stage 9 of 23)."
+commit transaction #10
+begin transaction #11
+## PostCommitPhase stage 9 of 23 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -941,25 +701,25 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "19"
-  +  version: "20"
+  -  version: "14"
+  +  version: "15"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Backfilling index (2 operations) — PostCommit phase (stage 18 of 23)."
-commit transaction #19
-begin transaction #20
-## PostCommitPhase stage 18 of 23 with 2 BackfillType ops
-backfill indexes [4 10] from index #8 in table #104
-commit transaction #20
-begin transaction #21
-## PostCommitPhase stage 19 of 23 with 4 MutationType ops
+update progress of schema change job #1: "Pending: Backfilling index (2 operations) — PostCommit phase (stage 10 of 23)."
+commit transaction #11
+begin transaction #12
+## PostCommitPhase stage 10 of 23 with 2 BackfillType ops
+backfill indexes [4 8] from index #6 in table #104
+commit transaction #12
+begin transaction #13
+## PostCommitPhase stage 11 of 23 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: BACKFILLING
   +    state: DELETE_ONLY
-     - constraint:
-         check:
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -970,21 +730,21 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "20"
-  +  version: "21"
+  -  version: "15"
+  +  version: "16"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (2 operations) — PostCommit phase (stage 20 of 23)."
-commit transaction #21
-begin transaction #22
-## PostCommitPhase stage 20 of 23 with 4 MutationType ops
+update progress of schema change job #1: "Pending: Updating schema metadata (2 operations) — PostCommit phase (stage 12 of 23)."
+commit transaction #13
+begin transaction #14
+## PostCommitPhase stage 12 of 23 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: MERGING
-     - constraint:
-         check:
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -995,32 +755,32 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "21"
-  +  version: "22"
+  -  version: "16"
+  +  version: "17"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Merging index (2 operations) — PostCommit phase (stage 21 of 23)."
-commit transaction #22
-begin transaction #23
-## PostCommitPhase stage 21 of 23 with 2 BackfillType ops
-merge temporary indexes [5 11] into backfilled indexes [4 10] in table #104
-commit transaction #23
-begin transaction #24
-## PostCommitPhase stage 22 of 23 with 6 MutationType ops
+update progress of schema change job #1: "Pending: Merging index (2 operations) — PostCommit phase (stage 13 of 23)."
+commit transaction #14
+begin transaction #15
+## PostCommitPhase stage 13 of 23 with 2 BackfillType ops
+merge temporary indexes [5 9] into backfilled indexes [4 8] in table #104
+commit transaction #15
+begin transaction #16
+## PostCommitPhase stage 14 of 23 with 6 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: MERGING
   +    state: WRITE_ONLY
-     - constraint:
-         check:
+     - direction: ADD
+       index:
   ...
        mutationId: 1
-       state: DELETE_ONLY
+       state: WRITE_ONLY
   -  - direction: ADD
   +  - direction: DROP
        index:
-         constraintId: 9
+         constraintId: 7
   ...
          version: 4
        mutationId: 1
@@ -1047,57 +807,19 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "22"
-  +  version: "23"
+  -  version: "17"
+  +  version: "18"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Validating index (2 operations) — PostCommit phase (stage 23 of 23)."
-commit transaction #24
-begin transaction #25
-## PostCommitPhase stage 23 of 23 with 2 ValidationType ops
-validate forward indexes [10] in table #104
+update progress of schema change job #1: "Pending: Validating index (2 operations) — PostCommit phase (stage 15 of 23)."
+commit transaction #16
+begin transaction #17
+## PostCommitPhase stage 15 of 23 with 2 ValidationType ops
+validate forward indexes [8] in table #104
 validate forward indexes [4] in table #104
-commit transaction #25
-begin transaction #26
-## PostCommitNonRevertiblePhase stage 1 of 5 with 36 MutationType ops
+commit transaction #17
+begin transaction #18
+## PostCommitPhase stage 16 of 23 with 17 MutationType ops
 upsert descriptor #104
-   table:
-  -  checks:
-  -  - columnIds:
-  -    - 3
-  -    expr: rowid IS NOT NULL
-  -    isNonNullConstraint: true
-  -    name: rowid_auto_not_null
-  -    validity: Dropping
-  +  checks: []
-     columns:
-     - id: 1
-  ...
-         oid: 20
-         width: 64
-  -  - defaultExpr: unique_rowid()
-  -    hidden: true
-  -    id: 3
-  -    name: rowid
-  -    nullable: true
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
-  ...
-           statement: ALTER TABLE t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)
-           statementTag: ALTER TABLE
-  -    revertible: true
-       targetRanks: <redacted>
-       targets: <redacted>
-  ...
-       - a
-       - b
-  -    - rowid
-  +    - crdb_internal_column_3_name_placeholder
-       - m
-       name: primary
   ...
      id: 104
      indexes:
@@ -1125,14 +847,14 @@ upsert descriptor #104
   ...
        mutationId: 1
        state: WRITE_ONLY
-  -  - direction: DROP
+  -  - direction: ADD
   -    index:
-  -      constraintId: 5
+  -      constraintId: 4
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 7
+  -      id: 6
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -1140,7 +862,7 @@ upsert descriptor #104
   -      - 3
   -      keyColumnNames:
   -      - rowid
-  -      name: crdb_internal_index_7_name_placeholder
+  -      name: crdb_internal_index_6_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnIds:
@@ -1152,11 +874,171 @@ upsert descriptor #104
   -      - b
   -      - m
   -      unique: true
-  -      useDeletePreservingEncoding: true
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 2
+  -      createdAtNanos: "1640998800000000000"
+  +      constraintId: 3
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 4
+  +      id: 5
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keySuffixColumnIds:
+         - 2
+  -      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_5_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 1
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_1_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+       state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 9
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 11
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_11_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - m
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 3
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 5
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - a
+         keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_5_name_placeholder
+  +      - 3
+  +      name: t_a_idx
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
   -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  -  nextConstraintId: 9
+  +  nextConstraintId: 10
+     nextFamilyId: 1
+  -  nextIndexId: 11
+  +  nextIndexId: 12
+     nextMutationId: 1
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 4
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 6
+       interleave: {}
+       keyColumnDirections:
+  ...
+       - 1
+       - 2
+  +    - 4
+       storeColumnNames:
+       - a
+       - b
+  +    - m
+       unique: true
+       vecConfig: {}
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "18"
+  +  version: "19"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "Pending: Updating schema metadata (5 operations) — PostCommit phase (stage 17 of 23)."
+commit transaction #18
+begin transaction #19
+## PostCommitPhase stage 17 of 23 with 7 MutationType ops
+upsert descriptor #104
+  ...
      - direction: ADD
        index:
   -      constraintId: 6
@@ -1193,169 +1075,44 @@ upsert descriptor #104
          constraintId: 8
          createdExplicitly: true
   ...
-       mutationId: 1
-       state: WRITE_ONLY
-  -  - constraint:
-  -      check:
-  -        columnIds:
-  -        - 3
-  -        expr: rowid IS NOT NULL
-  -        isNonNullConstraint: true
-  -        name: rowid_auto_not_null
-  -        validity: Dropping
-  -      constraintType: NOT_NULL
-  -      foreignKey: {}
-  -      name: rowid_auto_not_null
-  -      notNullColumn: 3
-  -      uniqueWithoutIndexConstraint: {}
-  -    direction: DROP
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-     - direction: DROP
-       index:
-  ...
-         - 3
-         keyColumnNames:
-  -      - rowid
-  +      - crdb_internal_column_3_name_placeholder
-         name: crdb_internal_index_1_name_placeholder
-         partitioning: {}
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      constraintId: 7
-  -      createdExplicitly: true
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 9
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 2
-  -      keyColumnNames:
-  -      - b
-  -      name: crdb_internal_index_9_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnIds:
-  -      - 3
-  -      - 1
-  -      - 4
-  -      storeColumnNames:
-  -      - rowid
-  -      - a
-  -      - m
-  -      unique: true
-  -      useDeletePreservingEncoding: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-       state: DELETE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 9
-  +      constraintId: 4
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 11
-  +      id: 6
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
-  -      - 2
-  +      - 3
-         keyColumnNames:
-  -      - b
-  -      name: crdb_internal_index_11_name_placeholder
-  +      - crdb_internal_column_3_name_placeholder
-  +      name: crdb_internal_index_6_name_placeholder
-         partitioning: {}
-         sharded: {}
-         storeColumnIds:
-         - 1
-  +      - 2
-         - 4
-         storeColumnNames:
-         - a
-  +      - b
-         - m
-         unique: true
-  -      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: ADD
-  -    index:
-  -      constraintId: 2
-  -      createdAtNanos: "1640998800000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 4
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - a
-  -      keySuffixColumnIds:
-  -      - 2
-  -      name: crdb_internal_index_4_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnNames: []
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-       state: WRITE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 3
-  +      createdAtNanos: "1640995200000000000"
-         createdExplicitly: true
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 5
-  +      id: 2
-         interleave: {}
-         keyColumnDirections:
-  ...
-         - a
-         keySuffixColumnIds:
-  -      - 2
-  -      name: crdb_internal_index_5_name_placeholder
-  +      - 3
-  +      name: t_a_idx
-         partitioning: {}
-         sharded: {}
-  -      storeColumnNames: []
-  -      useDeletePreservingEncoding: true
-         vecConfig: {}
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-  +  - column:
-  +      defaultExpr: unique_rowid()
-  +      hidden: true
-  +      id: 3
-  +      name: crdb_internal_column_3_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
+     - direction: DROP
+       index:
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
   +    mutationId: 1
   +    state: WRITE_ONLY
      name: t
@@ -1389,7 +1146,7 @@ upsert descriptor #104
   -    - 2
        - 4
        storeColumnNames:
-  +    - crdb_internal_column_3_name_placeholder
+  +    - rowid
        - a
   -    - b
        - m
@@ -1397,29 +1154,128 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "23"
-  +  version: "24"
+  -  version: "19"
+  +  version: "20"
 persist all catalog changes to storage
-adding table for stats refresh: 104
-update progress of schema change job #1: "Pending: Updating schema metadata (17 operations) — PostCommitNonRevertible phase (stage 2 of 5)."
-set schema change job #1 to non-cancellable
-commit transaction #26
-begin transaction #27
-## PostCommitNonRevertiblePhase stage 2 of 5 with 19 MutationType ops
+update progress of schema change job #1: "Pending: Backfilling index (1 operation) — PostCommit phase (stage 18 of 23)."
+commit transaction #19
+begin transaction #20
+## PostCommitPhase stage 18 of 23 with 1 BackfillType op
+backfill indexes [10] from index #8 in table #104
+commit transaction #20
+begin transaction #21
+## PostCommitPhase stage 19 of 23 with 3 MutationType ops
 upsert descriptor #104
   ...
-         oid: 20
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - constraint:
+         check:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "20"
+  +  version: "21"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommit phase (stage 20 of 23)."
+commit transaction #21
+begin transaction #22
+## PostCommitPhase stage 20 of 23 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - constraint:
+         check:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "21"
+  +  version: "22"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Merging index (1 operation) — PostCommit phase (stage 21 of 23)."
+commit transaction #22
+begin transaction #23
+## PostCommitPhase stage 21 of 23 with 1 BackfillType op
+merge temporary indexes [11] into backfilled indexes [10] in table #104
+commit transaction #23
+begin transaction #24
+## PostCommitPhase stage 22 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - constraint:
+         check:
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+         constraintId: 9
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "22"
+  +  version: "23"
+persist all catalog changes to storage
+update progress of schema change job #1: "Pending: Validating index (1 operation) — PostCommit phase (stage 23 of 23)."
+commit transaction #24
+begin transaction #25
+## PostCommitPhase stage 23 of 23 with 1 ValidationType op
+validate forward indexes [10] in table #104
+commit transaction #25
+begin transaction #26
+## PostCommitNonRevertiblePhase stage 1 of 4 with 41 MutationType ops
+upsert descriptor #104
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
+  -    expr: rowid IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: rowid_auto_not_null
+  -    validity: Dropping
+  +  checks: []
+     columns:
+     - id: 1
+  ...
          width: 64
-  +  - defaultExpr: unique_rowid()
+     - defaultExpr: unique_rowid()
+  -    hidden: true
+  -    id: 3
+  -    name: rowid
   +    id: 4
   +    name: m
-  +    nullable: true
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
+       nullable: true
+       type:
+  ...
+           statement: ALTER TABLE t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+       - a
+       - b
+  -    - rowid
+  +    - crdb_internal_column_3_name_placeholder
+       - m
+       name: primary
   ...
      modificationTime: {}
      mutations:
@@ -1435,6 +1291,42 @@ upsert descriptor #104
   -    direction: ADD
   -    mutationId: 1
   -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 7
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - 3
+         keyColumnNames:
+  -      - rowid
+  -      name: crdb_internal_index_7_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - 1
+         - 2
+  -      - 4
+         storeColumnNames:
+         - a
+         - b
+  -      - m
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+       state: DELETE_ONLY
   -  - direction: ADD
   -    index:
   -      constraintId: 8
@@ -1464,6 +1356,253 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        expr: rowid IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: rowid_auto_not_null
+  -        validity: Dropping
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: rowid_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 7
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+  -      encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 9
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      name: crdb_internal_index_9_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 3
+         - 1
+  -      - 4
+  -      storeColumnNames:
+  -      - rowid
+  -      - a
+  -      - m
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 5
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+         keyColumnNames:
+         - a
+         keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_5_name_placeholder
+  +      - 3
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+  ...
+     - direction: DROP
+       index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  +      constraintId: 4
+  +      createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 1
+  +      id: 6
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - 3
+         keyColumnNames:
+  -      - rowid
+  -      name: crdb_internal_index_1_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
+  +      name: crdb_internal_index_6_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - 1
+         - 2
+  +      - 4
+         storeColumnNames:
+         - a
+         - b
+  +      - m
+         unique: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 9
+  +      constraintId: 6
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 11
+  +      id: 8
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - b
+  -      name: crdb_internal_index_11_name_placeholder
+  +      name: crdb_internal_index_8_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+  +      - 3
+         - 1
+         - 4
+         storeColumnNames:
+  +      - crdb_internal_column_3_name_placeholder
+         - a
+         - m
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - a
+  -      keySuffixColumnIds:
+  -      - 3
+  -      name: t_a_idx
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 4
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - rowid
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 2
+  -      - 4
+  -      storeColumnNames:
+  -      - a
+  -      - b
+  -      - m
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      hidden: true
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+       mutationId: 1
+       state: WRITE_ONLY
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 6
+  +    constraintId: 8
+       createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 8
+  +    id: 10
+       interleave: {}
+       keyColumnDirections:
+  ...
+       sharded: {}
+       storeColumnIds:
+  -    - 3
+       - 1
+       - 4
+       storeColumnNames:
+  -    - rowid
+       - a
+       - m
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "23"
+  +  version: "24"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "Pending: Updating schema metadata (9 operations) — PostCommitNonRevertible phase (stage 2 of 4)."
+set schema change job #1 to non-cancellable
+commit transaction #26
+begin transaction #27
+## PostCommitNonRevertiblePhase stage 2 of 4 with 11 MutationType ops
+upsert descriptor #104
+  ...
      - direction: DROP
        index:
   -      constraintId: 1
@@ -1495,103 +1634,27 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-         constraintId: 4
-         createdExplicitly: true
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
-  ...
-         keySuffixColumnIds:
-         - 3
-  -      name: t_a_idx
-  +      name: crdb_internal_index_2_name_placeholder
-         partitioning: {}
-         sharded: {}
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
-  ...
-       direction: DROP
-       mutationId: 1
-  +    state: DELETE_ONLY
-  +  - direction: DROP
-  +    index:
-  +      constraintId: 6
-  +      createdExplicitly: true
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 8
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 2
-  +      keyColumnNames:
-  +      - b
-  +      name: crdb_internal_index_8_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 3
-  +      - 1
-  +      - 4
-  +      storeColumnNames:
-  +      - crdb_internal_column_3_name_placeholder
-  +      - a
-  +      - m
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-       state: WRITE_ONLY
-     name: t
-  ...
-     parentId: 100
-     primaryIndex:
-  -    constraintId: 6
-  +    constraintId: 8
-       createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 8
-  +    id: 10
-       interleave: {}
-       keyColumnDirections:
-  ...
-       sharded: {}
-       storeColumnIds:
-  -    - 3
-       - 1
-       - 4
-       storeColumnNames:
-  -    - crdb_internal_column_3_name_placeholder
-       - a
-       - m
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "24"
-  +  version: "25"
-persist all catalog changes to storage
-adding table for stats refresh: 104
-update progress of schema change job #1: "Pending: Updating schema metadata (7 operations) — PostCommitNonRevertible phase (stage 3 of 5)."
-commit transaction #27
-begin transaction #28
-## PostCommitNonRevertiblePhase stage 3 of 5 with 9 MutationType ops
-upsert descriptor #104
-  ...
-     modificationTime: {}
-     mutations:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - a
+  -      keySuffixColumnIds:
+  -      - 3
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 4
@@ -1625,31 +1688,17 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - a
-  -      keySuffixColumnIds:
-  -      - 3
-  -      name: crdb_internal_index_2_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
+         constraintId: 6
+         createdExplicitly: true
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
      - column:
          defaultExpr: unique_rowid()
   ...
-         version: 4
+       direction: DROP
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
@@ -1658,13 +1707,13 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "25"
-  +  version: "26"
+  -  version: "24"
+  +  version: "25"
 persist all catalog changes to storage
-update progress of schema change job #1: "Pending: Updating schema metadata (11 operations) — PostCommitNonRevertible phase (stage 4 of 5)."
-commit transaction #28
-begin transaction #29
-## PostCommitNonRevertiblePhase stage 4 of 5 with 13 MutationType ops
+update progress of schema change job #1: "Pending: Updating schema metadata (11 operations) — PostCommitNonRevertible phase (stage 3 of 4)."
+commit transaction #27
+begin transaction #28
+## PostCommitNonRevertiblePhase stage 3 of 4 with 13 MutationType ops
 upsert descriptor #104
   ...
        - 1
@@ -1681,19 +1730,6 @@ upsert descriptor #104
        version: 4
      modificationTime: {}
   -  mutations:
-  -  - column:
-  -      defaultExpr: unique_rowid()
-  -      hidden: true
-  -      id: 3
-  -      name: crdb_internal_column_3_name_placeholder
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: DROP
-  -    mutationId: 1
-  -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 6
@@ -1725,22 +1761,35 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      hidden: true
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
   +  mutations: []
      name: t
      nextColumnId: 5
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "26"
-  +  version: "27"
+  -  version: "25"
+  +  version: "26"
 persist all catalog changes to storage
 create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)"
   descriptor IDs: [104]
-update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommitNonRevertible phase (stage 5 of 5)."
-commit transaction #29
+update progress of schema change job #1: "Pending: Updating schema metadata (1 operation) — PostCommitNonRevertible phase (stage 4 of 4)."
+commit transaction #28
 notified job registry to adopt jobs: [2]
-begin transaction #30
-## PostCommitNonRevertiblePhase stage 5 of 5 with 3 MutationType ops
+begin transaction #29
+## PostCommitNonRevertiblePhase stage 4 of 4 with 3 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -1780,8 +1829,8 @@ upsert descriptor #104
        time: {}
   +  schemaLocked: true
      unexposedParentSchemaId: 101
-  -  version: "27"
-  +  version: "28"
+  -  version: "26"
+  +  version: "27"
 persist all catalog changes to storage
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable
@@ -1789,5 +1838,5 @@ updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 104
-commit transaction #30
+commit transaction #29
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_10_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_10_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -61,31 +65,24 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
@@ -93,11 +90,19 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -106,7 +111,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_11_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_11_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -61,31 +65,24 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
@@ -93,11 +90,19 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -106,7 +111,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_12_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_12_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -61,31 +65,24 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
@@ -93,11 +90,19 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -106,7 +111,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_13_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_13_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -57,49 +61,52 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 9 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -108,7 +115,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_14_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_14_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -57,49 +61,52 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 9 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 16 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -108,7 +115,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_15_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_15_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -61,43 +65,44 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -106,7 +111,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_16_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_16_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 16 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -61,43 +65,44 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -106,7 +111,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_17_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_17_of_23.explain
@@ -10,11 +10,12 @@ EXPLAIN (DDL) rollback at post-commit stage 17 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 31 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
@@ -42,15 +43,15 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
@@ -69,8 +70,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
@@ -83,29 +83,36 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
+      │    ├── 10 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 12 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
+      │    ├── 12 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
@@ -115,11 +122,15 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
-      │    └── 11 Mutation operations
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+      │    └── 13 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_18_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_18_of_23.explain
@@ -10,23 +10,25 @@ EXPLAIN (DDL) rollback at post-commit stage 18 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
@@ -37,27 +39,27 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
@@ -70,36 +72,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
-      │    └── 10 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
@@ -108,23 +87,52 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 13 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_19_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_19_of_23.explain
@@ -10,23 +10,25 @@ EXPLAIN (DDL) rollback at post-commit stage 19 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
@@ -37,27 +39,27 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
@@ -70,36 +72,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
-      │    └── 10 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
@@ -108,23 +87,52 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 13 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_20_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_20_of_23.explain
@@ -10,23 +10,25 @@ EXPLAIN (DDL) rollback at post-commit stage 20 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
@@ -37,27 +39,27 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
@@ -70,36 +72,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
-      │    └── 10 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
@@ -108,23 +87,52 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 13 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_21_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_21_of_23.explain
@@ -10,23 +10,25 @@ EXPLAIN (DDL) rollback at post-commit stage 21 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
@@ -37,27 +39,27 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
@@ -67,43 +69,16 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
-      │    └── 12 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
@@ -112,23 +87,54 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 14 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_22_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_22_of_23.explain
@@ -10,23 +10,25 @@ EXPLAIN (DDL) rollback at post-commit stage 22 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
@@ -37,27 +39,27 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
@@ -67,43 +69,16 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
-      │    └── 12 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
@@ -112,23 +87,54 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 14 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_23_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_23_of_23.explain
@@ -10,23 +10,25 @@ EXPLAIN (DDL) rollback at post-commit stage 23 of 23;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
@@ -37,27 +39,27 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    └── 38 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
@@ -70,37 +72,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 10}
-      │    └── 10 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
@@ -108,23 +87,52 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    └── 13 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
+      │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
-      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+      │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_9_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_9_of_23.explain
@@ -9,16 +9,16 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 23;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 23 elements transitioning toward ABSENT
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 32 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,17 +34,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
-      │    └── 28 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 35 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -60,30 +64,25 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
-      │    └── 7 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
@@ -91,10 +90,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
-      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
-      │    └── 9 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+      │    └── 10 Mutation operations
       │         ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
@@ -102,7 +103,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m 
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_PUBLIC
            │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
            └── 3 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
@@ -18,7 +18,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), ReferencedColumnIDs: [3], Usage: REGULAR}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), IndexID: 8 (t_pkey+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx+)}
@@ -72,7 +72,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3+), TypeName: "INT8"}
  │    │    │    ├── PUBLIC        → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), ReferencedColumnIDs: [3], Usage: REGULAR}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), IndexID: 8 (t_pkey+)}
- │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx+)}
@@ -103,7 +103,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3+), TypeName: "INT8"}
  │         │    ├── ABSENT → PUBLIC        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), ReferencedColumnIDs: [3], Usage: REGULAR}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), IndexID: 8 (t_pkey+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx+)}
@@ -171,14 +171,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 2 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    └── 2 Backfill operations
  │    │         ├── BackfillIndex {"IndexID":8,"SourceIndexID":1,"TableID":104}
  │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":1,"TableID":104}
  │    ├── Stage 3 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
@@ -187,7 +187,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 4 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
@@ -196,14 +196,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 5 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    └── 2 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
  │    ├── Stage 6 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 10, SourceIndexID: 1 (t_pkey-)}
  │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
@@ -218,7 +218,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    ├── 3 elements transitioning toward PUBLIC
  │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), IndexID: 8 (t_pkey+)}
- │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    └── 3 Validation operations
  │    │         ├── ValidateIndex {"IndexID":8,"TableID":104}
  │    │         ├── ValidateColumnNotNull {"ColumnID":5,"IndexIDForValidation":8,"TableID":104}
@@ -226,7 +226,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 8 of 16 in PostCommitPhase
  │    │    ├── 10 elements transitioning toward PUBLIC
  │    │    │    ├── VALIDATED → PUBLIC        ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3+), IndexID: 8 (t_pkey+)}
- │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx+)}
  │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_i_key+), ConstraintID: 7, TemporaryIndexID: 7, SourceIndexID: 8 (t_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key+)}
@@ -259,7 +259,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":1,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":1,"Ordinal":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":6,"Name":"t_i_key","TableID":104}
- │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":8}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":1}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
  │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -103,7 +103,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -103,7 +103,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -103,7 +103,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 10 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -105,7 +105,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 10 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -105,7 +105,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -103,7 +103,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -103,7 +103,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_1_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_1_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC        → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_2_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_2_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_3_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_3_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_4_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_4_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_5_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_5_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}
@@ -64,7 +64,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_6_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_6_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}
@@ -64,7 +64,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_7_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_7_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}
@@ -63,7 +63,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    └── 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_8_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_8_of_16.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (j), IndexID: 4 (t_i_j_idx-)}
@@ -63,7 +63,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    └── 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
@@ -23,7 +23,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 5}
@@ -77,7 +77,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 9, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), IndexID: 8 (t_pkey-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_j_idx", IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_i_j_shard_16), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (i), IndexID: 4 (t_i_j_idx-)}
@@ -101,7 +101,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 5 (crdb_internal_j_shard_3-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 5 (crdb_internal_j_shard_3-), ReferencedColumnIDs: [3], Usage: REGULAR}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_i_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
@@ -17,14 +17,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx+)}
  │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 12 (idx+)}
@@ -81,14 +81,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey+)}
- │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx+)}
- │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx+)}
- │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx+)}
  │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx+)}
@@ -116,14 +116,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx+)}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx+)}
  │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 12 (idx+)}
@@ -203,9 +203,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 2 of 15 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    └── 4 Backfill operations
  │    │         ├── BackfillIndex {"IndexID":16,"SourceIndexID":1,"TableID":104}
  │    │         ├── BackfillIndex {"IndexID":8,"SourceIndexID":1,"TableID":104}
@@ -214,9 +214,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 3 of 15 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
- │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    └── 6 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":16,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
@@ -227,9 +227,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 4 of 15 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    └── 6 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":16,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
@@ -240,9 +240,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 5 of 15 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
- │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    └── 4 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":16,"TableID":104,"TemporaryIndexID":17}
  │    │         ├── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
@@ -251,9 +251,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 6 of 15 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
- │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
@@ -273,9 +273,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 7 of 15 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
- │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
- │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
+ │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    └── 4 Validation operations
  │    │         ├── ValidateIndex {"IndexID":16,"TableID":104}
  │    │         ├── ValidateIndex {"IndexID":8,"TableID":104}
@@ -283,11 +283,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         └── ValidateIndex {"IndexID":12,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
  │    │    ├── 11 elements transitioning toward PUBLIC
- │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx+)}
- │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx+)}
- │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx+)}
  │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key+)}
@@ -315,13 +315,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":14,"Name":"t_i_key","TableID":104}
- │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":8,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":16}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":8,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":1}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
- │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":10,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":16}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":10,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":1}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":10,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
- │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":12,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":16}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":12,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":1}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":12,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
  │    │         ├── MarkRecreatedIndexAsVisible {"IndexID":8,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_10_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -113,13 +113,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_11_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -113,13 +113,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_12_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -113,13 +113,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_13_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -115,13 +115,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_14_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -115,13 +115,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_15_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -113,13 +113,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_1_of_15.explain
@@ -22,19 +22,19 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_2_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_3_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_4_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_5_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
@@ -70,15 +70,15 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_6_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
@@ -70,15 +70,15 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_7_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
@@ -69,13 +69,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    └── 16 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_8_of_15.explain
@@ -21,17 +21,17 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
@@ -69,13 +69,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    └── 16 Mutation operations

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_9_of_15.explain
@@ -25,14 +25,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
@@ -81,14 +81,14 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 12 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (idx-)}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (idx-)}
@@ -111,13 +111,13 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    ├── 12 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
-      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 16}
+      │    │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6, RecreateTargetIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (idx-)}
       │    │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
       │    │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/truncate/truncate.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/truncate/truncate.explain
@@ -36,15 +36,15 @@ Schema change plan for TRUNCATE TABLE ‹defaultdb›.‹public›.‹t›;
  │              ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
  │              ├── MakeMergedIndexWriteOnly {"IndexID":3,"TableID":104}
  │              ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
- │              ├── SetIndexName {"IndexID":3,"Name":"t_pkey","TableID":104}
  │              ├── SetIndexName {"IndexID":4,"Name":"t_j_key","TableID":104}
  │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":104}
+ │              ├── SetIndexName {"IndexID":3,"Name":"t_pkey","TableID":104}
  │              ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":3}
  │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
  │              ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":104}
- │              └── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              └── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 10 elements transitioning toward PUBLIC
@@ -95,16 +95,16 @@ Schema change plan for TRUNCATE TABLE ‹defaultdb›.‹public›.‹t›;
  │              ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
  │              ├── MakeMergedIndexWriteOnly {"IndexID":3,"TableID":104}
  │              ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
- │              ├── SetIndexName {"IndexID":3,"Name":"t_pkey","TableID":104}
  │              ├── SetIndexName {"IndexID":4,"Name":"t_j_key","TableID":104}
  │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":104}
+ │              ├── SetIndexName {"IndexID":3,"Name":"t_pkey","TableID":104}
  │              ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"SetHideIndexFlag":true,"TableID":104,"TargetPrimaryIndexID":3}
  │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
  │              ├── RefreshStats {"TableID":104}
  │              ├── MarkRecreatedIndexAsVisible {"IndexID":4,"TableID":104}
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"Pending: Updatin..."}
  └── PostCommitNonRevertiblePhase


### PR DESCRIPTION
Backport 1/1 commits from #154752 on behalf of @fqazi.

----

Previously, we adjusted the schema changer rules to ensure that
old secondary indexes are only dropped when the new secondary index is
usable. Unfortunately, one of the rules had an incorrect filter. To
address this, this patch fixes the filter to expect the new secondary
index, which will have the new flag. Additionally, the index recreation
logic for ALTER PRIMARY KEY was delaying when the new secondary indexes
could be made public.

Fixes: #154751

Release note: None

----

Release justification: fix for a bug introduced during 25.4 development