### PR TITLE
log,logflags: allow seeding test log config from env

### DIFF
--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -56,10 +56,22 @@ const redactionPolicyManagedEnvVar = "COCKROACH_REDACTION_POLICY_MANAGED"
 
 var RedactionPolicyManaged = envutil.EnvOrDefaultBool(redactionPolicyManagedEnvVar, false)
 
+// testLogConfigEnvVar is the env var used to specify a custom YAML log configuration
+// for tests. This can be overridden by the -test-log-config command-line flag.
+//
+// Example: To show all log channels (including HEALTH, STORAGE, KV_DISTRIBUTION)
+// inline with -show-logs:
+//
+//	export COCKROACH_TEST_LOG_CONFIG='sinks: {stderr: {channels: all, filter: INFO}}'
+const testLogConfigEnvVar = "COCKROACH_TEST_LOG_CONFIG"
+
+var envTestLogConfig = envutil.EnvOrDefaultString(testLogConfigEnvVar, "")
+
 func init() {
 	logflags.InitFlags(
 		&logging.showLogs,
 		&logging.testLogConfig,
+		envTestLogConfig, // default value
 		&logging.vmoduleConfig.mu.vmodule,
 	)
 

--- a/pkg/util/log/logflags/logflags.go
+++ b/pkg/util/log/logflags/logflags.go
@@ -16,8 +16,10 @@ const (
 
 // InitFlags creates logging flags which update the given variables. The passed mutex is
 // locked while the boolean variables are accessed during flag updates.
-func InitFlags(showLogs *bool, testLogConfig *string, vmodule flag.Value) {
+func InitFlags(
+	showLogs *bool, testLogConfig *string, testLogConfigDefault string, vmodule flag.Value,
+) {
 	flag.Var(vmodule, VModuleName, "comma-separated list of pattern=N settings for file-filtered logging (significantly hurts performance)")
-	flag.StringVar(testLogConfig, TestLogConfigName, "", "YAML log configuration for tests")
+	flag.StringVar(testLogConfig, TestLogConfigName, testLogConfigDefault, "YAML log configuration for tests")
 	flag.BoolVar(showLogs, ShowLogsName, *showLogs, "print logs instead of saving them in files")
 }


### PR DESCRIPTION
This makes it easier to apply a custom config to various test invocations without having to juggle flags.

Many KV-specific logs are not included by default, so they're not in `-show-logs`, which can be annoying.

Epic: none