### PR TITLE
changefeedccl: fix cloud storage sink ordering issue

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -124,6 +124,8 @@ func readNextMessages(
 			if m != nil {
 				log.Changefeed.Infof(context.Background(), `msg %s: %s->%s (%s) (%s)`,
 					m.Topic, m.Key, m.Value, m.Resolved, timeutil.Since(lastMessage))
+				fmt.Printf(`msg %s: %s->%s (%s) (%s)\n`,
+					m.Topic, m.Key, m.Value, m.Resolved, timeutil.Since(lastMessage))
 			} else {
 				log.Changefeed.Infof(context.Background(), `err %v`, err)
 			}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -1115,13 +1115,13 @@ func TestCloudStorageWTF(t *testing.T) {
 
 		// wait for checkpoint after T1
 		testutils.SucceedsSoon(t, func() error {
-			hwm, chkTS := getHwmAndChkpt()
-			if T1Ts.Less(chkTS) {
-				require.True(t, hwm.Less(chkTS))
-				t.Logf("got our checkpoint after T1. hwm: %s, chkTS: %s", hwm, chkTS)
+			hwm2, chkTS2 := getHwmAndChkpt()
+			if T1Ts.Less(chkTS2) {
+				require.True(t, hwm2.Less(chkTS2))
+				t.Logf("got our checkpoint after T1. hwm: %s, chkTS: %s", hwm2, chkTS2)
 				return nil
 			}
-			return errors.Newf("waiting for checkpoint after T1: %s < %s", T1Ts, chkTS)
+			return errors.Newf("waiting for checkpoint after T1: %s < %s", T1Ts, chkTS2)
 		})
 
 		// make subsequent checkpoints not happen

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -1135,7 +1135,8 @@ func TestCloudStorageWTF(t *testing.T) {
 		// becase the cloudfeed is wrapped by a sinkSynchronizer which makes it not scan for new data until a Flush(), which we are intentionally avoiding.
 		// -> do it hackily
 		testutils.SucceedsSoon(t, func() error {
-			out, err := exec.Command("grep", "-R", "T1", cf.(*cloudFeed).dir).Output()
+			cmd := fmt.Sprintf(`grep -RH "T1" %s | grep 2_begin`, cf.(*cloudFeed).dir)
+			out, err := exec.Command("bash", "-c", cmd).Output()
 			if err != nil {
 				return errors.Wrapf(err, "grepping for T1")
 			}
@@ -1172,7 +1173,8 @@ func TestCloudStorageWTF(t *testing.T) {
 		// 	`foo: [1]->{"after": {"v": "T2"}}`,
 		// })
 		testutils.SucceedsSoon(t, func() error {
-			out, err := exec.Command("grep", "-R", "T2", cf.(*cloudFeed).dir).Output()
+			cmd := fmt.Sprintf(`grep -RH "T2" %s | grep 1_after`, cf.(*cloudFeed).dir)
+			out, err := exec.Command("bash", "-c", cmd).Output()
 			if err != nil {
 				return errors.Wrapf(err, "grepping for T2")
 			}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -1142,6 +1142,7 @@ func TestCloudStorageWTF(t *testing.T) {
 			if len(out) == 0 {
 				return errors.New("no T1 found")
 			}
+			t.Logf("found T1: %s", string(out))
 			return nil
 		})
 		t.Logf("saw k@T1")
@@ -1166,7 +1167,7 @@ func TestCloudStorageWTF(t *testing.T) {
 		require.NoError(t, cf.(cdctest.EnterpriseTestFeed).Resume())
 		t.Logf("resumed")
 
-		// wait for k@T2 to be emitted
+		// wait for k@T2 to be emitted or re-emitted
 		// assertPayloads(t, cf, []string{
 		// 	`foo: [1]->{"after": {"v": "T2"}}`,
 		// })
@@ -1178,6 +1179,7 @@ func TestCloudStorageWTF(t *testing.T) {
 			if len(out) == 0 {
 				return errors.New("no T2 found")
 			}
+			t.Logf("found T2: %s", string(out))
 			return nil
 		})
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"maps"
 	"math"
 	"net/url"
 	"os"
@@ -26,20 +25,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -1021,168 +1018,56 @@ func TestCloudStorageWTF(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, db, stopServer := startTestFullServer(t, makeOptions(t, feedTestNoTenants))
-	defer stopServer()
-	sqlDB := sqlutils.MakeSQLRunner(db)
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		// Speed up checkpointing to force periodic span-level checkpoints.
+		changefeedbase.SpanCheckpointInterval.Override(context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+		changefeedbase.SpanCheckpointMaxBytes.Override(context.Background(), &s.Server.ClusterSettings().SV, 100<<20 /* 100 MiB */)
+		changefeedbase.SpanCheckpointLagThreshold.Override(context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
 
-	knobs := s.TestingKnobs().
-		DistSQL.(*execinfra.TestingKnobs).
-		Changefeed.(*TestingKnobs)
-
-	// Initialize table with 20 ranges.
-	sqlDB.Exec(t, `
-	  CREATE TABLE foo (key INT PRIMARY KEY);
-	  INSERT INTO foo (key) SELECT * FROM generate_series(1, 1000);
-	  ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, 1000, 50));
-	  `)
-
-	fooDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "d", "foo")
-	tableSpan := fooDesc.PrimaryIndexSpan(s.Codec())
-
-	// Checkpoint progress frequently, allow a large enough checkpoint, and
-	// reduce the lag threshold to allow lag checkpointing to trigger
-	changefeedbase.SpanCheckpointInterval.Override(
-		context.Background(), &s.ClusterSettings().SV, 10*time.Millisecond)
-	changefeedbase.SpanCheckpointMaxBytes.Override(
-		context.Background(), &s.ClusterSettings().SV, 100<<20 /* 100 MiB */)
-	changefeedbase.SpanCheckpointLagThreshold.Override(
-		context.Background(), &s.ClusterSettings().SV, 10*time.Millisecond)
-
-	// We'll start the changefeed with the cursor set to the current time (not insert time).
-	// NB: The changefeed created in this test doesn't actually send any message events.
-	var tsStr string
-	sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp() from foo`).Scan(&tsStr)
-	cursor := parseTimeToHLC(t, tsStr)
-	t.Logf("cursor: %v", cursor)
-
-	// Rangefeed will skip some of the checkpoints to simulate lagging spans.
-	var laggingSpans roachpb.SpanGroup
-	nonLaggingSpans := make(map[string]int)
-	var numSpans int
-	knobs.FeedKnobs.ShouldSkipCheckpoint = func(checkpoint *kvpb.RangeFeedCheckpoint) (skip bool) {
-		// Skip spans for the whole table.
-		if checkpoint.Span.Equal(tableSpan) {
-			return true
-		}
-		// Skip spans that we already picked to be lagging.
-		if laggingSpans.Encloses(checkpoint.Span) {
-			return true
-		}
-		// Skip additional updates for every 3rd non-lagging span so that we have
-		// a few spans lagging at a second timestamp above the cursor.
-		if i, ok := nonLaggingSpans[checkpoint.Span.String()]; ok {
-			return i%3 == 0
-		}
-		numSpans++
-		// Skip updates for every 3rd span so that we have a few spans lagging
-		// at the cursor.
-		if numSpans%3 == 0 {
-			laggingSpans.Add(checkpoint.Span)
-			return true
-		}
-		nonLaggingSpans[checkpoint.Span.String()] = len(nonLaggingSpans) + 1
-		return false
-	}
-
-	var jobID jobspb.JobID
-	sqlDB.QueryRow(t,
-		`CREATE CHANGEFEED FOR foo INTO 'null://'
-	WITH resolved='50ms', min_checkpoint_frequency='50ms', no_initial_scan, cursor=$1`, tsStr,
-	).Scan(&jobID)
-
-	// Helper to read job progress
-	jobRegistry := s.JobRegistry().(*jobs.Registry)
-	loadProgress := func() jobspb.Progress {
-		job, err := jobRegistry.LoadJob(context.Background(), jobID)
-		require.NoError(t, err)
-		return job.Progress()
-	}
-
-	// We should eventually checkpoint some spans that are ahead of the highwater.
-	// We'll wait until we have two unique timestamps.
-	testutils.SucceedsSoon(t, func() error {
-		progress := loadProgress()
-		cp := maps.Collect(loadCheckpoint(t, progress).All())
-		if len(cp) >= 2 {
-			return nil
-		}
-		return errors.New("waiting for checkpoint with two different timestamps")
-	})
-
-	sqlDB.Exec(t, "PAUSE JOB $1", jobID)
-	waitForJobState(sqlDB, t, jobID, jobs.StatePaused)
-
-	// We expect highwater to be 0 (because we skipped some spans) or exactly cursor
-	// (this is mostly due to racy updates sent from aggregators to the frontier).
-	// However, the checkpoint timestamp should be at least at the cursor.
-	progress := loadProgress()
-	require.True(t, progress.GetHighWater().IsEmpty() || progress.GetHighWater().Equal(cursor),
-		"expected empty highwater or %s, found %s", cursor, progress.GetHighWater())
-	spanLevelCheckpoint := loadCheckpoint(t, progress)
-	require.NotNil(t, spanLevelCheckpoint)
-	require.True(t, cursor.LessEq(spanLevelCheckpoint.MinTimestamp()))
-
-	// Construct a reverse index from spans to timestamps.
-	spanTimestamps := make(map[string]hlc.Timestamp)
-	for ts, spans := range spanLevelCheckpoint.All() {
-		for _, s := range spans {
-			spanTimestamps[s.String()] = ts
-		}
-	}
-
-	var rangefeedStartedOnce bool
-	var incorrectCheckpointErr error
-	knobs.FeedKnobs.OnRangeFeedStart = func(spans []kvcoord.SpanTimePair) {
-		// We only need to check the first rangefeed restart since
-		// any additional restarts (likely due to transient errors)
-		// may be using newer span-level checkpoints than the one
-		// we saved after the last pause.
-		if rangefeedStartedOnce {
-			return
-		}
-
-		setErr := func(stp kvcoord.SpanTimePair, expectedTS hlc.Timestamp) {
-			incorrectCheckpointErr = errors.Newf(
-				"rangefeed for span %s expected to start @%s, started @%s instead",
-				stp.Span, expectedTS, stp.StartAfter)
-		}
-
-		// Verify that the start time for each span is correct.
-		for _, sp := range spans {
-			if checkpointTS := spanTimestamps[sp.Span.String()]; checkpointTS.IsSet() {
-				// Any span in the checkpoint should be resumed at its checkpoint timestamp.
-				if !sp.StartAfter.Equal(checkpointTS) {
-					setErr(sp, checkpointTS)
+		// Optionally skip some rangefeed checkpoints to simulate lagging spans.
+		if s.TestingKnobs.DistSQL != nil && s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs) != nil {
+			if cfKnobs, ok := s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs); ok && cfKnobs != nil {
+				// Skip checkpoints for spans that don't contain the inserted key.
+				cfKnobs.FeedKnobs.ShouldSkipCheckpoint = func(rfc *kvpb.RangeFeedCheckpoint) bool {
+					insertedKey := "todo"
+					return !rfc.Span.ContainsKey([]byte(insertedKey))
 				}
-			} else {
-				// Any spans not in the checkpoint should be at the cursor.
-				if !sp.StartAfter.Equal(cursor) {
-					setErr(sp, cursor)
-				}
+				defer func() { cfKnobs.FeedKnobs.ShouldSkipCheckpoint = nil }()
 			}
 		}
 
-		rangefeedStartedOnce = true
-	}
-	knobs.FeedKnobs.ShouldSkipCheckpoint = nil
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `
+		CREATE TABLE foo (key INT PRIMARY KEY, v STRING);
+		INSERT INTO foo (key) SELECT * FROM generate_series(1, 1000);
+		ALTER TABLE foo SPLIT AT (SELECT * FROM generate_series(1, 1000, 50));
+		`)
 
-	sqlDB.Exec(t, "RESUME JOB $1", jobID)
-	waitForJobState(sqlDB, t, jobID, jobs.StateRunning)
+		fooDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "d", "foo")
+		tableSpan := fooDesc.PrimaryIndexSpan(s.Codec())
 
-	// Wait until highwater advances past cursor.
-	testutils.SucceedsSoon(t, func() error {
-		progress := loadProgress()
-		if hw := progress.GetHighWater(); hw != nil && cursor.Less(*hw) {
+		// Start a cloudstorage changefeed (cdcTest configures the sink for us).
+		// Force frequent resolved and checkpoint writes; no initial scan so we control emitted rows.
+		feedStmt := `CREATE CHANGEFEED FOR foo WITH resolved='50ms', min_checkpoint_frequency='50ms', no_initial_scan`
+		cf := feed(t, f, feedStmt)
+		defer closeFeed(t, cf)
+
+		// Emit a single row after the feed starts.
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a')`)
+
+		// Read and assert a single data row arrives.
+		require.NoError(t, withTimeout(cf, assertPayloadsTimeout(), func(ctx context.Context) error {
+			msgs, err := readNextMessages(ctx, cf, 1)
+			if err != nil {
+				return err
+			}
+			require.NotEmpty(t, msgs)
+			require.NotEmpty(t, msgs[0].Key)
+			require.NotEmpty(t, msgs[0].Value)
 			return nil
-		}
-		return errors.New("waiting for checkpoint advance")
-	})
+		}))
+	}
 
-	sqlDB.Exec(t, "PAUSE JOB $1", jobID)
-	waitForJobState(sqlDB, t, jobID, jobs.StatePaused)
-	// Verify the rangefeed started. This guards against the testing knob
-	// not being called, which was happening in earlier versions of the code.
-	require.True(t, rangefeedStartedOnce)
-	// Verify we didn't see incorrect timestamps when resuming.
-	require.NoError(t, incorrectCheckpointErr)
+	// Run using a cloudstorage sink via the cdcTest helper.
+	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
 }

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1542,7 +1542,10 @@ func (c *cloudFeed) readParquetResolvedPayload(path string) ([]byte, error) {
 }
 
 // Next implements the TestFeed interface.
-func (c *cloudFeed) Next() (*cdctest.TestFeedMessage, error) {
+func (c *cloudFeed) Next() (m *cdctest.TestFeedMessage, err error) {
+	defer func() {
+		fmt.Printf("cloudFeed.Next returned %v; %v\n", m, err)
+	}()
 	for {
 		if len(c.rows) > 0 {
 			e := c.rows[0]


### PR DESCRIPTION
Background: the cloud storage sink writes files to
cloud storage with names whose first component is
a timestamp. Beyond the normal changefeed ordering
guarantees, there is an additional guarantee that
if you read these files in lexicographic order,
the observed events will respect the changefeed
ordering guarantee.

However, under certain conditions (partially
lagging + restarts), we could emit 2 files with
the same timestamp name component that, if read in
order, resulted in a violation of the changefeed
ordering guarantee.

This patch fixes the issue by adding another
timestamp to the front of the tiebreaker name
component that tracks the oldest MVCC timestamp
for the file. It also adds a regression test for
this specific issue.

Epic: None
Release note: None
