### PR TITLE
release-25.3: roachtest: update liquibase test harness

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -13,11 +13,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
-var supportedLiquibaseHarnessCommit = "1790ddef2d0339c5c96839ac60ac424c130dadd8"
+var supportedLiquibaseHarnessCommit = "f43b967d60aa4ce7056a6d6ee0bc6d9f144c62d5"
 
 // This test runs the Liquibase test harness against a single cockroach node.
 func registerLiquibase(r registry.Registry) {
@@ -32,7 +31,8 @@ func registerLiquibase(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		startOpts := option.DefaultStartOpts()
-		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		// The liquibase-test-harness expects CockroachDB to be on port 26263.
+		startOpts.RoachprodOpts.SQLPort = 26263
 		// TODO(darrylwong): if https://github.com/liquibase/liquibase-test-harness/pull/724 is merged, enable secure mode
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
 
@@ -58,14 +58,13 @@ func registerLiquibase(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
 			t,
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install default-jre openjdk-8-jdk-headless maven`,
+			`sudo apt-get -qq install default-jre openjdk-17-jdk-headless maven`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -77,8 +76,8 @@ func registerLiquibase(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		// TODO(richardjcai): When liquibase-test-harness 1.0.3 is released and tagged,
-		//    use the tag version instead of the commit.
+		// TODO(sql-foundations): When liquibase-test-harness 1.0.12 is released and
+		//   tagged, use the tag version instead of the commit.
 		if err = c.RunE(ctx, option.WithNodes(node), "cd /mnt/data1/ && git clone https://github.com/liquibase/liquibase-test-harness.git"); err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +97,11 @@ sudo ln -sf /home/ubuntu/cockroach /cockroach/cockroach.sh`); err != nil {
 			t.Fatal(err)
 		}
 		// TODO(darrylwong): once secure mode is enabled, add --certs-dir=install.CockroachNodeCertsDir
-		if err = c.RunE(ctx, option.WithNodes(node), `/mnt/data1/liquibase-test-harness/src/test/resources/docker/setup_db.sh localhost`); err != nil {
+		if err = c.RunE(
+			ctx,
+			option.WithNodes(node),
+			fmt.Sprintf(`/mnt/data1/liquibase-test-harness/src/test/resources/docker/setup_db.sh localhost:%d`, startOpts.RoachprodOpts.SQLPort),
+		); err != nil {
 			t.Fatal(err)
 		}
 
@@ -109,21 +112,40 @@ sudo ln -sf /home/ubuntu/cockroach /cockroach/cockroach.sh`); err != nil {
 
 		const (
 			repoDir     = "/mnt/data1/liquibase-test-harness"
-			resultsPath = repoDir + "/target/surefire-reports/TEST-liquibase.harness.LiquibaseHarnessSuiteTest.xml"
+			resultsPath = repoDir + "/target/surefire-reports/"
 		)
 
+		// The Liquibase test harness currently has fixtures for 23.1, 23.2,
+		// and 24.1. We use the 24.1 here since its the most recent one.
 		// TODO(darrylwong): once secure mode is enabled, add -DdbUsername=roach -DdbPassword=system
 		cmd := fmt.Sprintf("cd /mnt/data1/liquibase-test-harness/ && "+
 			"mvn surefire-report:report-only test -Dtest=LiquibaseHarnessSuiteTest "+
-			"-DdbName=cockroachdb -DdbVersion=20.2 -DoutputDirectory=%s", repoDir)
+			"-DdbName=cockroachdb -DdbVersion=24.1 -DoutputDirectory=%s", repoDir)
 
 		err = c.RunE(ctx, option.WithNodes(node), cmd)
 		if err != nil {
 			t.L().Printf("error whilst running tests (may be expected): %#v", err)
 		}
 
+		// Load the list of all test results files and parse them individually.
+		result, err := repeatRunWithDetailsSingleNode(
+			ctx,
+			c,
+			t,
+			node,
+			"get list of test files",
+			`ls `+resultsPath+`*.xml`,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(result.Stdout) == 0 {
+			t.Fatal("could not find any test result files")
+		}
+
 		parseAndSummarizeJavaORMTestsResults(
-			ctx, t, c, node, "liquibase" /* ormName */, []byte(resultsPath),
+			ctx, t, c, node, "liquibase" /* ormName */, []byte(result.Stdout),
 			blocklistName,
 			expectedFailures,
 			ignoreList,

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -5,16 +5,10 @@
 
 package tests
 
-var liquibaseBlocklist = blocklist{
-	"liquibase.harness.change.ChangeObjectTests.apply addAutoIncrement against cockroachdb 20.2":            "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 20.2":          "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2": "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply alterSequence against cockroachdb 20.2":               "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 20.2":               "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply createSequence against cockroachdb 20.2":              "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 20.2":         "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply dropSequence against cockroachdb 20.2":                "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply renameSequence against cockroachdb 20.2":              "unknown",
-}
+var liquibaseBlocklist = blocklist{}
 
-var liquibaseIgnorelist = blocklist{}
+var liquibaseIgnorelist = blocklist{
+	`liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 24.1`:  "requires enterprise version of liquibase",
+	`liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 24.1`:       "requires enterprise version of liquibase",
+	`liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 24.1`: "requires enterprise version of liquibase",
+}


### PR DESCRIPTION
Backport 1/1 commits from #154801 on behalf of @rafiss.

----

This resolves an issue where the test started failing because of an outdated java version.

fixes https://github.com/cockroachdb/cockroach/issues/154519
fixes https://github.com/cockroachdb/cockroach/issues/154606
fixes https://github.com/cockroachdb/cockroach/issues/154516
fixes https://github.com/cockroachdb/cockroach/issues/154508
fixes https://github.com/cockroachdb/cockroach/issues/154504
fixes https://github.com/cockroachdb/cockroach/issues/154511

Release note: None

----

Release justification: