### PR TITLE
mixedversion: introduce singlePartition and protectedNodePartition mutators

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "helper.go",
         "mixedversion.go",
         "mutators.go",
+        "network_partition_mutator.go",
         "planner.go",
         "runner.go",
         "steps.go",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -581,6 +581,22 @@ func DisableAllFailureInjectionMutators() CustomOption {
 	}
 }
 
+func WithProtectedNodeNetworkPartition() CustomOption {
+	return func(opts *testOptions) {
+		DisableMutators(SingleNetworkPartition)(opts)
+		DisableMutators(ClusterSettingMutator("kv.expiration_leases_only.enabled"))(opts)
+		WithMutatorProbability(ProtectedNodeNetworkPartition, 1.0)(opts)
+	}
+}
+
+func WithSingleNetworkPartition() CustomOption {
+	return func(opts *testOptions) {
+		DisableMutators(ProtectedNodeNetworkPartition)(opts)
+		DisableMutators(ClusterSettingMutator("kv.expiration_leases_only.enabled"))(opts)
+		WithMutatorProbability(SingleNetworkPartition, 1.0)(opts)
+	}
+}
+
 // WithTag allows callers give the mixedversion test instance a
 // `tag`. The tag is used as prefix in the log messages emitted by
 // this upgrade test. This is only useful when running multiple

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -131,6 +130,26 @@ func randomUpgrades(rng *rand.Rand, plan *TestPlan) []stepSelector {
 		plan.newStepSelector().Filter(byUpgrade(allUpgrades[len(allUpgrades)-1])),
 	}
 	for _, upgrade := range allExceptLastUpgrade[:numChanges] {
+		selectors = append(selectors, plan.newStepSelector().Filter(byUpgrade(upgrade)))
+	}
+
+	return selectors
+}
+
+// allUpgrades returns selectors for the steps of all upgrades in the plan.
+func allUpgrades(plan *TestPlan) []stepSelector {
+	allUpgrades := plan.allUpgrades()
+
+	byUpgrade := func(upgrade *upgradePlan) func(*singleStep) bool {
+		return func(s *singleStep) bool {
+			// N.B. we need to filter by both from and to versions in order to
+			// exclude setup steps which have undefined ToVersions.
+			return s.context.System.FromVersion.Equal(upgrade.from) && s.context.System.ToVersion.Equal(upgrade.to)
+		}
+	}
+
+	var selectors []stepSelector
+	for _, upgrade := range allUpgrades {
 		selectors = append(selectors, plan.newStepSelector().Filter(byUpgrade(upgrade)))
 	}
 
@@ -395,7 +414,8 @@ func (m clusterSettingMutator) changeSteps(
 const (
 	// PanicNode is a mutator that will randomly cause a node to crash during
 	// the test, before safely restarting the node a random number of steps later.
-	PanicNode = "panic_node"
+	PanicNode              = "panic_node"
+	SingleNetworkPartition = "single_network_partition"
 )
 
 func shouldEnableFailureInjection(p *testPlanner) bool {
@@ -559,174 +579,4 @@ func GetFailer(planner *testPlanner, name string) (*failures.Failer, error) {
 	}
 
 	return planner.cluster.GetFailer(planner.logger, planner.cluster.CRDBNodes(), name, false)
-}
-
-type networkPartitionMutator struct{}
-
-func (m networkPartitionMutator) Name() string { return failures.IPTablesNetworkPartitionName }
-
-func (m networkPartitionMutator) IsCompatible(p *testPlanner) bool {
-	return shouldEnableFailureInjection(p)
-}
-
-func (m networkPartitionMutator) Probability() float64 {
-	// TODO(#154547)
-	return 0.0
-}
-
-func (m networkPartitionMutator) Generate(
-	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
-) ([]mutation, error) {
-	var mutations []mutation
-	upgrades := randomUpgrades(rng, plan)
-	idx := newStepIndex(plan)
-	nodeList := planner.currentContext.System.Descriptor.Nodes
-
-	f, err := GetFailer(planner, failures.IPTablesNetworkPartitionName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get failer for %s: %w", failures.IPTablesNetworkPartitionName, err)
-	}
-
-	for _, upgrade := range upgrades {
-		possiblePointsInTime := upgrade.
-			Filter(func(s *singleStep) bool {
-				// We don't want to set up a partition concurrently with other steps, and inserting
-				// before a concurrent step causes the step to run concurrently with that step, so
-				// we filter out any concurrent steps. We don't want to set up a partition while
-				// nodes are unavailable, as that could cause the cluster to lose quorum,
-				//	so we filter out steps with unavailable nodes.
-				var unavailableNodes bool
-				if planner.isMultitenant() {
-					unavailableNodes = s.context.Tenant.hasUnavailableNodes || s.context.System.hasUnavailableNodes
-				} else {
-					unavailableNodes = s.context.System.hasUnavailableNodes
-				}
-				return s.context.System.Stage >= InitUpgradeStage && !idx.IsConcurrent(s) && !unavailableNodes
-			})
-
-		stepToPartition := possiblePointsInTime.RandomStep(rng)
-		hasInvalidConcurrentStep := false
-		var firstStepInConcurrentBlock *singleStep
-
-		isInvalidRecoverStep := func(s *singleStep) bool {
-			// Restarting a node in the middle of a network partition has a chance of
-			// loss of quorum, so we do should recover the network partition before this
-			// if the restarted node is not the node being partitioned.
-			// e.g. In a 4-node cluster, if node 1 is partitioned from nodes 2, 3, and
-			// 4, then restarting node 2 would cause a loss of quorum since 3 and 4
-			// cannot talk to 1.
-
-			// TODO: The partitioned node should be able to restart safely, provided
-			// the necessary steps are altered to allow it.
-
-			_, restartSystem := s.impl.(restartWithNewBinaryStep)
-			_, restartTenant := s.impl.(restartVirtualClusterStep)
-			// Many hook steps require communication between specific nodes, so we
-			// should recover the network partition before running any incompatible
-			// hook steps.
-			_, runHook := s.impl.(runHookStep)
-			// Waiting for stable cluster version requires communication between
-			// all nodes in the cluster, so we should recover the network partition
-			// before running it.
-			_, waitForStable := s.impl.(waitForStableClusterVersionStep)
-
-			if idx.IsConcurrent(s) {
-				if firstStepInConcurrentBlock == nil {
-					firstStepInConcurrentBlock = s
-				}
-				hasInvalidConcurrentStep = true
-			} else {
-				hasInvalidConcurrentStep = false
-				firstStepInConcurrentBlock = nil
-			}
-
-			var unavailableNodes bool
-			if planner.isMultitenant() {
-				unavailableNodes = s.context.Tenant.hasUnavailableNodes || s.context.System.hasUnavailableNodes
-			} else {
-				unavailableNodes = s.context.System.hasUnavailableNodes
-			}
-			return unavailableNodes || restartTenant || restartSystem || (runHook && !planner.options.hooksSupportFailureInjection) || waitForStable
-		}
-
-		_, validStartStep := upgrade.CutAfter(func(s *singleStep) bool {
-			return s == stepToPartition[0]
-		})
-
-		validEndStep, _, cutStep := validStartStep.Cut(func(s *singleStep) bool {
-			return isInvalidRecoverStep(s)
-		})
-
-		// Inserting before a concurrent step will cause the step to run concurrently with that step,
-		// so we remove the concurrent steps from the list of possible insertions if they contain
-		// any invalid steps.
-		if hasInvalidConcurrentStep {
-			validEndStep, _ = validEndStep.CutAfter(func(s *singleStep) bool {
-				return s == firstStepInConcurrentBlock
-			})
-		}
-
-		partitionedNode, leftPartition, rightPartition := selectPartitions(rng, nodeList)
-		partitionType := failures.AllPartitionTypes[rng.Intn(len(failures.AllPartitionTypes))]
-
-		partition := failures.NetworkPartition{Source: leftPartition, Destination: rightPartition, Type: partitionType}
-
-		addPartition := stepToPartition.
-			InsertBefore(networkPartitionInjectStep{f, partition, partitionedNode})
-		var addRecoveryStep []mutation
-		var recoveryStep stepSelector
-		// If validEndStep is nil, it means that there are no steps after the partition step that are
-		// compatible with a network partition, so we immediately restart the node after the partition.
-		if validEndStep == nil {
-			recoveryStep = cutStep
-			addRecoveryStep = cutStep.InsertBefore(networkPartitionRecoveryStep{f, partition, partitionedNode})
-		} else {
-			recoveryStep = validEndStep.RandomStep(rng)
-			addRecoveryStep = recoveryStep.
-				Insert(rng, networkPartitionRecoveryStep{f, partition, partitionedNode})
-		}
-
-		failureContextSteps, _ := validStartStep.CutBefore(func(s *singleStep) bool {
-			return s == recoveryStep[0]
-		})
-
-		failureContextSteps.MarkNodesUnavailable(true, true)
-		addPartition[0].hasUnavailableSystemNodes = true
-		addPartition[0].hasUnavailableTenantNodes = true
-		addRecoveryStep[0].hasUnavailableSystemNodes = true
-		addRecoveryStep[0].hasUnavailableTenantNodes = true
-
-		mutations = append(mutations, addPartition...)
-		mutations = append(mutations, addRecoveryStep...)
-	}
-
-	return mutations, nil
-}
-func selectPartitions(
-	rng *rand.Rand, nodeList option.NodeListOption,
-) (option.NodeListOption, []install.Node, []install.Node) {
-	rand.Shuffle(len(nodeList), func(i, j int) {
-		nodeList[i], nodeList[j] = nodeList[j], nodeList[i]
-	})
-	partitionedNode := nodeList[0]
-
-	leftPartition := []install.Node{install.Node(partitionedNode)}
-	var rightPartition []install.Node
-	// To make an even distribution of partial vs total partitions, 50% of the
-	// time we will default to a total partition, and the other 50% we will
-	// randomly choose which nodes to partition.
-	isTotalPartition := rng.Float64() < 0.5
-	if isTotalPartition {
-		for _, n := range nodeList[1:] {
-			rightPartition = append(rightPartition, install.Node(n))
-		}
-	} else {
-		rightPartition = append(rightPartition, install.Node(nodeList[1]))
-		for _, n := range nodeList[2:] {
-			if rng.Float64() < 0.5 {
-				rightPartition = append(rightPartition, install.Node(n))
-			}
-		}
-	}
-	return option.NodeListOption{partitionedNode}, leftPartition, rightPartition
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -414,8 +414,9 @@ func (m clusterSettingMutator) changeSteps(
 const (
 	// PanicNode is a mutator that will randomly cause a node to crash during
 	// the test, before safely restarting the node a random number of steps later.
-	PanicNode              = "panic_node"
-	SingleNetworkPartition = "single_network_partition"
+	PanicNode                     = "panic_node"
+	SingleNetworkPartition        = "single_network_partition"
+	ProtectedNodeNetworkPartition = "protected_node_network_partition"
 )
 
 func shouldEnableFailureInjection(p *testPlanner) bool {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/network_partition_mutator.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/network_partition_mutator.go
@@ -1,0 +1,368 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mixedversion
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/errors"
+)
+
+// PartitionStrategy defines how network partitions are created during mixed-version tests.
+type PartitionStrategy interface {
+	String() string
+	selectProtectedNodes(rng *rand.Rand, nodes option.NodeListOption) (option.NodeListOption, error)
+	selectPartitions(rng *rand.Rand, protectedNodes, nodes option.NodeListOption) ([]failures.NetworkPartition, option.NodeListOption, error)
+}
+
+// singleNetworkPartitionMutator creates a single node-to-node partition.
+// With leader leases, this ensures that the cluster can always recover
+// from the partition and experiences no unavailability.
+type singlePartitionStrategy struct{}
+
+func (s singlePartitionStrategy) String() string {
+	return SingleNetworkPartition
+}
+
+func (s singlePartitionStrategy) selectProtectedNodes(
+	rng *rand.Rand, nodes option.NodeListOption,
+) (option.NodeListOption, error) {
+	// Since we at most inject one partition, we don't need to protect any nodes.
+	return nil, nil
+}
+
+func (s singlePartitionStrategy) selectPartitions(
+	rng *rand.Rand, protectedNodes, nodes option.NodeListOption,
+) ([]failures.NetworkPartition, option.NodeListOption, error) {
+	if len(nodes) < 3 {
+		return nil, nil, errors.New("at least three nodes are required to create a partition")
+	}
+	rng.Shuffle(len(nodes), func(i, j int) {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	})
+	src := install.Node(nodes[0])
+	dst := install.Node(nodes[1])
+	unavailableNodes := nodes[:2]
+
+	return []failures.NetworkPartition{{
+		Source:      install.Nodes{src},
+		Destination: install.Nodes{dst},
+		Type:        failures.AllPartitionTypes[rng.Intn(len(failures.AllPartitionTypes))],
+	}}, unavailableNodes, nil
+}
+
+// Network partition mutators are disabled by default, as we are still testing
+// their stability in select tests.
+// TODO(darryl): once we are confident in their stability, we should
+// enable them by default.
+var (
+	singleNetworkPartitionMutator = networkPartitionMutator{
+		strategy:    singlePartitionStrategy{},
+		probability: 0.0,
+	}
+)
+
+type networkPartitionMutator struct {
+	strategy    PartitionStrategy
+	probability float64
+}
+
+func (m networkPartitionMutator) Name() string {
+	return m.strategy.String()
+}
+
+func (m networkPartitionMutator) IsCompatible(p *testPlanner) bool {
+	// Disable network partitions for separate process deployments. Network partitions
+	// currently only support partitions between VMs, forcing us to unconditionally partition
+	// all processes on a VM. This can cause separate process tenants to shut down.
+	return shouldEnableFailureInjection(p) && p.deploymentMode != SeparateProcessDeployment
+}
+
+func (m networkPartitionMutator) Probability() float64 {
+	return m.probability
+}
+
+func (m networkPartitionMutator) Generate(
+	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
+) ([]mutation, error) {
+	var mutations []mutation
+	protectedNodes, err := m.strategy.selectProtectedNodes(rng, planner.currentContext.System.Descriptor.Nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := GetFailer(planner, failures.IPTablesNetworkPartitionName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get failer for %s", failures.IPTablesNetworkPartitionName)
+	}
+
+	// N.B. we iterate over all upgrades in order (over using randomUpgrades),
+	// as we want to enable leader leases as soon as possible. We take care of
+	// random selection later.
+	upgrades := allUpgrades(plan)
+	idx := newStepIndex(plan)
+
+	// We only want to inject partitions if leader leases are enabled. Epoch
+	// leases suffer from a known limitation where a leaseholder that is partitioned
+	// from its followers but still heart beating to node liveness may cause indefinite
+	// unavailability.
+	leaderLeasesEnabled := false
+	for i, upgrade := range upgrades {
+		// If leader leases are not yet enabled, check if we can enable them now.
+		if !leaderLeasesEnabled {
+			var leaderLeasesMut []mutation
+			// Attempt to enable leader leases if we are able to do so.
+			upgrade, leaderLeasesMut, err = m.maybeEnableLeaderLeases(upgrade)
+			if err != nil {
+				return nil, err
+			}
+
+			if leaderLeasesMut != nil {
+				mutations = append(mutations, leaderLeasesMut...)
+				leaderLeasesEnabled = true
+			} else {
+				// If the mutations are nil, that means we can't yet enable leader leases
+				// and we should skip attempting to add a partition for this upgrade.
+				continue
+			}
+		}
+
+		// For each upgrade, we inject a partition with 50% probability,
+		// except for the final upgrade. This is the most important one to
+		// test so we always inject one.
+		if i != len(upgrades)-1 && rng.Float64() < 0.5 {
+			continue
+		}
+
+		mut, err := m.generatePartition(rng, upgrade, idx, planner, protectedNodes, f)
+		if err != nil {
+			return nil, err
+		}
+		if mut != nil {
+			mutations = append(mutations, mut...)
+		}
+	}
+
+	return mutations, nil
+}
+
+// leaderLeasesMinVersion is the version in which leader leases were introduced.
+var leaderLeasesMinVersion = clusterupgrade.MustParseVersion("v25.1.0")
+
+// maybeEnableLeaderLeases checks if leader leases can be enabled within the given steps.
+// If so, it returns mutations to do so as soon as possible in the plan, as well as a
+// new stepSelector where all steps have leader leases enabled.
+func (m networkPartitionMutator) maybeEnableLeaderLeases(
+	steps stepSelector,
+) (stepSelector, []mutation, error) {
+	var stepsUnderLeaderLeases stepSelector
+	fromVersion := steps[0].context.System.FromVersion
+	toVersion := steps[0].context.System.ToVersion
+
+	// If we are not upgrading to >= 25.1, then we can't enable leader leases.
+	if !toVersion.AtLeast(leaderLeasesMinVersion) {
+		return nil, nil, nil
+	}
+
+	var firstStep stepSelector
+
+	// If we are upgrading from >= 25.1, then leader leases can be enabled immediately.
+	if fromVersion.AtLeast(leaderLeasesMinVersion) {
+		firstStepAfterClusterStart := steps.Filter(func(s *singleStep) bool {
+			return s.context.System.Stage >= OnStartupStage
+		})
+		if len(firstStepAfterClusterStart) == 0 {
+			return nil, nil, nil
+		}
+
+		firstStep = stepSelector{firstStepAfterClusterStart[0]}
+		stepsUnderLeaderLeases = firstStepAfterClusterStart[1:]
+	} else {
+		// If we are upgrading to 25.1, then we need to find the first step after
+		// at least one node has been restarted with the new version.
+		firstStepAfterRestart := steps.Filter(func(s *singleStep) bool {
+			_, isRestart := s.impl.(restartWithNewBinaryStep)
+			return isRestart
+		})
+		if len(firstStepAfterRestart) == 0 {
+			return nil, nil, nil
+		}
+
+		firstStep = stepSelector{firstStepAfterRestart[0]}
+		stepsUnderLeaderLeases = firstStepAfterRestart[1:]
+	}
+
+	var mutations []mutation
+	disableExpirationLeasesOnlyMutation := firstStep.InsertAfter(
+		setClusterSettingStep{
+			minVersion:         leaderLeasesMinVersion,
+			name:               "kv.expiration_leases_only.enabled",
+			value:              false,
+			virtualClusterName: install.SystemInterfaceName,
+		},
+	)
+	mutations = append(mutations, disableExpirationLeasesOnlyMutation...)
+
+	enableLeaderFortificationMutation := firstStep.InsertAfter(
+		setClusterSettingStep{
+			minVersion:         leaderLeasesMinVersion,
+			name:               "kv.raft.leader_fortification.fraction_enabled",
+			value:              1.0,
+			virtualClusterName: install.SystemInterfaceName,
+		},
+	)
+	mutations = append(mutations, enableLeaderFortificationMutation...)
+
+	return stepsUnderLeaderLeases, mutations, nil
+}
+
+func (m networkPartitionMutator) generatePartition(
+	rng *rand.Rand,
+	steps stepSelector,
+	idx stepIndex,
+	planner *testPlanner,
+	protectedNodes option.NodeListOption,
+	f *failures.Failer,
+) ([]mutation, error) {
+	const maxAttempts = 500
+	for range maxAttempts {
+		// Randomly select a step to inject before and a step to recover after.
+		// This ensures that we skip "uninteresting partition windows", i.e. immediately
+		// recovering after injecting.
+		injectIdx := rng.Intn(len(steps))
+		recoverIdx := rng.Intn(len(steps))
+
+		if m.isValidPartitionWindow(injectIdx, recoverIdx, steps, idx, planner) {
+			return m.createPartitionMutations(rng, injectIdx, recoverIdx, steps, f, protectedNodes, planner)
+		}
+	}
+	// We should always have at least one valid step (i.e. the preserve downgrade step) that
+	// supports a partition window. However, this step may have already been selected by another
+	// failure injection mutator (e.g. node panic). In this case, we just skip injecting a partition.
+	// TODO(darryl): ideally failure injection mutators could avoid having to coordinate within
+	// the mutators themselves, e.g. we could enforce that each upgrade only has at most one failure
+	// injection mutator.
+	return nil, nil
+}
+
+func (m networkPartitionMutator) isValidPartitionWindow(
+	injectIdx, recoverIdx int, steps stepSelector, idx stepIndex, planner *testPlanner,
+) bool {
+	if recoverIdx < injectIdx {
+		return false
+	}
+
+	injectStep := steps[injectIdx]
+	windowSteps := steps[injectIdx : recoverIdx+1]
+
+	// Don't concurrently run our inject step, as we don't want to cause unavailable nodes
+	// while other steps may be connecting to them.
+	if idx.IsConcurrent(injectStep) {
+		return false
+	}
+	// Don't inject a partition before we are done running setup steps.
+	if injectStep.context.System.Stage < InitUpgradeStage {
+		return false
+	}
+
+	// All steps in the window must be compatible with a network partition.
+	for _, s := range windowSteps {
+		if !m.isCompatibleWithPartition(s, planner) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m networkPartitionMutator) isCompatibleWithPartition(
+	s *singleStep, planner *testPlanner,
+) bool {
+	// Avoid restarting nodes while we have a partition injected, as it could
+	// lead to a loss of quorum.
+	// e.g. In a 3 node cluster, if we partition node 1 from node 2, then restarting
+	// node 3 will cause a loss of quorum.
+	//
+	// TODO: Loosen this restriction. In the above example, we can't restart node
+	// 3, but we can restart nodes 1 or 2 without causing a loss of quorum. Similarly
+	// if we are running under a protectedPartitionStrategy, we can restart any node
+	// that is not protected.
+	_, restartSystem := s.impl.(restartWithNewBinaryStep)
+	_, restartTenant := s.impl.(restartVirtualClusterStep)
+
+	// Many hook steps hardcode a connection to a specific node, or attempt to connect
+	// to a random node in the cluster without checking for availability.
+	// Unless enabled, we avoid running hooks while a partition is injected.
+	_, runHook := s.impl.(runHookStep)
+
+	// Waiting for the cluster version to finalize requires all nodes to be able to
+	// communicate with each other.
+	_, waitForStable := s.impl.(waitForStableClusterVersionStep)
+
+	if restartSystem || restartTenant || waitForStable {
+		return false
+	}
+
+	if runHook && !planner.options.hooksSupportFailureInjection {
+		return false
+	}
+
+	// Similar to avoiding node restarts, avoid injecting a partition if a node
+	// is already unavailable.
+	if s.context.System.hasUnavailableNodes {
+		return false
+	}
+	if s.context.Tenant != nil && s.context.Tenant.hasUnavailableNodes {
+		return false
+	}
+
+	return true
+}
+
+func (m networkPartitionMutator) createPartitionMutations(
+	rng *rand.Rand,
+	injectIdx int,
+	recoverIdx int,
+	steps stepSelector,
+	f *failures.Failer,
+	protectedNodes option.NodeListOption,
+	planner *testPlanner,
+) ([]mutation, error) {
+	partitions, unavailableNodes, err := m.strategy.selectPartitions(rng, protectedNodes, planner.currentContext.System.Descriptor.Nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	injectStep := stepSelector{steps[injectIdx]}
+	recoverStep := stepSelector{steps[recoverIdx]}
+
+	addPartitionStep := injectStep.InsertBefore(networkPartitionInjectStep{
+		f:                f,
+		partitions:       partitions,
+		unavailableNodes: unavailableNodes,
+	})
+
+	addRecoveryStep := recoverStep.InsertAfter(networkPartitionRecoveryStep{
+		f:                f,
+		partitions:       partitions,
+		unavailableNodes: unavailableNodes,
+	})
+
+	// Mark all steps in the failure window as having unavailable nodes, so
+	// other mutators don't attempt to also take down nodes in the same window.
+	failureContextSteps := steps[injectIdx : recoverIdx+1]
+	failureContextSteps.MarkNodesUnavailable(true, true)
+	addPartitionStep[0].hasUnavailableSystemNodes = true
+	addPartitionStep[0].hasUnavailableTenantNodes = true
+	addRecoveryStep[0].hasUnavailableSystemNodes = true
+	addRecoveryStep[0].hasUnavailableTenantNodes = true
+
+	return append(addPartitionStep, addRecoveryStep...), nil
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/network_partition_mutator.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/network_partition_mutator.go
@@ -212,7 +212,7 @@ func (m networkPartitionMutator) Generate(
 	// from its followers but still heart beating to node liveness may cause indefinite
 	// unavailability.
 	leaderLeasesEnabled := false
-	for i, upgrade := range upgrades {
+	for _, upgrade := range upgrades {
 		// If leader leases are not yet enabled, check if we can enable them now.
 		if !leaderLeasesEnabled {
 			var leaderLeasesMut []mutation
@@ -235,9 +235,12 @@ func (m networkPartitionMutator) Generate(
 		// For each upgrade, we inject a partition with 50% probability,
 		// except for the final upgrade. This is the most important one to
 		// test so we always inject one.
-		if i != len(upgrades)-1 && rng.Float64() < 0.5 {
-			continue
-		}
+		//
+		// TODO(darryl): for now these mutators are opt in only so we temporarily
+		// inject partitions with 100% probability per upgrade to increase signal.
+		//if i != len(upgrades)-1 && rng.Float64() < 0.5 {
+		//	continue
+		//}
 
 		mut, err := m.generatePartition(rng, upgrade, idx, planner, protectedNodes, f)
 		if err != nil {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/network_partition_mutator.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/network_partition_mutator.go
@@ -58,13 +58,103 @@ func (s singlePartitionStrategy) selectPartitions(
 	}}, unavailableNodes, nil
 }
 
-// Network partition mutators are disabled by default, as we are still testing
+// protectedNetworkPartitionMutator delegates a quorum of nodes as protected.
+// These protected nodes have voter replicas for all ranges pinned to them,
+// and will never be partitioned from each other. This ensures that as long as
+// we connect to a protected node, we should always have availability.
+type protectedPartitionStrategy struct {
+	// TODO(darryl): consider making replication factor configurable in the
+	// mixed version framework itself.
+	quorum int
+}
+
+func (p protectedPartitionStrategy) String() string {
+	return ProtectedNodeNetworkPartition
+}
+
+func (p protectedPartitionStrategy) selectProtectedNodes(
+	rng *rand.Rand, nodes option.NodeListOption,
+) (option.NodeListOption, error) {
+	if len(nodes) < 3 {
+		return nil, errors.New("at least three nodes are required for a protected partition")
+	}
+
+	rng.Shuffle(len(nodes), func(i, j int) {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	})
+	return nodes[:p.quorum], nil
+}
+
+func (p protectedPartitionStrategy) selectPartitions(
+	rng *rand.Rand, protectedNodes, nodes option.NodeListOption,
+) ([]failures.NetworkPartition, option.NodeListOption, error) {
+	protectedNodesMap := make(map[int]bool)
+	for _, node := range protectedNodes {
+		protectedNodesMap[node] = true
+	}
+
+	if len(nodes)-len(protectedNodesMap) < 1 {
+		return nil, nil, errors.New("at least one non protected node is required to create a partition")
+	}
+
+	// Build every possible connection between nodes, excluding ones between
+	// two protected nodes.
+	var connections [][2]int
+	for i := 0; i < len(nodes); i++ {
+		for j := i + 1; j < len(nodes); j++ {
+			if protectedNodesMap[nodes[i]] && protectedNodesMap[nodes[j]] {
+				continue
+			}
+			connections = append(connections, [2]int{nodes[i], nodes[j]})
+		}
+	}
+	rng.Shuffle(len(connections), func(i, j int) {
+		connections[i], connections[j] = connections[j], connections[i]
+	})
+
+	nodeToPartition := make(map[int]*failures.NetworkPartition)
+	unavailableNodes := make(option.NodeListOption, 0)
+	for _, conn := range connections[:rng.Intn(len(connections))+1] {
+		if _, ok := nodeToPartition[conn[0]]; !ok {
+			nodeToPartition[conn[0]] = &failures.NetworkPartition{
+				Source:      install.Nodes{install.Node(conn[0])},
+				Destination: install.Nodes{install.Node(conn[1])},
+				Type:        failures.AllPartitionTypes[rng.Intn(len(failures.AllPartitionTypes))],
+			}
+		} else {
+			nodeToPartition[conn[0]].Destination = append(nodeToPartition[conn[0]].Destination, install.Node(conn[1]))
+		}
+		// For simplicity, we say any node that has a partition touching it is unavailable,
+		// except the protected nodes, since those will always maintain quorum.
+		if !protectedNodesMap[conn[0]] {
+			unavailableNodes = unavailableNodes.Merge(option.NodeListOption{conn[0]})
+		}
+		if !protectedNodesMap[conn[1]] {
+			unavailableNodes = unavailableNodes.Merge(option.NodeListOption{conn[1]})
+		}
+	}
+
+	partitions := make([]failures.NetworkPartition, 0, len(nodeToPartition))
+	for _, partition := range nodeToPartition {
+		partitions = append(partitions, *partition)
+	}
+
+	return partitions, unavailableNodes, nil
+}
+
+// Both mutators are disabled by default, as we are still testing
 // their stability in select tests.
 // TODO(darryl): once we are confident in their stability, we should
 // enable them by default.
 var (
 	singleNetworkPartitionMutator = networkPartitionMutator{
 		strategy:    singlePartitionStrategy{},
+		probability: 0.0,
+	}
+	protectedNetworkPartitionMutator = networkPartitionMutator{
+		strategy: protectedPartitionStrategy{
+			quorum: 2,
+		},
 		probability: 0.0,
 	}
 )
@@ -96,6 +186,14 @@ func (m networkPartitionMutator) Generate(
 	protectedNodes, err := m.strategy.selectProtectedNodes(rng, planner.currentContext.System.Descriptor.Nodes)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(protectedNodes) > 0 {
+		protectedNodesMut, err := m.createProtectedNodes(plan.newStepSelector(), protectedNodes)
+		if err != nil {
+			return nil, err
+		}
+		mutations = append(mutations, protectedNodesMut...)
 	}
 
 	f, err := GetFailer(planner, failures.IPTablesNetworkPartitionName)
@@ -151,6 +249,25 @@ func (m networkPartitionMutator) Generate(
 	}
 
 	return mutations, nil
+}
+
+func (m networkPartitionMutator) createProtectedNodes(
+	steps stepSelector, protectedNodes option.NodeListOption,
+) ([]mutation, error) {
+	// Find the last system setup step. We want to set the zone constraints
+	// after the cluster is setup, but before any meaningful work is done.
+	setupSteps := steps.Filter(func(step *singleStep) bool {
+		return step.context.System.Stage == SystemSetupStage
+	})
+
+	if len(setupSteps) == 0 {
+		return nil, errors.New("no setup steps found")
+	}
+
+	lastSetupStep := setupSteps[len(setupSteps)-1]
+	return stepSelector{lastSetupStep}.InsertAfter(
+		pinVoterReplicasStep{protectedNodes: protectedNodes},
+	), nil
 }
 
 // leaderLeasesMinVersion is the version in which leader leases were introduced.
@@ -347,6 +464,7 @@ func (m networkPartitionMutator) createPartitionMutations(
 		f:                f,
 		partitions:       partitions,
 		unavailableNodes: unavailableNodes,
+		protectedNodes:   protectedNodes,
 	})
 
 	addRecoveryStep := recoverStep.InsertAfter(networkPartitionRecoveryStep{

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -236,6 +236,7 @@ const (
 var failureInjectionMutators = []mutator{
 	panicNodeMutator{},
 	singleNetworkPartitionMutator,
+	protectedNetworkPartitionMutator,
 }
 
 // clusterSettingMutators includes a list of all

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -130,6 +130,8 @@ type (
 		// to opt-out of mutators that are incompatible with a test, if
 		// necessary.
 		Name() string
+		// IsCompatible returns whether the mutator is compatible with the current test.
+		IsCompatible(*testPlanner) bool
 		// Probability returns the probability that this mutator will run
 		// in any given test run. Every mutator should run under some
 		// probability. Making this an explicit part of the interface
@@ -445,29 +447,10 @@ func (p *testPlanner) Plan() (*TestPlan, error) {
 		isLocal:        p.isLocal,
 	}
 
-	failureInjections := make(map[string]struct{})
-	for _, m := range failureInjectionMutators {
-		failureInjections[m.Name()] = struct{}{}
-	}
-
 	// Probabilistically enable some of the mutators on the base test
 	// plan generated above.
 	for _, mut := range planMutators {
 		if p.mutatorEnabled(mut) {
-			if _, found := failureInjections[mut.Name()]; found {
-				// We disable any failure injections that would occur on clusters with
-				// less than three nodes as this can lead to uninteresting failures
-				// (e.g. a single node panic failure).
-				if len(p.currentContext.Nodes()) < 3 {
-					continue
-				}
-				// We disable failure injections for local runs as some failure
-				// injections are not supported in that mode and can
-				// cause unintended behaviors (partitions using iptables).
-				if p.isLocal {
-					continue
-				}
-			}
 			mutations, err := mut.Generate(p.prng, testPlan, p)
 			if err != nil {
 				return nil, err
@@ -1195,6 +1178,10 @@ func (p *testPlanner) newRNG() *rand.Rand {
 }
 
 func (p *testPlanner) mutatorEnabled(mut mutator) bool {
+	if !mut.IsCompatible(p) {
+		return false
+	}
+
 	probability := mut.Probability()
 	if p, ok := p.options.overriddenMutatorProbabilities[mut.Name()]; ok {
 		probability = p

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -235,7 +235,7 @@ const (
 // failure injection mutators.
 var failureInjectionMutators = []mutator{
 	panicNodeMutator{},
-	networkPartitionMutator{},
+	singleNetworkPartitionMutator,
 }
 
 // clusterSettingMutators includes a list of all

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -387,6 +387,7 @@ func Test_maxNumPlanSteps(t *testing.T) {
 // - Failure recovery steps can only occur if there is an active failure injected.
 // - We can only bump the cluster version if no failures are currently injected.
 func TestNoConcurrentFailureInjections(t *testing.T) {
+	defer withTestBuildVersion("v25.2.0")()
 	const numIterations = 500
 	rngSource := rand.NewSource(randutil.NewPseudoSeed())
 	// Set all failure injection mutator probabilities to 1.
@@ -400,11 +401,17 @@ func TestNoConcurrentFailureInjections(t *testing.T) {
 	}
 
 	for range numIterations {
+		rng := rand.New(rngSource)
+		if rng.Float64() < 0.5 {
+			opts = append(opts, WithSingleNetworkPartition())
+		} else {
+			opts = append(opts, WithProtectedNodeNetworkPartition())
+		}
 		mvt := newTest(opts...)
 		mvt._getFailer = getFailer
 		mvt.InMixedVersion("test hook", dummyHook)
 		// Use different seed for each iteration
-		mvt.prng = rand.New(rngSource)
+		mvt.prng = rng
 
 		assertValidTest(mvt, t.Fatal)
 		plan, err := mvt.plan()

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -969,8 +969,9 @@ NEXT_STEP:
 // concurrently with every user-provided hook.
 type concurrentUserHooksMutator struct{}
 
-func (concurrentUserHooksMutator) Name() string         { return "concurrent_user_hooks_mutator" }
-func (concurrentUserHooksMutator) Probability() float64 { return 0.5 }
+func (concurrentUserHooksMutator) Name() string                     { return "concurrent_user_hooks_mutator" }
+func (concurrentUserHooksMutator) IsCompatible(_ *testPlanner) bool { return true }
+func (concurrentUserHooksMutator) Probability() float64             { return 0.5 }
 
 func (concurrentUserHooksMutator) Generate(
 	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
@@ -990,8 +991,9 @@ func (concurrentUserHooksMutator) Generate(
 // user-provided hook from the plan.
 type removeUserHooksMutator struct{}
 
-func (removeUserHooksMutator) Name() string         { return "remove_user_hooks_mutator" }
-func (removeUserHooksMutator) Probability() float64 { return 0.5 }
+func (removeUserHooksMutator) Name() string                     { return "remove_user_hooks_mutator" }
+func (removeUserHooksMutator) IsCompatible(_ *testPlanner) bool { return true }
+func (removeUserHooksMutator) Probability() float64             { return 0.5 }
 
 func (removeUserHooksMutator) Generate(
 	rng *rand.Rand, plan *TestPlan, planner *testPlanner,

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -783,7 +783,7 @@ func startOpts(opts ...option.StartStopOption) option.StartOpts {
 		startStopOpts(opts...)...,
 	)
 	// Enable verbose logging for auto_upgrade to help debug upgrade-related issues.
-	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=auto_upgrade=2")
+	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=auto_upgrade=2,allocator*=3")
 	return startOpts
 }
 
@@ -890,6 +890,7 @@ type networkPartitionInjectStep struct {
 	f                *failures.Failer
 	partitions       []failures.NetworkPartition
 	unavailableNodes option.NodeListOption
+	protectedNodes   option.NodeListOption
 }
 
 func (s networkPartitionInjectStep) Background() shouldStop { return nil }
@@ -899,8 +900,20 @@ func (s networkPartitionInjectStep) Description(debug bool) string {
 }
 
 func (s networkPartitionInjectStep) Run(
-	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
+	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper,
 ) error {
+	// Wait for all ranges to have voter replicas on protected nodes before injecting partition.
+	// We already waited when creating the initial zone configs, but we may have run operations
+	// that caused ranges to be placed outside our config, e.g. importing from a fixture.
+	retryOpts := retry.Options{
+		MaxDuration:    30 * time.Minute,
+		InitialBackoff: 5 * time.Second,
+		MaxBackoff:     5 * time.Second,
+	}
+	if err := waitForVoterReplicasOnNodes(ctx, l, rng, h, s.protectedNodes, retryOpts); err != nil {
+		return errors.Wrap(err, "ranges not ready for partition")
+	}
+
 	h.runner.monitor.ExpectProcessDead(s.unavailableNodes)
 	if h.DeploymentMode() == SeparateProcessDeployment {
 		opt := option.VirtualClusterName(h.Tenant.Descriptor.Name)
@@ -918,6 +931,61 @@ func (s networkPartitionInjectStep) Run(
 	}
 
 	return s.f.WaitForFailureToPropagate(ctx, l)
+}
+
+// waitForVoterReplicasOnNodes blocks until all ranges have voter replicas on the specified nodes.
+// If the retry loop fails, it logs non-compliant ranges before returning an error.
+func waitForVoterReplicasOnNodes(
+	ctx context.Context,
+	l *logger.Logger,
+	rng *rand.Rand,
+	h *Helper,
+	protectedNodes option.NodeListOption,
+	retryOpts retry.Options,
+) error {
+	// Only wait/check if we have protected nodes
+	if len(protectedNodes) == 0 {
+		return nil
+	}
+
+	// Build the WHERE clause to check for ranges with voters on protected nodes
+	var nodeConditions []string
+	for _, node := range protectedNodes {
+		nodeConditions = append(nodeConditions, fmt.Sprintf("array_position(voting_replicas, %d) IS NOT NULL", node))
+	}
+	nodeFilter := strings.Join(nodeConditions, " AND ")
+
+	// Block until all ranges have voter replicas on our protected nodes.
+	// Make sure we exclude dropped tables which will show when querying
+	// ranges, but may not respect our zone configs.
+	return retryOpts.Do(ctx, func(ctx context.Context) error {
+		query := fmt.Sprintf(`
+		WITH undropped AS (
+			SELECT table_id
+			FROM crdb_internal.tables
+			WHERE state != 'DROP'
+		)
+		SELECT
+			count(*) AS total_ranges,
+			count(*) FILTER (WHERE %s) AS ranges_with_all_voters
+		FROM [SHOW CLUSTER RANGES WITH TABLES, DETAILS] AS r
+		JOIN undropped AS t
+			ON r.table_id = t.table_id;
+		`, nodeFilter)
+
+		var totalRanges, rangesWithAllVoters int
+		row := h.System.QueryRow(rng, query)
+		if err := row.Scan(&totalRanges, &rangesWithAllVoters); err != nil {
+			return errors.Wrap(err, "failed to query voter replicas")
+		}
+
+		if rangesWithAllVoters != totalRanges {
+			l.Printf("protected nodes %v have voter replicas on %d/%d ranges", protectedNodes, rangesWithAllVoters, totalRanges)
+			return errors.Errorf("protected nodes %v have voter replicas on %d/%d ranges", protectedNodes, rangesWithAllVoters, totalRanges)
+		}
+		l.Printf("all protected nodes %v have voter replicas on all %d ranges", protectedNodes, totalRanges)
+		return nil
+	})
 }
 
 func (s networkPartitionInjectStep) ConcurrencyDisabled() bool {
@@ -1033,4 +1101,61 @@ func (s stageAllWorkloadBinariesStep) Run(
 }
 func (s stageAllWorkloadBinariesStep) ConcurrencyDisabled() bool {
 	return true
+}
+
+type pinVoterReplicasStep struct {
+	protectedNodes option.NodeListOption
+}
+
+func (s pinVoterReplicasStep) Background() shouldStop { return nil }
+
+func (s pinVoterReplicasStep) Description(debug bool) string {
+	return fmt.Sprintf("pin voter replicas to nodes %v", s.protectedNodes)
+}
+
+func (s pinVoterReplicasStep) Run(
+	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper,
+) error {
+	// We build a zone constraint that requires every node in `protectedNodes`
+	// to have a voter replica of every range.
+	var constraintParts []string
+	for _, node := range s.protectedNodes {
+		constraintParts = append(constraintParts, fmt.Sprintf(`"+node%d": 1`, node))
+	}
+	constraintsStr := fmt.Sprintf(`'{%s}'`, strings.Join(constraintParts, ", "))
+	// Setting voter constraints forces us to also set the replication factor.
+	replicationFactor := 2*len(s.protectedNodes) - 1
+	zoneConfig := fmt.Sprintf("constraints = %s, voter_constraints = %s, num_replicas = %d, num_voters = %d",
+		constraintsStr, constraintsStr, replicationFactor, replicationFactor)
+
+	// Apply the zone config for the default+system ranges and databases.
+	//
+	// N.B. If we start the cluster using fixtures, it will have additional databases such as
+	// `lotsatables` and `persistent_db`. However, these are small enough that they should be
+	// reallocated quickly.
+	for _, rangeName := range []string{"default", "system", "timeseries", "liveness", "meta", "tenants"} {
+		stmt := fmt.Sprintf("ALTER RANGE %s CONFIGURE ZONE USING %s", rangeName, zoneConfig)
+		if err := h.System.Exec(rng, stmt); err != nil {
+			return errors.Wrapf(err, "failed to set replica constraints for %s range", rangeName)
+		}
+	}
+
+	for _, databaseName := range []string{"defaultdb", "system"} {
+		stmt := fmt.Sprintf("ALTER DATABASE %s CONFIGURE ZONE USING %s", databaseName, zoneConfig)
+		if err := h.System.Exec(rng, stmt); err != nil {
+			return errors.Wrapf(err, "failed to set replica constraints for system database")
+		}
+	}
+
+	retryOpts := retry.Options{
+		MaxDuration:    5 * time.Minute,
+		InitialBackoff: 5 * time.Second,
+		MaxBackoff:     5 * time.Second,
+	}
+
+	return waitForVoterReplicasOnNodes(ctx, l, rng, h, s.protectedNodes, retryOpts)
+}
+
+func (s pinVoterReplicasStep) ConcurrencyDisabled() bool {
+	return false
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/separate_process
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/separate_process
@@ -44,8 +44,8 @@ Plan:
 ├── delete all-tenants override for the `version` key (9) [stage=system:tenant-setup;tenant:tenant-setup]
 ├── run startup hooks concurrently
 │   ├── run "create tables" hookId="planner_test.go:141", after 3m0s delay (10) [stage=system:on-startup;tenant:on-startup]
-│   └── run "initialize bank workload" hookId="mixedversion.go:884", after 100ms delay (11) [stage=system:on-startup;tenant:on-startup]
-├── run "bank workload" hookId="mixedversion.go:892" (12) [stage=system:background;tenant:background]
+│   └── run "initialize bank workload" hookId="mixedversion.go:900", after 100ms delay (11) [stage=system:on-startup;tenant:on-startup]
+├── run "bank workload" hookId="mixedversion.go:908" (12) [stage=system:background;tenant:background]
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── upgrade storage cluster
 │   │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (13) [stage=system:init;tenant:upgrading-system]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/shared_process
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/shared_process
@@ -53,8 +53,8 @@ Plan:
 ├── delete all-tenants override for the `version` key (16) [stage=system:tenant-setup;tenant:tenant-setup]
 ├── run startup hooks concurrently
 │   ├── run "create tables" hookId="planner_test.go:141", after 30s delay (17) [stage=system:on-startup;tenant:on-startup]
-│   └── run "initialize bank workload" hookId="mixedversion.go:884", after 3m0s delay (18) [stage=system:on-startup;tenant:on-startup]
-├── run "bank workload" hookId="mixedversion.go:892" (19) [stage=system:background;tenant:background]
+│   └── run "initialize bank workload" hookId="mixedversion.go:900", after 3m0s delay (18) [stage=system:on-startup;tenant:on-startup]
+├── run "bank workload" hookId="mixedversion.go:908" (19) [stage=system:background;tenant:background]
 ├── upgrade cluster from "v23.1.12" to "v23.2.0"
 │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (20) [stage=system:init;tenant:init]
 │   ├── prevent auto-upgrades on mixed-version-tenant-cyvju tenant by setting `preserve_downgrade_option` (21) [stage=system:init;tenant:init]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
@@ -35,10 +35,10 @@ Plan:
 ├── install fixtures for version "v22.2.3" (1) [stage=system-setup]
 ├── start cluster at version "v22.2.3" (2) [stage=system-setup]
 ├── wait for all nodes (:1-4) to acknowledge cluster version '22.2' on system tenant (3) [stage=system-setup]
-├── run "initialize bank workload" hookId="mixedversion.go:884" (4) [stage=on-startup]
+├── run "initialize bank workload" hookId="mixedversion.go:900" (4) [stage=on-startup]
 ├── start background hooks concurrently
-│   ├── run "bank workload" hookId="mixedversion.go:892", after 0s delay (5) [stage=background]
-│   └── run "csv server" hookId="mixedversion.go:861", after 0s delay (6) [stage=background]
+│   ├── run "bank workload" hookId="mixedversion.go:908", after 0s delay (5) [stage=background]
+│   └── run "csv server" hookId="mixedversion.go:877", after 0s delay (6) [stage=background]
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (7) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -72,8 +72,10 @@ func registerAcceptance(r registry.Registry) {
 		},
 		registry.OwnerTestEng: {
 			{
-				name:          "version-upgrade",
-				fn:            runVersionUpgrade,
+				name: "version-upgrade",
+				fn: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runVersionUpgrade(ctx, t, c, versionUpgradeChaosOpts{})
+				},
 				timeout:       2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
 				defaultLeases: true,
 				monitor:       true,

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -179,5 +179,6 @@ func RegisterTests(r registry.Registry) {
 	registerDBConsoleEndpoints(r)
 	registerDBConsoleEndpointsMixedVersion(r)
 	registerTTLRestart(r)
+	registerVersionUpgradeChaos(r)
 	perturbation.RegisterTests(r)
 }

--- a/pkg/roachprod/failureinjection/failures/network_partition.go
+++ b/pkg/roachprod/failureinjection/failures/network_partition.go
@@ -51,6 +51,19 @@ type NetworkPartition struct {
 	// Type describes the network partition being created.
 	Type PartitionType
 }
+
+func (p NetworkPartition) String() string {
+	switch p.Type {
+	case Bidirectional:
+		return fmt.Sprintf("n%d <--> n%v", p.Source, p.Destination)
+	case Incoming:
+		return fmt.Sprintf("n%d <-- n%v", p.Source, p.Destination)
+	case Outgoing:
+		return fmt.Sprintf("n%d --> n%v", p.Source, p.Destination)
+	}
+	panic("unknown PartitionType")
+}
+
 type NetworkPartitionArgs struct {
 	// List of network partitions to create.
 	//


### PR DESCRIPTION
We previously disabled network partition mutators in mixed version tests (#154548) due to flakiness. Here, we reenable them in select opt in tests (`version-upgrade/chaos`) with two new strategies for partition selection:

1. **Single Partition**: At most, we only allow one node to node partition from happening. This should ensure the leader/leasholder is never partitioned from all replicas and we maintain liveness.
2. **Protected Node Partition**: We pick a quorum of nodes to be marked as "protected". These nodes will be pinned such that they will always have voter replicas on them. We will never create partitions between any two protected nodes, but can create as many other partitions as we want. Since we always have a quorum of replicas that can communicate for every range, we should maintain liveness.

We also refactor the step insertion logic to use rejection sampling. The previous approach favored mutations that spanned (steps in between the inject and recover) 0 steps. With rejection sampling, we can more easily enforce that we are running at least one step under the partition.

In the future, we should re-assess the stability of these two strategies, and enable one/both by default for all mixed version tests.

Informs: https://github.com/cockroachdb/cockroach/issues/154547
Epic: none
Release note: none
