### PR TITLE
kvserver: set vmodule for TestClosedTimestampFrozenAfterSubsumption

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -628,7 +628,7 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 
 	// Increase the verbosity of the logs to help debug the test if it fails, especially
 	// raft related logs when the test tries to transfer the lease non-cooperatively.
-	testutils.SetVModule(t, "raft=4,*=1")
+	testutils.SetVModule(t, "raft=4,*=1,support_manager=4")
 
 	for _, test := range []struct {
 		name string

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -330,8 +330,9 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 		}
 	}
 	sm.metrics.HeartbeatSuccesses.Inc(int64(successes))
-	sm.metrics.HeartbeatFailures.Inc(int64(len(heartbeats) - successes))
-	log.KvExec.VInfof(ctx, 2, "sent heartbeats to %d stores", successes)
+	failures := int64(len(heartbeats) - successes)
+	sm.metrics.HeartbeatFailures.Inc(failures)
+	log.KvExec.VInfof(ctx, 2, "sent heartbeats to %d stores (%d failed)", successes, failures)
 }
 
 // withdrawSupport delegates support withdrawal to supporterStateHandler.


### PR DESCRIPTION
This commit adds vmodule for support_manager to debug
TestClosedTimestampFrozenAfterSubsumption flakes seen after store
support withdrawal.


Inform: https://github.com/cockroachdb/cockroach/issues/155517