### PR TITLE
kvserver: convert shared/external SSTs on applying

### DIFF
--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/redact"
 	"golang.org/x/time/rate"
@@ -239,39 +238,9 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			timingTag.stop("sst")
 		}
 
-		for i := range req.SharedTables {
-			sst := req.SharedTables[i]
-			pbToInternalKey := func(k *kvserverpb.SnapshotRequest_SharedTable_InternalKey) pebble.InternalKey {
-				return pebble.InternalKey{UserKey: k.UserKey, Trailer: pebble.InternalKeyTrailer(k.Trailer)}
-			}
-			sharedSSTs = append(sharedSSTs, pebble.SharedSSTMeta{
-				Backing:          stubBackingHandle{sst.Backing},
-				Smallest:         pbToInternalKey(sst.Smallest),
-				Largest:          pbToInternalKey(sst.Largest),
-				SmallestRangeKey: pbToInternalKey(sst.SmallestRangeKey),
-				LargestRangeKey:  pbToInternalKey(sst.LargestRangeKey),
-				SmallestPointKey: pbToInternalKey(sst.SmallestPointKey),
-				LargestPointKey:  pbToInternalKey(sst.LargestPointKey),
-				Level:            uint8(sst.Level),
-				Size:             sst.Size_,
-			})
-		}
-		for i := range req.ExternalTables {
-			sst := req.ExternalTables[i]
-			externalSSTs = append(externalSSTs, pebble.ExternalFile{
-				Locator:           remote.MakeLocator(redact.RedactableString(sst.Locator)),
-				ObjName:           sst.ObjectName,
-				StartKey:          sst.StartKey,
-				EndKey:            sst.EndKey,
-				EndKeyIsInclusive: sst.EndKeyIsInclusive,
-				HasPointKey:       sst.HasPointKey,
-				HasRangeKey:       sst.HasRangeKey,
-				SyntheticPrefix:   sst.SyntheticPrefix,
-				SyntheticSuffix:   sst.SyntheticSuffix,
-				Level:             uint8(sst.Level),
-				Size:              sst.Size_,
-			})
-		}
+		sharedSSTs = append(sharedSSTs, convertSharedSSTs(req.SharedTables)...)
+		externalSSTs = append(externalSSTs, convertExternalSSTs(req.ExternalTables)...)
+
 		if req.Final {
 			// We finished receiving all batches and log entries. It's possible that
 			// we did not receive any key-value pairs for some of the key spans, but

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -131,8 +131,8 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 
 	log.Event(ctx, "waiting for snapshot batches to begin")
 
-	var sharedSSTs []pebble.SharedSSTMeta
-	var externalSSTs []pebble.ExternalFile
+	var sharedSSTs []kvserverpb.SnapshotRequest_SharedTable
+	var externalSSTs []kvserverpb.SnapshotRequest_ExternalTable
 	var prevBytesEstimate int64
 
 	snapshotQ := s.cfg.KVAdmissionController.GetSnapshotQueue(s.StoreID())
@@ -238,8 +238,8 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			timingTag.stop("sst")
 		}
 
-		sharedSSTs = append(sharedSSTs, convertSharedSSTs(req.SharedTables)...)
-		externalSSTs = append(externalSSTs, convertExternalSSTs(req.ExternalTables)...)
+		sharedSSTs = append(sharedSSTs, req.SharedTables...)
+		externalSSTs = append(externalSSTs, req.ExternalTables...)
 
 		if req.Final {
 			// We finished receiving all batches and log entries. It's possible that
@@ -262,7 +262,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			log.Eventf(ctx, "all data received from snapshot and all SSTs were finalized")
 			var sharedSize int64
 			for i := range sharedSSTs {
-				sharedSize += int64(sharedSSTs[i].Size)
+				sharedSize += int64(sharedSSTs[i].Size_)
 			}
 
 			snapUUID, err := uuid.FromBytes(header.RaftMessageRequest.Message.Snapshot.Data)

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -312,8 +312,8 @@ type IncomingSnapshot struct {
 	placeholder      *ReplicaPlaceholder
 	raftAppliedIndex kvpb.RaftIndex      // logging only
 	msgAppRespCh     chan raftpb.Message // receives MsgAppResp if/when snap is applied
-	sharedSSTs       []pebble.SharedSSTMeta
-	externalSSTs     []pebble.ExternalFile
+	sharedSSTs       []kvserverpb.SnapshotRequest_SharedTable
+	externalSSTs     []kvserverpb.SnapshotRequest_ExternalTable
 	// clearedSpans represents the key spans in the existing store that will be
 	// cleared by doing the Ingest*. This is tracked so that we can convert the
 	// ssts into a WriteBatch if the total size of the ssts is small.
@@ -642,8 +642,8 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	// Ingest the SSTs if the snapshot is applied using a Pebble ingestion.
 	ingestStats, err := sw.commit(ctx, snapIngestion{
 		paths:      inSnap.SSTStorageScratch.SSTs(),
-		shared:     inSnap.sharedSSTs,
-		external:   inSnap.externalSSTs,
+		shared:     convertSharedSSTs(inSnap.sharedSSTs),
+		external:   convertExternalSSTs(inSnap.externalSSTs),
 		exciseSpan: desc.KeySpan().AsRawSpanWithNoLocals(),
 	})
 	if err != nil {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/objstorage"
+	"github.com/cockroachdb/pebble/objstorage/remote"
 	"github.com/cockroachdb/redact"
 )
 
@@ -852,4 +853,47 @@ func (r *Replica) destroyInfoRaftMuLocked() kvstorage.DestroyReplicaInfo {
 		FullReplicaID: r.ID(),
 		Keys:          r.shMu.state.Desc.RSpan(),
 	}
+}
+
+func convertSharedSSTs(sharedSSTs []kvserverpb.SnapshotRequest_SharedTable) []pebble.SharedSSTMeta {
+	res := make([]pebble.SharedSSTMeta, len(sharedSSTs))
+	pbToInternalKey := func(k *kvserverpb.SnapshotRequest_SharedTable_InternalKey) pebble.InternalKey {
+		return pebble.InternalKey{UserKey: k.UserKey, Trailer: pebble.InternalKeyTrailer(k.Trailer)}
+	}
+	for i, sst := range sharedSSTs {
+		res[i] = pebble.SharedSSTMeta{
+			Backing:          stubBackingHandle{sst.Backing},
+			Smallest:         pbToInternalKey(sst.Smallest),
+			Largest:          pbToInternalKey(sst.Largest),
+			SmallestRangeKey: pbToInternalKey(sst.SmallestRangeKey),
+			LargestRangeKey:  pbToInternalKey(sst.LargestRangeKey),
+			SmallestPointKey: pbToInternalKey(sst.SmallestPointKey),
+			LargestPointKey:  pbToInternalKey(sst.LargestPointKey),
+			Level:            uint8(sst.Level),
+			Size:             sst.Size_,
+		}
+	}
+	return res
+}
+
+func convertExternalSSTs(
+	externalSSTs []kvserverpb.SnapshotRequest_ExternalTable,
+) []pebble.ExternalFile {
+	res := make([]pebble.ExternalFile, len(externalSSTs))
+	for i, sst := range externalSSTs {
+		res[i] = pebble.ExternalFile{
+			Locator:           remote.MakeLocator(redact.RedactableString(sst.Locator)),
+			ObjName:           sst.ObjectName,
+			StartKey:          sst.StartKey,
+			EndKey:            sst.EndKey,
+			EndKeyIsInclusive: sst.EndKeyIsInclusive,
+			HasPointKey:       sst.HasPointKey,
+			HasRangeKey:       sst.HasRangeKey,
+			SyntheticPrefix:   sst.SyntheticPrefix,
+			SyntheticSuffix:   sst.SyntheticSuffix,
+			Level:             uint8(sst.Level),
+			Size:              sst.Size_,
+		}
+	}
+	return res
 }

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -642,8 +642,8 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	// Ingest the SSTs if the snapshot is applied using a Pebble ingestion.
 	ingestStats, err := sw.commit(ctx, snapIngestion{
 		paths:      inSnap.SSTStorageScratch.SSTs(),
-		shared:     convertSharedSSTs(inSnap.sharedSSTs),
-		external:   convertExternalSSTs(inSnap.externalSSTs),
+		shared:     inSnap.sharedSSTs,
+		external:   inSnap.externalSSTs,
 		exciseSpan: desc.KeySpan().AsRawSpanWithNoLocals(),
 	})
 	if err != nil {

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -198,7 +198,11 @@ func (s *snapWriter) commit(
 		ingestTo = s.eng.Engine()
 	}
 	stats, err := ingestTo.IngestAndExciseFiles(
-		ctx, ing.paths, ing.shared, ing.external, ing.exciseSpan)
+		ctx, ing.paths,
+		convertSharedSSTs(ing.shared),
+		convertExternalSSTs(ing.external),
+		ing.exciseSpan,
+	)
 	if err != nil {
 		return pebble.IngestOperationStats{}, errors.Wrapf(err,
 			"while ingesting %s and excising %v", ing.paths, ing.exciseSpan)
@@ -357,7 +361,7 @@ func (s *snapWriter) subsumeReplica(ctx context.Context, sub kvstorage.DestroyRe
 // WAG node. Use the proto counterparts of this type (see wagpb.Ingestion).
 type snapIngestion struct {
 	paths      []string
-	shared     []pebble.SharedSSTMeta
-	external   []pebble.ExternalFile
+	shared     []kvserverpb.SnapshotRequest_SharedTable
+	external   []kvserverpb.SnapshotRequest_ExternalTable
 	exciseSpan roachpb.Span
 }


### PR DESCRIPTION
This is to support storing the original shared/external SST protobufs (received over the wire) into a WAG node before applying a snapshot.

Related to #149604, #165186