### PR TITLE
release-25.2: copy: use longer timeout under race in TestCopyInReleasesLeases

### DIFF
--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -779,7 +779,7 @@ func TestCopyInReleasesLeases(t *testing.T) {
 	select {
 	case err := <-alterErr:
 		require.NoError(t, err)
-	case <-time.After(testutils.DefaultSucceedsSoonDuration):
+	case <-time.After(testutils.SucceedsSoonDuration()):
 		t.Fatal("alter did not complete")
 	}
 	require.NoError(t, conn.Close(ctx))


### PR DESCRIPTION
Backport 1/1 commits from #155477 on behalf of @yuzefovich.

----

Don't hard-code usage of `DefaultSucceedsSoonDuration` - use the helper function that gives longer duration under heavy configs.

Fixes: #155335.
Release note: None

----

Release justification: test-only change.