### PR TITLE
release-25.4: catalog/lease: update locked timestamps when updates are received

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -6687,7 +6687,6 @@ INSERT INTO baz.bar VALUES (110, 'a'), (210, 'b'), (310, 'c'), (410, 'd'), (510,
 	tenant10.Exec(t, `BACKUP DATABASE baz INTO 'userfile://defaultdb.myfililes/test4' with revision_history`)
 	expected = nil
 	for _, resume := range []exportResumePoint{
-		{mkSpan(id2, "/Tenant/10/Table/3", "/Tenant/10/Table/4"), withoutTS},
 		{mkSpan(id2, "/Tenant/10/Table/:id/1", "/Tenant/10/Table/:id/2"), withoutTS},
 		{mkSpan(id2, "/Tenant/10/Table/:id/1/210", "/Tenant/10/Table/:id/2"), withoutTS},
 		// We have two entries for 210 because of history and super small table

--- a/pkg/backup/targets.go
+++ b/pkg/backup/targets.go
@@ -185,7 +185,7 @@ func getAllDescChanges(
 	startTime, endTime hlc.Timestamp,
 	priorIDs map[descpb.ID]descpb.ID,
 ) ([]backuppb.BackupManifest_DescriptorRevision, error) {
-	startKey := codec.TablePrefix(keys.DescriptorTableID)
+	startKey := codec.IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	endKey := startKey.PrefixEnd()
 
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -830,7 +830,7 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 	}
 	codec := tf.leaseMgr.Codec()
 	start := timeutil.Now()
-	span := roachpb.Span{Key: codec.TablePrefix(keys.DescriptorTableID)}
+	span := roachpb.Span{Key: codec.IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)}
 	span.EndKey = span.Key.PrefixEnd()
 
 	tf.mu.Lock()

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -148,7 +148,7 @@ func FetchDescVersionModificationTime(
 	db := serverutils.OpenDBConn(
 		t, s.SQLAddr(), dbName, false, s.AppStopper())
 
-	tblKey := s.Codec().TablePrefix(keys.DescriptorTableID)
+	tblKey := s.Codec().IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	header := kvpb.RequestHeader{
 		Key:    tblKey,
 		EndKey: tblKey.PrefixEnd(),

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -211,9 +211,9 @@ func (s *SystemConfig) GetLargestObjectID(
 	// Search for the descriptor table entries within the SystemConfig. lowIndex
 	// (in s.Values) is the first and highIndex one past the last KV pair in the
 	// descriptor table.
-	lowBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID)
+	lowBound := keys.SystemSQLCodec.IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	lowIndex := s.getIndexBound(lowBound)
-	highBound := keys.SystemSQLCodec.TablePrefix(keys.DescriptorTableID + 1)
+	highBound := keys.SystemSQLCodec.IndexPrefix(keys.DescriptorTableID+1, keys.DescriptorTablePrimaryKeyIndexID)
 	highIndex := s.getIndexBound(highBound)
 	if lowIndex == highIndex {
 		return 0, fmt.Errorf("descriptor table not found in system config of %d values", len(s.Values))

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -426,9 +426,14 @@ const (
 	ZonesTableConfigColumnID = 2
 	ZonesTableConfigColFamID = 2
 
-	DescriptorTablePrimaryKeyIndexID         = 1
-	DescriptorTableDescriptorColID           = 2
-	DescriptorTableDescriptorColFamID        = 2
+	DescriptorTablePrimaryKeyIndexID  = 1
+	DescriptorTableDescriptorColID    = 2
+	DescriptorTableDescriptorColFamID = 2
+	// DescriptorTableDescriptorUpdateIndexID is not a real index. It is a special
+	// ID used to construct index entries that inform the lease subsystem of
+	// descriptor updates within a transaction. The value for such an entry is a
+	// descpb.DescriptorUpdates message.
+	DescriptorTableDescriptorUpdateIndexID   = 2
 	TenantsTablePrimaryKeyIndexID            = 1
 	SpanConfigurationsTablePrimaryKeyIndexID = 1
 	CommentsTablePrimaryKeyIndexID           = 1

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -449,7 +449,7 @@ func (r *Reporter) populateSQLInfo(uptime int64, sql *diagnosticspb.SQLInstanceI
 // type fields. Check out `schematelemetry` package for a better data source for
 // collecting redacted schema information.
 func (r *Reporter) collectSchemaInfo(ctx context.Context) ([]descpb.TableDescriptor, error) {
-	startKey := keys.MakeSQLCodec(r.TenantID).TablePrefix(keys.DescriptorTableID)
+	startKey := keys.MakeSQLCodec(r.TenantID).IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	endKey := startKey.PrefixEnd()
 	kvs, err := r.DB.Scan(ctx, startKey, endKey, 0)
 	if err != nil {

--- a/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
@@ -195,6 +195,15 @@ func (s *SQLWatcher) watchForDescriptorUpdates(
 			// Event for a tombstone on a tombstone -- nothing for us to do here.
 			return
 		}
+		// Skip over any modifications to the descriptor update tracking key, this
+		// is transaction information for the lease manager only.
+		if isUpdateKey, err := s.codec.DecodeDescUpdateKey(ev.Key); isUpdateKey || err != nil {
+			if err != nil {
+				log.Dev.Warningf(ctx, "failed to decode descriptor update key: %v", err)
+			}
+			return
+		}
+
 		value := ev.Value
 		if !ev.Value.IsPresent() {
 			// The descriptor was deleted.

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -287,6 +287,11 @@ func MakeDescMetadataKey(codec keys.SQLCodec, descID descpb.ID) roachpb.Key {
 	return codec.DescMetadataKey(uint32(descID))
 }
 
+// MakeDescUpdateKey returns the key for the descriptor.
+func MakeDescUpdateKey(codec keys.SQLCodec, id descpb.ID) roachpb.Key {
+	return codec.DescMetadataUpdateKey(uint32(id))
+}
+
 // CommentsMetadataPrefix returns the key prefix for all comments in the
 // system.comments table.
 func CommentsMetadataPrefix(codec keys.SQLCodec) roachpb.Key {

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1937,3 +1937,14 @@ message Descriptor {
     FunctionDescriptor function = 5;
   }
 }
+
+// DescriptorUpdates tracks updates to descriptors within a transaction, which
+// will be written to a special key.
+message DescriptorUpdates {
+  option (gogoproto.equal) = true;
+  // Needed for the descriptorProto interface.
+  option (gogoproto.goproto_getters) = true;
+
+  repeated uint32 descriptor_ids = 1 [(gogoproto.customname) = "DescriptorIDs", (gogoproto.casttype) = "ID"];
+  repeated uint32 descriptor_versions = 2  [(gogoproto.customname) = "DescriptorVersions", (gogoproto.casttype) = "DescriptorVersion"];
+}

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_google_btree//:btree",
     ],
 )
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
+	"github.com/google/btree"
 )
 
 var errRenewLease = errors.New("renew lease on id")
@@ -685,8 +686,13 @@ func ensureVersion(
 		return err
 	}
 
-	if s := m.findNewest(id); s != nil && s.GetVersion() < minVersion {
+	s := m.findNewest(id)
+	if s != nil && s.GetVersion() < minVersion {
 		return errors.Errorf("version %d for descriptor %s does not exist yet", minVersion, s.GetName())
+	} else if s != nil {
+		// Process any descriptor updates that will allow us to move the close timestamp
+		// forward.
+		m.processDescriptorUpdate(ctx, id, s.GetVersion(), s.GetModificationTime())
 	}
 	return nil
 }
@@ -1328,6 +1334,20 @@ const (
 	AcquireBackground
 )
 
+// descriptorTxnUpdate tracks updates to a set of descriptors in the
+// system.descriptors by a transaction, that should be made available
+// atomically.
+type descriptorTxnUpdate struct {
+	mu struct {
+		syncutil.Mutex
+		// DescriptorUpdates contains any descriptor versions that we are
+		// presently waiting for.
+		descpb.DescriptorUpdates
+	}
+	timestamp hlc.Timestamp
+	key       roachpb.Key
+}
+
 // Manager manages acquiring and releasing per-descriptor leases. It also
 // handles resolving descriptor names to descriptor IDs. The leases are managed
 // internally with a descriptor and expiration time exported by the
@@ -1366,6 +1386,14 @@ type Manager struct {
 
 		// rangeFeedRestartInProgress tracks if a range feed restart is in progress.
 		rangeFeedRestartInProgress bool
+
+		// descriptorTxnUpdatesToProcess is a list of descriptor txn updates that
+		// are waiting for new descriptor versions to be available.
+		descriptorTxnUpdatesToProcess *btree.BTreeG[*descriptorTxnUpdate]
+
+		// hasUpdatesToDelete tracks if there is data in the key space that
+		// should be cleaned up.
+		hasUpdatesToDelete bool
 	}
 
 	// closeTimeStamp for the range feed, which is the timestamp
@@ -1388,6 +1416,9 @@ type Manager struct {
 	descUpdateCh chan catalog.Descriptor
 	// descDelCh receives deleted descriptors from the range feed.
 	descDelCh chan descpb.ID
+	// descMetaDataUpdateCh receives updated transaction metadata from the
+	// range feed.
+	descMetaDataUpdateCh chan *descriptorTxnUpdate
 	// rangefeedErrCh receives any terminal errors from the rangefeed.
 	rangefeedErrCh chan error
 	// leaseGeneration increments any time a new or existing descriptor is
@@ -1524,6 +1555,10 @@ func NewLeaseManager(
 	lm.stopper.AddCloser(lm.sem.Closer("stopper"))
 	lm.stopper.AddCloser(stop.CloserFn(lm.AssertAllLeasesAreReleasedAfterDrain))
 	lm.mu.descriptors = make(map[descpb.ID]*descriptorState)
+	lm.mu.descriptorTxnUpdatesToProcess = btree.NewG(2, func(a, b *descriptorTxnUpdate) bool {
+		return a.timestamp.Less(b.timestamp)
+	})
+	lm.mu.hasUpdatesToDelete = true
 	lm.waitForInit = make(chan struct{})
 	// We are going to start the range feed later when StartRefreshLeasesTask
 	// is invoked inside pre-start. So, that guarantees all range feed events
@@ -1534,6 +1569,7 @@ func NewLeaseManager(
 	lm.draining.Store(false)
 	lm.descUpdateCh = make(chan catalog.Descriptor)
 	lm.descDelCh = make(chan descpb.ID)
+	lm.descMetaDataUpdateCh = make(chan *descriptorTxnUpdate)
 	lm.rangefeedErrCh = make(chan error)
 	lm.bytesMonitor = mon.NewMonitor(mon.Options{
 		Name:       mon.MakeName("leased-descriptors"),
@@ -1949,6 +1985,131 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 	return t
 }
 
+// hasDescUpdateBeenApplied checks if all versions of a descriptor update are
+// present. If not, it returns a new descpb.DescriptorUpdates containing the
+// versions that are still missing.
+func (m *Manager) hasDescUpdateBeenApplied(
+	updates descpb.DescriptorUpdates,
+) (allApplied bool, remaining descpb.DescriptorUpdates) {
+	allApplied = true
+	for idx, descID := range updates.DescriptorIDs {
+		descVersionState := m.findNewest(descID)
+		requiredVersion := updates.DescriptorVersions[idx]
+		// If a descriptor is missing, we still consider it as applied, since
+		// we will lease a newer version.
+		if descVersionState != nil && descVersionState.GetVersion() < requiredVersion {
+			allApplied = allApplied && descVersionState == nil
+			remaining.DescriptorIDs = append(remaining.DescriptorIDs, descID)
+			remaining.DescriptorVersions = append(remaining.DescriptorVersions, requiredVersion)
+		}
+	}
+	return allApplied, remaining
+}
+
+// getDescriptorTxnUpdateEntry returns the descriptorTxnUpdate entry for the given timestamp,
+// if there are any pending updates.
+func (m *Manager) getDescriptorTxnUpdateEntry(timestamp hlc.Timestamp) *descriptorTxnUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := &descriptorTxnUpdate{timestamp: timestamp}
+	entry, hasTS := m.mu.descriptorTxnUpdatesToProcess.Get(key)
+	if !hasTS {
+		return nil
+	}
+	return entry
+}
+
+// processDescriptorUpdate will process this descriptor update for txn
+// consistency.
+func (m *Manager) processDescriptorUpdate(
+	ctx context.Context, id descpb.ID, version descpb.DescriptorVersion, timestamp hlc.Timestamp,
+) {
+	entry := m.getDescriptorTxnUpdateEntry(timestamp)
+	// This timestamp has no pending update.
+	if entry == nil {
+		return
+	}
+	noEntriesLeft := func() bool {
+		// Lock this specific entry
+		entry.mu.Lock()
+		defer entry.mu.Unlock()
+		// Process this descriptor version inside the entry.
+		for idx, descID := range entry.mu.DescriptorIDs {
+			if descID != id {
+				continue
+			}
+			// The target version has not arrived yet for this update.
+			if entry.mu.DescriptorVersions[idx] > version {
+				return false
+			}
+			// Otherwise, let's move this version to the end first.
+			endIdx := len(entry.mu.DescriptorIDs) - 1
+			if idx != endIdx {
+				entry.mu.DescriptorIDs[idx], entry.mu.DescriptorIDs[endIdx] =
+					entry.mu.DescriptorIDs[endIdx], entry.mu.DescriptorIDs[idx]
+				entry.mu.DescriptorVersions[idx], entry.mu.DescriptorVersions[endIdx] =
+					entry.mu.DescriptorVersions[endIdx], entry.mu.DescriptorVersions[idx]
+			}
+			// Remove one element from the end after.
+			entry.mu.DescriptorIDs = entry.mu.DescriptorIDs[:len(entry.mu.DescriptorIDs)-1]
+			entry.mu.DescriptorVersions = entry.mu.DescriptorVersions[:len(entry.mu.DescriptorIDs)-1]
+			break
+		}
+		return len(entry.mu.DescriptorIDs) == 0
+	}()
+	// Everything is processed, so we can move the timestamp forward.
+	if noEntriesLeft {
+		// If the length is zero by this point, then we can move the timestamp forward
+		// and remove this entry.
+		targetTimestamp := m.markDescriptorUpdatesAsComplete()
+		if !targetTimestamp.IsEmpty() {
+			m.advanceCloseTimestamp(targetTimestamp)
+		}
+	}
+}
+
+// markDescriptorUpdatesAsComplete will move the close timestamp forward if
+// all descriptor updates have been applied.
+func (m *Manager) markDescriptorUpdatesAsComplete() hlc.Timestamp {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	timestamp := hlc.Timestamp{}
+	for {
+		minUpdate, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
+		if !hasMin {
+			break
+		}
+		shouldRemoveEntry := func() bool {
+			minUpdate.mu.Lock()
+			defer minUpdate.mu.Unlock()
+			return len(minUpdate.mu.DescriptorIDs) == 0
+		}()
+		if !shouldRemoveEntry {
+			break
+		}
+		timestamp = minUpdate.timestamp
+		m.mu.descriptorTxnUpdatesToProcess.Delete(minUpdate)
+	}
+	return timestamp
+}
+
+// advanceCloseTimestamp advances the close timestamp atomically, if the current
+// close timestamp is smaller.
+func (m *Manager) advanceCloseTimestamp(timestamp hlc.Timestamp) {
+	for {
+		oldTimestamp := m.closeTimestamp.Load().(hlc.Timestamp)
+		// Timestamp has already been advanced.
+		if !oldTimestamp.Less(timestamp) {
+			return
+		}
+		// Otherwise, attempt to swap the timestamp, if successful we
+		// will return.
+		if m.closeTimestamp.CompareAndSwap(oldTimestamp, timestamp) {
+			return
+		}
+	}
+}
+
 // StartRefreshLeasesTask starts a goroutine that refreshes the lease manager
 // leases for descriptors received in the latest system configuration via gossip or
 // rangefeeds. This function must be passed a non-nil gossip if
@@ -2063,6 +2224,30 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 				if evFunc := m.testingKnobs.TestingDescriptorRefreshedEvent; evFunc != nil {
 					evFunc(desc.DescriptorProto())
 				}
+			case descUpdate := <-m.descMetaDataUpdateCh:
+				// Check if the update has been applied.
+				allApplied, remaining := m.hasDescUpdateBeenApplied(descUpdate.mu.DescriptorUpdates)
+				descUpdate.mu.DescriptorUpdates = remaining
+				advanceTimestamp := func() bool {
+					m.mu.Lock()
+					defer m.mu.Unlock()
+					m.mu.hasUpdatesToDelete = true
+					// If there are no other earlier pending updates, advance the timestamp.
+					minUpdate, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
+					if allApplied && (!hasMin ||
+						!minUpdate.timestamp.Less(descUpdate.timestamp)) {
+						return true
+					}
+					// Otherwise, insert this into the queue of pending updates
+					m.mu.descriptorTxnUpdatesToProcess.ReplaceOrInsert(descUpdate)
+					return false
+				}()
+				if advanceTimestamp {
+					if m.testingKnobs.TestingOnUpdateReadTimestamp != nil {
+						m.testingKnobs.TestingOnUpdateReadTimestamp(descUpdate.timestamp)
+					}
+					m.advanceCloseTimestamp(descUpdate.timestamp)
+				}
 			case <-s.ShouldQuiesce():
 				return
 			}
@@ -2114,13 +2299,43 @@ func (m *Manager) watchForUpdates(ctx context.Context) {
 		if m.testingKnobs.DisableRangeFeedCheckpoint {
 			return
 		}
-		if len(ev.Value.RawBytes) == 0 {
+		// Check first if it is the special descriptor metadata key used to track
+		// descriptors modified by transactions.
+		if isUpdateKey, err := m.Codec().DecodeDescUpdateKey(ev.Key); err != nil || isUpdateKey {
+			if err != nil {
+				log.Dev.Warningf(ctx, "unable to decode update metadata key %v", ev.Key)
+				return
+			}
+			// Ignore deletes on this key space.
+			if len(ev.Value.RawBytes) == 0 {
+				return
+			}
+			// Otherwise, this is a descriptor update key.
+			var descUpdates descpb.DescriptorUpdates
+			err := ev.Value.GetProto(&descUpdates)
+			if err != nil {
+				log.Dev.Warningf(ctx, "unable to decode descriptor update value %v", err)
+				return
+			}
+			update := &descriptorTxnUpdate{
+				key:       ev.Key,
+				timestamp: ev.Timestamp(),
+			}
+			update.mu.DescriptorUpdates = descUpdates
+			select {
+			case <-m.stopper.ShouldQuiesce():
+			case <-ctx.Done():
+			case m.descMetaDataUpdateCh <- update:
+			}
+			return
+		} else if len(ev.Value.RawBytes) == 0 {
 			id, err := m.Codec().DecodeDescMetadataID(ev.Key)
 			if err != nil {
 				log.Dev.Infof(ctx, "unable to decode metadata key %v", ev.Key)
 				return
 			}
 			select {
+			case <-m.stopper.ShouldQuiesce():
 			case <-ctx.Done():
 			case m.descDelCh <- descpb.ID(id):
 			}
@@ -2140,14 +2355,15 @@ func (m *Manager) watchForUpdates(ctx context.Context) {
 				ev.Key, mut.GetID(), mut.GetName(), mut.GetVersion())
 		}
 		select {
+		case <-m.stopper.ShouldQuiesce():
 		case <-ctx.Done():
 		case m.descUpdateCh <- mut:
 		}
 	}
 
 	handleCheckpoint := func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-		if m.testingKnobs.TestingOnRangeFeedCheckPoint != nil {
-			m.testingKnobs.TestingOnRangeFeedCheckPoint()
+		if m.testingKnobs.TestingOnUpdateReadTimestamp != nil {
+			m.testingKnobs.TestingOnUpdateReadTimestamp(checkpoint.ResolvedTS)
 		}
 		// Track checkpoints that occur from the rangefeed to make sure progress
 		// is always made.
@@ -2157,7 +2373,15 @@ func (m *Manager) watchForUpdates(ctx context.Context) {
 			return
 		}
 		m.mu.rangeFeedCheckpoints += 1
-		m.closeTimestamp.Store(checkpoint.ResolvedTS)
+		m.advanceCloseTimestamp(checkpoint.ResolvedTS)
+		// Clean up all entries before the resolve timestamp.
+		for {
+			minTS, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
+			if !hasMin || !minTS.timestamp.Less(checkpoint.ResolvedTS) {
+				break
+			}
+			m.mu.descriptorTxnUpdatesToProcess.Delete(minTS)
+		}
 	}
 
 	// Assert that the range feed is already terminated.
@@ -2258,6 +2482,10 @@ func (m *Manager) RunBackgroundLeasingTask(ctx context.Context) {
 		rangeFeedProgressWatchDogTimeout,
 			rangeFeedProgressWatchDogEnabled := m.getRangeFeedMonitorSettings()
 		rangeFeedProgressWatchDog.Reset(rangeFeedProgressWatchDogTimeout)
+		// Descriptor update clean-up timer
+		var descriptorUpdateCleanupTimer timeutil.Timer
+		descriptorUpdateCleanupTimerDuration := 30 * time.Minute
+		descriptorUpdateCleanupTimer.Reset(descriptorUpdateCleanupTimerDuration)
 		for {
 			select {
 			case <-m.stopper.ShouldQuiesce():
@@ -2290,6 +2518,10 @@ func (m *Manager) RunBackgroundLeasingTask(ctx context.Context) {
 
 				// Clean up session based leases that have expired.
 				m.cleanupExpiredSessionLeases(ctx)
+			case <-descriptorUpdateCleanupTimer.C:
+				// Clean up the update key space.
+				m.cleanupUpdateKeys(ctx)
+				descriptorUpdateCleanupTimer.Reset(descriptorUpdateCleanupTimerDuration)
 			}
 		}
 	})
@@ -2397,6 +2629,27 @@ func (m *Manager) cleanupExpiredSessionLeases(ctx context.Context) {
 		}); err != nil {
 			log.Dev.Infof(ctx, "unable to delete leases from storage %s", err)
 		}
+	}
+}
+
+// cleanupUpdateKeys updates special keys that exist for tracking descriptor
+// updates within transactions.
+func (m *Manager) cleanupUpdateKeys(ctx context.Context) {
+	// Only clean update keys if we received any range feed updates.
+	m.mu.Lock()
+	hasUpdates := m.mu.hasUpdatesToDelete
+	m.mu.Unlock()
+	if !hasUpdates {
+		return
+	}
+	// Issue a DelRange on this key space.
+	err := m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		prefix := m.storage.codec.DescUpdatePrefix()
+		_, err := txn.KV().DelRange(ctx, prefix, prefix.PrefixEnd(), false)
+		return err
+	})
+	if err != nil {
+		log.Dev.Infof(ctx, "unable to delete descriptor update keys from storage: %v", err)
 	}
 }
 
@@ -2515,6 +2768,7 @@ func (m *Manager) DeleteOrphanedLeases(
 		retryOpts.MaxRetries = 10
 		m.deleteOrphanedLeasesFromStaleSession(ctx, retryOpts, timeThreshold, locality)
 		m.deleteOrphanedLeasesWithSameInstanceID(ctx, retryOpts, timeThreshold, instanceID)
+		m.cleanupUpdateKeys(ctx)
 	})
 }
 

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -68,9 +68,9 @@ type ManagerTestingKnobs struct {
 	// has been reset.
 	RangeFeedResetChannel chan struct{}
 
-	// TestingOnRangeFeedCheckPoint is invoked when a range feed checkpoint is
+	// TestingOnUpdateReadTimestamp is invoked when a range feed checkpoint is
 	// hit.
-	TestingOnRangeFeedCheckPoint func()
+	TestingOnUpdateReadTimestamp func(timestamp hlc.Timestamp)
 
 	LeaseStoreTestingKnobs StorageTestingKnobs
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2422,6 +2422,10 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retEr
 		}
 	}
 
+	if err := ex.extraTxnState.descCollection.EmitDescriptorUpdatesKey(ctx, ex.state.mu.txn); err != nil {
+		return err
+	}
+
 	if err := ex.state.mu.txn.Commit(ctx); err != nil {
 		return err
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -2049,6 +2049,9 @@ func (ief *InternalDB) txn(
 			if err != nil {
 				return err
 			}
+			if err := descsCol.EmitDescriptorUpdatesKey(ctx, kvTxn); err != nil {
+				return err
+			}
 			// We check this testing condition here since a retry cannot be generated
 			// after a successful commit. Since we commit below, this is our last
 			// chance to generate a retry for users of (*InternalDB).Txn.

--- a/pkg/sql/vecindex/manager_test.go
+++ b/pkg/sql/vecindex/manager_test.go
@@ -117,11 +117,6 @@ func TestVectorManager(t *testing.T) {
 	}).BuildCreatedMutable()
 
 	err := internalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) (err error) {
-		defer func() {
-			if err == nil {
-				err = txn.KV().Commit(ctx)
-			}
-		}()
 		b := txn.KV().NewBatch()
 
 		err = txn.Descriptors().WriteDescToBatch(ctx, false, newDB, b)


### PR DESCRIPTION
Backport 1/1 commits from #153961.

/cc @cockroachdb/release

---

Previously, the lease manager would increase its locked read time stamp was when a check point occurred on the range feed. This was not adequate because this could cause schema changes could be slowed down if the old version of descriptors was held. While the current design does not intentionally reserve, previous versions, a later update will start holding old versions intentionally to serve queries. To address this, this patch has schema changes write the list of descriptors modified to a special key `/Table/Descriptors/2/<First ID in Schema Change`, which will be used by the lease manager range feed to to update timestamps. Additionally, this patch also deflakes and fixes
`TestLeaseManagerLockedTimestampBasic`, which was not setup correctly.

Informs: #153618
Fixes: #153826
Fixes: https://github.com/cockroachdb/cockroach/issues/154075

Release note: None

Release justification: helps resolve a GA blocker
