### PR TITLE
sql/stats: improve SHOW STATISTICS with merged and forecasted stats

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -431,6 +431,18 @@ WHERE stat->>'name' = '__forecast__';
     "row_count": 18
 }
 
+# Verify that we display forecasted stats even when we don't show merged stats
+# that it is based on.
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE g WITH FORECAST]
+ORDER BY created
+----
+__auto__      {b}  1988-08-05 00:00:00 +0000 UTC  3   3   0  1
+__auto__      {b}  1988-08-07 00:00:00 +0000 UTC  9   9   0  1
+partial       {b}  1988-08-08 00:00:00 +0000 UTC  3   3   0  2
+__forecast__  {b}  1988-08-10 00:00:00 +0000 UTC  18  18  0  1
+
 # Verify that when the partial histogram is empty
 # the returned statistic is the latest full statistic
 # renamed to __merged__ with the created_at time

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -195,9 +195,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					statsList[i], statsList[j] = statsList[j], statsList[i]
 				}
 
+				merged := stats.MergedStatistics(ctx, statsList, p.ExtendedEvalContext().Settings)
+				statsList = append(merged, statsList...)
 				if withMerge {
-					merged := stats.MergedStatistics(ctx, statsList, p.ExtendedEvalContext().Settings)
-					statsList = append(merged, statsList...)
 					// Iterate in reverse order to match the ORDER BY "columnIDs".
 					for i := len(merged) - 1; i >= 0; i-- {
 						mergedRow, err := tableStatisticProtoToRow(&merged[i].TableStatisticProto)


### PR DESCRIPTION
This commit make `SHOW STATISTICS` compute merged stats unconditionally, and output them only if `WITH MERGE` is specified. Previously, we would compute merged stats only if `WITH MERGE` was specified, which could prevent us from seeing forecasted stats that depend on merged stats when specifying `WITH FORECAST` (without `MERGE`). This change is consistent with the stats cache, which computes merged stats unconditionally and uses them to create forecasts.

Fixes: #155612

Release note (bug fix): Previously, we could have inconsistencies between the forecasted stats shown in `SHOW STATISTICS ... WITH FORECAST` and forecasted stats in the stats cache depending on whether `WITH MERGE` was also specified. We now correctly display all forecasted stats, regardless of `WITH MERGE`.