### PR TITLE
release-25.2: backup: fix mr show backup for table level backup

### DIFF
--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -741,11 +741,16 @@ func backupShowerDefault(
 					case catalog.DatabaseDescriptor:
 						descriptorType = "database"
 						if desc.IsMultiRegion() {
-							regions, err := showRegions(typeIDToTypeDescriptor[desc.GetRegionConfig().RegionEnumID], desc.GetName())
-							if err != nil {
-								return nil, errors.Wrapf(err, "cannot generate regions column")
+							if mrEnum := typeIDToTypeDescriptor[desc.GetRegionConfig().RegionEnumID]; mrEnum != nil {
+								// The enum may not be in the backup, for example in a table
+								// level backup. Jury is out for whether databases should be
+								// shown in table level backups.
+								regions, err := showRegions(mrEnum, desc.GetName())
+								if err != nil {
+									return nil, errors.Wrapf(err, "cannot generate regions column")
+								}
+								regionsDatum = nullIfEmpty(regions)
 							}
-							regionsDatum = nullIfEmpty(regions)
 						}
 					case catalog.SchemaDescriptor:
 						descriptorType = "schema"

--- a/pkg/backup/testdata/backup-restore/show-backup-multiregion
+++ b/pkg/backup/testdata/backup-restore/show-backup-multiregion
@@ -61,3 +61,33 @@ d database incremental
 public schema incremental
 crdb_internal_region type incremental
 _crdb_internal_region type incremental
+
+
+query-sql
+SELECT object_name, regions FROM [SHOW BACKUP LATEST IN ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1')] where object_type='database' limit 1;
+----
+d ALTER DATABASE d SET PRIMARY REGION "us-east-1"; ALTER DATABASE d ADD REGION "eu-central-1"; ALTER DATABASE d ADD REGION "us-west-1";
+
+# Try backing up a table in the database
+exec-sql
+CREATE TABLE d.t (x INT);
+----
+
+exec-sql
+BACKUP TABLE d.t INTO ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1');
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1')];
+----
+d database full
+public schema full
+t table full
+
+exec-sql
+drop table d.t
+----
+
+exec-sql
+RESTORE TABLE d.t FROM LATEST IN ('nodelocal://1/database_backup_locality_aware_default?COCKROACH_LOCALITY=default', 'nodelocal://1/database_backup_locality_aware_west?COCKROACH_LOCALITY=region=us-west-1', 'nodelocal://1/database_backup_locality_aware_central?COCKROACH_LOCALITY=region=eu-central-1');
+----


### PR DESCRIPTION
Backport 1/1 commits from #155281 on behalf of @msbutler.

----

Previously, if a user took a table level backup of an MR database, show backup would fail. This occured because SHOW BACKUP will display the database object, and for MR databases, show backup expects to have access to the MR enum; however table level backups do not back up the enum. This patch relaxes the SHOW BACKUP MR DB requirement, allowing show backup for the table to succeed.

Epic: none

Release note: none

----

Release justification: