### PR TITLE
storage: mark add'l WAL latency metric essential

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10551,6 +10551,16 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric reports the number of a node's LSM compactions. If the number of compactions remains elevated while the LSM health does not improve, compactions are not keeping up with the workload. If the condition persists for an extended period, the cluster will initially exhibit performance issues that will eventually escalate into stability issues.
       essential: true
+    - name: storage.wal.failover.write_and_sync.latency
+      exported_name: storage_wal_failover_write_and_sync_latency
+      description: The observed latency for writing and syncing to the logical Write-Ahead Log.
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: Only populated when WAL failover is configured. Without WAL failover, the relevant metric is storage.wal.fsync.latency.
+      essential: true
     - name: storage.wal.fsync.latency
       exported_name: storage_wal_fsync_latency
       description: The fsync latency to the Write-Ahead Log device.
@@ -17352,15 +17362,6 @@ layers:
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: Only populated when WAL failover is configured. A high switch count indicates that many disk stalls were encountered.
-    - name: storage.wal.failover.write_and_sync.latency
-      exported_name: storage_wal_failover_write_and_sync_latency
-      description: The observed latency for writing and syncing to the logical Write-Ahead Log.
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-      how_to_use: Only populated when WAL failover is configured. Without WAL failover, the relevant metric is storage.wal.fsync.latency.
     - name: storage.write-amplification
       exported_name: storage_write_amplification
       description: |-

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2823,6 +2823,8 @@ Note that the measurement does not include the duration for replicating the eval
 		Name:        "storage.wal.failover.write_and_sync.latency",
 		Help:        "The observed latency for writing and syncing to the logical Write-Ahead Log.",
 		Measurement: "Nanoseconds",
+		Category:    metric.Metadata_STORAGE,
+		Essential:   true,
 		Unit:        metric.Unit_NANOSECONDS,
 		HowToUse: "Only populated when WAL failover is configured. Without WAL failover, the relevant " +
 			"metric is storage.wal.fsync.latency.",


### PR DESCRIPTION
This change marks the `storage.wal.failover.write_and_sync.latency` metric as "Essential" so it gets automatically pulled into the 'Essential Metrics' documentation at e.g.,
https://www.cockroachlabs.com/docs/stable/essential-metrics-self-hosted.html#storage

This is necessary since we are adding some words about this metric to the docs via cockroachdb/docs#20566

We would like to then backport this change to all supported versions of CockroachDB which have WAL failover (i.e., v24.1 and later).

Addresses part of DOC-13184