### PR TITLE
release-25.4: roachtest: fix schema change statement in mixed version test

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -118,7 +118,7 @@ func executeSupportedDDLs(
 		`TRUNCATE testdb.testsc.t3`,
 		`ALTER TABLE testdb.testsc.t2 RENAME TO t2_renamed`,
 		`ALTER TABLE testdb.testsc.t2_renamed RENAME TO t2`,
-		`ALTER TABLE testdb.testsc.t2 ALTER COLUMN j SET ON UPDATE j + 1`,
+		`ALTER TABLE testdb.testsc.t2 ALTER COLUMN j SET ON UPDATE 1`,
 		`ALTER TABLE testdb.testsc.t2 RENAME COLUMN k TO k_renamed`,
 		`ALTER TABLE testdb.testsc.t2 RENAME COLUMN k_renamed TO k`,
 	}


### PR DESCRIPTION
Backport 1/1 commits from #155072 on behalf of @rafiss.

----

The test was executing a schema change statement that doesn't succeed, since ON UPDATE expressions can't reference other columns.

fixes https://github.com/cockroachdb/cockroach/issues/155037
Release note: None

----

Release justification: test only change