### PR TITLE
roachtest: deflake azure backup fixture roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -195,6 +195,7 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 				"kv.snapshot_rebalance.max_rate":                    "256 MiB",
 				"server.debug.default_vmodule":                      "s3_storage=2",
 				"cloudstorage.s3.client_retry_token_bucket.enabled": "false",
+				"cloudstorage.azure.try.timeout":                    "0s",
 			},
 			install.EnvOption{
 				fmt.Sprintf("COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE=%s", azureCredentialsFilePath),


### PR DESCRIPTION
I suspect our azure external storage reader doesn't currently retry read timeouts. This patch disables the timeout to see if that deflakes the test. Once I've confirmed the root cause, i'll think through a fix.

Informs #155427

Release note: none