### PR TITLE
backup: use backup index by default

### DIFF
--- a/pkg/backup/backupdest/backup_index.go
+++ b/pkg/backup/backupdest/backup_index.go
@@ -37,7 +37,7 @@ var (
 		settings.ApplicationLevel,
 		"backup.index.read.enabled",
 		"if true, the backup index will be read when reading from a backup collection",
-		metamorphic.ConstantWithTestBool("backup.index.read.enabled", false),
+		metamorphic.ConstantWithTestBool("backup.index.read.enabled", true),
 	)
 )
 


### PR DESCRIPTION
Let's bake this on master for a little before 26.1 branch cut.

Epic: none

Release note: none