### PR TITLE
roachpb: add LeaseType to (Lease).SafeFormat

### DIFF
--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -382,7 +382,7 @@ func TestNotLeaseholderError(t *testing.T) {
 		err *NotLeaseHolderError
 	}{
 		{
-			exp: `[NotLeaseHolderError] r1: replica not lease holder; current lease is repl=(n1,s1):1 seq=2 start=0.000000002,0 epo=1 min-exp=0.000000003,0 pro=0.000000001,0 acq=Transfer`,
+			exp: `[NotLeaseHolderError] r1: replica not lease holder; current lease is repl=(n1,s1):1 seq=2 start=0.000000002,0 type=LeaseEpoch epo=1 min-exp=0.000000003,0 pro=0.000000001,0 acq=Transfer`,
 			err: &NotLeaseHolderError{
 				RangeID: 1,
 				Lease: &roachpb.Lease{

--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -84,7 +84,7 @@ func TestLeaseCommandLearnerReplica(t *testing.T) {
 	_, err = RequestLease(ctx, nil, cArgs, nil)
 
 	const expForLearner = `cannot replace lease <empty> ` +
-		`with repl=(n2,s2):2LEARNER seq=0 start=0,0 exp=<nil> pro=0,0 acq=Request: ` +
+		`with repl=(n2,s2):2LEARNER seq=0 start=0,0 type=LeaseExpiration exp=<nil> pro=0,0 acq=Request: ` +
 		`lease target replica cannot hold lease`
 	require.EqualError(t, err, expForLearner)
 }

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1949,7 +1949,7 @@ func (l Lease) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.SafeString("<empty>")
 		return
 	}
-	w.Printf("repl=%s seq=%d start=%s", l.Replica, l.Sequence, l.Start)
+	w.Printf("repl=%s seq=%d start=%s type=%s", l.Replica, l.Sequence, l.Start, l.Type())
 	switch l.Type() {
 	case LeaseExpiration:
 		w.Printf(" exp=%s", l.Expiration)
@@ -1991,6 +1991,10 @@ const (
 	// to be the range's raft leader.
 	LeaseLeader
 )
+
+func (t LeaseType) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%s", redact.SafeString(t.String()))
+}
 
 // TestingAllLeaseTypes returns a list of all lease types to test against.
 func TestingAllLeaseTypes() []LeaseType {

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1099,7 +1099,7 @@ func TestLeaseStringAndSafeFormat(t *testing.T) {
 				Sequence:        3,
 				AcquisitionType: LeaseAcquisitionType_Request,
 			},
-			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 exp=0.000000002,1 pro=0.000000001,0 acq=Request",
+			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 type=LeaseExpiration exp=0.000000002,1 pro=0.000000001,0 acq=Request",
 		},
 		{
 			name: "epoch",
@@ -1116,7 +1116,7 @@ func TestLeaseStringAndSafeFormat(t *testing.T) {
 				MinExpiration:   makeTS(2, 1),
 				AcquisitionType: LeaseAcquisitionType_Transfer,
 			},
-			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 epo=4 min-exp=0.000000002,1 pro=0.000000001,0 acq=Transfer",
+			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 type=LeaseEpoch epo=4 min-exp=0.000000002,1 pro=0.000000001,0 acq=Transfer",
 		},
 		{
 			name: "leader",
@@ -1133,7 +1133,7 @@ func TestLeaseStringAndSafeFormat(t *testing.T) {
 				Term:            5,
 				AcquisitionType: LeaseAcquisitionType_Transfer,
 			},
-			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 term=5 min-exp=0.000000002,1 pro=0.000000001,0 acq=Transfer",
+			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 type=LeaseLeader term=5 min-exp=0.000000002,1 pro=0.000000001,0 acq=Transfer",
 		},
 		{
 			name: "leader",
@@ -1150,7 +1150,7 @@ func TestLeaseStringAndSafeFormat(t *testing.T) {
 				Term:            5,
 				AcquisitionType: LeaseAcquisitionType_Request,
 			},
-			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 term=5 min-exp=0.000000002,1 pro=0.000000001,0 acq=Request",
+			exp: "repl=(n1,s1):1 seq=3 start=0.000000001,1 type=LeaseLeader term=5 min-exp=0.000000002,1 pro=0.000000001,0 acq=Request",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This is implied by the fields that were previously printed, but I think it is a bit easier if things are more explicit.

Epic: none
Release note: None