### PR TITLE
mixedversion: fix {cluster,binary}Version indexing papercut

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -525,7 +525,7 @@ func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *servic
 	defer cancel()
 
 	group := ctxgroup.WithContext(connectionCtx)
-	for j, node := range tr.getAvailableNodes(service.descriptor) {
+	for _, node := range tr.getAvailableNodes(service.descriptor) {
 		group.GoCtx(func(ctx context.Context) error {
 			bv, err := clusterupgrade.BinaryVersion(ctx, tr.conn(node, service.descriptor.Name))
 			if err != nil {
@@ -534,7 +534,7 @@ func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *servic
 					node, service.descriptor.Name, err,
 				)
 			}
-			newBinaryVersions[j] = bv
+			newBinaryVersions[node-1] = bv
 			return nil
 		})
 	}
@@ -556,7 +556,7 @@ func (tr *testRunner) refreshClusterVersions(ctx context.Context, service *servi
 	defer cancel()
 
 	group := ctxgroup.WithContext(connectionCtx)
-	for j, node := range tr.getAvailableNodes(service.descriptor) {
+	for _, node := range tr.getAvailableNodes(service.descriptor) {
 		group.GoCtx(func(ctx context.Context) error {
 			cv, err := clusterupgrade.ClusterVersion(ctx, tr.conn(node, service.descriptor.Name))
 			if err != nil {
@@ -566,7 +566,7 @@ func (tr *testRunner) refreshClusterVersions(ctx context.Context, service *servi
 				)
 			}
 
-			newClusterVersions[j] = cv
+			newClusterVersions[node-1] = cv
 			return nil
 		})
 	}


### PR DESCRIPTION
Before every step in mixed version tests, we make sure to refresh the framework's local knowledge of cluster/binary versions. However, we recently made sure to skip refreshing of nodes that are unavailable. This threw off the indexing when updating the versions.

Fixes: none
Epic: none
Release note: none