### PR TITLE
logictest: flush out indirect unsafe access in logictests

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
@@ -1,4 +1,4 @@
-# knob-opt: sync-event-log
+# knob-opt: sync-event-log allow-unsafe
 # LogicTest: multiregion-9node-3region-3azs-tenant
 
 # Only the root user can modify the system database's regions.

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_txn
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_txn
@@ -1,4 +1,5 @@
 # LogicTest: !local-prepared
+# knob-opt: allow-unsafe
 
 statement ok
 CREATE TABLE t (x INT);

--- a/pkg/ccl/logictestccl/testdata/logic_test/redact_descriptor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/redact_descriptor
@@ -1,4 +1,5 @@
 # LogicTest: !schema-locked-disabled
+# knob-opt: allow-unsafe
 
 # NB: "Xw==" is the byte representation of "_", which is what we use to redact fields.
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -1,4 +1,5 @@
 # LogicTest: !local-legacy-schema-changer !local-prepared
+# knob-opt: allow-unsafe
 
 # Include some hidden columns that won't be visible to triggers.
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -1,3 +1,5 @@
+# knob-opt: allow-unsafe
+
 statement ok
 CREATE SEQUENCE seq;
 

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -125,7 +125,8 @@ func (p *planner) HasPrivilege(
 	// Do a safety check on the object, if it is considered unsafe
 	// does the caller have the appropriate session data to access it?
 	if p.objectIsUnsafe(ctx, privilegeObject) {
-		if err := unsafesql.CheckInternalsAccess(ctx, p.SessionData(), p.stmt.AST, p.extendedEvalCtx.Annotations, &p.ExecCfg().Settings.SV); err != nil {
+		unsafeOverride := p.ExecCfg().EvalContextTestingKnobs.UnsafeOverride
+		if err := unsafesql.CheckInternalsAccess(ctx, p.SessionData(), p.stmt.AST, p.extendedEvalCtx.Annotations, &p.ExecCfg().Settings.SV, unsafeOverride); err != nil {
 			return false, err
 		}
 	}
@@ -961,7 +962,7 @@ func (p *planner) objectIsUnsafe(ctx context.Context, privilegeObject privilege.
 		return false
 	}
 
-	// All system descriptors are considered unsafe.
+	// All system descriptors are considered unsafe
 	if catalog.IsSystemDescriptor(d) {
 		return true
 	}

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -330,6 +330,7 @@ import (
 //      - noticetrace: runs the query and compares only the notices that
 //						appear. Cannot be combined with kvtrace.
 //      - nodeidx=N: runs the query on node N of the cluster.
+//      - allowunsafe: allows access to unsafe internals during execution.
 //
 //    The label is optional. If specified, the test runner stores a hash
 //    of the results of the query under the given label. If the label is
@@ -969,6 +970,9 @@ type logicQuery struct {
 	// roundFloatsInStringsSigFigs specifies the number of significant figures
 	// to round floats embedded in strings to where zero means do not round.
 	roundFloatsInStringsSigFigs int
+
+	// allowUnsafe indicates whether unsafe operations are allowed during execution.
+	allowUnsafe bool
 }
 
 var allowedKVOpTypes = []string{
@@ -1119,6 +1123,10 @@ type logicTest struct {
 	// retryDuration is the maximum duration to retry a statement when using
 	// the retry directive.
 	retryDuration time.Duration
+
+	// allowUnsafe is a variable which controls whether the test can access
+	// unsafe internals.
+	allowUnsafe bool
 }
 
 func (t *logicTest) t() *testing.T {
@@ -1493,6 +1501,7 @@ func (t *logicTest) newCluster(
 			DisableOptimizerRuleProbability: *disableOptRuleProbability,
 			OptimizerCostPerturbation:       *optimizerCostPerturbation,
 			ForceProductionValues:           serverArgs.ForceProductionValues,
+			UnsafeOverride:                  func() *bool { return &t.allowUnsafe },
 		}
 		knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
 			DeterministicExplain:            true,
@@ -2115,6 +2124,18 @@ func (c knobOptSynchronousEventLog) apply(args *base.TestingKnobs) {
 	args.EventLog.(*eventlog.EventLogTestingKnobs).SyncWrites = true
 }
 
+// knobOptAllowUnsafe always allows access to the unsafe internals.
+type knobOptAllowUnsafe struct{}
+
+var _ knobOpt = knobOptAllowUnsafe{}
+
+// apply implements the clusterOpt interface.
+func (c knobOptAllowUnsafe) apply(args *base.TestingKnobs) {
+	e := args.SQLEvalContext.(*eval.TestingKnobs)
+	v := true
+	e.UnsafeOverride = func() *bool { return &v }
+}
+
 // clusterOptIgnoreStrictGCForTenants corresponds to the
 // ignore-tenant-strict-gc-enforcement directive.
 type clusterOptIgnoreStrictGCForTenants struct{}
@@ -2268,6 +2289,8 @@ func readKnobOptions(t *testing.T, path string) []knobOpt {
 			res = append(res, knobOptDisableCorpusGeneration{})
 		case "sync-event-log":
 			res = append(res, knobOptSynchronousEventLog{})
+		case "allow-unsafe":
+			res = append(res, knobOptAllowUnsafe{})
 		default:
 			t.Fatalf("unrecognized knob option: %s", opt)
 		}
@@ -2954,6 +2977,9 @@ func (t *logicTest) processSubtest(
 						case "async":
 							query.expectAsync = true
 
+						case "allowunsafe":
+							query.allowUnsafe = true
+
 						default:
 							if strings.HasPrefix(opt, "round-in-strings") {
 								significantFigures, err := floatcmp.ParseRoundInStringsDirective(opt)
@@ -3599,6 +3625,7 @@ func (t *logicTest) unexpectedError(sql string, pos string, err error) (bool, er
 var uniqueHashPattern = regexp.MustCompile(`UNIQUE.*USING\s+HASH`)
 
 func (t *logicTest) execStatement(stmt logicStatement, disableCFMutator bool) (bool, error) {
+	defer t.setSafetyGate(stmt.sql, false)()
 	db := t.db
 	t.noticeBuffer = nil
 	if *showSQL {
@@ -3722,6 +3749,7 @@ func (t *logicTest) hashResults(results []string) (string, error) {
 }
 
 func (t *logicTest) execQuery(query logicQuery) error {
+	defer t.setSafetyGate(query.sql, query.allowUnsafe)()
 	if *showSQL {
 		t.outf("%s;", query.sql)
 	}
@@ -4609,6 +4637,7 @@ func RunLogicTest(
 		perErrorSummary:            make(map[string][]string),
 		rng:                        rng,
 		declarativeCorpusCollector: cc,
+		allowUnsafe:                true,
 	}
 	if *printErrorSummary {
 		defer lt.printErrorSummary()
@@ -4883,4 +4912,24 @@ func locateCockroachPredecessor(version string) (string, error) {
 		return "", err
 	}
 	return path, nil
+}
+
+// setSafetyGate is a utility function which controls whether access to the unsafe
+// internals is allowed by the contained sql statement. The reasoning behind it is
+// as follows. We want queries which explicitly access unsafe internals to have
+// access to them, but we want to prevent indirect access wherever possible.
+// Indirect access can be described as any query which doesn't reference an unsafe
+// object, but still accesses it under the hood. We want to flush out these cases
+// so that users can never execute statements which look safe, but block when executed.
+func (t *logicTest) setSafetyGate(sql string, skip bool) func() {
+	sql = strings.ToLower(sql)
+	explicitlyUnsafe := strings.Contains(sql, "crdb_internal.") || strings.Contains(sql, "system.")
+	if skip || explicitlyUnsafe {
+		return func() {}
+	}
+
+	t.allowUnsafe = false
+	return func() {
+		t.allowUnsafe = true
+	}
 }

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -67,13 +67,14 @@ func (t *parallelTest) processTestFile(path string, nodeIdx int, db *gosql.DB, c
 	// Set up a dummy logicTest structure to use that code.
 	rng, _ := randutil.NewTestRand()
 	l := &logicTest{
-		rootT:   t.T,
-		cluster: t.cluster,
-		nodeIdx: nodeIdx,
-		db:      db,
-		user:    username.RootUser,
-		verbose: testing.Verbose() || log.V(1),
-		rng:     rng,
+		rootT:       t.T,
+		cluster:     t.cluster,
+		nodeIdx:     nodeIdx,
+		db:          db,
+		user:        username.RootUser,
+		verbose:     testing.Verbose() || log.V(1),
+		rng:         rng,
+		allowUnsafe: true,
 	}
 	if err := l.processTestFile(path, logictest.TestClusterConfig{}); err != nil {
 		log.Dev.Errorf(context.Background(), "error processing %s: %s", path, err)

--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -156,7 +156,7 @@ PREPARE r1(bytes) AS
 		SELECT id FROM system.namespace WHERE name = 'defaultdb'
 	);
 
-query T
+query T allowunsafe
 EXECUTE r1('abc')
 ----
 \022[\012\011defaultdb\020d\0320\012\013\012\005admin\020\002\030\002\012\015\012\006public\020\200\020\030\000\012\012\012\004root\020\002\030\002\022\004root\030\003"\000(\001:\014\012\006public\022\002\010e@\000J\000Z\002\020\000p\000

--- a/pkg/sql/logictest/testdata/logic_test/distsql_inspect
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_inspect
@@ -102,7 +102,7 @@ ALTER TABLE table_ltree_array_leading SCATTER;
 statement ok
 INSPECT TABLE table_ltree_array_leading;
 
-query TI
+query TI allowunsafe
 SELECT * FROM last_inspect_job;
 ----
 succeeded 1

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,7 +1,7 @@
 # Legacy schema changer is skipped because mutation IDs throughout log
 # entries will differ. "event_log_legacy" file is for the legacy schema changer.
 # LogicTest: !local-legacy-schema-changer
-# knob-opt: sync-event-log
+# knob-opt: sync-event-log allow-unsafe
 
 # For some reason, some of the queries produce non-deterministic results if
 # distsql_workmem value is randomized, so we'll override it to the production

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -1,7 +1,7 @@
 # Only legacy schema changer is run because mutation IDs throughout log entries
 # will differ. "event_log" test file is for normal settings.
 # LogicTest: local-legacy-schema-changer
-# knob-opt: sync-event-log
+# knob-opt: sync-event-log allow-unsafe
 
 # For some reason, some of the queries produce non-deterministic results if
 # distsql_workmem value is randomized, so we'll override it to the production

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -3,6 +3,7 @@
 # them causes a nil pointer panic in the span resolver setup.
 #
 # LogicTest: !fakedist !fakedist-vec-off !fakedist-disk !local-mixed-25.2 !local-mixed-25.3
+# knob-opt: allow-unsafe
 
 
 # Helper view to show the most recent INSPECT job.

--- a/pkg/sql/logictest/testdata/logic_test/redact_descriptor
+++ b/pkg/sql/logictest/testdata/logic_test/redact_descriptor
@@ -1,3 +1,5 @@
+# knob-opt: allow-unsafe
+
 statement ok
 CREATE VIEW redacted_descriptors AS
     SELECT

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,4 +1,5 @@
 # LogicTest: !local-prepared
+# knob-opt: allow-unsafe
 
 subtest lost_table_data
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
@@ -1,3 +1,5 @@
+# knob-opt: allow-unsafe
+
 statement ok
 CREATE FUNCTION f1(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_index
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_index
@@ -1,4 +1,5 @@
 # LogicTest: !local-mixed-25.2
+# knob-opt: allow-unsafe
 
 # Set up functions that inspect function dependencies.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_table
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_table
@@ -1,3 +1,5 @@
+# knob-opt: allow-unsafe
+
 statement ok
 CREATE FUNCTION f1() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 1 $$;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_rewrite
@@ -1,3 +1,5 @@
+# knob-opt: allow-unsafe
+
 statement ok
 CREATE SEQUENCE seq;
 

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -1,4 +1,5 @@
 # LogicTest: !local-mixed-25.2 !local-schema-locked !local-prepared
+# knob-opt: allow-unsafe
 # TODO(andyk): Remove this once 25.3 is our minimum supported version.
 
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -549,8 +549,9 @@ func (b *Builder) buildFunction(
 	if overload.HasSQLBody() {
 		return b.buildUDF(f, def, inScope, outScope, outCol, colRefs)
 	}
+	unsafeOverride := b.evalCtx.TestingKnobs.UnsafeOverride
 	if b.isUnsafeBuiltin(overload, def) {
-		if err := unsafesql.CheckInternalsAccess(b.ctx, b.evalCtx.SessionData(), b.stmt, b.evalCtx.Annotations, &b.evalCtx.Settings.SV); err != nil {
+		if err := unsafesql.CheckInternalsAccess(b.ctx, b.evalCtx.SessionData(), b.stmt, b.evalCtx.Annotations, &b.evalCtx.Settings.SV, unsafeOverride); err != nil {
 			panic(err)
 		}
 	}
@@ -889,6 +890,14 @@ func (b *Builder) constructUnary(
 	panic(errors.AssertionFailedf("unhandled unary operator: %s", redact.Safe(un)))
 }
 
+// SupportedCRDBInternalBuiltins are the builtin internals that are "supported"
+// for real customer use in production for legacy reasons.
+var SupportedCRDBInternalBuiltins = map[string]struct{}{
+	// LOCKED: Do not add to this list.
+	// Supported builtins should now be added to information_schema.
+	`crdb_internal.datums_to_bytes`: {},
+}
+
 // isUnsafeBuiltin returns true if the given function definition
 // is a CRDB internal builtin function.
 func (b *Builder) isUnsafeBuiltin(
@@ -903,7 +912,9 @@ func (b *Builder) isUnsafeBuiltin(
 	}
 	for _, o := range def.Overloads {
 		if o.Schema == catconstants.CRDBInternalSchemaName {
-			return true
+			if _, ok := SupportedCRDBInternalBuiltins[def.Name]; !ok {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -721,6 +721,13 @@ func (b *Builder) checkPrivilege(name opt.MDDepName, ds cat.DataSource, priv pri
 	// Add dependency on this object to the metadata, so that the metadata can be
 	// cached and later checked for freshness.
 	b.factory.Metadata().AddDependency(name, ds, priv)
+
+	// If we're building within a builtin context (unsafe checks disabled),
+	// mark this dependency as coming from a builtin so it can bypass unsafe
+	// checks during memo staleness checking.
+	if b.skipUnsafeInternalsCheck {
+		b.factory.Metadata().AddDependency(name, ds, privilege.BUILTIN_UNSAFE_ALLOWED)
+	}
 }
 
 // resolveNumericColumnRefs converts a list of tree.ColumnIDs from a

--- a/pkg/sql/privilege/kind.go
+++ b/pkg/sql/privilege/kind.go
@@ -66,7 +66,11 @@ const (
 	REPLICATIONDEST          Kind = 39
 	REPLICATIONSOURCE        Kind = 40
 	INSPECT                  Kind = 41
-	largestKind                   = INSPECT
+	// BUILTIN_UNSAFE_ALLOWED is a special pseudo-privilege that marks a dependency
+	// as coming from a SQL-bodied builtin function. This allows the dependency to
+	// bypass unsafe internal checks during memo staleness checking.
+	BUILTIN_UNSAFE_ALLOWED Kind = 42
+	largestKind                 = BUILTIN_UNSAFE_ALLOWED
 )
 
 var isDeprecatedKind = map[Kind]bool{
@@ -162,6 +166,8 @@ func (k Kind) InternalKey() KindInternalKey {
 		return "REPLICATIONSOURCE"
 	case INSPECT:
 		return "INSPECT"
+	case BUILTIN_UNSAFE_ALLOWED:
+		return "BUILTIN_UNSAFE_ALLOWED"
 	default:
 		panic(errors.AssertionFailedf("unhandled kind: %d", int(k)))
 	}

--- a/pkg/sql/sem/eval/testing_knobs.go
+++ b/pkg/sql/sem/eval/testing_knobs.go
@@ -41,6 +41,16 @@ type TestingKnobs struct {
 	// We use clusterversion.Key rather than a roachpb.Version because it will be used
 	// to get initial values to use during bootstrap.
 	TenantLogicalVersionKeyOverride clusterversion.Key
+
+	// This knob needs to be used in the following ways:
+	// 1. In tests, there should be a way to override the allow unsafe variable.
+	// 2. If a test is not setup with a value, true should be the default.
+	// 3. There should be a way to setup a test so that there is no override.
+	//
+	// Conditions 2 and 3 remove the possibility for just a pointer to a boolean.
+	// If the value were nil, should the system set the override to true, or leave it nil?
+	// To fix the ambiguity, a function which returns nil can be used to indicate no override.
+	UnsafeOverride func() *bool
 }
 
 var _ base.ModuleTestingKnobs = &TestingKnobs{}

--- a/pkg/sql/unsafesql/BUILD.bazel
+++ b/pkg/sql/unsafesql/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings",
         "//pkg/sql/isql",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlerrors",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/unsafesql/unsafesql.go
+++ b/pkg/sql/unsafesql/unsafesql.go
@@ -48,7 +48,13 @@ func CheckInternalsAccess(
 	stmt tree.Statement,
 	ann *tree.Annotations,
 	sv *settings.Values,
+	override func() *bool,
 ) error {
+	allowUnsafe := sd.AllowUnsafeInternals
+	if override != nil && override() != nil {
+		allowUnsafe = *override()
+	}
+
 	// If the querier is internal, we should allow it.
 	if sd.Internal || sd.IsInternalAppName() {
 		return nil
@@ -56,7 +62,7 @@ func CheckInternalsAccess(
 
 	q := SafeFormatQuery(stmt, ann, sv)
 	// If an override is set, allow access to this virtual table.
-	if sd.AllowUnsafeInternals {
+	if allowUnsafe {
 		// Log this access to the SENSITIVE_ACCESS channel since the override condition bypassed normal access controls.
 		if accessedLogLimiter.ShouldProcess(timeutil.Now()) {
 			log.StructuredEvent(ctx, severity.WARNING, &eventpb.UnsafeInternalsAccessed{Query: q})
@@ -68,6 +74,7 @@ func CheckInternalsAccess(
 	if deniedLogLimiter.ShouldProcess(timeutil.Now()) {
 		log.StructuredEvent(ctx, severity.WARNING, &eventpb.UnsafeInternalsDenied{Query: q})
 	}
+
 	return sqlerrors.ErrUnsafeTableAccess
 }
 

--- a/pkg/sql/unsafesql/unsafesql_test.go
+++ b/pkg/sql/unsafesql/unsafesql_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/unsafesql"
@@ -64,6 +65,11 @@ func TestAccessCheckServer(t *testing.T) {
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			SQLEvalContext: &eval.TestingKnobs{
+				UnsafeOverride: func() *bool { return nil }, // no override
+			},
+		},
 	})
 	defer s.Stopper().Stop(ctx)
 

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/sem/eval",
         "//pkg/storage",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/skip",

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgurlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -365,6 +366,21 @@ func NewServer(params base.TestServerArgs) (TestServerInterface, error) {
 
 	if params.DefaultTenantName == "" {
 		params.DefaultTenantName = defaultTestTenantName
+	}
+
+	var evalTestingKnobs *eval.TestingKnobs
+	if params.Knobs.SQLEvalContext != nil {
+		evalTestingKnobs = params.Knobs.SQLEvalContext.(*eval.TestingKnobs)
+	} else {
+		evalTestingKnobs = &eval.TestingKnobs{}
+		params.Knobs.SQLEvalContext = evalTestingKnobs
+	}
+
+	if evalTestingKnobs.UnsafeOverride == nil {
+		v := true
+		evalTestingKnobs.UnsafeOverride = func() *bool {
+			return &v
+		}
 	}
 
 	srv, err := srvFactoryImpl.New(params)


### PR DESCRIPTION
We recently added a session variable which must be explicitly set
for a caller to access system and crdb_internal tables. There's a
concern however that the system will block due to "indirect" access, be
it query expansion, rewriting or anything else.

So users aren't surprised by this behavior, this PR modifies the
logictests so that by default, unless a query explicitly references the
system or crdb_internal tables, it will disallow access to the unsafe
internals. Doing so will hopefully flush out any possible instances of
unsafe access.

This PR also does a few things to make this possible:
 - Introduces a way in tests to override the session variable.
 - Adds a new knob option for the logictests, so that if there's
	 indirect access because a UDF is defined, the test writer can
	 explicitly allow for it.

Fixes: https://github.com/cockroachdb/cockroach/issues/154675
Fixes: https://github.com/cockroachdb/cockroach/issues/155367
Epic: [CRDB-55276](https://cockroachlabs.atlassian.net/browse/CRDB-55276)
Release note: None