### PR TITLE
release-25.4: sql/importer: make inspect after import validation a metamorphic setting

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -515,6 +515,9 @@ type TableDescriptor interface {
 	// keys, even if they're not defined by the user.
 	HasPrimaryKey() bool
 
+	// IsExpressionIndex returns if the given index is an expression index.
+	IsExpressionIndex(idx Index) bool
+
 	// AllColumns returns a slice of Column interfaces containing the
 	// table's public columns and column mutations, in the canonical order:
 	// - all public columns in the same order as in the underlying

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2236,6 +2236,18 @@ func (desc *wrapper) HasPrimaryKey() bool {
 	return !desc.PrimaryIndex.Disabled
 }
 
+// IsExpressionIndex implements the TableDescriptor interface.
+func (desc *wrapper) IsExpressionIndex(idx catalog.Index) bool {
+	for i := 0; i < idx.NumKeyColumns(); i++ {
+		colID := idx.GetKeyColumnID(i)
+		col := catalog.FindColumnByID(desc, colID)
+		if col != nil && col.IsExpressionIndexColumn() {
+			return true
+		}
+	}
+	return false
+}
+
 // HasColumnBackfillMutation implements the TableDescriptor interface.
 func (desc *wrapper) HasColumnBackfillMutation() bool {
 	for _, m := range desc.AllMutations() {

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logutil",
+        "//pkg/util/metamorphic",
         "//pkg/util/protoutil",
         "//pkg/util/retry",
         "//pkg/util/syncutil",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logutil"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -107,16 +108,44 @@ var performConstraintValidation = settings.RegisterBoolSetting(
 	settings.WithUnsafe,
 )
 
-// TODO(janexing): tune the default to True when INSPECT is merged in stable release.
-var importRowCountValidation = settings.RegisterBoolSetting(
+// ImportRowCountValidationMode represents the mode for row count validation after import.
+type ImportRowCountValidationMode int64
+
+const (
+	// ImportRowCountValidationOff disables row count validation after import.
+	ImportRowCountValidationOff ImportRowCountValidationMode = iota
+	// ImportRowCountValidationAsync enables asynchronous row count validation after import.
+	ImportRowCountValidationAsync
+	// ImportRowCountValidationSync enables synchronous (blocking) row count validation after import.
+	ImportRowCountValidationSync
+)
+
+// importRowCountValidationMetamorphicValue determines the default value for
+// importRowCountValidation in metamorphic test builds. It randomly selects
+// between "off", "async", and "sync" modes to increase test coverage.
+var importRowCountValidationMetamorphicValue = metamorphic.ConstantWithTestChoice(
+	"import-row-count-validation",
+	"off",   // no validation
+	"async", // background validation
+	"sync",  // blocking validation for tests
+)
+
+// TODO(janexing): tune the default to async when INSPECT is merged in stable release.
+var importRowCountValidation = settings.RegisterEnumSetting(
 	settings.ApplicationLevel,
-	"bulkio.import.row_count_validation.unsafe.enabled",
-	"enables asynchronous validation of imported data via INSPECT "+
-		"jobs. When enabled, an INSPECT job runs after import completion to "+
-		"detect potential data corruption. Disabling this setting may result "+
-		"in undetected data corruption if the import process fails.",
-	false,
+	"bulkio.import.row_count_validation.unsafe.mode",
+	"controls validation of imported data via INSPECT jobs. "+
+		"Options: 'off' (no validation), 'async' (background validation), "+
+		"'sync' (blocking validation). "+
+		"If disabled, IMPORT will not perform a post-import row count check.",
+	importRowCountValidationMetamorphicValue,
+	map[ImportRowCountValidationMode]string{
+		ImportRowCountValidationOff:   "off",
+		ImportRowCountValidationAsync: "async",
+		ImportRowCountValidationSync:  "sync",
+	},
 	settings.WithUnsafe,
+	settings.WithRetiredName("bulkio.import.row_count_validation.unsafe.enabled"),
 )
 
 // Resume is part of the jobs.Resumer interface.
@@ -296,10 +325,14 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		return err
 	}
 
-	if importRowCountValidation.Get(&p.ExecCfg().Settings.SV) {
+	validationMode := importRowCountValidation.Get(&p.ExecCfg().Settings.SV)
+	switch validationMode {
+	case ImportRowCountValidationOff:
+	// No validation required.
+	case ImportRowCountValidationAsync, ImportRowCountValidationSync:
 		tblDesc := tabledesc.NewBuilder(details.Tables[0].Desc).BuildImmutableTable()
 		if len(tblDesc.PublicNonPrimaryIndexes()) > 0 {
-			_, err := sql.TriggerInspectJob(
+			jobID, err := sql.TriggerInspectJob(
 				ctx,
 				fmt.Sprintf("import-validation-%s", tblDesc.GetName()),
 				p.ExecCfg(),
@@ -309,7 +342,15 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to trigger inspect for import validation for table %s", tblDesc.GetName())
 			}
-			log.Eventf(ctx, "triggered inspect job for import validation for table %s with AOST %s", tblDesc.GetName(), setPublicTimestamp)
+			log.Eventf(ctx, "triggered inspect job %d for import validation for table %s with AOST %s", jobID, tblDesc.GetName(), setPublicTimestamp)
+
+			// For sync mode, wait for the inspect job to complete.
+			if validationMode == ImportRowCountValidationSync {
+				if err := p.ExecCfg().JobRegistry.WaitForJobs(ctx, []jobspb.JobID{jobID}); err != nil {
+					return errors.Wrapf(err, "failed to wait for inspect job %d for table %s", jobID, tblDesc.GetName())
+				}
+				log.Eventf(ctx, "inspect job %d completed for table %s", jobID, tblDesc.GetName())
+			}
 		}
 	}
 

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -379,12 +379,26 @@ func (c *indexConsistencyCheck) loadCatalogInfo(ctx context.Context) error {
 			// We can only check a secondary index that has a 1-to-1 mapping between
 			// keys in the primary index. Unsupported indexes should be filtered out
 			// when the job is created.
+			// TODO(154862): support partial indexes
 			if idx.IsPartial() {
 				return errors.AssertionFailedf(
 					"unsupported index type for consistency check: partial index",
 				)
 			}
+			// TODO(154762): support hash sharded indexes
+			if idx.IsSharded() {
+				return errors.AssertionFailedf(
+					"unsupported index type for consistency check: hash-sharded index",
+				)
+			}
+			// TODO(154772): support expression indexes
+			if c.tableDesc.IsExpressionIndex(idx) {
+				return errors.AssertionFailedf(
+					"unsupported index type for consistency check: expression index",
+				)
+			}
 			switch idx.GetType() {
+			// TODO(154860): support inverted indexes
 			case idxtype.INVERTED, idxtype.VECTOR:
 				return errors.AssertionFailedf(
 					"unsupported index type for consistency check: %s", idx.GetType(),

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -137,3 +137,43 @@ statement ok
 INSPECT DATABASE test;
 
 subtest end
+
+subtest inspect_unsupported_indexes
+
+user root
+
+# Test that unsupported indexes (hash-sharded, expression) are skipped.
+# Table has both unsupported indexes and a regular index.
+statement ok
+CREATE TABLE t2 (x INT, y INT, z INT, INDEX hash_idx (x) USING HASH, INDEX expr_idx ((y + z)), INDEX regular_idx (z));
+
+statement ok
+INSERT INTO t2 (x, y, z) VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
+
+# Should succeed, checking only the regular index.
+skipif config local-mixed-25.2 local-mixed-25.3
+statement ok
+EXPERIMENTAL SCRUB TABLE t2 AS OF SYSTEM TIME '-1us';
+
+# Verify only one check was created (for the regular index).
+skipif config local-mixed-25.2 local-mixed-25.3
+query TI
+SELECT
+  json_extract_path_text(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload),
+    'inspectDetails', 'checks', '0', 'type'
+  ) AS check_type,
+  jsonb_array_length(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload) -> 'inspectDetails' -> 'checks'
+  ) AS num_checks
+FROM crdb_internal.system_jobs
+WHERE job_type = 'INSPECT'
+ORDER BY created DESC
+LIMIT 1
+----
+INSPECT_CHECK_INDEX_CONSISTENCY  1
+
+statement ok
+DROP TABLE t2;
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #154646.

/cc @cockroachdb/release

---

Previously, the setting `bulkio.import.row_count_validation.unsafe.enabled` was a boolean that controlled whether an INSPECT job would be triggered after an IMPORT operation. This commit replaces that boolean with a metamorphic enum setting.

The new enum has three values:
- `off`: No validation (default; preserves current behavior)
- `async`: Run INSPECT asynchronously in the background (future production default)
- `sync`: Run INSPECT synchronously and wait for completion (testing only)

The prior `true` value now maps to `async`. The new `sync` option is added specifically for testing. If the INSPECT job fails, it causes the IMPORT to fail as well, enabling roachtests to detect issues more easily without manual validation.

The setting has been renamed to `bulkio.import.row_count_validation.unsafe.mode` to reflect the new setting.

Informs: #154049
Epic: CRDB-30356

Release note: none

Release justification: required for MVP of INSPECT
