### PR TITLE
server: run tests with DRPC randomly enabled

### DIFF
--- a/pkg/server/api_v2_databases_metadata_test.go
+++ b/pkg/server/api_v2_databases_metadata_test.go
@@ -864,6 +864,7 @@ func TestTriggerMetadataUpdateJobTriggerFailed(t *testing.T) {
 	// won't be adopted in this test run.
 	adoptDuration := time.Hour
 	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: &jobs.TestingKnobs{
 				IntervalOverrides: jobs.TestingIntervalOverrides{

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -39,7 +39,11 @@ func TestListSessionsV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
+		},
+	})
 	ctx := context.Background()
 	defer testCluster.Stopper().Stop(ctx)
 

--- a/pkg/server/authserver/main_test.go
+++ b/pkg/server/authserver/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -22,6 +23,11 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -356,6 +356,9 @@ func TestDecommissionedNodeCannotConnect(t *testing.T) {
 	numNodes := 3
 	tcArgs := base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual, // saves time
+		ServerArgs: base.TestServerArgs{
+			DefaultDRPCOption: base.TestDRPCDisabled,
+		},
 	}
 
 	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)

--- a/pkg/server/debug/main_test.go
+++ b/pkg/server/debug/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -22,6 +23,11 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/diagnostics/main_test.go
+++ b/pkg/server/diagnostics/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -18,5 +19,10 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -189,6 +189,7 @@ func newTestDrainContext(t *testing.T, drainSleepCallCount *int) *testDrainConte
 			// We need to start the cluster insecure in order to not
 			// care about TLS settings for the RPC client connection.
 			ServerArgs: base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						DrainSleepFn: func(time.Duration) {

--- a/pkg/server/grpc_gateway_test.go
+++ b/pkg/server/grpc_gateway_test.go
@@ -30,6 +30,7 @@ func TestEndpointTelemetryBasic(t *testing.T) {
 		// Disable the default test tenant for now as this tests fails
 		// with it enabled. Tracked with #81590.
 		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultDRPCOption: base.TestDRPCDisabled,
 	})
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -25,7 +25,9 @@ func TestRequestMetricRegistered(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer ts.Stopper().Stop(ctx)
 
 	requestMetrics := rpc.NewRequestMetrics()

--- a/pkg/server/main_test.go
+++ b/pkg/server/main_test.go
@@ -30,6 +30,10 @@ func TestMain(m *testing.M) {
 		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
 	)()
 
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/privchecker/main_test.go
+++ b/pkg/server/privchecker/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -22,6 +23,11 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -968,7 +968,8 @@ func TestSQLDecommissioned(t *testing.T) {
 	tc := serverutils.StartCluster(t, 2, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual, // saves time
 		ServerArgs: base.TestServerArgs{
-			Insecure: true, // to set up a simple SQL client
+			DefaultDRPCOption: base.TestDRPCDisabled,
+			Insecure:          true, // to set up a simple SQL client
 		},
 	})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/server/settingswatcher/main_test.go
+++ b/pkg/server/settingswatcher/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,6 +21,11 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -48,6 +48,7 @@ func TestSettingWatcherOnTenant(t *testing.T) {
 	ctx := context.Background()
 	srv, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		DefaultDRPCOption: base.TestDRPCDisabled,
 	})
 	defer srv.Stopper().Stop(ctx)
 	s0 := srv.ApplicationLayer()
@@ -397,6 +398,7 @@ func TestOverflowRestart(t *testing.T) {
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		DefaultDRPCOption: base.TestDRPCDisabled,
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/server/status/main_test.go
+++ b/pkg/server/status/main_test.go
@@ -6,6 +6,7 @@
 package status_test
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -15,6 +16,10 @@ import (
 func init() {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 }
 
 //go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -799,6 +799,7 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 		ReplicationMode: base.ReplicationManual, // saves time
 		ServerArgs: base.TestServerArgs{
 			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(81590),
+			DefaultDRPCOption: base.TestDRPCDisabled,
 		},
 	})
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/server/storage_api/logfiles_test.go
+++ b/pkg/server/storage_api/logfiles_test.go
@@ -378,7 +378,9 @@ func TestStatusLogRedaction(t *testing.T) {
 			// Apply the redactable log boolean for this test.
 			defer log.TestingSetRedactable(redactableLogs)()
 
-			srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+			srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+				DefaultDRPCOption: base.TestDRPCDisabled,
+			})
 			defer srv.Stopper().Stop(context.Background())
 			ts := srv.ApplicationLayer()
 

--- a/pkg/server/storage_api/main_test.go
+++ b/pkg/server/storage_api/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -22,6 +23,11 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/structlogging/main_test.go
+++ b/pkg/server/structlogging/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -22,6 +23,11 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/systemconfigwatcher/main_test.go
+++ b/pkg/server/systemconfigwatcher/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,6 +21,11 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/tenantsettingswatcher/main_test.go
+++ b/pkg/server/tenantsettingswatcher/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,6 +21,11 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/tracedumper/main_test.go
+++ b/pkg/server/tracedumper/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,6 +21,11 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -83,7 +83,9 @@ func TestSQLRolesAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultDRPCOption: base.TestDRPCDisabled,
+	})
 	defer s.Stopper().Stop(context.Background())
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	var res serverpb.UserSQLRolesResponse


### PR DESCRIPTION
This change introduces a package-level setting that randomly enables DRPC.

Epic: CRDB-48935
Informs: #153924
Release note: None