### PR TITLE
kvserver: add split trigger support to TestReplicaLifecycleDataDriven

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1407,6 +1407,9 @@ func splitTriggerHelper(
 	// This avoids running the consistency checker on the RHS immediately after
 	// the split.
 	lastTS := hlc.Timestamp{}
+	// TODO(arul): instead of fetching the consistency checker timestamp here
+	// like this, we should instead pass it using the SplitTriggerHelperInput to
+	// make it easier to test.
 	if _, err := storage.MVCCGetProto(ctx, batch,
 		keys.QueueLastProcessedKey(split.LeftDesc.StartKey, "consistencyChecker"),
 		hlc.Timestamp{}, &lastTS, storage.MVCCGetOptions{}); err != nil {

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -397,6 +397,7 @@ func tryTxn(kv storage.MVCCKeyValue) (string, error) {
 	if err := maybeUnmarshalInline(kv.Value, &txn); err != nil {
 		return "", err
 	}
+	// TODO(arul): investigate why we need this new line here.
 	return txn.String() + "\n", nil
 }
 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/split_trigger.txt
@@ -1,0 +1,98 @@
+create-descriptor start=a end=z replicas=(1,2,3)
+----
+created descriptor: r1:{a-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+
+create-replica range-id=1 initialized
+----
+created replica: (n1,s1):1
+Put: 0,0 /Local/RangeID/1/r/RangeLease (0x01698972726c6c2d00): <empty>
+Put: 0,0 /Local/RangeID/1/r/RangeGCThreshold (0x016989726c67632d00): 0,0
+Put: 0,0 /Local/RangeID/1/r/RangeGCHint (0x016989727267636800): latest_range_delete_timestamp:<> gc_timestamp:<> gc_timestamp_next:<> 
+Put: 0,0 /Local/RangeID/1/r/RangeVersion (0x016989727276657200): 10.8-upgrading-step-007
+Put: 0,0 /Local/RangeID/1/r/RangeAppliedState (0x016989727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:142 sys_count:4 > raft_closed_timestamp:<> raft_applied_index_term:5 
+Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+Put: 0,0 /Local/RangeID/1/u/RaftHardState (0x016989757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
+Put: 0,0 /Local/RangeID/1/u/RaftTruncatedState (0x016989757266747400): index:10 term:5 
+
+# Set the range's lease to be a leader lease. Then, post-split, ensure the RHS
+# gets the correct lease type -- an expiration based lease. This is because
+# a leader lease is specific to the LHS's raft group.
+set-lease range-id=1 replica=2
+----
+ok
+
+create-split range-id=1 split-key=m
+----
+ok
+
+run-split-trigger range-id=1
+----
+Put: 0,0 /Local/RangeID/2/u/RangeLastReplicaGCTimestamp (0x01698a75726c727400): 0,0
+Put: 0,0 /Local/Range"m"/QueueLastProcessed/"consistencyChecker" (0x016b126d0001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
+Put: 0,0 /Local/RangeID/2/r/RangeLease (0x01698a72726c6c2d00): repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
+Put: 0,0 /Local/RangeID/2/r/RangeGCThreshold (0x01698a726c67632d00): 0.000000004,0
+Put: 0,0 /Local/RangeID/2/r/RangeGCHint (0x01698a727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
+Put: 0,0 /Local/RangeID/2/r/RangeVersion (0x01698a727276657200): 10.8-upgrading-step-007
+Put: 0,0 /Local/RangeID/2/r/RangeAppliedState (0x01698a727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:198 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+
+# Note the lease types for r1 and r2. r2 gets an expiration based lease.
+print-range-state
+----
+range desc: r1:{a-m} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5}
+		lease: repl=(n2,s2):2 seq=0 start=0,0 type=LeaseLeader term=10 min-exp=0.000000100,0 pro=0,0 acq=Unspecified
+range desc: r2:{m-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		lease: repl=(n2,s2):2 seq=0 start=0,0 type=LeaseExpiration exp=0.000000109,0 pro=0,0 acq=Unspecified
+
+# Next, create two more splits, but this time for ranges that are using an
+# expiration based lease and an epoch based lease. Show that the same lease type
+# is copied over to the RHS in both these cases.
+
+create-split range-id=1 split-key=f
+----
+ok
+
+set-lease range-id=1 replica=1 lease-type=epoch
+----
+ok
+
+run-split-trigger range-id=1
+----
+Put: 0,0 /Local/RangeID/3/u/RangeLastReplicaGCTimestamp (0x01698b75726c727400): 0,0
+Put: 0,0 /Local/Range"f"/QueueLastProcessed/"consistencyChecker" (0x016b12660001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
+Put: 0,0 /Local/RangeID/3/r/RangeLease (0x01698b72726c6c2d00): repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
+Put: 0,0 /Local/RangeID/3/r/RangeGCThreshold (0x01698b726c67632d00): 0.000000004,0
+Put: 0,0 /Local/RangeID/3/r/RangeGCHint (0x01698b727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
+Put: 0,0 /Local/RangeID/3/r/RangeVersion (0x01698b727276657200): 10.8-upgrading-step-007
+Put: 0,0 /Local/RangeID/3/r/RangeAppliedState (0x01698b727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:196 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+
+create-split range-id=2 split-key=v
+----
+ok
+
+set-lease range-id=2 replica=3 lease-type=expiration
+----
+ok
+
+run-split-trigger range-id=2
+----
+Put: 0,0 /Local/RangeID/4/u/RangeLastReplicaGCTimestamp (0x01698c75726c727400): 0,0
+Put: 0,0 /Local/Range"v"/QueueLastProcessed/"consistencyChecker" (0x016b12760001716c7074636f6e73697374656e6379436865636b657200): meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0
+Put: 0,0 /Local/RangeID/4/r/RangeLease (0x01698c72726c6c2d00): repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified
+Put: 0,0 /Local/RangeID/4/r/RangeGCThreshold (0x01698c726c67632d00): 0.000000004,0
+Put: 0,0 /Local/RangeID/4/r/RangeGCHint (0x01698c727267636800): latest_range_delete_timestamp:<> gc_timestamp:<wall_time:4 > gc_timestamp_next:<> 
+Put: 0,0 /Local/RangeID/4/r/RangeVersion (0x01698c727276657200): 10.8-upgrading-step-007
+Put: 0,0 /Local/RangeID/4/r/RangeAppliedState (0x01698c727261736b00): raft_applied_index:10 lease_applied_index:10 range_stats:<sys_bytes:199 sys_count:5 > raft_closed_timestamp:<> raft_applied_index_term:5 
+
+# Note the lease types for ranges r3 and r4.
+print-range-state sort-keys=true
+----
+range desc: r1:{a-f} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5}
+		lease: repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
+range desc: r3:{f-m} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		lease: repl=(n1,s1):1 seq=0 start=0,0 type=LeaseEpoch epo=20 min-exp=0,0 pro=0,0 acq=Unspecified
+range desc: r2:{m-v} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		lease: repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified
+range desc: r4:{v-z} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		lease: repl=(n3,s3):3 seq=0 start=0,0 type=LeaseExpiration exp=0.000000300,0 pro=0,0 acq=Unspecified


### PR DESCRIPTION
This patch adds a few directives to construct and evaluate split triggers.

We then use these directives to demonstrate that leases are correctly copied over from the LHS to the RHS. The interesting case is around leader leases, where if the LHS has a leader lease, the RHS gets an expiration based lease. For the other two lease types, the RHS's lease type stays the same.

Epic: none

Release note: None