### PR TITLE
pgwire: lower the max repeated error count before closing a connection

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1077,7 +1077,7 @@ func (s *Server) newConn(
 // maxRepeatedErrorCount is the number of times an error can be received
 // while reading from the network connection before the server decides to give
 // up and abort the connection.
-const maxRepeatedErrorCount = 1 << 15
+const maxRepeatedErrorCount = 1 << 8
 
 // serveImpl continuously reads from the network connection and pushes execution
 // instructions into a sql.StmtBuf, from where they'll be processed by a command


### PR DESCRIPTION
In 39067de (#71940) we added behavior to give up and close a network connection if a threshold of repeated errors was reached. It retried on errors since some network errors could be transient.

It was retrying tens of thousands of times, which is excessive. We lower this to 256 now. This is motivated by a few tests that identifed the error handling logic in this tight loop being quite expensive. Retrying fewer times means that we'll reduce CPU usage during failure scenarios.

fixes https://github.com/cockroachdb/cockroach/issues/153550
informs https://github.com/cockroachdb/cockroach/issues/153772#issuecomment-3335542579

Release note: None