### PR TITLE
cli, security: disable root user and auth changes for debug zip user

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -942,6 +942,22 @@ provided for node user if this flag is set.
 `,
 	}
 
+	DisallowRootLogin = FlagInfo{
+		Name: "disallow-root-login",
+		Description: `
+When set, prevents authentication attempts by clients presenting certificates
+with "root" as one of the principals (CommonName or SubjectAlternativeName).
+This applies to both SQL client connections and RPC connections. Authentication
+attempts by root will be rejected with an error.
+<PRE>
+
+</PRE>
+Note: Please ensure none of the certificates that are in use by the cluster or
+the SQL/RPC clients have a root in the SAN fields since the flag will block
+access to that client.
+`,
+	}
+
 	TLSCipherSuites = FlagInfo{
 		Name: "tls-cipher-suites",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -488,6 +488,7 @@ var startCtx struct {
 	serverRootCertDN       string
 	serverNodeCertDN       string
 	serverTLSCipherSuites  []string
+	disallowRootLogin      bool
 
 	// The TLS auto-handshake parameters.
 	initToken             string
@@ -543,6 +544,7 @@ func setStartContextDefaults() {
 	startCtx.serverCertPrincipalMap = nil
 	startCtx.serverRootCertDN = ""
 	startCtx.serverNodeCertDN = ""
+	startCtx.disallowRootLogin = false
 	startCtx.serverListenAddr = ""
 	startCtx.unencryptedLocalhostHTTP = false
 	startCtx.tempDir = ""

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -562,8 +562,9 @@ func init() {
 		// We add the disallow root login flag for disabling the root user from rpc
 		// and sql access for compliance reasons. We currently mark it as hidden
 		// since the flag behavior is experimental and subject to change.
-		// Additionally, a user needs to be configured for collecting debug zips if
-		// this flag is enabled, which we currently do not validate.
+		//
+		// NB: a user needs to be configured for collecting debug zips if this
+		// flag is enabled, which we currently do not validate.
 		cliflagcfg.BoolFlag(f, &startCtx.disallowRootLogin, cliflags.DisallowRootLogin)
 		_ = f.MarkHidden(cliflags.DisallowRootLogin.Name)
 
@@ -1156,7 +1157,7 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	if err := security.SetNodeSubject(startCtx.serverNodeCertDN); err != nil {
 		return err
 	}
-	security.EnableDisallowRootLogin(startCtx.disallowRootLogin)
+	security.SetDisallowRootLogin(startCtx.disallowRootLogin)
 	// Currently we don't handle the case where we are setting the --insecure flag
 	// as well as providing the --tls-cipher-suites, we should probably error out
 	// if both are set, issue: #144935.

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -150,6 +150,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",
+        "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",

--- a/pkg/rpc/auth.go
+++ b/pkg/rpc/auth.go
@@ -491,6 +491,7 @@ func (a kvAuth) selectAuthzMethod(ar authnResult) (requiredAuthzMethod, error) {
 // present in the cert user scopes.
 func checkRootOrNodeInScope(clientCert *x509.Certificate, serverTenantID roachpb.TenantID) error {
 	rootLoginDisabledValidate := false
+	debugUserScopedCert := false
 
 	containsFn := func(scope security.CertificateUserScope) bool {
 		// Only consider global scopes or scopes that match this server.
@@ -507,12 +508,16 @@ func checkRootOrNodeInScope(clientCert *x509.Certificate, serverTenantID roachpb
 			return true
 		}
 
+		if scope.Username == username.DebugUser {
+			debugUserScopedCert = true
+		}
+
 		return false
 	}
 	ok, err := security.CertificateUserScopeContainsFunc(clientCert, containsFn)
-	if ok || err != nil {
+	if ok || err != nil || debugUserScopedCert {
 		if rootLoginDisabledValidate {
-			return authErrorf("failed to perform RPC, as root login has been disallowed")
+			return authError("failed to perform RPC, as root login has been disallowed")
 		}
 
 		return err

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -89,8 +89,8 @@ func UnsetNodeSubject() {
 	nodeSubjectMu.unsetDN()
 }
 
-// EnableDisallowRootLogin enables or disables root login blocking.
-func EnableDisallowRootLogin(disallow bool) {
+// SetDisallowRootLogin sets whether root login should be disallowed.
+func SetDisallowRootLogin(disallow bool) {
 	disallowRootLoginMu.Lock()
 	defer disallowRootLoginMu.Unlock()
 	disallowRootLoginMu.disallowed = disallow

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -392,80 +392,95 @@ func TestAuthenticationHook(t *testing.T) {
 		tenantID                   roachpb.TenantID
 		isSubjectRoleOptionOrDNSet bool
 		subjectRequired            bool
+		disallowRootLogin          bool
 		expectedErr                string
 	}{
 		// Insecure mode, empty username.
-		{true, "", username.EmptyRole, "", "", true, false, false, roachpb.SystemTenantID, false, false, `user is missing`},
+		{true, "", username.EmptyRole, "", "", true, false, false, roachpb.SystemTenantID, false, false, false, `user is missing`},
 		// Insecure mode, non-empty username.
-		{true, "", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, `user "foo" is not allowed`},
+		{true, "", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, `user "foo" is not allowed`},
 		// Secure mode, no TLS state.
-		{false, "", username.EmptyRole, "", "", false, false, false, roachpb.SystemTenantID, false, false, `no client certificates in request`},
+		{false, "", username.EmptyRole, "", "", false, false, false, roachpb.SystemTenantID, false, false, false, `no client certificates in request`},
 		// Secure mode, bad user.
 		{false, "(CN=foo)", username.NodeUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, `certificate authentication failed for user "node"`},
+			false, false, false, `certificate authentication failed for user "node"`},
 		// Secure mode, node user.
-		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, ``},
+		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, false, ``},
 		// Secure mode, node cert and unrelated user.
 		{false, "(CN=node)", fooUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, `certificate authentication failed for user "foo"`},
+			false, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, root user.
 		{false, "(CN=root)", username.NodeUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, `certificate authentication failed for user "node"`},
+			false, false, false, `certificate authentication failed for user "node"`},
 		// Secure mode, tenant cert, foo user.
 		{false, "(OU=Tenants,CN=foo)", fooUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, `using tenant client certificate as user certificate is not allowed`},
+			false, false, false, `using tenant client certificate as user certificate is not allowed`},
 		// Secure mode, multiple cert principals.
-		{false, "(CN=foo)dns:bar", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, `user "foo" is not allowed`},
-		{false, "(CN=foo)dns:bar", barUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, `user "bar" is not allowed`},
+		{false, "(CN=foo)dns:bar", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, `user "foo" is not allowed`},
+		{false, "(CN=foo)dns:bar", barUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, `user "bar" is not allowed`},
 		// Secure mode, principal map.
-		{false, "(CN=foo)dns:bar", blahUser, "", "foo:blah", true, true, false, roachpb.SystemTenantID, false, false, `user "blah" is not allowed`},
-		{false, "(CN=foo)dns:bar", blahUser, "", "bar:blah", true, true, false, roachpb.SystemTenantID, false, false, `user "blah" is not allowed`},
+		{false, "(CN=foo)dns:bar", blahUser, "", "foo:blah", true, true, false, roachpb.SystemTenantID, false, false, false, `user "blah" is not allowed`},
+		{false, "(CN=foo)dns:bar", blahUser, "", "bar:blah", true, true, false, roachpb.SystemTenantID, false, false, false, `user "blah" is not allowed`},
 		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, "", "", true, true, false, roachpb.MustMakeTenantID(123),
-			false, false, `user "foo" is not allowed`},
+			false, false, false, `user "foo" is not allowed`},
 		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, `certificate authentication failed for user "foo"`},
+			false, false, false, `certificate authentication failed for user "foo"`},
 		{false, "(CN=foo)", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			false, false, `user "foo" is not allowed`},
+			false, false, false, `user "foo" is not allowed`},
 		{false, "(CN=foo)uri:crdb://tenant/1/user/foo", fooUser, "", "", true, false, false, roachpb.MustMakeTenantID(123),
-			false, false, `certificate authentication failed for user "foo"`},
+			false, false, false, `certificate authentication failed for user "foo"`},
 		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", blahUser, "", "", true, false, false, roachpb.MustMakeTenantID(123),
-			false, false, `certificate authentication failed for user "blah"`},
+			false, false, false, `certificate authentication failed for user "blah"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option not set.
 		{false, "(" + subjectDNString + ")", fooUser, "", "", true, true, false, roachpb.MustMakeTenantID(123),
-			false, false, `user "foo" is not allowed`},
+			false, false, false, `user "foo" is not allowed`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set matching TLS cert subject.
 		{false, "(" + subjectDNString + ")", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, false, `user "foo" is not allowed`},
+			true, false, false, `user "foo" is not allowed`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN empty.
 		{false, "(CN=foo)", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, `certificate authentication failed for user "foo"`},
+			true, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN mismatches on OU field.
 		{false, "(" + fieldMismatchSubjectDNString + ")", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, `certificate authentication failed for user "foo"`},
+			true, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN subset of role subject DN.
 		{false, "(" + subsetSubjectDNString + ")", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, `certificate authentication failed for user "foo"`},
+			true, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set mismatching TLS cert subject only on CN(required for
 		// matching) having DNS as foo.
 		{false, "(" + fieldMismatchOnlyOnCommonNameString + ")dns:foo", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, `certificate authentication failed for user "foo"`},
+			true, false, false, `certificate authentication failed for user "foo"`},
 		{false, "(" + rootDNString + ")", username.RootUser, rootDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, false, `user "root" is not allowed`},
+			true, false, false, `user "root" is not allowed`},
 		{false, "(" + nodeDNString + ")", username.NodeUser, nodeDNString, "", true, true, true, roachpb.MustMakeTenantID(123),
-			true, false, ""},
+			true, false, false, ""},
 		// tls cert dn matching root dn set, where CN != root
 		{false, "(" + subjectDNString + ")", username.RootUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, false, `user "root" is not allowed`},
+			true, false, false, `user "root" is not allowed`},
 		{false, "(" + subjectDNString + ")", fooUser, "", "", true, false, false, roachpb.MustMakeTenantID(123),
-			false, true, `user "foo" does not have a distinguished name set which subject_required cluster setting mandates`},
+			false, true, false, `user "foo" does not have a distinguished name set which subject_required cluster setting mandates`},
 		{false, "(" + subjectDNString + ")", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, true, `user "foo" is not allowed`},
+			true, true, false, `user "foo" is not allowed`},
+
+		// Test cases for disallow root login functionality
+		// Root user with disallow root login disabled - should succeed
+		{false, "(CN=root)", username.RootUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, ``},
+		// Root user with disallow root login enabled - should fail
+		{false, "(CN=root)", username.RootUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, true, `certificate authentication failed for user "root"`},
+		// Non-root user with disallow root login enabled - should succeed
+		{false, "(CN=foo)", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, true, `user "foo" is not allowed`},
+		// Node user with disallow root login enabled - should succeed
+		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, true, ``},
+		// Root user with tenant-scoped certificate and disallow root login enabled - should fail
+		{false, "(CN=root)uri:crdb://tenant/123/user/root", username.RootUser, "", "", true, false, false, roachpb.MustMakeTenantID(123), false, false, true, `certificate authentication failed for user "root"`},
+		// Root user with DNS SAN and disallow root login enabled - should fail
+		{false, "(CN=root)dns:root", username.RootUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, true, `certificate authentication failed for user "root"`},
 	}
 
 	ctx := context.Background()
@@ -475,11 +490,15 @@ func TestAuthenticationHook(t *testing.T) {
 			defer func() {
 				security.UnsetRootSubject()
 				security.UnsetNodeSubject()
+				security.EnableDisallowRootLogin(false)
 			}()
 			err := security.SetCertPrincipalMap(strings.Split(tc.principalMap, ","))
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Set the global flag for disallowing root login
+			security.EnableDisallowRootLogin(tc.disallowRootLogin)
 
 			var roleSubject *ldap.DN
 			if tc.isSubjectRoleOptionOrDNSet {

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -490,7 +490,7 @@ func TestAuthenticationHook(t *testing.T) {
 			defer func() {
 				security.UnsetRootSubject()
 				security.UnsetNodeSubject()
-				security.EnableDisallowRootLogin(false)
+				security.SetDisallowRootLogin(false)
 			}()
 			err := security.SetCertPrincipalMap(strings.Split(tc.principalMap, ","))
 			if err != nil {
@@ -498,7 +498,7 @@ func TestAuthenticationHook(t *testing.T) {
 			}
 
 			// Set the global flag for disallowing root login
-			security.EnableDisallowRootLogin(tc.disallowRootLogin)
+			security.SetDisallowRootLogin(tc.disallowRootLogin)
 
 			var roleSubject *ldap.DN
 			if tc.isSubjectRoleOptionOrDNSet {

--- a/pkg/security/username/username.go
+++ b/pkg/security/username/username.go
@@ -160,6 +160,12 @@ const TestUser = "testuser"
 // TestUserName is the SQLUsername for testuser.
 func TestUserName() SQLUsername { return SQLUsername{TestUser} }
 
+// DebugUser is used for collecting debug zip.
+const DebugUser = "debug_user"
+
+// DebugUserName is the SQLUsername for debug user.
+func DebugUserName() SQLUsername { return SQLUsername{DebugUser} }
+
 // MakeSQLUsernameFromUserInput normalizes a username string as
 // entered in an ambiguous context into a SQL username (performs case
 // folding and unicode normalization form C - NFC).

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -211,6 +211,12 @@ type BaseConfig struct {
 	// which a feature unique to the demo shell.
 	EnableDemoLoginEndpoint bool
 
+	// DisallowRootLogin when set, prevents authentication attempts by clients
+	// presenting certificates with "root" as one of the principals (CommonName
+	// or SubjectAlternativeName). This applies to both SQL client connections
+	// and RPC connections.
+	DisallowRootLogin bool
+
 	// ReadyFn is called when the server has started listening on its
 	// sockets.
 	//


### PR DESCRIPTION
**cli, security: add --disallow-root-login flag to disable root user**
We introduce a `--disallow-root-login` flag which now disables root user
 from access to both sql and rpc apis.

**rpc: enable debugzip user for privileged access**
This commit introduces support for the debug_user certificate
as a privileged user for RPC authentication, similar to the existing
root and node users. The debug_user is specifically designed
for collecting debug information (debug zip) and requires privileged
access to serverpb admin and status endpoints.

Modified `pkg/rpc/auth.go` to allow `debug_user` scope in
`checkRootOrNodeInScope()`, treating it as a privileged user
alongside root and node. Enhanced `pkg/rpc/auth_test.go` with
comprehensive test cases for `debug_user` authentication and
authorization across various scenarios.

The `debug_user` is not subject to the disallow-root-login flag and
should always be allowed for debugging purposes.

Release note (security update): 
We will be adding a new flag `--disallow-root-login` to the cockroach start 
command to explicitly allowcrestricting the root user from logging into the system. 
This change affects the [unstated, unchangeable root access rule](https://www.cockroachlabs.com/docs/stable/security-reference/authentication#the-unstated-unchangeable-root-access-rule) as part of
compliance requirements.  This flag is currently experimental and also needs an
additional user setup for debug zip collection as disabling the root user affects 
the debug zip service. We currently do not validate if this user is set up or not.

Note: Care must be taken to ensure none of the certificates that are in use by
the cluster or the SQL/RPC clients have a root in the SAN fields since the flag
will block access to that client.

A new `debug_user` certificate can now be used for privileged RPC access 
to collect debug information. The `debug_user` must be created manually using
the `CREATE USER` command and can be audited using the `SHOW USERS` command.
This user has privileged access to `serverpb` admin and status endpoints required for
debug zip collection.

Fixes: #150845, #152817

Epic: CRDB-49035