### PR TITLE
release-24.1.25-rc: workflows: update names of GitHub Action runner groups

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -53,7 +53,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   acceptance:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   check_generated_code:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   docker_image_amd64:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -110,7 +110,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   examples_orms:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
         run: ./cockroach/build/github/cleanup-engflow-keys.sh
         if: always()
   lint:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   local_roachtest:
-    runs-on: [self-hosted, basic_big_runner_group]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   local_roachtest_fips:
-    runs-on: [self-hosted, basic_runner_group_fips]
+    runs-on: [self-hosted, ubuntu_2004_fips]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -197,7 +197,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   linux_amd64_build:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -218,7 +218,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   linux_amd64_fips_build:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -239,7 +239,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   unit_tests:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Backport 1/1 commits from #154793 on behalf of @rickystewart.

----

Backport 1/1 commits from #154698.

/cc @cockroachdb/release

---

These are the new-style names that will make it easier to migrate to Ubuntu 22.04+ when the time comes.

Release justification: Non-production code changes