### PR TITLE
mixedversion: increase auto_upgrade verbosity in mixed version tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -779,9 +779,12 @@ func quoteVersionForPresentation(v string) string {
 // we should change the default and add an API for tests to opt-out of
 // the default scheduled backup if necessary.
 func startOpts(opts ...option.StartStopOption) option.StartOpts {
-	return option.NewStartOpts(
+	startOpts := option.NewStartOpts(
 		startStopOpts(opts...)...,
 	)
+	// Enable verbose logging for auto_upgrade to help debug upgrade-related issues.
+	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=auto_upgrade=2")
+	return startOpts
 }
 
 // startStopOpts does the same as `startOpts` but returns StartStopOptions


### PR DESCRIPTION
We sometimes see the auto upgrade process hang, and it would be nice to see additionally logging to help debug.

Epic: none
Release note: none
Fixes: none