### PR TITLE
release-25.3: sql: increase timeout in TestIndexBackfillerResumePreservesProgress

### DIFF
--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -668,7 +668,7 @@ func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 			return err
 		}
 		return nil
-	}, 5*time.Second)
+	}, 30*time.Second)
 
 	ensureJobState := func(targetState string) {
 		testutils.SucceedsWithin(t, func() error {
@@ -682,7 +682,7 @@ func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 					targetState, jobState)
 			}
 			return nil
-		}, 5*time.Second)
+		}, 30*time.Second)
 	}
 
 	var completedSpans roachpb.SpanGroup
@@ -738,7 +738,7 @@ func TestIndexBackfillerResumePreservesProgress(t *testing.T) {
 			}
 
 			return nil
-		}, 5*time.Second)
+		}, 30*time.Second)
 	}
 
 	for isBlockingBackfillProgress.Load() {


### PR DESCRIPTION
Backport 1/1 commits from #155792 on behalf of @rafiss.

----

This increases all three timeouts in the test from 5 seconds to 30 seconds

Resolves: #155646

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----

Release justification: