### PR TITLE
roachprod: prepare centralized - use centralized from roachprod lib

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -19,6 +19,10 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
+# Enable centralized API for roachprod to improve performance
+# when reading clusters info.
+export ROACHPROD_CENTRALIZED_API_ENABLED=true
+
 arm_probability="${ARM_PROBABILITY:-0.5}"
 fips_probability="${FIPS_PROBABILITY:-0.02}"
 

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1898,6 +1898,7 @@ GO_TARGETS = [
     "//pkg/roachprod/agents/parca:parca",
     "//pkg/roachprod/blobfixture:blobfixture",
     "//pkg/roachprod/blobfixture:blobfixture_test",
+    "//pkg/roachprod/centralizedapi:centralizedapi",
     "//pkg/roachprod/cloud/types:types",
     "//pkg/roachprod/cloud:cloud",
     "//pkg/roachprod/cloud:cloud_test",

--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -573,7 +573,12 @@ hosts file.
 									color.HiGreenString(""))
 							}
 						} else {
-							fmt.Fprintf(tw, "\t(-)")
+							fmt.Fprintf(tw, "\t%s\t%s\t%s\t%s\t%s\t",
+								color.HiGreenString(""),
+								color.HiGreenString(""),
+								color.HiWhiteString(""),
+								color.HiWhiteString(""),
+								color.HiGreenString(""))
 						}
 						fmt.Fprintf(tw, "\n")
 					}

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/roachprod/agents/fluentbit",
         "//pkg/roachprod/agents/opentelemetry",
         "//pkg/roachprod/agents/parca",
+        "//pkg/roachprod/centralizedapi",
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/cloud/types",
         "//pkg/roachprod/config",

--- a/pkg/roachprod/centralizedapi/BUILD.bazel
+++ b/pkg/roachprod/centralizedapi/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "centralizedapi",
+    srcs = ["centralizedapi.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/centralizedapi",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/cmd/roachprod-centralized/client"],
+)

--- a/pkg/roachprod/centralizedapi/centralizedapi.go
+++ b/pkg/roachprod/centralizedapi/centralizedapi.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package centralizedapi
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-centralized/client"
+)
+
+var (
+	once           sync.Once
+	centralizedapi *client.Client
+)
+
+// GetCentralizedAPIClient returns a singleton instance of the centralized API client.
+func GetCentralizedAPIClient() *client.Client {
+	once.Do(func() {
+		client, err := client.NewClientWithConfig(client.LoadConfigFromEnv())
+		if err != nil {
+			panic(err)
+		}
+		centralizedapi = client
+	})
+	return centralizedapi
+}

--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cloud/amazon",
+        "//pkg/cmd/roachprod-centralized/client",
+        "//pkg/roachprod/centralizedapi",
         "//pkg/roachprod/cloud/types",
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"time"
 
+	roachprodcentralized "github.com/cockroachdb/cockroach/pkg/cmd/roachprod-centralized/client"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/centralizedapi"
 	cloudcluster "github.com/cockroachdb/cockroach/pkg/roachprod/cloud/types"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
@@ -143,6 +145,22 @@ func (c *Cloud) ListCloud(ctx context.Context, l *logger.Logger, options vm.List
 	c.BadInstances = vm.List{}
 
 	providers := append(c.centralizedProviders, c.localProviders...)
+
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		// Use the centralized roachprod service to list clusters.
+		response, err := apiClient.ListClusters(context.Background(), l, roachprodcentralized.ListClustersOptions{})
+		if err != nil {
+			l.Errorf("Error listing clusters using the centralized API: %s", err)
+		} else {
+			c.Clusters = response.Clusters
+			c.BadInstances = response.BadInstances
+
+			// Remote providers are already listed by the centralized service,
+			// so only use local providers in the local listing.
+			providers = c.localProviders
+		}
+	}
 
 	// List all VMs across all providers in parallel.
 	providerVMs := make(map[string]vm.List)
@@ -366,6 +384,17 @@ func CreateCluster(l *logger.Logger, opts []*ClusterCreateOpts) (*cloudcluster.C
 	// `roachprod.Start` expects nodes/vms to be in sorted order
 	sort.Sort(c.VMs)
 
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		// Use the centralized roachprod service to upsert the cluster registration
+		// in its final state.
+		// Upsert is used here because the cluster may already exist in the
+		// centralized service if the cluster was picked up during a background sync.
+		if err = apiClient.RegisterClusterUpsert(context.Background(), l, c); err != nil {
+			return nil, err
+		}
+	}
+
 	return c, nil
 }
 
@@ -406,6 +435,14 @@ func GrowCluster(l *logger.Logger, c *cloudcluster.Cluster, numNodes int) error 
 	// `roachprod.Start` expects nodes/vms to be in sorted order
 	sort.Sort(c.VMs)
 
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		// Use the centralized roachprod service to create the cluster.
+		if err := apiClient.RegisterClusterUpdate(context.Background(), l, c); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -437,6 +474,15 @@ func ShrinkCluster(l *logger.Logger, c *cloudcluster.Cluster, numNodes int) erro
 
 	// Update the list of VMs in the cluster.
 	c.VMs = c.VMs[:len(c.VMs)-numNodes]
+
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		// Use the centralized roachprod service to create the cluster.
+		if err := apiClient.RegisterClusterUpdate(context.Background(), l, c); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -455,7 +501,10 @@ func DestroyCluster(l *logger.Logger, c *cloudcluster.Cluster) error {
 		publicRecords = append(publicRecords, v.PublicDNS)
 	}
 	dnsErr := vm.FanOutDNS(c.VMs, func(p vm.DNSProvider, vms vm.List) error {
-		publicRecordsErr := p.DeletePublicRecordsByName(context.Background(), publicRecords...)
+		var publicRecordsErr error
+		if !centralizedapi.GetCentralizedAPIClient().IsEnabled() {
+			publicRecordsErr = p.DeletePublicRecordsByName(context.Background(), publicRecords...)
+		}
 		srvRecordsErr := p.DeleteSRVRecordsBySubdomain(context.Background(), c.Name)
 		return errors.CombineErrors(publicRecordsErr, srvRecordsErr)
 	})
@@ -472,6 +521,15 @@ func DestroyCluster(l *logger.Logger, c *cloudcluster.Cluster) error {
 		return p.Delete(l, vms)
 	})
 	stopSpinner()
+
+	if clusterErr == nil {
+		apiClient := centralizedapi.GetCentralizedAPIClient()
+		if apiClient.IsEnabled() {
+			if err := apiClient.RegisterClusterDelete(context.Background(), l, c.Name); err != nil {
+				l.Printf("WARNING: failed to delete cluster %s from centralized service: %s", c.Name, err)
+			}
+		}
+	}
 	return errors.CombineErrors(dnsErr, clusterErr)
 }
 
@@ -486,5 +544,13 @@ func ExtendCluster(l *logger.Logger, c *cloudcluster.Cluster, extension time.Dur
 		return err
 	}
 	c.Lifetime = newLifetime
+
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		// Use the centralized roachprod service to create the cluster.
+		if err := apiClient.RegisterClusterUpdate(context.Background(), l, c); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/agents/fluentbit"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/agents/opentelemetry"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/agents/parca"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/centralizedapi"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	cloudcluster "github.com/cockroachdb/cockroach/pkg/roachprod/cloud/types"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
@@ -305,52 +306,56 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 		vms = append(vms, c.VMs...)
 	}
 
-	// Figure out if we're going to overwrite the DNS entries. We don't want to
-	// overwrite if we don't have all the VMs of interest, so we only do it if we
-	// have a list of all VMs from both AWS and GCE (so if both providers have
-	// been used to get the VMs and for GCP also if we listed the VMs in the
-	// default project).
-	refreshDNS := true
-
-	if p := vm.Providers[gce.ProviderName]; !p.Active() {
-		refreshDNS = false
-	} else {
-		var defaultProjectFound bool
-		for _, prj := range p.(*gce.Provider).GetProjects() {
-			if prj == gce.DefaultProject() {
-				defaultProjectFound = true
-				break
-			}
-		}
-		if !defaultProjectFound {
+	// If centralized API is not enabled, DNS entries are maintained by the centralized
+	// service, so we don't do anything here.
+	if !centralizedapi.GetCentralizedAPIClient().IsEnabled() {
+		// Figure out if we're going to overwrite the DNS entries. We don't want to
+		// overwrite if we don't have all the VMs of interest, so we only do it if we
+		// have a list of all VMs from both AWS and GCE (so if both providers have
+		// been used to get the VMs and for GCP also if we listed the VMs in the
+		// default project).
+		refreshDNS := true
+		if p := vm.Providers[gce.ProviderName]; !p.Active() {
 			refreshDNS = false
-		}
-	}
-	// If there are no DNS required providers, we shouldn't refresh DNS,
-	// it's probably a misconfiguration.
-	if len(config.DNSRequiredProviders) == 0 {
-		refreshDNS = false
-	} else {
-		// If any of the required providers is not active, we shouldn't refresh DNS.
-		for _, p := range config.DNSRequiredProviders {
-			if !vm.Providers[p].Active() {
+		} else {
+			var defaultProjectFound bool
+			for _, prj := range p.(*gce.Provider).GetProjects() {
+				if prj == gce.DefaultProject() {
+					defaultProjectFound = true
+					break
+				}
+			}
+			if !defaultProjectFound {
 				refreshDNS = false
-				break
 			}
 		}
-	}
-	// DNS entries are maintained in the GCE DNS registry for all vms, from all
-	// clouds.
-	if refreshDNS {
-		if !config.Quiet {
-			l.Printf("Refreshing DNS entries...")
+		// If there are no DNS required providers, we shouldn't refresh DNS,
+		// it's probably a misconfiguration.
+		if len(config.DNSRequiredProviders) == 0 {
+			refreshDNS = false
+		} else {
+			// If any of the required providers is not active, we shouldn't refresh DNS.
+			for _, p := range config.DNSRequiredProviders {
+				if !vm.Providers[p].Active() {
+					refreshDNS = false
+					break
+				}
+			}
 		}
-		if err := gce.Infrastructure.SyncDNS(l, vms); err != nil {
-			l.Errorf("failed to update DNS: %v", err)
-		}
-	} else {
-		if !config.Quiet {
-			l.Printf("Not refreshing DNS entries. We did not have all the VMs.")
+
+		// DNS entries are maintained in the GCE DNS registry for all vms, from all
+		// clouds.
+		if refreshDNS {
+			if !config.Quiet {
+				l.Printf("Refreshing DNS entries...")
+			}
+			if err := gce.Infrastructure.SyncDNS(l, vms); err != nil {
+				l.Errorf("failed to update DNS: %v", err)
+			}
+		} else {
+			if !config.Quiet {
+				l.Printf("Not refreshing DNS entries. We did not have all the VMs.")
+			}
 		}
 	}
 
@@ -1710,6 +1715,14 @@ func AddLabels(l *logger.Logger, clusterName string, labels map[string]string) e
 		}
 	}
 
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		err = apiClient.RegisterClusterUpdate(context.Background(), l, &c.Cluster)
+		if err != nil {
+			l.Errorf("failed to update cluster in centralized api: %v", err)
+		}
+	}
+
 	return saveCluster(l, &c.Cluster)
 }
 
@@ -1732,6 +1745,15 @@ func RemoveLabels(l *logger.Logger, clusterName string, labels []string) error {
 			delete(m.Labels, label)
 		}
 	}
+
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		err = apiClient.RegisterClusterUpdate(context.Background(), l, &c.Cluster)
+		if err != nil {
+			l.Errorf("failed to update cluster in centralized api: %v", err)
+		}
+	}
+
 	return saveCluster(l, &c.Cluster)
 }
 
@@ -1839,8 +1861,10 @@ func Create(
 		return LoadClusters()
 	}
 
-	if err := CreatePublicDNS(ctx, l, clusterName); err != nil {
-		l.Printf("Failed to create DNS for cluster %s: %v", clusterName, err)
+	if !centralizedapi.GetCentralizedAPIClient().IsEnabled() {
+		if err := CreatePublicDNS(ctx, l, clusterName); err != nil {
+			l.Printf("Failed to create DNS for cluster %s: %v", clusterName, err)
+		}
 	}
 
 	l.Printf("Created cluster %s; setting up SSH...", clusterName)
@@ -2508,7 +2532,7 @@ func ApplySnapshots(
 		return err
 	}
 
-	return c.Parallel(ctx, l, install.WithNodes(c.Nodes),
+	if err := c.Parallel(ctx, l, install.WithNodes(c.Nodes),
 		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
 			res := &install.RunResultDetails{Node: node}
 
@@ -2575,7 +2599,19 @@ func ApplySnapshots(
 				res.Err = err
 			}
 			return res, nil
-		})
+		}); err != nil {
+		return err
+	}
+
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		err = apiClient.RegisterClusterUpdate(context.Background(), l, &c.Cluster)
+		if err != nil {
+			l.Errorf("failed to update cluster in centralized api: %v", err)
+		}
+	}
+
+	return nil
 }
 
 func genMountCommands(devicePath, mountDir string) string {
@@ -2820,9 +2856,15 @@ func DestroyDNS(ctx context.Context, l *logger.Logger, clusterName string) error
 	}
 
 	return vm.FanOutDNS(c.VMs, func(p vm.DNSProvider, vms vm.List) error {
+
+		var err error
+		if !centralizedapi.GetCentralizedAPIClient().IsEnabled() {
+			err = p.DeletePublicRecordsByName(ctx, publicRecords...)
+		}
+
 		return errors.CombineErrors(
 			p.DeleteSRVRecordsBySubdomain(ctx, c.Name),
-			p.DeletePublicRecordsByName(ctx, publicRecords...),
+			err,
 		)
 	})
 }
@@ -3028,6 +3070,15 @@ func createAttachMountVolumes(
 		}
 		l.Printf("Successfully mounted volume to %s", cVM.ProviderID)
 	}
+
+	apiClient := centralizedapi.GetCentralizedAPIClient()
+	if apiClient.IsEnabled() {
+		err := apiClient.RegisterClusterUpdate(context.Background(), l, &c.Cluster)
+		if err != nil {
+			l.Errorf("failed to update cluster in centralized api: %v", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
roachprod-centralized: use in list|create|destroy
    
This patch enables the use of the roachprod centralized service for listing clusters and registering create and destroy operations by setting the environment variable `ROACHPROD_API_ENABLED=true`.

The instance of roachprod-centralized can be configured via `ROACHPROD_API_BASE_URL`. It depends on the bearer auth implemented earlier.

A few options can be configured (retry attempts, retry delays, timeouts, ...), and all options can be found in the `roachprod-centralized` client config file at `cmd/roachprod-centralized/client/config.go`.

The patch also brings a significant performance improvement when listing services in the IBM provider by reducing the number of calls executed to load VM informations. This was triggering timeouts when listing clusters under heavy load during roachtest operations.

Epic: none
Release note: None