### PR TITLE
sql/opt: fix RLS metadata clearing

### DIFF
--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1509,14 +1509,16 @@ func (e *emitter) emitPolicies(ob *OutputBuilder, table cat.Table, n *Node) {
 		ob.AddField("policies", "row-level security enabled, no policies applied.")
 	} else {
 		var sb strings.Builder
-		policies := table.Policies()
-		for _, grp := range [][]cat.Policy{policies.Permissive, policies.Restrictive} {
-			for _, policy := range grp {
-				if applied.Policies.Contains(policy.ID) {
-					if sb.Len() > 0 {
-						sb.WriteString(", ")
+		if table != nil {
+			policies := table.Policies()
+			for _, grp := range [][]cat.Policy{policies.Permissive, policies.Restrictive} {
+				for _, policy := range grp {
+					if applied.Policies.Contains(policy.ID) {
+						if sb.Len() > 0 {
+							sb.WriteString(", ")
+						}
+						sb.WriteString(policy.Name.Normalize())
 					}
-					sb.WriteString(policy.Name.Normalize())
 				}
 			}
 		}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -672,7 +672,12 @@ func TestMemoIsStale(t *testing.T) {
 	stale()
 	evalCtx.SessionData().UserProto = oldUser
 	notStale()
+
+	// User changes (after RLS was reinitialized)
 	o.Memo().Metadata().ClearRLSEnabled()
+	evalCtx.SessionData().UserProto = newUser
+	notStale()
+	evalCtx.SessionData().UserProto = oldUser
 	notStale()
 
 	// Stale row_security.

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -48,7 +48,10 @@ func (r *RowLevelSecurityMeta) MaybeInit(user username.SQLUsername, hasAdminRole
 
 // Clear unsets the initialized property. This is used as a test helper.
 func (r *RowLevelSecurityMeta) Clear() {
-	r = &RowLevelSecurityMeta{}
+	if r == nil {
+		return
+	}
+	*r = RowLevelSecurityMeta{}
 }
 
 // AddTableUse indicates that an RLS-enabled table was encountered while


### PR DESCRIPTION
This commit addresses two issues in the handling of RLS metadata in the sql/opt package:

- The RLS metadata was not being properly cleared after calling the Clear() function. This function is only used in test.
- Emitting RLS information during explain could theoretically result in a nil pointer dereference. While this path cannot be reached with a nil pointer under current conditions, the code was caught by an LLM. This change adds a defensive safeguard.

Closes #153192

Release note: none
Epic: none