### PR TITLE
release-24.1: sql: bump up cluster setting read timeout for benchmark tests

### DIFF
--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -698,7 +699,12 @@ func waitForSettingUpdate(
 	}
 	errNotReady := errors.New("setting updated but timed out waiting to read new value")
 	var observed string
-	err := retry.ForDuration(10*time.Second, func() error {
+	defaultDuration := 10 * time.Second
+	// Bench tests maybe more prone to flaking, so use a longer time limit for them.
+	if buildutil.CrdbBenchBuild {
+		defaultDuration *= 3
+	}
+	err := retry.ForDuration(defaultDuration, func() error {
 		observed = setting.Encoded(&execCfg.Settings.SV)
 		if observed != expectedEncodedValue {
 			return errNotReady


### PR DESCRIPTION
Backport 1/1 commits from #155162 on behalf of @fqazi.

----

Previously, we would see flakes on TestBenchmarkExpectation related to updating cluster settings and not being able to see the updated values after SET CLUSTER SETTING. We suspect this flake happens because under load, it may take longer for the cluster setting update to be visible. To address this, this patch modifies the cluster setting timeout for benchmark tests to prevent these flakes.

Fixes: #154219

Release note: None

----

Release justification: