### PR TITLE
release-25.3: streamclient: fix panic in sslinline parsing

### DIFF
--- a/pkg/crosscluster/streamclient/client_test.go
+++ b/pkg/crosscluster/streamclient/client_test.go
@@ -387,6 +387,23 @@ SXy25ZnLdt1xMg==
 		require.NoError(t, err)
 	})
 
+	t.Run("all valid certs but disabled", func(t *testing.T) {
+		query := url.Values{}
+		query.Add(SslInlineURLParam, "true")
+		query.Add(sslCertURLParam, validCert)
+		query.Add(sslKeyURLParam, validKey)
+		query.Add(sslRootCertURLParam, validCert)
+		query.Add(sslModeURLParam, "disable")
+
+		remote := url.URL{
+			Scheme:   "postgresql",
+			Host:     "localhost:26257",
+			RawQuery: query.Encode(),
+		}
+		_, err := setupPGXConfig(remote, options{})
+		require.NoError(t, err)
+	})
+
 	t.Run("invalid cert", func(t *testing.T) {
 		query := url.Values{}
 		query.Add(SslInlineURLParam, "true")

--- a/pkg/crosscluster/streamclient/pgconn.go
+++ b/pkg/crosscluster/streamclient/pgconn.go
@@ -138,7 +138,7 @@ func uriWithInlineTLSCertsRemoved(remote url.URL) (url.URL, *tlsCerts, error) {
 }
 
 func (c *tlsCerts) addTLSCertsToConfig(tlsConfig *tls.Config) {
-	if c == nil {
+	if c == nil || tlsConfig == nil {
 		return
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #155232 on behalf of @stevendanna.

----

If sslmode=disable, the underlying library returns a nil TLSConfig.

Fixes #155224

Release note (bug fix): Fix a bug that would result in a node crash if a PCR or LDR URI used sslinline=true with sslmode=disable.

----

Release justification: Low risk bug fix for a bug that can cause a crash.