### PR TITLE
release-24.3: dev: refine behavior of `--cpus` further

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=24301
+DEV_VERSION=24302
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/acceptance.go
+++ b/pkg/cmd/dev/acceptance.go
@@ -72,9 +72,7 @@ func (d *dev) acceptance(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test", "//pkg/acceptance:acceptance_test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if filter != "" {
 		args = append(args, fmt.Sprintf("--test_filter=%s", filter))
 	}

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -81,9 +81,7 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if timeout > 0 {
 		args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
 	}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -370,10 +370,7 @@ func (d *dev) getBasicBuildArgs(
 	}
 
 	args = append(args, "build")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
-
+	addCommonBazelArguments(&args)
 	canDisableNogo := true
 	shouldBuildWithTestConfig := false
 	for _, target := range targets {

--- a/pkg/cmd/dev/compose.go
+++ b/pkg/cmd/dev/compose.go
@@ -82,9 +82,7 @@ func (d *dev) compose(cmd *cobra.Command, _ []string) error {
 
 	var args []string
 	args = append(args, "test", "//pkg/compose:compose_test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if filter != "" {
 		args = append(args, fmt.Sprintf("--test_filter=%s", filter))
 	}

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -50,9 +50,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test", "//pkg/testutils/lint:lint_test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	args = append(args, additionalBazelArgs...)
 	args = append(args, "--nocache_test_results", "--test_arg", "-test.v")
 	if short {
@@ -120,9 +118,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 	if pkg != "" && filter == "" {
 		toLint := strings.TrimPrefix(pkg, "./")
 		args := []string{"build", toLint, "--run_validations"}
-		if numCPUs != 0 {
-			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-		}
+		addCommonBazelArguments(&args)
 		logCommand("bazel", args...)
 		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	} else if !short && filter == "" {
@@ -134,9 +130,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 			"//pkg/cmd/roachtest",
 			"--run_validations",
 		}
-		if numCPUs != 0 {
-			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-		}
+		addCommonBazelArguments(&args)
 		logCommand("bazel", args...)
 		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	} else if filter != "" {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -225,9 +225,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	var args []string
 	var goTags []string
 	args = append(args, "test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if race {
 		args = append(args, "--config=race", "--test_sharding_strategy=disabled")
 	}

--- a/pkg/cmd/dev/testdata/datadriven/bench
+++ b/pkg/cmd/dev/testdata/datadriven/bench
@@ -26,7 +26,7 @@ exec
 dev bench pkg/spanconfig/spanconfigkvsubscriber -f=BenchmarkSpanConfigDecoder --cpus=10 --ignore-cache=false -v --timeout=50s
 ----
 echo $HOME/.cache
-bazel test --local_cpu_resources=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.v --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test --local_resources=cpu=10 --jobs=10 --local_test_jobs=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.v --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/bench -f='BenchmarkTracing/1node/scan/trace=off' --test-args '-test.memprofile=mem.out -test.cpuprofile=cpu.out'

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -13,7 +13,7 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build cockroach-short --cpus=12
 ----
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
+bazel build --local_resources=cpu=12 --jobs=12 --local_test_jobs=12 //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -61,7 +61,7 @@ bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_timeout=60 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_resources=cpu=8 --jobs=8 --local_test_jobs=8 --test_arg -show-sql --test_timeout=60 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -204,9 +204,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	}
 	args = append(args, targets...)
 	args = append(args, "--test_env=GOTRACEBACK=all")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if ignoreCache {
 		args = append(args, "--nocache_test_results")
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -269,3 +269,11 @@ func (d *dev) getMergeBaseHash(ctx context.Context) (string, error) {
 	}
 	return strings.TrimSpace(string(baseBytes)), nil
 }
+
+func addCommonBazelArguments(args *[]string) {
+	if numCPUs != 0 {
+		*args = append(*args, fmt.Sprintf("--local_resources=cpu=%d", numCPUs))
+		*args = append(*args, fmt.Sprintf("--jobs=%d", numCPUs))
+		*args = append(*args, fmt.Sprintf("--local_test_jobs=%d", numCPUs))
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #155390.

/cc @cockroachdb/release

---

 - `--local_cpu_resources` changed to `--local_resources=cpu=`
 - `--cpus` now additionaly implies `--local_test_jobs`, which should be set to an equivalent value.

Also, using `--cpus` gives:

Epic: None
Fixes: #151139
Release Note: None

/cc @cockroachdb/release

Release justification: Non-production code changes
