### PR TITLE
sem/builtins: audit a few tests for randomized test tenant

### DIFF
--- a/pkg/backup/backup_tenant_test.go
+++ b/pkg/backup/backup_tenant_test.go
@@ -64,11 +64,9 @@ func TestBackupSharedProcessTenantNodeDown(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	hostDB.Exec(t, "ALTER TENANT test GRANT ALL CAPABILITIES")
-	err = tc.Server(0).TenantController().WaitForTenantCapabilities(ctx, testTenantID, map[tenantcapabilitiespb.ID]string{
-		tenantcapabilitiespb.CanUseNodelocalStorage: "true",
-	}, "")
-	require.NoError(t, err)
+	tc.GrantTenantCapabilities(
+		ctx, t, testTenantID,
+		map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanUseNodelocalStorage: "true"})
 
 	tenantSQL := sqlutils.MakeSQLRunner(tenantDB)
 	tenantSQL.Exec(t, "CREATE TABLE foo AS SELECT generate_series(1, 4000)")

--- a/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
+++ b/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
@@ -80,11 +80,9 @@ func testTenantMetricsCapabilityRPC(
 	require.Error(t, err)
 
 	s := helper.HostCluster().Server(0)
-	db := helper.HostCluster().ServerConn(0)
-	_, err = db.Exec("ALTER TENANT [10] GRANT CAPABILITY can_view_tsdb_metrics=true\n")
-	require.NoError(t, err)
-	capability := map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanViewTSDBMetrics: "true"}
-	serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), capability, "")
+	require.NoError(t, s.GrantTenantCapabilities(
+		ctx, serverutils.TestTenantID(),
+		map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanViewTSDBMetrics: "true"}))
 
 	err = http.PostJSONChecked("/ts/query", &query, &queryResp)
 	require.NoError(t, err)
@@ -104,10 +102,9 @@ func testTenantMetricsCapabilityRPC(
 	err = http.PostJSONChecked("/ts/query", &query, &queryResp)
 	require.Error(t, err)
 
-	_, err = db.Exec("ALTER TENANT [10] GRANT CAPABILITY can_view_all_metrics=true\n")
-	require.NoError(t, err)
-	capability = map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanViewAllMetrics: "true"}
-	serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), capability, "")
+	require.NoError(t, s.GrantTenantCapabilities(
+		ctx, serverutils.TestTenantID(),
+		map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanViewAllMetrics: "true"}))
 
 	err = http.PostJSONChecked("/ts/query", &query, &queryResp)
 	require.NoError(t, err)

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -283,12 +283,9 @@ func TestTenantProcessDebugging(t *testing.T) {
 			require.Equal(t, http.StatusForbidden, resp.StatusCode)
 			require.Contains(t, string(body), "tenant does not have capability to debug the running process")
 
-			_, err = db.Exec(`ALTER TENANT processdebug GRANT CAPABILITY can_debug_process=true`)
-			require.NoError(t, err)
-
-			serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), map[tenantcapabilitiespb.ID]string{
-				tenantcapabilitiespb.CanDebugProcess: "true",
-			}, "")
+			require.NoError(t, s.GrantTenantCapabilities(
+				ctx, serverutils.TestTenantID(),
+				map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanDebugProcess: "true"}))
 		}
 		resp, err := httpClient.Get(url.String())
 		require.NoError(t, err)
@@ -326,12 +323,9 @@ func TestTenantProcessDebugging(t *testing.T) {
 			require.Equal(t, http.StatusForbidden, resp.StatusCode)
 			require.Contains(t, string(body), "tenant does not have capability to debug the running process")
 
-			_, err = db.Exec(`ALTER TENANT processdebug GRANT CAPABILITY can_debug_process=true`)
-			require.NoError(t, err)
-
-			serverutils.WaitForTenantCapabilities(t, s, serverutils.TestTenantID(), map[tenantcapabilitiespb.ID]string{
-				tenantcapabilitiespb.CanDebugProcess: "true",
-			}, "")
+			require.NoError(t, s.GrantTenantCapabilities(
+				ctx, serverutils.TestTenantID(),
+				map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanDebugProcess: "true"}))
 		}
 		resp, err := httpClient.Get(url.String())
 		require.NoError(t, err)

--- a/pkg/sql/gcjob/gc_job_test.go
+++ b/pkg/sql/gcjob/gc_job_test.go
@@ -123,14 +123,10 @@ func TestDropRemovesManualSplits(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	if s.TenantController().StartedDefaultTestTenant() {
-		tenID := serverutils.TestTenantID()
-		_, err := s.SystemLayer().SQLConn(t).Exec(
-			"ALTER TENANT [$1] GRANT CAPABILITY can_admin_unsplit", tenID.ToUint64())
-		require.NoError(t, err)
-
-		expCaps := map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanAdminUnsplit: "true"}
-		serverutils.WaitForTenantCapabilities(t, s, tenID, expCaps, "admin_unsplit")
+	if s.DeploymentMode().IsExternal() {
+		require.NoError(t, s.GrantTenantCapabilities(
+			ctx, serverutils.TestTenantID(),
+			map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanAdminUnsplit: "true"}))
 	}
 
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -192,6 +192,7 @@ go_test(
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/sem/builtins/main_test.go
+++ b/pkg/sql/sem/builtins/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -25,10 +24,6 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
-
-	defer serverutils.TestingSetDefaultTenantSelectionOverride(
-		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
-	)()
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
This commit adjusts one test to work with randomized test tenant. Additionally, it exempts 3 tests from that randomization since those are specific to PerStore RPCs that we currently don't expose for secondary tenants.

It also adjusts `TestSerialNormalizationWithUniqueUnorderedID` which is quite heavy to exempt the default test tenant from rate limiting to avoid timeouts.

Informs: #76378.
Epic: CRDB-48945
Release note: None