### PR TITLE
release-25.4: kvserver: add subsume.locks_written metric 

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -17614,6 +17614,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: subsume.locks_written
+      exported_name: subsume_locks_written
+      description: Number of locks written to storage during subsume (range merge)
+      y_axis_label: Locks Written
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sysbytes
       exported_name: sysbytes
       description: Number of bytes in system KV pairs

--- a/pkg/kv/kvserver/batcheval/result/metrics.go
+++ b/pkg/kv/kvserver/batcheval/result/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	AddSSTableAsWrites           int // AddSSTable requests with IngestAsWrites set
 	SplitsWithEstimatedStats     int // Splits that computed stats estimates
 	SplitEstimatedTotalBytesDiff int // Difference between pre- and post-split total bytes.
+	SubsumeLocksWritten          int // number of locks written during a subsume
 }
 
 // Add absorbs the supplied Metrics into the receiver.
@@ -34,4 +35,5 @@ func (mt *Metrics) Add(o Metrics) {
 	mt.AddSSTableAsWrites += o.AddSSTableAsWrites
 	mt.SplitsWithEstimatedStats += o.SplitsWithEstimatedStats
 	mt.SplitEstimatedTotalBytesDiff += o.SplitEstimatedTotalBytesDiff
+	mt.SubsumeLocksWritten += o.SubsumeLocksWritten
 }

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -159,7 +159,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 	// them everywhere.
 	{
 		act := fmt.Sprintf("%+v", result.Metrics{})
-		exp := "{LeaseRequestSuccess:0 LeaseRequestError:0 LeaseTransferSuccess:0 LeaseTransferError:0 LeaseTransferLocksWritten:0 ResolveCommit:0 ResolveAbort:0 ResolvePoison:0 AddSSTableAsWrites:0 SplitsWithEstimatedStats:0 SplitEstimatedTotalBytesDiff:0}"
+		exp := "{LeaseRequestSuccess:0 LeaseRequestError:0 LeaseTransferSuccess:0 LeaseTransferError:0 LeaseTransferLocksWritten:0 ResolveCommit:0 ResolveAbort:0 ResolvePoison:0 AddSSTableAsWrites:0 SplitsWithEstimatedStats:0 SplitEstimatedTotalBytesDiff:0 SubsumeLocksWritten:0}"
 		if act != exp {
 			t.Errorf("need to update this test due to added fields: %v", act)
 		}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -778,7 +778,7 @@ func TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Increase the verbosity of the test to help investigate failures.
-	require.NoError(t, log.SetVModule("replica_range_lease=3,raft=4,txn=3,txn_coord_sender=3"))
+	defer testutils.SetVModule(t, "replica_range_lease=3,raft=4,txn=3,txn_coord_sender=3")()
 	const numNodes = 2
 	var manuals []*hlc.HybridManualClock
 	var clocks []*hlc.Clock
@@ -2955,7 +2955,7 @@ func TestLossQuorumCauseLeaderlessWatcherToSignalUnavailable(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Increase the verbosity of the test to help investigate failures.
-	require.NoError(t, log.SetVModule("replica_range_lease=3,raft=4"))
+	defer testutils.SetVModule(t, "replica_range_lease=3,raft=4")()
 
 	ctx := context.Background()
 	stickyVFSRegistry := fs.NewStickyRegistry()
@@ -6072,7 +6072,7 @@ func TestLeaseTransferReplicatesLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("cmd_lease=2"))
+	defer testutils.SetVModule(t, "cmd_lease=2")()
 
 	// Test Setup:
 	//
@@ -6106,9 +6106,9 @@ func TestLeaseTransferReplicatesLocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start with the lease on store 1.
-	t.Logf("transfering to s1")
+	t.Logf("transferring to s1")
 	require.NoError(t, tc.TransferRangeLease(desc, tc.Target(0)))
-	t.Logf("done transfering to s1")
+	t.Logf("done transferring to s1")
 
 	// Txn 1:
 	// - Acquire lock and block until we are are sure txn2 has returned.
@@ -6165,7 +6165,7 @@ func TestLeaseTransferReplicatesLocks(t *testing.T) {
 	// on tx1 to start).
 	<-txn2Started
 
-	t.Log("transfering lease from s1 -> s2")
+	t.Log("transferring lease from s1 -> s2")
 	require.NoError(t, tc.TransferRangeLease(desc, tc.Target(1)))
 	time.Sleep(250 * time.Millisecond)
 	t.Log("cancelling txn2")
@@ -6177,7 +6177,7 @@ func TestLeaseTransferDropsLocksIfLargerThanCommandSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("cmd_lease=2"))
+	defer testutils.SetVModule(t, "cmd_lease=2")()
 
 	// Test Plan:
 	//
@@ -6228,7 +6228,7 @@ func TestMergeDropsLocksIfLargerThanMax(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, log.SetVModule("cmd_subsume=2"))
+	defer testutils.SetVModule(t, "cmd_subsume=2")()
 
 	// Test Plan:
 	//

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -295,6 +295,13 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
+	metaSubsumeLocksWrittenCount = metric.Metadata{
+		Name:        "subsume.locks_written",
+		Help:        "Number of locks written to storage during subsume (range merge)",
+		Measurement: "Locks Written",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	metaReqCPUNanos = metric.Metadata{
 		Name:        "replicas.cpunanospersecond",
 		Help:        "Nanoseconds of CPU time in Replica request processing including evaluation but not replication",
@@ -3363,6 +3370,8 @@ type StoreMetrics struct {
 	SplitsWithEstimatedStats     *metric.Counter
 	SplitEstimatedTotalBytesDiff *metric.Counter
 
+	SubsumeLocksWritten *metric.Counter
+
 	FlushUtilization *metric.GaugeFloat64
 	FsyncLatency     *metric.ManualWindowHistogram
 
@@ -3717,6 +3726,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ResolveCommitCount: metric.NewCounter(metaResolveCommit),
 		ResolveAbortCount:  metric.NewCounter(metaResolveAbort),
 		ResolvePoisonCount: metric.NewCounter(metaResolvePoison),
+
+		// Subsume metrics
+		SubsumeLocksWritten: metric.NewCounter(metaSubsumeLocksWrittenCount),
 
 		Capacity:  metric.NewGauge(metaCapacity),
 		Available: metric.NewGauge(metaAvailable),
@@ -4515,6 +4527,9 @@ func (sm *StoreMetrics) handleMetricsResult(ctx context.Context, metric result.M
 
 	sm.SplitEstimatedTotalBytesDiff.Inc(int64(metric.SplitEstimatedTotalBytesDiff))
 	metric.SplitEstimatedTotalBytesDiff = 0
+
+	sm.SubsumeLocksWritten.Inc(int64(metric.SubsumeLocksWritten))
+	metric.SubsumeLocksWritten = 0
 
 	if metric != (result.Metrics{}) {
 		log.KvExec.Fatalf(ctx, "unhandled fields in metrics result: %+v", metric)

--- a/pkg/testutils/trace.go
+++ b/pkg/testutils/trace.go
@@ -7,7 +7,9 @@ package testutils
 
 import (
 	"regexp"
+	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -35,4 +37,22 @@ func MatchInOrder(s string, res ...string) error {
 		sPos += loc[1]
 	}
 	return nil
+}
+
+// SetVModule sets the logging vmodule. The returned func should be deferred by
+// the caller to reset the vmodule at the end of the test
+//
+//	defer testutils.SetVModules(t, "some_file=3")()
+//
+// Not safe for concurrent use.
+func SetVModule(t testing.TB, vmodule string) func() {
+	prevVModule := log.GetVModule()
+	if err := log.SetVModule(vmodule); err != nil {
+		t.Fatalf("failed to set vmodule: %s", err.Error())
+	}
+	return func() {
+		if err := log.SetVModule(prevVModule); err != nil {
+			t.Fatalf("failed to set vmodule: %s", err.Error())
+		}
+	}
 }


### PR DESCRIPTION
Backport 3/3 commits from #154722.

/cc @cockroachdb/release

---

The new subsume.locks_written metric tracks how many locks are moved
from the in-memory lock table to the replicated lock table during a
SubsumeRequest.

While here, I updated some log lines and added some assertions to
existing tests to make sure we were seeing non-zero values for both the
new metric and lease.transfer.locks_written.

Epic: none
Release note: None

Release justification: Additional observability for new feature.
