### PR TITLE
roachprod: implement GetVMSpecs for IBM

### DIFF
--- a/pkg/roachprod/vm/ibm/BUILD.bazel
+++ b/pkg/roachprod/vm/ibm/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
+        "//pkg/util/ctxgroup",
         "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/syncutil",

--- a/pkg/roachprod/vm/ibm/account_config.go
+++ b/pkg/roachprod/vm/ibm/account_config.go
@@ -121,7 +121,7 @@ func (p *Provider) configureCloudAccountFull(cc *ibmCloudConfig) error {
 	// Create a transit gateway for the account in the first region.
 	tgID, err := p.getOrCreateTransitGateway(supportedRegions[0])
 	if err != nil {
-		return errors.Wrap(err, "failed to create transit gateway")
+		return errors.Wrap(err, "failed to get or create transit gateway")
 	}
 
 	for region := range p.regions {

--- a/pkg/roachprod/vm/ibm/helpers.go
+++ b/pkg/roachprod/vm/ibm/helpers.go
@@ -1259,16 +1259,23 @@ type parsedCRN struct {
 	id     string
 }
 
+// parseCRN takes an IBM Cloud Resource Name string and parses it into
+// its components for easier use.
+// We don't store the resource ID in vm.VM, we need to parse the CRN if
+// we need the resource ID which is at index 9 after splitting.
+// CRN format:
+//
+//	crn:version:cname:ctype:service-name:location:scope:service-instance:resource-type:resource
+//
+// CRN e.g.
+//
+//	crn:v1:bluemix:public:is:ca-tor-1:a/ba0325a6257b4dabb3a7aa149a6578ae::instance:02q7_1a2940f7-b058-4742-8ef1-b1ee08273cf0
 func (p *Provider) parseCRN(crn string) (*parsedCRN, error) {
 
 	if crn == "" {
 		return nil, fmt.Errorf("empty CRN")
 	}
 
-	// CRN have the following format:
-	// crn:version:cname:ctype:service-name:location:scope:service-instance:resource-type:resource
-	// e.g.: crn:v1:bluemix:public:is:ca-tor-1:a/ba0325a6257b4dabb3a7aa149a6578ae::instance:02q7_1a2940f7-b058-4742-8ef1-b1ee08273cf0
-	// we're interested in the "resource" part, which is the 10th part
 	parts := strings.Split(crn, ":")
 
 	if len(parts) < 10 {
@@ -1279,6 +1286,9 @@ func (p *Provider) parseCRN(crn string) (*parsedCRN, error) {
 		id: parts[9],
 	}
 
+	// a CRN's location field can be a region or a zone, handle both cases
+	// region e.g. br-sao
+	// zone e.g. br-sao-1
 	splitsRegion := strings.Split(parts[5], "-")
 	if len(splitsRegion) < 3 {
 		c.region = parts[5]


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/146202

Implementation for previously unimplemented interface method GetVMSpecs() for IBM. This will allow for cluster information to be fetched in roachtest via FetchVMSpecs
* API: https://cloud.ibm.com/apidocs/resource-controller/resource-controller?code=go#get-resource-instance 

Also added comments to help contextualize some parts that I thought would be helpful while doing some debug.

See comment for e.g. vm specs
