### PR TITLE
roachprod: StageApplication uses new latest gcs obj key prefix for workload binary

### DIFF
--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -247,7 +247,7 @@ func StageApplication(
 			archSuffix = archInfo.DebugArchitecture
 		}
 		err := stageRemoteBinary(
-			ctx, l, c, applicationName, "cockroach/workload", version, archSuffix, destDir,
+			ctx, l, c, applicationName, "workload/workload", version, archSuffix, destDir,
 		)
 		return err
 	case "release":


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/154274

Roachprod dependent work for https://github.com/cockroachdb/cockroach/pull/155397 
Dependent on https://github.com/cockroachdb/cockroach/pull/155789 (won't merge this PR until the publish-artifact and subsequent backports go in)

Enables fetching workload binary using new key prefix

Will keep as draft until I manually test
* Either roachprod CLI directly (which one?) or can call StageApplication from a cluster