### PR TITLE
sql/parser: fix bug parsing WITH READ VIRTUAL CLUSTER with other opts

### DIFF
--- a/pkg/sql/parser/testdata/create_virtual_cluster
+++ b/pkg/sql/parser/testdata/create_virtual_cluster
@@ -95,12 +95,12 @@ CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" 
 CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '36h' -- identifiers removed
 
 parse
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ VIRTUAL CLUSTER
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '1h', READ VIRTUAL CLUSTER
 ----
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ VIRTUAL CLUSTER
-CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ VIRTUAL CLUSTER -- fully parenthesized
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ VIRTUAL CLUSTER -- literals removed
-CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ VIRTUAL CLUSTER -- identifiers removed
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '1h', READ VIRTUAL CLUSTER
+CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH RETENTION = ('1h'), READ VIRTUAL CLUSTER -- fully parenthesized
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH RETENTION = '_', READ VIRTUAL CLUSTER -- literals removed
+CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '1h', READ VIRTUAL CLUSTER -- identifiers removed
 
 parse
 CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH OPTIONS (READ VIRTUAL CLUSTER)

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2369,9 +2369,9 @@ func (o *TenantReplicationOptions) CombineWith(other *TenantReplicationOptions) 
 	if o.EnableReaderTenant != nil {
 		if other.EnableReaderTenant != nil {
 			return errors.New("READ VIRTUAL CLUSTER option specified multiple times")
-		} else {
-			o.EnableReaderTenant = other.EnableReaderTenant
 		}
+	} else {
+		o.EnableReaderTenant = other.EnableReaderTenant
 	}
 
 	return nil


### PR DESCRIPTION
Release note (bug fix): Fix a bug that would cause WITH READ VIRTUAL CLUSTER to be ignored if any other options were passed when running CREATE VIRTUAL CLUSTER FROM REPLICATION.
Epic: none.