### PR TITLE
sql/inspect: skip REFCURSOR stored columns in consistency check

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -349,3 +349,32 @@ statement ok
 DROP DATABASE dbfoo;
 
 subtest end
+
+subtest refcursor_stored_column
+
+statement ok
+CREATE TABLE refcursor_tbl (id INT PRIMARY KEY, a INT, c REFCURSOR);
+
+statement ok
+INSERT INTO refcursor_tbl VALUES (1, 10, 'cursor1'), (2, 20, 'cursor2');
+
+# Verify that we cannot index the refcursor. They can only be included
+# in an index as stored columns.
+statement error pq: unimplemented: column c has type refcursor, which is not indexable
+CREATE INDEX idx_refcursor ON refcursor_tbl (c);
+
+statement ok
+CREATE INDEX idx_refcursor ON refcursor_tbl (a) STORING (c);
+
+statement ok
+INSPECT TABLE refcursor_tbl WITH OPTIONS INDEX ALL;
+
+query TI
+SELECT * FROM last_inspect_job;
+----
+succeeded  1
+
+statement ok
+DROP TABLE refcursor_tbl;
+
+subtest end


### PR DESCRIPTION
REFCURSOR values cannot be compared for equality, which breaks the `INSPECT` command when an index stores a column of this type. During a consistency check, INSPECT attempts to compare stored column payloads between the primary and secondary indexes. This fails for REFCURSOR values because the column type cannot be used in an equality comparison.

This change skips REFCURSOR stored columns during the primary/secondary comparison.

Informs: #155676
Epic: CRDB-55075

Release note (bug fix): INSPECT can now be run on tables with indexes that store REFCURSOR-typed columns.