### PR TITLE
release-25.4: sql/inspect: deflake TestDetectIndexConsistencyErrors by disabling MVCC GC wait

### DIFF
--- a/pkg/sql/inspect/index_consistency_check_test.go
+++ b/pkg/sql/inspect/index_consistency_check_test.go
@@ -124,6 +124,9 @@ func TestDetectIndexConsistencyErrors(t *testing.T) {
 				Inspect: &sql.InspectTestingKnobs{
 					InspectIssueLogger: issueLogger,
 				},
+				GCJob: &sql.GCJobTestingKnobs{
+					SkipWaitingForMVCCGC: true,
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Backport 1/1 commits from #155434 on behalf of @spilchen.

----

We noticed a timeout in TestDetectIndexConsistencyErrors. The stacks where waiting for the MVCC GC to complete. Since that's not critical to the test, and there is a knob to avoid waiting for that, I am going to fix the flake by using the knob.

Fixes #155044
Epic: none
Release note: none

----

Release justification: