### PR TITLE
kvstorage: remove ClearRangeThresholdPointKeys

### DIFF
--- a/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica.txt
@@ -19,20 +19,16 @@ Put: "a"/Intent/00000000-0000-0000-0000-000000000000:
 Put: 0.000000001,0 "y\xff" (0x79ff00000000000000000109): ""
 Put: "y\xff"/Intent/00000000-0000-0000-0000-000000000000: 
 >> destroy:
-Delete (Sized at 31): 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): 
-Delete (Sized at 39): 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:11 (0x0169f67b757266746c000000000000000b00): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): 
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 
-Delete (Sized at 31): 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 
-Delete (Sized at 33): 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): 
-Delete (Sized at 34): 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
-Delete (Sized at 20): 0.000000001,0 /Local/Range"a"/RangeDescriptor (0x016b126100017264736300000000000000000109): 
-Delete (Sized at 36): /Local/Lock/Local/Range"a"/RangeDescriptor 0300000000000000000000000000000000 (0x017a6b12016b126100ff0172647363000100030000000000000000000000000000000012): 
-Delete (Sized at 26): /Local/Lock"a" 0300000000000000000000000000000000 (0x017a6b1261000100030000000000000000000000000000000012): 
-Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
-Delete (Sized at 11): 0.000000001,0 "a" (0x6100000000000000000109): 
-Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109): 
+Delete Range: [0,0 /Local/RangeID/123/r"" (0x0169f67b7200): , 0,0 /Local/RangeID/123/s"" (0x0169f67b7300): )
+Delete Range Keys: /Local/RangeID/123/{r""-s""} (0x0169f67b7200-0x0169f67b7300)
+Delete Range: [0,0 /Local/RangeID/123/u"" (0x0169f67b7500): , 0,0 /Local/RangeID/123/v"" (0x0169f67b7600): )
+Delete Range Keys: /Local/RangeID/123/{u""-v""} (0x0169f67b7500-0x0169f67b7600)
+Delete Range: [0,0 /Local/Range"a" (0x016b1261000100): , 0,0 /Local/Range"z" (0x016b127a000100): )
+Delete Range Keys: /Local/Range"{a"-z"} (0x016b1261000100-0x016b127a000100)
+Delete Range: [0,0 /Local/Lock/Local/Range"a" (0x017a6b12016b126100ff01000100): , 0,0 /Local/Lock/Local/Range"z" (0x017a6b12016b127a00ff01000100): )
+Delete Range Keys: /Local/Lock/Local/Range"{a"-z"} (0x017a6b12016b126100ff01000100-0x017a6b12016b127a00ff01000100)
+Delete Range: [0,0 /Local/Lock"a" (0x017a6b1261000100): , 0,0 /Local/Lock"z" (0x017a6b127a000100): )
+Delete Range Keys: /Local/Lock"{a"-z"} (0x017a6b1261000100-0x017a6b127a000100)
+Delete Range: [0,0 "a" (0x6100): , 0,0 "z" (0x7a00): )
+Delete Range Keys: {a-z} (0x6100-0x7a00)
 Put: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): next_replica_id:4 

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -98,7 +98,7 @@ func splitPreApply(
 		// update its HardState. Here, we can accidentally clear the HardState of
 		// that new replica.
 		if err := kvstorage.RemoveStaleRHSFromSplit(
-			ctx, readWriter, readWriter, split.RightDesc.RangeID, split.RightDesc.RSpan(),
+			readWriter, split.RightDesc.RangeID, split.RightDesc.RSpan(),
 		); err != nil {
 			log.KvExec.Fatalf(ctx, "failed to clear range data for removed rhs: %v", err)
 		}

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -6,15 +6,29 @@ Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vo
 Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:4 
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 >> sst:
-Delete Range: [0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): , 0,0 /Local/RangeID/101/v"" (0x0169ed7600): )
+Delete Range: [0,0 /Local/RangeID/101/r"" (0x0169ed7200): , 0,0 /Local/RangeID/101/s"" (0x0169ed7300): )
+Delete Range Keys: /Local/RangeID/101/{r""-s""} (0x0169ed7200-0x0169ed7300)
+Delete Range: [0,0 /Local/RangeID/101/u"" (0x0169ed7500): , 0,0 /Local/RangeID/101/v"" (0x0169ed7600): )
+Delete Range Keys: /Local/RangeID/101/{u""-v""} (0x0169ed7500-0x0169ed7600)
 Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
 >> sst:
-Delete Range: [0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): , 0,0 /Local/RangeID/102/v"" (0x0169ee7600): )
+Delete Range: [0,0 /Local/RangeID/102/r"" (0x0169ee7200): , 0,0 /Local/RangeID/102/s"" (0x0169ee7300): )
+Delete Range Keys: /Local/RangeID/102/{r""-s""} (0x0169ee7200-0x0169ee7300)
+Delete Range: [0,0 /Local/RangeID/102/u"" (0x0169ee7500): , 0,0 /Local/RangeID/102/v"" (0x0169ee7600): )
+Delete Range Keys: /Local/RangeID/102/{u""-v""} (0x0169ee7500-0x0169ee7600)
 Put: 0,0 /Local/RangeID/102/u/RangeTombstone (0x0169ee757266746200): next_replica_id:2147483647 
 >> sst:
-Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
+Delete Range: [0,0 /Local/Range"k" (0x016b126b000100): , 0,0 /Local/Range"z" (0x016b127a000100): )
+Delete Range Keys: /Local/Range"{k"-z"} (0x016b126b000100-0x016b127a000100)
 >> sst:
-Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109): 
+Delete Range: [0,0 /Local/Lock/Local/Range"k" (0x017a6b12016b126b00ff01000100): , 0,0 /Local/Lock/Local/Range"z" (0x017a6b12016b127a00ff01000100): )
+Delete Range Keys: /Local/Lock/Local/Range"{k"-z"} (0x017a6b12016b126b00ff01000100-0x017a6b12016b127a00ff01000100)
+>> sst:
+Delete Range: [0,0 /Local/Lock"k" (0x017a6b126b000100): , 0,0 /Local/Lock"z" (0x017a6b127a000100): )
+Delete Range Keys: /Local/Lock"{k"-z"} (0x017a6b126b000100-0x017a6b127a000100)
+>> sst:
+Delete Range: [0,0 "k" (0x6b00): , 0,0 "z" (0x7a00): )
+Delete Range Keys: {k-z} (0x6b00-0x7a00)
 >> repl: /Local/RangeID/123/{r""-s""}
 >> repl: /Local/Range"{a"-k"}
 >> repl: /Local/Lock/Local/Range"{a"-k"}


### PR DESCRIPTION
The heuristic in `ClearRangeData` was introduced in b320ff5c when CRDB used RocksDB. The optimization is no longer needed with Pebble, because Pebble does not load all range tombstones when reading SSTables. The tombstones are loaded and cached as needed, when iterating.
Upd [[thread](https://cockroachlabs.slack.com/archives/CAC6K3SLU/p1761042474041259)]: however, the RANGEDEL block is unsplittable, and can be loaded into memory entirely, so many range tombstones is still a concern.

Additional benefits of this change:

- no need for reading when destructing replicas, the batch is constructed with a blind `Writer`
- fewer corner cases in replica destruction code
- predictable replica destruction batches (which is convenient in tests)

Related to #152845