### PR TITLE
sql: optimizer scan misestimate logging improvements

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2906,6 +2906,37 @@ of transaction abort there will not be a corresponding row in the database.
 | `FamilyID` |  | no |
 | `PrimaryKey` |  | yes |
 
+### `scan_row_count_misestimate`
+
+An event of type `scan_row_count_misestimate` is recorded when the optimizer's row count estimate
+for a logical scan differs significantly from the actual number of rows read,
+and cluster setting `sql.log.scan_row_count_misestimate.enabled` is set.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TableName` | The fully qualified name of the table being scanned. | no |
+| `IndexName` | The name of the index being scanned. | no |
+| `EstimatedRowCount` | The optimizer's estimated row count for the scan. | no |
+| `ActualRowCount` | The actual number of rows read by all processors performing the scan. | no |
+| `NanosSinceStatsCollected` | Time in nanoseconds that have passed since full stats were collected on the table. | no |
+| `EstimatedStaleness` | Estimated fraction of stale rows in the table based on the time since stats were last collected. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+
 ### `slow_query`
 
 An event of type `slow_query` is recorded when a query triggers the "slow query" condition.

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -936,6 +936,9 @@ func (r *Refresher) EstimateStaleness(ctx context.Context, tableID descpb.ID) (f
 	staleTargetFraction := r.autoStatsFractionStaleRows(explicitSettings)
 
 	avgRefreshTime := avgFullRefreshTime(tableStats)
+	if avgRefreshTime == defaultAverageTimeBetweenRefreshes {
+		return 0, errors.New("insufficient auto stats history to estimate staleness")
+	}
 	statsAge := timeutil.Since(stat.CreatedAt)
 	if r.knobs != nil && r.knobs.StubTimeNow != nil {
 		statsAge = r.knobs.StubTimeNow().Sub(stat.CreatedAt)

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -333,6 +333,9 @@ func (m *ClientSessionEnd) LoggingChannel() logpb.Channel { return logpb.Channel
 func (m *LargeRow) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_EXEC }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ScanRowCountMisestimate) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_EXEC }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SlowQuery) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_EXEC }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -5580,6 +5580,72 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *ScanRowCountMisestimate) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TableName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableName)))
+		b = append(b, '"')
+	}
+
+	if m.IndexName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.IndexName)))
+		b = append(b, '"')
+	}
+
+	if m.EstimatedRowCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"EstimatedRowCount\":"...)
+		b = strconv.AppendUint(b, uint64(m.EstimatedRowCount), 10)
+	}
+
+	if m.ActualRowCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ActualRowCount\":"...)
+		b = strconv.AppendUint(b, uint64(m.ActualRowCount), 10)
+	}
+
+	if m.NanosSinceStatsCollected != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NanosSinceStatsCollected\":"...)
+		b = strconv.AppendInt(b, int64(m.NanosSinceStatsCollected), 10)
+	}
+
+	if m.EstimatedStaleness != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"EstimatedStaleness\":"...)
+		b = strconv.AppendFloat(b, float64(m.EstimatedStaleness), 'f', -1, 64)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *SchemaDescriptor) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -637,6 +637,34 @@ message SlowQuery {
   CommonSQLExecDetails exec = 3 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
 }
 
+// ScanRowCountMisestimate is recorded when the optimizer's row count estimate
+// for a logical scan differs significantly from the actual number of rows read,
+// and cluster setting `sql.log.scan_row_count_misestimate.enabled` is set.
+message ScanRowCountMisestimate {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The fully qualified name of the table being scanned.
+  string table_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The name of the index being scanned.
+  string index_name = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The optimizer's estimated row count for the scan.
+  uint64 estimated_row_count = 5 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The actual number of rows read by all processors performing the scan.
+  uint64 actual_row_count = 6 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Time in nanoseconds that have passed since full stats were collected on
+  // the table.
+  int64 nanos_since_stats_collected = 7 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Estimated fraction of stale rows in the table based on the time since stats
+  // were last collected.
+  double estimated_staleness = 8 [(gogoproto.jsontag) = ",omitempty"];
+}
+
 // CommonLargeRowDetails contains the fields common to both LargeRow and
 // LargeRowInternal events.
 message CommonLargeRowDetails {


### PR DESCRIPTION
This commit is a follow-up to #154370. It changes misestimate logging to use structured logging on the `SQL_EXEC` log channel with a new `ScanRowCountMisestimate` event, instead of unstructured logs on DEV. It also adds an error case to `stats.EstimateStaleness()` when there are 1 or fewer full automatic stats collections, and uses the fully qualified table name in logs.

Part of: #153748, #153873

Release note: Changes scan misestimate logging gated behind `sql.log.scan_row_count_misestimate.enabled` to use structured logging including the table and index being scanned, the estimated and actual row counts, the time since the last table stats collection, and the table's estimated staleness.