### PR TITLE
*: replace some usages of global rand

### DIFF
--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -62,6 +62,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -1360,9 +1361,10 @@ func (g *Gossip) manage(rpcContext *rpc.Context) {
 		var cullTimer, stallTimer timeutil.Timer
 		defer cullTimer.Stop()
 		defer stallTimer.Stop()
+		rng, _ := randutil.NewPseudoRand()
 
-		cullTimer.Reset(jitteredInterval(g.cullInterval))
-		stallTimer.Reset(jitteredInterval(g.stallInterval))
+		cullTimer.Reset(jitteredInterval(g.cullInterval, rng))
+		stallTimer.Reset(jitteredInterval(g.stallInterval, rng))
 		for {
 			select {
 			case <-g.server.stopper.ShouldQuiesce():
@@ -1372,7 +1374,7 @@ func (g *Gossip) manage(rpcContext *rpc.Context) {
 			case <-g.tighten:
 				g.tightenNetwork(ctx, rpcContext)
 			case <-cullTimer.C:
-				cullTimer.Reset(jitteredInterval(g.cullInterval))
+				cullTimer.Reset(jitteredInterval(g.cullInterval, rng))
 				func() {
 					g.mu.Lock()
 					if !g.outgoing.hasSpace() {
@@ -1402,7 +1404,7 @@ func (g *Gossip) manage(rpcContext *rpc.Context) {
 					g.mu.Unlock()
 				}()
 			case <-stallTimer.C:
-				stallTimer.Reset(jitteredInterval(g.stallInterval))
+				stallTimer.Reset(jitteredInterval(g.stallInterval, rng))
 				func() {
 					g.mu.Lock()
 					defer g.mu.Unlock()
@@ -1415,8 +1417,8 @@ func (g *Gossip) manage(rpcContext *rpc.Context) {
 
 // jitteredInterval returns a randomly jittered (+/-25%) duration
 // from checkInterval.
-func jitteredInterval(interval time.Duration) time.Duration {
-	return time.Duration(float64(interval) * (0.75 + 0.5*rand.Float64()))
+func jitteredInterval(interval time.Duration, rng *rand.Rand) time.Duration {
+	return time.Duration(float64(interval) * (0.75 + 0.5*rng.Float64()))
 }
 
 // tightenNetwork "tightens" the network by starting a new gossip client to the

--- a/pkg/server/diagnostics/BUILD.bazel
+++ b/pkg/server/diagnostics/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/system",

--- a/pkg/server/diagnostics/diagnostics.go
+++ b/pkg/server/diagnostics/diagnostics.go
@@ -149,9 +149,9 @@ func addInfoToURL(
 }
 
 // randomly shift `d` to be up to `jitterSeconds` shorter or longer.
-func addJitter(d time.Duration) time.Duration {
+func addJitter(d time.Duration, rng *rand.Rand) time.Duration {
 	const jitterSeconds = 120
-	j := time.Duration(rand.Intn(jitterSeconds*2)-jitterSeconds) * time.Second
+	j := time.Duration(rng.Intn(jitterSeconds*2)-jitterSeconds) * time.Second
 	return d + j
 }
 

--- a/pkg/server/diagnostics/update_checker.go
+++ b/pkg/server/diagnostics/update_checker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -74,6 +75,7 @@ func (u *UpdateChecker) PeriodicallyCheckForUpdates(ctx context.Context, stopper
 		SpanOpt:  stop.SterileRootSpan,
 	}, func(ctx context.Context) {
 		defer logcrash.RecoverAndReportNonfatalPanic(ctx, &u.Settings.SV)
+		rng, _ := randutil.NewPseudoRand()
 		nextUpdateCheck := u.StartTime
 
 		var timer timeutil.Timer
@@ -84,7 +86,7 @@ func (u *UpdateChecker) PeriodicallyCheckForUpdates(ctx context.Context, stopper
 
 			nextUpdateCheck = u.maybeCheckForUpdates(ctx, now, nextUpdateCheck, runningTime)
 
-			timer.Reset(addJitter(nextUpdateCheck.Sub(timeutil.Now())))
+			timer.Reset(addJitter(nextUpdateCheck.Sub(timeutil.Now()), rng))
 			select {
 			case <-stopper.ShouldQuiesce():
 				return

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -111,6 +111,9 @@ var LeaseRenewalCrossValidate = settings.RegisterBoolSetting(
 func (s storage) jitteredLeaseDuration() time.Duration {
 	leaseDuration := LeaseDuration.Get(&s.settings.SV)
 	jitterFraction := LeaseJitterFraction.Get(&s.settings.SV)
+	// TODO(yuzefovich): it would probably be worth replacing this usage of
+	// global rand with rng tied to the 'storage' object. It's not clear whether
+	// we need concurrency safety or not.
 	return time.Duration(float64(leaseDuration) * (1 - jitterFraction +
 		2*jitterFraction*rand.Float64()))
 }

--- a/pkg/sql/contention/BUILD.bazel
+++ b/pkg/sql/contention/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/metric",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/sql/index_split_scatter.go
+++ b/pkg/sql/index_split_scatter.go
@@ -8,7 +8,6 @@ package sql
 import (
 	"bytes"
 	"context"
-	"math/rand"
 	"sort"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/errors"
 )
@@ -317,6 +317,7 @@ func (is *indexSplitAndScatter) MaybeSplitIndexSpans(
 	if is.testingKnobs.BeforeIndexSplitAndScatter != nil {
 		is.testingKnobs.BeforeIndexSplitAndScatter(splitPoints)
 	}
+	rng, _ := randutil.NewPseudoRand()
 	for i := 0; i < nSplits; i++ {
 		// Evenly space out the ranges that we select from the ranges that are
 		// returned.
@@ -328,7 +329,7 @@ func (is *indexSplitAndScatter) MaybeSplitIndexSpans(
 
 		// Jitter the expiration time by 20% up or down from the default.
 		maxJitter := backfillSplitExpiration.Nanoseconds() / 5
-		jitter := rand.Int63n(maxJitter*2) - maxJitter
+		jitter := rng.Int63n(maxJitter*2) - maxJitter
 		expirationTime := backfillSplitExpiration.Nanoseconds() + jitter
 
 		b.AddRawRequest(&kvpb.AdminSplitRequest{

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/golang/geo/s1"
 	"github.com/twpayne/go-geom"
@@ -2200,11 +2199,10 @@ Flags shown square brackets after the geometry type have the following meaning:
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "geometry", Typ: types.Geometry}, {Name: "npoints", Typ: types.Int4}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				geometry := tree.MustBeDGeometry(args[0]).Geometry
 				npoints := int(tree.MustBeDInt(args[1]))
-				seed := timeutil.Now().Unix()
-				generatedPoints, err := geomfn.GenerateRandomPoints(geometry, npoints, rand.New(rand.NewSource(seed)))
+				generatedPoints, err := geomfn.GenerateRandomPoints(geometry, npoints, evalCtx.GetRNG())
 				if err != nil {
 					if errors.Is(err, geomfn.ErrGenerateRandomPointsInvalidPoints) {
 						return tree.DNull, nil

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -7,7 +7,6 @@ package sql
 
 import (
 	"context"
-	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -502,6 +502,7 @@ func (p *planner) copySplitPointsToNewIndexes(
 		step = 1
 	}
 	expirationTime := kvserverbase.SplitByLoadMergeDelay.Get(execCfg.SV()).Nanoseconds()
+	rng, _ := randutil.NewPseudoRand()
 	for i := 0; i < nSplits; i++ {
 		// Evenly space out the ranges that we select from the ranges that are
 		// returned.
@@ -513,7 +514,7 @@ func (p *planner) copySplitPointsToNewIndexes(
 
 		// Jitter the expiration time by 20% up or down from the default.
 		maxJitter := expirationTime / 5
-		jitter := rand.Int63n(maxJitter*2) - maxJitter
+		jitter := rng.Int63n(maxJitter*2) - maxJitter
 		expirationTime += jitter
 
 		log.Dev.Infof(ctx, "truncate sending split request for key %s", sp)


### PR DESCRIPTION
**sem/builtins: use RNG from eval context for 'st_generatepoints'**

***: replace some usages of global rand**

When we use `rand.*` methods like `math/rand.Intn`, under the hood we hit
the global rand source, which is protected by a mutex, so we could be subject
to contention on that lock. This commit updates some of such usages in
favor of object-specific rand source to avoid that. Note that allocating
a separate rand source is not free (the allocation itself is about 5KiB
in size), so we modify spots where the lifecycle matches that of the
server or when the affected code is heavy already / not on the hot path
(also when it's clear that the access is from within a single
goroutine).

Epic: None
Release note: None