### PR TITLE
Update diagram for ALTER EXTERNAL CONNECTION

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -25,7 +25,7 @@ FILES = [
     "alter_database_to_schema_stmt",
     "alter_ddl_stmt",
     "alter_default_privileges_stmt",
-    "alter_external_connection_stmt",
+    "alter_external_connection",
     "alter_func_stmt",
     "alter_func_options_stmt",
     "alter_func_rename_stmt",

--- a/docs/generated/sql/bnf/alter_external_connection.bnf
+++ b/docs/generated/sql/bnf/alter_external_connection.bnf
@@ -1,0 +1,3 @@
+alter_external_connection_stmt ::=
+	'ALTER' 'EXTERNAL' 'CONNECTION' connection_name 'AS' connection_uri
+	| 'ALTER' 'EXTERNAL' 'CONNECTION' 'IF' 'EXISTS' connection_name 'AS' connection_uri

--- a/docs/generated/sql/bnf/alter_external_connection_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_external_connection_stmt.bnf
@@ -1,3 +1,0 @@
-alter_external_connection_stmt ::=
-	'ALTER' 'EXTERNAL' 'CONNECTION' label_spec 'AS' string_or_placeholder
-	| 'ALTER' 'EXTERNAL' 'CONNECTION' 'IF' 'EXISTS' label_spec 'AS' string_or_placeholder

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -416,6 +416,12 @@ var specs = []stmtSpec{
 		nosplit: true,
 	},
 	{
+		name:    "alter_external_connection",
+		stmt:    "alter_external_connection_stmt",
+		replace: map[string]string{"label_spec": "connection_name", "string_or_placeholder": "connection_uri"},
+		unlink:  []string{"connection_name", "connection_uri"},
+	},
+	{
 		name:    "alter_index",
 		stmt:    "alter_index_stmt",
 		inline:  []string{"alter_oneindex_stmt", "alter_index_cmds", "alter_index_cmd", "partition_by_index", "partition_by_inner", "partition_by", "table_index_name", "alter_split_index_stmt", "alter_unsplit_index_stmt", "alter_rename_index_stmt", "alter_zone_index_stmt", "var_set_list", "alter_index_visible_stmt", "set_zone_config", "alter_index_visible"},

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -25,7 +25,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:alter_database_to_schema_stmt.bnf",
     "//docs/generated/sql/bnf:alter_ddl_stmt.bnf",
     "//docs/generated/sql/bnf:alter_default_privileges_stmt.bnf",
-    "//docs/generated/sql/bnf:alter_external_connection_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_external_connection.bnf",
     "//docs/generated/sql/bnf:alter_func_dep_extension_stmt.bnf",
     "//docs/generated/sql/bnf:alter_func_options_stmt.bnf",
     "//docs/generated/sql/bnf:alter_func_owner_stmt.bnf",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -35,7 +35,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:alter_database_to_schema_stmt.bnf",
     "//docs/generated/sql/bnf:alter_ddl_stmt.bnf",
     "//docs/generated/sql/bnf:alter_default_privileges_stmt.bnf",
-    "//docs/generated/sql/bnf:alter_external_connection_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_external_connection.bnf",
     "//docs/generated/sql/bnf:alter_func_dep_extension_stmt.bnf",
     "//docs/generated/sql/bnf:alter_func_options_stmt.bnf",
     "//docs/generated/sql/bnf:alter_func_owner_stmt.bnf",


### PR DESCRIPTION
docgen: update ALTER EXTERNAL CONNECTION diagram
Epic: none
Release note: none
Release justification: non-production code change

Part of [DOC-13254](https://cockroachlabs.atlassian.net/browse/DOC-13254)

New diagram:
<img width="1023" height="283" alt="Screenshot 2025-10-17 at 7 24 43 PM" src="https://github.com/user-attachments/assets/21975cb9-e9ef-4162-8782-7249436bad05" />
