### PR TITLE
general: add vscode debugger configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,59 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Cockroach Demo",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "${workspaceFolder}/cockroach-short",
+            "args": [
+                "demo",
+                "--empty",
+                "--max-sql-memory",
+                "5G"
+            ],
+            "console": "integratedTerminal",
+            "preLaunchTask": "build cockroach for launch (short)",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}",
+                    "to": ""
+                }
+            ]
+        },
+        {
+            "name": "Launch Cockroach Demo",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "${workspaceFolder}/cockroach-short",
+            "args": [
+                "demo",
+                "--empty",
+                "--max-sql-memory",
+                "5G"
+            ],
+            "console": "integratedTerminal",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}",
+                    "to": ""
+                }
+            ]
+        },
+        {
+            "name": "Attach to Process",
+            "type": "go",
+            "request": "attach",
+            "processId": "${command:pickProcess}",
+            "mode": "local",
+            "substitutePath": [
+                {
+                    "from": "${user}/go/src",
+                    "to": ""
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "[go]": {
+        "editor.rulers": [
+            80,
+            100,
+        ],
+    },
+    "[git-commit]": {
+        "editor.rulers": [
+            72,
+            100,
+        ],
+        "editor.wordWrap": "off",
+    },
+    "go.lintTool":"golangci-lint",
+    "go.lintFlags": [
+        "--fast"
+    ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"label": "build cockroach for launch (short)",
+			"command": "${workspaceFolder}/dev build cockroach short -- -c dbg",
+			"problemMatcher": [
+				"$go"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "shell",
+			"label": "build cockroach binary(s) in debug mode",
+			"command": "${workspaceFolder}/dev build ${input:targets} -- -c dbg",
+			"problemMatcher": [
+				"$go"
+			],
+			"group": {
+				"kind": "build"
+			}
+		}
+	],
+	"inputs": [
+		{
+			"id": "targets",
+			"description": "`dev` build targets, separated by spaces",
+			"default": "",
+			"type": "promptString"
+		}
+	]
+}


### PR DESCRIPTION
These are basic configs for building and launching from VSCode's
debugger, linting with `golangci-lint` to match CI, and adding editor
rulers based on the style guides.

Epic: none

Release note: None
