### PR TITLE
sql/backfill: skip TestVectorIndexMergingDuringBackfillWithPrefix under duress

### DIFF
--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -352,7 +352,7 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "too slow")
+	skip.UnderDuress(t, "too slow")
 
 	// Channel to block the backfill process
 	blockBackfill := make(chan struct{})


### PR DESCRIPTION
We just saw another failure under deadlock with secondary tenant where the cluster simply seems too overloaded. Let's skip this test under all heavy configs.

Fixes: #155139.
Release note: None