### PR TITLE
release-25.4: sql/stats: add partial stats with WHERE clause mixed version logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_partial_stats
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_partial_stats
@@ -1,0 +1,47 @@
+# LogicTest: cockroach-go-testserver-configs
+
+# Sanity check that partial stats with a WHERE clause can only be collected once
+# the cluster is upgraded to 25.4.
+
+statement ok
+CREATE TABLE t (a INT, INDEX (a));
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3), (4), (5);
+
+statement ok
+ANALYZE t;
+
+# Clear the stat cache so that creating partial statistics has access to the
+# latest full statistic.
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
+statement error pq: creating partial statistics with a WHERE clause is not yet supported
+CREATE STATISTICS pstat ON a FROM t WHERE a > 2;
+
+upgrade 0
+
+statement error pq: unimplemented: CREATE STATISTICS with a WHERE clause is not supported until v25.4
+CREATE STATISTICS pstat ON a FROM t WHERE a > 2;
+
+upgrade 1
+
+statement error pq: unimplemented: CREATE STATISTICS with a WHERE clause is not supported until v25.4
+CREATE STATISTICS pstat ON a FROM t WHERE a > 2;
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+statement ok
+CREATE STATISTICS pstat ON a FROM t WHERE a > 2;
+
+query TTIIIT colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count, partial_predicate
+FROM [SHOW STATISTICS FOR TABLE t]
+WHERE statistics_name = 'pstat'
+----
+statistics_name  column_names  row_count  distinct_count  null_count  partial_predicate
+pstat            {a}           3          3               0           a > 2

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 11,
+    shard_count = 12,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.2/generated_test.go
@@ -115,6 +115,13 @@ func TestLogic_mixed_version_ltree(
 	runLogicTest(t, "mixed_version_ltree")
 }
 
+func TestLogic_mixed_version_partial_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_partial_stats")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 8,
+    shard_count = 9,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.3/generated_test.go
@@ -101,6 +101,13 @@ func TestLogic_mixed_version_ltree(
 	runLogicTest(t, "mixed_version_ltree")
 }
 
+func TestLogic_mixed_version_partial_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_partial_stats")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Backport 1/1 commits from #155107 on behalf of @Uzair5162.

----

This commit adds a mixed version logic test to ensure that partial statistics with a `WHERE` clause can't be collected on clusters not on version 25.4. We added support for partial stats with `WHERE` clauses in #152469 behind a version gate.

Part of: #153309

Release note: None

----

Release justification: test-only change.