### PR TITLE
changefeedccl: deflake TestChangefeedTestTimesOut

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -10973,6 +10973,16 @@ func TestChangefeedTestTimesOut(t *testing.T) {
 
 		expectResolvedTimestamp(t, nada) // Make sure feed is running.
 
+		cfKnobs := s.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+		//nolint:returnerrcheck
+		cfKnobs.HandleDistChangefeedError = func(err error) error {
+			if err != nil && strings.Contains(err.Error(), "client connection is closing") {
+				return nil
+			}
+			return err
+		}
 		const expectTimeout = 500 * time.Millisecond
 		var observedError error
 		require.NoError(t,


### PR DESCRIPTION
There is a race condition that occurs after the main part of the test is
completed. This change discards that error since it's not relevant.

An alternative is to add it to ignoreErrs but I'm not sure it also
provides value to other tests.

Fixes: #154411
Release note: none