### PR TITLE
kv/storeliveness: smear `StoreLiveness` heartbeats via `HeartbeatCoordinator`

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -17365,6 +17365,38 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storeliveness.transport.batch-duration
+      exported_name: storeliveness_transport_batch_duration
+      description: Duration spent collecting messages into batches by the Store Liveness Transport
+      y_axis_label: Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: storeliveness.transport.batch-size-bytes
+      exported_name: storeliveness_transport_batch_size_bytes
+      description: Size in bytes of batches sent by the Store Liveness Transport
+      y_axis_label: Bytes
+      type: HISTOGRAM
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: storeliveness.transport.batches-sent
+      exported_name: storeliveness_transport_batches_sent
+      description: Number of message batches sent by the Store Liveness Transport
+      y_axis_label: Batches
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storeliveness.transport.messages-per-batch
+      exported_name: storeliveness_transport_messages_per_batch
+      description: Number of messages per batch sent by the Store Liveness Transport
+      y_axis_label: Messages
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: storeliveness.transport.receive-queue-bytes
       exported_name: storeliveness_transport_receive_queue_bytes
       description: Total byte size of pending incoming messages from Store Liveness Transport

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2255,7 +2255,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	sm := storeliveness.NewSupportManager(
 		slpb.StoreIdent{NodeID: s.nodeDesc.NodeID, StoreID: s.StoreID()}, s.StateEngine(),
 		s.cfg.StoreLiveness.Options, s.cfg.Settings, s.stopper, s.cfg.Clock,
-		s.cfg.StoreLiveness.HeartbeatTicker, s.cfg.StoreLiveness.Transport,
+		s.cfg.StoreLiveness.HeartbeatTicker, s.cfg.StoreLiveness.HeartbeatCoordinator,
 		s.cfg.StoreLiveness.SupportManagerKnobs(),
 	)
 	s.cfg.StoreLiveness.Transport.ListenMessages(s.StoreID(), sm)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -255,7 +255,7 @@ func createTestStoreWithoutStart(
 		)
 		require.NoError(t, err)
 		knobs := cfg.TestingKnobs.StoreLivenessKnobs
-		cfg.StoreLiveness = storeliveness.NewNodeContainer(stopper, options, transport, knobs)
+		cfg.StoreLiveness = storeliveness.NewNodeContainer(stopper, options, transport, knobs, cfg.Settings)
 	}
 
 	stores := NewStores(cfg.AmbientCtx, cfg.Clock)

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/taskpacer",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
@@ -60,7 +61,7 @@ go_test(
     embed = [":storeliveness"],
     exec_properties = select({
         "//build/toolchains:is_heavy": {"test.Pool": "large"},
-        "//conditions:default": {"test.Pool": "default"},
+        "//conditions:default": {"test.Pool": "large"},
     }),
     deps = [
         "//pkg/base",
@@ -89,6 +90,7 @@ go_test(
         "//pkg/util/metric",
         "//pkg/util/netutil",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "config.go",
         "doc.go",
         "fabric.go",
+        "heartbeat_coodinator.go",
         "metrics.go",
         "node_manager.go",
         "persist.go",
@@ -47,6 +48,7 @@ go_test(
     name = "storeliveness_test",
     size = "large",
     srcs = [
+        "heartbeat_coodinator_test.go",
         "main_test.go",
         "multi_store_test.go",
         "persist_test.go",

--- a/pkg/kv/kvserver/storeliveness/heartbeat_coodinator.go
+++ b/pkg/kv/kvserver/storeliveness/heartbeat_coodinator.go
@@ -7,7 +7,6 @@ package storeliveness
 
 import (
 	"context"
-	"sort"
 	"time"
 
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
@@ -17,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/taskpacer"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -26,6 +26,28 @@ var HeartbeatBatchingDuration = settings.RegisterDurationSetting(
 	"duration over which heartbeat messages are batched to per-node destination queues;",
 	10*time.Millisecond,
 )
+
+var HeartbeatSmearDuration = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"kv.store_liveness.heartbeat_smear_duration",
+	"duration over which heartbeat messages are smeared to prevent goroutine "+
+		"spikes; all heartbeats for all nodes are sent within this window at "+
+		"the start of each tick",
+	10*time.Millisecond,
+)
+
+type heartbeatPacerConfig struct {
+	refresh time.Duration
+	smear   time.Duration
+}
+
+func (c *heartbeatPacerConfig) GetRefresh() time.Duration {
+	return c.refresh
+}
+
+func (c *heartbeatPacerConfig) GetSmear() time.Duration {
+	return c.smear
+}
 
 type HeartbeatCoordinator struct {
 	transport BatchMessageSender
@@ -48,9 +70,7 @@ type DestinationQueue struct {
 var _ MessageSender = (*HeartbeatCoordinator)(nil)
 
 func NewHeartbeatCoordinator(
-	transport BatchMessageSender,
-	stopper *stop.Stopper,
-	settings *cluster.Settings,
+	transport BatchMessageSender, stopper *stop.Stopper, settings *cluster.Settings,
 ) *HeartbeatCoordinator {
 	metrics := newHeartbeatCoordinatorMetrics()
 
@@ -69,13 +89,13 @@ func NewHeartbeatCoordinator(
 			c.run(ctx)
 		},
 	); err != nil {
-		log.KvExec.Warningf(context.Background(), "failed to start HeartbeatCoordinator: %v", err)
+		log.KvExec.Warningf(context.Background(),
+			"failed to start HeartbeatCoordinator: %v", err)
 	}
 
 	return c
 }
 
-// run contains the main processing goroutine which waits for signals and processes heartbeats.
 func (c *HeartbeatCoordinator) run(ctx context.Context) {
 	var batchTimer timeutil.Timer
 	defer batchTimer.Stop()
@@ -108,7 +128,7 @@ func (c *HeartbeatCoordinator) run(ctx context.Context) {
 			// signaling times from across all stores' goroutines.
 
 			// Process the batch.
-			c.drainAndSend(ctx)
+			c.drainAndSmear(ctx)
 
 		case <-c.stopper.ShouldQuiesce():
 			return
@@ -127,12 +147,16 @@ func (c *HeartbeatCoordinator) run(ctx context.Context) {
 func (c *HeartbeatCoordinator) SendAsync(ctx context.Context, msg slpb.Message) bool {
 	if msg.Type == slpb.MsgHeartbeatResp {
 		c.metrics.MessagesSentImmediate.Inc(1)
-		log.KvExec.VInfof(ctx, 2, "HeartbeatCoordinator sending immediate response to node %d", msg.To.NodeID)
+		log.KvExec.VInfof(ctx, 2,
+			"HeartbeatCoordinator sending immediate response to node %d",
+			msg.To.NodeID)
 
 		success := c.transport.SendAsync(ctx, msg)
 		if !success {
 			c.metrics.SendErrors.Inc(1)
-			log.KvExec.Warningf(ctx, "Failed to send immediate heartbeat response to node %d", msg.To.NodeID)
+			log.KvExec.Warningf(ctx,
+				"Failed to send immediate heartbeat response to node %d",
+				msg.To.NodeID)
 		}
 		return success
 	}
@@ -140,8 +164,9 @@ func (c *HeartbeatCoordinator) SendAsync(ctx context.Context, msg slpb.Message) 
 }
 
 // Enqueue adds messages to the appropriate destination queue.
-func (c *HeartbeatCoordinator) Enqueue(messages []slpb.Message) int {
-	log.KvExec.VInfof(context.Background(), 2, "HeartbeatCoordinator enqueuing %d messages", len(messages))
+func (c *HeartbeatCoordinator) Enqueue(ctx context.Context, messages []slpb.Message) int {
+	log.KvExec.VInfof(context.Background(), 2,
+		"HeartbeatCoordinator enqueuing %d messages", len(messages))
 	successes := 0
 	for _, msg := range messages {
 		nodeID := msg.To.NodeID
@@ -149,27 +174,21 @@ func (c *HeartbeatCoordinator) Enqueue(messages []slpb.Message) int {
 		queue, isNew := c.getOrCreateQueue(nodeID)
 		if isNew {
 			c.metrics.ActiveQueues.Inc(1)
-			log.KvExec.VInfof(context.Background(), 1, "HeartbeatCoordinator created new queue for node %d", nodeID)
+			log.KvExec.VInfof(ctx, 1,
+				"HeartbeatCoordinator created new queue for node %d", nodeID)
 		}
 
-		queue.messages <- msg
-		c.metrics.MessagesEnqueued.Inc(1)
-		successes++
+		select {
+		case queue.messages <- msg:
+			c.metrics.MessagesEnqueued.Inc(1)
+			successes++
+		default:
+			c.metrics.MessagesDropped.Inc(1)
+			log.KvExec.Warningf(ctx, "dropped heartbeat to node %d, queue full", nodeID)
+		}
 	}
 
-	c.updateTotalMessagesMetric()
-
 	return successes
-}
-
-// updateTotalMessagesMetric updates the total messages in queues metric.
-func (c *HeartbeatCoordinator) updateTotalMessagesMetric() {
-	totalMessages := 0
-	c.nodeQueues.Range(func(nodeID roachpb.NodeID, queue *DestinationQueue) bool {
-		totalMessages += len(queue.messages)
-		return true
-	})
-	c.metrics.TotalMessagesInQueues.Update(int64(totalMessages))
 }
 
 // getOrCreateQueue returns the queue for the given nodeID, creating it if necessary.
@@ -187,19 +206,6 @@ func (c *HeartbeatCoordinator) getOrCreateQueue(nodeID roachpb.NodeID) (Destinat
 	return *stored, !loaded
 }
 
-func (c *HeartbeatCoordinator) ClearQueues() {
-	c.nodeQueues.Range(func(nodeID roachpb.NodeID, queue *DestinationQueue) bool {
-		for {
-			select {
-			case <-queue.messages:
-			default:
-				return true
-			}
-		}
-	})
-	c.updateTotalMessagesMetric()
-}
-
 func (c *HeartbeatCoordinator) SignalToSend() {
 	select {
 	case c.signalChan <- struct{}{}:
@@ -209,7 +215,8 @@ func (c *HeartbeatCoordinator) SignalToSend() {
 	}
 }
 
-func (c *HeartbeatCoordinator) drainAndSend(ctx context.Context) {
+func (c *HeartbeatCoordinator) drainAndSmear(ctx context.Context) {
+	startTime := timeutil.Now()
 
 	var nodeIDs []roachpb.NodeID
 	c.nodeQueues.Range(func(nodeID roachpb.NodeID, queue *DestinationQueue) bool {
@@ -223,15 +230,44 @@ func (c *HeartbeatCoordinator) drainAndSend(ctx context.Context) {
 		return
 	}
 
-	sort.Slice(nodeIDs, func(i, j int) bool {
-		return nodeIDs[i] < nodeIDs[j]
-	})
+	smearDuration := HeartbeatSmearDuration.Get(&c.settings.SV)
+	pacerConfig := &heartbeatPacerConfig{
+		refresh: smearDuration,
+		smear:   smearDuration / 10,
+	}
+	pacer := taskpacer.New(pacerConfig)
+	pacer.StartTask(timeutil.Now())
 
-	for _, nodeID := range nodeIDs {
-		c.processNodeQueue(ctx, nodeID)
+	workLeft := len(nodeIDs)
+	nodeIndex := 0
+
+	for workLeft > 0 {
+		todo, by := pacer.Pace(timeutil.Now(), workLeft)
+
+		if todo <= 0 {
+			c.metrics.PacerErrors.Inc(1)
+			break
+		}
+
+		for j := 0; j < todo && nodeIndex < len(nodeIDs); j++ {
+			nodeID := nodeIDs[nodeIndex]
+			c.processNodeQueue(ctx, nodeID)
+			nodeIndex++
+		}
+
+		workLeft -= todo
+
+		if workLeft > 0 && by.After(timeutil.Now()) {
+			sleepDuration := by.Sub(timeutil.Now())
+			if sleepDuration > 0 {
+				time.Sleep(sleepDuration)
+			}
+		}
 	}
 
-	log.KvExec.VInfof(ctx, 2, "HeartbeatCoordinator processed %d nodes", len(nodeIDs))
+	totalDuration := timeutil.Since(startTime)
+	log.KvExec.VInfof(ctx, 2,
+		"HeartbeatCoordinator processed %d nodes in %v", len(nodeIDs), totalDuration)
 }
 
 // processNodeQueue processes all messages in a specific node's queue.
@@ -242,15 +278,15 @@ func (c *HeartbeatCoordinator) processNodeQueue(ctx context.Context, nodeID roac
 	}
 
 	var messages []slpb.Message
+loop:
 	for {
 		select {
 		case msg := <-(*queue).messages:
 			messages = append(messages, msg)
 		default:
-			goto done
+			break loop
 		}
 	}
-done:
 
 	if len(messages) == 0 {
 		return

--- a/pkg/kv/kvserver/storeliveness/heartbeat_coodinator.go
+++ b/pkg/kv/kvserver/storeliveness/heartbeat_coodinator.go
@@ -1,0 +1,266 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package storeliveness
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+var HeartbeatBatchingDuration = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"kv.store_liveness.heartbeat_batching_duration",
+	"duration over which heartbeat messages are batched to per-node destination queues;",
+	10*time.Millisecond,
+)
+
+type HeartbeatCoordinator struct {
+	transport BatchMessageSender
+	stopper   *stop.Stopper
+	settings  *cluster.Settings
+	// nodeQueues maps node IDs to their destination queues.
+	// The node IDs represent the destination nodes of the heartbeat messages.
+	// This map is used for efficient batched sending of heartbeat messages.
+	nodeQueues syncutil.Map[roachpb.NodeID, DestinationQueue]
+	// signalChan is a channel used to signal the HeartbeatCoordinator to start
+	// sending heartbeat messages to their destination nodes in a smeared manner.
+	signalChan chan struct{}
+	metrics    *HeartbeatCoordinatorMetrics
+}
+
+type DestinationQueue struct {
+	messages chan slpb.Message
+}
+
+var _ MessageSender = (*HeartbeatCoordinator)(nil)
+
+func NewHeartbeatCoordinator(
+	transport BatchMessageSender,
+	stopper *stop.Stopper,
+	settings *cluster.Settings,
+) *HeartbeatCoordinator {
+	metrics := newHeartbeatCoordinatorMetrics()
+
+	c := &HeartbeatCoordinator{
+		transport:  transport,
+		stopper:    stopper,
+		settings:   settings,
+		signalChan: make(chan struct{}, 1),
+		metrics:    metrics,
+	}
+
+	if err := stopper.RunAsyncTask(
+		context.Background(),
+		"storeliveness.HeartbeatCoordinator: run",
+		func(ctx context.Context) {
+			c.run(ctx)
+		},
+	); err != nil {
+		log.KvExec.Warningf(context.Background(), "failed to start HeartbeatCoordinator: %v", err)
+	}
+
+	return c
+}
+
+// run contains the main processing goroutine which waits for signals and processes heartbeats.
+func (c *HeartbeatCoordinator) run(ctx context.Context) {
+	var batchTimer timeutil.Timer
+	defer batchTimer.Stop()
+	for {
+		select {
+		// N.B. this outer most case captures the first signal.
+		case <-c.signalChan:
+			// N.B. (cont.) once the first signal is captured, we start a batching timer.
+			batchingDuration := HeartbeatBatchingDuration.Get(&c.settings.SV)
+			batchTimer.Reset(batchingDuration)
+			for done := false; !done; {
+				select {
+				// N.B. (cont.) this inner most case captures & ingores subsequent
+				// signals that occur within the batching window.
+				case <-c.signalChan:
+					// Do nothing here.
+
+				case <-batchTimer.C:
+					// N.B. (cont.) once the batching window is reached, we break
+					// out of the loop. This pattern essentially collects multiple
+					// signals and acts as a batching mechanism.
+					done = true
+				}
+			}
+			// N.B. (fin.) thi is to increase the bactches we send per batching
+			// window as we wait for other stores to enqueue their messages.
+			// There's no guarentee that all stores, even though they
+			// share the HeartbeatTicker, will signal the coordinator at exactly
+			// the same time. This mecahnism ensures we account for jitter in
+			// signaling times from across all stores' goroutines.
+
+			// Process the batch.
+			c.drainAndSend(ctx)
+
+		case <-c.stopper.ShouldQuiesce():
+			return
+		}
+	}
+}
+
+// SendAsync implements MessageSender.
+// This method is a thin shim over the underlying transport's SendAsync:
+//   - Heartbeat responses (MsgHeartbeatResp) are sent immediately to bypass smearing,
+//     with metrics and logging recorded here.
+//   - All other messages are simply forwarded to the transport.
+//
+// Note: heartbeat request batching/smearing is handled via Enqueue/SignalToSend,
+// not through SendAsync.
+func (c *HeartbeatCoordinator) SendAsync(ctx context.Context, msg slpb.Message) bool {
+	if msg.Type == slpb.MsgHeartbeatResp {
+		c.metrics.MessagesSentImmediate.Inc(1)
+		log.KvExec.VInfof(ctx, 2, "HeartbeatCoordinator sending immediate response to node %d", msg.To.NodeID)
+
+		success := c.transport.SendAsync(ctx, msg)
+		if !success {
+			c.metrics.SendErrors.Inc(1)
+			log.KvExec.Warningf(ctx, "Failed to send immediate heartbeat response to node %d", msg.To.NodeID)
+		}
+		return success
+	}
+	return c.transport.SendAsync(ctx, msg)
+}
+
+// Enqueue adds messages to the appropriate destination queue.
+func (c *HeartbeatCoordinator) Enqueue(messages []slpb.Message) int {
+	log.KvExec.VInfof(context.Background(), 2, "HeartbeatCoordinator enqueuing %d messages", len(messages))
+	successes := 0
+	for _, msg := range messages {
+		nodeID := msg.To.NodeID
+
+		queue, isNew := c.getOrCreateQueue(nodeID)
+		if isNew {
+			c.metrics.ActiveQueues.Inc(1)
+			log.KvExec.VInfof(context.Background(), 1, "HeartbeatCoordinator created new queue for node %d", nodeID)
+		}
+
+		queue.messages <- msg
+		c.metrics.MessagesEnqueued.Inc(1)
+		successes++
+	}
+
+	c.updateTotalMessagesMetric()
+
+	return successes
+}
+
+// updateTotalMessagesMetric updates the total messages in queues metric.
+func (c *HeartbeatCoordinator) updateTotalMessagesMetric() {
+	totalMessages := 0
+	c.nodeQueues.Range(func(nodeID roachpb.NodeID, queue *DestinationQueue) bool {
+		totalMessages += len(queue.messages)
+		return true
+	})
+	c.metrics.TotalMessagesInQueues.Update(int64(totalMessages))
+}
+
+// getOrCreateQueue returns the queue for the given nodeID, creating it if necessary.
+// Returns (queue, isNew) where isNew indicates if the queue was just created.
+func (c *HeartbeatCoordinator) getOrCreateQueue(nodeID roachpb.NodeID) (DestinationQueue, bool) {
+	if queue, ok := c.nodeQueues.Load(nodeID); ok {
+		return *queue, false
+	}
+
+	queue := &DestinationQueue{
+		messages: make(chan slpb.Message, 1000),
+	}
+
+	stored, loaded := c.nodeQueues.LoadOrStore(nodeID, queue)
+	return *stored, !loaded
+}
+
+func (c *HeartbeatCoordinator) ClearQueues() {
+	c.nodeQueues.Range(func(nodeID roachpb.NodeID, queue *DestinationQueue) bool {
+		for {
+			select {
+			case <-queue.messages:
+			default:
+				return true
+			}
+		}
+	})
+	c.updateTotalMessagesMetric()
+}
+
+func (c *HeartbeatCoordinator) SignalToSend() {
+	select {
+	case c.signalChan <- struct{}{}:
+		c.metrics.SignalsAccepted.Inc(1)
+	default:
+		c.metrics.SignalsIgnored.Inc(1)
+	}
+}
+
+func (c *HeartbeatCoordinator) drainAndSend(ctx context.Context) {
+
+	var nodeIDs []roachpb.NodeID
+	c.nodeQueues.Range(func(nodeID roachpb.NodeID, queue *DestinationQueue) bool {
+		if len(queue.messages) > 0 {
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+		return true
+	})
+
+	if len(nodeIDs) == 0 {
+		return
+	}
+
+	sort.Slice(nodeIDs, func(i, j int) bool {
+		return nodeIDs[i] < nodeIDs[j]
+	})
+
+	for _, nodeID := range nodeIDs {
+		c.processNodeQueue(ctx, nodeID)
+	}
+
+	log.KvExec.VInfof(ctx, 2, "HeartbeatCoordinator processed %d nodes", len(nodeIDs))
+}
+
+// processNodeQueue processes all messages in a specific node's queue.
+func (c *HeartbeatCoordinator) processNodeQueue(ctx context.Context, nodeID roachpb.NodeID) {
+	queue, ok := c.nodeQueues.Load(nodeID)
+	if !ok {
+		return
+	}
+
+	var messages []slpb.Message
+	for {
+		select {
+		case msg := <-(*queue).messages:
+			messages = append(messages, msg)
+		default:
+			goto done
+		}
+	}
+done:
+
+	if len(messages) == 0 {
+		return
+	}
+
+	success := c.transport.SendBatchDirect(ctx, nodeID, messages)
+	if !success {
+		c.metrics.SendErrors.Inc(int64(len(messages)))
+		log.KvExec.Warningf(ctx, "Failed to send batch to node %d", nodeID)
+	} else {
+		c.metrics.MessagesSent.Inc(int64(len(messages)))
+	}
+}

--- a/pkg/kv/kvserver/storeliveness/heartbeat_coodinator_test.go
+++ b/pkg/kv/kvserver/storeliveness/heartbeat_coodinator_test.go
@@ -1,0 +1,323 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package storeliveness
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBatchTransport captures batches sent via SendBatchDirect for testing.
+type mockBatchTransport struct {
+	mu           sync.Mutex
+	batches      [][]slpb.Message
+	sentMessages []slpb.Message
+}
+
+func (m *mockBatchTransport) SendAsync(ctx context.Context, msg slpb.Message) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sentMessages = append(m.sentMessages, msg)
+	return true
+}
+
+func (m *mockBatchTransport) SendBatchDirect(
+	ctx context.Context, nodeID roachpb.NodeID, messages []slpb.Message,
+) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Make a copy of the batch
+	batch := make([]slpb.Message, len(messages))
+	copy(batch, messages)
+	m.batches = append(m.batches, batch)
+	return true
+}
+
+func (m *mockBatchTransport) getBatches() [][]slpb.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([][]slpb.Message, len(m.batches))
+	copy(result, m.batches)
+	return result
+}
+
+func (m *mockBatchTransport) getBatchMessages() []slpb.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var batchMessages []slpb.Message
+
+	// Add messages from batches (sent via SendBatchDirect)
+	for _, batch := range m.batches {
+		batchMessages = append(batchMessages, batch...)
+	}
+
+	return batchMessages
+}
+
+func (m *mockBatchTransport) getAsyncMessages() []slpb.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]slpb.Message, len(m.sentMessages))
+	copy(result, m.sentMessages)
+	return result
+}
+
+func (m *mockBatchTransport) clearBatchMessages() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.batches = m.batches[:0]
+}
+
+func (m *mockBatchTransport) clearAsyncMessages() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sentMessages = m.sentMessages[:0]
+}
+
+func (m *mockBatchTransport) getBatchCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.batches)
+}
+
+var _ BatchMessageSender = (*mockBatchTransport)(nil)
+
+// TestHeartbeatCoordinatorResponsesBypassBatching verifies that heartbeat
+// responses are sent immediately and bypass the batching mechanism.
+func TestHeartbeatCoordinatorResponsesBypassBatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	settings := cluster.MakeTestingClusterSettings()
+	transport := &mockBatchTransport{}
+
+	coordinator := NewHeartbeatCoordinator(transport, stopper, settings)
+
+	response := slpb.Message{
+		Type:       slpb.MsgHeartbeatResp,
+		From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+		To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+		Epoch:      1,
+		Expiration: hlc.Timestamp{WallTime: 100},
+	}
+
+	sent := coordinator.SendAsync(ctx, response)
+	require.True(t, sent)
+
+	// Response should be sent immediately via SendAsync, not batched.
+	asyncMessages := transport.getAsyncMessages()
+	require.Len(t, asyncMessages, 1)
+	require.Equal(t, slpb.MsgHeartbeatResp, asyncMessages[0].Type)
+
+	// No batches should be created.
+	require.Equal(t, 0, transport.getBatchCount())
+
+	require.Equal(t, int64(1), coordinator.metrics.MessagesSentImmediate.Count())
+	require.Equal(t, int64(0), coordinator.metrics.MessagesEnqueued.Count())
+}
+
+// TestHeartbeatCoordinatorRequestsAreBatched verifies that heartbeat requests
+// are enqueued and sent as batches after the batching duration.
+func TestHeartbeatCoordinatorRequestsAreBatched(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	settings := cluster.MakeTestingClusterSettings()
+	transport := &mockBatchTransport{}
+
+	// Set a short batching duration for the test.
+	HeartbeatBatchingDuration.Override(ctx, &settings.SV, 20*time.Millisecond)
+
+	coordinator := NewHeartbeatCoordinator(transport, stopper, settings)
+
+	// Enqueue multiple requests to the same node.
+	requests := []slpb.Message{
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+			Epoch:      1,
+			Expiration: hlc.Timestamp{WallTime: 100},
+		},
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+			Epoch:      2,
+			Expiration: hlc.Timestamp{WallTime: 200},
+		},
+	}
+
+	successes := coordinator.Enqueue(requests)
+	require.Equal(t, 2, successes)
+
+	coordinator.SignalToSend()
+
+	// Wait for batching duration plus some buffer.
+	time.Sleep(50 * time.Millisecond)
+
+	batches := transport.getBatches()
+	require.Len(t, batches, 1)
+	require.Len(t, batches[0], 2)
+
+	require.Equal(t, int64(2), coordinator.metrics.MessagesEnqueued.Count())
+	require.Equal(t, int64(2), coordinator.metrics.MessagesSent.Count())
+	require.Equal(t, int64(1), coordinator.metrics.SignalsAccepted.Count())
+}
+
+// TestHeartbeatCoordinatorMultipleNodes verifies that messages to different
+// nodes are sent in separate batches.
+func TestHeartbeatCoordinatorMultipleNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	settings := cluster.MakeTestingClusterSettings()
+	transport := &mockBatchTransport{}
+
+	HeartbeatBatchingDuration.Override(ctx, &settings.SV, 20*time.Millisecond)
+
+	coordinator := NewHeartbeatCoordinator(transport, stopper, settings)
+
+	requests := []slpb.Message{
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+			Epoch:      1,
+			Expiration: hlc.Timestamp{WallTime: 100},
+		},
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 3, StoreID: 3},
+			Epoch:      1,
+			Expiration: hlc.Timestamp{WallTime: 100},
+		},
+	}
+
+	coordinator.Enqueue(requests)
+	coordinator.SignalToSend()
+
+	time.Sleep(50 * time.Millisecond)
+
+	batches := transport.getBatches()
+	require.Len(t, batches, 2)
+	require.Len(t, batches[0], 1)
+	require.Len(t, batches[1], 1)
+
+	require.Equal(t, int64(2), coordinator.metrics.ActiveQueues.Value())
+}
+
+// TestHeartbeatCoordinatorClearQueues verifies that ClearQueues removes all
+// pending messages from the queues.
+func TestHeartbeatCoordinatorClearQueues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	settings := cluster.MakeTestingClusterSettings()
+	transport := &mockBatchTransport{}
+
+	coordinator := NewHeartbeatCoordinator(transport, stopper, settings)
+
+	requests := []slpb.Message{
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+			Epoch:      1,
+			Expiration: hlc.Timestamp{WallTime: 100},
+		},
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 3, StoreID: 3},
+			Epoch:      1,
+			Expiration: hlc.Timestamp{WallTime: 100},
+		},
+	}
+
+	coordinator.Enqueue(requests)
+
+	require.Equal(t, int64(2), coordinator.metrics.TotalMessagesInQueues.Value())
+
+	coordinator.ClearQueues()
+
+	require.Equal(t, int64(0), coordinator.metrics.TotalMessagesInQueues.Value())
+
+	coordinator.SignalToSend()
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal(t, 0, transport.getBatchCount())
+}
+
+// TestHeartbeatCoordinatorBatchingWindow verifies that additional signals
+// during the batching window don't interrupt the batching process.
+func TestHeartbeatCoordinatorBatchingWindow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	settings := cluster.MakeTestingClusterSettings()
+	transport := &mockBatchTransport{}
+
+	HeartbeatBatchingDuration.Override(ctx, &settings.SV, 50*time.Millisecond)
+
+	coordinator := NewHeartbeatCoordinator(transport, stopper, settings)
+
+	coordinator.Enqueue([]slpb.Message{
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+			Epoch:      1,
+			Expiration: hlc.Timestamp{WallTime: 100},
+		},
+	})
+	coordinator.SignalToSend()
+
+	time.Sleep(10 * time.Millisecond)
+	coordinator.Enqueue([]slpb.Message{
+		{
+			Type:       slpb.MsgHeartbeat,
+			From:       slpb.StoreIdent{NodeID: 1, StoreID: 1},
+			To:         slpb.StoreIdent{NodeID: 2, StoreID: 2},
+			Epoch:      2,
+			Expiration: hlc.Timestamp{WallTime: 200},
+		},
+	})
+	coordinator.SignalToSend() // This signal should be drained during collection window.
+
+	time.Sleep(80 * time.Millisecond)
+
+	batches := transport.getBatches()
+	require.Len(t, batches, 1)
+	require.Len(t, batches[0], 2)
+}

--- a/pkg/kv/kvserver/storeliveness/metrics.go
+++ b/pkg/kv/kvserver/storeliveness/metrics.go
@@ -110,10 +110,14 @@ type HeartbeatCoordinatorMetrics struct {
 	MessagesEnqueued      *metric.Counter
 	MessagesSent          *metric.Counter
 	MessagesSentImmediate *metric.Counter // responses that bypass smearing
+	MessagesDropped       *metric.Counter
 
 	// Queue metrics.
-	ActiveQueues          *metric.Gauge
-	TotalMessagesInQueues *metric.Gauge
+	ActiveQueues *metric.Gauge
+
+	// Timing metrics.
+	TickDuration  *metric.Gauge
+	SmearDuration *metric.Gauge
 
 	// Signal metrics.
 	SignalsAccepted *metric.Counter
@@ -130,8 +134,10 @@ func newHeartbeatCoordinatorMetrics() *HeartbeatCoordinatorMetrics {
 		MessagesEnqueued:      metric.NewCounter(metaHeartbeatCoordinatorMessagesEnqueued),
 		MessagesSent:          metric.NewCounter(metaHeartbeatCoordinatorMessagesSent),
 		MessagesSentImmediate: metric.NewCounter(metaHeartbeatCoordinatorMessagesSentImmediate),
+		MessagesDropped:       metric.NewCounter(metaHeartbeatCoordinatorMessagesDropped),
 		ActiveQueues:          metric.NewGauge(metaHeartbeatCoordinatorActiveQueues),
-		TotalMessagesInQueues: metric.NewGauge(metaHeartbeatCoordinatorTotalMessagesInQueues),
+		TickDuration:          metric.NewGauge(metaHeartbeatCoordinatorTickDuration),
+		SmearDuration:         metric.NewGauge(metaHeartbeatCoordinatorSmearDuration),
 		SignalsAccepted:       metric.NewCounter(metaHeartbeatCoordinatorSignalsAccepted),
 		SignalsIgnored:        metric.NewCounter(metaHeartbeatCoordinatorSignalsIgnored),
 		SignalsDrained:        metric.NewCounter(metaHeartbeatCoordinatorSignalsDrained),
@@ -282,8 +288,16 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 	metaHeartbeatCoordinatorMessagesSentImmediate = metric.Metadata{
-		Name:        "storeliveness.heartbeat_coordinator.messages_sent_immediate",
-		Help:        "Total number of heartbeat response messages sent immediately (bypassing smearing)",
+		Name: "storeliveness.heartbeat_coordinator.messages_sent_immediate",
+		Help: "Total number of heartbeat response messages sent " +
+			"immediately (bypassing smearing)",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaHeartbeatCoordinatorMessagesDropped = metric.Metadata{
+		Name: "storeliveness.heartbeat_coordinator.messages_dropped",
+		Help: "Total number of heartbeat messages dropped due to message " +
+			"buffer queues being full",
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -293,10 +307,16 @@ var (
 		Measurement: "Queues",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaHeartbeatCoordinatorTotalMessagesInQueues = metric.Metadata{
-		Name:        "storeliveness.heartbeat_coordinator.total_messages_in_queues",
-		Help:        "Current total number of messages across all queues",
-		Measurement: "Messages",
+	metaHeartbeatCoordinatorTickDuration = metric.Metadata{
+		Name:        "storeliveness.heartbeat_coordinator.tick_duration_ms",
+		Help:        "Heartbeat tick duration in milliseconds",
+		Measurement: "Duration",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaHeartbeatCoordinatorSmearDuration = metric.Metadata{
+		Name:        "storeliveness.heartbeat_coordinator.smear_duration_ms",
+		Help:        "Heartbeat smear duration in milliseconds",
+		Measurement: "Duration",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaHeartbeatCoordinatorSendErrors = metric.Metadata{
@@ -318,8 +338,9 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 	metaHeartbeatCoordinatorSignalsIgnored = metric.Metadata{
-		Name:        "storeliveness.heartbeat_coordinator.signals_ignored",
-		Help:        "Total number of signals ignored by the heartbeat coordinator (already processing)",
+		Name: "storeliveness.heartbeat_coordinator.signals_ignored",
+		Help: "Total number of signals ignored by the heartbeat " +
+			"coordinator (already processing)",
 		Measurement: "Signals",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -349,8 +370,9 @@ var (
 		Unit:        metric.Unit_BYTES,
 	}
 	metaBatchDuration = metric.Metadata{
-		Name:        "storeliveness.transport.batch-duration",
-		Help:        "Duration spent collecting messages into batches by the Store Liveness Transport",
+		Name: "storeliveness.transport.batch-duration",
+		Help: "Duration spent collecting messages into batches by the " +
+			"Store Liveness Transport",
 		Measurement: "Duration",
 		Unit:        metric.Unit_NANOSECONDS,
 	}

--- a/pkg/kv/kvserver/storeliveness/node_manager.go
+++ b/pkg/kv/kvserver/storeliveness/node_manager.go
@@ -29,7 +29,11 @@ type NodeContainer struct {
 
 // NewNodeContainer creates a new NodeContainer.
 func NewNodeContainer(
-	stopper *stop.Stopper, options Options, transport *Transport, knobs *TestingKnobs, settings *cluster.Settings,
+	stopper *stop.Stopper,
+	options Options,
+	transport *Transport,
+	knobs *TestingKnobs,
+	settings *cluster.Settings,
 ) *NodeContainer {
 	ticker := timeutil.NewBroadcastTicker(options.HeartbeatInterval)
 	stopper.AddCloser(stop.CloserFn(ticker.Stop))

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -31,10 +31,23 @@ var Enabled = settings.RegisterBoolSetting(
 	true,
 )
 
+var PacedHeartbeatsEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.store_liveness.paced_heartbeats.enabled",
+	"if enabled, heartbeat messages will be paced across configurable interval to avoid "+
+		"bursts of network traffic; if disabled, heartbeats will be sent immediately",
+	true,
+)
+
 // MessageSender is the interface that defines how Store Liveness messages are
 // sent. Transport is the production implementation of MessageSender.
 type MessageSender interface {
 	SendAsync(ctx context.Context, msg slpb.Message) (sent bool)
+}
+
+type BatchMessageSender interface {
+	MessageSender
+	SendBatchDirect(ctx context.Context, nodeID roachpb.NodeID, messages []slpb.Message) bool
 }
 
 // SupportManager orchestrates requesting and providing Store Liveness support.
@@ -313,6 +326,7 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	livenessInterval := sm.options.SupportDuration
 	heartbeats := rsfu.getHeartbeatsToSend(sm.storeID, sm.clock.Now(), livenessInterval)
+
 	if err := rsfu.write(ctx, sm.engine); err != nil {
 		log.KvExec.Warningf(ctx, "failed to write requester meta: %v", err)
 		sm.metrics.HeartbeatFailures.Inc(int64(len(heartbeats)))
@@ -320,18 +334,26 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	}
 	sm.requesterStateHandler.checkInUpdate(rsfu)
 
-	// Send heartbeats to each remote store.
-	successes := 0
-	for _, msg := range heartbeats {
-		if sent := sm.sender.SendAsync(ctx, msg); sent {
-			successes++
-		} else {
-			log.KvExec.Warningf(ctx, "failed to send heartbeat to store %+v", msg.To)
+	pacedHeartbeatsEnabled := PacedHeartbeatsEnabled.Get(&sm.settings.SV)
+	heartbeatCoordinator := sm.sender.(*HeartbeatCoordinator)
+
+	var successes int
+	if pacedHeartbeatsEnabled {
+		// Paced heartbeats are enabled, use HeartbeatCoordinator.
+		successes = heartbeatCoordinator.Enqueue(heartbeats)
+		heartbeatCoordinator.SignalToSend()
+	} else {
+		// Paced heartbeats are disabled, send heartbeats immediately.
+		for _, heartbeat := range heartbeats {
+			if sm.sender.SendAsync(ctx, heartbeat) {
+				successes++
+			}
 		}
 	}
+
 	sm.metrics.HeartbeatSuccesses.Inc(int64(successes))
 	sm.metrics.HeartbeatFailures.Inc(int64(len(heartbeats) - successes))
-	log.KvExec.VInfof(ctx, 2, "sent heartbeats to %d stores", successes)
+	log.KvExec.VInfof(ctx, 2, "sent heartbeats to %d stores (paced: %v)", successes, pacedHeartbeatsEnabled)
 }
 
 // withdrawSupport delegates support withdrawal to supporterStateHandler.

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -34,7 +34,7 @@ var Enabled = settings.RegisterBoolSetting(
 var PacedHeartbeatsEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.store_liveness.paced_heartbeats.enabled",
-	"if enabled, heartbeat messages will be paced across configurable interval to avoid "+
+	"if enabled, heartbeat messages will be paced across `HeartbeatSmearDuration` to avoid "+
 		"bursts of network traffic; if disabled, heartbeats will be sent immediately",
 	true,
 )
@@ -340,7 +340,7 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	var successes int
 	if pacedHeartbeatsEnabled {
 		// Paced heartbeats are enabled, use HeartbeatCoordinator.
-		successes = heartbeatCoordinator.Enqueue(heartbeats)
+		successes = heartbeatCoordinator.Enqueue(ctx, heartbeats)
 		heartbeatCoordinator.SignalToSend()
 	} else {
 		// Paced heartbeats are disabled, send heartbeats immediately.

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -49,8 +49,9 @@ func TestSupportManagerRequestsSupport(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
-	heartbeatCoordinator := NewHeartbeatCoordinator(sender, stopper, settings)
-	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, heartbeatCoordinator, nil)
+
+	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	require.NoError(t, sm.Start(ctx))
 
 	// Start sending heartbeats to the remote store by calling SupportFrom.
@@ -124,8 +125,9 @@ func TestSupportManagerProvidesSupport(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
-	heartbeatCoordinator := NewHeartbeatCoordinator(sender, stopper, settings)
-	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, heartbeatCoordinator, nil)
+
+	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	cb := func(supportWithdrawn map[roachpb.StoreID]struct{}) {
 		require.Equal(t, 1, len(supportWithdrawn))
 		_, ok := supportWithdrawn[roachpb.StoreID(2)]
@@ -212,8 +214,9 @@ func TestSupportManagerEnableDisable(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
-	heartbeatCoordinator := NewHeartbeatCoordinator(sender, stopper, settings)
-	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, heartbeatCoordinator, nil)
+
+	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	require.NoError(t, sm.Start(ctx))
 
 	// Start sending heartbeats by calling SupportFrom.
@@ -223,7 +226,7 @@ func TestSupportManagerEnableDisable(t *testing.T) {
 	// Disable Store Liveness and make sure heartbeats stop.
 	Enabled.Override(ctx, &settings.SV, false)
 	// One heartbeat may race in while heartbeats are being disabled.
-	ensureNoHeartbeats(t, sender, sm.options.HeartbeatInterval, 1)
+	ensurePendingHeartbeatsComplete(t, sender, sm, 2)
 
 	// Enable Store Liveness again and make sure heartbeats are sent.
 	Enabled.Override(ctx, &settings.SV, true)
@@ -247,8 +250,9 @@ func TestSupportManagerRestart(t *testing.T) {
 	clock := hlc.NewClockForTesting(manual)
 	clockBehind := hlc.NewClockForTesting(manualBehind)
 	sender := &testMessageSender{}
-	heartbeatCoordinator := NewHeartbeatCoordinator(sender, stopper, settings)
-	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, heartbeatCoordinator, nil)
+
+	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	// Initialize the SupportManager without starting the main goroutine.
 	require.NoError(t, sm.onRestart(ctx))
 
@@ -281,7 +285,7 @@ func TestSupportManagerRestart(t *testing.T) {
 
 	// Simulate a restart by creating a new SupportManager with the same engine.
 	// Use a regressed clock.
-	sm = NewSupportManager(store, engine, options, settings, stopper, clockBehind, nil, sender, nil)
+	sm = NewSupportManager(store, engine, options, settings, stopper, clockBehind, nil, coordinator, nil)
 	now := sm.clock.Now()
 	require.False(t, requestedTime.Less(now))
 	require.False(t, withdrawalTime.Less(now))
@@ -311,6 +315,7 @@ func TestSupportManagerDiskStall(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
+
 	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
 	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	// Initialize the SupportManager without starting the main goroutine.
@@ -348,7 +353,8 @@ func TestSupportManagerDiskStall(t *testing.T) {
 			ctx, "heartbeat", sm.sendHeartbeats,
 		),
 	)
-	ensureNoHeartbeats(t, sender, sm.options.HeartbeatInterval, 0)
+
+	ensurePendingHeartbeatsComplete(t, sender, sm, 0)
 
 	// SupportFrom and SupportFor calls are still being answered.
 	epoch, _ := sm.SupportFrom(remoteStore)
@@ -380,8 +386,9 @@ func TestSupportManagerReceiveQueueLimit(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
-	heartbeatCoordinator := NewHeartbeatCoordinator(sender, stopper, settings)
-	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, heartbeatCoordinator, nil)
+
+	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	// Initialize the SupportManager without starting the main goroutine.
 	require.NoError(t, sm.onRestart(ctx))
 
@@ -422,11 +429,12 @@ func TestSupportManagerHeartbeatNewStore(t *testing.T) {
 	manual := hlc.NewHybridManualClock()
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
-	heartbeatCoordinator := NewHeartbeatCoordinator(sender, stopper, settings)
+
+	coordinator := NewHeartbeatCoordinator(sender, stopper, settings)
 	// Set a very large heartbeat interval to ensure heartbeats for new stores are
 	// sent out before the heartbeat ticker is signalled.
 	options.HeartbeatInterval = time.Hour
-	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, heartbeatCoordinator, nil)
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, nil, coordinator, nil)
 	require.NoError(t, sm.Start(ctx))
 
 	// Start sending heartbeats to the remote store by calling SupportFrom.
@@ -457,18 +465,15 @@ func ensureHeartbeats(t *testing.T, sender *testMessageSender, expectedNum int) 
 	return msgs
 }
 
-func ensureNoHeartbeats(
-	t *testing.T, sender *testMessageSender, hbInterval time.Duration, slack int,
+func ensurePendingHeartbeatsComplete(
+	t *testing.T, sender *testMessageSender, sm *SupportManager, slack int,
 ) {
-	sender.drainSentMessages()
-	err := testutils.SucceedsWithinError(
-		func() error {
-			if sender.getNumSentMessages() > slack {
-				return errors.New("heartbeats are sent")
-			} else {
-				return errors.New("no heartbeats")
-			}
-		}, hbInterval*10,
-	)
-	require.Regexp(t, err, "no heartbeats")
+	testutils.SucceedsSoon(t, func() error {
+		sender.drainSentMessages()
+		time.Sleep(50 * sm.options.HeartbeatInterval) // arbitrary duration to ensure no heartbeats
+		if sender.getNumSentMessages() > 0 {
+			return errors.New("heartbeats are being sent")
+		}
+		return nil
+	})
 }

--- a/pkg/kv/kvserver/storeliveness/testutils.go
+++ b/pkg/kv/kvserver/storeliveness/testutils.go
@@ -101,6 +101,15 @@ func (tms *testMessageSender) SendAsync(_ context.Context, msg slpb.Message) (se
 	return true
 }
 
+func (tms *testMessageSender) SendBatchDirect(
+	_ context.Context, nodeID roachpb.NodeID, messages []slpb.Message,
+) bool {
+	tms.mu.Lock()
+	defer tms.mu.Unlock()
+	tms.messages = append(tms.messages, messages...)
+	return true
+}
+
 func (tms *testMessageSender) drainSentMessages() []slpb.Message {
 	tms.mu.Lock()
 	defer tms.mu.Unlock()
@@ -116,6 +125,7 @@ func (tms *testMessageSender) getNumSentMessages() int {
 }
 
 var _ MessageSender = (*testMessageSender)(nil)
+var _ BatchMessageSender = (*testMessageSender)(nil)
 
 // UnreliableHandler allows users to selectively drop StoreLiveness messages.
 type UnreliableHandler struct {

--- a/pkg/kv/kvserver/storeliveness/transport.go
+++ b/pkg/kv/kvserver/storeliveness/transport.go
@@ -28,7 +28,7 @@ const (
 	// Outgoing messages are queued per-node on a channel of this size.
 	sendBufferSize = 1000
 
-	//
+	// Outgoing batches are queued per-node on a channel of this size.
 	batchSendBufferSize = 1000
 
 	// When no message has been queued for this duration, the corresponding
@@ -466,7 +466,6 @@ func (t *Transport) SendBatchDirect(
 
 	select {
 	case bq.messages <- messages:
-		// Successfully enqueued the batch
 		return true
 	default:
 		if logQueueFullEvery.ShouldLog() {
@@ -510,11 +509,9 @@ func (t *Transport) processBatchQueue(
 			return nil
 
 		case <-idleTimer.C:
-			// No batches for idle timeout period - shut down
 			return nil
 
 		case messages := <-bq.messages:
-			// Send the pre-formed batch
 			batch := &slpb.MessageBatch{
 				Messages: messages,
 				Now:      t.clock.NowAsClockTimestamp(),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -681,7 +681,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		if storeKnobs := cfg.TestingKnobs.Store; storeKnobs != nil {
 			knobs = storeKnobs.(*kvserver.StoreTestingKnobs).StoreLivenessKnobs
 		}
-		storeLiveness = storeliveness.NewNodeContainer(stopper, options, transport, knobs)
+		storeLiveness = storeliveness.NewNodeContainer(stopper, options, transport, knobs, st)
 	}
 
 	ctSender := sidetransport.NewSender(stopper, st, clock, kvNodeDialer)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -225,7 +225,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 			t.Fatal(err)
 		}
 		knobs := cfg.TestingKnobs.StoreLivenessKnobs
-		cfg.StoreLiveness = storeliveness.NewNodeContainer(ltc.stopper, options, transport, knobs)
+		cfg.StoreLiveness = storeliveness.NewNodeContainer(ltc.stopper, options, transport, knobs, cfg.Settings)
 	}
 	nodeCountFn := func() int {
 		var count int


### PR DESCRIPTION
This PR introduces a `HeartbeatCoordinator` component that batches and temporally smears Store Liveness heartbeat messages across destination nodes to prevent synchronized network traffic spikes.

### Changes

Although this PR has a lot of changes, focusing on these three files will make the review easier and more manageable.

```sh
pkg/kv/kvserver/storeliveness
├── heartbeat_coodinator.go
├── support_manager.go
└── transport.go
```

A significant portion of the LOC is from new metrics and tests that were added.

### Background

  Currently, all stores in a cluster send heartbeats simultaneously at each heartbeat interval tick. In large clusters (e.g., multi-store nodes, with many nodes in a cluster), this creates synchronized bursts of network traffic every heartbeat interval, potentially
  causing:
  - Goroutine count spikes
  - Network congestion
  - CPU scheduling pressure
  
  
 ### TL;DR of Changes

  #### Core Implementation

  **New Component: `HeartbeatCoordinator`**
  - Batches heartbeat requests per destination node
  - Smears message sending across a configurable time window using `taskpacer`
  - Bypasses smearing for heartbeat responses (sent immediately)
  - Maintains per-node destination queues with buffered channels (1000 capacity)

  **New Workflow:**
  1. `SupportManager.sendHeartbeats()` enqueues messages to coordinator if pacing is enabled
  2. Coordinator collects messages during batching window (default 10ms)
  3. Messages are drained and sent to nodes using `taskpacer` over smear duration (default 10ms)
  4. Each destination node receives a single batch via `Transport.SendBatchDirect()`. `SendBatchDirect()` method bypasses Transport's internal queuing and sends pre-formed batches directly. This allows the HeartbeatCoordinator to control batching and timing.
  
  
### Backward Compatibility

  - Feature is controlled by kv.store_liveness.paced_heartbeats.enabled (default: true)
  - When disabled, heartbeats are sent immediately via the existing path
    - Responses always bypass smearing for minimal latency
    
### Testing
- `heartbeatCoordinator_Test.go` details a myriad of tests to verify heartbeat behaviour works as expected.
- Updated `transport_test.go` with unittests to ensure new functions added work as intended
- Updated `support_manager_test.go`, `store_liveness_test.go`, and `testutils.go` to work with smearing changes

#### Roachpod testing
- Ran a prototype with a [similar design](https://github.com/cockroachdb/cockroach/pull/154942) (TL;DR of prototype, the heartbeats were smeared via `SupportManager` goroutines being put to sleep; this current design ensures that `SupportManager` goroutines do not get blocked) on a roachpod with 150 node cluster to verify smearing works. 

| Before changes (current behaviour on master) | After changes (prototype) |
|--------|--------|
| <img width="2680" height="570" alt="image" src="https://github.com/user-attachments/assets/32fe6ee0-437f-48eb-b3f1-087a3eafe6ac" /> | <img width="2692" height="634" alt="image" src="https://github.com/user-attachments/assets/66b5b82b-bbc4-4f47-a13e-5f6d42a1c6d4" /> |



Fixes: #148210
Release note: None

