### PR TITLE
sql/inspect: fix AS OF SYSTEM TIME span bounds in index checks

### DIFF
--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -159,7 +159,7 @@ func (c *indexConsistencyCheck) Start(
 	alloc := &tree.DatumAlloc{}
 	bounds, hasRows, err := spanutils.SpanToQueryBounds(
 		ctx, cfg.DB.KV(), cfg.Codec, pkColIDs, pkColTypes, pkColDirs,
-		len(c.tableDesc.GetFamilies()), span, alloc,
+		len(c.tableDesc.GetFamilies()), span, alloc, c.asOf,
 	)
 	if err != nil {
 		return errors.Wrap(err, "converting span to query bounds")

--- a/pkg/sql/inspect/index_consistency_check_test.go
+++ b/pkg/sql/inspect/index_consistency_check_test.go
@@ -606,3 +606,70 @@ func TestIndexConsistencyWithReservedWordColumns(t *testing.T) {
 	require.InEpsilon(t, 1.0, fractionCompleted, 0.01, "progress should reach 100%% on successful completion")
 	requireCheckCountsMatch(t, r, jobID)
 }
+
+// TestMissingIndexEntryWithHistoricalQuery verifies that INSPECT can detect
+// missing index entries when querying at a historical timestamp (AS OF SYSTEM
+// TIME), including cases where data has since been deleted.
+//
+// This test overlaps with TestDetectIndexConsistencyErrors but is kept to
+// expand coverage. It exercises scenarios that TestDetectIndexConsistencyErrors
+// missed and specifically validates INSPECT’s handling of AS OF SYSTEM TIME and
+// mixed-case table names.
+func TestMissingIndexEntryWithHistoricalQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	r := sqlutils.MakeSQLRunner(db)
+	codec := s.ApplicationLayer().Codec()
+
+	// Create the table and the row entry.
+	// We use a table with mixed case as a regression case for #38184.
+	r.ExecMultiple(t,
+		`CREATE DATABASE t`,
+		`CREATE TABLE t."tEst" ("K" INT PRIMARY KEY, v INT)`,
+		`CREATE INDEX secondary ON t."tEst" (v)`,
+		`INSERT INTO t."tEst" VALUES (10, 20)`,
+	)
+
+	// Construct datums for our row values (k, v).
+	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(20)}
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "tEst")
+	secondaryIndex := tableDesc.PublicNonPrimaryIndexes()[0]
+
+	// Delete the secondary index entry to create corruption.
+	err := deleteSecondaryIndexEntry(ctx, codec, values, kvDB, tableDesc, secondaryIndex)
+	require.NoError(t, err)
+
+	// Enable INSPECT command.
+	r.Exec(t, `SET enable_inspect_command = true`)
+
+	// Run INSPECT and expect it to find the missing index entry.
+	// INSPECT returns an error when inconsistencies are found.
+	_, err = db.Query(`INSPECT TABLE t."tEst" WITH OPTIONS INDEX ALL`)
+	require.Error(t, err, "expected INSPECT to return an error when inconsistencies are found")
+	require.Contains(t, err.Error(), "INSPECT found inconsistencies")
+
+	// Run again with AS OF SYSTEM TIME.
+	time.Sleep(1 * time.Millisecond)
+	_, err = db.Query(`INSPECT TABLE t."tEst" AS OF SYSTEM TIME '-1ms' WITH OPTIONS INDEX ALL`)
+	require.Error(t, err, "expected INSPECT to return an error when inconsistencies are found")
+	require.Contains(t, err.Error(), "INSPECT found inconsistencies")
+
+	// Verify that AS OF SYSTEM TIME actually operates in the past by:
+	// 1. Getting a timestamp before we delete the row
+	// 2. Deleting the entire row
+	// 3. Running INSPECT at the historical timestamp
+	// At that historical timestamp, the row existed and was corrupted, so INSPECT
+	// should still find the corruption even though the row no longer exists.
+	ts := r.QueryStr(t, `SELECT cluster_logical_timestamp()`)[0][0]
+	r.Exec(t, `DELETE FROM t."tEst"`)
+
+	_, err = db.Query(fmt.Sprintf(
+		`INSPECT TABLE t."tEst" AS OF SYSTEM TIME '%s' WITH OPTIONS INDEX ALL`, ts,
+	))
+	require.Error(t, err, "expected INSPECT to find corruption at historical timestamp")
+	require.Contains(t, err.Error(), "INSPECT found inconsistencies",
+		"INSPECT should detect the missing index entry that existed at the historical timestamp")
+}

--- a/pkg/sql/spanutils/BUILD.bazel
+++ b/pkg/sql/spanutils/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -45,6 +46,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/spanutils/query_bounds_test.go
+++ b/pkg/sql/spanutils/query_bounds_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -202,7 +203,7 @@ func TestSpanToQueryBounds(t *testing.T) {
 			actualBounds, actualHasRows, err := spanutils.SpanToQueryBounds(ctx, kvDB, codec, pkColIDs, pkColTypes, pkColDirs, 1, roachpb.Span{
 				Key:    startKey,
 				EndKey: endKey,
-			}, &alloc)
+			}, &alloc, hlc.Timestamp{})
 
 			// Verify results.
 			require.NoError(t, err)
@@ -423,6 +424,7 @@ func TestSpanToQueryBoundsCompositeKeys(t *testing.T) {
 						EndKey: endKey,
 					},
 					&alloc,
+					hlc.Timestamp{},
 				)
 
 				// Verify results.

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/ctxgroup",
+        "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -356,6 +357,7 @@ func (t *ttlProcessor) work(ctx context.Context, output execinfra.RowReceiver) e
 				numFamilies,
 				span,
 				&alloc,
+				hlc.Timestamp{}, // Use current time bounds; TTL only deletes live rows.
 			); err != nil {
 				return errors.Wrapf(err, "SpanToQueryBounds error index=%d span=%s", i, span)
 			} else if hasRows {


### PR DESCRIPTION
INSPECT's index consistency checks could miss spans when using AS OF SYSTEM TIME if those spans had no data at the current time but did at the historical timestamp. This was due to SpanToQueryBounds() using the current time for KV scans instead of the historical time.

This commit:
- Adds an asOf parameter to SpanToQueryBounds() for historical scans
- Updates INSPECT to pass the query's timestamp
- Keeps existing behavior for TTL and tests by passing an empty timestamp

The issue was uncovered while converting TestScrubIndexMissingIndexEntry to INSPECT. The test is now TestMissingIndexEntryWithHistoricalQuery and validates correctness of historical scans.

Informs: #155485
Epic: CRDB-55075

Release note (bug fix): INSPECT now correctly checks index consistency at the historical timestamp when using AS OF SYSTEM TIME, even for spans with no current data.