### PR TITLE
sql: add `ALTER TABLE ... DROP STORED` to the declerative schema changer

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -260,6 +260,13 @@ func TestBackupRollbacks_base_alter_table_alter_column_drop_on_update(t *testing
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_alter_column_set_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1013,6 +1020,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_alter_column_drop_on_updat
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_on_update"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1772,6 +1786,13 @@ func TestBackupSuccess_base_alter_table_alter_column_drop_on_update(t *testing.T
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_alter_column_set_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2525,6 +2546,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_alter_column_drop_on_update(
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_on_update"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "alter_table_add_column.go",
         "alter_table_add_constraint.go",
         "alter_table_alter_column_drop_not_null.go",
+        "alter_table_alter_column_drop_stored.go",
         "alter_table_alter_column_set_default.go",
         "alter_table_alter_column_set_not_null.go",
         "alter_table_alter_column_set_on_update.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -43,6 +43,7 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableDropNotNull)(nil)):        {fn: alterTableDropNotNull, on: true, checks: isV253Active},
 	reflect.TypeOf((*tree.AlterTableSetOnUpdate)(nil)):        {fn: alterTableSetOnUpdate, on: true, checks: isV254Active},
 	reflect.TypeOf((*tree.AlterTableRenameColumn)(nil)):       {fn: alterTableRenameColumn, on: true, checks: isV254Active},
+	reflect.TypeOf((*tree.AlterTableDropStored)(nil)):         {fn: alterTableDropStored, on: true, checks: isV261Active},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_drop_stored.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_drop_stored.go
@@ -1,0 +1,69 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func alterTableDropStored(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	stmt tree.Statement,
+	t *tree.AlterTableDropStored,
+) {
+	alterColumnPreChecks(b, tn, tbl, t.Column)
+	colElems := b.ResolveColumn(tbl.TableID, t.Column, ResolveParams{
+		RequiredPrivilege: privilege.CREATE,
+	})
+	colElem := colElems.FilterColumn().MustGetOneElement()
+	columnID := colElem.ColumnID
+	// Block alters on system columns.
+	panicIfSystemColumn(colElem, t.Column)
+	// Ensure that the column is stored (not virtual)
+	panicIfVirtualColumn(b, tbl.TableID, columnID, t.Column)
+	// Retrieve the compute expression element
+	exprElem := retrieveColumnComputeExpressionElem(b, tbl.TableID, columnID)
+	// Ensure that the column is computed
+	if exprElem == nil {
+		panic(pgerror.Newf(
+			pgcode.InvalidColumnDefinition,
+			"column %q is not a computed column",
+			tree.ErrString(&t.Column)))
+	}
+	b.Drop(exprElem)
+}
+
+// panicIfVirtualColumn blocks operation if the column is virtual.
+func panicIfVirtualColumn(
+	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID, columnName tree.Name,
+) {
+	colTypeEl := mustRetrieveColumnTypeElem(b, tableID, columnID)
+	if colTypeEl.IsVirtual {
+		panic(pgerror.Newf(
+			pgcode.InvalidColumnDefinition,
+			"column %q is not a stored computed column",
+			tree.ErrString(&columnName)))
+	}
+}
+
+// retrieveColumnComputeExpressionElem returns the compute expression
+// element of the column. Returns nil if no expression exists and for
+// older versions that store the expression as part of the ColumnType
+func retrieveColumnComputeExpressionElem(
+	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
+) (expr *scpb.ColumnComputeExpression) {
+	return b.QueryByID(tableID).FilterColumnComputeExpression().Filter(func(
+		_ scpb.Status, _ scpb.TargetStatus, e *scpb.ColumnComputeExpression) bool {
+		return e.ColumnID == columnID
+	}).MustGetZeroOrOneElement()
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -227,3 +227,8 @@ var isV253Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMo
 var isV254Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
 	return activeVersion.IsActive(clusterversion.V25_4)
 }
+
+var isV261Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
+	// change the cluster version once V26_1 is created
+	return activeVersion.IsActive(clusterversion.V25_4)
+}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -13,10 +13,6 @@ CREATE TABLE defaultdb.foo (
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo ALTER COLUMN i DROP STORED
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo RENAME CONSTRAINT foobar TO baz
 ----
 

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -260,6 +260,13 @@ func TestEndToEndSideEffects_alter_table_alter_column_drop_on_update(t *testing.
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_alter_column_set_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1013,6 +1020,13 @@ func TestExecuteWithDMLInjection_alter_table_alter_column_drop_on_update(t *test
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_on_update"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1772,6 +1786,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_alter_column_drop_on_update(t *t
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_alter_column_set_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2525,6 +2546,13 @@ func TestPause_alter_table_alter_column_drop_on_update(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_on_update"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3284,6 +3312,13 @@ func TestPauseMixedVersion_alter_table_alter_column_drop_on_update(t *testing.T)
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_alter_column_set_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4037,6 +4072,13 @@ func TestRollback_alter_table_alter_column_drop_on_update(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_on_update"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_alter_column_drop_stored(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.definition
@@ -1,0 +1,7 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT AS (i + 1) STORED);
+----
+
+test
+ALTER TABLE t ALTER COLUMN j DROP STORED
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.explain
@@ -1,0 +1,42 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT AS (i + 1) STORED);
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE t ALTER COLUMN j DROP STORED;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER COLUMN ‹j› DROP STORED;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 2 (j), ReferencedColumnIDs: [1], Usage: REGULAR}
+ │         └── 2 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":104}
+ │              └── RemoveColumnComputeExpression {"ColumnID":2,"TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │    │    │    └── ABSENT → PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── ABSENT → PUBLIC ColumnComputeExpression:{DescID: 104 (t), ColumnID: 2 (j), ReferencedColumnIDs: [1], Usage: REGULAR}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
+ │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 2 (j), ReferencedColumnIDs: [1], Usage: REGULAR}
+ │         └── 4 Mutation operations
+ │              ├── SetTableSchemaLocked {"TableID":104}
+ │              ├── RemoveColumnComputeExpression {"ColumnID":2,"TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
+ └── PostCommitPhase
+      └── Stage 1 of 1 in PostCommitPhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT AS (i + 1) STORED);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE t ALTER COLUMN j DROP STORED;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER COLUMN ‹j› DROP STORED;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored.side_effects
@@ -1,0 +1,145 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT AS (i + 1) STORED);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+ALTER TABLE t ALTER COLUMN j DROP STORED;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.drop_stored
+## StatementPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  -  - computeExpr: i + 1:::INT8
+  -    id: 2
+  +  - id: 2
+       name: j
+       nullable: true
+  ...
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  -  - computeExpr: i + 1:::INT8
+  -    id: 2
+  +  - id: 2
+       name: j
+       nullable: true
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "2": j
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "1": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER COLUMN ‹j› DROP STORED
+  +        statement: ALTER TABLE t ALTER COLUMN j DROP STORED
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     replacementOf:
+       time: {}
+  -  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ALTER COLUMN j DROP STORED"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "2": j
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "1": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER COLUMN ‹j› DROP STORED
+  -        statement: ALTER TABLE t ALTER COLUMN j DROP STORED
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     replacementOf:
+       time: {}
+  +  schemaLocked: true
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #3
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_drop_stored/alter_table_alter_column_drop_stored__rollback_1_of_1.explain
@@ -1,0 +1,23 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT AS (i + 1) STORED);
+
+/* test */
+ALTER TABLE t ALTER COLUMN j DROP STORED;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 1;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN j DROP STORED;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── ABSENT → PUBLIC ColumnComputeExpression:{DescID: 104 (t), ColumnID: 2 (j), ReferencedColumnIDs: [1], Usage: REGULAR}
+      │    └── 3 Mutation operations
+      │         ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":2,"TableID":104}}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_PUBLIC
+           │    └── ABSENT → TRANSIENT_PUBLIC TableSchemaLocked:{DescID: 104 (t)}
+           └── 3 Mutation operations
+                ├── SetTableSchemaLocked {"Locked":true,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}


### PR DESCRIPTION
Previously, `ALTER TABLE ... DROP STORED` would run with the legacy schema changer. This change enables the comment be run by the declerative schema changer.

Epic: none

Fixes: #139603

Release note (sql change): `ALTER TABLE ... DROP STORED` will use the declerative schema changer to run.