### PR TITLE
roachtest: allow local runs of azure backup roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -354,7 +354,6 @@ go_library(
         "@com_github_prometheus_common//model",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_golang_google_protobuf//proto",
         "@org_golang_x_exp//maps",
         "@org_golang_x_oauth2//clientcredentials",

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -65,10 +65,6 @@ const (
 	AssumeRoleGCSCredentials    = "GOOGLE_CREDENTIALS_ASSUME_ROLE"
 	AssumeRoleGCSServiceAccount = "GOOGLE_SERVICE_ACCOUNT"
 
-	AzureClientIDEnvVar     = "AZURE_CLIENT_ID"
-	AzureClientSecretEnvVar = "AZURE_CLIENT_SECRET"
-	AzureTenantIDEnvVar     = "AZURE_TENANT_ID"
-
 	// rows2TiB is the number of rows to import to load 2TB of data (when
 	// replicated).
 	rows2TiB   = 65_104_166

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -10,7 +10,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"net/url"
-	"os"
 	"path"
 	"time"
 
@@ -34,20 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
-
-// At the moment, Azure VMs do not have managed identities set up yet.
-// Therefore, in order to use implicit authentication, we need to put a
-// credentials file on each VM and point the
-// `COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE` environment variable at the
-// file.
-// Currently, the only set of credentials that have write access to the storage
-// buckets are the Teamcity credentials, so the Azure fixture roachtests cannot
-// be run locally until those managed identities are set up.
-// TODO (kev-cao): Once managed identities are set up, we can remove this file
-// and rely on the managed identity to authenticate with Azure Blob Storage.
-const azureCredentialsFilePath = "/home/ubuntu/azure-credentials.yaml"
 
 // Maps a fixture database name to the expected number of tables in the
 // database, useful for verifying that the fingerprint of the fixture is as
@@ -196,9 +182,6 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 				"server.debug.default_vmodule":                      "s3_storage=2",
 				"cloudstorage.s3.client_retry_token_bucket.enabled": "false",
 				"cloudstorage.azure.try.timeout":                    "0s",
-			},
-			install.EnvOption{
-				fmt.Sprintf("COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE=%s", azureCredentialsFilePath),
 			},
 		))
 }
@@ -653,7 +636,6 @@ func registerBackupFixtures(r registry.Registry) {
 			Suites:            bf.suites,
 			Skip:              bf.skip,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				require.NoError(t, maybePutAzureCredentialsFile(ctx, c, azureCredentialsFilePath))
 				registry := GetFixtureRegistry(ctx, t, c.Cloud())
 
 				handle, err := registry.Create(ctx, bf.fixture.Name, t.L())
@@ -687,44 +669,6 @@ func registerBackupFixtures(r registry.Registry) {
 			},
 		})
 	}
-}
-
-func maybePutAzureCredentialsFile(ctx context.Context, c cluster.Cluster, path string) error {
-	if c.Cloud() != spec.Azure {
-		return nil
-	}
-
-	type azureCreds struct {
-		TenantID     string `yaml:"azure_tenant_id"`
-		ClientID     string `yaml:"azure_client_id"`
-		ClientSecret string `yaml:"azure_client_secret"`
-	}
-
-	azureEnvVars := []string{AzureTenantIDEnvVar, AzureClientIDEnvVar, AzureClientSecretEnvVar}
-	azureEnvValues := make(map[string]string)
-	for _, envVar := range azureEnvVars {
-		val := os.Getenv(envVar)
-		if val == "" {
-			return errors.Newf("environment variable %s is not set", envVar)
-		}
-		azureEnvValues[envVar] = val
-	}
-
-	creds := azureCreds{
-		TenantID:     azureEnvValues[AzureTenantIDEnvVar],
-		ClientID:     azureEnvValues[AzureClientIDEnvVar],
-		ClientSecret: azureEnvValues[AzureClientSecretEnvVar],
-	}
-
-	credsYaml, err := yaml.Marshal(creds)
-	if err != nil {
-		return errors.Wrapf(err, "failed to marshal Azure credentials to YAML")
-	}
-
-	return errors.Wrap(
-		c.PutString(ctx, string(credsYaml), path, 0700),
-		"failed to put Azure credentials file in cluster",
-	)
 }
 
 func registerBlobFixtureGC(r registry.Registry) {


### PR DESCRIPTION
Previously the azure backup roachtest could only in the nightlies, and not by developers on their machines. This patch removes the clunky credentials auth path the test used to use. Now, the test auths to the bucket via an IAM policy that the developer needs to set up following the internal azure roachprod tutorial.

Epic: none

Release note: none