### PR TITLE
release-25.4: sql/inspect: serialize inspect progress metadata pushes

### DIFF
--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	pbtypes "github.com/gogo/protobuf/types"
@@ -71,6 +72,12 @@ type inspectProcessor struct {
 	logger         inspectLogger
 	concurrency    int
 	clock          *hlc.Clock
+	mu             struct {
+		// Guards calls to output.Push because DistSQLReceiver.Push is not
+		// concurrency safe and progress metadata can be emitted from multiple
+		// worker goroutines.
+		syncutil.Mutex
+	}
 }
 
 var _ execinfra.Processor = (*inspectProcessor)(nil)
@@ -310,7 +317,7 @@ func (p *inspectProcessor) sendInspectProgress(
 		},
 	}
 
-	output.Push(nil, meta)
+	p.pushProgressMeta(output, meta)
 	return nil
 }
 
@@ -350,8 +357,19 @@ func (p *inspectProcessor) sendSpanCompletionProgress(
 		},
 	}
 
-	output.Push(nil, meta)
+	p.pushProgressMeta(output, meta)
 	return nil
+}
+
+// pushProgressMeta serializes metadata pushes so only one goroutine interacts
+// with the DistSQL receiver at a time (DistSQLReceiver.Push is not concurrency
+// safe).
+func (p *inspectProcessor) pushProgressMeta(
+	output execinfra.RowReceiver, meta *execinfrapb.ProducerMetadata,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	output.Push(nil, meta)
 }
 
 // newInspectProcessor constructs a new inspectProcessor from the given InspectSpec.


### PR DESCRIPTION
Backport 1/1 commits from #155358 on behalf of @spilchen.

----

Concurrent inspect processors were racing when calling DistSQLReceiver.Push, which is not concurrency-safe. This commit introduces a per-processor mutex to serialize all Push calls.

Resolves: #155309, resolves #155311, resolves #155312, resolves #155313, resolves #155314, resolves #155315
Epic: CRDB-30356
Release note: none

----

Release justification: required for MVP of INSPECT in 25.4