### PR TITLE
dev-inf: Fix stage chaining in Claude Code GH action

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -215,3 +215,20 @@ jobs:
             3. If bugs were found, what actions are recommended
 
             **If all three stages detected bugs**, this indicates a potential issue that warrants investigation.
+
+      - name: Comment on PR if bugs confirmed
+        if: contains(steps.stage3_result.outputs.result, 'STAGE3_RESULT: POTENTIAL_BUG_CONFIRMED')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "## Potential Bug(s) Detected
+
+          The three-stage Claude Code analysis has identified potential bug(s) in this PR that may warrant investigation.
+
+          **Analysis Results:**
+          - ⚠️ Stage 1 (Initial Screening): Potential bugs detected
+          - ⚠️ Stage 2 (Database Expert Review): Potential bugs not ruled out
+          - ⚠️ Stage 3 (Principal Engineer Review): Potential bugs not ruled out
+
+          **Next Steps:**
+          Please review the detailed findings in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -67,9 +67,13 @@ jobs:
         id: stage1_result
         if: steps.stage1.conclusion == 'success'
         run: |
-          RESULT=$(cat "${{ steps.stage1.outputs.execution_file }}" | jq -r '.result' | tail -1)
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
-          echo "Stage 1 result: $RESULT"
+          RESULT=$(jq -r 'select(.type == "result") | .result' "${{ steps.stage1.outputs.execution_file }}")
+          {
+            echo 'result<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "Stage 1 result extracted (${#RESULT} characters)"
 
       - name: Stage 2 - Database Expert Review
         id: stage2
@@ -114,9 +118,13 @@ jobs:
         id: stage2_result
         if: steps.stage2.conclusion == 'success'
         run: |
-          RESULT=$(cat "${{ steps.stage2.outputs.execution_file }}" | jq -r '.result' | tail -1)
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
-          echo "Stage 2 result: $RESULT"
+          RESULT=$(jq -r 'select(.type == "result") | .result' "${{ steps.stage2.outputs.execution_file }}")
+          {
+            echo 'result<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "Stage 2 result extracted (${#RESULT} characters)"
 
       - name: Stage 3 - Principal Engineer Final Review
         id: stage3
@@ -176,9 +184,13 @@ jobs:
         id: stage3_result
         if: steps.stage3.conclusion == 'success'
         run: |
-          RESULT=$(cat "${{ steps.stage3.outputs.execution_file }}" | jq -r '.result' | tail -1)
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
-          echo "Stage 3 result: $RESULT"
+          RESULT=$(jq -r 'select(.type == "result") | .result' "${{ steps.stage3.outputs.execution_file }}")
+          {
+            echo 'result<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "Stage 3 result extracted (${#RESULT} characters)"
 
       - name: Final Analysis Report
         if: always()
@@ -224,11 +236,6 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} --body "## Potential Bug(s) Detected
 
           The three-stage Claude Code analysis has identified potential bug(s) in this PR that may warrant investigation.
-
-          **Analysis Results:**
-          - ⚠️ Stage 1 (Initial Screening): Potential bugs detected
-          - ⚠️ Stage 2 (Database Expert Review): Potential bugs not ruled out
-          - ⚠️ Stage 3 (Principal Engineer Review): Potential bugs not ruled out
 
           **Next Steps:**
           Please review the detailed findings in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -63,9 +63,17 @@ jobs:
             - `STAGE1_RESULT - POTENTIAL_BUG_DETECTED` or
             - `STAGE1_RESULT - NO_BUG_FOUND`
 
+      - name: Extract Stage 1 Result
+        id: stage1_result
+        if: steps.stage1.conclusion == 'success'
+        run: |
+          RESULT=$(cat "${{ steps.stage1.outputs.execution_file }}" | jq -r '.result' | tail -1)
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "Stage 1 result: $RESULT"
+
       - name: Stage 2 - Database Expert Review
         id: stage2
-        if: contains(steps.stage1.outputs.result, 'STAGE1_RESULT - POTENTIAL_BUG_DETECTED')
+        if: contains(steps.stage1_result.outputs.result, 'STAGE1_RESULT - POTENTIAL_BUG_DETECTED')
         uses: cockroachdb/claude-code-action@v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
@@ -85,7 +93,7 @@ jobs:
             found potential issues. Your job is to confirm or reject those findings.
 
             **Stage 1 Results**:
-            ${{ steps.stage1.outputs.result }}
+            ${{ steps.stage1_result.outputs.result }}
 
             Review the Stage 1 findings and perform your own analysis. Do not identify
             new bugs unless they're glaringly obvious.
@@ -102,9 +110,17 @@ jobs:
             - `STAGE2_RESULT - POTENTIAL_BUG_DETECTED [detailed description of confirmed bugs]` or
             - `STAGE2_RESULT - NO_BUG_FOUND`
 
+      - name: Extract Stage 2 Result
+        id: stage2_result
+        if: steps.stage2.conclusion == 'success'
+        run: |
+          RESULT=$(cat "${{ steps.stage2.outputs.execution_file }}" | jq -r '.result' | tail -1)
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "Stage 2 result: $RESULT"
+
       - name: Stage 3 - Principal Engineer Final Review
         id: stage3
-        if: contains(steps.stage2.outputs.result, 'STAGE2_RESULT - POTENTIAL_BUG_DETECTED')
+        if: contains(steps.stage2_result.outputs.result, 'STAGE2_RESULT - POTENTIAL_BUG_DETECTED')
         uses: cockroachdb/claude-code-action@v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
@@ -124,10 +140,10 @@ jobs:
             Two previous stages have found potential issues that need final validation.
 
             **Stage 1 Results**:
-            ${{ steps.stage1.outputs.result }}
+            ${{ steps.stage1_result.outputs.result }}
 
             **Stage 2 Results**:
-            ${{ steps.stage2.outputs.result }}
+            ${{ steps.stage2_result.outputs.result }}
 
             This is the final gate before flagging this PR as having critical bugs.
             Only confirm bugs that could cause:
@@ -156,6 +172,14 @@ jobs:
             - `STAGE3_RESULT: POTENTIAL_BUG_CONFIRMED` or
             - `STAGE3_RESULT: NO_BUG_FOUND`
 
+      - name: Extract Stage 3 Result
+        id: stage3_result
+        if: steps.stage3.conclusion == 'success'
+        run: |
+          RESULT=$(cat "${{ steps.stage3.outputs.execution_file }}" | jq -r '.result' | tail -1)
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "Stage 3 result: $RESULT"
+
       - name: Final Analysis Report
         if: always()
         uses: cockroachdb/claude-code-action@v1
@@ -176,9 +200,9 @@ jobs:
 
             Generate a final summary report based on the completed analysis stages:
 
-            **Stage 1 Result**: ${{ steps.stage1.outputs.result || 'Not completed' }}
-            **Stage 2 Result**: ${{ steps.stage2.outputs.result || 'Skipped - Stage 1 found no bugs' }}
-            **Stage 3 Result**: ${{ steps.stage3.outputs.result || 'Skipped - Stage 2 did not confirm bugs' }}
+            **Stage 1 Result**: ${{ steps.stage1_result.outputs.result || 'Not completed' }}
+            **Stage 2 Result**: ${{ steps.stage2_result.outputs.result || 'Skipped - Stage 1 found no bugs' }}
+            **Stage 3 Result**: ${{ steps.stage3_result.outputs.result || 'Skipped - Stage 2 did not confirm bugs' }}
 
             **Analysis Process**:
             - Stage 1 (Initial Screening): ${{ steps.stage1.conclusion }}


### PR DESCRIPTION
The claude-code-action doesn't export a 'result' output variable.
Added extraction steps between each stage to:
1. Read the execution_file output from each stage
2. Parse the JSON to extract the result field
3. Set it as an output for the next stage's conditional

This fixes the issue where Stage 2 and Stage 3 were being skipped
even when bugs were detected in earlier stages.

Epic: none
Release note: none