### PR TITLE
release-25.4: roachtest: increase server.sqlliveness.ttl in copyfrom

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -150,10 +150,14 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=copy_from=2,insert=2")
 	// The roachtest frequently runs on overloaded instances and can timeout as
 	// a result. We've seen cases where the atomic COPY takes about 2 minutes to
-	// complete, so we set the closed TS to 5 minutes (to give enough safety
-	// gap, otherwise the closed TS system might continuously push the COPY txn
-	// not allowing it ever to complete).
-	clusterSettings := install.MakeClusterSettings(install.ClusterSettingsOption{"kv.closed_timestamp.target_duration": "300s"})
+	// complete, so we set the closed TS and SQL liveness TTL to 5 minutes (to
+	// give enough safety gap, otherwise the closed TS system and lease system
+	// expireation might continuously push the COPY txn not allowing it ever to
+	// complete).
+	clusterSettings := install.MakeClusterSettings(install.ClusterSettingsOption{
+		"kv.closed_timestamp.target_duration": "300s",
+		"server.sqlliveness.ttl":              "300s",
+	})
 	c.Start(ctx, t.L(), startOpts, clusterSettings, c.All())
 	initTest(ctx, t, c, sf)
 	db, err := c.ConnE(ctx, t.L(), 1)


### PR DESCRIPTION
Backport 1/1 commits from #155555 on behalf of @yuzefovich.

----

`copyfrom/atomic` often fails with `RETRY_COMMIT_DEADLINE_EXCEEDED` error. Based on some guidance from KV folks, it sounds like (apart from the closed TS system that has already been adjusted) the most likely explanation is that the lease on a descriptor has expired while the txn was running. Before 24.1 we used expiry based leasing, then we introduced session based leasing, and the migration to only use that has been completed in the beginning of the year. If I'm reading the code right, then the lease duration depends on the SQL liveness TTL, so this commit bumps the relevant cluster setting from 40s to 5m to give enough time for atomic COPY to finish.

I did 50 runs of the test, and all of them passed.

Fixes: #155300.
Release note: None

----

Release justification: test-only change.