### PR TITLE
release-25.2: backup: skip TestBackupExportRequestTimeout under deadlock

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -7586,6 +7586,8 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDeadlock(t)
+
 	allowRequest := make(chan struct{})
 	defer close(allowRequest)
 


### PR DESCRIPTION
Backport 1/1 commits from #154980 on behalf of @msbutler.

----

Informs #154840

Release note: none

----

Release justification: