### PR TITLE
release-25.3: schemachanger: add function back-references for unvalidated check constraints

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
@@ -115,6 +115,10 @@ SELECT get_fn_depended_on_by($fn_id)
 statement ok
 ALTER TABLE t1 ADD CONSTRAINT cka CHECK (f1(a) > 1);
 
+# Regression test for issue #155400 - add new constraint with NOT VALID
+statement ok
+ALTER TABLE t1 ADD CONSTRAINT ckb CHECK (f1(b) > 2) NOT VALID;
+
 query T
 SELECT get_checks($tbl_id);
 ----
@@ -134,6 +138,15 @@ SELECT get_checks($tbl_id);
         "constraintId": 3,
         "expr": "[FUNCTION 100106](a) \u003e 1:::INT8",
         "name": "cka"
+    },
+    {
+        "columnIds": [
+            2
+        ],
+        "constraintId": 4,
+        "expr": "[FUNCTION 100106](b) \u003e 2:::INT8",
+        "name": "ckb",
+        "validity": "Unvalidated"
     }
 ]
 
@@ -144,7 +157,8 @@ SELECT get_fn_depended_on_by($fn_id)
     {
         "constraintIds": [
             2,
-            3
+            3,
+            4
         ],
         "id": 111
     }
@@ -165,7 +179,8 @@ SELECT get_fn_depended_on_by($fn_id)
     {
         "constraintIds": [
             2,
-            3
+            3,
+            4
         ],
         "id": 111
     },
@@ -189,7 +204,8 @@ SELECT get_fn_depended_on_by($fn_id)
     {
         "constraintIds": [
             2,
-            3
+            3,
+            4
         ],
         "id": 111
     },
@@ -211,7 +227,8 @@ SELECT get_fn_depended_on_by($fn_id)
     {
         "constraintIds": [
             2,
-            3
+            3,
+            4
         ],
         "id": 111
     }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint_unvalidated.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint_unvalidated.go
@@ -43,6 +43,16 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
+				emit(func(this *scpb.CheckConstraintUnvalidated) *scop.AddTableConstraintBackReferencesInFunctions {
+					if len(this.UsesFunctionIDs) == 0 {
+						return nil
+					}
+					return &scop.AddTableConstraintBackReferencesInFunctions{
+						FunctionIDs:                this.UsesFunctionIDs,
+						BackReferencedTableID:      this.TableID,
+						BackReferencedConstraintID: this.ConstraintID,
+					}
+				}),
 			),
 		),
 		toAbsent(
@@ -70,6 +80,16 @@ func init() {
 					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:           this.UsesSequenceIDs,
 						BackReferencedTableID: this.TableID,
+					}
+				}),
+				emit(func(this *scpb.CheckConstraintUnvalidated) *scop.RemoveTableConstraintBackReferencesFromFunctions {
+					if len(this.UsesFunctionIDs) == 0 {
+						return nil
+					}
+					return &scop.RemoveTableConstraintBackReferencesFromFunctions{
+						FunctionIDs:                this.UsesFunctionIDs,
+						BackReferencedTableID:      this.TableID,
+						BackReferencedConstraintID: this.ConstraintID,
 					}
 				}),
 			),


### PR DESCRIPTION
Backport 1/1 commits from #155404 on behalf of @spilchen.

----

When adding a check constraint with NOT VALID that references a function, the declarative schema changer was not creating the necessary references between the constraint and the function. This caused validation to fail with "depends-on function has no corresponding depended-on-by back reference".

The fix adds the missing dependency in the opgen rules. Interestingly, the opgen rules for validated constraints do have the proper function dep handling.

Fixes #155400

Release note (bug fix): Added proper dependency handling when adding a constraint with NOT VALID that references a UDF.

----

Release justification: bug fix for issue found in support case that could cause a table to enter into an invalid state that would impair normal cluster operation.