### PR TITLE
release-24.1: sql: skip test crdb_internal.scan_storage_internal_keys

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -414,7 +414,9 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					"crdb_internal.request_statement_bundle",
 					"crdb_internal.reset_activity_tables",
 					"crdb_internal.revalidate_unique_constraints_in_all_tables",
-					"crdb_internal.validate_ttl_scheduled_jobs":
+					"crdb_internal.scan_storage_internal_keys",
+					"crdb_internal.validate_ttl_scheduled_jobs",
+					"crdb_internal.fingerprint":
 					// Skipped due to long execution time.
 					continue
 				}


### PR DESCRIPTION
Backport 1/1 commits from #147732.

/cc @cockroachdb/release

---

Fixes: #147197
Release note: none

Release justification:  test only change
