### PR TITLE
rangefeed: extract TxnPushNotifier

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "stream_manager.go",
         "task.go",
         "test_helpers.go",
+        "txn_push_notifier.go",
         "unbuffered_registration.go",
         "unbuffered_sender.go",
     ],

--- a/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
@@ -211,6 +211,7 @@ type processorTestHelper struct {
 	rts                      *resolvedTimestamp
 	syncEventC               func()
 	sendSpanSync             func(*roachpb.Span)
+	rawScheduler             *Scheduler
 	scheduler                *ClientScheduler
 	toBufferedStreamIfNeeded func(s Stream) Stream
 }
@@ -348,7 +349,7 @@ func withSettings(st *cluster.Settings) option {
 	}
 }
 
-func withPushTxnsIntervalAge(interval, age time.Duration) option {
+func withPushTxnsIntervalAge(age time.Duration) option {
 	return func(config *testConfig) {
 		config.PushTxnsAge = age
 	}
@@ -451,6 +452,7 @@ func newTestProcessor(
 		h.sendSpanSync = func(span *roachpb.Span) {
 			p.syncSendAndWait(&syncEvent{c: make(chan struct{}), testRegCatchupSpan: span})
 		}
+		h.rawScheduler = sch
 		h.scheduler = &p.scheduler
 		switch cfg.feedType {
 		case scheduledProcessorWithUnbufferedSender:

--- a/pkg/kv/kvserver/rangefeed/txn_push_notifier.go
+++ b/pkg/kv/kvserver/rangefeed/txn_push_notifier.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rangefeed
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+// TxnPushNotifier enqueues a PushTxnEvent for all processors yielded by
+// visitProcessors every interval.
+type TxnPushNotifier struct {
+	interval        time.Duration
+	settings        *cluster.Settings
+	scheduler       *Scheduler
+	visitProcessors func(func(int64))
+}
+
+func NewTxnPushNotifier(
+	interval time.Duration,
+	settings *cluster.Settings,
+	scheduler *Scheduler,
+	visitProcessors func(func(int64)),
+) *TxnPushNotifier {
+	return &TxnPushNotifier{
+		interval:        interval,
+		settings:        settings,
+		scheduler:       scheduler,
+		visitProcessors: visitProcessors,
+	}
+}
+
+func (t *TxnPushNotifier) Start(ctx context.Context, stopper *stop.Stopper) error {
+	taskOpts := stop.TaskOpts{
+		TaskName: "rangefeed-txn-push-notifier",
+		SpanOpt:  stop.SterileRootSpan,
+	}
+	ctx, hdl, err := stopper.GetHandle(ctx, taskOpts)
+	if err != nil {
+		return err
+	}
+	go func(ctx context.Context, hdl *stop.Handle) {
+		defer hdl.Activate(ctx).Release(ctx)
+
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
+		ticker := time.NewTicker(t.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if !PushTxnsEnabled.Get(&t.settings.SV) {
+					continue
+				}
+
+				batch := t.scheduler.NewEnqueueBatch()
+				t.visitProcessors(batch.Add)
+				t.scheduler.EnqueueBatch(batch, PushTxnQueued)
+				batch.Close()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}(ctx, hdl)
+	return nil
+}


### PR DESCRIPTION
This addresses a testing TODO by extracting the txn push notification goroutine into a struct that can be tested without a store.

This perhaps makes it a bit synthetic of a test since we don't have a test that ensures that the store starts the push notifier. But, we weren't testing anything at all before so this still feels like an improvement.

Epic: none
Release note: None