### PR TITLE
stress: rename Stress to DevStress

### DIFF
--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -107,7 +107,7 @@ func TestRestoreRetryFastFails(t *testing.T) {
 	// runtime does not exceed the max duration of the retry policy, or
 	// else very few attempts will be made.
 	maxDuration := 500 * time.Millisecond
-	if skip.Stress() {
+	if skip.DevStress() {
 		// Under stress, the restore will take longer to complete, so we need to
 		// increase max duration accordingly.
 		maxDuration = 1500 * time.Millisecond

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -107,7 +107,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		// extend the TTL by 10x to handle cases where the system is too
 		// overloaded to heartbeat at sub-second intervals.
 		ttlOverride := 250 * time.Millisecond
-		if skip.Stress() {
+		if skip.DevStress() {
 			ttlOverride *= 10
 		}
 		heartbeatOverride := ttlOverride / 10

--- a/pkg/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/crosscluster/replicationtestutils/testutils.go
@@ -582,7 +582,7 @@ func (c *TenantStreamingClusters) SrcExec(exec srcInitExecFunc) {
 
 func WaitUntilStartTimeReached(t *testing.T, db *sqlutils.SQLRunner, ingestionJobID jobspb.JobID) {
 	timeout := 45 * time.Second
-	if skip.Stress() || util.RaceEnabled {
+	if skip.DevStress() || util.RaceEnabled {
 		timeout *= 5
 	}
 	testutils.SucceedsWithin(t, func() error {

--- a/pkg/sql/mvcc_statistics_update_job_test.go
+++ b/pkg/sql/mvcc_statistics_update_job_test.go
@@ -203,7 +203,7 @@ func TestTenantGlobalAggregatedLivebytes(t *testing.T) {
 		// Exact match for non stress tests, and allow values to differ by up to
 		// 5% in stress situations.
 		confidenceLevel := 0.0
-		if skip.Stress() {
+		if skip.DevStress() {
 			confidenceLevel = 0.05
 		}
 		testutils.SucceedsSoon(t, func() error {

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -127,7 +127,7 @@ func UnderShort(t SkippableTest, args ...interface{}) {
 // UnderStress skips this test when running under stress.
 func UnderStress(t SkippableTest, args ...interface{}) {
 	t.Helper()
-	if DevStress() {
+	if Stress() {
 		maybeSkip(t, "disabled under stress", args...)
 	}
 }
@@ -136,7 +136,7 @@ func UnderStress(t SkippableTest, args ...interface{}) {
 // given issue ID as the reason.
 func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
-	if DevStress() {
+	if Stress() {
 		maybeSkip(t, withIssue("disabled under stress", githubIssueID), args...)
 	}
 }
@@ -191,7 +191,7 @@ func UnderDuressWithIssue(t SkippableTest, githubIssueID int, args ...interface{
 // Duress captures the conditions that currently lead us to believe that tests
 // may be slower than normal.
 func Duress() bool {
-	return util.RaceEnabled || DevStress() || syncutil.DeadlockEnabled
+	return util.RaceEnabled || Stress() || syncutil.DeadlockEnabled
 }
 
 // UnderBench returns true iff a test is currently running under `go
@@ -225,7 +225,7 @@ func OnArch(t SkippableTest, arch string, args ...interface{}) {
 
 func testConfig() string {
 	configs := []string{}
-	if DevStress() {
+	if Stress() {
 		configs = append(configs, "stress")
 	}
 	if util.RaceEnabled {

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -127,7 +127,7 @@ func UnderShort(t SkippableTest, args ...interface{}) {
 // UnderStress skips this test when running under stress.
 func UnderStress(t SkippableTest, args ...interface{}) {
 	t.Helper()
-	if Stress() {
+	if DevStress() {
 		maybeSkip(t, "disabled under stress", args...)
 	}
 }
@@ -136,7 +136,7 @@ func UnderStress(t SkippableTest, args ...interface{}) {
 // given issue ID as the reason.
 func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
-	if Stress() {
+	if DevStress() {
 		maybeSkip(t, withIssue("disabled under stress", githubIssueID), args...)
 	}
 }
@@ -188,10 +188,10 @@ func UnderDuressWithIssue(t SkippableTest, githubIssueID int, args ...interface{
 	}
 }
 
-// Duress catures the conditions that currently lead us to
-// believe that tests may be slower than normal.
+// Duress captures the conditions that currently lead us to believe that tests
+// may be slower than normal.
 func Duress() bool {
-	return util.RaceEnabled || Stress() || syncutil.DeadlockEnabled
+	return util.RaceEnabled || DevStress() || syncutil.DeadlockEnabled
 }
 
 // UnderBench returns true iff a test is currently running under `go
@@ -225,7 +225,7 @@ func OnArch(t SkippableTest, arch string, args ...interface{}) {
 
 func testConfig() string {
 	configs := []string{}
-	if Stress() {
+	if DevStress() {
 		configs = append(configs, "stress")
 	}
 	if util.RaceEnabled {

--- a/pkg/testutils/skip/stress.go
+++ b/pkg/testutils/skip/stress.go
@@ -7,17 +7,24 @@ package skip
 
 import "github.com/cockroachdb/cockroach/pkg/util/envutil"
 
-var nightlyStress = envutil.EnvOrDefaultBool("COCKROACH_NIGHTLY_STRESS", false)
+var (
+	nightlyStress = envutil.EnvOrDefaultBool("COCKROACH_NIGHTLY_STRESS", false)
+	stress        = envutil.EnvOrDefaultBool("COCKROACH_STRESS", false)
+)
 
-var stress = envutil.EnvOrDefaultBool("COCKROACH_STRESS", false)
-
-// NightlyStress returns true iff the process is running as part of CockroachDB's
-// nightly stress tests.
+// NightlyStress returns true iff the process is running as part of
+// CockroachDB's nightly stress tests.
 func NightlyStress() bool {
 	return nightlyStress
 }
 
-// Stress returns true iff the process is running under a local _dev_ instance of the stress, i.e., ./dev test ... --stress
-func Stress() bool {
+// DevStress returns true iff the process is running under a local _dev_ instance
+// of the stress, i.e., ./dev test ... --stress
+func DevStress() bool {
 	return stress
+}
+
+// Stress returns true iff the process is running under local or nightly stress.
+func Stress() bool {
+	return DevStress() || NightlyStress()
 }


### PR DESCRIPTION
This renames the current implementation of Stress to DevStress and then adds a new Stress function that covers both local and nightly stress runs.

Epic: none
Release note: None