### PR TITLE
kvserver: remove whitespace in flow_control_integration_test.go

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1570,7 +1570,7 @@ func TestFlowControlLeaderNotLeaseholderV2(t *testing.T) {
 		h.query(n1, v2FlowTokensQueryStr)
 
 		h.comment(`
--- (Issuing another 1x1MiB, 3x replicated write that's admitted via 
+-- (Issuing another 1x1MiB, 3x replicated write that's admitted via
 -- the work queue on the leaseholder. It shouldn't deduct any tokens.)
 `)
 		h.put(ctx, k, 1, testFlowModeToPri(mode))
@@ -1858,7 +1858,7 @@ func TestFlowControlSendQueue(t *testing.T) {
 --   Block admission [n2,n3,n4,n5].
 --   Regular write -4 MiB.
 --   Regular write -1  MiB.
---   - Blocks on wait-for-eval, however the test bypasses this instance.    
+--   - Blocks on wait-for-eval, however the test bypasses this instance.
 --   - Metrics should reflect 2 streams being prevented from forming a send queue.
 --   Allow admission [n1,n2,n3,n4,n5] (all).
 --   Assert all tokens returned.
@@ -1932,11 +1932,11 @@ func TestFlowControlSendQueue(t *testing.T) {
 -- Send queue metrics from n1, n3's send queue should have been force-flushed.`)
 	h.query(n1, flowSendQueueQueryStr)
 	h.comment(`
--- Observe the total tracked tokens per-stream on n1, n3's flushed entries 
+-- Observe the total tracked tokens per-stream on n1, n3's flushed entries
 -- will also be tracked here.`)
 	h.query(n1, v2FlowPerStreamTrackedQueryStr, flowPerStreamTrackedQueryHeaderStrs...)
 	h.comment(`
--- Per-store tokens available from n1, these should reflect the deducted 
+-- Per-store tokens available from n1, these should reflect the deducted
 -- tokens from force-flushing n3.`)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
 
@@ -2025,7 +2025,7 @@ func TestFlowControlSendQueue(t *testing.T) {
 	setTokenReturnEnabled(true /* enabled */, 0, 1, 2, 3, 4)
 	h.waitForAllTokensReturned(ctx, 5, 0 /* serverIdx */)
 	h.comment(`
--- Per-store tokens available from n1. Expect these to return to the same as 
+-- Per-store tokens available from n1. Expect these to return to the same as
 -- the initial state.
 `)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
@@ -2060,7 +2060,7 @@ func TestFlowControlSendQueue(t *testing.T) {
 	h.comment(`
 -- Observe the total tracked tokens per-stream on n1. We should expect to see the
 -- 1 MiB write being tracked across a quorum of streams, while the 4 MiB write
--- is tracked across each stream (except s1). Two(/4 non-leader) replica send 
+-- is tracked across each stream (except s1). Two(/4 non-leader) replica send
 -- streams should be prevented from forming a send queue and have higher tracked
 -- tokens than the other two.
 `)
@@ -2246,7 +2246,7 @@ func TestFlowControlSendQueueManyInflight(t *testing.T) {
 -- queue prevented from forming. Lastly, we will unblock admission and stress
 -- the raft in-flights tracker as the queue is drained.`)
 	h.comment(`
--- Initial per-store tokens available from n1. 
+-- Initial per-store tokens available from n1.
 `)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
 	h.comment(`-- (Blocking below-raft admission on [n1,n2,n3].)`)
@@ -2460,7 +2460,7 @@ func TestFlowControlSendQueueRangeRelocate(t *testing.T) {
 -- be tracked here.`)
 			h.query(n1, v2FlowPerStreamTrackedQueryStr, flowPerStreamTrackedQueryHeaderStrs...)
 			h.comment(`
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.`)
 			h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
 
@@ -2748,7 +2748,7 @@ func TestFlowControlRangeSplitMergeMixedVersion(t *testing.T) {
 	h.waitForSendQueueSize(ctx, merged.RangeID, 0 /* expSize 0 MiB */, 0 /* serverIdx */)
 
 	h.comment(`
--- Send queue and flow token metrics from n1, post-split-merge. 
+-- Send queue and flow token metrics from n1, post-split-merge.
 -- We do not expect to see the send queue develop for s3.`)
 	h.query(n1, flowSendQueueQueryStr)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
@@ -2961,7 +2961,7 @@ func TestFlowControlSendQueueRangeMigrate(t *testing.T) {
 -- be tracked here.`)
 	h.query(n1, v2FlowPerStreamTrackedQueryStr, flowPerStreamTrackedQueryHeaderStrs...)
 	h.comment(`
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.`)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
 
@@ -3146,7 +3146,7 @@ func TestFlowControlSendQueueRangeSplitMerge(t *testing.T) {
 -- be tracked here.`)
 	h.query(n1, v2FlowPerStreamTrackedQueryStr, flowPerStreamTrackedQueryHeaderStrs...)
 	h.comment(`
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.`)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
 
@@ -3417,7 +3417,7 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 -- n3, using 4x1 MiB (deduction, the write itself is small) writes. Then,
 -- we will write 1 MiB to the range and wait for the closedTS to fall
 -- behind on n3. We expect that the closedTS falling behind will trigger
--- an error that is returned to the mux rangefeed client, which will in turn 
+-- an error that is returned to the mux rangefeed client, which will in turn
 -- allows the rangefeed  request to be re-routed to another replica.`)
 	// Block admission on n3, while allowing every other node to admit.
 	setTokenReturnEnabled(true /* enabled */, 0, 1)
@@ -3451,7 +3451,7 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 -- be tracked here.`)
 	h.query(n1, v2FlowPerStreamTrackedQueryStr, flowPerStreamTrackedQueryHeaderStrs...)
 	h.comment(`
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.`)
 	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
 
@@ -3820,12 +3820,12 @@ var flowPerStoreDeductionQueryHeaderStrs = []string{
 // v2FlowTokensQueryStr is the query string to fetch flow tokens metrics from
 // the node metrics table.
 const v2FlowTokensQueryStr = `
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -3834,12 +3834,12 @@ ORDER BY
 // flowSendQueueQueryStr is the query string to fetch flow control send queue
 // metrics from the node metrics table.
 const flowSendQueueQueryStr = `
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/admission_post_split_merge_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/admission_post_split_merge_v2_encoding_apply_to_all
@@ -11,12 +11,12 @@ echo
 -- that are yet to get admitted. We see 2*3*1MiB=6MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns. The 2*1MiB writes
 -- happened on what is soon going to be the LHS and RHS of a range being split.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -65,12 +65,12 @@ ORDER BY
 -- post-split LHS and RHS ranges respectively. We should see 15MiB extra tokens
 -- deducted which comes from (2MiB+3MiB)*3=15MiB. So we stand at
 -- 6MiB+15MiB=21MiB now.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -131,12 +131,12 @@ ORDER BY
 -- from 4MiB*3=12MiB. So we stand at 21MiB+12MiB=33MiB tokens deducted now. The
 -- RHS of the range is gone now, and the previously 3*3MiB=9MiB of tokens
 -- deducted for it are released at the subsuming LHS leaseholder.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -189,12 +189,12 @@ ORDER BY
 -- {regular,elastic} tokens returned, including those from:
 -- - the LHS before the merge, and
 -- - the LHS and RHS before the original split.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/admission_post_split_merge_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/admission_post_split_merge_v2_encoding_apply_to_elastic
@@ -11,12 +11,12 @@ echo
 -- that are yet to get admitted. We see 2*3*1MiB=6MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns. The 2*1MiB writes
 -- happened on what is soon going to be the LHS and RHS of a range being split.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -65,12 +65,12 @@ ORDER BY
 -- post-split LHS and RHS ranges respectively. We should see 15MiB extra tokens
 -- deducted which comes from (2MiB+3MiB)*3=15MiB. So we stand at
 -- 6MiB+15MiB=21MiB now.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -131,12 +131,12 @@ ORDER BY
 -- from 4MiB*3=12MiB. So we stand at 21MiB+12MiB=33MiB tokens deducted now. The
 -- RHS of the range is gone now, and the previously 3*3MiB=9MiB of tokens
 -- deducted for it are released at the subsuming LHS leaseholder.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -189,12 +189,12 @@ ORDER BY
 -- {regular,elastic} tokens returned, including those from:
 -- - the LHS before the merge, and
 -- - the LHS and RHS before the original split.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/basic_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/basic_v2_encoding_apply_to_all
@@ -2,12 +2,12 @@ echo
 ----
 ----
 -- Flow token metrics, before issuing the 1MiB replicated write.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -78,12 +78,12 @@ ORDER BY
 -- and it being admitted on n1, n2 and n3. We should see 3*1MiB = 3MiB of
 -- {regular,elastic} tokens deducted and returned, and {8*3=24MiB,16*3=48MiB} of
 -- {regular,elastic} tokens available. Everything should be accounted for.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/basic_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/basic_v2_encoding_apply_to_elastic
@@ -2,12 +2,12 @@ echo
 ----
 ----
 -- Flow token metrics, before issuing the 1MiB replicated write.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -78,12 +78,12 @@ ORDER BY
 -- and it being admitted on n1, n2 and n3. We should see 3*1MiB = 3MiB of
 -- {regular,elastic} tokens deducted and returned, and {8*3=24MiB,16*3=48MiB} of
 -- {regular,elastic} tokens available. Everything should be accounted for.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/blocked_admission_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/blocked_admission_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
 -- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -95,12 +95,12 @@ ORDER BY
 -- Flow token metrics from n1 after work gets admitted. We see 15MiB returns of
 -- {regular,elastic} tokens, and the available capacities going back to what
 -- they were.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/blocked_admission_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/blocked_admission_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
 -- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -95,12 +95,12 @@ ORDER BY
 -- Flow token metrics from n1 after work gets admitted. We see 15MiB returns of
 -- {regular,elastic} tokens, and the available capacities going back to what
 -- they were.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/class_prioritization_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/class_prioritization_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB elastic 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of elastic tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -48,12 +48,12 @@ ORDER BY
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of {regular,elastic}
 -- tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -88,12 +88,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after work gets admitted. All {regular,elastic}
 -- tokens deducted are returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/class_prioritization_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/class_prioritization_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB elastic 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of elastic tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -48,12 +48,12 @@ ORDER BY
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of {regular,elastic}
 -- tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -88,12 +88,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after work gets admitted. All {regular,elastic}
 -- tokens deducted are returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
 -- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -81,12 +81,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
 -- 5MiB previously held by n2.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
 -- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -81,12 +81,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
 -- 5MiB previously held by n2.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/granter_admit_one_by_one_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/granter_admit_one_by_one_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1024KiB, i.e. 1MiB 3x replicated writes
 -- that are yet to get admitted. We see 3*1MiB=3MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -65,12 +65,12 @@ ORDER BY
 -- Flow token metrics from n1 after work gets admitted. We see 3MiB returns of
 -- {regular,elastic} tokens, and the available capacities going back to what
 -- they were. In #105185, by now we would've observed panics.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/granter_admit_one_by_one_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/granter_admit_one_by_one_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1024KiB, i.e. 1MiB 3x replicated writes
 -- that are yet to get admitted. We see 3*1MiB=3MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -65,12 +65,12 @@ ORDER BY
 -- Flow token metrics from n1 after work gets admitted. We see 3MiB returns of
 -- {regular,elastic} tokens, and the available capacities going back to what
 -- they were. In #105185, by now we would've observed panics.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/leader_not_leaseholder_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/leader_not_leaseholder_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -47,12 +47,12 @@ ORDER BY
 
 -- Flow token metrics from n1 having lost the lease but retained raft
 -- leadership. No deducted tokens are released.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -83,12 +83,12 @@ ORDER BY
 
 
 -- (Allow below-raft admission to proceed. All tokens should be returned.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -118,18 +118,18 @@ ORDER BY
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
 
 
--- (Issuing another 1x1MiB, 3x replicated write that's admitted via 
+-- (Issuing another 1x1MiB, 3x replicated write that's admitted via
 -- the work queue on the leaseholder. It shouldn't deduct any tokens.)
 
 
 -- Looking at n1's flow token metrics, there's no change. No additional tokens
 -- are deducted since the write is not being proposed here.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -161,12 +161,12 @@ ORDER BY
 
 -- Looking at n2's flow token metrics, there's no activity. n2 never acquired
 -- the raft leadership.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/leader_not_leaseholder_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/leader_not_leaseholder_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -47,12 +47,12 @@ ORDER BY
 
 -- Flow token metrics from n1 having lost the lease but retained raft
 -- leadership. No deducted tokens are released.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -83,12 +83,12 @@ ORDER BY
 
 
 -- (Allow below-raft admission to proceed. All tokens should be returned.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -118,18 +118,18 @@ ORDER BY
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
 
 
--- (Issuing another 1x1MiB, 3x replicated write that's admitted via 
+-- (Issuing another 1x1MiB, 3x replicated write that's admitted via
 -- the work queue on the leaseholder. It shouldn't deduct any tokens.)
 
 
 -- Looking at n1's flow token metrics, there's no change. No additional tokens
 -- are deducted since the write is not being proposed here.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -161,12 +161,12 @@ ORDER BY
 
 -- Looking at n2's flow token metrics, there's no activity. n2 never acquired
 -- the raft leadership.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_remove_self_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_remove_self_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -48,12 +48,12 @@ ORDER BY
 -- Flow token metrics from n1 after raft leader removed itself from raft group.
 -- All {regular,elastic} tokens deducted are returned. Note that the available
 -- tokens increases, as n1 has seen 4 replication streams, s1,s2,s3,s4.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -122,12 +122,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after work gets admitted. Tokens were already
 -- returned earlier, so there's no change.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_remove_self_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_remove_self_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -48,12 +48,12 @@ ORDER BY
 -- Flow token metrics from n1 after raft leader removed itself from raft group.
 -- All {regular,elastic} tokens deducted are returned. Note that the available
 -- tokens increases, as n1 has seen 4 replication streams, s1,s2,s3,s4.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -122,12 +122,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after work gets admitted. Tokens were already
 -- returned earlier, so there's no change.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -141,12 +141,12 @@ ORDER BY
 -- Flow token metrics from n1 after work gets admitted. All {regular,elastic}
 -- tokens deducted are returned, including from when s3 was removed as a raft
 -- member.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_membership_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -141,12 +141,12 @@ ORDER BY
 -- Flow token metrics from n1 after work gets admitted. All {regular,elastic}
 -- tokens deducted are returned, including from when s3 was removed as a raft
 -- member.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_all
@@ -4,12 +4,12 @@ echo
 -- Flow token metrics from n1 after issuing 1 1MiB 5x replicated write
 -- that's not admitted. Since this test is ignoring crashed nodes for token
 -- deduction purposes, we see a deduction of 5MiB tokens.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -89,12 +89,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after issuing 1 1MiB 5x replicated write
 -- that's not admitted. We'll have deducted another 5*1MiB=5MiB worth of tokens.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -154,12 +154,12 @@ ORDER BY
 -- 2MiB previously held by those nodes (2MiB each). We're reacting to it's raft
 -- progress state, noting that since we've truncated our log, we need to catch
 -- it up via snapshot. So we release all held tokens.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -214,12 +214,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after work gets admitted. We see the remaining
 -- 6MiB of tokens returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_elastic
@@ -4,12 +4,12 @@ echo
 -- Flow token metrics from n1 after issuing 1 1MiB 5x replicated write
 -- that's not admitted. Since this test is ignoring crashed nodes for token
 -- deduction purposes, we see a deduction of 5MiB tokens.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -89,12 +89,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after issuing 1 1MiB 5x replicated write
 -- that's not admitted. We'll have deducted another 5*1MiB=5MiB worth of tokens.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -154,12 +154,12 @@ ORDER BY
 -- 2MiB previously held by those nodes (2MiB each). We're reacting to it's raft
 -- progress state, noting that since we've truncated our log, we need to catch
 -- it up via snapshot. So we release all held tokens.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -214,12 +214,12 @@ ORDER BY
 
 -- Flow token metrics from n1 after work gets admitted. We see the remaining
 -- 6MiB of tokens returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/range_split_merge_mixed_version
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/range_split_merge_mixed_version
@@ -43,12 +43,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1, post-split and 1 MiB put on
 -- each side.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -84,12 +84,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1, post-split-merge.
 -- We expect to not see a force flush of the send queue for s3 again.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -123,14 +123,14 @@ ORDER BY
 (Sent 1 MiB BulkNormalPri put request to post-split-merge range)
 
 
--- Send queue and flow token metrics from n1, post-split-merge. 
+-- Send queue and flow token metrics from n1, post-split-merge.
 -- We do not expect to see the send queue develop for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -178,12 +178,12 @@ post-merge response br=(err: <nil>), *kvpb.PutResponse pErr=<nil>
 
 
 -- Flow token metrics from n1, all tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue
@@ -28,18 +28,18 @@ echo
 --   Block admission [n2,n3,n4,n5].
 --   Regular write -4 MiB.
 --   Regular write -1  MiB.
---   - Blocks on wait-for-eval, however the test bypasses this instance.    
+--   - Blocks on wait-for-eval, however the test bypasses this instance.
 --   - Metrics should reflect 2 streams being prevented from forming a send queue.
 --   Allow admission [n1,n2,n3,n4,n5] (all).
 --   Assert all tokens returned.
 --
 -- Start by printing the relevant metrics on n1, first the flow token metrics.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -70,12 +70,12 @@ ORDER BY
 
 
 -- Send queue metrics from n1.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -196,12 +196,12 @@ ORDER BY
 
 -- The send queue metrics from n1 should reflect the 1 MiB write being queued
 -- for n3 and 1 MiB tracked for n2 that is yet to be admitted.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -239,12 +239,12 @@ ORDER BY
 
 
 -- Flow token metrics from n1, the disconnect should be reflected in the metrics.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -275,12 +275,12 @@ ORDER BY
 
 
 -- Send queue metrics from n1, n3's send queue should have been force-flushed.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -295,7 +295,7 @@ ORDER BY
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
 
 
--- Observe the total tracked tokens per-stream on n1, n3's flushed entries 
+-- Observe the total tracked tokens per-stream on n1, n3's flushed entries
 -- will also be tracked here.
 SELECT
   chr(96 + dense_rank() OVER (ORDER BY range_id)) as range_id,
@@ -312,7 +312,7 @@ ORDER BY
   a        | 3        | 5.0 MiB               
 
 
--- Per-store tokens available from n1, these should reflect the deducted 
+-- Per-store tokens available from n1, these should reflect the deducted
 -- tokens from force-flushing n3.
 SELECT
   store_id,
@@ -342,12 +342,12 @@ ORDER BY
 
 
 -- Send queue metrics from n1, n3's should not be allowed to form a send queue.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -384,12 +384,12 @@ ORDER BY
 
 
 -- Flow token metrics from n1.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -545,12 +545,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1. The 1 MiB write should be queued
 -- for n4,n5, while the quorum (n1,n2,n3) proceeds.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -587,7 +587,7 @@ ORDER BY
 -- [n1(enabled),n2(enabled),n3(enabled),n4(enabled),n5(enabled)]
 
 
--- Per-store tokens available from n1. Expect these to return to the same as 
+-- Per-store tokens available from n1. Expect these to return to the same as
 -- the initial state.
 SELECT
   store_id,
@@ -618,12 +618,12 @@ ORDER BY
 -- Send queue and flow token metrics from n1. The 4 MiB write should not be
 -- queued, but instead exhaust all available regular eval and send tokens across
 -- each stream, except s1 (as admission is not blocked).
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -667,7 +667,7 @@ ORDER BY
 
 -- Observe the total tracked tokens per-stream on n1. We should expect to see the
 -- 1 MiB write being tracked across a quorum of streams, while the 4 MiB write
--- is tracked across each stream (except s1). Two(/4 non-leader) replica send 
+-- is tracked across each stream (except s1). Two(/4 non-leader) replica send
 -- streams should be prevented from forming a send queue and have higher tracked
 -- tokens than the other two.
 SELECT
@@ -689,12 +689,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -731,12 +731,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_many_inflight
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_many_inflight
@@ -104,12 +104,12 @@ ORDER BY
 -- Send queue metrics from n1, a send queue should have formed for one of the
 -- replica send streams, while the other (non-leader stream) should have been
 -- prevented from forming. It should be 1024*4KiB=4MiB in size.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -147,12 +147,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_feed
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_feed
@@ -8,7 +8,7 @@ echo
 -- n3, using 4x1 MiB (deduction, the write itself is small) writes. Then,
 -- we will write 1 MiB to the range and wait for the closedTS to fall
 -- behind on n3. We expect that the closedTS falling behind will trigger
--- an error that is returned to the mux rangefeed client, which will in turn 
+-- an error that is returned to the mux rangefeed client, which will in turn
 -- allows the rangefeed  request to be re-routed to another replica.
 
 
@@ -31,12 +31,12 @@ SELECT
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -69,7 +69,7 @@ ORDER BY
   a        | 3        | 4.0 MiB               
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -107,12 +107,12 @@ SELECT
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_migrate
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_migrate
@@ -15,12 +15,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -53,7 +53,7 @@ ORDER BY
   a        | 3        | 4.0 MiB               
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -78,12 +78,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1 post-migrate. The migrate should
 -- have triggered a force flush of the send queue.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -122,12 +122,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1 post-migrate and post 1 MiB put.
 -- We expect to see the send queue develop for s3 again.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -162,12 +162,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_has_token_store
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_has_token_store
@@ -8,12 +8,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -48,7 +48,7 @@ ORDER BY
   a        | 5        | 0 B                   
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -105,12 +105,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -146,12 +146,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from leaseholder n1.
 -- All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_has_token_store_transfer_lease
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_has_token_store_transfer_lease
@@ -8,12 +8,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -48,7 +48,7 @@ ORDER BY
   a        | 5        | 0 B                   
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -119,12 +119,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -160,12 +160,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from leaseholder n6.
 -- All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_leader_store
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_leader_store
@@ -8,12 +8,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -48,7 +48,7 @@ ORDER BY
   a        | 5        | 0 B                   
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -119,12 +119,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -160,12 +160,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from leaseholder n6.
 -- All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_leader_store_transfer_lease
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_leader_store_transfer_lease
@@ -8,12 +8,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -48,7 +48,7 @@ ORDER BY
   a        | 5        | 0 B                   
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -119,12 +119,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -160,12 +160,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from leaseholder n6.
 -- All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_send_queue_store
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_send_queue_store
@@ -8,12 +8,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -48,7 +48,7 @@ ORDER BY
   a        | 5        | 0 B                   
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -105,12 +105,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -146,12 +146,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from leaseholder n1.
 -- All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_send_queue_store_transfer_lease
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_relocate_from_send_queue_store_transfer_lease
@@ -8,12 +8,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -48,7 +48,7 @@ ORDER BY
   a        | 5        | 0 B                   
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -119,12 +119,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1. All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -160,12 +160,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from leaseholder n6.
 -- All tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_split_merge
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_split_merge
@@ -21,12 +21,12 @@ echo
 
 
 -- Send queue metrics from n1, n3's send queue should have 1 MiB for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -59,7 +59,7 @@ ORDER BY
   a        | 3        | 4.0 MiB               
 
 
--- Per-store tokens available from n1, these should reflect the lack of tokens 
+-- Per-store tokens available from n1, these should reflect the lack of tokens
 -- for s3.
 SELECT
   store_id,
@@ -101,12 +101,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1, post-split.
 -- We expect to see a force flush of the send queue for s3.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -151,12 +151,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1, post-split and 1 MiB put on
 -- each side.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -192,12 +192,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1, post-split-merge.
 -- We expect to see a force flush of the send queue for s3 again.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -236,12 +236,12 @@ ORDER BY
 
 -- Send queue and flow token metrics from n1, post-split-merge and 1 MiB put.
 -- We expect to see the send queue develop for s3 again.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY
@@ -276,12 +276,12 @@ ORDER BY
 
 
 -- Send queue and flow token metrics from n1, all tokens should be returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%send_queue%'
   AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/split_merge_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/split_merge_v2_encoding_apply_to_all
@@ -10,12 +10,12 @@ echo
 -- Flow token metrics from n1 after issuing + admitting the 1MiB 3x
 -- replicated write to the pre-split range. There should be 3MiB of
 -- {regular,elastic} tokens {deducted,returned}.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -64,12 +64,12 @@ ORDER BY
 -- post-split LHS and RHS ranges respectively. We should see 15MiB extra tokens
 -- {deducted,returned}, which comes from (2MiB+3MiB)*3=15MiB. So we stand at
 -- 3MiB+15MiB=18MiB now.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -128,12 +128,12 @@ ORDER BY
 -- Flow token metrics from n1 after issuing 4MiB of replicated writes to
 -- the post-merged range. We should see 12MiB extra tokens {deducted,returned},
 -- which comes from 4MiB*3=12MiB. So we stand at 18MiB+12MiB=30MiB now.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/split_merge_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/split_merge_v2_encoding_apply_to_elastic
@@ -10,12 +10,12 @@ echo
 -- Flow token metrics from n1 after issuing + admitting the 1MiB 3x
 -- replicated write to the pre-split range. There should be 3MiB of
 -- {regular,elastic} tokens {deducted,returned}.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -64,12 +64,12 @@ ORDER BY
 -- post-split LHS and RHS ranges respectively. We should see 15MiB extra tokens
 -- {deducted,returned}, which comes from (2MiB+3MiB)*3=15MiB. So we stand at
 -- 3MiB+15MiB=18MiB now.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -128,12 +128,12 @@ ORDER BY
 -- Flow token metrics from n1 after issuing 4MiB of replicated writes to
 -- the post-merged range. We should see 12MiB extra tokens {deducted,returned},
 -- which comes from 4MiB*3=12MiB. So we stand at 18MiB+12MiB=30MiB now.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/transfer_lease_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/transfer_lease_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -47,12 +47,12 @@ ORDER BY
 
 -- Flow token metrics from n1 having lost the lease and raft leadership. All
 -- deducted tokens are returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/transfer_lease_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/transfer_lease_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -47,12 +47,12 @@ ORDER BY
 
 -- Flow token metrics from n1 having lost the lease and raft leadership. All
 -- deducted tokens are returned.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range_v2_encoding_apply_to_all
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB elastic 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of elastic tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -45,12 +45,12 @@ ORDER BY
 -- (Allow below-raft admission to proceed. We've disabled the piggybacked token
 -- return mechanism so no tokens are returned via this path. But the tokens will
 -- be returned anyway because the range is not quiesced and keeps pinging.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -81,12 +81,12 @@ ORDER BY
 
 
 -- (Issuing another 1x1MiB 3x elastic write.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -119,12 +119,12 @@ ORDER BY
 -- (Allow below-raft admission to proceed. We've enabled the piggybacked token
 -- return mechanism so tokens are returned either via this path, or the normal
 -- MsgAppResp flow, depending on which is exercised first.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range_v2_encoding_apply_to_elastic
@@ -7,12 +7,12 @@ echo
 -- Flow token metrics from n1 after issuing 1x1MiB elastic 3x replicated write
 -- that's not admitted. We see 1*1MiB*3=3MiB deductions of elastic tokens with
 -- no corresponding returns.
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -45,12 +45,12 @@ ORDER BY
 -- (Allow below-raft admission to proceed. We've disabled the piggybacked token
 -- return mechanism so no tokens are returned via this path. But the tokens will
 -- be returned anyway because the range is not quiesced and keeps pinging.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -81,12 +81,12 @@ ORDER BY
 
 
 -- (Issuing another 1x1MiB 3x elastic write.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;
@@ -119,12 +119,12 @@ ORDER BY
 -- (Allow below-raft admission to proceed. We've enabled the piggybacked token
 -- return mechanism so tokens are returned either via this path, or the normal
 -- MsgAppResp flow, depending on which is exercised first.)
-SELECT 
+SELECT
   name,
   crdb_internal.humanize_bytes(value::INT8)
-FROM 
+FROM
   crdb_internal.node_metrics
-WHERE 
+WHERE
   name LIKE '%kvflowcontrol%tokens%'
 ORDER BY
   name ASC;


### PR DESCRIPTION
This makes it easier to edit this test file if your editor removes trailing whitespace by default.

Epic: none
Release note: None