### PR TITLE
sql: harden recent change about DO block recursion

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -79,8 +79,13 @@ func TestCompare(t *testing.T) {
 	}
 	configs := map[string]testConfig{
 		"mutators": {
-			setup:           sqlsmith.Setups[sqlsmith.RandTableSetupName],
-			opts:            []sqlsmith.SmitherOption{sqlsmith.CompareMode()},
+			setup: sqlsmith.Setups[sqlsmith.RandTableSetupName],
+			opts: []sqlsmith.SmitherOption{
+				sqlsmith.CompareMode(),
+				// TODO(yuzefovich): perhaps allow DO blocks again after they
+				// have been stabilized in other tests.
+				sqlsmith.DisableDoBlocks(),
+			},
 			ignoreSQLErrors: true,
 			conns: []testConn{
 				{

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -163,7 +163,7 @@ func (p *planner) EvalRoutineExpr(
 		if routineDepthValue := ctx.Value(routineDepthKey{}); routineDepthValue != nil {
 			routineDepth = routineDepthValue.(int)
 		}
-		const maxDepth = 10000
+		const maxDepth = 100
 		if routineDepth > maxDepth {
 			return nil, pgerror.Newf(pgcode.ProgramLimitExceeded,
 				"routine reached recursion depth limit: %d (probably infinite loop)", maxDepth)


### PR DESCRIPTION
This commit reduces the max depth of recursion when evaluating routines with `tail-call-optimization-enabled=false` (recently added in 7b879efb5233d7e293170456e99ee4fcff80cfad) from 10k to 100. We've just seen a few cases where TestRandomSyntaxSQLSmith failed because DO block didn't respect context cancellation within 5s. I've manually tried it out a few times, and things worked, so my hypothesis is that extremely deep stacks (that are produced with the TCO disabled) is the root cause for slow cancellation, so let's just error out sooner.

This commit also brings back the skip of DO blocks in TestComposeCompare (thinking there is that we should stabilize them in other tests first).

Fixes: #155208.
Fixes: #155210.
Release note: None