### PR TITLE
packer: bump teamcity-agent-arm volume size to 512GB

### DIFF
--- a/build/packer/teamcity-agent-arm.json
+++ b/build/packer/teamcity-agent-arm.json
@@ -18,7 +18,7 @@
         "ssh_timeout": "10m",
         "ami_block_device_mappings": {
             "device_name": "/dev/sda1",
-            "volume_size": "256",
+            "volume_size": "512",
             "volume_type": "gp2",
             "delete_on_termination": true
         },


### PR DESCRIPTION
Epic: none
Release note: none