### PR TITLE
roachtest: metamorphically enable decommissioning nudger

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1135,19 +1135,6 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// Increase the speed of decommissioning.
 		run(db, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='2GiB'`)
 
-		// Metamorphically enable the decommissioning nudger to get more test
-		// coverage on decommissioning nudger.
-		{
-			seed := timeutil.Now().UnixNano()
-			t.L().Printf("seed: %d", seed)
-			rng := rand.New(rand.NewSource(seed))
-
-			if rng.Intn(2) == 0 {
-				run(db, `SET CLUSTER SETTING kv.enqueue_in_replicate_queue_on_problem.interval = '10m'`)
-				t.L().Printf("metamorphically enabled decommissioning nudger")
-			}
-		}
-
 		// Wait for initial up-replication.
 		err := roachtestutil.WaitForReplication(ctx, t.L(), db, replicationFactor, roachprod.AtLeastReplicationFactor)
 		require.NoError(t, err)


### PR DESCRIPTION
Epic: none 
Release note: none

---
**roachtest: merge runDecommissionBench and runDecommissionBenchLong**

Previously, decommission roachtests with duration > 0 used
runDecommissionBenchLong, while the default used runDecommissionBench. It’s
unclear to me why both were needed since most of the logic was duplicated except
for minor differences. As a result, registering a decommission roachtest with a
longer duration and setting whileUpreplicating = true or slow writes would not
work, because the long version missed setup steps for additional nodes and slow
writes. It's unclear whether this was intentional. This commit merges the two
functions, keeping things more consistent.

---
**roachtest: metamorphically enable decommissioning nudger**

This commit enables the decommissioning nudger metamorphically for two
roachtests. I selected these two ad hoc — one is labeled as slow, and the other
has been intermittently failing on master to improve observability and help root
casue.

