### PR TITLE
server: skip TestHealthAPI

### DIFF
--- a/pkg/server/storage_api/health_test.go
+++ b/pkg/server/storage_api/health_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,6 +30,7 @@ func TestHealthAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 155052)
 	ctx := context.Background()
 
 	t.Run("sql", func(t *testing.T) {


### PR DESCRIPTION
part of #155052

Epic: None
Release note: None