### PR TITLE
wagpb: clarify structure of WAG nodes

### DIFF
--- a/pkg/kv/kvserver/kvstorage/wag/testdata/TestWrite.txt
+++ b/pkg/kv/kvserver/kvstorage/wag/testdata/TestWrite.txt
@@ -1,13 +1,13 @@
 echo
 ----
 >> create
-Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): NodeCreate r123/4:0
+Put: 0,0 /Local/Store/wag/1 (0x01737761676e000000000000000100): EventCreate r123/4:0
 > Put: 0,0 "state-machine-key" (0x73746174652d6d616368696e652d6b657900): "state"
 >> init
-Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): NodeSnap r123/4:10
+Put: 0,0 /Local/Store/wag/2 (0x01737761676e000000000000000200): EventSnap r123/4:10
 ingestion: SSTs:"tmp/1.sst" SSTs:"tmp/2.sst" 
 >> split
-Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): NodeApply r123/4:199
-Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): NodeSplit r123/4:200 create:567
+Put: 0,0 /Local/Store/wag/3 (0x01737761676e000000000000000300): EventApply r123/4:199
+Put: 0,0 /Local/Store/wag/4 (0x01737761676e000000000000000400): EventApply r123/4:200 EventSplit:567
 > Put: 0,0 "lhs-key" (0x6c68732d6b657900): "lhs-state"
 > Put: 0,0 "rhs-key" (0x7268732d6b657900): "rhs-state"

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -104,8 +104,10 @@ message Mutation {
 // Ingestion describes a Pebble ingestion.
 message Ingestion {
   repeated string SSTs = 1;
-  repeated cockroach.kv.kvserver.kvserverpb.SnapshotRequest.SharedTable shared_tables = 2;
-  repeated cockroach.kv.kvserver.kvserverpb.SnapshotRequest.ExternalTable external_tables = 3;
+  repeated cockroach.kv.kvserver.kvserverpb.SnapshotRequest.SharedTable shared_tables = 2 [
+    (gogoproto.nullable) = false];
+  repeated cockroach.kv.kvserver.kvserverpb.SnapshotRequest.ExternalTable external_tables = 3 [
+    (gogoproto.nullable) = false];
 
   // TODO(pav-kv): add the excise span, to mirror the IngestAndExciseFiles call
   // on storage.Engine.

--- a/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
+++ b/pkg/kv/kvserver/kvstorage/wag/wagpb/wag.proto
@@ -10,31 +10,31 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/
 import "gogoproto/gogo.proto";
 import "kv/kvserver/kvserverpb/raft.proto";
 
-// NodeType defines the type of the WAG node. It corresponds to a replica
-// lifecycle event, and specifies how the node is addressed and interpreted.
-enum NodeType {
-  // NodeEmpty is the "empty" type. Can be used as a nil/no-op indicator. We
+// EventType defines the type of a replica lifecycle event.
+enum EventType {
+  // EventEmpty is the "empty" type. Can be used as a nil/no-op indicator. We
   // just have it so that all "real" types are specified explicitly.
-  NodeEmpty = 0;
-  // NodeCreate corresponds to a creation of an uninitialized replica. All
+  EventEmpty = 0;
+  // EventCreate corresponds to a creation of an uninitialized replica. All
   // replicas on a Store go through this transition.
-  NodeCreate = 1;
-  // NodeSnap corresponds to initializing/resetting a replica state machine with
-  // a snapshot. Happens when an uninitialized replica is initialized, or when
-  // an initialized replica is caught up on a later applied state. A NodeSnap
+  EventCreate = 1;
+  // EventSnap corresponds to initializing/resetting a replica state machine
+  // with a snapshot. Happens when an uninitialized replica is initialized, or
+  // an initialized replica is caught up on a later applied state. An EventSnap
   // also subsumes replicas (if any) that overlap with this replica in keyspace.
-  NodeSnap = 2;
-  // NodeApply corresponds to applying a replica's raft log up to a specific
+  EventSnap = 2;
+  // EventApply corresponds to applying a replica's raft log up to a specific
   // committed index.
-  NodeApply = 3;
-  // NodeSplit corresponds to applying a split command on a replica, and
-  // creating the replica of the post-split RHS range.
-  NodeSplit = 4;
-  // NodeMerge corresponds to applying a merge command on this replica and its
-  // immediate RHS neighbour in the keyspace.
-  NodeMerge = 5;
+  EventApply = 3;
+  // EventSplit corresponds to creating a RHS replica as a result of applying a
+  // split. Comes in conjunction with EventApply of the replica being split.
+  EventSplit = 4;
+  // EventMerge corresponds to merging a replica into its immediate LHS
+  // neighbour in the keyspace. Comes in conjunction with EventApply of the LHS
+  // replica.
+  EventMerge = 5;
   // NodeDestroy correspond to destroying the replica and its state machine.
-  NodeDestroy = 6;
+  EventDestroy = 6;
 }
 
 // Addr describes the full address of a WAG node, consisting of RangeID,
@@ -56,44 +56,67 @@ message Addr {
     (gogoproto.customname) = "ReplicaID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID"];
   // Index identifies the raft log entry associated with this WAG node.
-  //  - For NodeCreate, it is 0 and signifies an uninitialized replica.
-  //  - For NodeSnap, it is the index of the snapshot, and the index at which
+  //  - For EventCreate, it is 0 and signifies an uninitialized replica.
+  //  - For EventSnap, it is the index of the snapshot, and the index at which
   //  the raft log is initialized.
-  //  - For NodeApply, it is the log index identifying a prefix of the raft log.
-  //  - For NodeSplit and NodeMerge, it identifies the raft log command
-  //  containing the corresponding split/merge trigger.
-  //  - For NodeDestroy, it is MaxUint64.
+  //  - For EventApply, it is the log index identifying a prefix of the raft log.
+  //  - For EventSplit, it is the initial index of the RHS replica.
+  //  - For EventDestroy and EventMerge, it is MaxUint64.
   uint64 index = 4 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftIndex"];
 }
 
-// Node describes a node of the WAG.
+message ReplicaEvent {
+  // RangeID is the ID of the range that the replica event pertains to.
+  int64 range_id = 1 [
+    (gogoproto.customname) = "RangeID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+  // Type identifies the type of the replica lifecycle event that this node
+  // represents, such as replica creation, destruction, split or merge.
+  EventType type = 2;
+}
+
+// Node describes a node of the WAG. One WAG node corresponds one lifecycle
+// event of a replica (or multiple replicas, when their state needs to be
+// synchronized), which can be one of:
+//
+//  1. Create an uninitialized replica.
+//  2. Initialize or advance the replica with a snapshot.
+//  3. Apply a committed slice of the replica's raft log.
+//  4. Destroy the replica.
+//
+// In case (3), the Node corresponds to one batch computed by the command
+// application stack. Note that it can also touch other replicas, such as when
+// it's a split or merge command.
 message Node {
   // Addr is the full address of the node, consisting of RangeID, ReplicaID, and
   // index into the raft log.
   Addr addr = 1 [(gogoproto.nullable) = false];
-  // Type identifies the type of the replica lifecycle event that this node
-  // represents, such as replica creation, destruction, split or merge.
-  NodeType type = 2;
   // Mutation contains the mutation that will be applied to the state machine
   // engine when applying this WAG node.
-  Mutation mutation = 3 [(gogoproto.nullable) = false];
+  Mutation mutation = 2 [(gogoproto.nullable) = false];
 
-  // Create is the RangeID that this node brings into existence in the state
-  // machine, or 0 if the node does not create new ranges. It is non-zero for
-  // NodeCreate and NodeSplit.
-  int64 create = 4 [
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
-  // Destroy contains the RangeIDs that this node removes from the state
-  // machine, because they are known to have been merged.
-  // - For NodeMerge, it contains the ID of the RHS range being merged.
-  // - For NodeSnap, it contains the list of subsumed ranges.
-  repeated int64 destroy = 5 [
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+  // Event contains the "main" replica lifecycle event associated with this WAG
+  // node, i.e. the one that happens with the replica referenced by Addr.
+  ReplicaEvent event = 3 [(gogoproto.nullable) = false];
+
+  // Events contains the replica lifecycle events associated with this WAG node
+  // that are done in lock-step with the "main" event. These may happen with the
+  // replica identified by Addr, and/or other replicas. For example, a replica
+  // split/merge contains an EventSplit/EventMerge of the RHS replica.
+  //
+  // Events are mostly informational, but they will be used at WAG replay time,
+  // as hints on when to load and unload created/destroyed replicas state.
+  repeated ReplicaEvent events = 4 [(gogoproto.nullable) = false];
 }
 
-// Mutation contains a mutation that can be applied to the state machine engine.
-// It can be represented by an encoded Pebble write batch or SSTable ingestion.
+// Mutation contains a mutation to be applied to the state machine engine. It
+// can be represented by an encoded Pebble write batch and/or an ingestion.
+//
+// If the Mutation contains both an ingestion and a write batch, then the
+// ingestion is applied first. Ingestions are expected to be idempotent
+// (practically, they only update the MVCC keyspace), due to the fact that they
+// can't be applied atomically with the batch and may need to be replayed.
 message Mutation {
   // Batch contains an encoded Pebble write batch.
   bytes batch = 1;

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -478,26 +478,21 @@ func tryWAGKey(kv storage.MVCCKeyValue) (string, error) {
 		return "", err
 	}
 
-	str := fmt.Appendf(nil, "%v %s", node.Type, node.Addr)
-	if c, d := node.Create, node.Destroy; c != 0 || len(d) != 0 {
-		if c != 0 {
-			str = fmt.Appendf(str, " create:%d", c)
-		}
-		if len(d) != 0 {
-			str = fmt.Appendf(str, " destroy:%v", d)
-		}
+	str := fmt.Appendf(nil, "%v %s", node.Event.Type, node.Addr)
+	for _, e := range node.Events {
+		str = fmt.Appendf(str, " %v:%d", e.Type, e.RangeID)
 	}
 
+	if ing := node.Mutation.Ingestion; ing != nil {
+		// TODO(pav-kv): make this format nicely. Currently, this proto is too big.
+		str = fmt.Appendf(str, "\ningestion: %v", ing)
+	}
 	if b := node.Mutation.Batch; len(b) > 0 {
 		bs, err := DecodeWriteBatch(b)
 		if err != nil {
 			bs = "failed to decode write batch: " + err.Error()
 		}
 		str = fmt.Appendf(str, "\n%s", text.Indent(bs, "> "))
-	}
-	if ing := node.Mutation.Ingestion; ing != nil {
-		// TODO(pav-kv): make this format nicely. Currently, this proto is too big.
-		str = fmt.Appendf(str, "\ningestion: %v", ing)
 	}
 
 	return string(str), nil


### PR DESCRIPTION
A WAG node now strictly corresponds to the command application stack's batching. One apply batch can encompass one or multiple raft log commands, and the applied state is written once. This applied state will go into the WAG node's `Mutation`, so that we don't have to recompute it when replaying the WAG.

Part of #149604