### PR TITLE
release-25.3: roachtest: disable schema_locked for ORM tests using root

### DIFF
--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -71,6 +71,7 @@ func alterZoneConfigAndClusterSettings(
 		`SET CLUSTER SETTING server.user_login.password_encryption = 'scram-sha-256';`,
 
 		// Enable experimental/preview/compatibility features.
+		`SET CLUSTER SETTING sql.defaults.create_table_with_schema_locked='false';`,
 		`SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled = 'true';`,
 		`ALTER ROLE ALL SET multiple_active_portals_enabled = 'true';`,
 		`ALTER ROLE ALL SET serial_normalization = 'sql_sequence_cached'`,


### PR DESCRIPTION
Previously, when we disabled schema_locked for the ORM roachtests, we disabled it using `ALTER ROLE ALL` which only applies non-root users. So a subset of tests that use the root user would still fail with schema_locked errors. To address this, this patch will use the cluster setting `sql.defaults.create_table_with_schema_locked` which also applies to the root user.

Fixes: #154853
Fixes: #154810

Release note: None
Release justification: test only change