### PR TITLE
changefeedccl: Fix timestamp for descriptor fetches during changefeed…

### DIFF
--- a/pkg/backup/backupresolver/targets.go
+++ b/pkg/backup/backupresolver/targets.go
@@ -661,6 +661,7 @@ func LoadAllDescs(
 	ctx context.Context, execCfg *sql.ExecutorConfig, asOf hlc.Timestamp,
 ) (allDescs []catalog.Descriptor, _ error) {
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		fmt.Printf("LoadAllDescs: setting fixed timestamp to %s\n", asOf)
 		err := txn.KV().SetFixedTimestamp(ctx, asOf)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/cdceval/plan.go
+++ b/pkg/ccl/changefeedccl/cdceval/plan.go
@@ -7,6 +7,7 @@ package cdceval
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -172,6 +173,7 @@ func withPlanner(
 	fn func(ctx context.Context, execCtx sql.JobExecContext, cleanup func()) error,
 ) error {
 	return sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		fmt.Printf("withPlanner: setting fixed timestamp to %s\n", schemaTS)
 		if err := txn.KV().SetFixedTimestamp(ctx, schemaTS); err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -7,6 +7,7 @@ package cdcevent
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -107,6 +108,7 @@ func refreshUDT(
 	// descs.Collection directly here.
 	// TODO (SQL Schema): #53751.
 	if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		fmt.Printf("refreshUDT: setting fixed timestamp to %s\n", ts)
 		err := txn.SetFixedTimestamp(ctx, ts)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -120,8 +120,8 @@ func getTargetsFromDatabaseSpec(
 	err = sql.DescsTxn(ctx, execCfg, func(
 		ctx context.Context, txn isql.Txn, descs *descs.Collection,
 	) error {
-		// TODO: Set fixed timestamp here.
 		if timestamp != (hlc.Timestamp{}) {
+			fmt.Printf("getTargetsFromDatabaseSpec: setting fixed timestamp to %s\n", timestamp)
 			if err := txn.KV().SetFixedTimestamp(ctx, timestamp); err != nil {
 				return errors.Wrapf(err, "setting timestamp for table descriptor fetch")
 			}

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -57,12 +57,17 @@ func makeChangefeedConfigFromJobDetails(
 		Targets:  targets,
 	}, nil
 }
+func AllTargets(
+	ctx context.Context, cd jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig,
+) (changefeedbase.Targets, error) {
+	return AllTargetsWithTS(ctx, cd, execCfg, hlc.Timestamp{})
+}
 
 // AllTargets gets all the targets listed in a ChangefeedDetails,
 // from the statement time name map in old protos
 // or the TargetSpecifications in new ones.
-func AllTargets(
-	ctx context.Context, cd jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig,
+func AllTargetsWithTS(
+	ctx context.Context, cd jobspb.ChangefeedDetails, execCfg *sql.ExecutorConfig, timestamp hlc.Timestamp,
 ) (changefeedbase.Targets, error) {
 	targets := changefeedbase.Targets{}
 	var err error
@@ -76,7 +81,7 @@ func AllTargets(
 					if len(cd.TargetSpecifications) > 1 {
 						return changefeedbase.Targets{}, errors.AssertionFailedf("database-level changefeed is not supported with multiple targets")
 					}
-					targets, err = getTargetsFromDatabaseSpec(ctx, ts, execCfg)
+					targets, err = getTargetsFromDatabaseSpec(ctx, ts, execCfg, timestamp)
 					if err != nil {
 						return changefeedbase.Targets{}, err
 					}
@@ -110,11 +115,17 @@ func AllTargets(
 }
 
 func getTargetsFromDatabaseSpec(
-	ctx context.Context, ts jobspb.ChangefeedTargetSpecification, execCfg *sql.ExecutorConfig,
+	ctx context.Context, ts jobspb.ChangefeedTargetSpecification, execCfg *sql.ExecutorConfig, timestamp hlc.Timestamp,
 ) (targets changefeedbase.Targets, err error) {
 	err = sql.DescsTxn(ctx, execCfg, func(
 		ctx context.Context, txn isql.Txn, descs *descs.Collection,
 	) error {
+		// TODO: Set fixed timestamp here.
+		if timestamp != (hlc.Timestamp{}) {
+			if err := txn.KV().SetFixedTimestamp(ctx, timestamp); err != nil {
+				return errors.Wrapf(err, "setting timestamp for table descriptor fetch")
+			}
+		}
 		databaseDescriptor, err := descs.ByIDWithLeased(txn.KV()).Get().Database(ctx, ts.DescID)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -377,7 +377,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	if ca.knobs.OverrideExecCfg != nil {
 		execCfg = ca.knobs.OverrideExecCfg(execCfg)
 	}
-	ca.targets, err = AllTargets(ctx, ca.spec.Feed, execCfg)
+	ca.targets, err = AllTargetsWithTS(ctx, ca.spec.Feed, execCfg, *ca.spec.InitialHighWater)
 	if err != nil {
 		log.Changefeed.Warningf(ca.Ctx(), "moving to draining due to error getting targets: %v", err)
 		ca.MoveToDraining(err)
@@ -451,6 +451,9 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	kvFeedHighWater := ca.frontier.Frontier()
 	if needsInitialScan {
 		kvFeedHighWater = ca.spec.Feed.StatementTime
+		fmt.Printf("Using statement time for kv feed high water: %s\n", kvFeedHighWater)
+	} else {
+		fmt.Printf("Using frontier for kv feed high water: %s\n", kvFeedHighWater)
 	}
 
 	// TODO(yevgeniy): Introduce separate changefeed monitor that's a parent
@@ -562,6 +565,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 	if schemaChange.Policy == changefeedbase.OptSchemaChangePolicyIgnore || initialScanOnly {
 		sf = schemafeed.DoNothingSchemaFeed
 	} else {
+		fmt.Printf("creating schema feed with initial frontier: %s\n", initialHighWater)
 		sf = schemafeed.New(ctx, cfg, schemaChange.EventClass, ca.targets,
 			initialHighWater, &ca.metrics.SchemaFeedMetrics, config.Opts.GetCanHandle())
 	}
@@ -1330,7 +1334,8 @@ func newChangeFrontierProcessor(
 	if cf.knobs.OverrideExecCfg != nil {
 		execCfg = cf.knobs.OverrideExecCfg(execCfg)
 	}
-	targets, err := AllTargets(ctx, spec.Feed, execCfg)
+	fmt.Printf("change frontier getting targets with initial high water: %s\n", spec.InitialHighWater)
+	targets, err := AllTargetsWithTS(ctx, spec.Feed, execCfg, *spec.InitialHighWater)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1793,6 +1793,7 @@ func (b *changefeedResumer) resumeWithRetries(
 		}
 
 		if flowErr != nil {
+			fmt.Printf("resumeWithRetries flowErr: %v\n", flowErr)
 			return flowErr
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -516,7 +516,7 @@ func coreChangefeed(
 			knobs.BeforeDistChangefeed()
 		}
 
-		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh, nil, targets)
+		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh, nil, targets, hlc.Timestamp{})
 		if err == nil {
 			log.Changefeed.Infof(ctx, "core changefeed completed with no error")
 			return nil
@@ -726,7 +726,8 @@ func createChangefeedJobRecord(
 		return nil, changefeedbase.Targets{}, errors.AssertionFailedf("unknown changefeed level: %s", changefeedStmt.Level)
 	}
 
-	targets, err := AllTargets(ctx, details, p.ExecCfg())
+	// get the statement time
+	targets, err := AllTargetsWithTS(ctx, details, p.ExecCfg(), details.StatementTime)
 	if err != nil {
 		return nil, changefeedbase.Targets{}, err
 	}
@@ -1739,13 +1740,20 @@ func (b *changefeedResumer) resumeWithRetries(
 
 			confPoller := make(chan struct{})
 			g := ctxgroup.WithContext(ctx)
-			targets, err := AllTargets(ctx, details, execCfg)
+			var changefeedStartTS hlc.Timestamp
+			if h := localState.progress.GetHighWater(); h != nil && !h.IsEmpty() {
+				changefeedStartTS = *h
+			} else {
+				changefeedStartTS = details.StatementTime
+			}
+			targets, err := AllTargetsWithTS(ctx, details, execCfg, changefeedStartTS)
 			if err != nil {
 				return err
 			}
+			fmt.Printf("resumeWithRetries initially found %d target tables\n", targets.NumUniqueTables())
 			g.GoCtx(func(ctx context.Context) error {
 				defer close(confPoller)
-				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh, onTracingEvent, targets)
+				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh, onTracingEvent, targets, changefeedStartTS)
 			})
 			g.GoCtx(func(ctx context.Context) error {
 				t := time.NewTicker(15 * time.Second)
@@ -1782,6 +1790,10 @@ func (b *changefeedResumer) resumeWithRetries(
 			if knobs != nil && knobs.HandleDistChangefeedError != nil {
 				flowErr = knobs.HandleDistChangefeedError(flowErr)
 			}
+		}
+
+		if flowErr != nil {
+			return flowErr
 		}
 
 		// Terminate changefeed if needed.

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -169,17 +169,73 @@ func TestDatabaseLevelChangefeedBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+	// testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+	// 	sqlDB := sqlutils.MakeSQLRunner(s.DB)
+	// 	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+	// 	sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
+	// 	sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
+	// 	sqlDB.Exec(t, `CREATE TABLE foo2 (a INT PRIMARY KEY, b STRING)`)
+	// 	sqlDB.Exec(t, `INSERT INTO foo2 VALUES (0, 'initial')`)
+	// 	sqlDB.Exec(t, `UPSERT INTO foo2 VALUES (0, 'updated')`)
+
+	// 	foo := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d`)
+	// 	defer closeFeed(t, foo)
+
+	// 	// 'initial' is skipped because only the latest value ('updated') is
+	// 	// emitted by the initial scan.
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo: [0]->{"after": {"a": 0, "b": "updated"}}`,
+	// 		`foo2: [0]->{"after": {"a": 0, "b": "updated"}}`,
+	// 	})
+
+	// 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b')`)
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo: [1]->{"after": {"a": 1, "b": "a"}}`,
+	// 		`foo: [2]->{"after": {"a": 2, "b": "b"}}`,
+	// 	})
+
+	// 	sqlDB.Exec(t, `INSERT INTO foo2 VALUES (1, 'a'), (2, 'b')`)
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo2: [1]->{"after": {"a": 1, "b": "a"}}`,
+	// 		`foo2: [2]->{"after": {"a": 2, "b": "b"}}`,
+	// 	})
+
+	// 	sqlDB.Exec(t, `UPSERT INTO foo VALUES (2, 'c'), (3, 'd')`)
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo: [2]->{"after": {"a": 2, "b": "c"}}`,
+	// 		`foo: [3]->{"after": {"a": 3, "b": "d"}}`,
+	// 	})
+
+	// 	sqlDB.Exec(t, `UPSERT INTO foo2 VALUES (2, 'c'), (3, 'd')`)
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo2: [2]->{"after": {"a": 2, "b": "c"}}`,
+	// 		`foo2: [3]->{"after": {"a": 3, "b": "d"}}`,
+	// 	})
+
+	// 	sqlDB.Exec(t, `DELETE FROM foo WHERE a = 1`)
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo: [1]->{"after": null}`,
+	// 	})
+
+	// 	sqlDB.Exec(t, `DELETE FROM foo2 WHERE a = 1`)
+	// 	assertPayloads(t, foo, []string{
+	// 		`foo2: [1]->{"after": null}`,
+	// 	})
+	// }
+
+	// cdcTest(t, testFn)
+
+	testFn2 := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
-		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
 		sqlDB.Exec(t, `CREATE TABLE foo2 (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `INSERT INTO foo2 VALUES (0, 'initial')`)
-		sqlDB.Exec(t, `UPSERT INTO foo2 VALUES (0, 'updated')`)
 
 		foo := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d`)
 		defer closeFeed(t, foo)
+		sqlDB.Exec(t, `UPSERT INTO foo VALUES (0, 'updated')`)
+		sqlDB.Exec(t, `UPSERT INTO foo2 VALUES (0, 'updated')`)
 
 		// 'initial' is skipped because only the latest value ('updated') is
 		// emitted by the initial scan.
@@ -223,7 +279,7 @@ func TestDatabaseLevelChangefeedBasics(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn)
+	cdcTest(t, testFn2)
 }
 
 func TestDatabaseLevelChangefeedWithIncludeFilter(t *testing.T) {

--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -7,6 +7,7 @@ package changefeedccl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 	"github.com/linkedin/goavro/v2"
@@ -54,13 +56,13 @@ type enrichedSourceProvider struct {
 }
 
 func GetTableSchemaInfo(
-	ctx context.Context, cfg *execinfra.ServerConfig, targets changefeedbase.Targets,
+	ctx context.Context, cfg *execinfra.ServerConfig, targets changefeedbase.Targets, initialHighWater hlc.Timestamp,
 ) (map[descpb.ID]tableSchemaInfo, error) {
 	schemaInfo := make(map[descpb.ID]tableSchemaInfo)
 	execCfg := cfg.ExecutorConfig.(*sql.ExecutorConfig)
 	err := targets.EachTarget(func(target changefeedbase.Target) error {
 		id := target.DescID
-		td, dbd, sd, err := getDescriptors(ctx, execCfg, id)
+		td, dbd, sd, err := getDescriptors(ctx, execCfg, id, initialHighWater)
 		if err != nil {
 			return err
 		}
@@ -548,13 +550,17 @@ func init() {
 const originCockroachDB = "cockroachdb"
 
 func getDescriptors(
-	ctx context.Context, execCfg *sql.ExecutorConfig, tableID descpb.ID,
+	ctx context.Context, execCfg *sql.ExecutorConfig, tableID descpb.ID, initialHighWater hlc.Timestamp,
 ) (catalog.TableDescriptor, catalog.DatabaseDescriptor, catalog.SchemaDescriptor, error) {
 	var tableDescriptor catalog.TableDescriptor
 	var dbDescriptor catalog.DatabaseDescriptor
 	var schemaDescriptor catalog.SchemaDescriptor
 	var err error
 	f := func(ctx context.Context, txn descs.Txn) error {
+		fmt.Printf("getDescriptors: setting fixed timestamp to %s\n", initialHighWater)
+		if err := txn.KV().SetFixedTimestamp(ctx, initialHighWater); err != nil {
+			return err
+		}
 		byIDGetter := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get()
 		tableDescriptor, err = byIDGetter.Table(ctx, tableID)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -557,9 +557,11 @@ func getDescriptors(
 	var schemaDescriptor catalog.SchemaDescriptor
 	var err error
 	f := func(ctx context.Context, txn descs.Txn) error {
-		fmt.Printf("getDescriptors: setting fixed timestamp to %s\n", initialHighWater)
-		if err := txn.KV().SetFixedTimestamp(ctx, initialHighWater); err != nil {
-			return err
+		if initialHighWater != (hlc.Timestamp{}) {
+			fmt.Printf("getDescriptors: setting fixed timestamp to %s\n", initialHighWater)
+			if err := txn.KV().SetFixedTimestamp(ctx, initialHighWater); err != nil {
+				return err
+			}
 		}
 		byIDGetter := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get()
 		tableDescriptor, err = byIDGetter.Table(ctx, tableID)

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -109,7 +109,8 @@ func newEventConsumer(
 		if encodingOpts.Envelope == changefeedbase.OptEnvelopeEnriched {
 			var schemaInfo map[descpb.ID]tableSchemaInfo
 			if inSet(changefeedbase.EnrichedPropertySource, encodingOpts.EnrichedProperties) {
-				schemaInfo, err = GetTableSchemaInfo(ctx, cfg, feed.Targets)
+				// TODO(log-head): should cursor be used here instead of initialHighWater?
+				schemaInfo, err = GetTableSchemaInfo(ctx, cfg, feed.Targets, *spec.InitialHighWater)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -288,9 +288,12 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 	initialTableDescsFn := func(
 		ctx context.Context, txn descs.Txn,
 	) error {
-		fmt.Printf("primeInitialTableDescs: setting fixed timestamp to %s\n", tf.initialFrontier)
-		if err := txn.KV().SetFixedTimestamp(ctx, tf.initialFrontier); err != nil {
-			return err
+		if tf.initialFrontier != (hlc.Timestamp{}) {
+			fmt.Printf("primeInitialTableDescs: setting fixed timestamp to %s\n", tf.initialFrontier)
+			if err := txn.KV().SetFixedTimestamp(ctx, tf.initialFrontier); err != nil {
+				// fmt.Printf("primeInitialTableDescs: failed setting fixed timestamp to %s\n", tf.initialFrontier)
+				return err
+			}
 		}
 		descriptors := txn.Descriptors()
 		err := tf.targets.EachTableID(func(id descpb.ID) error {

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -288,13 +288,22 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 	initialTableDescsFn := func(
 		ctx context.Context, txn descs.Txn,
 	) error {
-		descriptors := txn.Descriptors()
-		initialDescs = initialDescs[:0]
+		fmt.Printf("primeInitialTableDescs: setting fixed timestamp to %s\n", tf.initialFrontier)
 		if err := txn.KV().SetFixedTimestamp(ctx, tf.initialFrontier); err != nil {
 			return err
 		}
+		descriptors := txn.Descriptors()
+		err := tf.targets.EachTableID(func(id descpb.ID) error {
+			fmt.Printf("targets have table id %d\n", id)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		initialDescs = initialDescs[:0]
 		// Note that all targets are currently guaranteed to be tables.
 		return tf.targets.EachTableID(func(id descpb.ID) error {
+			fmt.Printf("primeInitialTableDescs: fetching table descriptor %d at timestamp %s\n", id, tf.initialFrontier)
 			tableDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, id)
 			if err != nil {
 				return err
@@ -305,8 +314,10 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 	}
 
 	if err := tf.db.DescsTxn(ctx, initialTableDescsFn); err != nil {
+		fmt.Printf("primeInitialTableDescs: error fetching table descriptors: %v\n", err)
 		return err
 	}
+	fmt.Printf("primeInitialTableDescs: fetched %d table descriptors", len(initialDescs))
 
 	func() {
 		tf.mu.Lock()

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -106,6 +106,10 @@ message ChangeFrontierSpec {
   // ResolvedSpans contains the resolved spans that should be restored
   // when the changefeed resumes.
   repeated cockroach.sql.jobs.jobspb.ResolvedSpan resolved_spans = 8 [(gogoproto.nullable) = false];
+
+  // InitialHighWater represents a point in time where all data is known to have
+  // been seen for this changefeed job.
+  optional util.hlc.Timestamp initial_high_water = 9;
 }
 
 // ChangefeedProgressConfig is the configuration for the changefeed's progress tracking.


### PR DESCRIPTION
… creation

When a changefeed is planned and executed, there are several places where target table descriptors are fetched. With a db-level changefeed, the set of tables can change during changefeed startup. Now, the timestamp is set to the initial high water for retrieving table descriptors.  Fixes: #154549 Epic: CRDB-1421

Release note: None