### PR TITLE
schemachangerccl: bump up timeout for job completion

### DIFF
--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -965,14 +965,13 @@ func waitForSchemaChangesToSucceed(t *testing.T, tdb *sqlutils.SQLRunner) {
 }
 
 func waitForSchemaChangesToFinish(t *testing.T, tdb *sqlutils.SQLRunner) {
-	// Wait longer on stress for schema changes.
-	if skip.Stress() {
-		old := tdb.SucceedsSoonDuration
-		tdb.SucceedsSoonDuration = time.Minute * 2
-		defer func() {
-			tdb.SucceedsSoonDuration = old
-		}()
-	}
+	// Schema changes in more complex tests can be slower, so give them
+	// a lot more headroom to complete.
+	old := tdb.SucceedsSoonDuration
+	tdb.SucceedsSoonDuration = time.Minute * 2
+	defer func() {
+		tdb.SucceedsSoonDuration = old
+	}()
 	tdb.CheckQueryResultsRetry(
 		t, schemaChangeWaitQuery(`('succeeded', 'failed')`), [][]string{},
 	)


### PR DESCRIPTION
Previously, tests in the schema changer package waited up to 45 seconds for schema changes to complete. Unfortunately, certain schema changes involving ALTER PRIMARY KEY may have multiple backfills, where this timeout would not be sufficient. To address this, this patch extends the schema change timeout to 2 minutes to have these tests flake less.

Fixes: #155696
Fixes: #155654

Release note: None