### PR TITLE
kvstorage: encapsulate variants of replica destruction

### DIFF
--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -7,6 +7,7 @@ package kvstorage
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -29,6 +30,14 @@ const (
 	// perhaps we should fix Pebble to handle large numbers of range tombstones in
 	// an sstable better.
 	ClearRangeThresholdPointKeys = 64
+
+	// MergedTombstoneReplicaID is the replica ID written into the RangeTombstone
+	// for replicas of a range which is known to have been merged. This value
+	// should prevent any messages from stale replicas of that range from ever
+	// resurrecting merged replicas. Whenever merging or subsuming a replica we
+	// know new replicas can never be created so this value is used even if we
+	// don't know the current replica ID.
+	MergedTombstoneReplicaID roachpb.ReplicaID = math.MaxInt32
 )
 
 // ClearRangeDataOptions specify which parts of a Replica are to be destroyed.

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -174,3 +174,28 @@ func DestroyReplica(
 		NextReplicaID: next, // NB: NextReplicaID > 0
 	})
 }
+
+// SubsumeReplica is like DestroyReplica, but it does not delete the user keys
+// (and the corresponding system and lock table keys). The latter are inherited
+// by the subsuming range.
+//
+// Returns SelectOpts which can be used to reflect on the key spans that this
+// function clears.
+// TODO(pav-kv): get rid of SelectOpts.
+func SubsumeReplica(
+	ctx context.Context, reader storage.Reader, writer storage.Writer, info DestroyReplicaInfo,
+) (rditer.SelectOpts, error) {
+	// NB: set MustUseClearRange to true because this call is used for generating
+	// SSTables when ingesting a snapshot, which requires Clears and Puts to be
+	// written in key order. DestroyReplica sets RangeTombstoneKey after clearing
+	// the unreplicated span which may contain higher keys.
+	opts := ClearRangeDataOptions{
+		ClearReplicatedByRangeID:   true,
+		ClearUnreplicatedByRangeID: true,
+		MustUseClearRange:          true,
+	}
+	return rditer.SelectOpts{
+		ReplicatedByRangeID:   opts.ClearReplicatedByRangeID,
+		UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
+	}, DestroyReplica(ctx, reader, writer, info, MergedTombstoneReplicaID, opts)
+}

--- a/pkg/kv/kvserver/kvstorage/destroy_test.go
+++ b/pkg/kv/kvserver/kvstorage/destroy_test.go
@@ -69,13 +69,7 @@ func TestDestroyReplica(t *testing.T) {
 	})
 	mutate("destroy", func(rw storage.ReadWriter) {
 		require.NoError(t, DestroyReplica(
-			ctx, rw, rw,
-			DestroyReplicaInfo{FullReplicaID: r.id, Keys: r.keys}, r.id.ReplicaID+1,
-			ClearRangeDataOptions{
-				ClearUnreplicatedByRangeID: true,
-				ClearReplicatedByRangeID:   true,
-				ClearReplicatedBySpan:      r.keys,
-			},
+			ctx, rw, rw, DestroyReplicaInfo{FullReplicaID: r.id, Keys: r.keys}, r.id.ReplicaID+1,
 		))
 	})
 

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -359,7 +359,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		rhsRepl.mu.Unlock()
 		rhsRepl.readOnlyCmdMu.Unlock()
 
-		// Use math.MaxInt32 (mergedTombstoneReplicaID) as the nextReplicaID as an
+		// Use math.MaxInt32 (MergedTombstoneReplicaID) as the nextReplicaID as an
 		// extra safeguard against creating new replicas of the RHS. This isn't
 		// required for correctness, since the merge protocol should guarantee that
 		// no new replicas of the RHS can ever be created, but it doesn't hurt to
@@ -367,7 +367,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		if err := kvstorage.DestroyReplica(
 			ctx, b.batch, b.batch,
 			rhsRepl.destroyInfoRaftMuLocked(),
-			mergedTombstoneReplicaID,
+			kvstorage.MergedTombstoneReplicaID,
 			kvstorage.ClearRangeDataOptions{
 				ClearReplicatedByRangeID:   true,
 				ClearUnreplicatedByRangeID: true,

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -8,7 +8,6 @@ package kvserver
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
@@ -55,14 +54,6 @@ func (s destroyStatus) IsAlive() bool {
 func (s destroyStatus) Removed() bool {
 	return s.reason == destroyReasonRemoved
 }
-
-// mergedTombstoneReplicaID is the replica ID written into the tombstone
-// for replicas which are part of a range which is known to have been merged.
-// This value should prevent any messages from stale replicas of that range from
-// ever resurrecting merged replicas. Whenever merging or subsuming a replica we
-// know new replicas can never be created so this value is used even if we
-// don't know the current replica ID.
-const mergedTombstoneReplicaID roachpb.ReplicaID = math.MaxInt32
 
 // postDestroyRaftMuLocked is called after the replica destruction is durably
 // written to Pebble.

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -88,23 +88,10 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	ms := r.GetMVCCStats()
 	batch := r.store.TODOEngine().NewWriteBatch()
 	defer batch.Close()
-	desc := r.Desc()
-	inited := desc.IsInitialized()
 
-	opts := kvstorage.ClearRangeDataOptions{
-		ClearReplicatedBySpan: desc.RSpan(), // zero if !inited
-		// TODO(tbg): if it's uninitialized, we might as well clear
-		// the replicated state because there isn't any. This seems
-		// like it would be simpler, but needs a code audit to ensure
-		// callers don't call this in in-between states where the above
-		// assumption doesn't hold.
-		ClearReplicatedByRangeID:   inited,
-		ClearUnreplicatedByRangeID: true,
-	}
 	// TODO(sep-raft-log): need both engines separately here.
 	if err := kvstorage.DestroyReplica(
-		ctx, r.store.TODOEngine(), batch,
-		r.destroyInfoRaftMuLocked(), nextReplicaID, opts,
+		ctx, r.store.TODOEngine(), batch, r.destroyInfoRaftMuLocked(), nextReplicaID,
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -348,11 +349,11 @@ func (rgcq *replicaGCQueue) process(
 			}
 		}
 
-		// A tombstone is written with a value of mergedTombstoneReplicaID because
+		// A tombstone is written with a value of MergedTombstoneReplicaID because
 		// we know the range to have been merged. See the Merge case of
 		// runPreApplyTriggers() for details.
 		if err := repl.store.RemoveReplica(
-			ctx, repl, mergedTombstoneReplicaID, "dangling subsume via replica GC queue",
+			ctx, repl, kvstorage.MergedTombstoneReplicaID, "dangling subsume via replica GC queue",
 		); err != nil {
 			return false, err
 		}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -818,7 +818,7 @@ func (r *Replica) clearSubsumedReplicaInMemoryData(
 		// allowed in (perhaps not involving any of the RangeIDs known to the merge
 		// but still touching its keyspace) and causing corruption.
 		ph, err := r.store.removeInitializedReplicaRaftMuLocked(
-			ctx, sr, mergedTombstoneReplicaID, "subsumed by snapshot",
+			ctx, sr, kvstorage.MergedTombstoneReplicaID, "subsumed by snapshot",
 			RemoveOptions{
 				// The data was already destroyed by clearSubsumedReplicaDiskData.
 				DestroyData:       false,

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -150,7 +150,7 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(ctx context.Context) err
 	for _, sub := range s.subsume {
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		if err := s.writeSST(ctx, func(ctx context.Context, w storage.Writer) error {
-			opts, err := kvstorage.SubsumeReplica(ctx, reader, w, sub)
+			opts, err := kvstorage.SubsumeReplica(ctx, reader, w, sub, true /* forceSortedKeys */)
 			s.cleared = append(s.cleared, rditer.Select(sub.RangeID, opts)...)
 			return err
 		}); err != nil {

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -163,7 +163,7 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(ctx context.Context) err
 				UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
 			})...)
 			// NB: Actually clear RangeID local key spans.
-			return kvstorage.DestroyReplica(ctx, reader, w, sub, mergedTombstoneReplicaID, opts)
+			return kvstorage.DestroyReplica(ctx, reader, w, sub, kvstorage.MergedTombstoneReplicaID, opts)
 		}); err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -150,20 +150,9 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(ctx context.Context) err
 	for _, sub := range s.subsume {
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		if err := s.writeSST(ctx, func(ctx context.Context, w storage.Writer) error {
-			// NOTE: We set mustClearRange to true because we are setting
-			// RangeTombstoneKey. Since Clears and Puts need to be done in increasing
-			// order of keys, it is not safe to use ClearRangeIter.
-			opts := kvstorage.ClearRangeDataOptions{
-				ClearReplicatedByRangeID:   true,
-				ClearUnreplicatedByRangeID: true,
-				MustUseClearRange:          true,
-			}
-			s.cleared = append(s.cleared, rditer.Select(sub.RangeID, rditer.SelectOpts{
-				ReplicatedByRangeID:   opts.ClearReplicatedByRangeID,
-				UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
-			})...)
-			// NB: Actually clear RangeID local key spans.
-			return kvstorage.DestroyReplica(ctx, reader, w, sub, kvstorage.MergedTombstoneReplicaID, opts)
+			opts, err := kvstorage.SubsumeReplica(ctx, reader, w, sub)
+			s.cleared = append(s.cleared, rditer.Select(sub.RangeID, opts)...)
+			return err
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR moves all variants of replica destruction writes to `kvstorage` package. It also decouples the `DestroyReplica` helper into two: one that fully removes the replica, and one that doesn't touch the user keys (`SubsumeReplica`).

Finally, `ClearRangeData` and its various options are no longer exposed outside the package, and become its implementation detail. `ClearRangeData` will likely be further broken down in a follow-up since it is not flexible enough for supporting separated raft storage.

Related to #152845

Related to #152845