### PR TITLE
workload: add changefeed-max-rate, changefeed-start-delay, and changefeed-resolved-target

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -419,7 +419,8 @@ func (l requiresCCLBinaryDataLoader) InitialDataLoad(
 type QueryLoad struct {
 	// WorkerFns is one function per worker. It is to be called once per unit of
 	// work to be done.
-	WorkerFns []func(context.Context) error
+	WorkerFns     []func(context.Context) error
+	ChangefeedFns []func(context.Context) error
 
 	// Close, if set, is called before the process exits, giving workloads a
 	// chance to print some information or perform cleanup.


### PR DESCRIPTION
```
--changefeed                            Optionally run a changefeed over the tables
--changefeed-max-rate float             Maximum frequency of changefeed ingestion. If 0, no limit.
--changefeed-resolved-target duration   The target frequency of resolved messages. O to disable resolved reporting and accept server defaults. (default 5s)
--changefeed-start-delay duration       How long to wait before starting the changefeed
```

`--changefeed-max-rate` can be used in conjunction with `--max-rate` to
simulate an under-provisioned or correctly provisioned sink for the
given workload.

`---changefeed-start-delay` can be used to force a catch-up scan.

Note that I've also renamed --with-changefeed to --changefeed so that
all the changefeed options show up next to each other in the help.

The resolved timestamp reporting is a bit of a hack but it seems to work
for now.

Epic: none

Release note: None