### PR TITLE
logictest: de-flake recently added geo test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -2137,6 +2137,11 @@ INSERT INTO t151995 (c0, c1) VALUES (
 statement ok
 ANALYZE t151995;
 
+# Clear the stat cache so that the new statistic is guaranteed to be used (which
+# are needed for the inverted join to be picked).
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
 statement error geos error: IllegalArgumentException: BufferOp::getResultGeometry distance must be a finite value
 SELECT *
   FROM t151995 AS t1


### PR DESCRIPTION
In recently merged change we added a test that assumes the inverted join is picked for a query. However, if we happen to not use the freshly collected table stats, we default to using a cross join. Fix this by clearing the stats cache before running the query.

Fixes: #155016.
Release note: None