### PR TITLE
roachtest: deflake mixed-version backup/restore roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -221,7 +221,10 @@ func backupRestoreRoundTrip(
 
 			t.L().Printf("verifying backup %d", i+1)
 			// Verify content in backups.
-			err = d.verifyBackupCollection(ctx, t.L(), testRNG, collection, true /* checkFiles */, true /* internalSystemJobs */)
+			err = d.verifyBackupCollection(
+				ctx, t.L(), testRNG, collection,
+				true /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
+			)
 			if err != nil {
 				return err
 			}
@@ -538,7 +541,8 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 
 		t.L().Printf("performing online restore of backup")
 		if _, _, err := d.runRestore(
-			ctx, t.L(), testRNG, collection, false /* checkFiles */, true, /* internalSystemJobs */
+			ctx, t.L(), testRNG, collection,
+			false /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
As part of the 25.4 migration, all descriptors are rewritten to use the new serialization format. If this occurs during a restore, the restore will fail due to version mismatches. This test deflakes our mixed-version backup-restore roachtests to rerun the restore if it encounters that error.

Fixes: #154611

Fixes: #154850

Release note: None