### PR TITLE
release-25.4: changefeedccl: deflake TestChangefeedSchemaTTL

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6939,6 +6939,7 @@ func TestChangefeedSchemaTTL(t *testing.T) {
 		// Create the data table; it will only contain a single row with multiple
 		// versions.
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `CREATE USER joe`)
 
 		counter := 0
 		upsertRow := func() {
@@ -6968,6 +6969,15 @@ func TestChangefeedSchemaTTL(t *testing.T) {
 		// Force a GC of the table. This should cause both older versions of the
 		// table to be deleted, with the middle version being lost to the changefeed.
 		forceTableGC(t, s.SystemServer, sqlDB, "system", "descriptor")
+
+		// Do an unnecessary version bump on the descriptor, which will purge old
+		// versions of the descriptor that the lease manager may have cached for
+		// historical queries. When schema_locked support is active, the act of
+		// detecting polling inside pauseOrResumePolling can cause old versions
+		// to be cached. The historical descriptors are cleared everytime a
+		// version bump occurs, otherwise this test can flake if the prior versions
+		// need to decode a row is already cached.
+		waitForSchemaChange(t, sqlDB, "ALTER TABLE foo OWNER TO joe")
 
 		// Resume our changefeed normally.
 		atomic.StoreInt32(&shouldWait, 0)


### PR DESCRIPTION
Backport 1/1 commits from #154879 on behalf of @fqazi.

----

Previously, TestChangefeedSchemaTTL started flaking when create_table_with_schema_locked was enabled by default in the test suite. This happened because schema_locked tables can cause historical versions of descriptors to be cached in the lease manager, as the changefeed logic intentionally queries prior versions. As a result, even after the test garbage-collected the descriptors table, these old versions could remain in the in-memory cache, leading to flakes. To address this, this patch adds a canary schema change, which bumps the descriptor's version. When a descriptor's version is bumped, all older cached versions are purged.

Fixes: #149167
Informs: #153138
Informs: #154229
Informs: #154304
Informs: #154931

Release note: None

----

Release justification: test only change