### PR TITLE
eval,serverutils,unsafesql: add AllowInternalAccess testing knob

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -125,7 +125,8 @@ func (p *planner) HasPrivilege(
 	// Do a safety check on the object, if it is considered unsafe
 	// does the caller have the appropriate session data to access it?
 	if p.objectIsUnsafe(ctx, privilegeObject) {
-		if err := unsafesql.CheckInternalsAccess(ctx, p.SessionData(), p.stmt.AST, p.extendedEvalCtx.Annotations, &p.ExecCfg().Settings.SV); err != nil {
+		alwaysAllowAccess := p.ExecCfg().EvalContextTestingKnobs.AllowInternalAccess
+		if err := unsafesql.CheckInternalsAccess(ctx, p.SessionData(), p.stmt.AST, p.extendedEvalCtx.Annotations, &p.ExecCfg().Settings.SV, alwaysAllowAccess); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -549,8 +549,9 @@ func (b *Builder) buildFunction(
 	if overload.HasSQLBody() {
 		return b.buildUDF(f, def, inScope, outScope, outCol, colRefs)
 	}
+	alwaysAllowAccess := b.evalCtx.TestingKnobs.AllowInternalAccess
 	if b.isUnsafeBuiltin(overload, def) {
-		if err := unsafesql.CheckInternalsAccess(b.ctx, b.evalCtx.SessionData(), b.stmt, b.evalCtx.Annotations, &b.evalCtx.Settings.SV); err != nil {
+		if err := unsafesql.CheckInternalsAccess(b.ctx, b.evalCtx.SessionData(), b.stmt, b.evalCtx.Annotations, &b.evalCtx.Settings.SV, alwaysAllowAccess); err != nil {
 			panic(err)
 		}
 	}

--- a/pkg/sql/sem/eval/testing_knobs.go
+++ b/pkg/sql/sem/eval/testing_knobs.go
@@ -41,6 +41,8 @@ type TestingKnobs struct {
 	// We use clusterversion.Key rather than a roachpb.Version because it will be used
 	// to get initial values to use during bootstrap.
 	TenantLogicalVersionKeyOverride clusterversion.Key
+
+	AllowInternalAccess func() bool
 }
 
 var _ base.ModuleTestingKnobs = &TestingKnobs{}

--- a/pkg/sql/unsafesql/unsafesql.go
+++ b/pkg/sql/unsafesql/unsafesql.go
@@ -48,7 +48,13 @@ func CheckInternalsAccess(
 	stmt tree.Statement,
 	ann *tree.Annotations,
 	sv *settings.Values,
+	alwaysAllowAccess func() bool,
 ) error {
+
+	if alwaysAllowAccess != nil && alwaysAllowAccess() {
+		return nil
+	}
+
 	// If the querier is internal, we should allow it.
 	if sd.Internal || sd.IsInternalAppName() {
 		return nil

--- a/pkg/sql/unsafesql/unsafesql_test.go
+++ b/pkg/sql/unsafesql/unsafesql_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/unsafesql"
@@ -64,6 +65,11 @@ func TestAccessCheckServer(t *testing.T) {
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			SQLEvalContext: &eval.TestingKnobs{
+				AllowInternalAccess: func() bool { return false },
+			},
+		},
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/sem/eval",
         "//pkg/storage",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/skip",


### PR DESCRIPTION
adds a AllowInternalAccess field to the eval context testing knob that allows a callback to be registered for always allowing access of unsafe internals. This is also enabled by default in test servers, so changing the default value of the allow_unsafe_internals shouldn't impact unit tests

Epic: CRDB-55276
Release note: None