### PR TITLE
release-25.4: spanconfigjob: include underlying error in job failure message

### DIFF
--- a/pkg/spanconfig/spanconfigmanager/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigmanager/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/sql/catalog",
         "//pkg/sql/isql",
         "//pkg/testutils",
+        "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",


### PR DESCRIPTION
Backport 1/1 commits from #155463 on behalf of @spilchen.

----

Previously, when the span config reconciliation job exhausted its internal retries, it would fail with a generic "reconciliation unsuccessful, failing job" message without including the underlying cause of the failure.

This change tracks the last reconciliation error and wraps it in the final job error message.

Closes #155380

Epic: None
Release note: none

----

Release justification: reduces toil when investigating errors from the spanconfig