### PR TITLE
drtprod: fix datadog cluster tag

### DIFF
--- a/pkg/cmd/drtprod/scripts/setup_datadog_cluster
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_cluster
@@ -46,7 +46,7 @@ EOF"
 drtprod ssh $CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
 export DD_SITE=${dd_site}
 export DD_API_KEY=${DD_API_KEY}
-export DD_TAGS=env:development,cluster${CLUSTER%:*},team:drt,service:drt-cockroachdb
+export DD_TAGS=env:development,cluster:${CLUSTER%:*},team:drt,service:drt-cockroachdb
 EOF"
 
 drtprod opentelemetry-start $CLUSTER \

--- a/pkg/cmd/drtprod/scripts/setup_datadog_workload
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_workload
@@ -79,6 +79,7 @@ processors:
         - workload_tpcc.*
         - workload_kv_.*
         - workload_tpch.*
+        - workload_ycsb.*
 
 # The */datadog elements are defined in the primary configuration file.
 service:
@@ -98,7 +99,7 @@ EOF"
 drtprod ssh $WORKLOAD_CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
 export DD_SITE=${dd_site}
 export DD_API_KEY=${DD_API_KEY}
-export DD_TAGS=env:development,cluster${CLUSTER%:*},team:drt,service:drt-cockroachdb
+export DD_TAGS=env:development,cluster:${CLUSTER%:*},team:drt,service:drt-cockroachdb
 EOF"
 
 drtprod opentelemetry-start $WORKLOAD_CLUSTER \


### PR DESCRIPTION
This commit fixes the DD_TAGS `cluster` tag. This tag was missing a
colon between the key and value, which resulted in the tag not
getting populated in Datadog.

This commit also adds the workload_ycsb.* metrics as metrics to be
scraped by workload clusters.

Epic: None
Release note: None