### PR TITLE
release-25.4: roachtest: only run liquibase test on GCE

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -156,11 +156,12 @@ sudo ln -sf /home/ubuntu/cockroach /cockroach/cockroach.sh`); err != nil {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "liquibase",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "liquibase",
+		Owner:   registry.OwnerSQLFoundations,
+		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
+		// This test uses custom ports, which is Only supported on GCE.
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.Tool),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLiquibase(ctx, t, c)


### PR DESCRIPTION
Backport 1/1 commits from #155067 on behalf of @rafiss.

----

The test needs custom ports, which only works in GCE.

fixes https://github.com/cockroachdb/cockroach/issues/155040
Release note: None

----

Release justification: