### PR TITLE
build: allow testing of PR commits for microbenchmark CI

### DIFF
--- a/.github/actions/microbenchmark-build/action.yml
+++ b/.github/actions/microbenchmark-build/action.yml
@@ -7,6 +7,9 @@ inputs:
   pkg:
     description: "test package to build"
     required: true
+  base_offset:
+    description: "offset base by this many commits"
+    required: false
 outputs:
   merge_base:
     description: "merge base"
@@ -33,7 +36,7 @@ runs:
       if: inputs.ref == 'base'
       run: |
         set -e
-        NUM_COMMITS=${{ github.event.pull_request.commits }}          
+        NUM_COMMITS=$(( ${{ github.event.pull_request.commits }} - ${{ inputs.base_offset || 0 }} ))          
         MERGE_BASE=$(git rev-parse HEAD~${NUM_COMMITS})
         echo "merge_base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -14,6 +14,10 @@ env:
   HEAD: ${{ github.event.pull_request.head.sha }}
   BUCKET: "cockroach-microbench-ci"
   PACKAGE: "pkg/sql/tests"
+  # Base offset: increases the base commit selection by the given offset, so
+  # benchmarks are able to run against commits in the PR. Use only for testing;
+  # always reset to default (0) before merging.
+  BASE_OFFSET: 0
 jobs:
   base:
     name: build merge base
@@ -31,6 +35,7 @@ jobs:
         with:
           ref: base
           pkg: ${{ env.PACKAGE }}
+          base_offset: ${{ env.BASE_OFFSET }}
   head:
     name: build head
     runs-on: [self-hosted, ubuntu_2004]


### PR DESCRIPTION
Previously, the microbenchmarks CI job would always use the merge base as the baseline when testing against the PR. Sometimes when trying to determine the cause of a regression an author might want to make modifications that affect both the base and the head of the PR in terms of the microbenchmark without having to merge a different PR to achieve this result.

For convenience a commit from the PR can now be selected by adjusting the BASE_OFFSET env variable on `microbenchmarks-ci.yaml`. This is only for testing purposes and should be reverted once the author has completed their testing.

Epic: None
Release note: None