### PR TITLE
sql: add safety gates for pausable portal cleanup and flow invalidation

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1979,7 +1979,10 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 		}
 		if !p.resumableFlow.cleanup.isComplete {
 			p.resumableFlow.cleanup.appendFunc(func(ctx context.Context) {
-				p.resumableFlow.flow.Cleanup(ctx)
+				if p.resumableFlow.flow != nil {
+					p.resumableFlow.flow.Cleanup(ctx)
+					p.resumableFlow.flow = nil
+				}
 			})
 		}
 	}


### PR DESCRIPTION
Informs: https://github.com/cockroachlabs/support/issues/3463

When a pausable portal encounters an error during execution, two issues can lead to panics on subsequent resume attempts:

1. The underlying FlowBase gets reset to nil during cleanup, but the portal's flow reference remains non-nil, causing hasFlowForPausablePortal() to incorrectly return true.

2. Errored portals are not removed from the portal map because deletion only occurs when execStmt() returns a non-nil fsm.Event.

This change adds two defensive checks:
- Nil the whole flow object hanging off the `portalInfo` while cleaning up the flow.
- Ensure errored portals are properly cleaned up regardless of event state

These gates prevent nil pointer dereferences when resuming portals that have been partially cleaned up due to errors.

Release note: None