### PR TITLE
sql: use existing PK index for inverted index valdiation

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1785,8 +1785,10 @@ func countExpectedRowsForInvertedIndex(
 	if withFirstMutationPublic {
 		// Make the mutations public in an in-memory copy of the descriptor and
 		// add it to the Collection's synthetic descriptors, so that we can use
-		// SQL below to perform the validation.
-		fakeDesc, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints, catalog.RetainDroppingColumns)
+		// SQL below to perform the validation. Avoid making PK swaps public, otherwise
+		// in the declarative schema changer we can select incomplete primary indexes
+		// for validation.
+		fakeDesc, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints, catalog.RetainDroppingColumns, catalog.IgnorePKSwaps)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -5265,3 +5265,23 @@ statement ok
 RESET experimental_enable_unique_without_index_constraints
 
 subtest end
+
+# Tests for a regression found by #155145 where the wrong primary index could
+# be scanned for when validating inverted indexes recreated after an ALTER
+# PRIMARY KEY.
+subtest validate_alter_pk_with_inverted
+
+statement ok
+CREATE TABLE t_alter_pk_with_inverted(
+    a STRING NOT NULL,
+    d DECIMAL[],
+    INVERTED INDEX (d)
+  );
+
+statement ok
+INSERT INTO t_alter_pk_with_inverted VALUES ('test', ARRAY[1.0, 2.0]);
+
+statement ok
+ALTER TABLE t_alter_pk_with_inverted ALTER PRIMARY KEY USING COLUMNS (a) USING HASH;
+
+subtest end


### PR DESCRIPTION
Previously, when we were validating inverted index, we made all first mutations public. For a PK swap operation this meant that incomplete primary indexes would be made public, which may not be fully ready for scans depending on the plan. This meant after recent changes to have better plans for alter primary key, we could end up scanning incomplete primary indexes. To address this, this patch ensures that only non-PK swap indexes are used for validating inverted indexes.

Fixes: #155145
Fixes: #155141
Fixes: https://github.com/cockroachdb/cockroach/issues/155053
Fixes: https://github.com/cockroachdb/cockroach/issues/155038

Release note: None