### PR TITLE
sql: add rows_read metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8747,6 +8747,22 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.rows_read.count
+      exported_name: sql_statements_rows_read_count
+      description: Number of rows read by SQL statements from primary and secondary indexes
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.rows_read.count.internal
+      exported_name: sql_statements_rows_read_count_internal
+      description: Number of rows read by SQL statements from primary and secondary indexes (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.stats.activity.update.latency
       exported_name: sql_stats_activity_update_latency
       description: The latency of updates made by the SQL activity updater job. Includes failed update attempts

--- a/pkg/roachprod/agents/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/agents/opentelemetry/cockroachdb_metrics.go
@@ -2169,6 +2169,8 @@ var cockroachdbMetrics = map[string]string{
     "sql_statements_active_internal": "sql.statements.active.internal",
     "sql_statements_auto_retry_count": "sql.statements.auto_retry.count",
     "sql_statements_auto_retry_count_internal": "sql.statements.auto_retry.count.internal",
+    "sql_statements_rows_read_count": "sql.statements.rows_read.count",
+    "sql_statements_rows_read_count_internal": "sql.statements.rows_read.count.internal",
     "sql_stats_activity_update_latency": "sql.stats.activity.update.latency",
     "sql_stats_activity_update_latency_bucket": "sql.stats.activity.update.latency.bucket",
     "sql_stats_activity_update_latency_count": "sql.stats.activity.update.latency.count",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -972,6 +972,7 @@ go_test(
         "//pkg/util/log/logconfig",
         "//pkg/util/log/logpb",
         "//pkg/util/log/logtestutils",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/protoutil",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -625,6 +625,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			FullTableOrIndexScanRejectedCount: metric.NewCounter(getMetricMeta(MetaFullTableOrIndexScanRejected, internal)),
 			TxnRetryCount:                     metric.NewCounter(getMetricMeta(MetaTxnRetry, internal)),
 			StatementRetryCount:               metric.NewCounter(getMetricMeta(MetaStatementRetry, internal)),
+			StatementRowsRead:                 metric.NewCounter(getMetricMeta(MetaStatementRowsRead, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1514,6 +1514,12 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaStatementRowsRead = metric.Metadata{
+		Name:        "sql.statements.rows_read.count",
+		Help:        "Number of rows read by SQL statements from primary and secondary indexes",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -83,6 +83,11 @@ type EngineMetrics struct {
 	// StatementRetryCount counts the number of automatic statement retries that
 	// have occurred under READ COMMITTED isolation.
 	StatementRetryCount *metric.Counter
+
+	// StatementRowsRead counts the number of rows read by SQL statements from
+	// primary and secondary indexes. Note that some secondary indexes can have
+	// multiple index rows per primary index row (e.g. inverted and vector).
+	StatementRowsRead *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.
@@ -196,6 +201,10 @@ func (ex *connExecutor) recordStatementSummary(
 	if automaticRetryStmtCount > 0 {
 		autoRetryReason = planner.autoRetryStmtReason
 	}
+
+	// Update SQL statement metrics.
+	ex.metrics.EngineMetrics.StatementRowsRead.Inc(stats.rowsRead)
+
 	if ex.statsCollector.EnabledForTransaction() {
 		recordedStmtStats := &sqlstats.RecordedStmtStats{
 			FingerprintID:        stmtFingerprintID,


### PR DESCRIPTION
Add new `sql.statements.rows_read.count` metric that counts the number of rows read by SQL statements. This is the same value that's collected by SQL stats for each statement and transaction, except in aggregated metric form.

Epic: none

Release note (sql change): Added sql.statements.rows_read.count metric that counts the number of rows read by SQL statements.