### PR TITLE
workload: one or zero number of accounts (rows)

### DIFF
--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -233,13 +233,21 @@ func (b *bank) Ops(
 		hists := reg.GetHandle()
 
 		workerFn := func(ctx context.Context) error {
+			if b.rows == 0 {
+				return nil
+			}
+
 			tableIdx := rng.IntN(b.tables)
 			updateStmt := updateStmts[tableIdx]
 
-			from := rng.IntN(b.rows)
-			to := rng.IntN(b.rows - 1)
-			for from == to && b.rows != 1 {
+			from := 0
+			to := 0
+			if b.rows != 1 {
+				from = rng.IntN(b.rows)
 				to = rng.IntN(b.rows - 1)
+				for from == to {
+					to = rng.IntN(b.rows - 1)
+				}
 			}
 			amount := rand.IntN(maxTransfer)
 			start := timeutil.Now()


### PR DESCRIPTION
Previously, if a value of 1 was passed in for the num accounts (rows) in the bank workload, the workload would panic. This change updates the operations to handle 0 and 1 numbers of accounts.

Fixes: #153849