### PR TITLE
jobs: convert max adoptions per period to cluster setting

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -61,7 +61,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/cidr",
-        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -100,7 +100,8 @@ func (r *Registry) claimJobs(ctx context.Context, s sqlliveness.Session) error {
 		}
 		numRows, err := txn.Exec(
 			ctx, "claim-jobs", txn.KV(), claimQuery,
-			s.ID().UnsafeBytes(), r.ID(), maxAdoptionsPerLoop)
+			s.ID().UnsafeBytes(), r.ID(), maxAdoptionsPerLoop.Get(&r.settings.SV),
+		)
 		if err != nil {
 			return errors.Wrap(err, "could not query jobs table")
 		}

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -20,6 +20,7 @@ const (
 	adoptIntervalSettingKey    = "jobs.registry.interval.adopt"
 	cancelIntervalSettingKey   = "jobs.registry.interval.cancel"
 	gcIntervalSettingKey       = "jobs.registry.interval.gc"
+	maxAdoptionsPerLoopKey     = "jobs.registry.max_adoptions_per_loop"
 	retentionTimeSettingKey    = "jobs.retention_time"
 	cancelUpdateLimitKey       = "jobs.cancel_update_limit"
 	debugPausePointsSettingKey = "jobs.debug.pausepoints"
@@ -29,6 +30,10 @@ const (
 const (
 	// defaultAdoptInterval is the default adopt interval.
 	defaultAdoptInterval = 30 * time.Second
+
+	// defaultMaxAdoptionsPerLoop is the default maximum number of jobs a node
+	// can adopt in one adoption loop.
+	defaultMaxAdoptionsPerLoop = 10
 
 	// defaultCancelInterval is the default cancel interval.
 	defaultCancelInterval = 10 * time.Second
@@ -69,6 +74,14 @@ var (
 			"states but are not running",
 		defaultAdoptInterval,
 		settings.PositiveDuration,
+	)
+
+	maxAdoptionsPerLoop = settings.RegisterIntSetting(
+		settings.ApplicationLevel,
+		maxAdoptionsPerLoopKey,
+		"the maximum number of jobs a node can adopt in one adoption loop",
+		defaultMaxAdoptionsPerLoop,
+		settings.PositiveInt,
 	)
 
 	cancelIntervalSetting = settings.RegisterDurationSetting(

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/cidr"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -885,9 +884,6 @@ func (r *Registry) LoadJobWithTxn(
 	}
 	return j, nil
 }
-
-// TODO (sajjad): make maxAdoptionsPerLoop a cluster setting.
-var maxAdoptionsPerLoop = envutil.EnvOrDefaultInt(`COCKROACH_JOB_ADOPTIONS_PER_PERIOD`, 10)
 
 const removeClaimsForDeadSessionsQuery = `
 UPDATE system.jobs


### PR DESCRIPTION
Previously, tuning the maximum number of adoptions per adoption period was configured via the `COCKROACH_JOB_ADOPTIONS_PER_PERIOD` environment variable. This made configuring the maximum number of adoptions somewhat tedious as it required a restart of the Cockroach process to refresh the setting. This commit converts the setting from an environment variable to a cluster setting.

Informs: #146799

Release note: Add `jobs.registry.max_adoptions_per_loop` cluster setting to configure maximum number of jobs a node can adopt per adoption loop.