### PR TITLE
logical: add initial/catchup scan metrics to offline scan

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -456,9 +456,11 @@ type logicalReplicationPlanner struct {
 }
 
 type logicalReplicationPlanInfo struct {
-	sourceSpans         []roachpb.Span
-	partitionPgUrls     []string
-	destTableBySrcID    map[descpb.ID]dstTableMetadata
+	sourceSpans      []roachpb.Span
+	partitionPgUrls  []string
+	destTableBySrcID map[descpb.ID]dstTableMetadata
+	// Number of processors writing data on the destination cluster (offline or
+	// otherwise).
 	writeProcessorCount int
 }
 
@@ -738,6 +740,7 @@ func (p *logicalReplicationPlanner) planOfflineInitialScan(
 				SQLInstanceID: instanceID,
 				Core:          execinfrapb.ProcessorCoreUnion{LogicalReplicationOfflineScan: &spec},
 			})
+			info.writeProcessorCount++
 		}
 	}
 


### PR DESCRIPTION
This patch teaches the LDR offline scan processor to emit checkpoint range stats and update the `logical_replication.scanning_ranges` and `logical_replication.catchup_ranges` metrics.

Informs: #152273

Release note: LDR now updates the `logical_replication.scanning_ranges` and `logical_replication.catchup_ranges` metrics during fast initial scan.