### PR TITLE
release-25.4: changefeedccl: unskip TestChangefeedProgressSkewMetrics

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -928,6 +928,10 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (retu
 		ca.sliMetrics.setResolved(ca.sliMetricsID, ca.frontier.Frontier())
 	}
 
+	if ca.knobs.ShouldFlushFrontier != nil && ca.knobs.ShouldFlushFrontier(resolved) {
+		return ca.flushFrontier(ctx)
+	}
+
 	forceFlush := resolved.BoundaryType != jobspb.ResolvedSpan_NONE
 
 	// NB: if we miss flush window, and the flush frequency is fairly high (minutes),

--- a/pkg/ccl/changefeedccl/changefeed_progress_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_progress_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -189,7 +188,7 @@ RETURNING cluster_logical_timestamp()`).Scan(&tsStr)
 func TestChangefeedProgressSkewMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 155015, "test will not work without periodic frontier flushing")
+
 	testutils.RunTrueAndFalse(t, "per-table tracking", func(t *testing.T, perTableTracking bool) {
 		testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 			sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -234,6 +233,10 @@ func TestChangefeedProgressSkewMetrics(t *testing.T) {
 						return true, nil
 					}
 					return false, nil
+				}
+
+				knobs.ShouldFlushFrontier = func(rs jobspb.ResolvedSpan) bool {
+					return true
 				}
 			}
 

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -71,6 +71,10 @@ type TestingKnobs struct {
 		partitions []sql.SpanPartition, draining []roachpb.NodeID,
 	) ([]sql.SpanPartition, error)
 
+	// ShouldFlushFrontier returns true if the change aggregator should flush
+	// its frontier after processing a resolved span.
+	ShouldFlushFrontier func(rs jobspb.ResolvedSpan) bool
+
 	// ShouldCheckpointToJobRecord returns true if change frontier should checkpoint itself
 	// to the job record.
 	ShouldCheckpointToJobRecord func(hw hlc.Timestamp) bool


### PR DESCRIPTION
This test was previously skipped because it relied on periodic
aggregator frontier flushing to work. It has now been modified
to use a testing knob instead.

Informs #155083

Release note: None

---

Release justification: test-only change