### PR TITLE
gssapi: add shim for old __res_nsearch version

### DIFF
--- a/build/bazelutil/cc/BUILD.bazel
+++ b/build/bazelutil/cc/BUILD.bazel
@@ -1,0 +1,16 @@
+cc_library(
+    name = "resolver_compat",
+    srcs = ["res_compat.c"],
+    visibility = ["//visibility:public"],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "resolver_libs",
+    linkopts = [
+        "-Wl,--push-state,--no-as-needed",
+        "-lresolv",
+        "-Wl,--pop-state",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/build/bazelutil/cc/res_compat.c
+++ b/build/bazelutil/cc/res_compat.c
@@ -1,0 +1,14 @@
+// res_compat.c
+#include <resolv.h>
+
+// Provide a weak __res_nsearch for old krb5 objects.
+// Forward to the public res_nsearch symbol on modern glibc.
+__attribute__((weak))
+int __res_nsearch(res_state statp,
+                  const char *dname,
+                  int class,
+                  int type,
+                  unsigned char *answer,
+                  int anslen) {
+  return res_nsearch(statp, dname, class, type, answer, anslen);
+}

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -11,17 +11,12 @@ go_library(
         "//conditions:default": ["empty.go"],
     }),
     cdeps = select({
-        "@io_bazel_rules_go//go/platform:linux": ["//c-deps:libkrb5"],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//c-deps:libkrb5", "//build/bazelutil/cc:resolver_compat","//build/bazelutil/cc:resolver_libs",
+        ],
         "//conditions:default": [],
     }),
     cgo = True,
-    clinkopts = select({
-        # NB: On Ubuntu, res_nsearch is found in the resolv_wrapper library,
-        # found in the libresolv-wrapper package.
-        "//build/toolchains:is_dev_linux": ["-ldl -lresolv -lresolv_wrapper"],
-        "@io_bazel_rules_go//go/platform:linux": ["-ldl -lresolv"],
-        "//conditions:default": [],
-    }),
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/gssapiccl",
     visibility = ["//visibility:public"],
     deps = select({


### PR DESCRIPTION
Release note: none.
Epic: none.