### PR TITLE
serverutils: fix log message for globalDefaultSelectionOverride

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -141,7 +141,7 @@ func ShouldStartDefaultTestTenant(
 				t.Logf("cluster virtualization disabled in global scope due to issue: #%d (expected label: %s)", issueNum, label)
 			}
 		} else {
-			t.Log(defaultTestTenantMessage(shared) + "\n(override via TestingSetDefaultTenantSelectionOverride)")
+			t.Log(defaultTestTenantMessage(override.SharedProcessMode()) + "\n(override via TestingSetDefaultTenantSelectionOverride)")
 		}
 		return override
 	}


### PR DESCRIPTION
Previously, if we used `globalDefaultSelectionOverride` to force usage of shared process tenant, we'd still see a log message as if external process tenant was started. This was the case since we didn't use the right boolean, and this is now fixed.

Epic: None
Release note: None