### PR TITLE
admission: add logic to fill CPU time token buckets

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "admission",
     srcs = [
         "admission.go",
+        "cpu_time_token_filler.go",
         "cpu_time_token_granter.go",
         "disk_bandwidth.go",
         "elastic_cpu_grant_coordinator.go",
@@ -58,6 +59,7 @@ go_library(
 go_test(
     name = "admission_test",
     srcs = [
+        "cpu_time_token_filler_test.go",
         "cpu_time_token_granter_test.go",
         "disk_bandwidth_test.go",
         "elastic_cpu_granter_test.go",

--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -1,0 +1,179 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+// timePerTick is how frequently cpuTimeTokenFiller ticks its time.Ticker & adds
+// tokens to the buckets. Must be < 1s. Must divide 1s evenly.
+const timePerTick = 1 * time.Millisecond
+
+// cpuTimeTokenFiller starts a goroutine which periodically calls
+// cpuTimeTokenAllocator to add tokens to a cpuTimeTokenGranter. For example, on
+// an 8 vCPU machine, we may want to allow burstable tier-0 work to use 6 seconds
+// of CPU time per second. Then cpuTimeTokenAllocator.rates[tier0][canBurst] would
+// equal 6 seconds per second, and cpuTimeTokenFiller would add 6 seconds of token
+// every second, but smoothly -- 1ms at a time. See cpuTimeTokenGranter for details
+// on the multi-dimensional token buckets owned by cpuTimeTokenGranter; the TLDR is
+// there is one bucket per <resource tier, burst qualification> pair.
+//
+// cpuTimeTokenFiller owns the time.Ticker logic. The details of the token allocation
+// are left to the cpuTimeTokenAllocator, in order to improve clarity & testability.
+//
+// Note that the combination of cpuTimeTokenFiller & cpuTimeTokenAllocator are written
+// to be robust against delayed and dropped time.Timer ticks. That
+// is, in the presence of delayed and dropped ticks, the correct number of tokens will
+// be added to the buckets; they just may be added in a less smooth fashion than
+// normal. If ticks are delayed more than roughly 1s, not enough tokens will be
+// added to the bucket, but we do not expect this significant of a delay in practice
+// (admission control will be running).
+//
+// See ticker docs, where it is mentioned ticks can be dropped, if receivers are
+// slow: https://pkg.go.dev/time#NewTicker
+//
+// The mechanism by which the goroutine adds the correct number of tokens, in the
+// presence of delayed or dropped ticks, is:
+//   - time is split into intervals of 1s
+//   - intervals are split into 1s / timePerTick(=1ms) time.Ticker ticks
+//   - cpuTimeTokenAllocator attempts to allocate remaining tokens for interval evenly
+//     across remaining ticks in the interval
+//   - once interval is complete, all remaining tokens needed for that interval
+//     are added (e.g. see t.allocateTokens(1) below), then a new interval starts
+type cpuTimeTokenFiller struct {
+	allocator  tokenAllocator
+	timeSource timeutil.TimeSource
+	closeCh    chan struct{}
+	// Used only in unit tests.
+	tickCh *chan struct{}
+}
+
+// tokenAllocator abstracts cpuTimeTokenAllocator for testing.
+type tokenAllocator interface {
+	allocateTokens(remainingTicksInInInterval int64)
+	resetInterval()
+}
+
+func (f *cpuTimeTokenFiller) start() {
+	ticker := f.timeSource.NewTicker(timePerTick)
+	intervalStart := f.timeSource.Now()
+	// Every 1s a new interval starts. every timePerTick time token allocation
+	// is done. The expected number of ticks left in the interval is passed to
+	// the allocator. The expected number of ticks left can jump around, if
+	// time.Timer ticks are delayed or dropped.
+	go func() {
+		lastRemainingTicks := int64(0)
+		for {
+			select {
+			case t := <-ticker.Ch():
+				var remainingTicks int64
+				elapsedSinceIntervalStart := t.Sub(intervalStart)
+				if elapsedSinceIntervalStart >= time.Second {
+					// INVARIANT: During each interval, allocateTokens(1) must be called, before
+					// resetInterval() can be called.
+					//
+					// Without this invariant, cpuTimeTokenAllocator.rates tokens would not be
+					// allocated every 1s.
+					if lastRemainingTicks > 1 {
+						f.allocator.allocateTokens(1)
+					}
+					intervalStart = t
+					f.allocator.resetInterval()
+					remainingTicks = int64(time.Second / timePerTick)
+				} else {
+					remainingSinceIntervalStart := time.Second - elapsedSinceIntervalStart
+					if remainingSinceIntervalStart < 0 {
+						panic(errors.AssertionFailedf("remainingSinceIntervalStart is negative %d", remainingSinceIntervalStart))
+					}
+					// ceil(a / b) == (a + b - 1) / b, when using integer division.
+					// Round up so that we don't accumulate tokens to give in a burst on the
+					// last tick.
+					remainingTicks =
+						int64((remainingSinceIntervalStart + timePerTick - 1) / timePerTick)
+				}
+				f.allocator.allocateTokens(max(1, remainingTicks))
+				lastRemainingTicks = remainingTicks
+				// Only non-nil in unit tests.
+				if f.tickCh != nil {
+					*f.tickCh <- struct{}{}
+				}
+			case <-f.closeCh:
+				return
+			}
+		}
+	}()
+}
+
+// cpuTimeTokenAllocator allocates tokens to a cpuTimeTokenGranter. See the comment
+// above cpuTimeTokenFiller for a high level picture. The responsibility of
+// cpuTimeTokenAllocator is to gradually allocate rates tokens every interval,
+// while respecting bucketCapacity. We have split up the ticking & token allocation
+// logic, in order to improve clarity & testability.
+type cpuTimeTokenAllocator struct {
+	granter *cpuTimeTokenGranter
+
+	// Mutable fields. No mutex, since only a single goroutine will call the
+	// cpuTimeTokenAllocator.
+
+	// rates stores the number of token added to each bucket every interval.
+	rates [numResourceTiers][numBurstQualifications]int64
+	// bucketCapacity stores the maximum number of tokens that can be in each bucket.
+	// That is, if a bucket is already at capacity, no more tokens will be added.
+	bucketCapacity [numResourceTiers][numBurstQualifications]int64
+	// allocated stores the number of tokens added to each bucket in the current
+	// interval.
+	allocated [numResourceTiers][numBurstQualifications]int64
+}
+
+var _ tokenAllocator = &cpuTimeTokenAllocator{}
+
+// allocateTokens allocates tokens to a cpuTimeTokenGranter. allocateTokens
+// adds rates tokens every interval, while respecting bucketCapacity.
+// allocateTokens adds tokens evenly among the expected remaining ticks in
+// the interval.
+// INVARIANT: remainingTicks >= 1.
+// TODO(josh): Expand to cover tenant-specific token buckets too.
+func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval int64) {
+	allocateFunc := func(total int64, allocated int64, remainingTicks int64) (toAllocate int64) {
+		remainingTokens := total - allocated
+		// ceil(a / b) == (a + b - 1) / b, when using integer division.
+		// Round up so that we don't accumulate tokens to give in a burst on the
+		// last tick.
+		toAllocate = (remainingTokens + remainingTicks - 1) / remainingTicks
+		if toAllocate < 0 {
+			panic(errors.AssertionFailedf("toAllocate is negative %d", toAllocate))
+		}
+		if toAllocate+allocated > total {
+			toAllocate = total - allocated
+		}
+		return toAllocate
+	}
+
+	var delta [numResourceTiers][numBurstQualifications]int64
+	for wc := range a.rates {
+		for kind := range a.rates[wc] {
+			toAllocateTokens := allocateFunc(
+				a.rates[wc][kind], a.allocated[wc][kind], expectedRemainingTicksInInterval)
+			a.allocated[wc][kind] += toAllocateTokens
+			delta[wc][kind] = toAllocateTokens
+		}
+	}
+	a.granter.refill(delta, a.bucketCapacity)
+}
+
+// resetInterval is called to signal the beginning of a new interval. allocateTokens
+// adds rates tokens every interval.
+func (a *cpuTimeTokenAllocator) resetInterval() {
+	for wc := range a.allocated {
+		for kind := range a.allocated[wc] {
+			a.allocated[wc][kind] = 0
+		}
+	}
+}

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -1,0 +1,143 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admission
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestCPUTimeTokenFiller(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Fixed time for reproducibility.
+	unixNanos := int64(1758938600000000000) // 2025-09-24T14:30:00Z
+	startTime := time.Unix(0, unixNanos).UTC()
+	testTime := timeutil.NewManualTime(startTime)
+
+	var buf strings.Builder
+	allocator := testTokenAllocator{buf: &buf}
+	var filler cpuTimeTokenFiller
+	flushAndReset := func() string {
+		fmt.Fprintf(&buf, "elapsed: %s\n", testTime.Since(startTime))
+		str := buf.String()
+		buf.Reset()
+		return str
+	}
+
+	tickCh := make(chan struct{})
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "cpu_time_token_filler"), func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "init":
+			filler = cpuTimeTokenFiller{
+				allocator:  &allocator,
+				closeCh:    make(chan struct{}),
+				timeSource: testTime,
+				tickCh:     &tickCh,
+			}
+			filler.start()
+			return flushAndReset()
+		case "advance":
+			var dur time.Duration
+			d.ScanArgs(t, "dur", &dur)
+			testTime.AdvanceInOneTick(dur)
+			<-tickCh
+			return flushAndReset()
+		case "stop":
+			close(filler.closeCh)
+			return flushAndReset()
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}
+
+type testTokenAllocator struct {
+	buf *strings.Builder
+}
+
+func (a *testTokenAllocator) resetInterval() {
+	fmt.Fprintf(a.buf, "resetInterval()\n")
+}
+
+func (a *testTokenAllocator) allocateTokens(remainingTicks int64) {
+	fmt.Fprintf(a.buf, "allocateTokens(%d)\n", remainingTicks)
+}
+
+func TestCPUTimeTokenAllocator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	granter := &cpuTimeTokenGranter{}
+	tier0Granter := &cpuTimeTokenChildGranter{
+		tier:   testTier0,
+		parent: granter,
+	}
+	tier1Granter := &cpuTimeTokenChildGranter{
+		tier:   testTier1,
+		parent: granter,
+	}
+	var requesters [numResourceTiers]*testRequester
+	requesters[testTier0] = &testRequester{
+		additionalID: "tier0",
+		granter:      tier0Granter,
+	}
+	requesters[testTier1] = &testRequester{
+		additionalID: "tier1",
+		granter:      tier1Granter,
+	}
+	granter.requester[testTier0] = requesters[testTier0]
+	granter.requester[testTier1] = requesters[testTier1]
+
+	allocator := cpuTimeTokenAllocator{
+		granter: granter,
+	}
+	allocator.rates[testTier0][canBurst] = 5
+	allocator.rates[testTier0][noBurst] = 4
+	allocator.rates[testTier1][canBurst] = 3
+	allocator.rates[testTier1][noBurst] = 2
+	allocator.bucketCapacity = allocator.rates
+
+	var buf strings.Builder
+	flushAndReset := func(printGranter bool) string {
+		if printGranter {
+			fmt.Fprint(&buf, granter.String())
+		}
+		str := buf.String()
+		buf.Reset()
+		return str
+	}
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "cpu_time_token_allocator"), func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "resetInterval":
+			allocator.resetInterval()
+			return flushAndReset(false /* printGranter */)
+		case "allocate":
+			var remainingTicks int64
+			d.ScanArgs(t, "remaining", &remainingTicks)
+			allocator.allocateTokens(remainingTicks)
+			return flushAndReset(true /* printGranter */)
+		case "clear":
+			granter.mu.buckets[testTier0][canBurst].tokens = 0
+			granter.mu.buckets[testTier0][noBurst].tokens = 0
+			granter.mu.buckets[testTier1][canBurst].tokens = 0
+			granter.mu.buckets[testTier1][noBurst].tokens = 0
+			return flushAndReset(true /* printGranter */)
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/pkg/util/admission/cpu_time_token_granter_test.go
+++ b/pkg/util/admission/cpu_time_token_granter_test.go
@@ -149,6 +149,24 @@ func TestCPUTimeTokenGranter(t *testing.T) {
 			requesters[scanResourceTier(t, d)].tookWithoutPermission(int64(v))
 			return flushAndReset(false /* init */)
 
+		case "refill":
+			// The delta & the bucket capacity are hard-coded. It is unwiedly
+			// to make them data-driven arguments, and the payoff would be
+			// low anyway.
+			var delta [numResourceTiers][numBurstQualifications]int64
+			delta[testTier0][canBurst] = 5
+			delta[testTier0][noBurst] = 4
+			delta[testTier1][canBurst] = 3
+			delta[testTier1][noBurst] = 1
+			var bucketCapacity [numResourceTiers][numBurstQualifications]int64
+			bucketCapacity[testTier0][canBurst] = 4
+			bucketCapacity[testTier0][noBurst] = 3
+			bucketCapacity[testTier1][canBurst] = 10
+			bucketCapacity[testTier1][noBurst] = 1
+			granter.refill(delta, bucketCapacity)
+			fmt.Fprintf(&buf, "refill(%v %v)\n", delta, bucketCapacity)
+			return flushAndReset(false /* init */)
+
 		// For cpuTimeTokenChildGranter, this is a NOP. Still, it will be
 		// called in production. So best to test it doesn't panic, or similar.
 		case "continue-grant-chain":

--- a/pkg/util/admission/testdata/cpu_time_token_allocator
+++ b/pkg/util/admission/testdata/cpu_time_token_allocator
@@ -1,0 +1,92 @@
+allocate remaining=5
+----
+cpuTTG canBurst noBurst
+tier0  1        1
+tier1  1        1
+
+allocate remaining=4
+----
+cpuTTG canBurst noBurst
+tier0  2        2
+tier1  2        2
+
+allocate remaining=3
+----
+cpuTTG canBurst noBurst
+tier0  3        3
+tier1  3        2
+
+allocate remaining=2
+----
+cpuTTG canBurst noBurst
+tier0  4        4
+tier1  3        2
+
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2
+
+resetInterval
+----
+
+# No more tokens added due to burst budget.
+allocate remaining=5
+----
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2
+
+# clear simulates tokens being taken due to admitted work.
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# In the interval, one call to allocateTokens made already,
+# so we do not expect the full rates to end up in the buckets.
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  4        3
+tier1  2        1
+
+resetInterval
+----
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# In this interval, no call to allocateTokens so far, so we do
+# expect the full rates to end up in the bucket.
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2
+
+resetInterval
+----
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+allocate remaining=2
+----
+cpuTTG canBurst noBurst
+tier0  3        2
+tier1  2        1
+
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2

--- a/pkg/util/admission/testdata/cpu_time_token_filler
+++ b/pkg/util/admission/testdata/cpu_time_token_filler
@@ -1,0 +1,96 @@
+init
+----
+elapsed: 0s
+
+# Let 2s pass, 200ms at a time. Expect a call to allocateTokens
+# per 200ms advance (since advance uses AdvanceInOneTick). Expect
+# a reset every 1s.
+advance dur=200ms
+----
+allocateTokens(800)
+elapsed: 200ms
+
+advance dur=200ms
+----
+allocateTokens(600)
+elapsed: 400ms
+
+advance dur=200ms
+----
+allocateTokens(400)
+elapsed: 600ms
+
+advance dur=200ms
+----
+allocateTokens(200)
+elapsed: 800ms
+
+advance dur=200ms
+----
+allocateTokens(1)
+resetInterval()
+allocateTokens(1000)
+elapsed: 1s
+
+advance dur=200ms
+----
+allocateTokens(800)
+elapsed: 1.2s
+
+advance dur=200ms
+----
+allocateTokens(600)
+elapsed: 1.4s
+
+advance dur=200ms
+----
+allocateTokens(400)
+elapsed: 1.6s
+
+advance dur=200ms
+----
+allocateTokens(200)
+elapsed: 1.8s
+
+advance dur=200ms
+----
+allocateTokens(1)
+resetInterval()
+allocateTokens(1000)
+elapsed: 2s
+
+# Let 1s pass in one tick. Expect allocateTokens(1) to be called.
+# Expect a reset.
+advance dur=1000ms
+----
+allocateTokens(1)
+resetInterval()
+allocateTokens(1000)
+elapsed: 3s
+
+# Let 1s pass in a different tick interval than every 200ms.
+advance dur=400ms
+----
+allocateTokens(600)
+elapsed: 3.4s
+
+advance dur=200ms
+----
+allocateTokens(400)
+elapsed: 3.6s
+
+advance dur=200ms
+----
+allocateTokens(200)
+elapsed: 3.8s
+
+advance dur=200ms
+----
+allocateTokens(1)
+resetInterval()
+allocateTokens(1000)
+elapsed: 4s
+
+stop
+----
+elapsed: 4s

--- a/pkg/util/admission/testdata/cpu_time_token_granter
+++ b/pkg/util/admission/testdata/cpu_time_token_granter
@@ -205,3 +205,23 @@ kvtier0: returnGrant(1)
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        1
+
+# Test refill, which is the interface cpuTimeTokenFiller uses to add tokens to
+# the buckets. The final allocation of tokens in the buckets is a result of
+# the delta argument to refill, the bucket capacities in certain cases capping how
+# tokens should be added, and one queued request being granted admission.
+init tier1waiter=1
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
+tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 1
+
+refill
+----
+kvtier1: granted in chain 0, and returning 1
+refill([[5 4] [3 1]] [[4 3] [10 1]])
+cpuTTG canBurst noBurst
+tier0  3        2
+tier1  2        0

--- a/pkg/util/timeutil/manual_time.go
+++ b/pkg/util/timeutil/manual_time.go
@@ -85,6 +85,14 @@ func (m *ManualTime) Advance(duration time.Duration) {
 	m.AdvanceTo(m.Now().Add(duration))
 }
 
+// AdvanceInOneTick forwards the current time by the given duration. If
+// tick(s) are needed, only one will be sent out. This simulates a ticker
+// dropping ticks, as can happen if receivers are slow:
+// https://pkg.go.dev/time#NewTicker
+func (m *ManualTime) AdvanceInOneTick(duration time.Duration) {
+	m.AdvanceToInOneTick(m.Now().Add(duration))
+}
+
 // Backwards moves the clock back by duration. Duration is expected to be
 // positive, and it will be subtracted from the current time.
 func (m *ManualTime) Backwards(duration time.Duration) {
@@ -102,7 +110,17 @@ func (m *ManualTime) Backwards(duration time.Duration) {
 func (m *ManualTime) AdvanceTo(now time.Time) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.advanceToLocked(now)
+	m.advanceToLocked(now, false /* skipIntermediateTicks */)
+}
+
+// AdvanceToInOneTick advances the current time to t. If t is earlier than the current
+// time then AdvanceTo is a no-op. If tick(s) are needed, only one will be sent out.
+// This simulates a ticker dropping ticks, as can happen if receivers are slow:
+// https://pkg.go.dev/time#NewTicker
+func (m *ManualTime) AdvanceToInOneTick(now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.advanceToLocked(now, true /* skipIntermediateTicks */)
 }
 
 // MustAdvanceTo is like AdvanceTo, except it panics if now is below m's current time.
@@ -112,10 +130,10 @@ func (m *ManualTime) MustAdvanceTo(now time.Time) {
 	if now.Before(m.mu.now) {
 		panic(fmt.Sprintf("attempting to move ManualTime backwards from %s to %s", m.mu.now, now))
 	}
-	m.advanceToLocked(now)
+	m.advanceToLocked(now, false /* skipIntermediateTicks */)
 }
 
-func (m *ManualTime) advanceToLocked(now time.Time) {
+func (m *ManualTime) advanceToLocked(now time.Time, skipIntermediateTicks bool) {
 	if !now.After(m.mu.now) {
 		return
 	}
@@ -134,6 +152,17 @@ func (m *ManualTime) advanceToLocked(now time.Time) {
 	// Fire off any tickers.
 	for e := m.mu.tickers.Front(); e != nil; e = e.Next() {
 		t := e.Value.(*manualTicker)
+		if skipIntermediateTicks {
+			if !t.nextTick.After(now) {
+				select {
+				case t.ch <- now:
+				default:
+					panic("ticker channel full")
+				}
+				t.nextTick = now.Add(t.duration)
+			}
+			continue
+		}
 		for !t.nextTick.After(now) {
 			select {
 			case t.ch <- t.nextTick:

--- a/pkg/util/timeutil/manual_time_test.go
+++ b/pkg/util/timeutil/manual_time_test.go
@@ -126,6 +126,9 @@ func TestManualTime(t *testing.T) {
 		advanceTo := func(d time.Duration) {
 			mt.AdvanceTo(t0.Add(d))
 		}
+		advanceToInOneTick := func(d time.Duration) {
+			mt.AdvanceToInOneTick(t0.Add(d))
+		}
 		t1 := mt.NewTicker(1 * time.Second)
 		t2 := mt.NewTicker(5 * time.Second)
 
@@ -149,6 +152,11 @@ func TestManualTime(t *testing.T) {
 		ensureSend(t, t1.Ch(), 6*time.Second)
 
 		ensureSend(t, t2.Ch(), 5*time.Second)
+
+		// 7s tick will be dropped.
+		advanceToInOneTick(8 * time.Second)
+		ensureSend(t, t1.Ch(), 8*time.Second)
+		ensureNoSend(t, t1.Ch())
 
 		t1.Stop()
 		advanceTo(12 * time.Second)


### PR DESCRIPTION
**timeutil: implement AdvanceInOneTick**

This commit implements AdvanceInOneTick (& AdvanceToInOneTick).
These move forward ManualTime in a single tick in the sense
of time.Ticker. This enables simulating delayed and dropped
ticks, as can happen if receivers are slow, as per the
time.Ticker docs.

The next commit uses this new functionality in an admission
control test.

Release note: None

**admission: add logic to fill CPU time token buckets**

This commit introduces cpuTimeTokenFiller. cpuTimeTokenFiller
starts up a goroutine which periodically adds tokens to a
cpuTimeTokenGranter. For example, on an 8 vCPU machine, we may
want to allow burstable tier-0 work to use 6 seconds of CPU
time per second. Then cpuTimeTokenFiller would add 6 seconds
of token every second. cpuTimeTokenFiller is designed to be
robust against delayed or dropped time.Timer ticks, as could
happen if goroutine scheduling latency is elevated.

Fixes: https://github.com/cockroachdb/cockroach/issues/154470

Release note: None.