### PR TITLE
release-25.3: opt: never pick unbounded generic plans over bounded custom plans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -470,3 +470,73 @@ query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1, 2);
 ----
 plan type: custom
+
+statement ok
+DEALLOCATE p
+
+# Regression test for #155159. Do not choose a generic query plan with unbounded
+# cardinality when the custom plans have bounded cardinality.
+statement ok
+CREATE TABLE t155159 (
+  id INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX (a, b)
+)
+
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+SET optimizer_prefer_bounded_cardinality = false
+
+statement ok
+PREPARE p AS SELECT id FROM t155159 WHERE a = $1 AND b >= $2 ORDER BY b, id LIMIT 250
+
+statement ok
+EXECUTE p (33, 44)
+
+statement ok
+EXECUTE p (33, 44)
+
+statement ok
+EXECUTE p (33, 44)
+
+statement ok
+EXECUTE p (33, 44)
+
+statement ok
+EXECUTE p (33, 44)
+
+query T
+EXPLAIN ANALYZE EXECUTE p (33, 44)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
+  missing stats
+  table: t155159@t155159_a_b_idx
+  spans: [/33/44 - /33]
+  limit: 250
+
+statement ok
+DEALLOCATE p

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -8,7 +8,8 @@ package memo
 import "testing"
 
 type testAux struct {
-	fullScanCount uint8
+	fullScanCount        uint8
+	unboundedCardinality bool
 }
 
 func TestCostLess(t *testing.T) {
@@ -38,7 +39,8 @@ func TestCostLess(t *testing.T) {
 		{Cost{C: 2.0, Flags: CostFlags{}}, Cost{C: 1.0, Flags: CostFlags{UnboundedCardinality: true}}, true},
 		{Cost{C: 1.0, Flags: CostFlags{UnboundedCardinality: true}}, Cost{C: 2.0, Flags: CostFlags{}}, false},
 		// Auxiliary information should not affect the comparison.
-		{Cost{C: 1.0, aux: testAux{0}}, Cost{C: 1.0, aux: testAux{1}}, false},
+		{Cost{C: 1.0, aux: testAux{0, false}}, Cost{C: 1.0, aux: testAux{1, true}}, false},
+		{Cost{C: 1.0, aux: testAux{1, true}}, Cost{C: 1.0, aux: testAux{0, false}}, false},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -57,8 +59,10 @@ func TestCostAdd(t *testing.T) {
 		{Cost{C: 1.5}, Cost{C: 2.5}, Cost{C: 4.0}},
 		{Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true}}, Cost{C: 2.0}, Cost{C: 3.0, Flags: CostFlags{FullScanPenalty: true}}},
 		{Cost{C: 1.0}, Cost{C: 2.0, Flags: CostFlags{HugeCostPenalty: true}}, Cost{C: 3.0, Flags: CostFlags{HugeCostPenalty: true}}},
-		{Cost{C: 1.0, aux: testAux{1}}, Cost{C: 1.0, aux: testAux{2}}, Cost{C: 2.0, aux: testAux{3}}},
-		{Cost{C: 1.0, aux: testAux{200}}, Cost{C: 1.0, aux: testAux{100}}, Cost{C: 2.0, aux: testAux{255}}},
+		{Cost{C: 1.0, aux: testAux{1, false}}, Cost{C: 1.0, aux: testAux{2, false}}, Cost{C: 2.0, aux: testAux{3, false}}},
+		{Cost{C: 1.0, aux: testAux{200, false}}, Cost{C: 1.0, aux: testAux{100, false}}, Cost{C: 2.0, aux: testAux{255, false}}},
+		{Cost{C: 1.0, aux: testAux{1, false}}, Cost{C: 1.0, aux: testAux{2, true}}, Cost{C: 2.0, aux: testAux{3, true}}},
+		{Cost{C: 1.0, aux: testAux{200, true}}, Cost{C: 1.0, aux: testAux{100, false}}, Cost{C: 2.0, aux: testAux{255, true}}},
 	}
 	for _, tc := range testCases {
 		tc.left.Add(tc.right)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -623,12 +623,14 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	cost.C += cpuCostFactor
 
 	// Add a one-time cost for any operator with unbounded cardinality. This
-	// ensures we prefer plans that push limits as far down the tree as possible,
-	// all else being equal.
+	// ensures we prefer plans that push limits as far down the tree as
+	// possible, all else being equal.
 	//
-	// Also add a cost flag for unbounded cardinality.
+	// Also add a cost flag for unbounded cardinality, and a penalty if the
+	// corresponding session setting is enabled.
 	if candidate.Relational().Cardinality.IsUnbounded() {
 		cost.C += cpuCostFactor
+		cost.SetUnboundedCardinality()
 		if c.evalCtx.SessionData().OptimizerPreferBoundedCardinality {
 			cost.Flags.UnboundedCardinality = true
 		}

--- a/pkg/sql/prep/statement.go
+++ b/pkg/sql/prep/statement.go
@@ -185,10 +185,14 @@ func (p *planCosts) NumCustom() int {
 // average cost of the custom plans.
 func (p *planCosts) IsGenericOptimal() bool {
 	// Check cost flags and full scan counts.
-	if gc := p.generic.FullScanCount(); gc > 0 || !p.generic.Flags.Empty() {
+	if gc := p.generic.FullScanCount(); gc > 0 ||
+		p.generic.HasUnboundedCardinality() ||
+		!p.generic.Flags.Empty() {
 		for i := 0; i < p.custom.length; i++ {
-			if p.custom.costs[i].Flags.Less(p.generic.Flags) ||
-				gc > p.custom.costs[i].FullScanCount() {
+			custom := &p.custom.costs[i]
+			if custom.Flags.Less(p.generic.Flags) ||
+				(p.generic.HasUnboundedCardinality() && !custom.HasUnboundedCardinality()) ||
+				gc > custom.FullScanCount() {
 				return false
 			}
 		}


### PR DESCRIPTION
Backport 1/5 commits from #155163.

/cc @cockroachdb/release

---

#### opt: never pick unbounded generic plans over bounded custom plans

The optimizer will no longer choose a generic query plan with unbounded
cardinality over a custom query plan with bounded cardinality,
regardless of `optimizer_prefer_bounded_cardinality`.

In order to implement this behavior, a flag had to be added to
`memo.Cost` that is separate from `UnboundedCardinalityPenalty`. The
penalty is only added to the cost when
`optimizer_prefer_bounded_cardinality` is enabled. The new flag is
unconditionally set, allowing the decision between a generic and custom
plan to work as expected regardless of the session setting. This is a
tad confusing, so I did my best to document the differences clearly.

Fixes #155159

Release note (performance improvement): The optimizer chooses suboptimal
generic query plans in fewer cases.

---

Release justification: Avoid choosing bad generic query plans.


