### PR TITLE
opt: normalize LIKE ... ESCAPE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -730,8 +730,7 @@ statement ok
 CREATE TABLE t108901 AS SELECT g::FLOAT8 AS _float8 FROM generate_series(1, 5) AS g;
 ALTER TABLE t108901 SPLIT AT VALUES (1), (2), (3);
 ALTER TABLE t108901 RELOCATE VOTERS VALUES (ARRAY[1], 1), (ARRAY[2], 2), (ARRAY[3], 3);
-SET testing_optimizer_random_seed = 1613845022891698972;
-SET testing_optimizer_disable_rule_probability = 0.500000;
+SET disable_optimizer_rules = PruneWindowOutputCols;
 
 statement error integer out of range
 SELECT 1 FROM t108901 WHERE

--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -76,16 +76,6 @@ func (c *CustomFuncs) NormalizeTupleEquality(left, right memo.ScalarListExpr) op
 	return result
 }
 
-// FirstScalarListExpr returns the first ScalarExpr in the given list.
-func (c *CustomFuncs) FirstScalarListExpr(list memo.ScalarListExpr) opt.ScalarExpr {
-	return list[0]
-}
-
-// SecondScalarListExpr returns the second ScalarExpr in the given list.
-func (c *CustomFuncs) SecondScalarListExpr(list memo.ScalarListExpr) opt.ScalarExpr {
-	return list[1]
-}
-
 // MakeTimeZoneFunction constructs a new timezone() function with the given zone
 // and timestamp as arguments. The type of the function result is TIMESTAMPTZ if
 // ts is of type TIMESTAMP, or TIMESTAMP if is of type TIMESTAMPTZ.

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -660,6 +660,22 @@ func (c *CustomFuncs) IsLeakproof(expr memo.RelExpr) bool {
 
 // ----------------------------------------------------------------------
 //
+// ScalarListExpr functions
+//   General functions related to ScalarListExpr.
+//
+// ----------------------------------------------------------------------
+
+// ScalarExprAt returns the ScalarExpr in the i-th position in the given list.
+// Returns ok=false if i is out of bounds.
+func (c *CustomFuncs) ScalarExprAt(list memo.ScalarListExpr, i int) (_ opt.ScalarExpr, ok bool) {
+	if i >= 0 && i < len(list) {
+		return list[i], true
+	}
+	return nil, false
+}
+
+// ----------------------------------------------------------------------
+//
 // Ordering functions
 //   General functions related to orderings.
 //

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -220,14 +220,13 @@
     (Function $args:* $private:(FunctionPrivate "timezone"))
     $right:(ConstValue) &
         (IsTimestampTZ $right) &
-        (IsTimestamp $ts:(SecondScalarListExpr $args)) &
-        ^(IsConstValueOrGroupOfConstValues $ts)
+        (Let ($ts $tsOk):(ScalarExprAt $args 1) $tsOk) &
+        (IsTimestamp $ts) &
+        ^(IsConstValueOrGroupOfConstValues $ts) &
+        (Let ($zone $zoneOk):(ScalarExprAt $args 0) $zoneOk)
 )
 =>
-((OpName)
-    $ts
-    (MakeTimeZoneFunction (FirstScalarListExpr $args) $right)
-)
+((OpName) $ts (MakeTimeZoneFunction $zone $right))
 
 # NormalizeCmpTimeZoneFunctionTZ normalizes timezone functions within
 # comparison operators. It only matches expressions when:
@@ -249,14 +248,13 @@
     (Function $args:* $private:(FunctionPrivate "timezone"))
     $right:(ConstValue) &
         (IsTimestamp $right) &
-        (IsTimestampTZ $tz:(SecondScalarListExpr $args)) &
-        ^(IsConstValueOrGroupOfConstValues $tz)
+        (Let ($tz $tzOk):(ScalarExprAt $args 1) $tzOk) &
+        (IsTimestampTZ $tz) &
+        ^(IsConstValueOrGroupOfConstValues $tz) &
+        (Let ($zone $zoneOk):(ScalarExprAt $args 0) $zoneOk)
 )
 =>
-((OpName)
-    $tz
-    (MakeTimeZoneFunction (FirstScalarListExpr $args) $right)
-)
+((OpName) $tz (MakeTimeZoneFunction $zone $right))
 
 # FoldEqTrue replaces x = True with x.
 [FoldEqTrue, Normalize]

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -452,3 +452,21 @@ $udf
 (Indirection $input:* $index:* & (IsJSON $input))
 =>
 (FetchVal $input $index)
+
+# ConvertLikeEscapeToLike converts a LIKE x ESCAPE '\' expression, which is
+# parsed as a like_escape function call, to a LIKE expression. This is valid
+# because the default escape character is '\'.
+#
+# Note that the FunctionExpr match pattern is enough to ensure that we are not
+# transforming a UDF because UDF invocations are always built as UDFCallExprs.
+[ConvertLikeEscapeToLike, Normalize]
+(Function
+    $args:*
+    $private:(FunctionPrivate "like_escape") &
+        (Let ($input $iOk):(ScalarExprAt $args 0) $iOk) &
+        (Let ($pattern $pOk):(ScalarExprAt $args 1) $pOk) &
+        (Let ($escape $eOk):(ScalarExprAt $args 2) $eOk) &
+        (ConstStringEquals $escape "\\")
+)
+=>
+(Like $input $pattern)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -2689,3 +2689,60 @@ project
  └── projections
       ├── b.arr:5[1] [as=arr:8, outer=(5)]
       └── b.arr:5[2] [as=arr:9, outer=(5)]
+
+# --------------------------------------------------
+# ConvertLikeEscapeToLike
+# --------------------------------------------------
+
+norm expect=ConvertLikeEscapeToLike
+SELECT s LIKE 'foo%' ESCAPE '\' FROM a
+----
+project
+ ├── columns: like_escape:8
+ ├── scan a
+ │    └── columns: s:4
+ └── projections
+      └── s:4 LIKE 'foo%' [as=like_escape:8, outer=(4)]
+
+norm expect=ConvertLikeEscapeToLike
+SELECT like_escape(s, 'foo%', '\') FROM a
+----
+project
+ ├── columns: like_escape:8
+ ├── scan a
+ │    └── columns: s:4
+ └── projections
+      └── s:4 LIKE 'foo%' [as=like_escape:8, outer=(4)]
+
+norm expect-not=ConvertLikeEscapeToLike
+SELECT s LIKE 'foo%' ESCAPE '/' FROM a
+----
+project
+ ├── columns: like_escape:8
+ ├── immutable
+ ├── scan a
+ │    └── columns: s:4
+ └── projections
+      └── like_escape(s:4, 'foo%', '/') [as=like_escape:8, outer=(4), immutable]
+
+norm expect-not=ConvertLikeEscapeToLike
+SELECT s LIKE 'foo%' ESCAPE 'f' FROM a
+----
+project
+ ├── columns: like_escape:8
+ ├── immutable
+ ├── scan a
+ │    └── columns: s:4
+ └── projections
+      └── like_escape(s:4, 'foo%', 'f') [as=like_escape:8, outer=(4), immutable]
+
+norm expect-not=ConvertLikeEscapeToLike
+SELECT not_like_escape(s, 'foo%', '\') FROM a
+----
+project
+ ├── columns: not_like_escape:8
+ ├── immutable
+ ├── scan a
+ │    └── columns: s:4
+ └── projections
+      └── not_like_escape(s:4, 'foo%', e'\\') [as=not_like_escape:8, outer=(4), immutable]


### PR DESCRIPTION
#### logictest: make test case deterministic

This commit makes a test case in `distsql_agg` deterministic no matter
how many optimizer rules have been defined. It now explicitly disables
an optimizer rule, which is required to reproduce the behavior, rather
than using the `testing_optimizer_random_seed` and
`testing_optimizer_disable_rule_probability` session settings.

Release note: None

#### opt: make scalar list custom func accessor safer

The custom functions `FirstScalarListExpr` and `SecondScalarListExpr`
have been replaced by `ScalarExprAt`. This function is safer because it
returns ok=false if the given index is out-of-bounds instead of
panicking. This function has been added to `general_funcs.go` instead of
`comp_funcs.go` in preparation for usage outside of `comp.opt`.

Release note: None

#### opt: normalize LIKE ... ESCAPE

An expression in the form `a LIKE b ESCAPE '/'`, which is parsed as
`like_escape(a, b, '/')`, is now normalized to `a LIKE b`. This is valid
because `\` is the default escape character, so the expressions are
equivalent.

This normalization allows for further optimization, for example:

```sql
CREATE TABLE t (s STRING, INDEX (s));

EXPLAIN SELECT s FROM t WHERE s LIKE 'foo\_bar' ESCAPE '\';
-- BEFORE:
--  • filter
--  │ filter: like_escape(s, e'foo\\_bar', e'\\')
--  │
--  └── • scan
--        table: t@t_pkey
--        spans: FULL SCAN

-- AFTER:
--   • scan
--     table: t@t_s_idx
--     spans: [/'foo_bar' - /'foo_bar']
```

Informs #30192

Release note (performance improvement): Queries with filters in the form
`a LIKE b ESCAPE '\'` are now index-accelerated in some cases which they
were not before.
