### PR TITLE
kvnemesis: log a metrics report

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -113,6 +113,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -244,6 +244,21 @@ func (mr *MetricsRecorder) AppRegistry() *metric.Registry {
 	return mr.mu.appRegistry
 }
 
+// NodeRegistry returns the metric registry for node-level metrics.
+func (mr *MetricsRecorder) NodeRegistry() *metric.Registry {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	return mr.mu.logRegistry
+}
+
+// StoreRegistry returns the metric registry for store-level metrics
+// corresponding to the provided store ID.
+func (mr *MetricsRecorder) StoreRegistry(id roachpb.StoreID) *metric.Registry {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	return mr.mu.storeRegistries[id]
+}
+
 // AddNode adds various metric registries an initialized server, along
 // with its descriptor and start time.
 // The registries are:


### PR DESCRIPTION
This commit adds logging of some key metrics at the end of each kvnemesis run.

Fixes: #153793

Release note: None

----

This is what the report looks like for a run of `TestKVNemesisMultiNode`:
```
Metric                              | Node 1               | Node 2               | Node 3               | Node 4
------------------------------------+----------------------+----------------------+----------------------+---------------------
raft.commands.proposed              | 2906                 | 117                  | 273                  | 118
raft.commands.reproposed.new-lai    | 0                    | 1                    | 12                   | 0
raft.commands.reproposed.unchanged  | 78                   | 0                    | 0                    | 0
txn.server_side.1PC.success         | 84                   | 0                    | 1                    | 0
txnrecovery.successes.committed     | 0                    | 0                    | 0                    | 0
txnwaitqueue.deadlocks_total        | 0                    | 0                    | 4                    | 0
txn.aborts                          | 13                   | 10                   | 8                    | 12
txn.durations                       | μ=25ms p99=260ms     | μ=82ms p99=671ms     | μ=81ms p99=1.476s    | μ=224ms p99=4.832s
txn.restarts.writetooold            | 8                    | 1                    | 2                    | 1
txn.restarts.serializable           | 1                    | 0                    | 0                    | 0
txn.restarts.readwithinuncertainty  | 0                    | 0                    | 0                    | 0
```