### PR TITLE
release-25.3: changefeedccl: fix test flake by waiting for rangefeed start

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9285,6 +9285,10 @@ func TestDistSenderRangeFeedPopulatesVirtualTable(t *testing.T) {
 		})
 		defer closeFeed(t, cf)
 
+		// We need to ensure that the reason the user doesn't see the table
+		// is not because the rangefeed hasn't started yet.
+		waitForHighwater(t, cf.(cdctest.EnterpriseTestFeed), s.Server.JobRegistry().(*jobs.Registry))
+
 		for _, c := range cases {
 			testutils.SucceedsSoon(t, func() error {
 				asUser(t, f, c.user, func(userDB *sqlutils.SQLRunner) {


### PR DESCRIPTION
Backport 1/1 commits from #152689 on behalf of @aerfrei.

----

Previously, this test would flake because a table that we were asserting the admin user could see hadn't yet become visible. Now we assert the changefeed and rangefeed have started by waiting for a highwater mark.

Epic: none
Fixes: #152060

Release note: None

----

Release justification: Test only change in response to test flake