### PR TITLE
restore: prevent scatter of non-empty ranges in online restore

### DIFF
--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -86,6 +86,10 @@ type BackupRestoreTestingKnobs struct {
 	// RunBeforeDownloadCleanup is called before we cleanup after all external
 	// files have been download.
 	RunBeforeDownloadCleanup func() error
+
+	// AfterAddRemoteSST is called after a remote SST is linked to pebble during
+	// the link phase of online restore.
+	AfterAddRemoteSST func() error
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
In conventional restore, we prevent the scattering of non-empty ranges by passing in a max size for the `AdminScatter` request. In online restore, while we expect to almost always be scattering empty ranges, due to the fact that the link phase can retry, it is possible to scatter ranges that contain external SSTs. This breaks our golden rule of only scattering empty ranges. This commit teaches online restore to only ever scatter empty ranges.

Fixes: #144599

Release note: None