### PR TITLE
roachtest: deflake online restore recovery

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -453,7 +453,6 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 
 	c.Start(ctx, t.L(), roachtestutil.MaybeUseMemoryBudget(t, 50), install.MakeClusterSettings(), c.CRDBNodes())
 	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
-	const jobStatusWait = time.Minute * 5
 
 	m.Go(func(ctx context.Context) error {
 		testUtils, err := setupBackupRestoreTestUtils(
@@ -465,19 +464,13 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 		}
 		defer testUtils.CloseConnections()
 
-		dbs := []string{"bank", "tpcc", schemaChangeDB}
-		d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
+		dbs := []string{"bank"}
+		d, _, tables, err := createDriversForBackupRestore(
 			ctx, t, c, m, testRNG, workloadSeed, testUtils, dbs,
 		)
 		if err != nil {
 			return err
 		}
-
-		stopBackgroundCommands, err := runBackgroundWorkload()
-		if err != nil {
-			return err
-		}
-		defer stopBackgroundCommands()
 
 		dbConn := c.Conn(ctx, t.L(), c.CRDBNodes().RandNode()[0])
 		defer dbConn.Close()
@@ -488,49 +481,24 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 			Execute: allNodes,
 		}
 
-		// We set this pausepoint so that the download job is paused before it
-		// begins downloading external files. This allows us to guarantee that when
-		// we delete an SST file, it won't have already been downloaded by the
-		// download phase and therefore not trigger a failure.
-		// We also must set this BEFORE taking backups. In the event of a full
-		// cluster backup, the link phase of OR will reset the pausepoints back to
-		// the point of the backup, which means this pausepoint will be wiped if it
-		// is set after the backups.
-		if _, err := dbConn.ExecContext(
-			ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'",
-		); err != nil {
-			return errors.Wrap(err, "failed to set pausepoint for online restore")
-		}
-
 		t.L().Printf("starting backup")
+		// By taking a table/database backup instead of a full cluster backup, we
+		// can delete the SST files prior to the restore without impacting the link
+		// phase (the link phase of a full cluster OR includes copying system table
+		// rows, which can be impacted by the deletion of SST files).
 		collection, err := d.createBackupCollection(
 			ctx, t.L(), t, testRNG, bspec, bspec, "online-restore-recovery-backup",
 			true /* internalSystemsJobs */, false, /* isMultitenant */
+			withNumBackups(1), withBackupScope(
+				newDatabaseBackup(testRNG, dbs, tables),
+			),
 		)
 		if err != nil {
 			return err
 		}
 
-		// If we're running a cluster backup, we need to reset the cluster
-		// to restore it. We also intentionally stop background commands so
-		// the workloads don't report errors.
-		if _, ok := collection.btype.(*clusterBackup); ok {
-			t.L().Printf("resetting cluster before restoring full cluster backup")
-			stopBackgroundCommands()
-			expectDeathsFn := func(n int) {
-				m.ExpectDeaths(int32(n))
-			}
-
-			// Between each reset grab a debug zip from the cluster.
-			zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
-			if err := testUtils.cluster.FetchDebugZip(ctx, t.L(), zipPath); err != nil {
-				t.L().Printf("failed to fetch a debug zip: %v", err)
-			}
-			if err := testUtils.resetCluster(
-				ctx, t.L(), clusterupgrade.CurrentVersion(), expectDeathsFn, []install.ClusterSettingOption{},
-			); err != nil {
-				return err
-			}
+		if err := d.deleteRandomSST(ctx, t.L(), dbConn, collection); err != nil {
+			return err
 		}
 
 		t.L().Printf("performing online restore of backup")
@@ -542,37 +510,6 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 		downloadJobID, err := d.getORDownloadJobID(ctx, t.L(), testRNG)
 		if err != nil {
 			return err
-		}
-		if err := WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
-			return errors.Wrapf(
-				err, "waiting for download job %v to reach paused state", downloadJobID,
-			)
-		}
-
-		// defaultdb is going to be set offline by the failed download job, so we
-		// need to switch to the system database first to avoid any errors.
-		if _, err := dbConn.ExecContext(ctx, "USE system"); err != nil {
-			return err
-		}
-
-		if _, err := dbConn.ExecContext(
-			ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = ''",
-		); err != nil {
-			return errors.Wrap(err, "failed to remove pausepoint for online restore")
-		}
-
-		if err := d.deleteUserTableSST(ctx, t.L(), dbConn, collection); err != nil {
-			return err
-		}
-		if _, err := dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID); err != nil {
-			return errors.Wrapf(
-				err, "failed to resume download job %v after deleting sst", downloadJobID,
-			)
-		}
-		if err := WaitForResume(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
-			return errors.Wrapf(
-				err, "waiting for download job %v to reach resumed state", downloadJobID,
-			)
 		}
 		if err := WaitForFailed(ctx, dbConn, jobspb.JobID(downloadJobID), 10*time.Minute); err != nil {
 			return errors.Wrapf(

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2031,6 +2031,7 @@ func (d *BackupRestoreTestDriver) runBackup(
 	bType fmt.Stringer,
 	internalSystemJobs bool,
 	isMultitenant bool,
+	collectionOpts collectionOpts,
 ) (backupCollection, string, error) {
 	pauseAfter := 1024 * time.Hour // infinity
 	var pauseResumeDB *gosql.DB
@@ -2056,10 +2057,13 @@ func (d *BackupRestoreTestDriver) runBackup(
 	var collection backupCollection
 	switch b := bType.(type) {
 	case fullBackup:
-		btype := d.newBackupScope(rng, isMultitenant)
-		name := d.backupCollectionName(d.nextBackupID(), b.namePrefix, btype)
+		scope := collectionOpts.backupScope
+		if scope == nil {
+			scope = d.newBackupScope(rng, isMultitenant)
+		}
+		name := d.backupCollectionName(d.nextBackupID(), b.namePrefix, scope)
 		createOptions := newBackupOptions(rng, d.testUtils.onlineRestore)
-		collection = newBackupCollection(name, btype, createOptions, d.cluster.IsLocal())
+		collection = newBackupCollection(name, scope, createOptions, d.cluster.IsLocal())
 		l.Printf("creating full backup for %s", collection.name)
 	case incrementalBackup:
 		collection = b.collection
@@ -2227,6 +2231,26 @@ func (mvb *mixedVersionBackup) createBackupCollection(
 	return nil
 }
 
+type collectionOpts struct {
+	// number of backups in the collection, including the full backup
+	numBackups  int
+	backupScope backupScope
+}
+
+type collectionOpt func(*collectionOpts)
+
+func withNumBackups(num int) collectionOpt {
+	return func(o *collectionOpts) {
+		o.numBackups = num
+	}
+}
+
+func withBackupScope(scope backupScope) collectionOpt {
+	return func(o *collectionOpts) {
+		o.backupScope = scope
+	}
+}
+
 // createBackupCollection creates a new backup collection to be
 // restored/verified at the end of the test. A full backup is created,
 // and an incremental one is created on top of it. Both backups are
@@ -2242,18 +2266,23 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	backupNamePrefix string,
 	internalSystemJobs bool,
 	isMultitenant bool,
+	opt ...collectionOpt,
 ) (*backupCollection, error) {
 	var collection backupCollection
 	backupEndTimes := make([]string, 0)
 	var latestIncBackupEndTime string
 	var fullBackupEndTime string
+	var collOpts collectionOpts
+	for _, o := range opt {
+		o(&collOpts)
+	}
 
 	// Create full backup.
 	if err := d.testUtils.runJobOnOneOf(ctx, l, fullBackupSpec.Execute.Nodes, func() error {
 		var err error
 		collection, fullBackupEndTime, err = d.runBackup(
 			ctx, l, tasker, rng, fullBackupSpec.Plan.Nodes, fullBackupSpec.PauseProbability,
-			fullBackup{backupNamePrefix}, internalSystemJobs, isMultitenant,
+			fullBackup{backupNamePrefix}, internalSystemJobs, isMultitenant, collOpts,
 		)
 		return err
 	}); err != nil {
@@ -2262,10 +2291,15 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	backupEndTimes = append(backupEndTimes, fullBackupEndTime)
 
 	// Create incremental backups.
-	numIncrementals := possibleNumIncrementalBackups[rng.Intn(len(possibleNumIncrementalBackups))]
-	if d.testUtils.mock {
+	var numIncrementals int
+	if collOpts.numBackups > 0 {
+		numIncrementals = collOpts.numBackups - 1
+	} else if d.testUtils.mock {
 		numIncrementals = 2
+	} else {
+		numIncrementals = possibleNumIncrementalBackups[rng.Intn(len(possibleNumIncrementalBackups))]
 	}
+
 	l.Printf("creating %d incremental backups", numIncrementals)
 	for i := range numIncrementals {
 		d.randomWait(l, rng)
@@ -2274,6 +2308,7 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 			collection, latestIncBackupEndTime, err = d.runBackup(
 				ctx, l, tasker, rng, incBackupSpec.Plan.Nodes, incBackupSpec.PauseProbability,
 				incrementalBackup{collection: collection, incNum: i + 1}, internalSystemJobs, isMultitenant,
+				collOpts,
 			)
 			return err
 		}); err != nil {
@@ -2303,7 +2338,8 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 				var err error
 				collection, latestIncBackupEndTime, err = d.runBackup(
 					ctx, l, tasker, rng, incBackupSpec.Plan.Nodes, incBackupSpec.PauseProbability,
-					compact, internalSystemJobs, isMultitenant)
+					compact, internalSystemJobs, isMultitenant, collOpts,
+				)
 				return err
 			}); err != nil {
 				return nil, err
@@ -2335,35 +2371,21 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	return d.saveContents(ctx, l, rng, &collection, fingerprintAOST)
 }
 
-// deleteUserTableSST deletes an SST that covers a user table from the full
-// backup in a collection. This is used to test online restore recovery. We
-// delete from the full backup specifically to avoid deleting an SST from an
-// incremental that is skipped due to a compacted backup. This ensures that
-// deleting an SST will cause the download job to fail (assuming it hasn't
-// already been downloaded).
-// Note: We delete specifically a user-table SST as opposed to choosing a random
-// SST because the temporary system table SSTs may be GC'd before the download
-// phase attempts to download the SST. This would cause the download job to
-// succeed instead of failing as expected. See
-// https://github.com/cockroachdb/cockroach/issues/148408 for more details.
-// TODO (kev-cao): Investigate if blocking storage level compaction would
-// prevent GC of temporary system tables and allow us to delete a random SST
-// instead. Technically, it is still possible, but unlikely, for storage to
-// compact away a user-table SST before the download job attempts to download
-// it, which would result in false positives in the test.
-func (d *BackupRestoreTestDriver) deleteUserTableSST(
+// deleteRandomSST deletes a random SST from a backup collection. This is used
+// to test online restore recovery. We delete from the full backup specifically
+// to avoid deleting an SST from an incremental that is skipped due to a
+// compacted backup. This ensures that deleting an SST will cause the download
+// job to fail (assuming it hasn't already been downloaded).
+func (d *BackupRestoreTestDriver) deleteRandomSST(
 	ctx context.Context, l *logger.Logger, db *gosql.DB, collection *backupCollection,
 ) error {
 	var sstPath string
 	if err := db.QueryRowContext(
 		ctx,
 		`SELECT path FROM
-		(
-			SELECT row_number() OVER (), * FROM
-			[SHOW BACKUP FILES FROM LATEST IN $1]
-		)
+		[SHOW BACKUP FILES FROM LATEST IN $1]
 		WHERE backup_type = 'full'
-		ORDER BY row_number DESC
+		ORDER BY random()
 		LIMIT 1`,
 		collection.uri(),
 	).Scan(&sstPath); err != nil {


### PR DESCRIPTION
This test attempts to deflake the online-restore recovery roachtests. We previously attempted to ensure the deletion of system tables SSTs (which could be GC'd after the link phase and therefore be skipped by the download phase) by deleting only the last SSTs from `SHOW BACKUP FILES`.

This patch instead teaches the test to take only table/database backups and to delete the SSTs before the link phase. By taking only table/database backups, we can ensure that the link phase will succeed even if SSTs are missing. This should make the test more resilient to flaking.

Fixes: #154926

Release note: None