### PR TITLE
release-25.3: concurrency: disable kv.lock_table.unreplicated_lock_reliability.split.enabled

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -123,7 +123,7 @@ var UnreplicatedLockReliabilitySplit = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lock_table.unreplicated_lock_reliability.split.enabled",
 	"whether the replica should attempt to keep unreplicated locks during range splits",
-	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability.split.enabled", true),
+	false,
 )
 
 // UnreplicatedLockReliabilityLeaseTransfer controls whether the replica will attempt


### PR DESCRIPTION
In #155318, we discovered that the RHS replica's lock table may already have concurrently running transactions holding locks. As a result, adding these locks may put the lock table in an unexpected state.

Informs #155318

Release note (bug fix): Disable a feature
(kv.lock_table.unreplicated_lock_reliability.split.enabled) that could lead to a node crash.

Release justification: Bug fix for node-crashing bug.