### PR TITLE
server,security: remove some deprecated ioutil usages

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -772,11 +772,6 @@
             "pkg/.*_generated\\.go$": "generated code",
             "pkg/roachprod/vm/aws/embedded\\.go$": "generated code",
             "pkg/security/securitytest/embedded\\.go$": "generated code",
-            "pkg/security/securityassets/security_assets.go$": "excluded until all uses of io/ioutil are replaced",
-            "pkg/security/securitytest/securitytest.go$": "excluded until all uses of io/ioutil are replaced",
-            "pkg/server/dumpstore/dumpstore.go$": "excluded until all uses of io/ioutil are replaced",
-            "pkg/server/dumpstore/dumpstore_test.go$": "excluded until all uses of io/ioutil are replaced",
-            "pkg/server/profiler/profilestore_test.go$": "excluded until all uses of io/ioutil are replaced",
             "pkg/util/bulk/tracing_aggregator.go$":"temporary exclusion until #100438 is resolved",
             "pkg/util/log/file_api.go$": "excluded until all uses of io/ioutil are replaced",
             "pkg/build/bazel/bazel\\.go$": "Runfile function deprecated"

--- a/pkg/server/dumpstore/dumpstore_test.go
+++ b/pkg/server/dumpstore/dumpstore_test.go
@@ -8,7 +8,7 @@ package dumpstore
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -187,9 +187,17 @@ func populate(t *testing.T, dirName string, fileNames []string, sizes []int64) [
 	}
 
 	// Retrieve the file list for the remainder of the test.
-	files, err := ioutil.ReadDir(dirName)
+	entries, err := os.ReadDir(dirName)
 	if err != nil {
 		t.Fatal(err)
+	}
+	files := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, info)
 	}
 	return files
 }

--- a/pkg/server/profiler/profilestore_test.go
+++ b/pkg/server/profiler/profilestore_test.go
@@ -8,7 +8,7 @@ package profiler
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -221,9 +221,17 @@ func populate(t *testing.T, dirName string, fileNames []string) []os.FileInfo {
 	}
 
 	// Retrieve the file list for the remainder of the test.
-	files, err := ioutil.ReadDir(dirName)
+	entries, err := os.ReadDir(dirName)
 	if err != nil {
 		t.Fatal(err)
+	}
+	files := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, info)
 	}
 	return files
 }


### PR DESCRIPTION
The `ioutil` package is deprecated. Update callsites to a more suitable alternative.

Fixes #92861.

Release note: None.

Epic: None.