### PR TITLE
dev: describe useful environment variable in test help

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -96,6 +96,12 @@ pkg/kv/kvserver:kvserver_test) instead.`,
 
     dev test pkg/server -- --test_env=COCKROACH_RANDOM_SEED=1234
         Run a test with a specified seed by passing the --test_env flag directly to bazel
+
+    Test-relevant environment variables:
+        COCKROACH_RANDOM_SEED=n                             Set a seed for the random number generator.
+        COCKROACH_TEST_TENANT=(shared|external|disabled)    Specify or disable randomized tenant testing.
+        COCKROACH_TEST_DRPC=(enabled|disabled)              Enable/Disable DRPC (gRPC replacement).
+        COCKROACH_FORCE_RUN_SKIPPED_TESTS=true              Ignore skip.UnderStress and friends.
 `,
 		Args: cobra.MinimumNArgs(0),
 		RunE: runE,


### PR DESCRIPTION
I always forget the names of these and usually have to grep for them. Maybe others will also find this useful.

Epic: none
Release note: None