### PR TITLE
randgen: import plpgsql/parser to inject sql/parser.ParseDoBlockFn

### DIFF
--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/oidext",
         "//pkg/sql/parser",
         "//pkg/sql/pgrepl/lsn",
+        "//pkg/sql/plpgsql/parser",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/cast",

--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -19,6 +19,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	// Ensure that sql/parser.ParseDoBlockFn is injected from the PLpgSQL
+	// parser.
+	_ "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"


### PR DESCRIPTION
We recently extended sqlsmith to generate DO blocks. Those are handled in the sql parser via an injected function, so we need to ensure that the injection happens. We got a test failure where usage of `randgen` package resulted in a crash, so make it depend on the `plpgsql/parser` to do the injection.

Fixes: #154806.
Release note: None