### PR TITLE
release-25.3: pgwire: make max repeated error count configurable via cluster setting

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -94,6 +94,15 @@ var logVerboseSessionAuth = settings.RegisterBoolSetting(
 	false,
 	settings.WithPublic)
 
+var maxRepeatedErrorCount = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"sql.pgwire.max_repeated_error_count",
+	"the maximum number of times an error can be received while reading from a "+
+		"network connection before the server aborts the connection",
+	1<<15, // 32768
+	settings.PositiveInt,
+)
+
 const (
 	// ErrSSLRequired is returned when a client attempts to connect to a
 	// secure server in cleartext.
@@ -1071,11 +1080,6 @@ func (s *Server) newConn(
 	return c
 }
 
-// maxRepeatedErrorCount is the number of times an error can be received
-// while reading from the network connection before the server decides to give
-// up and abort the connection.
-const maxRepeatedErrorCount = 1 << 8
-
 // serveImpl continuously reads from the network connection and pushes execution
 // instructions into a sql.StmtBuf, from where they'll be processed by a command
 // "processor" goroutine (a connExecutor).
@@ -1447,7 +1451,7 @@ func (s *Server) serveImpl(
 			// 3. we reached an arbitrary threshold of repeated errors.
 			if netutil.IsClosedConnection(err) ||
 				errors.Is(err, context.Canceled) ||
-				repeatedErrorCount > maxRepeatedErrorCount {
+				repeatedErrorCount > int(maxRepeatedErrorCount.Get(&s.execCfg.Settings.SV)) {
 				break
 			}
 		} else {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1074,7 +1074,7 @@ func (s *Server) newConn(
 // maxRepeatedErrorCount is the number of times an error can be received
 // while reading from the network connection before the server decides to give
 // up and abort the connection.
-const maxRepeatedErrorCount = 1 << 15
+const maxRepeatedErrorCount = 1 << 8
 
 // serveImpl continuously reads from the network connection and pushes execution
 // instructions into a sql.StmtBuf, from where they'll be processed by a command


### PR DESCRIPTION
Backport:
  * 1/1 commits from "pgwire: lower the max repeated error count before closing a connection" (#154916)
  * 1/1 commits from "pgwire: make max repeated error count configurable via cluster setting" (#155656)

Please see individual commits for details.

Release justification: low risk change that is gated by an opt-in cluster setting; will help reduce CPU usage during network timeouts.
