### PR TITLE
sql/stats: handle range counts when skipping dropped enum hist buckets

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1987,3 +1987,132 @@ CREATE TABLE public.t (
   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 ) WITH (schema_locked = true);
+
+# Testcase for issue 154461: drop an enum value when the histogram contains
+# range counts.
+subtest 154461
+
+statement ok
+USE test
+
+statement ok
+CREATE TYPE e154461 AS ENUM ('e', 'f', 'g')
+
+statement ok
+CREATE TABLE t154461 (a e154461, INDEX (a)) WITH (sql_stats_histogram_buckets_count = 2)
+
+statement ok
+INSERT INTO t154461 VALUES ('e'), ('e'), ('f'), ('g'), ('g')
+
+statement ok
+CREATE STATISTICS s FROM t154461
+
+query T
+SELECT * FROM t154461 WHERE a != 'g' ORDER BY a
+----
+e
+e
+f
+
+let $hist_id_1
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t154461]
+WHERE statistics_name = 's' AND column_names = '{a}'
+
+query TIRI colnames,nosort
+SHOW HISTOGRAM $hist_id_1
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+'e'          0           0                    2
+'g'          1           1                    2
+
+query T
+SELECT jsonb_pretty(stat)
+FROM (
+  SELECT json_array_elements(statistics) - 'created_at' - 'id' - 'avg_size' AS stat
+  FROM [SHOW STATISTICS USING JSON FOR TABLE t154461]
+)
+WHERE stat->>'columns' = '["a"]'
+----
+{
+    "columns": [
+        "a"
+    ],
+    "distinct_count": 3,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 2,
+            "num_range": 0,
+            "upper_bound": "e"
+        },
+        {
+            "distinct_range": 1,
+            "num_eq": 2,
+            "num_range": 1,
+            "upper_bound": "g"
+        }
+    ],
+    "histo_col_type": "test.public.e154461",
+    "histo_version": 3,
+    "name": "s",
+    "null_count": 0,
+    "row_count": 5
+}
+
+# Now drop the enum value that is the first bucket in the 2-bucket histogram.
+
+statement ok
+DELETE FROM t154461 WHERE a = 'e'
+
+statement ok
+ALTER TYPE e154461 DROP VALUE 'e'
+
+query T
+SELECT * FROM t154461 WHERE a != 'g' ORDER BY a
+----
+f
+
+let $hist_id_1
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t154461]
+WHERE statistics_name = 's' AND column_names = '{a}'
+
+query TIRI colnames,nosort
+SHOW HISTOGRAM $hist_id_1
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+'f'          0           0                    1
+'g'          0           0                    2
+
+query T
+SELECT jsonb_pretty(stat)
+FROM (
+  SELECT json_array_elements(statistics) - 'created_at' - 'id' - 'avg_size' AS stat
+  FROM [SHOW STATISTICS USING JSON FOR TABLE t154461]
+)
+WHERE stat->>'columns' = '["a"]'
+----
+{
+    "columns": [
+        "a"
+    ],
+    "distinct_count": 2,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 1,
+            "num_range": 0,
+            "upper_bound": "f"
+        },
+        {
+            "distinct_range": 0,
+            "num_eq": 2,
+            "num_range": 0,
+            "upper_bound": "g"
+        }
+    ],
+    "histo_col_type": "test.public.e154461",
+    "histo_version": 3,
+    "name": "s",
+    "null_count": 0,
+    "row_count": 5
+}

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -300,7 +300,7 @@ type HistogramBucket struct {
 
 	// DistinctRange is the estimated number of distinct values between the upper
 	// bound of the previous bucket and UpperBound (both boundaries are
-	// exclusive).
+	// exclusive). The first bucket should always have DistinctRange=0.
 	DistinctRange float64
 
 	// UpperBound is the upper bound of the bucket.

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -398,21 +398,9 @@ WHERE stat->>'name' = '__forecast__'
     "histo_buckets": [
         {
             "distinct_range": 0,
-            "num_eq": 0,
-            "num_range": 0,
-            "upper_bound": "-1"
-        },
-        {
-            "distinct_range": 0,
             "num_eq": 1,
             "num_range": 0,
             "upper_bound": "0"
-        },
-        {
-            "distinct_range": 0,
-            "num_eq": 0,
-            "num_range": 0,
-            "upper_bound": "1"
         }
     ],
     "histo_col_type": "INT8",

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -377,12 +377,6 @@ WHERE stat->>'name' = '__forecast__';
         },
         {
             "distinct_range": 0,
-            "num_eq": 0,
-            "num_range": 0,
-            "upper_bound": "10"
-        },
-        {
-            "distinct_range": 0,
             "num_eq": 2,
             "num_range": 0,
             "upper_bound": "11"
@@ -410,12 +404,6 @@ WHERE stat->>'name' = '__forecast__';
             "num_eq": 1,
             "num_range": 0,
             "upper_bound": "15"
-        },
-        {
-            "distinct_range": 0,
-            "num_eq": 0,
-            "num_range": 0,
-            "upper_bound": "16"
         },
         {
             "distinct_range": 0,

--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -226,7 +226,7 @@ func statisticsMutator(
 			colType := tree.MustBeStaticallyKnownType(col.Type)
 			h := randHistogram(rng, colType)
 			statIdx := colNameToStatIdx[col.Name]
-			if err := allStats[statIdx].SetHistogram(&h); err != nil {
+			if err := allStats[statIdx].SetHistogram(context.Background(), &h); err != nil {
 				panic(err)
 			}
 		}

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -90,20 +90,17 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 			if err := typedesc.EnsureTypeIsHydrated(ctx, histogram.ColumnType, &resolver); err != nil {
 				return nil, err
 			}
-			var a tree.DatumAlloc
-			for _, b := range histogram.Buckets {
-				var upperBound string
-				datum, err := stats.DecodeUpperBound(histogram.Version, histogram.ColumnType, &a, b.UpperBound)
-				if err != nil {
-					upperBound = fmt.Sprintf("<error: %v>", err)
-				} else {
-					upperBound = datum.String()
-				}
+			decodedBuckets, _, err := histogram.DecodeBuckets(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, b := range decodedBuckets {
+				upperBound := b.UpperBound.String()
 				row := tree.Datums{
 					tree.NewDString(upperBound),
-					tree.NewDInt(tree.DInt(b.NumRange)),
+					tree.NewDInt(tree.DInt(int64(b.NumRange))),
 					tree.NewDFloat(tree.DFloat(b.DistinctRange)),
-					tree.NewDInt(tree.DInt(b.NumEq)),
+					tree.NewDInt(tree.DInt(int64(b.NumEq))),
 				}
 				if _, err := v.rows.AddRow(ctx, row); err != nil {
 					v.Close(ctx)

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -182,7 +182,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					}
 					obs := &stats.TableStatistic{TableStatisticProto: *stat}
 					if obs.HistogramData != nil && !obs.HistogramData.ColumnType.UserDefined() {
-						if err := stats.DecodeHistogramBuckets(obs); err != nil {
+						if err := stats.DecodeHistogramBuckets(ctx, obs); err != nil {
 							return nil, err
 						}
 					}

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -1265,6 +1265,7 @@ func TestUpperBoundsRoundTrip(t *testing.T) {
 	h.buckets = make([]cat.HistogramBucket, numBuckets)
 	for i := 0; i < numBuckets; i++ {
 		h.buckets[i].UpperBound = upperBounds[i]
+		h.buckets[i].NumEq = 1
 	}
 	hd, err := h.toHistogramData(context.Background(), typ, st)
 	if err != nil {
@@ -1274,7 +1275,7 @@ func TestUpperBoundsRoundTrip(t *testing.T) {
 	// original ones.
 	var stat TableStatistic
 	stat.HistogramData = &hd
-	if err = DecodeHistogramBuckets(&stat); err != nil {
+	if err = DecodeHistogramBuckets(context.Background(), &stat); err != nil {
 		t.Fatal(err)
 	}
 	evalCtx := eval.MakeTestingEvalContext(st)

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -8,6 +8,7 @@ package stats
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -55,7 +56,7 @@ type JSONHistoBucket struct {
 }
 
 // SetHistogram fills in the HistogramColumnType and HistogramBuckets fields.
-func (js *JSONStatistic) SetHistogram(h *HistogramData) error {
+func (js *JSONStatistic) SetHistogram(ctx context.Context, h *HistogramData) error {
 	typ := h.ColumnType
 	if typ == nil {
 		return fmt.Errorf("histogram type is unset")
@@ -66,26 +67,19 @@ func (js *JSONStatistic) SetHistogram(h *HistogramData) error {
 	js.HistogramColumnType = typ.SQLStringFullyQualified()
 	js.HistogramBuckets = make([]JSONHistoBucket, 0, len(h.Buckets))
 	js.HistogramVersion = h.Version
-	var a tree.DatumAlloc
-	for i := range h.Buckets {
-		b := &h.Buckets[i]
-		if b.UpperBound == nil {
-			return fmt.Errorf("histogram bucket upper bound is unset")
-		}
-		datum, err := DecodeUpperBound(h.Version, typ, &a, b.UpperBound)
-		if err != nil {
-			if h.ColumnType.Family() == types.EnumFamily && errors.Is(err, types.EnumValueNotFound) {
-				// Skip over buckets for enum values that were dropped.
-				continue
-			}
-			return err
-		}
 
+	decodedBuckets, distinctAdjustment, err := h.DecodeBuckets(ctx)
+	if err != nil {
+		return err
+	}
+	js.DistinctCount = uint64(math.Max(0, float64(js.DistinctCount)+distinctAdjustment))
+	for i := range decodedBuckets {
+		b := &decodedBuckets[i]
 		js.HistogramBuckets = append(js.HistogramBuckets, JSONHistoBucket{
-			NumEq:         b.NumEq,
-			NumRange:      b.NumRange,
+			NumEq:         int64(b.NumEq),
+			NumRange:      int64(b.NumRange),
 			DistinctRange: b.DistinctRange,
-			UpperBound:    tree.AsStringWithFlags(datum, tree.FmtExport|tree.FmtAlwaysQualifyUserDefinedTypeNames),
+			UpperBound:    tree.AsStringWithFlags(b.UpperBound, tree.FmtExport|tree.FmtAlwaysQualifyUserDefinedTypeNames),
 		})
 	}
 	return nil
@@ -123,7 +117,7 @@ func (js *JSONStatistic) DecodeAndSetHistogram(
 		}
 		h.ColumnType = typ
 	}
-	return js.SetHistogram(h)
+	return js.SetHistogram(ctx, h)
 }
 
 // GetHistogram converts the json histogram into HistogramData.

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -714,7 +715,7 @@ func (sc *TableStatisticsCache) parseStats(
 				}
 			}
 		}
-		if err = DecodeHistogramBuckets(res); err != nil {
+		if err = DecodeHistogramBuckets(ctx, res); err != nil {
 			return nil, nil, err
 		}
 		// Update the HistogramData proto to nil out Buckets field to allow for
@@ -726,8 +727,12 @@ func (sc *TableStatisticsCache) parseStats(
 
 // DecodeHistogramBuckets decodes encoded HistogramData in tabStat and writes
 // the resulting buckets into tabStat.Histogram.
-func DecodeHistogramBuckets(tabStat *TableStatistic) error {
-	h := tabStat.HistogramData
+func DecodeHistogramBuckets(ctx context.Context, tabStat *TableStatistic) error {
+	buckets, distinctAdjustment, err := tabStat.HistogramData.DecodeBuckets(ctx)
+	if err != nil {
+		return err
+	}
+	tabStat.DistinctCount = uint64(math.Max(0, float64(tabStat.DistinctCount)+distinctAdjustment))
 	if tabStat.NullCount > 0 {
 		// A bucket for NULL is not persisted, but we create a fake one to
 		// make histograms easier to work with. The length of res.Histogram
@@ -735,37 +740,166 @@ func DecodeHistogramBuckets(tabStat *TableStatistic) error {
 		// buckets.
 		// TODO(michae2): Combine this with setHistogramBuckets, especially if we
 		// need to change both after #6224 is fixed (NULLS LAST in index ordering).
-		tabStat.Histogram = make([]cat.HistogramBucket, 1, len(h.Buckets)+1)
+		tabStat.Histogram = make([]cat.HistogramBucket, 1, len(buckets)+1)
 		tabStat.Histogram[0] = cat.HistogramBucket{
 			NumEq:         float64(tabStat.NullCount),
 			NumRange:      0,
 			DistinctRange: 0,
 			UpperBound:    tree.DNull,
 		}
+		tabStat.Histogram = append(tabStat.Histogram, buckets...)
 	} else {
-		tabStat.Histogram = make([]cat.HistogramBucket, 0, len(h.Buckets))
+		tabStat.Histogram = buckets
+	}
+	return nil
+}
+
+// DecodeBuckets decodes encoded HistogramData buckets. It also handles skipping
+// buckets for any dropped enum values, in which case distinctAdjustment might
+// be non-zero.
+func (h *HistogramData) DecodeBuckets(
+	ctx context.Context,
+) (buckets []cat.HistogramBucket, distinctAdjustment float64, err error) {
+	if h.Buckets == nil {
+		return nil, 0, nil
 	}
 
-	// Decode the histogram data so that it's usable by the opt catalog.
+	buckets = make([]cat.HistogramBucket, 0, len(h.Buckets))
+
+	// Decode the upper bound of each bucket.
 	var a tree.DatumAlloc
+	var carriedNumRange, carriedDistinctRange float64
 	for i := range h.Buckets {
 		bucket := &h.Buckets[i]
+		numRange := float64(bucket.NumRange)
+		distinctRange := bucket.DistinctRange
+		// If we dropped all enum values counted by these range counts, zero them.
+		if h.ColumnType.Family() == types.EnumFamily && i > 0 {
+			if err := enumValueExistsBetweenEncodedUpperBounds(
+				h.Version, h.ColumnType, h.Buckets[i-1].UpperBound, bucket.UpperBound,
+			); err != nil {
+				distinctAdjustment -= distinctRange
+				numRange = 0
+				distinctRange = 0
+			}
+		}
 		datum, err := DecodeUpperBound(h.Version, h.ColumnType, &a, bucket.UpperBound)
 		if err != nil {
 			if h.ColumnType.Family() == types.EnumFamily && errors.Is(err, types.EnumValueNotFound) {
-				// Skip over buckets for enum values that were dropped.
+				// Skip over buckets for enum values that were dropped. Carry the range
+				// counts forward to the next bucket.
+				if bucket.NumEq > 0 {
+					distinctAdjustment -= 1
+				}
+				carriedNumRange += numRange
+				carriedDistinctRange += distinctRange
 				continue
 			}
-			return err
+			return nil, 0, err
 		}
-		tabStat.Histogram = append(tabStat.Histogram, cat.HistogramBucket{
+		buckets = append(buckets, cat.HistogramBucket{
 			NumEq:         float64(bucket.NumEq),
-			NumRange:      float64(bucket.NumRange),
-			DistinctRange: bucket.DistinctRange,
+			NumRange:      numRange + carriedNumRange,
+			DistinctRange: distinctRange + carriedDistinctRange,
 			UpperBound:    datum,
 		})
+		carriedNumRange = 0
+		carriedDistinctRange = 0
 	}
-	return nil
+
+	// If we skipped some buckets for enum values that were dropped, we might need
+	// to handle extra range counts at the beginning or end of the histogram
+	// (similar to histogram.addOuterBuckets).
+
+	// We don't use any session data for conversions or operations on upper
+	// bounds, so a nil *eval.Context works as our tree.CompareContext.
+	var compareCtx *eval.Context
+
+	// Start by adding a new final bucket for any range counts that were carried
+	// forward to the end of the histogram.
+	if carriedNumRange != 0 || carriedDistinctRange != 0 {
+		var finalVal tree.Datum
+		if len(buckets) > 0 {
+			finalVal = buckets[len(buckets)-1].UpperBound
+		} else {
+			// If we have no buckets, use a default value. (We'll only use this to get
+			// the maximum value below.)
+			collationEnv := &tree.CollationEnvironment{}
+			if defaultVal, err := tree.NewDefaultDatum(collationEnv, h.ColumnType); err == nil {
+				finalVal = defaultVal
+			}
+		}
+		// Try to append a new bucket with the maximum value.
+		if finalVal != nil {
+			if maxVal, ok := getMaxVal(ctx, finalVal, h.ColumnType, compareCtx); ok {
+				newFinalBucket := cat.HistogramBucket{
+					NumRange:      carriedNumRange,
+					DistinctRange: carriedDistinctRange,
+					UpperBound:    maxVal,
+				}
+				// If there are no other values between the maximum value and the final
+				// upper bound, steal the carried range count for NumEq of the new
+				// bucket.
+				if len(buckets) > 0 {
+					if prevVal, ok := maxVal.Prev(ctx, compareCtx); ok {
+						if cmp, err := prevVal.Compare(ctx, compareCtx, finalVal); err == nil && cmp == 0 {
+							newFinalBucket.NumEq = carriedNumRange
+							newFinalBucket.NumRange = 0
+							newFinalBucket.DistinctRange = 0
+						}
+					}
+				}
+				buckets = append(buckets, newFinalBucket)
+			} else if len(buckets) == 0 &&
+				len(h.ColumnType.TypeMeta.EnumData.LogicalRepresentations) == 1 {
+				// If there's only one enum value, it becomes the single value in the
+				// histogram.
+				buckets = []cat.HistogramBucket{{NumEq: carriedNumRange, UpperBound: finalVal}}
+			} else {
+				// If the final upper bound is already the maximum value, just drop the
+				// counts. They don't mean anything at this point.
+				distinctAdjustment -= carriedDistinctRange
+			}
+		}
+	}
+
+	// Now add a new first bucket for any extra range counts at the front of the
+	// histogram.
+	if len(buckets) > 0 {
+		firstBucket := &buckets[0]
+		firstVal := firstBucket.UpperBound
+		if firstBucket.NumRange != 0 || firstBucket.DistinctRange != 0 {
+			// Try to prepend a new bucket with the minimum value.
+			if minVal, ok := getMinVal(ctx, firstVal, h.ColumnType, compareCtx); ok {
+				newFirstBucket := cat.HistogramBucket{
+					UpperBound: minVal,
+				}
+				// If there are no other values between the minimum value and the first
+				// upper bound, steal the range counts from the first bucket for NumEq
+				// of the new bucket.
+				if nextVal, ok := minVal.Next(ctx, compareCtx); ok {
+					if cmp, err := nextVal.Compare(ctx, compareCtx, firstVal); err == nil && cmp == 0 {
+						newFirstBucket.NumEq = firstBucket.NumRange
+						firstBucket.NumRange = 0
+						firstBucket.DistinctRange = 0
+					}
+				}
+				buckets = append([]cat.HistogramBucket{newFirstBucket}, buckets...)
+			} else {
+				// If the first upper bound is already the minimum value, just drop the
+				// counts. They don't mean anything at this point.
+				distinctAdjustment -= firstBucket.DistinctRange
+				firstBucket.NumRange = 0
+				firstBucket.DistinctRange = 0
+			}
+		}
+	}
+
+	// Remove any extra zero buckets.
+	hist := histogram{buckets}
+	hist.removeZeroBuckets()
+
+	return hist.buckets, distinctAdjustment, nil
 }
 
 // setHistogramBuckets shallow-copies the passed histogram into the

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -3070,6 +3070,30 @@ func (t *T) EnumGetIdxOfPhysical(phys []byte) (int, error) {
 	return 0, err
 }
 
+// EnumGetFirstIdxOfPhysicalBetween returns the first index within the
+// TypeMeta's slice of enum physical representations that is greater than
+// physLower and less than physUpper, exclusive.
+func (t *T) EnumGetFirstIdxOfPhysicalBetween(physLower, physUpper []byte) (int, error) {
+	t.ensureHydratedEnum()
+	reps := t.TypeMeta.EnumData.PhysicalRepresentations
+	for i := range reps {
+		if bytes.Compare(reps[i], physUpper) >= 0 {
+			continue
+		}
+		if bytes.Compare(reps[i], physLower) > 0 {
+			return i, nil
+		}
+	}
+	err := errors.Wrapf(EnumValueNotFound,
+		"could not find value between %v and %v in enum %q representation %s %s",
+		physLower, physUpper,
+		t.TypeMeta.Name.FQName(true /* explicitCatalog */),
+		t.TypeMeta.EnumData.debugString(),
+		debugutil.Stack(),
+	)
+	return 0, err
+}
+
 // EnumValueNotYetPublicError enum value is not public yet.
 var EnumValueNotYetPublicError = pgerror.New(pgcode.InvalidParameterValue, "enum value is not yet public")
 


### PR DESCRIPTION
**opt/props: only check histogram NumRange=0 in test builds**

These assertions that the first histogram bucket has NumRange=0 are
useful for catching bugs, but a liability in production
environments. Even with malformed histograms, we should not be failing
query execution. Only check these assertions in test builds.

Informs: #154461

Release note (bug fix): Change assertions about histogram NumRange=0 to
only be checked in test builds.

---

**sql/stats: handle range counts when skipping dropped enum hist buckets**

In #136538 we changed DecodeHistogramBuckets to skip over histogram
buckets for dropped enum values. This change assumed that histogram
buckets for enum types would never contain range counts, but this is not
true. For example, if the number of distinct enum values exceeds the
number of histogram buckets there could be range counts.

Fixes: #154461

Release note (bug fix): Fix a bug in which range counts in table
statistics histograms were not handled correctly after a user-defined
enum type was modified.