### PR TITLE
sql/hints: add facilities to invalidate query plans when their hints change

### DIFF
--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -95,6 +95,10 @@ type DependencyDigest struct {
 	// StatsGeneration tracks if any new statistics have been published.
 	StatsGeneration int64
 
+	// HintsGeneration tracks if any new hints have been published in
+	// system.statement_hints.
+	HintsGeneration int64
+
 	// SystemConfig tracks the current system config, which is refreshed on
 	// any zone config update.
 	SystemConfig *config.SystemConfig
@@ -108,6 +112,7 @@ type DependencyDigest struct {
 func (d *DependencyDigest) Equal(other *DependencyDigest) bool {
 	return d.LeaseGeneration == other.LeaseGeneration &&
 		d.StatsGeneration == other.StatsGeneration &&
+		d.HintsGeneration == other.HintsGeneration &&
 		// Note: If the system config is modified a new SystemConfig structure
 		// is always allocated. Individual fields cannot change on the caller,
 		// so for the purpose of the dependency digest its sufficient to just

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -603,15 +603,17 @@ func (oc *optCatalog) LeaseByStableID(ctx context.Context, stableID cat.StableID
 
 // GetDependencyDigest is part of the cat.Catalog interface.
 func (oc *optCatalog) GetDependencyDigest() cat.DependencyDigest {
-	// The stats cache may not be setup in some tests like
+	// The stats and hints caches may not be setup in some tests like
 	// TestPortalsDestroyedOnTxnFinish. In which case always
 	// return the empty digest.
-	if oc.planner.ExecCfg().TableStatsCache == nil {
+	if oc.planner.ExecCfg().TableStatsCache == nil ||
+		oc.planner.ExecCfg().StatementHintsCache == nil {
 		return cat.DependencyDigest{}
 	}
 	return cat.DependencyDigest{
 		LeaseGeneration: oc.planner.Descriptors().GetLeaseGeneration(),
 		StatsGeneration: oc.planner.execCfg.TableStatsCache.GetGeneration(),
+		HintsGeneration: oc.planner.execCfg.StatementHintsCache.GetGeneration(),
 		SystemConfig:    oc.planner.execCfg.SystemConfig.GetSystemConfig(),
 		CurrentDatabase: oc.planner.CurrentDatabase(),
 		SearchPath:      oc.planner.SessionData().SearchPath,

--- a/pkg/sql/tests/dependency_digest_test.go
+++ b/pkg/sql/tests/dependency_digest_test.go
@@ -21,6 +21,7 @@ import (
 
 // TestDependencyDigestOptimization validates that dependency digest information
 // is properly invalidated in the face of modifications for prepared queries.
+// TODO(drewk,michae2): Once statement hints are hooked up, add a case for them.
 func TestDependencyDigestOptimization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
#### sql/hints: add statement hint cache generation

This commit adds a generation to the statement hints cache, which is
incremented every time the cache processes a rangefeed event. The generation
is used as part of the `cat.DependencyDigest`, used to decide whether an
expensive staleness check is necessary for a cached plan.

Informs #148160

Release note: None

#### sql/hints: include row ID when fetching hints

The row ID of each hint is now included with the hints fetched from the
hint cache. In a future PR, cached query plans will store the row IDs of the
hints they retrieved from the cache, and will compare against the re-fetched
IDs to determine if the query plan is stale (e.g. hints were added or removed).

Informs #148160

Release note: None