### PR TITLE
kvserver: disable buffered sender

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -90,7 +90,7 @@ var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
 	"kv.rangefeed.buffered_sender.enabled",
 	"use buffered sender for all range feeds instead of buffering events "+
 		"separately per client per range",
-	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", true),
+	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", false),
 )
 
 func init() {


### PR DESCRIPTION
We want to be sure of our queue limit story before enabling this by default.

Epic: none
Release note: None
Release justification: Disable in-development feature for release.