### PR TITLE
roachtest/mixedversion: dedicated versioned workload binary

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -257,6 +257,7 @@ func uploadBinaryVersion(
 	v *Version,
 ) (string, error) {
 	dstBinary := BinaryPathForVersion(t, v, binary)
+	l.Printf("Attempting to download %s to nodes as %s", dstBinary, nodes)
 	var defaultBinary string
 	var isOverridden bool
 	switch binary {

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -286,6 +286,7 @@ func uploadBinaryVersion(
 		dir := filepath.Dir(dstBinary)
 		// Avoid staging the binary if it already exists.
 		if err := c.RunE(ctx, option.WithNodes(nodes), "test -e", dstBinary); err == nil {
+			l.Printf("binary %s already exists on nodes %s", dstBinary, nodes) // expecting this line to print
 			return dstBinary, nil
 		}
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -346,16 +346,17 @@ type (
 		// predecessorFunc computes the predecessor of a particular
 		// release. By default, random predecessors are used, but tests
 		// may choose to always use the latest predecessor as well.
-		predecessorFunc                predecessorFunc
-		waitForReplication             bool
-		skipVersionProbability         float64
-		settings                       []install.ClusterSettingOption
-		enabledDeploymentModes         []DeploymentMode
-		tag                            string
-		overriddenMutatorProbabilities map[string]float64
-		hooksSupportFailureInjection   bool
-		workloadNodes                  option.NodeListOption
-		enableUpReplication            bool
+		predecessorFunc                          predecessorFunc
+		waitForReplication                       bool
+		skipVersionProbability                   float64
+		settings                                 []install.ClusterSettingOption
+		enabledDeploymentModes                   []DeploymentMode
+		tag                                      string
+		overriddenMutatorProbabilities           map[string]float64
+		hooksSupportFailureInjection             bool
+		workloadNodes                            option.NodeListOption
+		workloadNodesWithDedicatedWorkloadBinary option.NodeListOption
+		enableUpReplication                      bool
 	}
 
 	CustomOption func(*testOptions)
@@ -599,6 +600,17 @@ func WithTag(tag string) CustomOption {
 func WithWorkloadNodes(nodes option.NodeListOption) CustomOption {
 	return func(opts *testOptions) {
 		opts.workloadNodes = nodes
+	}
+}
+
+// WithWorkloadNodesWithDedicatedWorkloadBinary tells the mixedversion
+// framework that this test's cluster includes workload node(s) so the
+// framework can stage all the dedicated workload binaries included in the
+// upgrade plan on the workload node so the test can use versioned workload
+// commands without the test itself having to stage those binaries.
+func WithWorkloadNodesWithDedicatedWorkloadBinary(nodes option.NodeListOption) CustomOption {
+	return func(opts *testOptions) {
+		opts.workloadNodesWithDedicatedWorkloadBinary = nodes
 	}
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -657,6 +657,17 @@ func (p *testPlanner) systemSetupSteps() []testStep {
 			}))
 	}
 
+	if len(p.options.workloadNodesWithDedicatedWorkloadBinary) > 0 {
+		// Add step for staging all dedicated workload binaries needed for test on
+		// workload node(s)
+		steps = append(steps,
+			p.newSingleStepWithContext(setupContext, stageAllDedicatedWorkloadBinariesStep{
+				versions:      p.versions,
+				rt:            p.rt,
+				workloadNodes: p.options.workloadNodesWithDedicatedWorkloadBinary,
+			}))
+	}
+
 	return steps
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -56,8 +56,8 @@ func runSchemaChangeMixedVersions(
 		ctx, t, t.L(), c, c.All(),
 		// Disable version skipping and limit the test to only one upgrade as the workload is only
 		// compatible with the branch it was built from and the major version before that.
-		mixedversion.NumUpgrades(1),
-		mixedversion.DisableSkipVersionUpgrades,
+		//mixedversion.NumUpgrades(1),
+		//mixedversion.DisableSkipVersionUpgrades,
 		// Always use latest predecessors, since mixed-version bug fixes only
 		// appear in the latest patch of the predecessor version.
 		// See: https://github.com/cockroachdb/cockroach/issues/121411.

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -26,7 +26,7 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		// schemachange/mixed-versions tests random schema changes (via the schemachange workload)
 		// in a mixed version state, validating that the cluster is still healthy (via debug doctor examine).
-		Name:    "schemachange/mixed-versions",
+		Name:    "schemachange/mixed-versions/will",
 		Owner:   registry.OwnerSQLFoundations,
 		Cluster: r.MakeClusterSpec(4, spec.WorkloadNode()),
 		// Disabled on IBM because s390x is only built on master and mixed-version
@@ -62,6 +62,7 @@ func runSchemaChangeMixedVersions(
 		// appear in the latest patch of the predecessor version.
 		// See: https://github.com/cockroachdb/cockroach/issues/121411.
 		mixedversion.AlwaysUseLatestPredecessors,
+		mixedversion.WithWorkloadNodesWithDedicatedWorkloadBinary(c.WorkloadNode()),
 	)
 	tester := newSchemaChangeMixedVersionTester(t, c, maxOps, concurrency)
 
@@ -103,6 +104,7 @@ func newSchemaChangeMixedVersionTester(
 func (t schemaChangeMixedVersionTester) initWorkload(
 	ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper,
 ) error {
+	// Just a util to get the binary path, this shouldn't upload a binary because we front loaded that work
 	binaryPath, _, err := clusterupgrade.UploadWorkload(
 		ctx, t.t, l, t.c, t.c.WorkloadNode(), h.System.FromVersion)
 	if err != nil {
@@ -119,6 +121,7 @@ func (t schemaChangeMixedVersionTester) schemaChangeAndValidationStep(
 	t.numFeatureRuns += 1
 	l.Printf("Workload step run: %d", t.numFeatureRuns)
 	workloadSeed := r.Int63()
+	// Just a util to get the binary path, this shouldn't upload a binary because we front loaded that work
 	binaryPath, _, err := clusterupgrade.UploadWorkload(
 		ctx, t.t, l, t.c, t.c.WorkloadNode(), h.System.FromVersion)
 	if err != nil {

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -50,7 +52,6 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 func runSchemaChangeMixedVersions(
 	ctx context.Context, t test.Test, c cluster.Cluster, maxOps int, concurrency int,
 ) {
-	numFeatureRuns := 0
 	mvt := mixedversion.NewTest(
 		ctx, t, t.L(), c, c.All(),
 		// Disable version skipping and limit the test to only one upgrade as the workload is only
@@ -62,41 +63,85 @@ func runSchemaChangeMixedVersions(
 		// See: https://github.com/cockroachdb/cockroach/issues/121411.
 		mixedversion.AlwaysUseLatestPredecessors,
 	)
+	tester := newSchemaChangeMixedVersionTester(t, c, maxOps, concurrency)
 
-	// Run the schemachange workload on a random node, along with validating the schema changes for the cluster on a random node.
-	schemaChangeAndValidationStep := func(
-		ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper,
-	) error {
-		numFeatureRuns += 1
-		l.Printf("Workload step run: %d", numFeatureRuns)
-		workloadSeed := r.Int63()
-		runCmd := roachtestutil.NewCommand("COCKROACH_RANDOM_SEED=%d ./workload run schemachange", workloadSeed).
-			Flag("verbose", 1).
-			Flag("max-ops", maxOps).
-			Flag("concurrency", concurrency).
-			Arg("{pgurl%s}", c.All()).
-			String()
-		if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runCmd); err != nil {
-			return err
-		}
+	mvt.OnStartup(
+		"set up schemachange workload",
+		tester.initWorkload,
+	)
 
-		randomNode := c.All().SeededRandNode(r)[0]
-		doctorURL := fmt.Sprintf("{pgurl:%d}", randomNode)
-		// Now we validate that nothing is broken after the random schema changes have been run.
-		runCmd = roachtestutil.NewCommand("%s debug doctor examine cluster", test.DefaultCockroachPath).
-			Flag("url", doctorURL).
-			String()
-		return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runCmd)
-	}
+	mvt.InMixedVersion("run schemachange workload and validation in mixed version",
+		tester.schemaChangeAndValidationStep)
 
-	// Stage our workload node with the schemachange workload.
-	mvt.OnStartup("set up schemachange workload", func(ctx context.Context, l *logger.Logger, r *rand.Rand, helper *mixedversion.Helper) error {
-		return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf("./workload init schemachange {pgurl%s}", c.WorkloadNode()))
-	})
-
-	mvt.InMixedVersion("run schemachange workload and validation in mixed version", schemaChangeAndValidationStep)
-
-	mvt.AfterUpgradeFinalized("run schemachange workload and validation after upgrade has finalized", schemaChangeAndValidationStep)
+	mvt.AfterUpgradeFinalized("run schemachange workload and validation after upgrade has finalized",
+		tester.schemaChangeAndValidationStep)
 
 	mvt.Run()
+}
+
+// schemaChangeMixedVersionTester bundles state and configuration to pass to
+// test hooks
+type schemaChangeMixedVersionTester struct {
+	t              test.Test
+	c              cluster.Cluster
+	maxOps         int
+	concurrency    int
+	numFeatureRuns int
+}
+
+func newSchemaChangeMixedVersionTester(
+	t test.Test, c cluster.Cluster, maxOps int, concurrency int,
+) schemaChangeMixedVersionTester {
+	return schemaChangeMixedVersionTester{
+		t:           t,
+		c:           c,
+		maxOps:      maxOps,
+		concurrency: concurrency,
+	}
+}
+
+func (t schemaChangeMixedVersionTester) initWorkload(
+	ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper,
+) error {
+	binaryPath, _, err := clusterupgrade.UploadWorkload(
+		ctx, t.t, l, t.c, t.c.WorkloadNode(), h.System.FromVersion)
+	if err != nil {
+		return err
+	}
+	initCmd := roachtestutil.NewCommand("%s init schemachange", binaryPath).
+		Arg("{pgurl%s}", t.c.WorkloadNode()).String()
+	return t.c.RunE(ctx, option.WithNodes(t.c.WorkloadNode()), initCmd)
+}
+
+func (t schemaChangeMixedVersionTester) schemaChangeAndValidationStep(
+	ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper,
+) error {
+	t.numFeatureRuns += 1
+	l.Printf("Workload step run: %d", t.numFeatureRuns)
+	workloadSeed := r.Int63()
+	binaryPath, _, err := clusterupgrade.UploadWorkload(
+		ctx, t.t, l, t.c, t.c.WorkloadNode(), h.System.FromVersion)
+	if err != nil {
+		return err
+	}
+	runCmd := roachtestutil.NewCommand("%s run schemachange", binaryPath).
+		Flag("verbose", 1).
+		Flag("max-ops", t.maxOps).
+		Flag("concurrency", t.concurrency).
+		Arg("{pgurl%s}", t.c.All()).
+		EnvVar("COCKROACH_RANDOM_SEED", strconv.FormatInt(workloadSeed, 10)).
+		String()
+
+	if err := t.c.RunE(ctx, option.WithNodes(t.c.WorkloadNode()), runCmd); err != nil {
+		return err
+	}
+
+	randomNode := t.c.All().SeededRandNode(r)[0]
+	doctorURL := fmt.Sprintf("{pgurl:%d}", randomNode)
+	// Now we validate that nothing is broken after the random schema changes have been run.
+	runCmd = roachtestutil.NewCommand("%s debug doctor examine cluster", test.DefaultCockroachPath).
+		Flag("url", doctorURL).
+		String()
+	return t.c.RunE(ctx, option.WithNodes(t.c.WorkloadNode()), runCmd)
+
 }

--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -212,7 +212,7 @@ func StageApplication(
 	if err != nil {
 		return err
 	}
-
+	l.Printf("StageApplication %s with version %s for os %s and arch %s", applicationName, version, os, arch)
 	switch applicationName {
 	case "cockroach":
 		err := stageRemoteBinary(


### PR DESCRIPTION
11/6/25: Currently, mixedversion relies on including non supported versioned during the upgrade plan. Although "skip-version" upgrades are allowed, that only includes `24.x+`. Also the specific workload for this test `schemachange` doesn't support skip versions. Given all of the, the upgrade plan would be at most 3. The current upgrade plan is 2. That level of coverage increase in addition to the mixedversion and workload expectations that this would break make this change challenging. 
https://cockroachlabs.slack.com/archives/D08V7URRX52/p1762458712973069?thread_ts=1762458595.101659&cid=D08V7URRX52

Acknowledging the lack of coverage here, but putting this aside as there is no great path forward.

-----
Informs https://github.com/cockroachdb/cockroach/issues/154274 

Enables versioned workload binaries for mixedversion tests

#### New Bucket vs Reuse Existing Bucket
Existing `gs://cockroach-edge-artifacts-prod` policy for prefix `cockroach/`
```
    { name = "cockroach-edge-artifacts-prod", cleanup = [{
      age    = 30
      prefix = "cockroach/"
    }], public = true, enable_versioning = false }
```
While we can create a new bucket, we can also continue to use the `gs://cockroach-edge-artifacts-prod` bucket, but change the prefix of `latest` key workload binary objects. This approach would let us be able to reuse the `publish-artifacts` `edge` argument without having to write new support for a new one or add a flag for a new bucket. (still needs a change, but just changing the prefix is relatively simple IMO) 
Discussion: https://cockroachlabs.slack.com/archives/C03SG8QKYRJ/p1760976858868889 
Also this way avoids adding new lifecycle policies to the bucket
If we want the new bucket, here's the terraform PR: https://github.com/cockroachlabs/crl-infrastructure/pull/4277

# Dependencies
#### publish-artifacts: need unsupported workload binary versions
Change Workload binary keys from something like
`gs://cockroach-edge-artifacts-prod/cockroach/workload.release-24.1`
to a different key prefix
i.e. `gs://cockroach-edge-artifacts-prod/workload/workload.release-24.1`
publish-artifacts PR: https://github.com/cockroachdb/cockroach/pull/155789
* Needs to be backported (to everything? 🥹)

https://github.com/cockroachdb/cockroach/pull/156820

https://github.com/cockroachdb/cockroach/pull/156822
https://github.com/cockroachdb/cockroach/pull/156855
https://github.com/cockroachdb/cockroach/pull/156863
https://github.com/cockroachdb/cockroach/pull/156883
https://github.com/cockroachdb/cockroach/pull/156885
https://github.com/cockroachdb/cockroach/pull/156887

#### New Upgrade Plan selector that only uses supported versions
Didn't realize we wouldn't be able to backport changes to non supported versions. Therefore, if a test wants to use a a dedicated versioned workload binary, then it's upgrade path can only contain supported versions.

The question is how would that list be maintained? 

i.e. the naive approach would to just be to hard code a list in `master`. Then every time a release becomes unsupported, that change would need to made to master and backported to all currently supported versions.  Also everytime a new release branch get's cut, that change would need to be made to master (wouldn't need to back port this one). That seems like a lot of overhead.

If this information was centralized, I think that would be more intuitive, but keeping centralized config seems to be an anti pattern with all the other config being version controlled

#### roachprod: StageApplication change to use new latest key prefix
roachprod PR: https://github.com/cockroachdb/cockroach/pull/155803

