### PR TITLE
release-25.4: changefeedccl: make bulk delivery of rangefeed events optional

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -596,6 +596,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		WithDiff:             filters.WithDiff,
 		WithFiltering:        filters.WithFiltering,
 		WithFrontierQuantize: changefeedbase.Quantize.Get(&cfg.Settings.SV),
+		WithBulkDelivery:     changefeedbase.BulkDelivery.Get(&cfg.Settings.SV),
 		NeedsInitialScan:     needsInitialScan,
 		SchemaChangeEvents:   schemaChange.EventClass,
 		SchemaChangePolicy:   schemaChange.Policy,

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -215,6 +215,14 @@ var ProtectTimestampLag = settings.RegisterDurationSetting(
 	10*time.Minute,
 	settings.PositiveDuration)
 
+// BulkDelivery enables bulk delivery of rangefeed events, which can improve performance during catchup scans.
+var BulkDelivery = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"changefeed.bulk_delivery.enabled",
+	"if true, rangefeed events are delivered in bulk during catchup scans; "+
+		"if false, rangefeed events are delivered individually",
+	metamorphic.ConstantWithTestBool("changefeed.bulk_delivery.enabled", true))
+
 // MaxProtectedTimestampAge controls the frequency of protected timestamp record updates
 var MaxProtectedTimestampAge = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -148,7 +148,7 @@ func TestKVFeed(t *testing.T) {
 		st := timers.New(time.Minute).GetOrCreateScopedTimers("")
 		f := newKVFeed(buf, tc.spans,
 			tc.schemaChangeEvents, tc.schemaChangePolicy,
-			tc.needsInitialScan, tc.withDiff, true /* withFiltering */, tc.withFrontierQuantize,
+			tc.needsInitialScan, tc.withDiff, true /* withFiltering */, changefeedbase.BulkDelivery.Get(&settings.SV), tc.withFrontierQuantize,
 			0, /* consumerID */
 			tc.initialHighWater, tc.initialSpanTimePairs, tc.endTime,
 			codec,

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -34,6 +34,7 @@ type rangeFeedConfig struct {
 	WithDiff             bool
 	WithFiltering        bool
 	WithFrontierQuantize time.Duration
+	WithBulkDelivery     bool
 	ConsumerID           int64
 	RangeObserver        kvcoord.RangeObserver
 	Knobs                TestingKnobs
@@ -97,7 +98,10 @@ func (p rangefeedFactory) Run(ctx context.Context, sink kvevent.Writer, cfg rang
 	// Bulk delivery is an optimization that decreases rangefeed overhead during
 	// catchup scans. It results in the emission of BulkEvents instead of
 	// individual events where possible.
-	rfOpts := []kvcoord.RangeFeedOption{kvcoord.WithBulkDelivery()}
+	var rfOpts []kvcoord.RangeFeedOption
+	if cfg.WithBulkDelivery {
+		rfOpts = append(rfOpts, kvcoord.WithBulkDelivery())
+	}
 	if cfg.WithDiff {
 		rfOpts = append(rfOpts, kvcoord.WithDiff())
 	}


### PR DESCRIPTION
Backport 1/1 commits from #154870.

/cc @cockroachdb/release

Release justification: add cluster setting safeguard

---

This is a temporary opt-out until we can properly test the performance
impact of bulk delivery.

Epic: none

Release note (general change): The changefeed bulk
delivery setting was made optional.

