### PR TITLE
sidetransport: remove a call to timeutil.Now()

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -697,8 +697,10 @@ func (b *updatesBuf) PaceBroadcastUpdate(ctx context.Context, condVar *sync.Cond
 		}
 		b.mu.Unlock()
 
-		if workLeft > 0 && timeutil.Now().Before(by) {
-			time.Sleep(by.Sub(timeutil.Now()))
+		if workLeft > 0 {
+			if wait := timeutil.Until(by); wait > 0 {
+				time.Sleep(wait)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This removes an extra call to timeutil.Now(). Just something I noticed when reading the code. timeutil.Unit() should be able to use the monotonic clock if `by` has a monotonic clock reading already which is also nice.

It might be nice to make a version of the pacer that can use crtime.Mono but that is a larger change.

Epic: none
Release note: None