### PR TITLE
sql: address index-out-of-bounds panic in annotated node

### DIFF
--- a/pkg/sql/sem/tree/annotation.go
+++ b/pkg/sql/sem/tree/annotation.go
@@ -28,6 +28,7 @@ func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
 		// Avoid index-out-of bounds panics in production builds. The impact is
 		// that the node will be treated as if it doesn't have the annotation,
 		// which is better than the process crash.
+		// TODO(155405): Address this panic on the setter side.
 		return nil
 	}
 	return ann.Get(n.AnnIdx)
@@ -35,6 +36,12 @@ func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
 
 // SetAnnotation sets the annotation associated with this node.
 func (n AnnotatedNode) SetAnnotation(ann *Annotations, annotation interface{}) {
+	if n.AnnIdx == NoAnnotation {
+		*ann = append(*ann, nil)
+		n.AnnIdx = AnnotationIdx(len(*ann))
+	}
+	// TODO(155405): Avoid index-of-bounds panics in SetAnnotation in production.
+
 	ann.Set(n.AnnIdx, annotation)
 }
 


### PR DESCRIPTION
Previously, resolving a name node without annotations would cause a
panic when setting the annotation. This change properly updates a
previously unannotated node and the annotations struct.

Informs: #151848
Informs: #155405
Informs: #148365

Release note (bug fix): Fixes a potential index-out-of-bounds panic when
setting an annotation on a previously unannotated SQL syntax tree node.
