### PR TITLE
release-25.4: mixedversion: disable upreplication mutator

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -351,6 +351,7 @@ type (
 		overriddenMutatorProbabilities map[string]float64
 		hooksSupportFailureInjection   bool
 		workloadNodes                  option.NodeListOption
+		enableUpReplication            bool
 	}
 
 	CustomOption func(*testOptions)
@@ -406,6 +407,12 @@ type (
 // `NewTest` to enable the use of mixed-version hooks during failure injections.
 func EnableHooksDuringFailureInjection(opts *testOptions) {
 	opts.hooksSupportFailureInjection = true
+}
+
+// EnableUpReplication is an option that can be passed to `NewTest` to enable
+// up-replication to 5X before panicking a node during failure injection tests.
+func EnableUpReplication(opts *testOptions) {
+	opts.enableUpReplication = true
 }
 
 // NeverUseFixtures is an option that can be passed to `NewTest` to

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -411,7 +411,7 @@ func (m panicNodeMutator) Generate(
 
 	// If we have at least 5 nodes, we can safely upreplicate to 5X before panicking a node.
 	// This allows for a longer panic duration before recovery.
-	supportsUpReplication := len(nodeList) >= 5
+	supportsUpReplication := planner.options.enableUpReplication && len(nodeList) >= 5
 
 	for _, upgrade := range upgrades {
 		possiblePointsInTime := upgrade.

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -600,6 +600,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster, c
 		customOpts = append([]mixedversion.CustomOption{
 			mixedversion.NeverUseFixtures,
 			mixedversion.EnableHooksDuringFailureInjection,
+			mixedversion.EnableUpReplication,
 		},
 			customOpts...)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #155106.

/cc @cockroachdb/release

---

This mutator can cause timeouts upreplicating non trivial amounts of data. It should be default disabled except for curated tests.

Informs: #142194
Fixes: https://github.com/cockroachdb/cockroach/issues/151984
Fixes: https://github.com/cockroachdb/cockroach/issues/154838
Release note: none
Epic: none

Release justification: roachtest fixes 
