### PR TITLE
dev-inf: Fix jq command to handle JSON array format

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -66,7 +66,7 @@ jobs:
         id: stage1_result
         if: steps.stage1.conclusion == 'success'
         run: |
-          RESULT=$(jq -r 'select(.type == "result") | .result' "${{ steps.stage1.outputs.execution_file }}")
+          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "${{ steps.stage1.outputs.execution_file }}")
           {
             echo 'result<<EOF'
             echo "$RESULT"
@@ -116,7 +116,7 @@ jobs:
         id: stage2_result
         if: steps.stage2.conclusion == 'success'
         run: |
-          RESULT=$(jq -r 'select(.type == "result") | .result' "${{ steps.stage2.outputs.execution_file }}")
+          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "${{ steps.stage2.outputs.execution_file }}")
           {
             echo 'result<<EOF'
             echo "$RESULT"
@@ -181,7 +181,7 @@ jobs:
         id: stage3_result
         if: steps.stage3.conclusion == 'success'
         run: |
-          RESULT=$(jq -r 'select(.type == "result") | .result' "${{ steps.stage3.outputs.execution_file }}")
+          RESULT=$(jq -r '.[] | select(.type == "result") | .result' "${{ steps.stage3.outputs.execution_file }}")
           {
             echo 'result<<EOF'
             echo "$RESULT"


### PR DESCRIPTION
The execution file is a JSON array, not JSONL format. Updated all
extraction steps to use '.[]' to iterate over the array before
filtering by type.

Changed from: jq -r 'select(.type == "result") | .result'
Changed to: jq -r '.[] | select(.type == "result") | .result'

This fixes the error: "Cannot index array with string 'type'"

Tested locally with both array and JSONL formats to verify the fix works.

Epic: none
Release note: none