### PR TITLE
workload_generator: fix constraint prefix check and computed columns

### DIFF
--- a/pkg/workload/workload_generator/schema_utils.go
+++ b/pkg/workload/workload_generator/schema_utils.go
@@ -492,11 +492,17 @@ func mapSQLType(sql string, col *Column, rng *rand.Rand) (GeneratorType, map[str
 	return GenTypeString, args
 }
 
-func mapIntegerType(_ string, col *Column, args map[string]any) (GeneratorType, map[string]any) {
+func mapIntegerType(sql string, col *Column, args map[string]any) (GeneratorType, map[string]any) {
 	if col.IsPrimaryKey || col.IsUnique {
 		return GenTypeSequence, map[string]any{"start": 1, "seed": args["seed"]}
 	}
-	setArgsRange(args, -(1 << 31), (1<<31)-1)
+	if sql == "smallint" || sql == "int2" {
+		setArgsRange(args, -(1 << 15), (1<<15)-1)
+	} else {
+		// default is regular INT
+		// INT is 32-bit in CockroachDB even on 64-bit platforms
+		setArgsRange(args, -(1 << 31), (1<<31)-1)
+	}
 	return GenTypeInteger, args
 }
 


### PR DESCRIPTION
This PR has the following changes:
1 While extracting the table schemas from the create_statements file, we use a prefix-based check to identify whether a line has a column information or a constraint. This check fails in case the prefix of the column name matches. e.g.
a line beginning with "CHECK" is a constraint. But, if the column name is "checksum", this matches and causes an issue to identify the column as a constraint. To fix this, the check is changed to be "CHECK ". A TODO is added to use sql parser instead of this string match and regex logics.

2. Computed columns are not supported in import. So, the computed columns are ignored if thay are present in the table definition.

Release Note: None
Epic: None