### PR TITLE
sql: fix early exit from merge index planner

### DIFF
--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -58,7 +58,7 @@ func (im *IndexBackfillerMergePlanner) MergeIndexes(
 		g.Add(sourceIndexSpan)
 		g.Sub(progress.CompletedSpans[i]...)
 		spansToDo[i] = g.Slice()
-		if len(spansToDo) > 0 {
+		if len(spansToDo[i]) > 0 {
 			hasToDo = true
 		}
 	}


### PR DESCRIPTION
The MergeIndexes() method of the IndexBackfillerMergePlanner has a check to see if there are any spans to merge before proceeding with building the plan for the merge. Previously the check for this was checking whether there were any elements in spansToDo, which is allocated to have one entry per source index ID, causing the length check to be vacuously true. The logic probably meant to to check the length of the spans list for each individual source index ID, which this patch puts into place.

Epic: none
Release note: None