### PR TITLE
release-25.4: crosscluster/physical: add alter connection watcher

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -324,35 +324,13 @@ func (r *logicalReplicationResumer) ingest(
 		return err
 	}
 
-	refreshConn := func(ctx context.Context) error {
-		ingestionJob := r.job
-		details := ingestionJob.Details().(jobspb.LogicalReplicationDetails)
-		resolvedDest, err := resolveDest(ctx, jobExecCtx.ExecCfg(), details.SourceClusterConnUri)
-		if err != nil {
-			return err
-		}
-		pollingInterval := 2 * time.Minute
-		if knobs := jobExecCtx.ExecCfg().StreamingTestingKnobs; knobs != nil && knobs.ExternalConnectionPollingInterval != nil {
-			pollingInterval = *knobs.ExternalConnectionPollingInterval
-		}
-		t := time.NewTicker(pollingInterval)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-confPoller:
-				return nil
-			case <-t.C:
-				newDest, err := reloadDest(ctx, ingestionJob.ID(), jobExecCtx.ExecCfg())
-				if err != nil {
-					log.Dev.Warningf(ctx, "failed to check for updated configuration: %v", err)
-				} else if newDest != resolvedDest {
-					return errors.Mark(errors.Newf("replan due to detail change: old=%s, new=%s", resolvedDest, newDest), sql.ErrPlanChanged)
-				}
-			}
-		}
-	}
+	refreshConn := replicationutils.GetAlterConnectionChecker(
+		r.job.ID(),
+		uris[0].Serialize(),
+		geURIFromLoadedJobDetails,
+		execCfg,
+		confPoller,
+	)
 
 	defer func() {
 		if l := payload.MetricsLabel; l != "" {
@@ -1087,29 +1065,8 @@ func getRetryPolicy(knobs *sql.StreamingTestingKnobs) retry.Options {
 	}
 }
 
-func resolveDest(
-	ctx context.Context, execCfg *sql.ExecutorConfig, sourceURI string,
-) (string, error) {
-	configUri, err := streamclient.ParseConfigUri(sourceURI)
-	if err != nil {
-		return "", err
-	}
-
-	clusterUri, err := configUri.AsClusterUri(ctx, execCfg.InternalDB)
-	if err != nil {
-		return "", err
-	}
-
-	return clusterUri.Serialize(), nil
-}
-
-func reloadDest(ctx context.Context, id jobspb.JobID, execCfg *sql.ExecutorConfig) (string, error) {
-	reloadedJob, err := execCfg.JobRegistry.LoadJob(ctx, id)
-	if err != nil {
-		return "", err
-	}
-	newDetails := reloadedJob.Details().(jobspb.LogicalReplicationDetails)
-	return resolveDest(ctx, execCfg, newDetails.SourceClusterConnUri)
+func geURIFromLoadedJobDetails(details jobspb.Details) string {
+	return details.(jobspb.LogicalReplicationDetails).SourceClusterConnUri
 }
 
 func init() {

--- a/pkg/crosscluster/physical/stream_ingestion_dist.go
+++ b/pkg/crosscluster/physical/stream_ingestion_dist.go
@@ -96,12 +96,16 @@ func startDistIngestion(
 		updateStatus(ctx, ingestionJob, jobspb.InitializingReplication, msg)
 	}
 
-	client, err := connectToActiveClient(ctx, ingestionJob, execCtx.ExecCfg().InternalDB,
-		streamclient.WithStreamID(streamID))
+	clusterUris, err := getClusterUris(ctx, ingestionJob, execCtx.ExecCfg().InternalDB)
+	if err != nil {
+		return err
+	}
+	client, err := streamclient.GetFirstActiveClient(ctx, clusterUris, execCtx.ExecCfg().InternalDB, streamclient.WithStreamID(streamID))
 	if err != nil {
 		return err
 	}
 	defer closeAndLog(ctx, client)
+
 	if err := waitUntilProducerActive(ctx, client, streamID, heartbeatTimestamp, ingestionJob.ID()); err != nil {
 		return err
 	}
@@ -197,11 +201,23 @@ func startDistIngestion(
 		}
 		return ingestor.ingestSpanConfigs(ctx, details.SourceTenantName)
 	}
+
+	refreshConnStopper := make(chan struct{})
+
+	refreshConn := replicationutils.GetAlterConnectionChecker(
+		ingestionJob.ID(),
+		clusterUris[0].Serialize(),
+		geURIFromIngestionJobDetails,
+		execCtx.ExecCfg(),
+		refreshConnStopper,
+	)
+
 	execInitialPlan := func(ctx context.Context) error {
 		defer func() {
 			stopReplanner()
 			close(tracingAggCh)
 			close(spanConfigIngestStopper)
+			close(refreshConnStopper)
 		}()
 		ctx = logtags.AddTag(ctx, "stream-ingest-distsql", nil)
 
@@ -273,11 +289,15 @@ func startDistIngestion(
 		return err
 	}
 
-	err = ctxgroup.GoAndWait(ctx, execInitialPlan, replanner, tracingAggLoop, streamSpanConfigs)
+	err = ctxgroup.GoAndWait(ctx, execInitialPlan, replanner, tracingAggLoop, streamSpanConfigs, refreshConn)
 	if errors.Is(err, sql.ErrPlanChanged) {
 		execCtx.ExecCfg().JobRegistry.MetricsStruct().StreamIngest.(*Metrics).ReplanCount.Inc(1)
 	}
 	return err
+}
+
+func geURIFromIngestionJobDetails(details jobspb.Details) string {
+	return details.(jobspb.StreamIngestionDetails).SourceClusterConnUri
 }
 
 func sortSpans(partitions []streamclient.PartitionInfo) roachpb.Spans {

--- a/pkg/crosscluster/replicationutils/BUILD.bazel
+++ b/pkg/crosscluster/replicationutils/BUILD.bazel
@@ -2,10 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "replicationutils",
-    srcs = ["utils.go"],
+    srcs = [
+        "connection_checker.go",
+        "utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/crosscluster/streamclient",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",
@@ -28,6 +32,7 @@ go_library(
         "//pkg/testutils/fingerprintutils",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/crosscluster/replicationutils/connection_checker.go
+++ b/pkg/crosscluster/replicationutils/connection_checker.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package replicationutils
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// GetAlterConnectionChecker returns a function that will poll for an altered
+// external connection. The initial URI passed to this function should be the
+// same one passed to subsequent client creation calls.
+func GetAlterConnectionChecker(
+	id jobspb.JobID,
+	initialURI string,
+	uriGetter URIGetter,
+	execCfg *sql.ExecutorConfig,
+	stopper chan struct{},
+) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		pollingInterval := 2 * time.Minute
+		if knobs := execCfg.StreamingTestingKnobs; knobs != nil && knobs.ExternalConnectionPollingInterval != nil {
+			pollingInterval = *knobs.ExternalConnectionPollingInterval
+		}
+		t := time.NewTicker(pollingInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-stopper:
+				return nil
+			case <-t.C:
+				reloadedJob, err := execCfg.JobRegistry.LoadJob(ctx, id)
+				if err != nil {
+					return err
+				}
+				newURI, err := resolveURI(ctx, execCfg, uriGetter(reloadedJob.Details()))
+				if err != nil {
+					log.Dev.Warningf(ctx, "failed to load uri: %v", err)
+				} else if newURI != initialURI {
+					return errors.Mark(errors.Newf("uri has been updated: old=%s, new=%s", errors.Redact(initialURI), errors.Redact(newURI)), sql.ErrPlanChanged)
+				}
+			}
+		}
+	}
+}
+
+type URIGetter func(details jobspb.Details) string
+
+func resolveURI(
+	ctx context.Context, execCfg *sql.ExecutorConfig, sourceURI string,
+) (string, error) {
+	configUri, err := streamclient.ParseConfigUri(sourceURI)
+	if err != nil {
+		return "", err
+	}
+
+	clusterUri, err := configUri.AsClusterUri(ctx, execCfg.InternalDB)
+	if err != nil {
+		return "", err
+	}
+
+	return clusterUri.Serialize(), nil
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2176,8 +2176,6 @@ type StreamingTestingKnobs struct {
 	// for whether the job record is updated on a progress update.
 	CutoverProgressShouldUpdate func() bool
 
-	//ExternalConnectionPollingInterval override the LDR alter
-	// connection polling frequency.
 	ExternalConnectionPollingInterval *time.Duration
 
 	DistSQLRetryPolicy *retry.Options


### PR DESCRIPTION
Backport 2/2 commits from #154298.

/cc @cockroachdb/release

---

PCR now automatically updates the uri used if it's apart of an external
connection that is altered.

Informs #153471

Release note: none
