### PR TITLE
release-25.4: sql/stats: handle range counts when skipping dropped enum hist buckets

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -300,7 +300,7 @@ type HistogramBucket struct {
 
 	// DistinctRange is the estimated number of distinct values between the upper
 	// bound of the previous bucket and UpperBound (both boundaries are
-	// exclusive).
+	// exclusive). The first bucket should always have DistinctRange=0.
 	DistinctRange float64
 
 	// UpperBound is the upper bound of the bucket.


### PR DESCRIPTION
Backport 1/2 commits from #155035.

/cc @cockroachdb/release

---

**opt/props: only check histogram NumRange=0 in test builds**

These assertions that the first histogram bucket has NumRange=0 are
useful for catching bugs, but a liability in production
environments. Even with malformed histograms, we should not be failing
query execution. Only check these assertions in test builds.

Informs: #154461

Release note (bug fix): Change assertions about histogram NumRange=0 to
only be checked in test builds.

---

Release justification: low-risk fix for a critical support issue.