### PR TITLE
release-25.2: changefeedccl: disable roachtest on IBM due to missing Kafka support

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2412,12 +2412,13 @@ func registerCDC(r registry.Registry) {
 		Run:              runCDCMultipleSchemaChanges,
 	})
 	r.Add(registry.TestSpec{
-		Name:             "cdc/tpcc-100/10min/sink=kafka/envelope=enriched",
-		Owner:            registry.OwnerCDC,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllClouds,
+		Name:      "cdc/tpcc-100/10min/sink=kafka/envelope=enriched",
+		Owner:     registry.OwnerCDC,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
+		Leases:    registry.MetamorphicLeases,
+		// Disabled on IBM due to lack of Kafka support on s390x.
+		CompatibleClouds: registry.AllClouds.NoIBM(),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)


### PR DESCRIPTION
Backport 1/1 commits from #153792 on behalf of @aerfrei.

----

Marks the 10 minute tpcc-100 test as disabled on IBM platforms, since kafka is not supported on s390x.

Fixes: #153759

Release note: None

----

Release justification: Test only.