### PR TITLE
norm: rule to simplify const comparison with ANY values

### DIFF
--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -101,6 +101,27 @@ $result
 =>
 $result
 
+# FoldComparisonWithAny evaluates a comparison operation over a constant
+# and an ANY/SOME clause, replacing the entire expression with a constant.
+# It iterates over elements in the clause and tries to find constants that
+# make the comparison a definite value.
+[FoldComparisonWithAny, Normalize]
+(AnyScalar
+    $left:* & (IsConstValueOrGroupOfConstValues $left)
+    $right:* & (IsTuple $right)
+    $cmp:* &
+        (Let
+            ($result $ok):(FoldComparisonWithAny
+                $cmp
+                $left
+                $right
+            )
+            $ok
+        )
+)
+=>
+$result
+
 # FoldComparison is similar to FoldBinary, but it involves a comparison
 # operation. As with FoldBinary, FoldComparison applies as long as the
 # evaluation would not cause an error.

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -789,6 +789,132 @@ values
  └── (false,)
 
 # --------------------------------------------------
+# FoldComparisonWithAny
+# --------------------------------------------------
+norm expect=FoldComparisonWithAny
+SELECT 1 >= any(1, (select x from t limit 1))
+----
+values
+ ├── columns: "?column?":4!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── (true,)
+
+norm expect=FoldComparisonWithAny
+SELECT 5 > any(8, 9, 10, 11)
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,)
+
+norm expect=FoldComparisonWithAny
+SELECT 1 <= any(1, 2, 3, (select x from t limit 1))
+----
+values
+ ├── columns: "?column?":4!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── (true,)
+
+norm expect=FoldComparisonWithAny
+SELECT 10 < any(1, 2, 3, 4)
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,)
+
+norm expect=FoldComparisonWithAny
+SELECT 10 < any(1, 2, NULL, 4)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,)
+
+norm expect=FoldComparisonWithAny
+SELECT 10 > any(1, 2, NULL, 4)
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,)
+
+norm expect=FoldComparisonWithAny
+SELECT 10 > any(1, 2, NULL, (select x from t limit 1))
+----
+values
+ ├── columns: "?column?":4!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── (true,)
+
+norm expect=FoldComparisonWithAny
+SELECT 'cockroaches' LIKE any('%bugs%', '%roaches%')
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (true,)
+
+norm expect=FoldComparisonWithAny
+SELECT 'cockroaches' LIKE any('%bugs%', '%birds%')
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (false,)
+
+norm expect-not=FoldComparisonWithAny
+SELECT 1 > any(5, 4, random()+1)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1 > ANY (5, 4, random() + 1.0),)
+
+norm expect-not=FoldComparisonWithAny
+SELECT 1 > any(5, NULL, random()+1)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1 > ANY (5, NULL, random() + 1.0),)
+
+norm expect-not=FoldComparisonWithAny
+SELECT 1 > any(NULL, random()+1)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1 > ANY (NULL, random() + 1.0),)
+
+# --------------------------------------------------
 # FoldCast
 # --------------------------------------------------
 norm expect=FoldCast


### PR DESCRIPTION
Given a constant value compared using the ANY or
SOME operators, we check for constants
in the right hand side that can be used to
simplify the comparison to True. For example,
the expression: 0.1 < ANY (c0, 0.4) can now be simplified since 0.1 < 0.4.

Fixes #132328
Release note: None
Epic: CRDB-42979