### PR TITLE
release-25.3: stmtbundle: include skipped FKs into `schema.sql`

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -593,7 +593,7 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	// update this logic to not include virtual tables into schema.sql but still
 	// create stats files for them.
 	var tables, sequences, views []tree.TableName
-	var addFKs []*tree.AlterTable
+	var addFKs, skipFKs []*tree.AlterTable
 	err := b.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Catalog objects can show up multiple times in our lists, so
 		// deduplicate them.
@@ -772,9 +772,13 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 				include = hasDelete || hasUpdate || hasUpsert
 			},
 		)
-		addFKs = opt.GetAllFKsAmongTables(refTables, func(t cat.Table) (tree.TableName, error) {
-			return b.plan.catalog.fullyQualifiedNameWithTxn(ctx, t, txn)
-		})
+		addFKs, skipFKs = opt.GetAllFKs(
+			ctx,
+			b.plan.catalog,
+			refTables,
+			func(t cat.Table) (tree.TableName, error) {
+				return b.plan.catalog.fullyQualifiedNameWithTxn(ctx, t, txn)
+			})
 		var err error
 		tables, err = getNames(len(refTables), func(i int) cat.DataSource {
 			return refTables[i]
@@ -883,6 +887,10 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		// we need to add them separately.
 		for _, addFK := range addFKs {
 			fmt.Fprintf(&buf, "%s;\n", addFK)
+		}
+		// Include FK constraints that were skipped in commented out form.
+		for _, skipFK := range skipFKs {
+			fmt.Fprintf(&buf, "-- %s;\n", skipFK)
 		}
 	}
 	for i := range views {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -4338,12 +4338,23 @@ func (b *Builder) getEnvData() (exec.ExplainEnvData, error) {
 			refTableIncluded.Add(int(table.ID()))
 		},
 	)
-	envOpts.AddFKs = opt.GetAllFKsAmongTables(
+	var skipFKs []*tree.AlterTable
+	envOpts.AddFKs, skipFKs = opt.GetAllFKs(
+		b.ctx,
+		b.catalog,
 		refTables,
 		func(t cat.Table) (tree.TableName, error) {
 			return b.catalog.FullyQualifiedName(b.ctx, t)
 		},
 	)
+	// Given that we include all FK-related tables when visiting them, we should
+	// not skip any FKs - we'll return an error if we find any in test-only
+	// builds.
+	if buildutil.CrdbTestBuild {
+		if len(skipFKs) > 0 {
+			return envOpts, errors.AssertionFailedf("unexpectedly skipped adding FKs in EXPLAIN (OPT): %v", skipFKs)
+		}
+	}
 	var err error
 	envOpts.Tables, err = getNames(len(refTables), func(i int) cat.DataSource {
 		return refTables[i]


### PR DESCRIPTION
Backport 1/1 commits from #155541 on behalf of @yuzefovich.

----

Earlier this year we refactored how we handle FKs in stmt bundles. Namely, we now use IGNORE_FOREIGN_KEYS option of SHOW CREATE TABLE (which produces DDLs with FK constraints omitted) and then we include only "relevant" FKs as ALTER TABLE ... ADD CONSTRAINT stmts later. This behavior can be confusing since now CREATE TABLE stmt from the bundle cannot be relied upon as the source of truth for the table's schema. In order to partially remedy the situation, this commit extends the logic to also include ALTER TABLE stmts for "skipped" FKs where the origin (i.e. referencing) table is included into the bundle, but these ALTERs are commented out (to keep the bundle being recreatable).

Informs: https://github.com/cockroachlabs/support/issues/3459
Epic: None
Release note: None

----

Release justification: low-risk supportability improvement.