### PR TITLE
sql: resolve index names

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1072,6 +1072,20 @@ func TestTenantLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestTenantLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestTenantLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestTenantLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1091,6 +1091,20 @@ func TestReadCommittedLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestReadCommittedLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestReadCommittedLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestReadCommittedLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1050,6 +1050,20 @@ func TestRepeatableReadLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestRepeatableReadLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestRepeatableReadLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestRepeatableReadLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3500,8 +3500,16 @@ func (it *sessionDataMutatorIterator) mutator(
 	return ret
 }
 
+// SetDatabase sets the database for the session. It is exported for use in
+// inspect which is outside the sql package.
+func (it *sessionDataMutatorIterator) SetDatabase(dbName string) {
+	it.applyOnEachMutator(func(m sessionDataMutator) {
+		m.SetDatabase(dbName)
+	})
+}
+
 // SetSessionDefaultIntSize sets the default int size for the session.
-// It is exported for use in import which is a CCL package.
+// It is exported for use in import is outside the sql package.
 func (it *sessionDataMutatorIterator) SetSessionDefaultIntSize(size int32) {
 	it.applyOnEachMutator(func(m sessionDataMutator) {
 		m.SetDefaultIntSize(size)

--- a/pkg/sql/inspect/inspect_plan.go
+++ b/pkg/sql/inspect/inspect_plan.go
@@ -48,7 +48,7 @@ func newInspectRun(
 
 		switch stmt.Typ {
 		case tree.InspectTable:
-			table, err := p.ResolveExistingObjectEx(ctx, stmt.Table, true /* required */, tree.ResolveRequireTableDesc)
+			table, err := p.ResolveExistingObjectEx(ctx, stmt.Table.ToUnresolvedObjectName(), true /* required */, tree.ResolveRequireTableDesc)
 			if err != nil {
 				return inspectRun{}, err
 			}
@@ -119,7 +119,7 @@ func inspectPlanHook(
 		return nil, nil, false, err
 	}
 
-	if err := inspectStmt.Validate(); err != nil {
+	if err := inspectStmt.Populate(); err != nil {
 		return nil, nil, false, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -109,10 +109,6 @@ CREATE INDEX idx_c3 ON bar (c3);
 statement error pq: index "bar@idx_c1" does not belong to table "foo"
 INSPECT TABLE foo WITH OPTIONS INDEX (bar@idx_c1);
 
-# TODO(148365): The table name should be used to disambiguate.
-statement error index name "idx_c1" is ambiguous \(found in test.public.foo and test.public.bar\)
-INSPECT TABLE bar WITH OPTIONS INDEX (idx_c1);
-
 statement error index "dbfake.foo.idx_c1" does not belong to database "test"
 INSPECT DATABASE test WITH OPTIONS INDEX (dbfake.foo.idx_c1);
 

--- a/pkg/sql/logictest/testdata/logic_test/inspect_database_resolve_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/inspect_database_resolve_indexes
@@ -1,0 +1,46 @@
+# fakedist* configs are skipped because SetupAllNodesPlanning requires a
+# non-nil txn, which is not available in job-based flows like INSPECT. Using
+# them causes a nil pointer panic in the span resolver setup.
+#
+# LogicTest: !fakedist !fakedist-vec-off !fakedist-disk !local-mixed-25.2 !local-mixed-25.3
+
+statement ok
+CREATE DATABASE dbfoo;
+CREATE TABLE dbfoo.public.t2 (c1 INT, INDEX idx_c1 (c1));
+CREATE TABLE dbfoo.public.t1 (c1 INT, INDEX idx_c1 (c1));
+
+statement ok
+SET enable_inspect_command = true;
+
+statement ok
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (t1@idx_c1);
+
+statement ok
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (t2@idx_c1);
+
+statement ok
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (public.t1@idx_c1);
+
+statement ok
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (dbfoo.t1@idx_c1);
+
+statement ok
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (dbfoo.t2@idx_c1);
+
+statement ok
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (dbfoo.public.t1@idx_c1);
+
+statement error pq: index name "idx_c1" is ambiguous \(found in dbfoo.public.t2 and dbfoo.public.t1\)
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (idx_c1);
+
+statement error index name "idx_c1" is ambiguous \(found in dbfoo.public.t2 and dbfoo.public.t1\)
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (public.idx_c1);
+
+statement error index name "idx_c1" is ambiguous \(found in dbfoo.public.t2 and dbfoo.public.t1\)
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (dbfoo.idx_c1);
+
+statement error index name "idx_c1" is ambiguous \(found in dbfoo.public.t2 and dbfoo.public.t1\)
+INSPECT DATABASE dbfoo WITH OPTIONS INDEX (dbfoo.public.idx_c1);
+
+statement ok
+DROP DATABASE dbfoo;

--- a/pkg/sql/logictest/testdata/logic_test/inspect_table_resolve_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/inspect_table_resolve_indexes
@@ -1,0 +1,72 @@
+# fakedist* configs are skipped because SetupAllNodesPlanning requires a
+# non-nil txn, which is not available in job-based flows like INSPECT. Using
+# them causes a nil pointer panic in the span resolver setup.
+#
+# LogicTest: !fakedist !fakedist-vec-off !fakedist-disk !local-mixed-25.2 !local-mixed-25.3
+
+statement ok
+CREATE DATABASE dbfoo;
+CREATE DATABASE dbbar;
+CREATE SCHEMA dbfoo.s1;
+CREATE TABLE dbfoo.public.t1 (c1 INT, INDEX idx_c1 (c1));
+CREATE TABLE dbfoo.s1.t1 (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
+CREATE TABLE dbbar.public.t1 (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
+CREATE TABLE dbbar.public.t2 (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
+
+statement ok
+SET enable_inspect_command = true;
+
+subtest all_forms
+
+statement ok
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (t1@idx_c1);
+
+statement error pq: index "s1.t1@idx_c1" does not belong to table "dbfoo.public.t1"
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (s1.t1@idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (dbfoo.t1@idx_c1);
+
+statement error pq: index "dbfoo.s1.t1@idx_c1" does not belong to table "dbfoo.public.t1"
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (dbfoo.s1.t1@idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (idx_c1);
+
+statement error pq: index "s1.t1@idx_c1" does not belong to table "dbfoo.public.t1"
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (s1.idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (dbfoo.idx_c1);
+
+statement error pq: index "dbfoo.s1.t1@idx_c1" does not belong to table "dbfoo.public.t1"
+INSPECT TABLE dbfoo.t1 WITH OPTIONS INDEX (dbfoo.s1.idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (t1@idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (s1.t1@idx_c1);
+
+statement error index "dbfoo.public.t1@idx_c1" does not belong to table "dbfoo.s1.t1"
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (dbfoo.t1@idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (dbfoo.s1.t1@idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (s1.idx_c1);
+
+statement error pq: index "dbfoo.public.t1@idx_c1" does not belong to table "dbfoo.s1.t1"
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (dbfoo.idx_c1);
+
+statement ok
+INSPECT TABLE dbfoo.s1.t1 WITH OPTIONS INDEX (dbfoo.s1.idx_c1);
+
+subtest end
+
+statement ok
+DROP DATABASE dbfoo;

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1025,6 +1025,20 @@ func TestLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -745,6 +745,20 @@ func TestLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestLogic_internal_executor(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1060,6 +1060,20 @@ func TestLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1179,6 +1179,20 @@ func TestLogic_inspect(
 	runLogicTest(t, "inspect")
 }
 
+func TestLogic_inspect_database_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_database_resolve_indexes")
+}
+
+func TestLogic_inspect_table_resolve_indexes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "inspect_table_resolve_indexes")
+}
+
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7879,9 +7879,11 @@ inspect_stmt:
 inspect_table_stmt:
   INSPECT TABLE table_name opt_as_of_clause opt_inspect_options_clause
   {
+    name := $3.unresolvedObjectName().ToTableName()
+
     $$.val = &tree.Inspect{
       Typ: tree.InspectTable,
-      Table: $3.unresolvedObjectName(),
+      Table: &name,
       AsOf: $4.asOfClause(),
       Options: $5.inspectOptions(),
     }

--- a/pkg/sql/sem/tree/annotation.go
+++ b/pkg/sql/sem/tree/annotation.go
@@ -28,6 +28,7 @@ func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
 		// Avoid index-out-of bounds panics in production builds. The impact is
 		// that the node will be treated as if it doesn't have the annotation,
 		// which is better than the process crash.
+		// TODO(155405): Address this panic on the setter side.
 		return nil
 	}
 	return ann.Get(n.AnnIdx)
@@ -35,6 +36,12 @@ func (n AnnotatedNode) GetAnnotation(ann *Annotations) interface{} {
 
 // SetAnnotation sets the annotation associated with this node.
 func (n AnnotatedNode) SetAnnotation(ann *Annotations, annotation interface{}) {
+	if n.AnnIdx == NoAnnotation {
+		*ann = append(*ann, nil)
+		n.AnnIdx = AnnotationIdx(len(*ann))
+	}
+	// TODO(155405): Avoid index-of-bounds panics in SetAnnotation in production.
+
 	ann.Set(n.AnnIdx, annotation)
 }
 

--- a/pkg/sql/sem/tree/inspect.go
+++ b/pkg/sql/sem/tree/inspect.go
@@ -89,29 +89,6 @@ func (n *Inspect) Populate() error {
 		return err
 	}
 
-	// TODO(155056): Better validate index names from the options with the name
-	// of the database or table from the command.
-	// TODO(148365): Check for duplicated index names (including the name of the
-	// database or table from the command).
-	for _, index := range n.Options.NamedIndexes() {
-		switch n.Typ {
-		case InspectTable:
-			if index.Table.ObjectName != "" {
-				if n.Table.Object() != index.Table.Object() {
-					return pgerror.Newf(pgcode.InvalidName, "index %q does not belong to table %q", index.String(), n.Table.String())
-				}
-			} else {
-				index.Table.ObjectName = n.Table.ObjectName
-			}
-		case InspectDatabase:
-			if index.Table.ExplicitCatalog && n.Database.Object() != index.Table.Catalog() {
-				return pgerror.Newf(pgcode.InvalidName, "index %q does not belong to database %q", index.String(), n.Database.String())
-			} else {
-
-			}
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
- **sql: address index-out-of-bounds panic in annotated node**
- **sql: use INSPECT parameters to disambiguate index names**
- **sql: use table or database parameter to help resolve `INSPECT` indexes**
