### PR TITLE
mixedversion: fix panic in refresh{Cluster,Binary}Version

### DIFF
--- a/pkg/cmd/roachtest/option/node_list_option.go
+++ b/pkg/cmd/roachtest/option/node_list_option.go
@@ -42,6 +42,15 @@ func (n NodeListOption) Equals(o NodeListOption) bool {
 	return true
 }
 
+func (n NodeListOption) Contains(node int) bool {
+	for _, n := range n {
+		if n == node {
+			return true
+		}
+	}
+	return false
+}
+
 // Option implements Option.
 func (n NodeListOption) Option() {}
 


### PR DESCRIPTION
A recent change https://github.com/cockroachdb/cockroach/pull/155713 fixed the indexing when nodes were unavailable. However, this change did not account for multi cluster tests where the roachprod node ID is not the same as the CRDB node ID, i.e. we can't assume the 4th VM is the same as the 4th node in the cluster.

Fixes: none
Epic: none
Release note: none