### PR TITLE
cli(tsdump): upsample counter metric of 30 min interval during Datadog upload

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -76,9 +76,9 @@ var debugTimeSeriesDumpOpts = struct {
 var hostNameOverride string
 
 // datadogSeriesThreshold holds the threshold for the number of series
-// that will be uploaded to Datadog in a single request. We have capped it to 100
+// that will be uploaded to Datadog in a single request. We have capped it to 50
 // to avoid hitting the Datadog API limits.
-var datadogSeriesThreshold = 100
+var datadogSeriesThreshold = 50
 
 const uploadWorkerErrorMessage = "--upload-workers is set to an invalid value." +
 	" please select a value which between 1 and 100."


### PR DESCRIPTION
Previously, We were uploading counter metric types to Datadog without considering the metric interval. The Datadog honours the interval which is set in the metrics summary. Here, the  value is set as `10` seconds considering default scrape interval. This resulted into improper visulisation of the metrics which are generated at 30min interval. To address this, this patch upsample counter metric type of 30 min interval to 10 second interval. This means that we add 180 data points (30min/10sec=180) so that the counter metrics can be visualised properly irrespective of the metric interval.

Epic: none
Part of: CRDB-54228
Release note: None