### PR TITLE
kvstorage: make replica destruction always sorted

### DIFF
--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -192,6 +192,16 @@ var schema = [...]interface{}{
 	//   pertain to just one replica of a range. They are unreplicated and
 	//   unaddressable. The typical example is the Raft log. They all share
 	//   `LocalRangeIDPrefix` and `localRangeIDUnreplicatedInfix`.
+	//
+	// WARNING: when adding a new key in this section, decide whether it should be
+	// classified as "raft" or "state machine" key, correspondingly to which
+	// engine it resides in:
+	//
+	//	- keys <= RangeTombstoneKey in this prefix are "state machine" engine keys
+	//	- keys > RangeTombstoneKey in this prefix are "raft" engine keys
+	//	- historical exception: RaftReplicaIDKey belongs to the state machine
+	//
+	// Failure to classify may result in replica state corruption in storage.
 	localRangeIDUnreplicatedInfix,  // "u"
 	RangeTombstoneKey,              // "rftb"
 	RaftHardStateKey,               // "rfth"

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -45,66 +45,6 @@ func ClearRangeThresholdPointKeys() int {
 	return clearRangeThresholdPointKeys
 }
 
-// clearRangeDataOptions specify which parts of a Replica are to be destroyed.
-type clearRangeDataOptions struct {
-	// clearReplicatedByRangeID indicates that replicated RangeID-based keys
-	// (abort span, etc) should be removed.
-	clearReplicatedByRangeID bool
-	// clearUnreplicatedByRangeID indicates that unreplicated RangeID-based keys
-	// (logstore state incl. HardState, etc) should be removed.
-	clearUnreplicatedByRangeID bool
-	// clearReplicatedBySpan causes the state machine data (i.e. the replicated state
-	// for the given RSpan) that is key-addressable (i.e. range descriptor, user keys,
-	// locks) to be removed. No data is removed if this is the zero span.
-	clearReplicatedBySpan roachpb.RSpan
-
-	// If mustUseClearRange is true, a Pebble range tombstone will always be used
-	// to clear the key spans (unless empty). This is typically used when we need
-	// to write additional keys to an SST after this clear, e.g. a replica
-	// tombstone, since keys must be written in order. When this is false, a
-	// heuristic will be used instead.
-	mustUseClearRange bool
-}
-
-// clearRangeData clears the data associated with a range descriptor selected
-// by the provided options.
-//
-// TODO(tbg): could rename this to XReplica. The use of "Range" in both the
-// "CRDB Range" and "storage.ClearRange" context in the setting of this method could
-// be confusing.
-func clearRangeData(
-	ctx context.Context,
-	rangeID roachpb.RangeID,
-	reader storage.Reader,
-	writer storage.Writer,
-	opts clearRangeDataOptions,
-) error {
-	keySpans := rditer.Select(rangeID, rditer.SelectOpts{
-		Ranged: rditer.SelectRangedOptions{
-			RSpan:      opts.clearReplicatedBySpan,
-			SystemKeys: true,
-			LockTable:  true,
-			UserKeys:   true,
-		},
-		ReplicatedByRangeID:   opts.clearReplicatedByRangeID,
-		UnreplicatedByRangeID: opts.clearUnreplicatedByRangeID,
-	})
-
-	pointKeyThreshold := ClearRangeThresholdPointKeys()
-	if opts.mustUseClearRange {
-		pointKeyThreshold = 1
-	}
-
-	for _, keySpan := range keySpans {
-		if err := storage.ClearRangeWithHeuristic(
-			ctx, reader, writer, keySpan.Key, keySpan.EndKey, pointKeyThreshold,
-		); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // DestroyReplicaTODO is the plan for splitting DestroyReplica into cross-engine
 // writes.
 //
@@ -175,18 +115,30 @@ func destroyReplicaImpl(
 	}
 
 	_ = DestroyReplicaTODO // 2.1 + 2.2 + 3.1
-	// NB: if required, set mustUseClearRange to true. This call can be used for
-	// generating SSTables when ingesting a snapshot, which requires Clears and
-	// Puts to be written in key order. DestroyReplica sets RangeTombstoneKey
-	// after clearing the unreplicated span which may contain higher keys.
-	if err := clearRangeData(ctx, info.RangeID, reader, writer, clearRangeDataOptions{
-		clearReplicatedByRangeID:   true,
-		clearUnreplicatedByRangeID: true,
-		clearReplicatedBySpan:      info.Keys,
-		mustUseClearRange:          forceSortedKeys,
-	}); err != nil {
-		return err
+	// NB: if forceSortedKeys is true, disable the heuristic and force deletion by
+	// range keys. This call can be used for generating SSTables when ingesting a
+	// snapshot, which requires Clears and Puts to be written in key order. Since
+	// we write RangeTombstoneKey further down, ensure that this is the only point
+	// key here.
+	pointKeyThreshold := ClearRangeThresholdPointKeys()
+	if forceSortedKeys {
+		pointKeyThreshold = 1
 	}
+	// TODO(pav-kv): decompose this loop to delete raft and state machine keys
+	// separately. The main challenge is the unreplicated span because it is
+	// scattered across 2 engines.
+	for _, span := range rditer.Select(info.RangeID, rditer.SelectOpts{
+		UnreplicatedByRangeID: true,
+		ReplicatedByRangeID:   true,
+		Ranged:                rditer.SelectAllRanged(info.Keys),
+	}) {
+		if err := storage.ClearRangeWithHeuristic(
+			ctx, reader, writer, span.Key, span.EndKey, pointKeyThreshold,
+		); err != nil {
+			return err
+		}
+	}
+
 	// Save a tombstone to ensure that replica IDs never get reused.
 	_ = DestroyReplicaTODO // 2.3
 	return sl.SetRangeTombstone(ctx, writer, kvserverpb.RangeTombstone{

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -144,11 +144,7 @@ func DestroyReplica(
 	info DestroyReplicaInfo,
 	next roachpb.ReplicaID,
 ) error {
-	return destroyReplicaImpl(ctx, reader, writer, info, next, clearRangeDataOptions{
-		clearReplicatedByRangeID:   true,
-		clearUnreplicatedByRangeID: true,
-		clearReplicatedBySpan:      info.Keys,
-	})
+	return destroyReplicaImpl(ctx, reader, writer, info, next, false /* forceSortedKeys */)
 }
 
 func destroyReplicaImpl(
@@ -157,7 +153,7 @@ func destroyReplicaImpl(
 	writer storage.Writer,
 	info DestroyReplicaInfo,
 	next roachpb.ReplicaID,
-	opts clearRangeDataOptions,
+	forceSortedKeys bool,
 ) error {
 	if next <= info.ReplicaID {
 		return errors.AssertionFailedf("%v must not survive its own tombstone", info.FullReplicaID)
@@ -179,7 +175,16 @@ func destroyReplicaImpl(
 	}
 
 	_ = DestroyReplicaTODO // 2.1 + 2.2 + 3.1
-	if err := clearRangeData(ctx, info.RangeID, reader, writer, opts); err != nil {
+	// NB: if required, set mustUseClearRange to true. This call can be used for
+	// generating SSTables when ingesting a snapshot, which requires Clears and
+	// Puts to be written in key order. DestroyReplica sets RangeTombstoneKey
+	// after clearing the unreplicated span which may contain higher keys.
+	if err := clearRangeData(ctx, info.RangeID, reader, writer, clearRangeDataOptions{
+		clearReplicatedByRangeID:   true,
+		clearUnreplicatedByRangeID: true,
+		clearReplicatedBySpan:      info.Keys,
+		mustUseClearRange:          forceSortedKeys,
+	}); err != nil {
 		return err
 	}
 	// Save a tombstone to ensure that replica IDs never get reused.
@@ -207,19 +212,12 @@ func SubsumeReplica(
 	info DestroyReplicaInfo,
 	forceSortedKeys bool,
 ) (rditer.SelectOpts, error) {
-	// NB: if required, set MustUseClearRange to true. This call can be used for
-	// generating SSTables when ingesting a snapshot, which requires Clears and
-	// Puts to be written in key order. DestroyReplica sets RangeTombstoneKey
-	// after clearing the unreplicated span which may contain higher keys.
-	opts := clearRangeDataOptions{
-		clearReplicatedByRangeID:   true,
-		clearUnreplicatedByRangeID: true,
-		mustUseClearRange:          forceSortedKeys,
-	}
+	// Forget about the user keys.
+	info.Keys = roachpb.RSpan{}
 	return rditer.SelectOpts{
-		ReplicatedByRangeID:   opts.clearReplicatedByRangeID,
-		UnreplicatedByRangeID: opts.clearUnreplicatedByRangeID,
-	}, destroyReplicaImpl(ctx, reader, writer, info, MergedTombstoneReplicaID, opts)
+		ReplicatedByRangeID:   true,
+		UnreplicatedByRangeID: true,
+	}, destroyReplicaImpl(ctx, reader, writer, info, MergedTombstoneReplicaID, forceSortedKeys)
 }
 
 // RemoveStaleRHSFromSplit removes all data for the RHS replica of a split. This

--- a/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica.txt
@@ -19,7 +19,7 @@ Put: "a"/Intent/00000000-0000-0000-0000-000000000000:
 Put: 0.000000001,0 "y\xff" (0x79ff00000000000000000109): ""
 Put: "y\xff"/Intent/00000000-0000-0000-0000-000000000000: 
 >> destroy:
-Delete (Sized at 31): 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): 
+Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:4 
 Delete (Sized at 39): 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:11 (0x0169f67b757266746c000000000000000b00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): 
@@ -35,4 +35,3 @@ Delete (Sized at 26): /Local/Lock"a" 0300000000000000000000000000000000 (0x017a6
 Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
 Delete (Sized at 11): 0.000000001,0 "a" (0x6100000000000000000109): 
 Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109): 
-Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:4 

--- a/pkg/kv/kvserver/rditer/select.go
+++ b/pkg/kv/kvserver/rditer/select.go
@@ -53,6 +53,17 @@ type SelectRangedOptions struct {
 	UserKeys bool
 }
 
+// SelectAllRanged returns SelectRangeOptions that covers all span-based
+// replicated keys in the given range.
+func SelectAllRanged(span roachpb.RSpan) SelectRangedOptions {
+	return SelectRangedOptions{
+		RSpan:      span,
+		SystemKeys: true,
+		LockTable:  true,
+		UserKeys:   true,
+	}
+}
+
 // SelectOpts configures which spans for a Replica to return from Select.
 // A Replica comprises replicated (i.e. belonging to the state machine) spans
 // and unreplicated spans, and depending on external circumstances one may want

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -360,7 +360,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		rhsRepl.readOnlyCmdMu.Unlock()
 
 		if _, err := kvstorage.SubsumeReplica(
-			ctx, b.batch, b.batch, rhsRepl.destroyInfoRaftMuLocked(), false, /* forceSortedKeys */
+			ctx, b.batch, b.batch, rhsRepl.destroyInfoRaftMuLocked(),
 		); err != nil {
 			return errors.Wrapf(err, "unable to subsume replica before merge")
 		}

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -149,7 +149,7 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(ctx context.Context) err
 	for _, sub := range s.subsume {
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		if err := s.writeSST(ctx, func(ctx context.Context, w storage.Writer) error {
-			opts, err := kvstorage.SubsumeReplica(ctx, reader, w, sub, true /* forceSortedKeys */)
+			opts, err := kvstorage.SubsumeReplica(ctx, reader, w, sub)
 			s.cleared = append(s.cleared, rditer.Select(sub.RangeID, opts)...)
 			return err
 		}); err != nil {

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -225,7 +225,7 @@ func (s *snapWriteBuilder) clearResidualDataOnNarrowSnapshot(ctx context.Context
 	}) {
 		if err := s.writeSST(ctx, func(ctx context.Context, w storage.Writer) error {
 			return storage.ClearRangeWithHeuristic(
-				ctx, reader, w, span.Key, span.EndKey, kvstorage.ClearRangeThresholdPointKeys,
+				ctx, reader, w, span.Key, span.EndKey, kvstorage.ClearRangeThresholdPointKeys(),
 			)
 		}); err != nil {
 			return err

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -6,11 +6,11 @@ Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vo
 Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:4 
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 >> sst:
-Delete Range: [0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): , 0,0 /Local/RangeID/101/v"" (0x0169ed7600): )
 Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
+Delete (Sized at 30): 0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): 
 >> sst:
-Delete Range: [0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): , 0,0 /Local/RangeID/102/v"" (0x0169ee7600): )
 Put: 0,0 /Local/RangeID/102/u/RangeTombstone (0x0169ee757266746200): next_replica_id:2147483647 
+Delete (Sized at 30): 0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): 
 >> sst:
 Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
 >> sst:


### PR DESCRIPTION
This PR refactors replica destruction helpers in `kvstorage` (`DestroyReplica` and `SubsumeReplica`) so that they always generate storage writes ordered by engine key. This is to support the most restrictive user of `SubsumeReplica`: `prepareSnapApply` feeds these writes into SSTables (which assert on the keys order), part of snapshot ingestion path.

Other byproducts of this PR:

- `ClearRangeData` and its options are removed due to being redundant and not flexible.
- A decision is made to split the unreplicated RangeID-local keyspace into "state machine" and "raft", separated by the `RangeTombstone` key. This leaves us with only one exception: `RaftReplicaID` key in the middle of the "raft" keyspace is said to be a "state machine" key. We can migrate it to the correct half later, together with other storage migrations.
- The loop unwinding in `destroyReplicaImpl` brings us very close to logical separation of engines in this function. We now only need to handle the `RaftReplicaID` key correctly.
- The heuristic from `ClearRangeWithHeuristic` is now always used with the same threshold. There are no forced `ClearRawRange`s in the snapshot path anymore, unless opted in by tests.

Related to #152845