### PR TITLE
catalog/lease: retain descriptor versions for old timestamps

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1482,7 +1482,8 @@ func (tc *Collection) GetIndexComment(
 // MaybeSetReplicationSafeTS modifies a txn to apply the replication safe timestamp,
 // if we are executing against a PCR reader catalog.
 func (tc *Collection) MaybeSetReplicationSafeTS(ctx context.Context, txn *kv.Txn) error {
-	now := tc.leased.lm.GetReadTimestamp(txn.DB().Clock().Now())
+	now := tc.leased.lm.GetReadTimestamp(ctx, txn.DB().Clock().Now())
+	defer now.Release(ctx)
 	desc, err := tc.leased.lm.Acquire(ctx, now, keys.SystemDatabaseID)
 	if err != nil {
 		return err

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -124,6 +124,7 @@ go_test(
         "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scplan",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlinstance/instancestorage",

--- a/pkg/sql/catalog/lease/descriptor_set.go
+++ b/pkg/sql/catalog/lease/descriptor_set.go
@@ -91,6 +91,13 @@ func (l *descriptorSet) findNewest() *descriptorVersionState {
 	return l.data[len(l.data)-1]
 }
 
+func (l *descriptorSet) findPrevious() *descriptorVersionState {
+	if len(l.data) < 2 {
+		return nil
+	}
+	return l.data[len(l.data)-2]
+}
+
 func (l *descriptorSet) findPreviousToExpire(dropped bool) *descriptorVersionState {
 	// If there are no versions, then no previous version exists.
 	if len(l.data) == 0 {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1307,6 +1307,77 @@ func (m *Manager) purgeOldVersions(
 		err = nil
 	}
 
+	// Optionally, acquire the refcount on the previous version.
+	acquireLeaseOnPrevious := func() error {
+		if dropped || !LockedLeaseTimestamp.Get(&m.storage.settings.SV) {
+			return nil
+		}
+		var handles []*closeTimeStampHandle
+		// Release the timestamp handles, which will allow this lease to be cleaned
+		// up if the timestamps are destroyed. Note: The descriptor state cannot
+		// be locked for the release mechanism.
+		defer func() {
+			for _, handle := range handles {
+				handle.release(ctx)
+			}
+		}()
+		state := m.findDescriptorState(id, false)
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		// Find the previous version and determine the timestamp handle that
+		// it belongs to.
+		prev := state.mu.active.findPrevious()
+		// If there is no previous or the previous version is a historical descriptor,
+		// nothing needs to be done (i.e. no active lease or already setup for
+		// expiration).
+		if prev == nil || prev.session.Load() == nil || prev.expiration.Load() != nil {
+			return nil
+		}
+		// Get all the close timestamp handles that require this descriptor version.
+		handles = m.shouldRetainPriorVersions(ctx, prev.GetModificationTime())
+		if handles == nil {
+			return nil
+		}
+		var gatheredErrors error
+		for _, handle := range handles {
+			if err := func() error {
+				handle.mu.Lock()
+				defer handle.mu.Unlock()
+				if handle.mu.leasesToRelease == nil {
+					return nil
+				}
+				// If there is already an old version of the descriptor, then we have
+				// a huge problem. We are violating the two versions invariant, since at
+				// least 3 versions exist.
+				if _, ok := handle.mu.leasesToRelease[id]; ok {
+					return errors.AssertionFailedf("two version invariant was violated, since "+
+						"we are retaining more than two versions for %s (%d) (versions: %d (%s), %d (%s), %d (%s))",
+						prev.Underlying().GetName(),
+						prev.GetID(),
+						handle.mu.leasesToRelease[id].Underlying().GetVersion(),
+						handle.mu.leasesToRelease[id].(*descriptorVersionState).getExpiration(ctx),
+						prev.GetVersion(),
+						prev.getExpiration(ctx),
+						state.mu.active.findNewest().GetVersion(),
+						state.mu.active.findNewest().getExpiration(ctx))
+				}
+				// Bump the refcount on the previous version of the descriptor and attach
+				// it to the relevant timestamp.
+				prev.incRefCount(ctx, false)
+				handle.mu.leasesToRelease[id] = prev
+				return nil
+			}(); err != nil {
+				// Gather errors and keep acquiring for other timestamps.
+				gatheredErrors = errors.Join(gatheredErrors, err)
+			}
+		}
+		return gatheredErrors
+	}
+
+	if err = acquireLeaseOnPrevious(); err != nil {
+		log.Dev.Errorf(ctx, "unable to acquire lease on previous version of descriptor: %s", err)
+	}
+
 	if isInactive := catalog.HasInactiveDescriptorError(err); err == nil || isInactive {
 		removeInactives(isInactive)
 		if desc != nil {
@@ -1345,6 +1416,61 @@ type descriptorTxnUpdate struct {
 	}
 	timestamp hlc.Timestamp
 	key       roachpb.Key
+}
+
+// closeTimeStampHandle represents a close timestamp tracked by the lease
+// manager.
+type closeTimeStampHandle struct {
+	timestamp hlc.Timestamp
+	// refCount is the reference count for this handle.
+	refCount atomic.Int64
+	// freeOnRelease is set to true if the handle should be released when the
+	// refCount hits zero.
+	freeOnRelease atomic.Bool
+	mu            struct {
+		syncutil.Mutex
+		// leasesToRelease tracks old leases that should be released when the
+		// the reference count hits zero.
+		leasesToRelease map[descpb.ID]LeasedDescriptor
+	}
+}
+
+// newCloseTimeStampHandle creates a new close timestamp handle for the lease
+// manager.
+func newCloseTimeStampHandle(timestamp hlc.Timestamp) *closeTimeStampHandle {
+	ch := &closeTimeStampHandle{
+		timestamp: timestamp,
+	}
+	ch.mu.leasesToRelease = make(map[descpb.ID]LeasedDescriptor)
+	return ch
+}
+
+// acquire acquires a reference on the close timestamp.
+func (c *closeTimeStampHandle) acquire(_ context.Context) {
+	c.refCount.Add(1)
+}
+
+// release releases a close timestamp handle.
+func (c *closeTimeStampHandle) release(ctx context.Context) {
+	// If freeOnRelease is set when the reference count hits zero, then
+	// clean up instantly.
+	newCount := c.refCount.Add(-1)
+	if newCount == 0 && c.freeOnRelease.Load() {
+		c.cleanupHandle(ctx)
+	}
+	if buildutil.CrdbTestBuild && newCount < 0 {
+		panic(errors.AssertionFailedf("double free of a close timestamp handle"))
+	}
+}
+
+// cleanupHandle releases all old leases held by this older timestamp.
+func (c *closeTimeStampHandle) cleanupHandle(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, v := range c.mu.leasesToRelease {
+		v.Release(ctx)
+	}
+	c.mu.leasesToRelease = nil
 }
 
 // Manager manages acquiring and releasing per-descriptor leases. It also
@@ -1393,10 +1519,14 @@ type Manager struct {
 		// hasUpdatesToDelete tracks if there is data in the key space that
 		// should be cleaned up.
 		hasUpdatesToDelete bool
+
+		// activeCloseTimestamps contains the most recent timestamp handles currently
+		// in use by transactions.
+		activeCloseTimestamps []*closeTimeStampHandle
 	}
 
-	// closeTimeStamp for the range feed, which is the timestamp
-	// that we have all the updates for.
+	// closeTimeStamp is the most recent closeTimeStamp handle, for
+	// which the range feed will have all the updates for.
 	closeTimestamp atomic.Value
 
 	draining atomic.Bool
@@ -1564,7 +1694,7 @@ func NewLeaseManager(
 	// that will be generated will be after the current time. So, historical
 	// queries with in this tenant (i.e. PCR catalog reader) before this point are
 	// guaranteed to be up to date.
-	lm.closeTimestamp.Store(db.KV().Clock().Now())
+	lm.closeTimestamp.Store(newCloseTimeStampHandle(clock.Now()))
 	lm.draining.Store(false)
 	lm.descUpdateCh = make(chan catalog.Descriptor)
 	lm.descDelCh = make(chan descpb.ID)
@@ -2062,7 +2192,7 @@ func (m *Manager) processDescriptorUpdate(
 		// and remove this entry.
 		targetTimestamp := m.markDescriptorUpdatesAsComplete()
 		if !targetTimestamp.IsEmpty() {
-			m.advanceCloseTimestamp(targetTimestamp)
+			m.advanceCloseTimestamp(ctx, targetTimestamp)
 		}
 	}
 }
@@ -2094,19 +2224,86 @@ func (m *Manager) markDescriptorUpdatesAsComplete() hlc.Timestamp {
 
 // advanceCloseTimestamp advances the close timestamp atomically, if the current
 // close timestamp is smaller.
-func (m *Manager) advanceCloseTimestamp(timestamp hlc.Timestamp) {
+func (m *Manager) advanceCloseTimestamp(ctx context.Context, timestamp hlc.Timestamp) {
+	timestampHandle := newCloseTimeStampHandle(timestamp)
 	for {
-		oldTimestamp := m.closeTimestamp.Load().(hlc.Timestamp)
+		oldTimestamp := m.closeTimestamp.Load().(*closeTimeStampHandle)
 		// Timestamp has already been advanced.
-		if !oldTimestamp.Less(timestamp) {
+		if !oldTimestamp.timestamp.Less(timestamp) {
 			return
 		}
-		// Otherwise, attempt to swap the timestamp, if successful we
+		// Otherwise, attempt to swap the timestamp, if successful, we
 		// will return.
-		if m.closeTimestamp.CompareAndSwap(oldTimestamp, timestamp) {
-			return
+		if m.closeTimestamp.CompareAndSwap(oldTimestamp, timestampHandle) {
+			// Insert the new timestamp handle.
+			m.insertNewTimestampHandle(timestampHandle)
+			// Now that the new timestamp is set, we can mark the old one as ready
+			// for removal.
+			oldTimestamp.freeOnRelease.Swap(true)
+			// Purge any old timestamp handles.
+			m.maybeFreeOldTimestampHandles(ctx)
 		}
 	}
+}
+
+// insertNewTimestampHandle adds a new close timestamp handle.
+func (m *Manager) insertNewTimestampHandle(handle *closeTimeStampHandle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Insert at a lower position
+	idx := sort.Search(len(m.mu.activeCloseTimestamps), func(i int) bool {
+		return !m.mu.activeCloseTimestamps[i].timestamp.Less(handle.timestamp)
+	})
+	if idx == len(m.mu.activeCloseTimestamps) {
+		m.mu.activeCloseTimestamps = append(m.mu.activeCloseTimestamps, handle)
+		return
+	}
+	// Otherwise insert in the middle.
+	m.mu.activeCloseTimestamps = append(m.mu.activeCloseTimestamps, nil)
+	copy(m.mu.activeCloseTimestamps[idx+1:], m.mu.activeCloseTimestamps[idx:])
+	m.mu.activeCloseTimestamps[idx] = handle
+}
+
+// shouldRetainPriorVersions acquires the close timestamp handles that can make
+// use of leases at the modification timestamp.
+func (m *Manager) shouldRetainPriorVersions(
+	ctx context.Context, modificationTime hlc.Timestamp,
+) []*closeTimeStampHandle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*closeTimeStampHandle
+	// We will retain this lease with all active prior close timestamp handles.
+	for i := 0; i < len(m.mu.activeCloseTimestamps); i++ {
+		t := m.mu.activeCloseTimestamps[i]
+		if modificationTime.LessEq(t.timestamp) {
+			t.acquire(ctx)
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// maybeFreeOldTimestampHandles cleans up any old close timestamps that
+// have hit a refcount of zero.
+func (m *Manager) maybeFreeOldTimestampHandles(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	numTimestamps := len(m.mu.activeCloseTimestamps)
+	for i := 0; i < numTimestamps; i++ {
+		t := m.mu.activeCloseTimestamps[i]
+		if !t.freeOnRelease.Load() || t.refCount.Load() != 0 {
+			continue
+		}
+		t.cleanupHandle(ctx)
+		// Move complete elements to the end.
+		if numTimestamps > 1 {
+			m.mu.activeCloseTimestamps[numTimestamps-1], m.mu.activeCloseTimestamps[i] =
+				m.mu.activeCloseTimestamps[i], m.mu.activeCloseTimestamps[numTimestamps-1]
+		}
+		numTimestamps--
+		i--
+	}
+	m.mu.activeCloseTimestamps = m.mu.activeCloseTimestamps[:numTimestamps]
 }
 
 // StartRefreshLeasesTask starts a goroutine that refreshes the lease manager
@@ -2242,10 +2439,7 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 					return false
 				}()
 				if advanceTimestamp {
-					if m.testingKnobs.TestingOnUpdateReadTimestamp != nil {
-						m.testingKnobs.TestingOnUpdateReadTimestamp(descUpdate.timestamp)
-					}
-					m.advanceCloseTimestamp(descUpdate.timestamp)
+					m.advanceCloseTimestamp(ctx, descUpdate.timestamp)
 				}
 			case <-s.ShouldQuiesce():
 				return
@@ -2264,7 +2458,24 @@ func (m *Manager) GetLeaseGeneration() int64 {
 // GetSafeReplicationTS gets the timestamp till which the leased descriptors
 // have been synced.
 func (m *Manager) GetSafeReplicationTS() hlc.Timestamp {
-	return m.closeTimestamp.Load().(hlc.Timestamp)
+	return m.closeTimestamp.Load().(*closeTimeStampHandle).timestamp
+}
+
+// getSafeReplicationTSHandle returns a handle for the current close time
+// stamp and acquires a ref count. The caller is responsible for releasing
+// this ref count.
+func (m *Manager) getSafeReplicationTSHandle(ctx context.Context) *closeTimeStampHandle {
+	for {
+		handle := m.closeTimestamp.Load().(*closeTimeStampHandle)
+		handle.acquire(ctx)
+		// Ensure that the timestamp is not marked as released. Otherwise, backing
+		// descriptors may get freed from under us.
+		if !handle.freeOnRelease.Load() {
+			return handle
+		}
+		// Handle is being freed, acquire a new one.
+		handle.release(ctx)
+	}
 }
 
 // closeRangeFeed closes the currently open range feed, which will involve
@@ -2361,18 +2572,15 @@ func (m *Manager) watchForUpdates(ctx context.Context) {
 	}
 
 	handleCheckpoint := func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-		if m.testingKnobs.TestingOnUpdateReadTimestamp != nil {
-			m.testingKnobs.TestingOnUpdateReadTimestamp(checkpoint.ResolvedTS)
-		}
-		// Track checkpoints that occur from the rangefeed to make sure progress
-		// is always made.
-		m.mu.Lock()
-		defer m.mu.Unlock()
 		if m.testingKnobs.DisableRangeFeedCheckpoint {
 			return
 		}
+		// Track checkpoints that occur from the rangefeed to make sure progress
+		// is always made.
+		m.advanceCloseTimestamp(ctx, checkpoint.ResolvedTS)
+		m.mu.Lock()
+		defer m.mu.Unlock()
 		m.mu.rangeFeedCheckpoints += 1
-		m.advanceCloseTimestamp(checkpoint.ResolvedTS)
 		// Clean up all entries before the resolve timestamp.
 		for {
 			minTS, hasMin := m.mu.descriptorTxnUpdatesToProcess.Min()
@@ -3192,15 +3400,17 @@ func (m *Manager) deleteOrphanedLeasesWithSameInstanceID(
 }
 
 // GetReadTimestamp returns a locked timestamp to use for lease management.
-func (m *Manager) GetReadTimestamp(timestamp hlc.Timestamp) ReadTimestamp {
+func (m *Manager) GetReadTimestamp(ctx context.Context, timestamp hlc.Timestamp) ReadTimestamp {
 	if LockedLeaseTimestamp.Get(&m.settings.SV) {
-		replicationTS := m.GetSafeReplicationTS()
-		if !replicationTS.IsEmpty() && replicationTS.Less(timestamp) {
+		replicationTS := m.getSafeReplicationTSHandle(ctx)
+		if replicationTS.timestamp.Less(timestamp) {
 			return LeaseTimestamp{
 				ReadTimestamp:  timestamp,
-				LeaseTimestamp: replicationTS,
+				LeaseTimestamp: replicationTS.timestamp,
+				handle:         replicationTS,
 			}
 		}
+		replicationTS.release(ctx)
 	}
 	// Fallback to existing behavior with timestamps.
 	return LeaseTimestamp{

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/sqllivenesstestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -1741,15 +1740,9 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// Skip until future PRs fix this test.
-	skip.WithIssue(t, 153826)
 
 	var blockUpdates atomic.Bool
-	var blockCheckPoint atomic.Bool
-	var targetTS atomic.Value
-	targetTS.Store(hlc.Timestamp{})
 	updateCh := make(chan struct{})
-	rangeFeedCh := make(chan struct{})
 
 	st := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
@@ -1766,20 +1759,6 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 							return
 						}
 						<-updateCh
-						//nolint:descriptormarshal
-						targetTS.Store(descriptor.GetTable().GetModificationTime())
-						blockCheckPoint.Store(true)
-					},
-					TestingOnUpdateReadTimestamp: func(timestamp hlc.Timestamp) {
-						if !blockCheckPoint.Load() {
-							return
-						}
-						ts := targetTS.Load().(hlc.Timestamp)
-						if ts.IsEmpty() || timestamp.Less(ts) {
-							return
-						}
-						<-rangeFeedCh
-						targetTS.Store(hlc.Timestamp{})
 					},
 				},
 			},
@@ -1805,53 +1784,51 @@ func TestLeaseManagerLockedTimestampBasic(t *testing.T) {
 	r.QueryRow(t, "SELECT 't1'::REGCLASS::OID;").Scan(&id)
 	lm := s.LeaseManager().(*Manager)
 
-	// Note: We only need to hold old leases because the logic for doing this
-	// automatically is not merged yet. Once it is merged, the release of them
-	// will be delayed until the timestamp is updated.
-	var heldDescriptors []LeasedDescriptor
-	releaseHeldDescriptors := func() {
-		for _, ld := range heldDescriptors {
-			ld.Release(ctx)
-		}
-		heldDescriptors = nil
-	}
-	defer releaseHeldDescriptors()
-
-	getDescriptorVersion := func() descpb.DescriptorVersion {
-		ts := lm.GetReadTimestamp(s.Clock().Now())
+	getDescriptorVersion := func(ts ReadTimestamp) descpb.DescriptorVersion {
 		state := lm.findDescriptorState(descpb.ID(id), false)
 		require.NotNilf(t, state, "the descriptor was not leased yet")
 		ld, _, err := state.findForTimestamp(ctx, ts)
 		require.NoError(t, err)
-		heldDescriptors = append(heldDescriptors, ld)
+		defer ld.Release(ctx)
 		return ld.GetVersion()
 	}
 
-	waitForTimestampChange := func() {
-		initial := lm.GetSafeReplicationTS()
-		rangeFeedCh <- struct{}{}
+	waitForTimestampChange := func(ts ReadTimestamp) {
 		testutils.SucceedsSoon(t, func() error {
-			if lm.GetSafeReplicationTS() == initial {
+			if lm.GetSafeReplicationTS() == ts.GetTimestamp() {
 				return errors.New("timestamp did not change")
 			}
 			return nil
 		})
 	}
-	// Allow one descriptor version to be published and a range feed check point.
+	// Allow one descriptor version to be published.
+	ts := lm.GetReadTimestamp(ctx, srv.Clock().Now())
+	var releaseTS = func() {
+		if ts == nil {
+			return
+		}
+		ts.Release(ctx)
+		ts = nil
+	}
+	defer releaseTS()
 	updateCh <- struct{}{}
-	waitForTimestampChange()
-	initialVersion := getDescriptorVersion()
-	// A new version is published, but it won't be visible to our transaction yet.
+	waitForTimestampChange(ts)
+	releaseTS()
+	ts = lm.GetReadTimestamp(ctx, srv.Clock().Now())
+	initialVersion := getDescriptorVersion(ts)
+	// The old version will still be cached as long as this timestamp is in use.
+	// Even if we released the leases already.
 	updateCh <- struct{}{}
-	nextVersion := getDescriptorVersion()
+	nextVersion := getDescriptorVersion(ts)
 	require.Equalf(t, initialVersion, nextVersion, "new version should not be leased yet")
-	waitForTimestampChange()
-	// A new version should show up after the range feed check point.
-	nextVersion = getDescriptorVersion()
-	require.Equalf(t, initialVersion+1, nextVersion, "new version should be leasable now")
-	releaseHeldDescriptors()
+	waitForTimestampChange(ts)
+	// If we release the old timestamp, then the old version will be released.
+	releaseTS()
+	ts = lm.GetReadTimestamp(ctx, srv.Clock().Now())
+	nextVersion = getDescriptorVersion(ts)
+	require.Equalf(t, initialVersion+1, nextVersion, "new version should be visible now")
 	close(updateCh)
-	close(rangeFeedCh)
+	releaseTS()
 	require.NoError(t, grp.Wait())
 }
 
@@ -1911,7 +1888,7 @@ func TestLeaseManagerLockedTimestampCluster(t *testing.T) {
 	lm := tc.Server(2).LeaseManager().(*Manager)
 	assertDescriptorsCount := func(expectedCount int) {
 		state := lm.findDescriptorState(descpb.ID(id), false)
-		require.NotNilf(t, state, "descriptor was not leased yet")
+		require.NotNilf(t, state, "the descriptor was not leased yet")
 		state.mu.Lock()
 		defer state.mu.Unlock()
 		require.Equal(t, expectedCount, len(state.mu.active.data),

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -68,10 +68,6 @@ type ManagerTestingKnobs struct {
 	// has been reset.
 	RangeFeedResetChannel chan struct{}
 
-	// TestingOnUpdateReadTimestamp is invoked when a range feed checkpoint is
-	// hit.
-	TestingOnUpdateReadTimestamp func(timestamp hlc.Timestamp)
-
 	LeaseStoreTestingKnobs StorageTestingKnobs
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4594,6 +4594,8 @@ func (ex *connExecutor) notifyStatsRefresherOfNewTables(ctx context.Context) {
 			return
 		}
 		ex.planner.execCfg.StatsRefresher.NotifyMutation(desc, cnt)
+		// Release the lease after.
+		ex.extraTxnState.descCollection.ReleaseSpecifiedLeases(ctx, []lease.IDVersion{{Version: desc.GetVersion(), ID: desc.GetID()}})
 	}
 }
 

--- a/pkg/sql/regions/cached_db_regions.go
+++ b/pkg/sql/regions/cached_db_regions.go
@@ -30,7 +30,8 @@ func NewCachedDatabaseRegionsAt(
 	ctx context.Context, _ *kv.DB, lm *lease.Manager, at hlc.Timestamp,
 ) (cdr *CachedDatabaseRegions, err error) {
 	cdr = &CachedDatabaseRegions{}
-	rs := lm.GetReadTimestamp(at)
+	rs := lm.GetReadTimestamp(ctx, at)
+	defer rs.Release(ctx)
 	desc, err := lm.Acquire(ctx, rs, keys.SystemDatabaseID)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -218,7 +218,9 @@ func (f fakeLeaseManager) GetLeaseGeneration() int64 {
 	return 0
 }
 
-func (f fakeLeaseManager) GetReadTimestamp(timestamp hlc.Timestamp) lease.ReadTimestamp {
+func (f fakeLeaseManager) GetReadTimestamp(
+	_ context.Context, timestamp hlc.Timestamp,
+) lease.ReadTimestamp {
 	return lease.TimestampToReadTimestamp(timestamp)
 }
 


### PR DESCRIPTION
Previously, when we added support locked timestamps leasing we would not hold descriptors that previous versions that older timestamps may need. This could lead to use needing to reading old versions from KV more frequently as well as limiting when transactions could commit in this mode. To address this, this patch allows the lease manager to hold older versions while the timestamps is in use.

Fixes: #153618

Release note: None