### PR TITLE
rpc: disable loopbackTransport via NoLoopbackDialer knob

### DIFF
--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -56,11 +56,16 @@ type ContextTestingKnobs struct {
 	// this value if non-nil at construction time.
 	StorageClusterID *uuid.UUID
 
-	// NoLoopbackDialer, when set, indicates that a test does not care
-	// about the special loopback dial semantics.
-	// If this is left unset, the test is responsible for ensuring
-	// SetLoopbackDialer() has been called on the rpc.Context.
-	// (This is done automatically by server.Server/server.SQLServerWrapper.)
+	// NoLoopbackDialer, when true, indicates that a test does not care about the
+	// special loopback dial semantics. In this case, an error results from use of
+	// the loopbackTransport or loopbackDialerFn (which would indicate a
+	// programming error in RPCContext, since NoLoopbackDialer is consulted when
+	// determining whether to use those).
+	//
+	// When false, SetLoopbackDialer() must have been called on the rpc.Context In
+	// productino code, this is done automatically by
+	// server.Server/server.SQLServerWrapper, but some lower-level tests may have
+	// to do it manually.
 	NoLoopbackDialer bool
 }
 


### PR DESCRIPTION
Prior to this commit, the NoLoopbackDialer knob would replace the loopback dialer implementation with the regular TCP dialer. However, the loopbackTransport (which is what causes a call to the loopbackDialerFn in the first place) has its own call path and in particular, it sets different gRPC options that might be cheaper than what is commonly used (for example, no snappy compression). It is desirable to remove this discrepancy.

This commit disables use of the loopbackTransport entirely if the knob is set, the desired effect being that when talking to a TestCluster under this knob, it doesn't matter for performance whether the SQL gateway matches the location of the lease; local communication should be exactly as expensive as "remote" communication (all within the same process, but communicating through identical TCP network connections).

Unblocks #153865.

Epic: CRDB-55052