### PR TITLE
roachprod: add chaos CLI for failure injection

### DIFF
--- a/pkg/cmd/roachprod/cli/BUILD.bazel
+++ b/pkg/cmd/roachprod/cli/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "cli",
     srcs = [
         "bash_completion.go",
+        "chaos.go",
+        "chaos_network.go",
         "commands.go",
         "flags.go",
         "handlers.go",
@@ -22,7 +24,9 @@ go_library(
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
+        "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
+        "//pkg/roachprod/logger",
         "//pkg/roachprod/roachprodutil",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/ui",

--- a/pkg/cmd/roachprod/cli/chaos.go
+++ b/pkg/cmd/roachprod/cli/chaos.go
@@ -1,0 +1,395 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// FailureStage represents a single stage in the failure injection lifecycle
+type FailureStage string
+
+const (
+	// StageAll runs the complete lifecycle: Setup → Inject → Wait → Recover → Cleanup
+	StageAll FailureStage = "all"
+	// StageSetup runs only the setup phase
+	StageSetup FailureStage = "setup"
+	// StageInject runs only the inject phase
+	StageInject FailureStage = "inject"
+	// StageRecover runs only the recover phase
+	StageRecover FailureStage = "recover"
+	// StageCleanup runs only the cleanup phase
+	StageCleanup FailureStage = "cleanup"
+)
+
+// ValidStages returns all valid lifecycle stage values for a failure
+func ValidStages() []string {
+	return []string{
+		string(StageAll),
+		string(StageSetup),
+		string(StageInject),
+		string(StageRecover),
+		string(StageCleanup),
+	}
+}
+
+// Global chaos options that apply to all chaos commands
+var (
+	chaosWaitBeforeCleanup time.Duration
+	chaosRunForever        bool
+	chaosCertsDir          string
+	chaosReplicationFactor int
+	chaosStage             string
+)
+
+// GlobalChaosOpts captures global chaos flags
+type GlobalChaosOpts struct {
+	WaitBeforeCleanup time.Duration
+	RunForever        bool
+	Stage             FailureStage
+}
+
+// buildChaosCmd creates the root chaos command
+func (cr *commandRegistry) buildChaosCmd() *cobra.Command {
+	chaosCmd := &cobra.Command{
+		Use:   "chaos [command]",
+		Short: "Failure injection related commands",
+		Long: `Failure injection related commands for testing cluster resilience.
+
+Failure injection commands allow you to inject various types of failures into a
+cluster to test its behavior under adverse conditions. Each failure type has its
+own lifecycle: Setup → Inject → Wait → Recover → Cleanup.
+
+Global flags control the duration and cleanup behavior of all chaos commands.
+`,
+	}
+
+	// Add global flags
+	chaosCmd.PersistentFlags().DurationVar(&chaosWaitBeforeCleanup,
+		"wait-before-cleanup", 5*time.Minute,
+		"time to wait before cleaning up the failure")
+	chaosCmd.PersistentFlags().BoolVar(&chaosRunForever,
+		"run-forever", false,
+		"if set, takes precedence over --wait-before-cleanup. On graceful shutdown, cleans up the injected failure")
+	chaosCmd.PersistentFlags().StringVar(&chaosCertsDir,
+		"certs-dir", install.CockroachNodeCertsDir,
+		"local path to certs directory for secure clusters")
+	chaosCmd.PersistentFlags().IntVar(&chaosReplicationFactor,
+		"replication-factor", 0,
+		"expected replication factor for the cluster (0 = use default of 3)")
+	chaosCmd.PersistentFlags().StringVar(&chaosStage,
+		"stage", string(StageAll),
+		`lifecycle stage to execute. Options:
+  - all: runs the complete lifecycle (Setup → Inject → Wait → Recover → Cleanup)
+  - setup: runs only the setup phase (prepares failure dependencies)
+  - inject: runs only the inject phase (activates the failure)
+  - recover: runs only the recover phase (removes the failure)
+  - cleanup: runs only the cleanup phase (removes failure dependencies)
+Default: all`)
+
+	// Add subcommands
+	chaosCmd.AddCommand(cr.buildChaosNetworkCmd())
+
+	return chaosCmd
+}
+
+// getGlobalChaosOpts returns the global chaos options from flags.
+// It validates the stage flag and returns an error if invalid.
+func getGlobalChaosOpts() (GlobalChaosOpts, error) {
+	stage := FailureStage(chaosStage)
+
+	// Validate stage
+	validStages := ValidStages()
+	isValid := false
+	for _, s := range validStages {
+		if string(stage) == s {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		return GlobalChaosOpts{}, errors.Newf("invalid stage %q, must be one of: %s",
+			chaosStage, strings.Join(validStages, ", "))
+	}
+
+	return GlobalChaosOpts{
+		WaitBeforeCleanup: chaosWaitBeforeCleanup,
+		RunForever:        chaosRunForever,
+		Stage:             stage,
+	}, nil
+}
+
+// getClusterOptions returns cluster options for creating a failer
+func getClusterOptions() []failures.ClusterOptionFunc {
+	opts := []failures.ClusterOptionFunc{
+		failures.Secure(!insecure),
+		failures.LocalCertsPath(chaosCertsDir),
+	}
+	if chaosReplicationFactor > 0 {
+		opts = append(opts, failures.ReplicationFactor(chaosReplicationFactor))
+	}
+	return opts
+}
+
+// parseInt32SliceToNodes converts a uint32 slice to install.Nodes
+func parseInt32SliceToNodes(nodes []int32) install.Nodes {
+	if len(nodes) == 0 {
+		return nil
+	}
+	result := make(install.Nodes, len(nodes))
+	for i, n := range nodes {
+		result[i] = install.Node(n)
+	}
+	return result
+}
+
+// createFailer creates a failer instance from the registry.
+// State validation is enabled (disableStateValidation=false) only when stage is StageAll.
+// For individual stages, state validation is disabled (disableStateValidation=true) to allow
+// running stages independently without enforcing the complete lifecycle order.
+func createFailer(
+	clusterName string, failureName string, stage FailureStage, opts ...failures.ClusterOptionFunc,
+) (*failures.Failer, error) {
+	registry := failures.GetFailureRegistry()
+	disableStateValidation := stage != StageAll
+	return registry.GetFailer(
+		clusterName,
+		failureName,
+		config.Logger,
+		disableStateValidation,
+		opts...,
+	)
+}
+
+// runFailureLifecycle executes the failure lifecycle based on the specified stage.
+// If stage is StageAll, runs the complete lifecycle: Setup → Inject → Wait → Recover → Cleanup.
+// Otherwise, runs only the specified individual stage.
+func runFailureLifecycle(
+	ctx context.Context,
+	l *logger.Logger,
+	failer *failures.Failer,
+	args failures.FailureArgs,
+	opts GlobalChaosOpts,
+) error {
+	switch opts.Stage {
+	case StageSetup:
+		return runSetupStage(ctx, l, failer, args)
+	case StageInject:
+		return runInjectStage(ctx, l, failer, args)
+	case StageRecover:
+		return runRecoverStage(ctx, l, failer, args)
+	case StageCleanup:
+		return runCleanupStage(ctx, l, failer, args)
+	case StageAll:
+		return runFullLifecycle(ctx, l, failer, args, opts)
+	default:
+		return errors.Newf("unknown stage: %s", opts.Stage)
+	}
+}
+
+// runSetupStage runs only the setup phase
+func runSetupStage(
+	ctx context.Context, l *logger.Logger, failer *failures.Failer, args failures.FailureArgs,
+) error {
+	l.Printf("Running setup stage...")
+	if err := failer.Setup(ctx, l, args); err != nil {
+		return errors.Wrap(err, "failed to setup failure")
+	}
+
+	l.Printf("Setup stage completed successfully")
+	return nil
+}
+
+// runInjectStage runs only the inject phase
+func runInjectStage(
+	ctx context.Context, l *logger.Logger, failer *failures.Failer, args failures.FailureArgs,
+) error {
+	l.Printf("Running inject stage...")
+	if err := failer.Inject(ctx, l, args); err != nil {
+		return errors.Wrap(err, "failed to inject failure")
+	}
+	l.Printf("Inject stage completed successfully")
+	return nil
+}
+
+// runRecoverStage runs only the recover phase.
+// When running recover individually with state validation disabled, we use SetInjectArgs
+// to provide the necessary context for recovery without actually running the inject phase.
+func runRecoverStage(
+	ctx context.Context, l *logger.Logger, failer *failures.Failer, args failures.FailureArgs,
+) error {
+	l.Printf("Running recover stage...")
+	// Set the inject args directly so Recover() has the necessary context
+	failer.SetInjectArgs(args)
+	if err := failer.Recover(ctx, l); err != nil {
+		return errors.Wrap(err, "failed to recover from failure")
+	}
+
+	if err := failer.WaitForFailureToRecover(ctx, l); err != nil {
+		return errors.Wrap(err, "failed to wait for failure to recover")
+	}
+
+	l.Printf("Recover stage completed successfully")
+	return nil
+}
+
+// runCleanupStage runs only the cleanup phase.
+// When running cleanup individually with state validation disabled, we use SetSetupArgs
+// to provide the necessary context for cleanup without actually running the setup phase.
+func runCleanupStage(
+	ctx context.Context, l *logger.Logger, failer *failures.Failer, args failures.FailureArgs,
+) error {
+	l.Printf("Running cleanup stage...")
+
+	// Set the setup args directly so Cleanup() has the necessary context
+	failer.SetSetupArgs(args)
+	if err := failer.Cleanup(ctx, l); err != nil {
+		return errors.Wrap(err, "failed to cleanup failure")
+	}
+	l.Printf("Cleanup stage completed successfully")
+	return nil
+}
+
+// runFullLifecycle executes the complete failure lifecycle:
+// Setup → Inject → Wait → Recover → Cleanup
+func runFullLifecycle(
+	ctx context.Context,
+	l *logger.Logger,
+	failer *failures.Failer,
+	args failures.FailureArgs,
+	opts GlobalChaosOpts,
+) error {
+	// Ensure cleanup always runs, even if we panic or get interrupted
+	cleanupDone := false
+	defer func() {
+		if !cleanupDone {
+			l.Printf("Running cleanup due to early exit...")
+			if err := failer.Cleanup(ctx, l); err != nil {
+				l.Errorf("Cleanup failed: %v", err)
+			}
+		}
+	}()
+
+	// Setup phase
+	if err := runSetupStage(ctx, l, failer, args); err != nil {
+		return err
+	}
+
+	// Inject phase
+	if err := runInjectStage(ctx, l, failer, args); err != nil {
+		return err
+	}
+
+	// Wait phase
+	if opts.RunForever {
+		l.Printf("Failure injected. Waiting for interrupt (Ctrl+C)...")
+		<-waitForInterrupt()
+		l.Printf("Interrupt received. Beginning recovery...")
+	} else {
+		l.Printf("Failure injected. Waiting %s before recovery...", opts.WaitBeforeCleanup)
+		select {
+		case <-time.After(opts.WaitBeforeCleanup):
+			l.Printf("Wait period complete. Beginning recovery...")
+		case <-waitForInterrupt():
+			l.Printf("Interrupt received. Beginning recovery...")
+		}
+	}
+
+	// Recover phase
+	if err := runRecoverStage(ctx, l, failer, args); err != nil {
+		return err
+	}
+
+	// Cleanup phase
+	if err := runCleanupStage(ctx, l, failer, args); err != nil {
+		return err
+	}
+
+	cleanupDone = true
+	l.Printf("Failure lifecycle completed successfully")
+	return nil
+}
+
+// waitForInterrupt returns a channel that receives a signal when SIGINT or SIGTERM is received
+func waitForInterrupt() <-chan os.Signal {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	return sigCh
+}
+
+// validateClusterAndNodes validates that:
+// 1. The cluster exists
+// 2. The source and destination nodes are valid for the cluster
+func validateClusterAndNodes(clusterName string, srcNodes, destNodes install.Nodes) error {
+	// Get cluster to validate it exists and get node count
+	c, err := roachprod.GetClusterFromCache(
+		config.Logger,
+		clusterName,
+		install.SimpleSecureOption(!insecure),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "cluster %q not found", clusterName)
+	}
+
+	// Validate source nodes
+	if err := validateNodesInCluster(c, srcNodes, "source"); err != nil {
+		return err
+	}
+
+	// Validate destination nodes
+	if err := validateNodesInCluster(c, destNodes, "destination"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateNodesInCluster validates that all nodes are within the cluster's range
+func validateNodesInCluster(c *install.SyncedCluster, nodes install.Nodes, name string) error {
+	if len(nodes) == 0 {
+		return errors.Newf("%s nodes cannot be empty", name)
+	}
+
+	clusterNodes := c.Nodes
+	if len(clusterNodes) == 0 {
+		return errors.Newf("cluster has no nodes")
+	}
+
+	maxNode := clusterNodes[len(clusterNodes)-1]
+	for _, n := range nodes {
+		if n < 1 || n > maxNode {
+			return errors.Newf("%s node %d is out of range (cluster has nodes 1-%d)",
+				name, n, maxNode)
+		}
+	}
+	return nil
+}
+
+// formatNodeList formats a node list for display
+func formatNodeList(nodes install.Nodes) string {
+	if len(nodes) == 0 {
+		return "none"
+	}
+	parts := make([]string, len(nodes))
+	for i, n := range nodes {
+		parts[i] = fmt.Sprintf("%d", n)
+	}
+	return strings.Join(parts, ",")
+}

--- a/pkg/cmd/roachprod/cli/chaos_network.go
+++ b/pkg/cmd/roachprod/cli/chaos_network.go
@@ -1,0 +1,331 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// buildChaosNetworkCmd creates the network chaos command
+func (cr *commandRegistry) buildChaosNetworkCmd() *cobra.Command {
+	networkCmd := &cobra.Command{
+		Use:   "network [command]",
+		Short: "Network failure-related commands",
+		Long:  `Network failure-related commands for testing cluster behavior under network issues.`,
+	}
+
+	// Add subcommands
+	networkCmd.AddCommand(cr.buildNetworkPartitionCmd())
+	networkCmd.AddCommand(cr.buildNetworkLatencyCmd())
+
+	return networkCmd
+}
+
+// buildNetworkPartitionCmd creates the network partition command
+func (cr *commandRegistry) buildNetworkPartitionCmd() *cobra.Command {
+	partitionCmd := &cobra.Command{
+		Use:   "partition [command]",
+		Short: "Network partition-related commands",
+		Long: `Network partition-related commands for creating network partitions between nodes.
+
+Network partitions use iptables to drop packets between specified nodes, simulating
+network failures. Partitions can be bidirectional (both directions) or asymmetric
+(one direction only).
+`,
+	}
+
+	// Add subcommands
+	partitionCmd.AddCommand(cr.buildNetworkPartitionBidirectionalCmd())
+	partitionCmd.AddCommand(cr.buildNetworkPartitionAsymmetricCmd())
+
+	return partitionCmd
+}
+
+// buildNetworkPartitionBidirectionalCmd creates the bidirectional partition command
+func (cr *commandRegistry) buildNetworkPartitionBidirectionalCmd() *cobra.Command {
+	var srcNodes, destNodes []int32
+
+	cmd := &cobra.Command{
+		Use:   "bidirectional <cluster>",
+		Short: "Drops traffic in both directions between source and destination nodes",
+		Long: `Drops traffic in both directions between source and destination nodes using iptables.
+
+Creates a complete network partition where nodes in the source set cannot communicate
+with nodes in the destination set in either direction. This simulates a complete
+network split.
+
+Examples:
+  # Partition node 1 from nodes 2 and 3
+  roachprod chaos network partition bidirectional mycluster --src 1 --dest 2,3
+
+  # Partition nodes 1-2 from nodes 3-4
+  roachprod chaos network partition bidirectional mycluster --src 1,2 --dest 3,4
+
+  # Run partition for 10 minutes before cleanup
+  roachprod chaos network partition bidirectional mycluster \
+    --src 1 --dest 2 --wait-before-cleanup 10m
+`,
+		Args: cobra.ExactArgs(1),
+		Run: Wrap(func(cmd *cobra.Command, args []string) error {
+			clusterName := args[0]
+			src := parseInt32SliceToNodes(srcNodes)
+			dest := parseInt32SliceToNodes(destNodes)
+			if err := validateClusterAndNodes(clusterName, src, dest); err != nil {
+				return err
+			}
+
+			// Build failure args
+			failureArgs := failures.NetworkPartitionArgs{
+				Partitions: []failures.NetworkPartition{{
+					Source:      src,
+					Destination: dest,
+					Type:        failures.Bidirectional,
+				}},
+			}
+
+			config.Logger.Printf("Creating bidirectional partition: %s <-> %s",
+				formatNodeList(src), formatNodeList(dest))
+
+			opts, err := getGlobalChaosOpts()
+			if err != nil {
+				return err
+			}
+
+			// Create failer from registry
+			failer, err := createFailer(
+				clusterName,
+				failures.IPTablesNetworkPartitionName,
+				opts.Stage,
+				getClusterOptions()...,
+			)
+			if err != nil {
+				return err
+			}
+
+			return runFailureLifecycle(
+				context.Background(),
+				config.Logger,
+				failer,
+				failureArgs,
+				opts,
+			)
+		}),
+	}
+
+	cmd.Flags().Int32SliceVarP(&srcNodes, "src", "s", nil,
+		"source nodes that will have the network partition created")
+	cmd.Flags().Int32SliceVarP(&destNodes, "dest", "d", nil,
+		"destination nodes that will have the network partition created")
+	_ = cmd.MarkFlagRequired("src")
+	_ = cmd.MarkFlagRequired("dest")
+
+	return cmd
+}
+
+// buildNetworkPartitionAsymmetricCmd creates the asymmetric partition command
+func (cr *commandRegistry) buildNetworkPartitionAsymmetricCmd() *cobra.Command {
+	var srcNodes, destNodes []int32
+	var direction string
+
+	cmd := &cobra.Command{
+		Use:   "asymmetric <cluster>",
+		Short: "Creates an asymmetric network partition with directional traffic dropping",
+		Long: `Creates an asymmetric network partition with directional traffic dropping using iptables.
+
+An asymmetric partition drops traffic in only one direction, which can simulate
+firewall misconfigurations or one-way network failures seen in production.
+
+Direction options:
+  incoming: drops incoming traffic on the source from the destination
+  outgoing: drops outgoing traffic from the source to the destination
+
+Examples:
+  # Drop incoming traffic on node 1 from nodes 2,3
+  roachprod chaos network partition asymmetric mycluster \
+    --src 1 --dest 2,3 --direction incoming
+
+  # Drop outgoing traffic from nodes 1,2 to nodes 3,4
+  roachprod chaos network partition asymmetric mycluster \
+    --src 1,2 --dest 3,4 --direction outgoing
+
+  # Run partition until interrupted (Ctrl+C)
+  roachprod chaos network partition asymmetric mycluster \
+    --src 1 --dest 2 --direction incoming --run-forever
+`,
+		Args: cobra.ExactArgs(1),
+		Run: Wrap(func(cmd *cobra.Command, args []string) error {
+			var partitionType failures.PartitionType
+			switch direction {
+			case "incoming":
+				partitionType = failures.Incoming
+			case "outgoing":
+				partitionType = failures.Outgoing
+			default:
+				return errors.Newf("--direction must be 'incoming' or 'outgoing', got: %s", direction)
+			}
+
+			clusterName := args[0]
+			src := parseInt32SliceToNodes(srcNodes)
+			dest := parseInt32SliceToNodes(destNodes)
+			if err := validateClusterAndNodes(clusterName, src, dest); err != nil {
+				return err
+			}
+
+			// Build failure args
+			failureArgs := failures.NetworkPartitionArgs{
+				Partitions: []failures.NetworkPartition{{
+					Source:      src,
+					Destination: dest,
+					Type:        partitionType,
+				}},
+			}
+
+			if partitionType == failures.Incoming {
+				config.Logger.Printf("Creating asymmetric partition: %s <-X- %s (dropping incoming)",
+					formatNodeList(src), formatNodeList(dest))
+			} else {
+				config.Logger.Printf("Creating asymmetric partition: %s -X-> %s (dropping outgoing)",
+					formatNodeList(src), formatNodeList(dest))
+			}
+
+			opts, err := getGlobalChaosOpts()
+			if err != nil {
+				return err
+			}
+
+			// Create failer from registry
+			failer, err := createFailer(
+				clusterName,
+				failures.IPTablesNetworkPartitionName,
+				opts.Stage,
+				getClusterOptions()...,
+			)
+			if err != nil {
+				return err
+			}
+
+			// Execute lifecycle
+			return runFailureLifecycle(
+				context.Background(),
+				config.Logger,
+				failer,
+				failureArgs,
+				opts,
+			)
+		}),
+	}
+
+	cmd.Flags().Int32SliceVarP(&srcNodes, "src", "s", nil,
+		"source nodes that will have the network partition created")
+	cmd.Flags().Int32SliceVarP(&destNodes, "dest", "d", nil,
+		"destination nodes that will have the network partition created")
+	cmd.Flags().StringVar(&direction, "direction", "",
+		"direction from which to drop traffic (incoming|outgoing)")
+	_ = cmd.MarkFlagRequired("src")
+	_ = cmd.MarkFlagRequired("dest")
+	_ = cmd.MarkFlagRequired("direction")
+
+	return cmd
+}
+
+// buildNetworkLatencyCmd creates the network latency command
+func (cr *commandRegistry) buildNetworkLatencyCmd() *cobra.Command {
+	var srcNodes, destNodes []int32
+	var delay time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "latency <cluster>",
+		Short: "Injects artificial network latency between nodes using tc and iptables",
+		Long: `Injects artificial network latency between nodes using tc (traffic control) and iptables.
+
+This command adds a specified delay to network packets traveling from source nodes
+to destination nodes. The delay is one-way; for round-trip latency, you may need
+to run the command twice with source and destination swapped.
+
+The latency is implemented using Linux tc (traffic control) with netem (network
+emulation) qdisc, which provides realistic network delay simulation.
+
+Examples:
+  # Add 100ms latency from node 1 to nodes 2,3
+  roachprod chaos network latency mycluster --src 1 --dest 2,3 --delay 100ms
+
+  # Add 1 second latency between node groups
+  roachprod chaos network latency mycluster --src 1,2 --dest 3,4 --delay 1s
+
+  # Run with custom cleanup time
+  roachprod chaos network latency mycluster \
+    --src 1 --dest 2 --delay 500ms --wait-before-cleanup 15m
+`,
+		Args: cobra.ExactArgs(1),
+		Run: Wrap(func(cmd *cobra.Command, args []string) error {
+			if delay <= 0 {
+				return errors.New("--delay must be greater than 0")
+			}
+
+			clusterName := args[0]
+			src := parseInt32SliceToNodes(srcNodes)
+			dest := parseInt32SliceToNodes(destNodes)
+			if err := validateClusterAndNodes(clusterName, src, dest); err != nil {
+				return err
+			}
+
+			// Build failure args
+			failureArgs := failures.NetworkLatencyArgs{
+				ArtificialLatencies: []failures.ArtificialLatency{{
+					Source:      src,
+					Destination: dest,
+					Delay:       delay,
+				}},
+			}
+
+			config.Logger.Printf("Injecting %s latency: %s -> %s",
+				delay, formatNodeList(src), formatNodeList(dest))
+
+			opts, err := getGlobalChaosOpts()
+			if err != nil {
+				return err
+			}
+
+			// Create failer from registry
+			failer, err := createFailer(
+				clusterName,
+				failures.NetworkLatencyName,
+				opts.Stage,
+				getClusterOptions()...,
+			)
+			if err != nil {
+				return err
+			}
+
+			// Execute lifecycle
+			return runFailureLifecycle(
+				context.Background(),
+				config.Logger,
+				failer,
+				failureArgs,
+				opts,
+			)
+		}),
+	}
+
+	cmd.Flags().Int32SliceVarP(&srcNodes, "src", "s", nil,
+		"source nodes that will experience the injected latency")
+	cmd.Flags().Int32SliceVarP(&destNodes, "dest", "d", nil,
+		"destination nodes that will experience the injected latency")
+	cmd.Flags().DurationVar(&delay, "delay", 0,
+		"delay to inject between source and destination nodes (e.g. 100ms, 1s)")
+	_ = cmd.MarkFlagRequired("src")
+	_ = cmd.MarkFlagRequired("dest")
+	_ = cmd.MarkFlagRequired("delay")
+
+	return cmd
+}

--- a/pkg/cmd/roachprod/cli/resgistry.go
+++ b/pkg/cmd/roachprod/cli/resgistry.go
@@ -73,5 +73,6 @@ func (cr *commandRegistry) register() {
 		cr.buildFetchLogsCmd(),
 		cr.buildGetLatestPProfCmd(),
 		cr.buildFetchCertsDir(),
+		cr.buildChaosCmd(),
 	})
 }

--- a/pkg/roachprod/failureinjection/failures/failer.go
+++ b/pkg/roachprod/failureinjection/failures/failer.go
@@ -214,3 +214,15 @@ func (f *Failer) Cleanup(ctx context.Context, l *logger.Logger) error {
 	}
 	return nil
 }
+
+// SetSetupArgs sets the setupArgs field directly. This should only be used when
+// state validation is disabled and you need to manually provide args for cleanup.
+func (f *Failer) SetSetupArgs(args FailureArgs) {
+	f.setupArgs = args
+}
+
+// SetInjectArgs sets the injectArgs field directly. This should only be used when
+// state validation is disabled and you need to manually provide args for recovery.
+func (f *Failer) SetInjectArgs(args FailureArgs) {
+	f.injectArgs = args
+}


### PR DESCRIPTION
This commit introduces the `roachprod chaos` command tree, providing CLI support for the failure injection library to test cluster resilience under various failure scenarios.

Changes:
- Add `chaos` root command with global flags for controlling failure duration and cleanup behavior
- Implement network failure commands:
- `chaos network-partition`: bidirectional and asymmetric network splits
- `chaos network-latency`: artificial network delay injection

Example usage:
```shell
roachprod chaos network-partition $CLUSTER --src 1 --dest 2,3 --type asymmetric
```
Epic: none

Release note: None

Fixes: #140634