### PR TITLE
identmap: use case-insensitive matching

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       timeout: 10s
       retries: 25
   psql:
-    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20241009-173040
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20251023-150915
     user: "${UID}:${GID}"
     depends_on:
       cockroach:

--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -109,12 +109,12 @@ func TestGSS(t *testing.T) {
 			user:     "tester",
 			gssErr:   "",
 		},
-		// Verify case-sensitivity.
+		// Verify names are matched without case-sensitivity.
 		{
 			conf:     `host all all all gss map=demo`,
 			identMap: `demo /^(.*)@MY.EX$ \1`,
 			user:     "tester",
-			gssErr:   `system identity "tester@my.ex" did not map to a database role`,
+			gssErr:   ``,
 		},
 		// Validating the use of "map" as a filter.
 		{

--- a/pkg/sql/pgwire/identmap/ident_map.go
+++ b/pkg/sql/pgwire/identmap/ident_map.go
@@ -85,9 +85,12 @@ func From(r io.Reader) (*Conf, error) {
 		var sysPattern *regexp.Regexp
 		var err error
 		if sysName := parts[2]; sysName[0] == '/' {
-			sysPattern, err = regexp.Compile(sysName[1:])
+			// Use case-insensitive matching since system identities (e.g., certificate CNs)
+			// are normalized to lowercase before being passed to the user map.
+			sysPattern, err = regexp.Compile("(?i)" + sysName[1:])
 		} else {
-			sysPattern, err = regexp.Compile("^" + regexp.QuoteMeta(sysName) + "$")
+			// Use case-insensitive matching for literal patterns as well.
+			sysPattern, err = regexp.Compile("(?i)^" + regexp.QuoteMeta(sysName) + "$")
 		}
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse line %d", lineNo)
@@ -143,7 +146,7 @@ func (c *Conf) Map(mapName, systemIdentity string) ([]username.SQLUsername, bool
 	var names []username.SQLUsername
 	seen := make(map[string]bool)
 	for _, elt := range elts {
-		if n := elt.substitute(systemIdentity); n != "" && !seen[n] {
+		if n := elt.substitute(systemIdentity); n != "" {
 			// We're returning this as a for-validation username since a
 			// pattern-based mapping could still result in invalid characters
 			// being incorporated into the input.
@@ -151,8 +154,11 @@ func (c *Conf) Map(mapName, systemIdentity string) ([]username.SQLUsername, bool
 			if err != nil {
 				return nil, true, err
 			}
-			names = append(names, u)
-			seen[n] = true
+			normalized := u.Normalized()
+			if !seen[normalized] {
+				names = append(names, u)
+				seen[normalized] = true
+			}
 		}
 	}
 	return names, true, nil

--- a/pkg/sql/pgwire/testdata/auth/identity_map
+++ b/pkg/sql/pgwire/testdata/auth/identity_map
@@ -48,13 +48,13 @@ host     all      all  all     cert-password map=testing
 # testing testuser2 carl              # Cert that doesn't correspond to a db user
 # testing testuser@example.com carl   # Cert with a non-SQL principal baked in
 # Active configuration:
-# map-name system-username         database-username
-testing    ^testuser$              carl
-testing    (.*)@cockroachlabs.com  \1                # substituteAt=0
-testing    ^testuser$              another_carl
-testing    ^will_be_carl$          carl
-testing    ^testuser2$             carl
-testing    ^testuser@example\.com$ carl
+# map-name system-username             database-username
+testing    (?i)^testuser$              carl
+testing    (?i)(.*)@cockroachlabs.com  \1                # substituteAt=0
+testing    (?i)^testuser$              another_carl
+testing    (?i)^will_be_carl$          carl
+testing    (?i)^testuser2$             carl
+testing    (?i)^testuser@example\.com$ carl
 
 sql
 CREATE USER carl WITH PASSWORD 'doggo';
@@ -274,7 +274,7 @@ host     all      all  all     cert-password map=testing
 # testing testuser root               # Exact remapping
 # Active configuration:
 # map-name system-username database-username
-testing    ^testuser$      root
+testing    (?i)^testuser$  root
 
 connect user=testuser database=mydb
 ----
@@ -303,7 +303,7 @@ host     all      all  all     cert-password map=testing
 # testing testuser node               # Exact remapping
 # Active configuration:
 # map-name system-username database-username
-testing    ^testuser$      node
+testing    (?i)^testuser$  node
 
 connect user=testuser database=mydb
 ----


### PR DESCRIPTION
All usernames in CockroachDB are normalized to lower-case. Previously, the identity map would not account for this, and would use a case sensitive match to check the identities to be mapped.

Epic: None
Release note (bug fix): The username remapping functionality specified by the server.identity_map.configuration cluster setting now matches identities and usernames with a case-insensitive comparison.
