### PR TITLE
kv: migrate off log.Dev

### DIFF
--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -176,7 +176,7 @@ func TestClientRetryNonTxn(t *testing.T) {
 					}
 					notify <- struct{}{}
 					if err != nil {
-						log.Dev.Errorf(context.Background(), "error on non-txn request: %s", err)
+						log.KvExec.Errorf(context.Background(), "error on non-txn request: %s", err)
 					}
 					doneCall <- errors.Wrapf(
 						err, "%d: expected success on non-txn call to %s",

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -218,7 +218,7 @@ func (s *CrossRangeTxnWrapperSender) Send(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, *kvpb.Error) {
 	if ba.Txn != nil {
-		log.Dev.Fatalf(ctx, "CrossRangeTxnWrapperSender can't handle transactional requests")
+		log.KvExec.Fatalf(ctx, "CrossRangeTxnWrapperSender can't handle transactional requests")
 	}
 
 	br, pErr := s.wrapped.Send(ctx, ba)
@@ -1167,7 +1167,7 @@ func (db *DB) sendUsingSender(
 	br, pErr := sender.Send(ctx, ba)
 	if pErr != nil {
 		if log.V(1) {
-			log.Dev.Infof(ctx, "failed batch: %s", pErr)
+			log.KvExec.Infof(ctx, "failed batch: %s", pErr)
 		}
 		return nil, pErr
 	}

--- a/pkg/kv/range_lookup.go
+++ b/pkg/kv/range_lookup.go
@@ -249,13 +249,13 @@ func RangeLookup(
 		if rc == kvpb.INCONSISTENT {
 			return nil, nil, nil
 		}
-		log.Dev.Warningf(ctx, "range lookup of key %s found only non-matching ranges %v; retrying",
+		log.KvExec.Warningf(ctx, "range lookup of key %s found only non-matching ranges %v; retrying",
 			key, prefetchedRanges)
 	}
 
 	ctxErr := ctx.Err()
 	if ctxErr == nil {
-		log.Dev.Fatalf(ctx, "retry loop broke before context expired")
+		log.KvExec.Fatalf(ctx, "retry loop broke before context expired")
 	}
 	return nil, nil, ctxErr
 }
@@ -320,7 +320,7 @@ func lookupRangeFwdScan(
 		RequestHeader: kvpb.RequestHeaderFromSpan(bounds.AsRawSpanWithNoLocals()),
 	})
 	if !TestingIsRangeLookup(ba) {
-		log.Dev.Fatalf(ctx, "BatchRequest %v not detectable as RangeLookup", ba)
+		log.KvExec.Fatalf(ctx, "BatchRequest %v not detectable as RangeLookup", ba)
 	}
 
 	br, pErr := sender.Send(ctx, ba)
@@ -394,7 +394,7 @@ func lookupRangeRevScan(
 		RequestHeader: kvpb.RequestHeaderFromSpan(revBounds.AsRawSpanWithNoLocals()),
 	})
 	if !TestingIsRangeLookup(ba) {
-		log.Dev.Fatalf(ctx, "BatchRequest %v not detectable as RangeLookup", ba)
+		log.KvExec.Fatalf(ctx, "BatchRequest %v not detectable as RangeLookup", ba)
 	}
 
 	br, pErr := sender.Send(ctx, ba)

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -406,7 +406,7 @@ func (txn *Txn) TestingSetPriority(priority enginepb.TxnPriority) {
 	// non-randomized, priority for the transaction.
 	txn.mu.userPriority = roachpb.UserPriority(-priority)
 	if err := txn.mu.sender.SetUserPriority(txn.mu.userPriority); err != nil {
-		log.Dev.Fatalf(context.TODO(), "%+v", err)
+		log.KvExec.Fatalf(context.TODO(), "%+v", err)
 	}
 	txn.mu.Unlock()
 }
@@ -1056,7 +1056,7 @@ func (txn *Txn) rollback(ctx context.Context) *kvpb.Error {
 						// already committed. We don't spam the logs with those.
 						log.VEventf(ctx, 2, "async rollback failed: %s", pErr)
 					} else {
-						log.Dev.Infof(ctx, "async rollback failed: %s", pErr)
+						log.KvExec.Infof(ctx, "async rollback failed: %s", pErr)
 					}
 				}
 				return nil
@@ -1172,7 +1172,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 					// We sent transactional requests, so the TxnCoordSender was supposed to
 					// turn retryable errors into TransactionRetryWithProtoRefreshError. Note that this
 					// applies only in the case where this is the root transaction.
-					log.Dev.Fatalf(ctx, "unexpected UnhandledRetryableError at the txn.exec() level: %s", err)
+					log.KvExec.Fatalf(ctx, "unexpected UnhandledRetryableError at the txn.exec() level: %s", err)
 				}
 			} else if t := (*kvpb.TransactionRetryWithProtoRefreshError)(nil); errors.As(err, &t) {
 				if txn.ID() != t.PrevTxnID {
@@ -1219,13 +1219,13 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 					txn.DebugName(), attempt, err, maxRetries, rollbackErr,
 				),
 				ErrAutoRetryLimitExhausted)
-			log.Dev.Warningf(ctx, "%v", err)
+			log.KvExec.Warningf(ctx, "%v", err)
 			break
 		}
 
 		const warnEvery = 10
 		if attempt%warnEvery == 0 {
-			log.Dev.Warningf(ctx, "have retried transaction: %s %d times, most recently because of the "+
+			log.KvExec.Warningf(ctx, "have retried transaction: %s %d times, most recently because of the "+
 				"retryable error: %s. Is the transaction stuck in a retry loop?", txn.DebugName(), attempt, err)
 		}
 
@@ -1395,7 +1395,7 @@ func (txn *Txn) Send(
 		if requestTxnID != retryErr.PrevTxnID {
 			// KV should not return errors for transactions other than the one that sent
 			// the request.
-			log.Dev.Fatalf(ctx, "retryable error for the wrong txn. "+
+			log.KvExec.Fatalf(ctx, "retryable error for the wrong txn. "+
 				"requestTxnID: %s, retryErr.PrevTxnID: %s. retryErr: %s",
 				requestTxnID, retryErr.PrevTxnID, retryErr)
 		}
@@ -1629,7 +1629,7 @@ func (txn *Txn) UpdateStateOnRemoteRetryableErr(ctx context.Context, pErr *kvpb.
 	defer txn.mu.Unlock()
 
 	if pErr.TransactionRestart() == kvpb.TransactionRestart_NONE {
-		log.Dev.Fatalf(ctx, "unexpected non-retryable error: %s", pErr)
+		log.KvExec.Fatalf(ctx, "unexpected non-retryable error: %s", pErr)
 	}
 
 	// If the transaction has been reset since this request was sent,

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -432,7 +432,7 @@ func TestWrongTxnRetry(t *testing.T) {
 
 	var retries int
 	txnClosure := func(ctx context.Context, outerTxn *Txn) error {
-		log.Dev.Infof(ctx, "outer retry")
+		log.KvExec.Infof(ctx, "outer retry")
 		retries++
 		// Ensure the KV transaction is created.
 		if err := outerTxn.Put(ctx, "a", "b"); err != nil {


### PR DESCRIPTION
These are the last calls to `log.Dev`.

Closes #152584.
Epic: CRDB-52421