### PR TITLE
write unification first try

### DIFF
--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -199,7 +199,7 @@ func ResolveDest(
 	defer rootStore.Close()
 	priors, err := FindAllIncrementalPaths(
 		ctx, execCfg, incrementalStore, rootStore,
-		chosenSuffix, OmitManifest, len(dest.IncrementalStorage) > 0,
+		chosenSuffix, len(dest.IncrementalStorage) > 0,
 	)
 	if err != nil {
 		return ResolvedDestination{}, errors.Wrap(err, "adjusting backup destination to append new layer to existing backup")

--- a/pkg/backup/backupdest/incrementals_test.go
+++ b/pkg/backup/backupdest/incrementals_test.go
@@ -243,7 +243,7 @@ func TestFindAllIncrementalPaths(t *testing.T) {
 
 			incs, err := backupdest.FindAllIncrementalPaths(
 				ctx, &execCfg, incStore, store,
-				targetSubdir, false /* includeManifest */, false, /* customIncLocation */
+				targetSubdir, false, /* customIncLocation */
 			)
 			require.NoError(t, err)
 			require.Len(t, incs, len(targetChain)-1)
@@ -324,7 +324,7 @@ func TestFindAllIncrementalPathsFallbackLogic(t *testing.T) {
 
 		incs, err := backupdest.FindAllIncrementalPaths(
 			ctx, &execCfg, stores.inc, stores.root,
-			subdir, false /* includeManifest */, false, /* customIncLocation */
+			subdir, false, /* customIncLocation */
 		)
 		require.NoError(t, err)
 		require.Len(t, incs, numBackups-1)
@@ -348,7 +348,7 @@ func TestFindAllIncrementalPathsFallbackLogic(t *testing.T) {
 
 		incs, err := backupdest.FindAllIncrementalPaths(
 			ctx, &execCfg, stores.customInc, stores.root,
-			subdir, false /* includeManifest */, true, /* customIncLocation */
+			subdir, true, /* customIncLocation */
 		)
 		require.NoError(t, err)
 		require.Len(t, incs, numBackups-1)
@@ -390,14 +390,14 @@ func TestFindAllIncrementalPathsFallbackLogic(t *testing.T) {
 		// List from both default and custom incremental locations.
 		incs, err := backupdest.FindAllIncrementalPaths(
 			ctx, &execCfg, stores.inc, stores.root,
-			subdir, false /* includeManifest */, false, /* customIncLocation */
+			subdir, false, /* customIncLocation */
 		)
 		require.NoError(t, err)
 		require.Len(t, incs, numDefaultIncs)
 
 		incs, err = backupdest.FindAllIncrementalPaths(
 			ctx, &execCfg, stores.customInc, stores.root,
-			subdir, false /* includeManifest */, true, /* customIncLocation */
+			subdir, true, /* customIncLocation */
 		)
 		require.NoError(t, err)
 		require.Len(t, incs, numCustomIncs)

--- a/pkg/backup/backupinfo/manifest_handling.go
+++ b/pkg/backup/backupinfo/manifest_handling.go
@@ -301,9 +301,8 @@ func readManifest(
 		}
 	}
 
-	var encryptionKey []byte
 	if encryption != nil {
-		encryptionKey, err = backupencryption.GetEncryptionKey(ctx, encryption, kmsEnv)
+		encryptionKey, err := backupencryption.GetEncryptionKey(ctx, encryption, kmsEnv)
 		if err != nil {
 			return backuppb.BackupManifest{}, 0, err
 		}


### PR DESCRIPTION
…ed setting

This patch removes the bulkio.backup.deprecated_full_backup_with_subdir.enabled
cluster setting, since when set to true, the backups will now fail.

Release note (ops change): this patch removes the
bulkio.backup.deprecated_full_backup_with_subdir.enabled cluster setting, since
backups will now fail if it is set to true.