### PR TITLE
release-25.2: fk_read_committed: set explicit lock wait timeouts

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/fk_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/fk_read_committed
@@ -135,11 +135,12 @@ statement ok
 SELECT 1;
 
 statement async fk_delete
-WITH sleep AS (SELECT pg_sleep(1)) DELETE FROM parent_150282@parent_150282_i_idx WHERE i = 2;
+WITH sleep AS (SELECT pg_sleep(2)) DELETE FROM parent_150282@parent_150282_i_idx WHERE i = 2;
 
 user testuser
 
 statement ok
+SET lock_timeout = '10s';
 SET enable_implicit_fk_locking_for_serializable = on;
 SET enable_shared_locking_for_serializable = on;
 SET enable_durable_locking_for_serializable = on;
@@ -174,11 +175,12 @@ statement ok
 SELECT 1;
 
 statement async fk_update
-WITH sleep AS (SELECT pg_sleep(1)) UPDATE parent_150282 SET p = 4 WHERE i = 2;
+WITH sleep AS (SELECT pg_sleep(2)) UPDATE parent_150282 SET p = 4 WHERE i = 2;
 
 user testuser
 
 statement ok
+SET lock_timeout = '10s';
 SET enable_implicit_fk_locking_for_serializable = on;
 SET enable_shared_locking_for_serializable = on;
 SET enable_durable_locking_for_serializable = on;
@@ -320,7 +322,7 @@ user root
 
 # Give the delete a moment to wait on the p=3 lock by testuser2.
 statement ok
-SELECT pg_sleep(1)
+SELECT pg_sleep(2)
 
 # The serializable insert needs this locking to properly sychronize with the
 # read committed delete.
@@ -339,7 +341,7 @@ user testuser
 
 # Give the insert a moment to wait on the p=2 update by testuser.
 statement ok
-SELECT pg_sleep(1)
+SELECT pg_sleep(2)
 
 statement ok
 ROLLBACK
@@ -348,7 +350,7 @@ user testuser2
 
 # Give the insert a moment to lock p=1.
 statement ok
-SELECT pg_sleep(1)
+SELECT pg_sleep(2)
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
Backport 1/1 commits from #153811.

/cc @cockroachdb/release

---

Previously, we enabled locking for serializable inserts in this test without setting a lock timeout. In the event that the pg_sleep() in these race tests completes and the UPDATE/DELETE gets locks before the INSERT runs, the INSERT will wait indefinitely for the locks because the lock_timeout defaults to 0 (no timeout). Because the test itself is waiting for the INSERT to finish, the deadlock between the INSERT and the UPDATE/DELETE is never detected, resulting in the test timing out after a long wait.

This change doesn't prevent the test from failing, but should make what is going on a little more obvious. If the test is failing with any regularity, we should increase the pg_sleep() time, but so far this seems like a rarity.

Informs: #153453
Release note: None

Release Justification: Minor, test only fix to quiet a flake.