### PR TITLE
release-25.4: roachtest: restrict knex test to GCE only

### DIFF
--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -129,11 +129,11 @@ func registerKnex(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:  "knex",
 		Owner: registry.OwnerSQLFoundations,
-		// Requires a pre-built node-oracledb binary for linux arm64.
+		// Requires a pre-built node-oracledb binary for linux arm64 and s390x.
 		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.OnlyAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKnex(ctx, t, c)


### PR DESCRIPTION
Backport 1/1 commits from #155796 on behalf of @rafiss.

----

The knex test requires pre-built node-oracledb binaries which are not available for IBM cloud's s390x architecture. This was causing the test to fail during npm install with error "NJS-067: a pre-built node-oracledb binary was not found for linux s390x".

Restrict the test to run only on GCE to avoid this dependency issue.

Resolves: #155605

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----

Release justification: test only change