### PR TITLE
kvserver: don't allow cancellation of RemoveReplica call

### DIFF
--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -315,7 +315,11 @@ func (rgcq *replicaGCQueue) process(
 		// possible if we currently think we're processing a pre-emptive snapshot
 		// but discover in RemoveReplica that this range has since been added and
 		// knows that.
-		if err := repl.store.RemoveReplica(ctx, repl, nextReplicaID, "MVCC GC queue"); err != nil {
+		//
+		// We expect RemoveReplica to run to completion, so we construct a context
+		// that can't be cancelled from above.
+		noCancelCtx := context.WithoutCancel(ctx)
+		if err := repl.store.RemoveReplica(noCancelCtx, repl, nextReplicaID, "MVCC GC queue"); err != nil {
 			// Should never get an error from RemoveReplica.
 			const format = "error during replicaGC: %v"
 			logcrash.ReportOrPanic(ctx, &repl.store.ClusterSettings().SV, format, err)


### PR DESCRIPTION
It appears we can get a cancellation from Pebble during RemoveReplica. We've seen this before in #155121. Here, we construct a context that can't be cancelled.

TODO: Should we push this down into RemoveReplica, can we ever handle RemoveReplica failing?

TODO: Is there anywhere else that might be impacted by pebble being able to error from context cancellation.

Informs #140958
Fixes #155121

Release note: None