### PR TITLE
storeliveness: prototype heartbeat pacing

### DIFF
--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/taskpacer",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/kvserver/storeliveness/multi_store_test.go
+++ b/pkg/kv/kvserver/storeliveness/multi_store_test.go
@@ -40,8 +40,8 @@ import (
 // stall, or a partial partition), and ensure that only the affected stores lose
 // support.
 
-const numNodes = 3
-const numStoresPerNode = 2
+const numNodes = 5
+const numStoresPerNode = 3
 
 func checkSupportFrom(
 	t *testing.T, sm *storeliveness.SupportManager, storeID slpb.StoreIdent, supportExpected bool,

--- a/pkg/kv/kvserver/storeliveness/multi_store_test.go
+++ b/pkg/kv/kvserver/storeliveness/multi_store_test.go
@@ -40,8 +40,8 @@ import (
 // stall, or a partial partition), and ensure that only the affected stores lose
 // support.
 
-const numNodes = 5
-const numStoresPerNode = 3
+const numNodes = 3
+const numStoresPerNode = 2
 
 func checkSupportFrom(
 	t *testing.T, sm *storeliveness.SupportManager, storeID slpb.StoreIdent, supportExpected bool,

--- a/pkg/kv/kvserver/storeliveness/testutils.go
+++ b/pkg/kv/kvserver/storeliveness/testutils.go
@@ -101,6 +101,10 @@ func (tms *testMessageSender) SendAsync(_ context.Context, msg slpb.Message) (se
 	return true
 }
 
+func (tms *testMessageSender) SendAllMessages(_ context.Context) {
+	// No-op.
+}
+
 func (tms *testMessageSender) drainSentMessages() []slpb.Message {
 	tms.mu.Lock()
 	defer tms.mu.Unlock()


### PR DESCRIPTION
DO NOT REVIEW

Changes:

1) To each send queue, I added `sendMessages` channel. Once signalled, it sends all the messages in the queue. 
2) Inside the Transport struct, I added a channel sendAllMessages that once signalled, it signals all message queues. This is where we could eventually pace. 
3) Created a new goroutine as the "Trasnport Send Coordinator" where it listens to the sendAllMessages channel, and it waits for 10ms to allow more stores to add their messages, and then signals to all queues to send their messages. 4) Changed some tests to adapt to the new behaviour
4) Paced the signalling to the sendQueues (In the second commit)