### PR TITLE
release-24.3: roachtest: increase closed TS lag in copyfrom roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -148,8 +148,12 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	// Enable the verbose logging on relevant files to have better understanding
 	// in case the test fails.
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=copy_from=2,insert=2")
-	// roachtest frequently runs on overloaded instances and can timeout as a result
-	clusterSettings := install.MakeClusterSettings(install.ClusterSettingsOption{"kv.closed_timestamp.target_duration": "60s"})
+	// The roachtest frequently runs on overloaded instances and can timeout as
+	// a result. We've seen cases where the atomic COPY takes about 2 minutes to
+	// complete, so we set the closed TS to 5 minutes (to give enough safety
+	// gap, otherwise the closed TS system might continuously push the COPY txn
+	// not allowing it ever to complete).
+	clusterSettings := install.MakeClusterSettings(install.ClusterSettingsOption{"kv.closed_timestamp.target_duration": "300s"})
 	c.Start(ctx, t.L(), startOpts, clusterSettings, c.All())
 	initTest(ctx, t, c, sf)
 	db, err := c.ConnE(ctx, t.L(), 1)


### PR DESCRIPTION
Backport 1/1 commits from #154883 on behalf of @yuzefovich.

----

The atomic COPY writes the whole thing as a single txn, and we've seen cases where this txn can be on the order of 2 minutes. We've already increased the closed TS target duration to 60s, but that means that the closed TS system could push the COPY txn. To avoid this kind of flake we bump the target duration to 5 minutes.

Fixes: #153927.
Release note: None

----

Release justification: test-only change.