### PR TITLE
release-25.4: roachtest: deflake backup/mvcc-range-tombstones

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -756,7 +756,7 @@ func runBackupMVCCRangeTombstones(
 			`IMPORT INTO orders CSV DATA ('%s') WITH delimiter='|', detached`,
 			strings.Join(files, "', '")),
 		).Scan(&jobID))
-		waitForState(jobID, jobs.StatePaused, "", 30*time.Minute)
+		waitForState(jobID, jobs.StatePaused, "", time.Hour)
 
 		t.Status("canceling import")
 		_, err = conn.ExecContext(ctx, fmt.Sprintf(`CANCEL JOB %s`, jobID))


### PR DESCRIPTION
Backport 1/1 commits from #154977 on behalf of @msbutler.

----

Informs #154841

Release note: none

----

Release justification: