### PR TITLE
build: increase timeouts for microbenchmark CI run groups

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -47,7 +47,7 @@ jobs:
           pkg: ${{ env.PACKAGE }}
   run-group-1:
     runs-on: [self-hosted, ubuntu_2004_microbench]
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: [base, head]
     steps:
       - name: Checkout
@@ -60,7 +60,7 @@ jobs:
           group: 1
   run-group-2:
     runs-on: [self-hosted, ubuntu_2004_microbench]
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: [base, head]
     steps:
       - name: Checkout


### PR DESCRIPTION
We've been hitting these limits due to some minor changes in the underlying benchmarks in these groups. This ups the limit so the job doesn't time out.

Epic: None
Release note: None