### PR TITLE
log/eventpb: remove unused proto imports

### DIFF
--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -9,8 +9,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "sql/catalog/descpb/structured.proto";
-import "util/log/eventpb/events.proto";
-import "util/log/eventpb/sql_audit_events.proto";
 import "util/log/logpb/event.proto";
 
 // Category: Telemetry events


### PR DESCRIPTION
There were left over in just merged 1ae7b24a72045978ce91ce0630a615542508e87a.

Epic: None
Release note: None