### PR TITLE
release-25.4: spanconfigreconcilerccl: deflake spanconfigreconcilerccl_test

### DIFF
--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -71,6 +71,9 @@ func (h *Handle) InitializeTenant(ctx context.Context, tenID roachpb.TenantID) *
 				SpanConfig:     h.scKnobs,
 				GCJob:          &tenantGCJobKnobs,
 				UpgradeManager: serverUpgradeKnobs,
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					UseTransactionalDescIDGenerator: true,
+				},
 			},
 		}
 		var err error

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
@@ -462,6 +463,9 @@ func newInternalPlanner(
 	p.extendedEvalCtx.NodeID = execCfg.NodeInfo.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
 	p.extendedEvalCtx.DescIDGenerator = execCfg.DescIDGenerator
+	if execCfg.TestingKnobs.UseTransactionalDescIDGenerator && txn != nil {
+		p.extendedEvalCtx.DescIDGenerator = descidgen.NewTransactionalGenerator(execCfg.Settings, execCfg.Codec, txn)
+	}
 
 	p.sessionDataMutatorIterator = smi
 


### PR DESCRIPTION
Backport 1/1 commits from #155167 on behalf of @fqazi.

----

Previously, the span config reconciller tests when running under a tenant did not use the transactional descriptor ID generator, which could lead to flake. Additionally, the transactional ID generator also was not being used for creating internal objects, when the testing knob is enabled. This patch fixes the multi-tenant tests to use the transactional ID generator and enables it for internal queries as well.

Fixes: #154585

Release note: None

----

Release justification: changes for a testing knob and a test