### PR TITLE
kvclient/rangefeed: skip TestRangefeedCatchupStarvation under race

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1886,6 +1886,7 @@ func TestRangeFeedMetadataAutoSplit(t *testing.T) {
 func TestRangefeedCatchupStarvation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "may oom with race detector")
 
 	testutils.RunValues(t, "feed_type", feedTypes, func(t *testing.T, rt rangefeedTestType) {
 		ctx := context.Background()


### PR DESCRIPTION
This commit skips TestRangefeedCatchupStarvation under race. The failure
occurred under the unbuffered sender, which hasn’t changed recently. It could be
related to how catch-up scan isn’t subject under the memory budget. I wasn't
able to find the memory profile from engflow to investigate further. Asked in
#dev-inf about it.

Fixes: https://github.com/cockroachdb/cockroach/issues/155334
Epic: none 
Release note: none 