### PR TITLE
release-25.3: changefeedccl: add missing error return during change frontier startup

### DIFF
--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
@@ -78,11 +78,11 @@ type SpanForwarder interface {
 func Restore(sf SpanForwarder, checkpoint *jobspb.TimestampSpansMap) error {
 	for ts, spans := range checkpoint.All() {
 		if ts.IsEmpty() {
-			return errors.New("checkpoint timestamp is empty")
+			return errors.AssertionFailedf("checkpoint timestamp is empty")
 		}
 		for _, sp := range spans {
 			if _, err := sf.Forward(sp, ts); err != nil {
-				return err
+				return errors.Wrapf(err, "forwarding span %v to %v", sp, ts)
 			}
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #152364.

/cc @cockroachdb/release

---

Before this change, when the change frontier encountered an error while
restoring a changefeed's span-level checkpoint, it would ignore the
error instead of moving to draining like change aggregators would.

Fixes #152104

Release note: None

---

Release justification: adding missing error handling which could allow data corruption to go unnoticed
