### PR TITLE
release-25.4: changefeedccl: remove max object count for multi-table pts testing

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1874,6 +1874,12 @@ func runCDCMultiTablePTSBenchmark(
 }
 
 func configureDBForMultiTablePTSBenchmark(db *gosql.DB) error {
+	// Multi-table PTS benchmarking should be able to test with more tables
+	// than the default limit set here. Setting this to 0 disables the limit.
+	if _, err := db.Exec("SET CLUSTER SETTING sql.schema.approx_max_object_count = 0"); err != nil {
+		return err
+	}
+
 	// This is used to trigger frequent garbage collection and
 	// protected timestamp updates.
 	if _, err := db.Exec("ALTER DATABASE defaultdb CONFIGURE ZONE USING gc.ttlseconds = 1"); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #154890 on behalf of @aerfrei.

----

Set the cluster setting sql.schema.approx_max_object_count = 0,
turning off the object count limit so we can run this test with
50k tables. That test currently fails during fixture setup due
to the newly introduced default schema object limit (20,000).
This test attempts to create more than 50,000 descriptors,
exceeding the limit and triggering a guardrail error.

Fixes: https://github.com/cockroachdb/cockroach/issues/154827
Fixes: https://github.com/cockroachdb/cockroach/issues/154826
Epic: [CRDB-1421](https://cockroachlabs.atlassian.net/browse/CRDB-1421)
Release note: None

----

Release justification: Test only.