### PR TITLE
schemachangerccl: limit number of stages tested for MR

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -129,7 +129,7 @@ const skipRate = .6
 
 // Stop once max stages has been hit.
 const maxStagesToTest = 8
-const maxStagesToTestMultiRegion = 6
+const maxStagesToTestMultiRegion = 4
 
 // shouldSkipBackup samples about 60% of total stages or up to
 // max stages.

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -965,6 +965,14 @@ func waitForSchemaChangesToSucceed(t *testing.T, tdb *sqlutils.SQLRunner) {
 }
 
 func waitForSchemaChangesToFinish(t *testing.T, tdb *sqlutils.SQLRunner) {
+	// Wait longer on stress for schema changes.
+	if skip.Stress() {
+		old := tdb.SucceedsSoonDuration
+		tdb.SucceedsSoonDuration = time.Minute * 2
+		defer func() {
+			tdb.SucceedsSoonDuration = old
+		}()
+	}
 	tdb.CheckQueryResultsRetry(
 		t, schemaChangeWaitQuery(`('succeeded', 'failed')`), [][]string{},
 	)


### PR DESCRIPTION
  Previously, this test was timing out frequently because of the number of
  stages that we were testing causing it to hit the test timeout. This
  patch reduces the number of stages tested on MR for declarative schema
  changes during backup / restore. This patch also adjusts timeout waiting
  for schema changes to allow for stress runs for testing.

  Release note: None
  Fixes: #154993
  Fixes: #155137
  Fixes: #154786
  Fixes: #152076
  Fixes: #155327
  Fixes: #154805
  Fixes: #155147