### PR TITLE
cli: add debug clear-gossip-bootstrap

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
@@ -1010,6 +1011,57 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+var debugClearGossipBootstrapCmd = &cobra.Command{
+	Use:   "clear-gossip-bootstrap <directory>",
+	Short: "clear the persisted gossip bootstrap addresses from a store",
+	Long: `
+Clears the persisted gossip bootstrap addresses from the specified store.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: clierrorplus.MaybeDecorateError(runDebugClearGossipBootstrap),
+}
+
+func runDebugClearGossipBootstrap(cmd *cobra.Command, args []string) error {
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	db, err := OpenEngine(args[0], stopper, fs.ReadWrite, storage.MustExist)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Read the persisted bootstrap info so we can log the addresses being cleared.
+	var bi gossip.BootstrapInfo
+	found, err := storage.MVCCGetProto(ctx, db, keys.StoreGossipKey(), hlc.Timestamp{}, &bi,
+		storage.MVCCGetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to read bootstrap info")
+	}
+
+	if !found {
+		return errors.New("no bootstrap info found in store")
+	}
+
+	fmt.Printf("Found bootstrap info with %d addresses:\n", len(bi.Addresses))
+	for _, addr := range bi.Addresses {
+		fmt.Printf("\t%s\n", addr.String())
+	}
+
+	// Clear the addresses by writing an empty BootstrapInfo.
+	emptyBI := gossip.BootstrapInfo{
+		Addresses: []util.UnresolvedAddr{},
+	}
+
+	if err := storage.MVCCPutProto(ctx, db, keys.StoreGossipKey(), hlc.Timestamp{}, &emptyBI,
+		storage.MVCCWriteOptions{}); err != nil {
+		return errors.Wrap(err, "failed to clear bootstrap info")
+	}
+
+	return nil
+}
+
 var debugGossipValuesCmd = &cobra.Command{
 	Use:   "gossip-values",
 	Short: "dump all the values in a node's gossip instance",
@@ -1327,6 +1379,7 @@ func runDebugIntentCount(cmd *cobra.Command, args []string) error {
 // Note: do NOT include commands that just call Pebble code without setting up an engine.
 var DebugCommandsRequiringEncryption = []*cobra.Command{
 	debugCheckStoreCmd,
+	debugClearGossipBootstrapCmd,
 	debugCompactCmd,
 	debugGCCmd,
 	debugIntentCount,
@@ -1341,6 +1394,7 @@ var DebugCommandsRequiringEncryption = []*cobra.Command{
 // Debug commands. All commands in this list to be added to root debug command.
 var debugCmds = []*cobra.Command{
 	debugCheckStoreCmd,
+	debugClearGossipBootstrapCmd,
 	debugCompactCmd,
 	debugGCCmd,
 	debugIntentCount,

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -150,6 +150,7 @@ func RegisterTests(r registry.Registry) {
 	registerSchemaChangeIndexTPCC800(r)
 	registerSchemaChangeInvertedIndex(r)
 	registerSchemaChangeMixedVersions(r)
+	registerStopAndCopyGossipBootstrap(r)
 	registerDeclSchemaChangeCompatMixedVersions(r)
 	registerSchemaChangeRandomLoad(r)
 	registerLargeSchemaBackupRestores(r)

--- a/pkg/cmd/roachtest/tests/stop_and_copy.go
+++ b/pkg/cmd/roachtest/tests/stop_and_copy.go
@@ -30,20 +30,24 @@ const (
 	tarFile         = dataDir + "cockroach.tar.gz"
 )
 
-type multiClusterConfig struct {
+type stopAndCopyTest struct {
+	cluster.Cluster
+	t          test.Test
 	srcCluster option.NodeListOption
 	dstCluster option.NodeListOption
 }
 
-func setupClusters(c cluster.Cluster) multiClusterConfig {
-	return multiClusterConfig{
+func setupClusters(c cluster.Cluster, t test.Test) stopAndCopyTest {
+	return stopAndCopyTest{
+		Cluster:    c,
+		t:          t,
 		srcCluster: c.Range(1, nodesPerCluster),
 		dstCluster: c.Range(nodesPerCluster+1, 2*nodesPerCluster),
 	}
 }
 
-func startCluster(
-	ctx context.Context, t test.Test, c cluster.Cluster, nodes option.NodeListOption, skipInit bool,
+func (s *stopAndCopyTest) startCluster(
+	ctx context.Context, nodes option.NodeListOption, skipInit bool,
 ) error {
 	clusterSetting := install.MakeClusterSettings()
 	srcStartOpts := option.NewStartOpts(
@@ -54,39 +58,62 @@ func startCluster(
 		srcStartOpts.RoachprodOpts.SkipInit = true
 	}
 
-	t.Status("starting cluster with nodes ", nodes)
-	return c.StartE(ctx, t.L(), srcStartOpts, clusterSetting, nodes)
+	s.t.Status("starting cluster with nodes ", nodes)
+	return s.StartE(ctx, s.t.L(), srcStartOpts, clusterSetting, nodes)
 }
 
-func copyAndTransferData(
-	ctx context.Context, t test.Test, c cluster.Cluster, cfg multiClusterConfig,
-) error {
-	t.Status("creating archive and transferring data to destination cluster")
+func (s *stopAndCopyTest) copyAndTransferData(ctx context.Context) error {
+	s.t.Status("creating archive and transferring data to destination cluster")
 	// This command creates a tar archive on the source cluster.
-	if err := c.RunE(ctx, option.WithNodes(cfg.srcCluster), "tar", "-czf", tarFile, "-C", dataDir, "cockroach"); err != nil {
+	if err := s.RunE(ctx, option.WithNodes(s.srcCluster), "tar", "-czf", tarFile, "-C", dataDir, "cockroach"); err != nil {
 		return errors.Wrapf(err, "creating tar archive")
 	}
 
 	// Fetch IP address of nodes from destination cluster.
-	dstNodeIps, err := c.InternalIP(ctx, t.L(), cfg.dstCluster)
+	dstNodeIps, err := s.InternalIP(ctx, s.t.L(), s.dstCluster)
 	if err != nil {
 		return errors.Wrapf(err, "getting destination IPs")
 	}
 
 	// This code copies data in parallel from source cluster nodes to their corresponding destination nodes.
-	m := t.NewGroup(task.WithContext(ctx))
-	for idx, n := range cfg.srcCluster {
+	m := s.t.NewGroup(task.WithContext(ctx))
+	for idx, n := range s.srcCluster {
 		node := n
 		dstIP := dstNodeIps[idx]
 		m.Go(func(ctx context.Context, l *logger.Logger) error {
-			return c.RunE(ctx, option.WithNodes(option.NodeListOption{node}), "scp", tarFile, fmt.Sprintf("ubuntu@%s:%s", dstIP, dataDir))
+			return s.RunE(ctx, option.WithNodes(option.NodeListOption{node}), "scp", tarFile, fmt.Sprintf("ubuntu@%s:%s", dstIP, dataDir))
 		})
 	}
 	m.Wait()
 
 	// This command extracts the tar archive in the destination data directory.
-	if err = c.RunE(ctx, option.WithNodes(cfg.dstCluster), "tar", "-xzf", tarFile, "-C", dataDir); err != nil {
+	if err = s.RunE(ctx, option.WithNodes(s.dstCluster), "tar", "-xzf", tarFile, "-C", dataDir); err != nil {
 		return errors.Wrapf(err, "extracting tar archive:")
+	}
+	return nil
+}
+
+func (s *stopAndCopyTest) clearGossipBootstrap(ctx context.Context) error {
+	s.t.Status("clearing gossip bootstrap info on destination cluster")
+	return s.RunE(ctx, option.WithNodes(s.dstCluster), fmt.Sprintf("./cockroach debug clear-gossip-bootstrap %s/cockroach", dataDir))
+}
+
+func (s *stopAndCopyTest) checkGossipNodes(ctx context.Context, nodes option.NodeListOption) error {
+	db := s.Conn(ctx, s.t.L(), nodes[0])
+	defer db.Close()
+	rows, err := db.Query("SELECT count(*) FROM crdb_internal.gossip_nodes")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var count int
+	if rows.Next() {
+		if err = rows.Scan(&count); err != nil {
+			return err
+		}
+	}
+	if count != nodesPerCluster {
+		return errors.Newf("expected %d nodes, got %d", nodesPerCluster, count)
 	}
 	return nil
 }
@@ -112,9 +139,9 @@ func fingerprintDatabases(
 // 4. Restarts the cluster with the relocated data
 func registerKVStopAndCopy(r registry.Registry) {
 	runStopAndCopy := func(ctx context.Context, t test.Test, c cluster.Cluster) {
-		cfg := setupClusters(c)
+		cfg := setupClusters(c, t)
 
-		if err := startCluster(ctx, t, c, cfg.srcCluster, false); err != nil {
+		if err := cfg.startCluster(ctx, cfg.srcCluster, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -133,12 +160,12 @@ func registerKVStopAndCopy(r registry.Registry) {
 		t.Status("stopping source cluster")
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), cfg.srcCluster)
 
-		if err := copyAndTransferData(ctx, t, c, cfg); err != nil {
+		if err := cfg.copyAndTransferData(ctx); err != nil {
 			t.Fatal(err)
 		}
 
 		// Start the destination cluster.
-		if err := startCluster(ctx, t, c, cfg.dstCluster, true); err != nil {
+		if err := cfg.startCluster(ctx, cfg.dstCluster, true); err != nil {
 			t.Fatal(err)
 		}
 
@@ -175,5 +202,101 @@ func registerKVStopAndCopy(r registry.Registry) {
 		Suites:           registry.Suites(registry.Weekly),
 		Run:              runStopAndCopy,
 		Timeout:          defaultTimeout,
+	})
+}
+
+func registerStopAndCopyGossipBootstrap(r registry.Registry) {
+	runStopAndCopy := func(ctx context.Context, t test.Test, c cluster.Cluster, clearGossip bool) {
+		cfg := setupClusters(c, t)
+
+		if err := cfg.startCluster(ctx, cfg.srcCluster, false /*skipInit*/); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Status("importing bank workload on source cluster")
+		c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach workload init bank --rows=1000 {pgurl:1}")
+
+		// It should be extremely unlikely, but if we shut down the cluster too quickly after
+		// startup it sometimes does not get the chance to persist any gossip bootstrap info.
+		t.Status("sleeping for 30 seconds")
+		time.Sleep(30 * time.Second)
+
+		t.Status("stopping source cluster")
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), cfg.srcCluster)
+
+		if err := cfg.copyAndTransferData(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		if clearGossip {
+			if err := cfg.clearGossipBootstrap(ctx); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Start the source cluster.
+		if err := cfg.startCluster(ctx, cfg.srcCluster, true /*skipInit*/); err != nil {
+			t.Fatal(err)
+		}
+
+		// Start the destination cluster.
+		if err := cfg.startCluster(ctx, cfg.dstCluster, true /*skipInit*/); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cfg.checkGossipNodes(ctx, cfg.srcCluster); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cfg.checkGossipNodes(ctx, cfg.dstCluster); err != nil {
+			if clearGossip {
+				t.Fatal(err)
+			} else {
+				// If we didn't clear the gossip bootstrap info, it's expected that the destination
+				// cluster will attempt to connect to the source cluster and fail to start properly.
+				t.L().Printf("expected error checking gossip nodes on source cluster: %s", err)
+				return
+			}
+		}
+	}
+
+	// stop-and-copy/gossip-bootstrap/clear tests that the cockroach debug clear-gossip-bootstrap
+	// command works as expected. It:
+	// 1. Starts the source cluster and imports some cold data into it.
+	// 2. Shuts down the source cluster.
+	// 3. Copies the storage data volumes to the destination cluster.
+	// 4. Wipes the gossip bootstrap metadata on the destination cluster.
+	// 5. Starts both clusters and verifies that they can both operate independently.
+	//
+	// This is intended to simulate a scenario where we take fixtures or snapshots of a cluster
+	// for testing purposes. Without wiping the gossip bootstrap metadata, the second cluster
+	// will read the persisted gossip bootstrap information and attempt to connect to the first cluster,
+	// causing node liveness issues.
+	r.Add(registry.TestSpec{
+		Name:             "stop-and-copy/gossip-bootstrap/clear",
+		Owner:            registry.OwnerTestEng,
+		Cluster:          r.MakeClusterSpec(2 * nodesPerCluster),
+		CompatibleClouds: registry.AllExceptLocal,
+		Suites:           registry.Suites(registry.Weekly),
+		Timeout:          30 * time.Minute,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runStopAndCopy(ctx, t, c, true)
+		},
+	})
+
+	// stop-and-copy/gossip-bootstrap/no-clear is similar to above, except we _don't_
+	// wipe the gossip bootstrap metadata on the destination cluster. We expect the
+	// destination cluster to attempt to connect to the source cluster and fail
+	// to start properly.
+	r.Add(registry.TestSpec{
+		Name:             "stop-and-copy/gossip-bootstrap/no-clear",
+		Owner:            registry.OwnerTestEng,
+		Cluster:          r.MakeClusterSpec(2 * nodesPerCluster),
+		CompatibleClouds: registry.AllExceptLocal,
+		Suites:           registry.Suites(registry.Weekly),
+		Timeout:          30 * time.Minute,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runStopAndCopy(ctx, t, c, false)
+		},
 	})
 }


### PR DESCRIPTION
We sometimes wish to take snapshots of CRDB clusters for testing purposes (e.g. test fixtures, faster start times, capturing state for future debugging). However, these snapshots contain persisted gossip bootstrap metadata.

On cluster restart, this will cause the cluster to attempt connections to the persisted ip addresses. This can cause issues if the original cluster is still running, or if the cloud provider reused the ip address for another VM in our project.

This change adds a clear-gossip-bootstrap command to cockroach debug which can be used to clear the persisted gossip bootstrap.

Fixes: none 
Epic: none
Release note: none