### PR TITLE
roachtest: fix test failure in DSC compat test

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -116,8 +116,8 @@ func executeSupportedDDLs(
 	// DDLs supported in V25_4.
 	v254DDLs := []string{
 		`TRUNCATE testdb.testsc.t3`,
-		`ALTER TABLE testdb.testsc.t RENAME TO t_renamed`,
-		`ALTER TABLE testdb.testsc.t_renamed RENAME TO t`,
+		`ALTER TABLE testdb.testsc.t2 RENAME TO t2_renamed`,
+		`ALTER TABLE testdb.testsc.t2_renamed RENAME TO t2`,
 		`ALTER TABLE testdb.testsc.t2 ALTER COLUMN j SET ON UPDATE j + 1`,
 		`ALTER TABLE testdb.testsc.t2 RENAME COLUMN k TO k_renamed`,
 		`ALTER TABLE testdb.testsc.t2 RENAME COLUMN k_renamed TO k`,


### PR DESCRIPTION
The test was failing since it was renaming a table that is used by a view.

fixes https://github.com/cockroachdb/cockroach/issues/154809

Release note: None