### PR TITLE
release-25.2: roachtest: deflake c2c/disconnect

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1809,9 +1809,11 @@ func registerClusterReplicationDisconnect(r registry.Registry) {
 		var dstNode int
 		srcTenantSQL.QueryRow(t, `select split_part(consumer, '[', 1) from crdb_internal.cluster_replication_node_streams order by random() limit 1`).Scan(&dstNode)
 
+		roachprodDstNode := dstNode + sp.srcNodes
+
 		disconnectDuration := sp.additionalDuration
 		rd.t.L().Printf("Disconnecting Src %d, Dest %d for %.2f minutes", srcNode,
-			dstNode, disconnectDuration.Minutes())
+			roachprodDstNode, disconnectDuration.Minutes())
 
 		// Normally, the blackholeFailer is accessed through the failer interface,
 		// at least in the failover tests. Because this test shouldn't use all the
@@ -1819,7 +1821,7 @@ func registerClusterReplicationDisconnect(r registry.Registry) {
 		// blakholeFailer struct directly. In other words, in this test, we
 		// shouldn't treat the blackholeFailer as an abstracted api.
 		blackholeFailer := &blackholeFailer{t: rd.t, c: rd.c, input: true, output: true}
-		blackholeFailer.FailPartial(ctx, srcNode, []int{dstNode})
+		blackholeFailer.FailPartial(ctx, srcNode, []int{roachprodDstNode})
 
 		time.Sleep(disconnectDuration)
 		// Calling this will log the latest topology.


### PR DESCRIPTION
Backport 1/1 commits from #154866 on behalf of @msbutler.

----

Previously, the c2c/disconnect roachtest was disconnecting two source nodes, instead of a pair of source/destination nodes.  This patch fixes this bug.

Informs: #152248
Informs: #150474

Release note: none

----

Release justification: