### PR TITLE
release-25.2.7-rc: concurrency: disable kv.lock_table.unreplicated_lock_reliability.split.enabled

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
-        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -122,7 +121,7 @@ var UnreplicatedLockReliabilitySplit = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lock_table.unreplicated_lock_reliability.split.enabled",
 	"whether the replica should attempt to keep unreplicated locks during range splits",
-	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability.split.enabled", true),
+	false,
 )
 
 // UnreplicatedLockReliabilityLeaseTransfer controls whether the replica will attempt


### PR DESCRIPTION
In #155318, we discovered that the RHS replica's lock table may already have concurrently running transactions holding locks. As a result, adding these locks may put the lock table in an unexpected state.

Informs #155318

Release note (bug fix): Disable a feature
(kv.lock_table.unreplicated_lock_reliability.split.enabled) that could lead to a node crash.

Release justification: Bug fix for node-crashing bug.