### PR TITLE
sql: don't run EXPLAIN ANALYZE via pausable portals

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1476,7 +1476,13 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		if portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 			portal.pauseInfo.execStmtInOpenState.ihWrapper = &instrumentationHelperWrapper{
 				ctx: ctx,
-				ih:  *ih,
+				// TODO(yuzefovich): we're capturing the instrumentationHelper
+				// by value here, meaning that modifications that happen later
+				// (notably in makeExecPlan) aren't captured. For example,
+				// explainPlan field will remain unset. However, so far we've
+				// only observed this impact EXPLAIN ANALYZE which doesn't run
+				// through the pausable portal path.
+				ih: *ih,
 			}
 		} else {
 			p.instrumentation = portal.pauseInfo.execStmtInOpenState.ihWrapper.ih

--- a/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
+++ b/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
@@ -1629,3 +1629,100 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 subtest end
+
+subtest explain_analyze
+
+# Regression test that EXPLAIN ANALYZE doesn't run through the pausable portal
+# path even when the feature is enabled (#137597).
+
+send crdb_only
+Query {"String": "SET multiple_active_portals_enabled = 'true';"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "BEGIN"}
+Parse {"Name": "qea1", "Query": "EXPLAIN ANALYZE SELECT 1;"}
+Bind {"DestinationPortal": "pea1", "PreparedStatement": "qea1"}
+Execute {"Portal": "pea1", "MaxRows": 1}
+Sync
+----
+
+until crdb_only ignore=DataRow
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Execute {"Portal": "pea1"}
+Sync
+----
+
+until crdb_only ignore=DataRow
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "BEGIN"}
+Parse {"Name": "qea2", "Query": "EXPLAIN ANALYZE (DEBUG) SELECT 1;"}
+Bind {"DestinationPortal": "pea2", "PreparedStatement": "qea2"}
+Execute {"Portal": "pea2", "MaxRows": 1}
+Sync
+----
+
+until crdb_only ignore=DataRow
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Execute {"Portal": "pea2"}
+Sync
+----
+
+until crdb_only ignore=DataRow
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+subtest end


### PR DESCRIPTION
This commit disables running EXPLAIN ANALYZE stmts via pausable portals model even if it's enabled. Previously, this led to a crash since different assumptions of how EXPLAIN ANALYZE is handled at the connExecutor level were broken, but it also doesn't make much sense to actually support this. After all, the result rows can only be produced _after_ the query execution effectively completed, which contradicts the spirit of the pausable portal feature.

I briefly looked into making it work, but it doesn't seem worth it. There is a fundamental contradiction right now that we defer finishing the instrumentationHelper (which populates the output of EXPLAIN ANALYZE), and it currently happens after we close the commandResult in which we can write the output.

Fixes: #137597.

Release note (bug fix): Previously, CockroachDB would crash when executing EXPLAIN ANALYZE statements with the pausable portal model (meaning that it was run via the extended PGWire protocol using Parse, Bind, Execute, when `multiple_active_portals_enabled` session variable is enabled). The bug has been present since 23.2 and is now fixed.