### PR TITLE
changefeedccl: fix progress skew metrics computation

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -146,6 +146,7 @@ go_library(
         "//pkg/util/httputil",
         "//pkg/util/humanizeutil",
         "//pkg/util/intsets",
+        "//pkg/util/iterutil",
         "//pkg/util/json",
         "//pkg/util/log",
         "//pkg/util/log/channel",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1783,7 +1783,7 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		// The feed's checkpoint is tracked in a map which is used to inform the
 		// checkpoint_progress metric which will return the lowest timestamp across
 		// all feeds in the scope.
-		cf.sliMetrics.setCheckpoint(cf.sliMetricsID, cf.frontier.Frontier())
+		cf.sliMetrics.setCheckpoint(cf.sliMetricsID, newResolved)
 
 		return cf.maybeEmitResolved(cf.Ctx(), newResolved)
 	}
@@ -2226,16 +2226,29 @@ func (cf *changeFrontier) maybeEmitResolved(ctx context.Context, newResolved hlc
 
 // updateProgressSkewMetrics updates the progress skew metrics.
 func (cf *changeFrontier) updateProgressSkewMetrics() {
-	maxSpanTS := cf.frontier.LatestTS()
-	maxTableTS := cf.frontier.Frontier()
-	for _, f := range cf.frontier.Frontiers() {
-		tableTS := f.Frontier()
-		if tableTS.After(maxTableTS) {
-			maxTableTS = tableTS
+	fastestSpanTS := cf.frontier.LatestTS()
+	fastestTableTS := func() hlc.Timestamp {
+		var maxTS hlc.Timestamp
+		for _, f := range cf.frontier.Frontiers() {
+			if f.Frontier().After(maxTS) {
+				maxTS = f.Frontier()
+			}
+		}
+		return maxTS
+	}()
+
+	slowestTS := cf.frontier.Frontier()
+	var spanSkew, tableSkew int64
+	if slowestTS.IsSet() {
+		if fastestSpanTS.IsSet() {
+			spanSkew = fastestSpanTS.WallTime - slowestTS.WallTime
+		}
+		if fastestTableTS.IsSet() {
+			tableSkew = fastestTableTS.WallTime - slowestTS.WallTime
 		}
 	}
 
-	cf.sliMetrics.setFastestTS(cf.sliMetricsID, maxSpanTS, maxTableTS)
+	cf.sliMetrics.setProgressSkew(cf.sliMetricsID, spanSkew, tableSkew)
 }
 
 func frontierIsBehind(frontier hlc.Timestamp, sv *settings.Values) bool {

--- a/pkg/ccl/changefeedccl/changefeed_progress_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_progress_test.go
@@ -273,8 +273,7 @@ WITH no_initial_scan, min_checkpoint_frequency='1s', resolved, metrics_label='%s
 					}
 					if !perTableTracking {
 						if tableSkew != 0 {
-							// TODO(#155083): Return an error here.
-							return nil
+							return errors.Newf("expected table skew to be 0, got %d", tableSkew)
 						}
 						return nil
 					}

--- a/pkg/util/iterutil/iterutil.go
+++ b/pkg/util/iterutil/iterutil.go
@@ -78,3 +78,15 @@ func MinFunc[E any](seq iter.Seq[E], cmp func(E, E) int) E {
 	}
 	return m
 }
+
+// MaxFunc returns the maximum element in seq, using cmp to compare elements.
+// If seq has no values, the zero value is returned.
+func MaxFunc[E any](seq iter.Seq[E], cmp func(E, E) int) E {
+	var m E
+	for i, v := range Enumerate(seq) {
+		if i == 0 || cmp(v, m) > 0 {
+			m = v
+		}
+	}
+	return m
+}

--- a/pkg/util/iterutil/iterutil_test.go
+++ b/pkg/util/iterutil/iterutil_test.go
@@ -95,3 +95,35 @@ func TestMinFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxFunc(t *testing.T) {
+	intCmp := func(a, b int) int {
+		return a - b
+	}
+
+	for name, tc := range map[string]struct {
+		input []int
+	}{
+		"empty": {
+			input: nil,
+		},
+		"one element": {
+			input: []int{1},
+		},
+		"multiple elements": {
+			input: []int{1, 3, 2},
+		},
+		"multiple elements with zero value": {
+			input: []int{1, 0, 3, 2},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := iterutil.MaxFunc(slices.Values(tc.input), intCmp)
+			if len(tc.input) == 0 {
+				require.Equal(t, 0, m)
+			} else {
+				require.Equal(t, slices.MaxFunc(tc.input, intCmp), m)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch fixes a bug where the progress skew metrics could show
incorrect data because the computation previously relied on comparing
the fastest span/table timestamps with the checkpointed timestamp
(overall resolved timestamp) and these two pieces of information
weren't kept in sync.

Fixes #155083

Release note: None