### PR TITLE
sql/inspect: add DETACHED option to run INSPECT without waiting

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3643,6 +3643,9 @@ only_signed_fconst ::=
 inspect_option ::=
 	'INDEX' 'ALL'
 	| 'INDEX' '(' table_index_name_list ')'
+	| 'DETACHED'
+	| 'DETACHED' '=' 'TRUE'
+	| 'DETACHED' '=' 'FALSE'
 
 virtual_cluster_name ::=
 	'VIRTUAL_CLUSTER_NAME'

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/physicalplan",
         "//pkg/sql/privilege",
         "//pkg/sql/rowexec",

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -15,6 +15,10 @@ WHERE job_type = 'INSPECT'
 ORDER BY created DESC
 LIMIT 1
 
+# Make job adoption faster. This is needed to speed up DETACHED jobs.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '500ms';
+
 statement ok
 CREATE TABLE foo (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
 
@@ -27,6 +31,9 @@ INSPECT DATABASE test;
 statement ok
 SET enable_inspect_command = true;
 
+subtest transaction_behavior
+
+# Test that regular INSPECT cannot run within a transaction.
 statement ok
 BEGIN;
 
@@ -36,7 +43,77 @@ INSPECT TABLE foo;
 statement ok
 ROLLBACK;
 
+statement notice NOTICE: INSPECT job [0-9]+ running in the background
+INSPECT TABLE foo WITH OPTIONS DETACHED
+
+# Wait for the detached job to eventually succeed.
+query T retry
+SELECT status FROM last_inspect_job
+----
+succeeded
+
+# Test that DETACHED INSPECT can run inside a transaction.
 statement ok
+BEGIN;
+
+statement notice NOTICE: INSPECT job [0-9]+ queued; will start after the current transaction commits
+INSPECT TABLE foo WITH OPTIONS DETACHED
+
+# Verify the job isn't committed yet. It will stay in the running stage because we haven't committed it yet.
+query T
+SELECT status FROM last_inspect_job
+----
+running
+
+statement ok
+COMMIT;
+
+# Wait for the new job to eventually succeed.
+query T retry
+SELECT status FROM last_inspect_job
+----
+succeeded
+
+subtest end
+
+subtest inspect_options
+
+# Test DETACHED option validation.
+
+# Failure if both DETACHED and DETACHED = FALSE are specified.
+statement error pq: conflicting INSPECT options: DETACHED specified with different values
+INSPECT TABLE foo WITH OPTIONS DETACHED, DETACHED = FALSE
+
+# DETACHED = TRUE is the same as DETACHED.
+# Both should check all indexes (2 total: idx_c1 and idx_c2).
+statement notice NOTICE: INSPECT job [0-9]+ running in the background
+INSPECT TABLE foo WITH OPTIONS DETACHED = TRUE
+
+query TI retry
+SELECT * FROM last_inspect_job
+----
+succeeded  2
+
+statement notice NOTICE: INSPECT job [0-9]+ running in the background
+INSPECT TABLE foo WITH OPTIONS DETACHED
+
+query TI retry
+SELECT * FROM last_inspect_job
+----
+succeeded  2
+
+# DETACHED = TRUE with a specific index (verify the number of checks).
+statement notice NOTICE: INSPECT job [0-9]+ running in the background
+INSPECT TABLE foo WITH OPTIONS DETACHED = TRUE, INDEX (idx_c1)
+
+query TI retry
+SELECT * FROM last_inspect_job
+----
+succeeded  1
+
+# Test regular (non-detached) inspect operations.
+
+statement notice NOTICE: waiting for INSPECT job to complete: [0-9]+\nIf the statement is canceled, the job will continue in the background.
 INSPECT TABLE foo;
 
 query TI
@@ -122,6 +199,8 @@ query TI
 SELECT * FROM last_inspect_job;
 ----
 succeeded  3
+
+subtest end
 
 subtest permissions
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7939,6 +7939,18 @@ inspect_option:
   {
     $$.val = &tree.InspectOptionIndex{IndexNames: $3.newTableIndexNames()}
   }
+| DETACHED
+  {
+    $$.val = &tree.InspectOptionDetached{Detached: *tree.MakeDBool(true)}
+  }
+| DETACHED '=' TRUE
+  {
+    $$.val = &tree.InspectOptionDetached{Detached: *tree.MakeDBool(true)}
+  }
+| DETACHED '=' FALSE
+  {
+    $$.val = &tree.InspectOptionDetached{Detached: *tree.MakeDBool(false)}
+  }
 
 // %Help: SHOW INSPECT ERRORS - list errors recorded by one INSPECT run
 // %Category: Misc

--- a/pkg/sql/parser/testdata/inspect
+++ b/pkg/sql/parser/testdata/inspect
@@ -32,6 +32,14 @@ INSPECT DATABASE x AS OF SYSTEM TIME _ WITH OPTIONS INDEX (index_name_1, index_n
 INSPECT DATABASE _ AS OF SYSTEM TIME 1 WITH OPTIONS INDEX (_, _) -- identifiers removed
 
 parse
+INSPECT DATABASE x WITH OPTIONS DETACHED, INDEX (index_name)
+----
+INSPECT DATABASE x WITH OPTIONS DETACHED, INDEX (index_name)
+INSPECT DATABASE x WITH OPTIONS DETACHED, INDEX (index_name) -- fully parenthesized
+INSPECT DATABASE x WITH OPTIONS DETACHED, INDEX (index_name) -- literals removed
+INSPECT DATABASE _ WITH OPTIONS DETACHED, INDEX (_) -- identifiers removed
+
+parse
 INSPECT TABLE x WITH OPTIONS INDEX (index_name)
 ----
 INSPECT TABLE x WITH OPTIONS INDEX (index_name)
@@ -78,6 +86,14 @@ INSPECT TABLE x WITH OPTIONS INDEX (index_name_1, index_name_2)
 INSPECT TABLE x WITH OPTIONS INDEX (index_name_1, index_name_2) -- fully parenthesized
 INSPECT TABLE x WITH OPTIONS INDEX (index_name_1, index_name_2) -- literals removed
 INSPECT TABLE _ WITH OPTIONS INDEX (_, _) -- identifiers removed
+
+parse
+INSPECT TABLE x WITH OPTIONS DETACHED
+----
+INSPECT TABLE x WITH OPTIONS DETACHED
+INSPECT TABLE x WITH OPTIONS DETACHED -- fully parenthesized
+INSPECT TABLE x WITH OPTIONS DETACHED -- literals removed
+INSPECT TABLE _ WITH OPTIONS DETACHED -- identifiers removed
 
 parse
 INSPECT TABLE db.schema.t1 WITH OPTIONS INDEX (index_name)


### PR DESCRIPTION
Adds support for running `INSPECT ... WITH OPTIONS (DETACHED)`, which submits the inspection as a background job and returns immediately with the job ID in a notice. This allows INSPECT to run inside a transaction.

**Note to reviewers:**
This was added to support running INSPECT within the random schema workload, which executes statements inside transactions. Previously, INSPECT could not run inside a transaction. It also gives us async behaviour. While expanding INSPECT test coverage, I have wanted to kick off an async run of INSPECT. Until now, I worked around it by using `statement_timeout` to force the job to run in the background so we could later wait on it. The detached option provides a cleaner approach. It is similar to how commands like BACKUP support an async mode.
 
Informs: #155483
Epic: CRDB-55075

Release note (sql change): INSPECT supports a DETACHED option to run the operation without waiting for it.