### PR TITLE
*: use testutils.SetVModule

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -336,7 +336,7 @@ func TestAlterChangefeedAddTargetFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("helpers_test=1"))
+	defer testutils.SetVModule(t, "helpers_test=1")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -394,7 +394,7 @@ func TestAlterChangefeedSwitchFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("helpers_test=1"))
+	defer testutils.SetVModule(t, "helpers_test=1")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1316,7 +1316,7 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Set verbose log to confirm whether or not we hit the same nil row issue as in #140669
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)
@@ -1984,7 +1984,7 @@ func TestAlterChangefeedRandomizedTargetChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("helpers_test=1"))
+	defer testutils.SetVModule(t, "helpers_test=1")()
 
 	rnd, _ := randutil.NewPseudoRand()
 

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -336,7 +336,7 @@ func TestAlterChangefeedAddTargetFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "helpers_test=1")()
+	testutils.SetVModule(t, "helpers_test=1")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -394,7 +394,7 @@ func TestAlterChangefeedSwitchFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "helpers_test=1")()
+	testutils.SetVModule(t, "helpers_test=1")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1316,7 +1316,7 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Set verbose log to confirm whether or not we hit the same nil row issue as in #140669
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)
@@ -1984,7 +1984,7 @@ func TestAlterChangefeedRandomizedTargetChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "helpers_test=1")()
+	testutils.SetVModule(t, "helpers_test=1")
 
 	rnd, _ := randutil.NewPseudoRand()
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1400,7 +1400,7 @@ func TestChangefeedMultiTable(t *testing.T) {
 func TestChangefeedCursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	require.NoError(t, log.SetVModule("event_processing=3,blocking_buffer=2"))
+	defer testutils.SetVModule(t, "event_processing=3,blocking_buffer=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2204,7 +2204,7 @@ func TestNoStopAfterNonTargetColumnDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2313,7 +2313,7 @@ func TestNoBackfillAfterNonTargetColumnDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2359,7 +2359,7 @@ func TestChangefeedColumnDropsWithFamilyAndNonFamilyTargets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2412,7 +2412,7 @@ func TestChangefeedColumnDropsOnMultipleFamiliesWithTheSameName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2466,7 +2466,7 @@ func TestChangefeedColumnDropsOnTheSameTableWithMultipleFamilies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2510,7 +2510,7 @@ func TestChangefeedColumnDropsOnTheSameTableWithMultipleFamiliesWithManualSchema
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2556,7 +2556,7 @@ func TestNoStopAfterNonTargetAddColumnWithBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2658,7 +2658,7 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1 min under race")
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3306,7 +3306,7 @@ func TestChangefeedSchemaChangeAllowBackfill_Legacy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3504,7 +3504,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3666,7 +3666,7 @@ func TestChangefeedSchemaChangeBackfillScope(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3730,7 +3730,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3762,7 +3762,7 @@ func TestChangefeedEachColumnFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 
@@ -3892,7 +3892,7 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	// requireErrorSoon times out after 30 seconds
 	skip.UnderStress(t)
@@ -3939,7 +3939,7 @@ func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -6456,7 +6456,7 @@ func TestChangefeedTruncateOrDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("table_event_filter=2"))
+	defer testutils.SetVModule(t, "table_event_filter=2")()
 
 	assertFailuresCounter := func(t *testing.T, m *Metrics, exp int64) {
 		t.Helper()
@@ -8657,8 +8657,8 @@ func TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart(t *testing.T)
 	defer log.Scope(t).Close(t)
 
 	// Add verbose logging to help debug future failures.
-	require.NoError(t, log.SetVModule("changefeed_processors=1,replica_rangefeed=2,"+
-		"replica_range_lease=3,raft=3"))
+	defer testutils.SetVModule(t, "changefeed_processors=1,replica_rangefeed=2,"+
+		"replica_range_lease=3,raft=3")()
 
 	// This test requires many range splits, which can be slow under certain test
 	// conditions. Skip potentially slow tests.
@@ -10997,7 +10997,7 @@ func TestSchemachangeDoesNotBreakSinklessFeed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
+	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -11876,7 +11876,7 @@ func TestChangefeedHeadersJSONVals(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("event_processing=3"))
+	defer testutils.SetVModule(t, "event_processing=3")()
 
 	// Make it easier to test the logs.
 	jsonHeaderWrongValTypeLogLim = log.Every(0)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1400,7 +1400,7 @@ func TestChangefeedMultiTable(t *testing.T) {
 func TestChangefeedCursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer testutils.SetVModule(t, "event_processing=3,blocking_buffer=2")()
+	testutils.SetVModule(t, "event_processing=3,blocking_buffer=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2204,7 +2204,7 @@ func TestNoStopAfterNonTargetColumnDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2313,7 +2313,7 @@ func TestNoBackfillAfterNonTargetColumnDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2359,7 +2359,7 @@ func TestChangefeedColumnDropsWithFamilyAndNonFamilyTargets(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2412,7 +2412,7 @@ func TestChangefeedColumnDropsOnMultipleFamiliesWithTheSameName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2466,7 +2466,7 @@ func TestChangefeedColumnDropsOnTheSameTableWithMultipleFamilies(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2510,7 +2510,7 @@ func TestChangefeedColumnDropsOnTheSameTableWithMultipleFamiliesWithManualSchema
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2556,7 +2556,7 @@ func TestNoStopAfterNonTargetAddColumnWithBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2658,7 +2658,7 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1 min under race")
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3306,7 +3306,7 @@ func TestChangefeedSchemaChangeAllowBackfill_Legacy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3504,7 +3504,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3666,7 +3666,7 @@ func TestChangefeedSchemaChangeBackfillScope(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3730,7 +3730,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -3762,7 +3762,7 @@ func TestChangefeedEachColumnFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 
@@ -3892,7 +3892,7 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	// requireErrorSoon times out after 30 seconds
 	skip.UnderStress(t)
@@ -3939,7 +3939,7 @@ func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -6456,7 +6456,7 @@ func TestChangefeedTruncateOrDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "table_event_filter=2")()
+	testutils.SetVModule(t, "table_event_filter=2")
 
 	assertFailuresCounter := func(t *testing.T, m *Metrics, exp int64) {
 		t.Helper()
@@ -8657,8 +8657,8 @@ func TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart(t *testing.T)
 	defer log.Scope(t).Close(t)
 
 	// Add verbose logging to help debug future failures.
-	defer testutils.SetVModule(t, "changefeed_processors=1,replica_rangefeed=2,"+
-		"replica_range_lease=3,raft=3")()
+	testutils.SetVModule(t, "changefeed_processors=1,replica_rangefeed=2,"+
+		"replica_range_lease=3,raft=3")
 
 	// This test requires many range splits, which can be slow under certain test
 	// conditions. Skip potentially slow tests.
@@ -10997,7 +10997,7 @@ func TestSchemachangeDoesNotBreakSinklessFeed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")()
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -11876,7 +11876,7 @@ func TestChangefeedHeadersJSONVals(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "event_processing=3")()
+	testutils.SetVModule(t, "event_processing=3")
 
 	// Make it easier to test the logs.
 	jsonHeaderWrongValTypeLogLim = log.Every(0)

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -562,7 +562,7 @@ func TestPTSRecordProtectsTargetsAndSystemTables(t *testing.T) {
 	ctx := context.Background()
 
 	// Useful for debugging.
-	defer testutils.SetVModule(t, "spanconfigstore=2,store=2,reconciler=3,mvcc_gc_queue=2,kvaccessor=2")()
+	testutils.SetVModule(t, "spanconfigstore=2,store=2,reconciler=3,mvcc_gc_queue=2,kvaccessor=2")
 
 	settings := cluster.MakeTestingClusterSettings()
 	spanconfigjob.ReconciliationJobCheckpointInterval.Override(ctx, &settings.SV, 1*time.Second)

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -562,7 +562,7 @@ func TestPTSRecordProtectsTargetsAndSystemTables(t *testing.T) {
 	ctx := context.Background()
 
 	// Useful for debugging.
-	require.NoError(t, log.SetVModule("spanconfigstore=2,store=2,reconciler=3,mvcc_gc_queue=2,kvaccessor=2"))
+	defer testutils.SetVModule(t, "spanconfigstore=2,store=2,reconciler=3,mvcc_gc_queue=2,kvaccessor=2")()
 
 	settings := cluster.MakeTestingClusterSettings()
 	spanconfigjob.ReconciliationJobCheckpointInterval.Override(ctx, &settings.SV, 1*time.Second)

--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -63,7 +63,8 @@ func TestRegionLivenessProber(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	// Force extra logging to diagnose flakes.
-	require.NoError(t, log.SetVModule("prober=2"))
+	defer testutils.SetVModule(t, "prober=2")()
+
 	// This test forces the SQL liveness TTL be a small number,
 	// which makes the heartbeats even more critical. Under stress and
 	// race environments this test becomes even more sensitive, if

--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -63,7 +63,7 @@ func TestRegionLivenessProber(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	// Force extra logging to diagnose flakes.
-	defer testutils.SetVModule(t, "prober=2")()
+	testutils.SetVModule(t, "prober=2")
 
 	// This test forces the SQL liveness TTL be a small number,
 	// which makes the heartbeats even more critical. Under stress and

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     embed = [":cloud"],
     deps = [
         "//pkg/cloud/cloudpb",
+        "//pkg/testutils",
         "//pkg/util/ioctx",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -225,7 +225,7 @@ func TestS3FaultInjection(t *testing.T) {
 
 	// Enable cloud transport logging.
 	defer log.Scope(t).Close(t)
-	defer testutils.SetVModule(t, "cloud_logging_transport=1")()
+	testutils.SetVModule(t, "cloud_logging_transport=1")
 
 	uri := fmt.Sprintf(
 		"s3://%s/%d-fault-injection-test?AUTH=implicit",

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -225,9 +225,7 @@ func TestS3FaultInjection(t *testing.T) {
 
 	// Enable cloud transport logging.
 	defer log.Scope(t).Close(t)
-	prevVModule := log.GetVModule()
-	defer func() { _ = log.SetVModule(prevVModule) }()
-	require.NoError(t, log.SetVModule("cloud_logging_transport=1"))
+	defer testutils.SetVModule(t, "cloud_logging_transport=1")()
 
 	uri := fmt.Sprintf(
 		"s3://%s/%d-fault-injection-test?AUTH=implicit",

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -165,7 +165,7 @@ func TestAzureFaultInjection(t *testing.T) {
 
 	// Enable cloud transport logging.
 	defer log.Scope(t).Close(t)
-	defer testutils.SetVModule(t, "cloud_logging_transport=1")()
+	testutils.SetVModule(t, "cloud_logging_transport=1")
 
 	testID := cloudtestutils.NewTestID()
 	uri := cfg.filePathImplicitAuth(fmt.Sprintf("%d-fault-injection-test", testID))

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -165,9 +165,7 @@ func TestAzureFaultInjection(t *testing.T) {
 
 	// Enable cloud transport logging.
 	defer log.Scope(t).Close(t)
-	prevVModule := log.GetVModule()
-	defer func() { _ = log.SetVModule(prevVModule) }()
-	require.NoError(t, log.SetVModule("cloud_logging_transport=1"))
+	defer testutils.SetVModule(t, "cloud_logging_transport=1")()
 
 	testID := cloudtestutils.NewTestID()
 	uri := cfg.filePathImplicitAuth(fmt.Sprintf("%d-fault-injection-test", testID))

--- a/pkg/cloud/cloud_logging_transport_test.go
+++ b/pkg/cloud/cloud_logging_transport_test.go
@@ -22,14 +22,14 @@ import (
 // TestMaybeAddLogging tests that logging is only added when log.V(1) is true.
 func TestMaybeAddLogging(t *testing.T) {
 	t.Run("logging-disabled", func(t *testing.T) {
-		defer testutils.SetVModule(t, "")()
+		testutils.SetVModule(t, "")
 		inner := &http.Transport{}
 		result := maybeAddLogging(inner)
 		require.Equal(t, inner, result, "should return inner transport when logging is disabled")
 	})
 
 	t.Run("logging-enabled", func(t *testing.T) {
-		defer testutils.SetVModule(t, "*=1")()
+		testutils.SetVModule(t, "*=1")
 		inner := &http.Transport{}
 		result := maybeAddLogging(inner)
 		require.NotEqual(t, inner, result, "should return wrapped transport when logging is enabled")

--- a/pkg/cloud/cloud_logging_transport_test.go
+++ b/pkg/cloud/cloud_logging_transport_test.go
@@ -13,25 +13,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
+// TestMaybeAddLogging tests that logging is only added when log.V(1) is true.
 func TestMaybeAddLogging(t *testing.T) {
-	// Test that logging is only added when log.V(1) is true
-	originalVModule := log.GetVModule()
-	defer func() { _ = log.SetVModule(originalVModule) }()
-
 	t.Run("logging-disabled", func(t *testing.T) {
-		_ = log.SetVModule("")
+		defer testutils.SetVModule(t, "")()
 		inner := &http.Transport{}
 		result := maybeAddLogging(inner)
 		require.Equal(t, inner, result, "should return inner transport when logging is disabled")
 	})
 
 	t.Run("logging-enabled", func(t *testing.T) {
-		_ = log.SetVModule("*=1")
+		defer testutils.SetVModule(t, "*=1")()
 		inner := &http.Transport{}
 		result := maybeAddLogging(inner)
 		require.NotEqual(t, inner, result, "should return wrapped transport when logging is enabled")

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -313,7 +313,7 @@ func TestGCSFaultInjection(t *testing.T) {
 
 	// Enable cloud transport logging.
 	defer log.Scope(t).Close(t)
-	defer testutils.SetVModule(t, "cloud_logging_transport=1")()
+	testutils.SetVModule(t, "cloud_logging_transport=1")
 
 	testID := cloudtestutils.NewTestID()
 	uri := fmt.Sprintf("gs://%s/%d-fault-injection-test?AUTH=implicit", bucket, testID)

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -313,9 +313,7 @@ func TestGCSFaultInjection(t *testing.T) {
 
 	// Enable cloud transport logging.
 	defer log.Scope(t).Close(t)
-	prevVModule := log.GetVModule()
-	defer func() { _ = log.SetVModule(prevVModule) }()
-	require.NoError(t, log.SetVModule("cloud_logging_transport=1"))
+	defer testutils.SetVModule(t, "cloud_logging_transport=1")()
 
 	testID := cloudtestutils.NewTestID()
 	uri := fmt.Sprintf("gs://%s/%d-fault-injection-test?AUTH=implicit", bucket, testID)

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -794,7 +794,7 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 	skip.UnderDeadlock(t)
 
 	// To help debug issues like #154179.
-	defer testutils.SetVModule(t, "dist_sender=3")()
+	testutils.SetVModule(t, "dist_sender=3")
 
 	testutils.RunValues(t, "lease-type", roachpb.ExpirationAndLeaderLeaseType(),
 		func(t *testing.T, leaseType roachpb.LeaseType) {

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -794,9 +794,7 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 	skip.UnderDeadlock(t)
 
 	// To help debug issues like #154179.
-	prevVModule := log.GetVModule()
-	defer func() { _ = log.SetVModule(prevVModule) }()
-	require.NoError(t, log.SetVModule("dist_sender=3"))
+	defer testutils.SetVModule(t, "dist_sender=3")()
 
 	testutils.RunValues(t, "lease-type", roachpb.ExpirationAndLeaderLeaseType(),
 		func(t *testing.T, leaseType roachpb.LeaseType) {

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -778,7 +778,7 @@ func TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Increase the verbosity of the test to help investigate failures.
-	defer testutils.SetVModule(t, "replica_range_lease=3,raft=4,txn=3,txn_coord_sender=3")()
+	testutils.SetVModule(t, "replica_range_lease=3,raft=4,txn=3,txn_coord_sender=3")
 	const numNodes = 2
 	var manuals []*hlc.HybridManualClock
 	var clocks []*hlc.Clock
@@ -2955,7 +2955,7 @@ func TestLossQuorumCauseLeaderlessWatcherToSignalUnavailable(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Increase the verbosity of the test to help investigate failures.
-	defer testutils.SetVModule(t, "replica_range_lease=3,raft=4")()
+	testutils.SetVModule(t, "replica_range_lease=3,raft=4")
 
 	ctx := context.Background()
 	stickyVFSRegistry := fs.NewStickyRegistry()
@@ -6072,7 +6072,7 @@ func TestLeaseTransferReplicatesLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "cmd_lease=2")()
+	testutils.SetVModule(t, "cmd_lease=2")
 
 	// Test Setup:
 	//
@@ -6182,7 +6182,7 @@ func TestLeaseTransferDropsLocksIfLargerThanCommandSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "cmd_lease=2")()
+	testutils.SetVModule(t, "cmd_lease=2")
 
 	// Test Plan:
 	//
@@ -6233,7 +6233,7 @@ func TestMergeDropsLocksIfLargerThanMax(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	defer testutils.SetVModule(t, "cmd_subsume=2")()
+	testutils.SetVModule(t, "cmd_subsume=2")
 
 	// Test Plan:
 	//

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1083,8 +1083,8 @@ func TestStoreRangeSplitWithTracing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	l := log.ScopeWithoutShowLogs(t)
-	_ = log.SetVModule("split_queue=1")
 	defer l.Close(t)
+	defer testutils.SetVModule(t, "split_queue=1")()
 
 	splitKey := roachpb.Key("b")
 	var targetRange atomic.Int32

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1084,7 +1084,7 @@ func TestStoreRangeSplitWithTracing(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	l := log.ScopeWithoutShowLogs(t)
 	defer l.Close(t)
-	defer testutils.SetVModule(t, "split_queue=1")()
+	testutils.SetVModule(t, "split_queue=1")
 
 	splitKey := roachpb.Key("b")
 	var targetRange atomic.Int32

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -628,7 +628,7 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 
 	// Increase the verbosity of the logs to help debug the test if it fails, especially
 	// raft related logs when the test tries to transfer the lease non-cooperatively.
-	defer testutils.SetVModule(t, "raft=4,*=1")()
+	testutils.SetVModule(t, "raft=4,*=1")
 
 	for _, test := range []struct {
 		name string

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -628,7 +628,7 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 
 	// Increase the verbosity of the logs to help debug the test if it fails, especially
 	// raft related logs when the test tries to transfer the lease non-cooperatively.
-	require.NoError(t, log.SetVModule("raft=4,*=1"))
+	defer testutils.SetVModule(t, "raft=4,*=1")()
 
 	for _, test := range []struct {
 		name string

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -159,7 +159,7 @@ ORDER BY name ASC;
 func TestFlowControlRangeSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer setRACv2DebugVModule(t)()
+	setRACv2DebugVModule(t)
 
 	testutils.RunValues(t, "kvadmission.flow_control.mode", []kvflowcontrol.ModeT{
 		kvflowcontrol.ApplyToElastic,
@@ -382,7 +382,7 @@ func TestFlowControlAdmissionPostSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderDuressWithIssue(t, 150840)
-	defer setRACv2DebugVModule(t)()
+	setRACv2DebugVModule(t)
 
 	testutils.RunValues(t, "kvadmission.flow_control.mode", []kvflowcontrol.ModeT{
 		kvflowcontrol.ApplyToElastic,
@@ -647,7 +647,7 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 func TestFlowControlRaftSnapshotV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer setRACv2DebugVModule(t)()
+	setRACv2DebugVModule(t)
 
 	const numServers int = 5
 
@@ -892,7 +892,7 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	// And also #148903, #148348, #144546, #141912.
 	skip.UnderDuressWithIssue(t, 149036)
-	defer setRACv2DebugVModule(t)()
+	setRACv2DebugVModule(t)
 
 	testutils.RunValues(t, "kvadmission.flow_control.mode", []kvflowcontrol.ModeT{
 		kvflowcontrol.ApplyToElastic,
@@ -1033,7 +1033,7 @@ func TestFlowControlRaftMembershipRemoveSelfV2(t *testing.T) {
 	// Under overload, token deductions may not line up as expected, likely due
 	// to dropping streams.
 	skip.UnderDuressWithIssue(t, 148079)
-	defer setRACv2DebugVModule(t)()
+	setRACv2DebugVModule(t)
 
 	testutils.RunValues(t, "kvadmission.flow_control.mode", []kvflowcontrol.ModeT{
 		kvflowcontrol.ApplyToElastic,
@@ -4069,9 +4069,9 @@ func BenchmarkFlowControlV2Basic(b *testing.B) {
 	})
 }
 
-func setRACv2DebugVModule(t *testing.T) (reset func()) {
+func setRACv2DebugVModule(t *testing.T) {
 	t.Helper()
-	return testutils.SetVModule(t, "replica_raft=1,replica_proposal_buf=1,"+
+	testutils.SetVModule(t, "replica_raft=1,replica_proposal_buf=1,"+
 		"raft_transport=2,kvadmission=1,work_queue=1,replica_flow_control=1,"+
 		"tracker=1,client_raft_helpers_test=1,range_controller=2,"+
 		"token_counter=2,token_tracker=2,processor=2")

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -4071,11 +4071,8 @@ func BenchmarkFlowControlV2Basic(b *testing.B) {
 
 func setRACv2DebugVModule(t *testing.T) (reset func()) {
 	t.Helper()
-	old := log.GetVModule()
-	require.NoError(t, log.SetVModule("replica_raft=1,replica_proposal_buf=1,"+
+	return testutils.SetVModule(t, "replica_raft=1,replica_proposal_buf=1,"+
 		"raft_transport=2,kvadmission=1,work_queue=1,replica_flow_control=1,"+
 		"tracker=1,client_raft_helpers_test=1,range_controller=2,"+
-		"token_counter=2,token_tracker=2,processor=2",
-	))
-	return func() { require.NoError(t, log.SetVModule(old)) }
+		"token_counter=2,token_tracker=2,processor=2")
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "//pkg/raft/tracker",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
+        "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
         "//pkg/util/admission/admissionpb",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
@@ -38,7 +38,7 @@ func TestBlockedStreamLogging(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := log.ScopeWithoutShowLogs(t)
 	// Causes every call to update the gauges to log.
-	defer testutils.SetVModule(t, "store_stream=2")()
+	testutils.SetVModule(t, "store_stream=2")
 	defer s.Close(t)
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
@@ -37,9 +38,7 @@ func TestBlockedStreamLogging(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := log.ScopeWithoutShowLogs(t)
 	// Causes every call to update the gauges to log.
-	prevVModule := log.GetVModule()
-	_ = log.SetVModule("store_stream=2")
-	defer func() { _ = log.SetVModule(prevVModule) }()
+	defer testutils.SetVModule(t, "store_stream=2")()
 	defer s.Close(t)
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -869,8 +869,8 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 func TestReplicateQueueTracingOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := log.ScopeWithoutShowLogs(t)
-	_ = log.SetVModule("replicate_queue=2")
 	defer s.Close(t)
+	defer testutils.SetVModule(t, "replicate_queue=2")()
 
 	// NB: This test injects a fake failure during replica rebalancing, and we use
 	// this `rejectSnapshots` variable as a flag to activate or deactivate that
@@ -2603,7 +2603,7 @@ func TestPriorityInversionRequeue(t *testing.T) {
 
 	var scratchRangeID int64
 	atomic.StoreInt64(&scratchRangeID, -1)
-	require.NoError(t, log.SetVModule("queue=5,replicate_queue=5,replica_command=5,replicate=5,replica=5"))
+	defer testutils.SetVModule(t, "queue=5,replicate_queue=5,replica_command=5,replicate=5,replica=5")()
 
 	const newLeaseholderStoreAndNodeID = 4
 	var waitUntilLeavingJoint = func() {}

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -870,7 +870,7 @@ func TestReplicateQueueTracingOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := log.ScopeWithoutShowLogs(t)
 	defer s.Close(t)
-	defer testutils.SetVModule(t, "replicate_queue=2")()
+	testutils.SetVModule(t, "replicate_queue=2")
 
 	// NB: This test injects a fake failure during replica rebalancing, and we use
 	// this `rejectSnapshots` variable as a flag to activate or deactivate that
@@ -2603,7 +2603,7 @@ func TestPriorityInversionRequeue(t *testing.T) {
 
 	var scratchRangeID int64
 	atomic.StoreInt64(&scratchRangeID, -1)
-	defer testutils.SetVModule(t, "queue=5,replicate_queue=5,replica_command=5,replicate=5,replica=5")()
+	testutils.SetVModule(t, "queue=5,replicate_queue=5,replica_command=5,replicate=5,replica=5")
 
 	const newLeaseholderStoreAndNodeID = 4
 	var waitUntilLeavingJoint = func() {}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1710,9 +1710,7 @@ func TestPebbleLoggingSlowReads(t *testing.T) {
 
 	testFunc := func(t *testing.T, fileStr string) int {
 		s := log.ScopeWithoutShowLogs(t)
-		prevVModule := log.GetVModule()
-		_ = log.SetVModule(fileStr + "=2")
-		defer func() { _ = log.SetVModule(prevVModule) }()
+		defer testutils.SetVModule(t, fileStr+"=2")()
 		defer s.Close(t)
 
 		ctx := context.Background()

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1710,7 +1710,7 @@ func TestPebbleLoggingSlowReads(t *testing.T) {
 
 	testFunc := func(t *testing.T, fileStr string) int {
 		s := log.ScopeWithoutShowLogs(t)
-		defer testutils.SetVModule(t, fileStr+"=2")()
+		testutils.SetVModule(t, fileStr+"=2")
 		defer s.Close(t)
 
 		ctx := context.Background()

--- a/pkg/testutils/trace.go
+++ b/pkg/testutils/trace.go
@@ -39,20 +39,19 @@ func MatchInOrder(s string, res ...string) error {
 	return nil
 }
 
-// SetVModule sets the logging vmodule. The returned func should be deferred by
-// the caller to reset the vmodule at the end of the test
-//
-//	defer testutils.SetVModules(t, "some_file=3")()
+// SetVModule sets the logging vmodule. The vmodule will be reset by the given
+// testing.TB's Cleanup method.
 //
 // Not safe for concurrent use.
-func SetVModule(t testing.TB, vmodule string) func() {
+func SetVModule(t testing.TB, vmodule string) {
+	t.Helper()
 	prevVModule := log.GetVModule()
 	if err := log.SetVModule(vmodule); err != nil {
 		t.Fatalf("failed to set vmodule: %s", err.Error())
 	}
-	return func() {
+	t.Cleanup(func() {
 		if err := log.SetVModule(prevVModule); err != nil {
 			t.Fatalf("failed to set vmodule: %s", err.Error())
 		}
-	}
+	})
 }


### PR DESCRIPTION
This replaces most uses of log.SetVModule in tests with testutils.SetVModule, which handles resetting the vmodule back to its original value.

Epic: none
Release note: None