### PR TITLE
release-25.4: sql: add comment about skipped FKs

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -894,9 +894,12 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		for _, addFK := range addFKs {
 			fmt.Fprintf(&buf, "%s;\n", addFK)
 		}
-		// Include FK constraints that were skipped in commented out form.
-		for _, skipFK := range skipFKs {
-			fmt.Fprintf(&buf, "-- %s;\n", skipFK)
+		if len(skipFKs) > 0 {
+			// Include FK constraints that were skipped in commented out form.
+			fmt.Fprintf(&buf, "-- NOTE: these FKs are active and are only commented out for ease of bundle recreation.\n--\n")
+			for _, skipFK := range skipFKs {
+				fmt.Fprintf(&buf, "-- %s;\n", skipFK)
+			}
 		}
 	}
 	for i := range views {


### PR DESCRIPTION
Backport 1/1 commits from #155721 on behalf of @yuzefovich.

----

We just made a change to include skipped FKs (those that we deemed "irrelevant") in the commented out form. This commit improves that logic by adding a comment for why these FKs are commented out, to reduce possible confusion.

Epic: None
Release note: None

----

Release justification: low-risk supportability improvement.