### PR TITLE
dev-inf: Fix YAML syntax error in GH action

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -174,8 +174,8 @@ jobs:
             3. A suggested fix
 
             **OUTPUT REQUIREMENT**: End your response with a single line containing only:
-            - `STAGE3_RESULT: POTENTIAL_BUG_CONFIRMED` or
-            - `STAGE3_RESULT: NO_BUG_FOUND`
+            - `STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED` or
+            - `STAGE3_RESULT - NO_BUG_FOUND`
 
       - name: Extract Stage 3 Result
         id: stage3_result
@@ -226,7 +226,7 @@ jobs:
             **If all three stages detected bugs**, this indicates a potential issue that warrants investigation.
 
       - name: Comment on PR if bugs confirmed
-        if: contains(steps.stage3_result.outputs.result, 'STAGE3_RESULT: POTENTIAL_BUG_CONFIRMED')
+        if: contains(steps.stage3_result.outputs.result, 'STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Changed Stage 3 output format from using colon to dash to avoid
YAML parsing error. The colon in 'STAGE3_RESULT: POTENTIAL_BUG_CONFIRMED'
was causing YAML to interpret it as a mapping instead of a string.

Changed to: 'STAGE3_RESULT - POTENTIAL_BUG_CONFIRMED'

This syntax error was preventing the entire workflow from running.

Epic: none
Release note: none