### PR TITLE
kvserver: add vmodule logging for TestReplicateQueueSeesLearnerOrJointConfig

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1220,6 +1220,7 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	// NB also see TestAllocatorRemoveLearner for a lower-level test.
+	testutils.SetVModule(t, "queue=4,replicate_queue=4,replica_command=4,allocator=4,replicate=4")
 
 	ctx := context.Background()
 	_, ltk := makeReplicationTestKnobs()


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/153988
Release note: none 