### PR TITLE
changefeedccl: remove unnecessary redact.Safe calls

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -2252,7 +2252,7 @@ func frontierIsBehind(frontier hlc.Timestamp, sv *settings.Values) bool {
 // frontier is behind
 func maybeLogBehindSpan(
 	ctx context.Context,
-	description string,
+	description redact.SafeString,
 	frontier span.Frontier,
 	frontierChanged bool,
 	sv *settings.Values,
@@ -2272,12 +2272,12 @@ func maybeLogBehindSpan(
 
 	if frontierChanged && slowLogEveryN.ShouldProcess(now) {
 		log.Changefeed.Infof(ctx, "%s new resolved timestamp %s is behind by %s",
-			redact.Safe(description), frontierTS, resolvedBehind)
+			description, frontierTS, resolvedBehind)
 	}
 
 	if slowLogEveryN.ShouldProcess(now) {
 		s := frontier.PeekFrontierSpan()
-		log.Changefeed.Infof(ctx, "%s span %s is behind by %s", redact.Safe(description), s, resolvedBehind)
+		log.Changefeed.Infof(ctx, "%s span %s is behind by %s", description, s, resolvedBehind)
 	}
 }
 

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 )
 
 // blockingBuffer is an implementation of Buffer which allocates memory
@@ -524,15 +523,13 @@ func logSlowAcquisition(
 		shouldLog := logSlowAcquire.ShouldLog()
 		if shouldLog {
 			log.Changefeed.Warningf(ctx, "have been waiting %s attempting to acquire changefeed quota (buffer=%s)",
-				timeutil.Since(start),
-				redact.SafeString(bufType))
+				timeutil.Since(start), bufType)
 		}
 
 		return func() {
 			if shouldLog {
 				log.Changefeed.Infof(ctx, "acquired changefeed quota after %s (buffer=%s)",
-					timeutil.Since(start),
-					redact.SafeString(bufType))
+					timeutil.Since(start), bufType)
 			}
 		}
 	}

--- a/pkg/ccl/changefeedccl/kvevent/metrics.go
+++ b/pkg/ccl/changefeedccl/kvevent/metrics.go
@@ -179,6 +179,9 @@ func (bt bufferType) alterMeta(meta metric.Metadata) metric.Metadata {
 	return meta
 }
 
+// SafeValue implements redact.SafeValue.
+func (bt bufferType) SafeValue() {}
+
 // MakeMetrics constructs a Metrics struct with the provided histogram window.
 func MakeMetrics(histogramWindow time.Duration) Metrics {
 	eventTypeMeta := func(et Type) metric.Metadata {

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -60,6 +60,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"SettingName": {},
 						"ValueOrigin": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent": {
+						"bufferType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/crosscluster/logical": {
 						"processorType": {},
 					},


### PR DESCRIPTION
This patch removes two unnecessary `redact.Safe` calls where the origin
of the data is within the changefeed packages and we know for sure
that they're safe to not redact so we can notate at the origin that the
data is safe instead of blanket unredacting at the destination.

Epic: None

Release note: None