### PR TITLE
kvserver/rangefeed: move from log.KvDistribution to log.KvExec

### DIFF
--- a/pkg/kv/kvserver/closedts/policyrefresher/policy_refresher.go
+++ b/pkg/kv/kvserver/closedts/policyrefresher/policy_refresher.go
@@ -69,7 +69,7 @@ func NewPolicyRefresher(
 	knobs *TestingKnobs,
 ) *PolicyRefresher {
 	if getLeaseholderReplicas == nil || getNodeLatencies == nil {
-		log.KvDistribution.Fatalf(context.Background(), "getLeaseholderReplicas and getNodeLatencies must be non-nil")
+		log.KvExec.Fatalf(context.Background(), "getLeaseholderReplicas and getNodeLatencies must be non-nil")
 		return nil
 	}
 	refresher := &PolicyRefresher{

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -653,7 +653,7 @@ func (b *updatesBuf) Push(ctx context.Context, update *ctpb.Update) {
 	if b.sizeLocked() != 0 {
 		lastIdx := b.lastIdxLocked()
 		if prevSeq := b.mu.data[lastIdx].SeqNum; prevSeq != update.SeqNum-1 {
-			log.KvDistribution.Fatalf(ctx, "bad sequence number; expected %d, got %d", prevSeq+1, update.SeqNum)
+			log.KvExec.Fatalf(ctx, "bad sequence number; expected %d, got %d", prevSeq+1, update.SeqNum)
 		}
 	}
 
@@ -762,7 +762,7 @@ func (b *updatesBuf) GetBySeq(ctx context.Context, seqNum ctpb.SeqNum) (*ctpb.Up
 			continue
 		}
 		if seqNum > lastSeq+1 {
-			log.KvDistribution.Fatalf(ctx, "skipping sequence numbers; requested: %d, last: %d", seqNum, lastSeq)
+			log.KvExec.Fatalf(ctx, "skipping sequence numbers; requested: %d, last: %d", seqNum, lastSeq)
 		}
 		idx := (b.mu.head + (int)(seqNum-firstSeq)) % len(b.mu.data)
 		return b.mu.data[idx], true
@@ -963,7 +963,7 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 				}
 				if err := r.maybeConnect(ctx, stopper); err != nil {
 					if !errors.HasType(err, (*netutil.InitialHeartbeatFailedError)(nil)) && everyN.ShouldLog() {
-						log.KvDistribution.Infof(ctx, "side-transport failed to connect to n%d: %s", r.nodeID, err)
+						log.KvExec.Infof(ctx, "side-transport failed to connect to n%d: %s", r.nodeID, err)
 					}
 					time.Sleep(errSleepTime)
 					continue
@@ -993,7 +993,7 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 				}
 				if err := r.stream.Send(msg); err != nil {
 					if err != io.EOF && everyN.ShouldLog() {
-						log.KvDistribution.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
+						log.KvExec.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
 							r.lastSent, r.nodeID, err)
 					}
 					// Keep track of the fact that we need a new connection.

--- a/pkg/kv/kvserver/closedts/tracker/heap_tracker.go
+++ b/pkg/kv/kvserver/closedts/tracker/heap_tracker.go
@@ -103,7 +103,7 @@ func (h *heapTracker) Track(ctx context.Context, ts hlc.Timestamp) RemovalToken 
 func (h *heapTracker) Untrack(ctx context.Context, tok RemovalToken) {
 	idx := tok.(heapToken).index
 	if idx == -1 {
-		log.KvDistribution.Fatalf(ctx, "attempting to untrack already-untracked item")
+		log.KvExec.Fatalf(ctx, "attempting to untrack already-untracked item")
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/pkg/kv/kvserver/closedts/tracker/lockfree_tracker.go
+++ b/pkg/kv/kvserver/closedts/tracker/lockfree_tracker.go
@@ -168,7 +168,7 @@ func (t *lockfreeTracker) Untrack(ctx context.Context, tok RemovalToken) {
 	// types.
 	refcnt := b.refcnt.Add(-1)
 	if refcnt < 0 {
-		log.KvDistribution.Fatalf(ctx, "negative bucket refcount: %d", refcnt)
+		log.KvExec.Fatalf(ctx, "negative bucket refcount: %d", refcnt)
 	}
 	if refcnt == 0 {
 		// Reset the bucket, so that future Track() calls can create a new one.

--- a/pkg/kv/kvserver/closedts/tracker/tracker_test.go
+++ b/pkg/kv/kvserver/closedts/tracker/tracker_test.go
@@ -167,7 +167,7 @@ func TestLockfreeTrackerRandomStress(t *testing.T) {
 	// hours of stressrace on GCE worker (and it failed once on CI stress too).
 	// Figure out why.
 	maxToleratedErrorMillis := 3 * c.maxEvaluationTime.Milliseconds()
-	log.KvDistribution.Infof(ctx, "maximum lower bound error: %dms. maximum request evaluation time: %s",
+	log.KvExec.Infof(ctx, "maximum lower bound error: %dms. maximum request evaluation time: %s",
 		maxOvershotMillis, c.maxEvaluationTime)
 	require.Lessf(t, maxOvershotMillis, maxToleratedErrorMillis,
 		"maximum tracker lowerbound error was %dms, above maximum tolerated %dms",
@@ -446,7 +446,7 @@ func (c *trackerChecker) run(ctx context.Context) error {
 		if c.maxOvershotNanos < overshotNanos {
 			c.maxOvershotNanos = overshotNanos
 		}
-		log.KvDistribution.VInfof(ctx, 1, "lower bound error: %dms", overshotNanos/1000000)
+		log.KvExec.VInfof(ctx, 1, "lower bound error: %dms", overshotNanos/1000000)
 	}
 }
 
@@ -517,7 +517,7 @@ func benchmarkTracker(ctx context.Context, b *testing.B, t Tracker) {
 				toks[i] = toks[i][:0]
 			}
 			mu.Unlock()
-			log.KvDistribution.VInfof(ctx, 1, "cleared %d reqs", n)
+			log.KvExec.VInfof(ctx, 1, "cleared %d reqs", n)
 		}
 	}()
 

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -248,7 +248,7 @@ type SharedBudgetAllocation struct {
 func (a *SharedBudgetAllocation) Use(ctx context.Context) {
 	if a != nil {
 		if atomic.AddInt32(&a.refCount, 1) == 1 {
-			log.KvDistribution.Fatalf(ctx, "unexpected shared memory allocation usage increase after free")
+			log.KvExec.Fatalf(ctx, "unexpected shared memory allocation usage increase after free")
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -196,7 +196,7 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 	// If the registration has a catch-up scan, run it.
 	if err := br.maybeRunCatchUpScan(ctx); err != nil {
 		err = errors.Wrap(err, "catch-up scan failed")
-		log.KvDistribution.Errorf(ctx, "%v", err)
+		log.KvExec.Errorf(ctx, "%v", err)
 		return err
 	}
 
@@ -229,7 +229,7 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 
 		if overflowed {
 			if wasOverflowedOnFirstIteration && br.shouldLogOverflow(oneCheckpointWithTimestampSent) {
-				log.KvDistribution.Warningf(ctx, "rangefeed %s overflowed during catch up scan from %s (useful checkpoint sent: %v)",
+				log.KvExec.Warningf(ctx, "rangefeed %s overflowed during catch up scan from %s (useful checkpoint sent: %v)",
 					br.span, br.catchUpTimestamp, oneCheckpointWithTimestampSent)
 			}
 

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -255,13 +255,13 @@ func setupData(
 		absPath = loc
 	}
 	if exists {
-		log.KvDistribution.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
+		log.KvExec.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
 		testutils.ReadAllFiles(filepath.Join(loc, "*"))
 		return emk(b, loc, opts.lBaseMaxBytes, opts.rwMode), loc
 	}
 
 	eng := emk(b, loc, opts.lBaseMaxBytes, fs.ReadWrite)
-	log.KvDistribution.Infof(ctx, "creating rangefeed benchmark data: %s", absPath)
+	log.KvExec.Infof(ctx, "creating rangefeed benchmark data: %s", absPath)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))
@@ -322,7 +322,7 @@ func setupData(
 		// optimizations which change the data size result in the same number of
 		// sstables.
 		if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
-			log.KvDistribution.Infof(ctx, "committing (%d/~%d) (%d/%d)", i/scaled, 20, i, len(order))
+			log.KvExec.Infof(ctx, "committing (%d/~%d) (%d/%d)", i/scaled, 20, i, len(order))
 			if err := batch.Commit(false /* sync */); err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/kv/kvserver/rangefeed/event_size.go
+++ b/pkg/kv/kvserver/rangefeed/event_size.go
@@ -205,7 +205,7 @@ func opsCurrMemUsage(ops opsEvent) int64 {
 		case *enginepb.MVCCAbortTxnOp:
 			currMemUsage += abortTxnOpMemUsage(t.TxnID)
 		default:
-			log.KvDistribution.Fatalf(context.Background(), "unknown logical op %T", t)
+			log.KvExec.Fatalf(context.Background(), "unknown logical op %T", t)
 		}
 	}
 	// For each op, a checkpoint may or may not be published depending on whether
@@ -276,7 +276,7 @@ func MemUsage(e event) int64 {
 		// For sync event, no rangefeed events will be published.
 		return eventOverhead + syncEventOverhead
 	default:
-		log.KvDistribution.Fatalf(context.Background(), "missing event variant: %+v", e)
+		log.KvExec.Fatalf(context.Background(), "missing event variant: %+v", e)
 	}
 	// For empty event, only eventOverhead is accounted.
 	return eventOverhead

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -191,37 +191,37 @@ func (r *baseRegistration) assertEvent(ctx context.Context, event *kvpb.RangeFee
 	switch t := event.GetValue().(type) {
 	case *kvpb.RangeFeedValue:
 		if t.Key == nil {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedValue.Key: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedValue.Key: %v", t)
 		}
 		if t.Value.RawBytes == nil {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedValue.Value.RawBytes: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedValue.Value.RawBytes: %v", t)
 		}
 		if t.Value.Timestamp.IsEmpty() {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedValue.Value.Timestamp: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedValue.Value.Timestamp: %v", t)
 		}
 	case *kvpb.RangeFeedCheckpoint:
 		if t.Span.Key == nil {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedCheckpoint.Span.Key: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedCheckpoint.Span.Key: %v", t)
 		}
 	case *kvpb.RangeFeedSSTable:
 		if len(t.Data) == 0 {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedSSTable.Data: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedSSTable.Data: %v", t)
 		}
 		if len(t.Span.Key) == 0 {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedSSTable.Span: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedSSTable.Span: %v", t)
 		}
 		if t.WriteTS.IsEmpty() {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedSSTable.Timestamp: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedSSTable.Timestamp: %v", t)
 		}
 	case *kvpb.RangeFeedDeleteRange:
 		if len(t.Span.Key) == 0 || len(t.Span.EndKey) == 0 {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty key in RangeFeedDeleteRange.Span: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty key in RangeFeedDeleteRange.Span: %v", t)
 		}
 		if t.Timestamp.IsEmpty() {
-			log.KvDistribution.Fatalf(ctx, "unexpected empty RangeFeedDeleteRange.Timestamp: %v", t)
+			log.KvExec.Fatalf(ctx, "unexpected empty RangeFeedDeleteRange.Timestamp: %v", t)
 		}
 	default:
-		log.KvDistribution.Fatalf(ctx, "unexpected RangeFeedEvent variant: %v", t)
+		log.KvExec.Fatalf(ctx, "unexpected RangeFeedEvent variant: %v", t)
 	}
 }
 
@@ -263,7 +263,7 @@ func (r *baseRegistration) maybeStripEvent(
 			// observed all values up to the checkpoint timestamp over a given
 			// key span if any updates to that span have been filtered out.
 			if !t.Span.Contains(r.span) {
-				log.KvDistribution.Fatalf(ctx, "registration span %v larger than checkpoint span %v", r.span, t.Span)
+				log.KvExec.Fatalf(ctx, "registration span %v larger than checkpoint span %v", r.span, t.Span)
 			}
 			t = copyOnWrite().(*kvpb.RangeFeedCheckpoint)
 			t.Span = r.span
@@ -278,7 +278,7 @@ func (r *baseRegistration) maybeStripEvent(
 		// SSTs are always sent in their entirety, it is up to the caller to
 		// filter out irrelevant entries.
 	default:
-		log.KvDistribution.Fatalf(ctx, "unexpected RangeFeedEvent variant: %v", t)
+		log.KvExec.Fatalf(ctx, "unexpected RangeFeedEvent variant: %v", t)
 	}
 	return ret
 }
@@ -364,7 +364,7 @@ func (reg *registry) Register(ctx context.Context, r registration) {
 	r.setID(reg.nextID())
 	if err := reg.tree.Insert(r, false /* fast */); err != nil {
 		// TODO(erikgrinaker): these errors should arguably be returned.
-		log.KvDistribution.Fatalf(ctx, "%v", err)
+		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 }
 
@@ -400,7 +400,7 @@ func (reg *registry) PublishToOverlapping(
 		// surprising. Revisit this once RangeFeed has more users.
 		minTS = hlc.MaxTimestamp
 	default:
-		log.KvDistribution.Fatalf(ctx, "unexpected RangeFeedEvent variant: %v", t)
+		log.KvExec.Fatalf(ctx, "unexpected RangeFeedEvent variant: %v", t)
 	}
 
 	reg.forOverlappingRegs(ctx, span, func(r registration) (bool, *kvpb.Error) {
@@ -468,13 +468,13 @@ func (reg *registry) remove(ctx context.Context, toDelete []interval.Interface) 
 	} else if len(toDelete) == 1 {
 		reg.updateMetricsOnUnregistration(toDelete[0].(registration))
 		if err := reg.tree.Delete(toDelete[0], false /* fast */); err != nil {
-			log.KvDistribution.Fatalf(ctx, "%v", err)
+			log.KvExec.Fatalf(ctx, "%v", err)
 		}
 	} else if len(toDelete) > 1 {
 		for _, i := range toDelete {
 			reg.updateMetricsOnUnregistration(i.(registration))
 			if err := reg.tree.Delete(i, true /* fast */); err != nil {
-				log.KvDistribution.Fatalf(ctx, "%v", err)
+				log.KvExec.Fatalf(ctx, "%v", err)
 			}
 		}
 		reg.tree.AdjustRanges()

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -224,7 +224,7 @@ func (rts *resolvedTimestamp) consumeLogicalOp(
 		return rts.intentQ.Del(t.TxnID)
 
 	default:
-		log.KvDistribution.Fatalf(ctx, "unknown logical op %T", t)
+		log.KvExec.Fatalf(ctx, "unknown logical op %T", t)
 		return false
 	}
 }
@@ -237,7 +237,7 @@ func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 		return false
 	}
 	if rts.closedTS.Less(rts.resolvedTS) {
-		log.KvDistribution.Fatalf(ctx, "closed timestamp below resolved timestamp: %s < %s",
+		log.KvExec.Fatalf(ctx, "closed timestamp below resolved timestamp: %s < %s",
 			rts.closedTS, rts.resolvedTS)
 	}
 	newTS := rts.closedTS
@@ -246,7 +246,7 @@ func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 	// timestamps cannot be resolved yet.
 	if txn := rts.intentQ.Oldest(); txn != nil {
 		if txn.timestamp.LessEq(rts.resolvedTS) {
-			log.KvDistribution.Fatalf(ctx, "unresolved txn equal to or below resolved timestamp: %s <= %s",
+			log.KvExec.Fatalf(ctx, "unresolved txn equal to or below resolved timestamp: %s <= %s",
 				txn.timestamp, rts.resolvedTS)
 		}
 		// txn.timestamp cannot be resolved, so the resolved timestamp must be Prev.
@@ -258,7 +258,7 @@ func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 	newTS.Logical = 0
 
 	if newTS.Less(rts.resolvedTS) {
-		log.KvDistribution.Fatalf(ctx, "resolved timestamp regression, was %s, recomputed as %s",
+		log.KvExec.Fatalf(ctx, "resolved timestamp regression, was %s, recomputed as %s",
 			rts.resolvedTS, newTS)
 	}
 	return rts.resolvedTS.Forward(newTS)
@@ -271,7 +271,7 @@ func (rts *resolvedTimestamp) assertNoChange(ctx context.Context) {
 	before := rts.resolvedTS
 	changed := rts.recompute(ctx)
 	if changed || before != rts.resolvedTS {
-		log.KvDistribution.Fatalf(ctx, "unexpected resolved timestamp change on recomputation, "+
+		log.KvExec.Fatalf(ctx, "unexpected resolved timestamp change on recomputation, "+
 			"was %s, recomputed as %s", before, rts.resolvedTS)
 	}
 }
@@ -289,9 +289,9 @@ func (rts *resolvedTimestamp) assertOpAboveRTS(
 		err := errors.AssertionFailedf(
 			"resolved timestamp %s equal to or above timestamp of operation %v", rts.resolvedTS, &op)
 		if fatal {
-			log.KvDistribution.Fatalf(ctx, "%v", err)
+			log.KvExec.Fatalf(ctx, "%v", err)
 		} else {
-			log.KvDistribution.Errorf(ctx, "%v", err)
+			log.KvExec.Errorf(ctx, "%v", err)
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -493,7 +493,7 @@ func (ss *schedulerShard) processEvents(ctx context.Context) {
 
 		if remaining != 0 && buildutil.CrdbTestBuild {
 			if (remaining^procEventType)&remaining != 0 {
-				log.KvDistribution.Fatalf(ctx,
+				log.KvExec.Fatalf(ctx,
 					"rangefeed processor attempted to reschedule event type %s that was not present in original event set %s",
 					procEventType, remaining)
 			}
@@ -501,7 +501,7 @@ func (ss *schedulerShard) processEvents(ctx context.Context) {
 
 		if e&Stopped != 0 {
 			if remaining != 0 {
-				log.KvDistribution.VWarningf(ctx, 5,
+				log.KvExec.VWarningf(ctx, 5,
 					"rangefeed processor %d didn't process all events on close", entry.id)
 			}
 			// We'll keep Stopped state to avoid calling stopped processor again

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -86,7 +86,7 @@ func (s *PerRangeEventSink) SendError(err *kvpb.Error) {
 		Error: *transformRangefeedErrToClientError(err),
 	})
 	if ev.Error == nil {
-		log.KvDistribution.Fatalf(context.Background(),
+		log.KvExec.Fatalf(context.Background(),
 			"unexpected: SendWithoutBlocking called with non-error event")
 	}
 	// Silence the error: expected to happen when the buffered sender is closed or

--- a/pkg/kv/kvserver/rangefeed/stream_manager.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager.go
@@ -108,7 +108,7 @@ func (sm *StreamManager) NewStream(streamID int64, rangeID roachpb.RangeID) (sin
 	case *UnbufferedSender:
 		return NewPerRangeEventSink(rangeID, streamID, sender)
 	default:
-		log.KvDistribution.Fatalf(context.Background(), "unexpected sender type %T", sm)
+		log.KvExec.Fatalf(context.Background(), "unexpected sender type %T", sm)
 		return nil
 	}
 }
@@ -133,7 +133,7 @@ func (sm *StreamManager) OnError(streamID int64) {
 // DisconnectStream disconnects the stream with the given streamID.
 func (sm *StreamManager) DisconnectStream(streamID int64, err *kvpb.Error) {
 	if err == nil {
-		log.KvDistribution.Fatalf(context.Background(),
+		log.KvExec.Fatalf(context.Background(),
 			"unexpected: DisconnectStream called with nil error")
 		return
 	}
@@ -166,7 +166,7 @@ func (sm *StreamManager) AddStream(streamID int64, d Disconnector) {
 		return
 	}
 	if _, ok := sm.streams.m[streamID]; ok {
-		log.KvDistribution.Fatalf(context.Background(), "stream %d already exists", streamID)
+		log.KvExec.Fatalf(context.Background(), "stream %d already exists", streamID)
 	}
 	sm.streams.m[streamID] = d
 	sm.metrics.ActiveMuxRangeFeed.Inc(1)
@@ -209,7 +209,7 @@ func (sm *StreamManager) Stop(ctx context.Context) {
 	sm.sender.cleanup(ctx)
 	sm.streams.Lock()
 	defer sm.streams.Unlock()
-	log.KvDistribution.VInfof(ctx, 2, "stopping stream manager: disconnecting %d streams", len(sm.streams.m))
+	log.KvExec.VInfof(ctx, 2, "stopping stream manager: disconnecting %d streams", len(sm.streams.m))
 	rangefeedClosedErr := kvpb.NewError(
 		kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED))
 	sm.metrics.ActiveMuxRangeFeed.Dec(int64(len(sm.streams.m)))
@@ -228,7 +228,7 @@ func (sm *StreamManager) Stop(ctx context.Context) {
 // sender.run may also finish without sending anything to the channel.
 func (sm *StreamManager) Error() <-chan error {
 	if sm.errCh == nil {
-		log.KvDistribution.Fatalf(context.Background(), "StreamManager.Error called before StreamManager.Start")
+		log.KvExec.Fatalf(context.Background(), "StreamManager.Error called before StreamManager.Start")
 	}
 	return sm.errCh
 }

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -60,7 +60,7 @@ func (s *initResolvedTSScan) Run(ctx context.Context) {
 	if err := s.iterateAndConsume(ctx); err != nil {
 		err = errors.Wrap(err, "initial resolved timestamp scan failed")
 		if ctx.Err() == nil { // cancellation probably caused the error
-			log.KvDistribution.Errorf(ctx, "%v", err)
+			log.KvExec.Errorf(ctx, "%v", err)
 		}
 		s.p.StopWithErr(kvpb.NewError(err))
 	} else {
@@ -249,7 +249,7 @@ func (a *txnPushAttempt) Run(ctx context.Context) {
 	defer a.Cancel()
 	if err := a.pushOldTxns(ctx); err != nil {
 		if ctx.Err() == nil { // cancellation probably caused the error
-			log.KvDistribution.Errorf(ctx, "pushing old intents failed: %v", err)
+			log.KvExec.Errorf(ctx, "pushing old intents failed: %v", err)
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -127,7 +127,7 @@ func (ubs *UnbufferedSender) sendBuffered(
 // Important to be thread-safe.
 func (ubs *UnbufferedSender) sendUnbuffered(event *kvpb.MuxRangeFeedEvent) error {
 	if event.Error != nil {
-		log.KvDistribution.Fatalf(context.Background(), "unexpected: SendUnbuffered called with error event")
+		log.KvExec.Fatalf(context.Background(), "unexpected: SendUnbuffered called with error event")
 	}
 	return ubs.sender.Send(event)
 }
@@ -156,7 +156,7 @@ func (ubs *UnbufferedSender) run(
 			for _, clientErr := range toSend {
 				onError(clientErr.StreamID)
 				if err := ubs.sender.Send(clientErr); err != nil {
-					log.KvDistribution.Infof(ctx, "failed to send rangefeed error to client: %v", err)
+					log.KvExec.Infof(ctx, "failed to send rangefeed error to client: %v", err)
 					return err
 				}
 			}

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -293,7 +293,7 @@ func (st *sidetransportAccess) forward(
 
 func (st *sidetransportAccess) assertNoRegression(ctx context.Context, cur, up closedTimestamp) {
 	if cur.regression(up) {
-		log.KvDistribution.Fatalf(ctx, "side-transport update saw closed timestamp regression on r%d: "+
+		log.KvExec.Fatalf(ctx, "side-transport update saw closed timestamp regression on r%d: "+
 			"(lai=%d, ts=%s) -> (lai=%d, ts=%s)", st.rangeID, cur.lai, cur.ts, up.lai, up.ts)
 	}
 }

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -419,7 +419,7 @@ func logSlowRangefeedRegistration(ctx context.Context) func() {
 	return func() {
 		elapsed := start.Elapsed()
 		if elapsed >= slowRaftMuWarnThreshold {
-			log.KvDistribution.Warningf(ctx, "rangefeed registration took %s", elapsed)
+			log.KvExec.Warningf(ctx, "rangefeed registration took %s", elapsed)
 		}
 	}
 }
@@ -871,9 +871,9 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 		expensiveLog := m.RangeFeedSlowClosedTimestampLogN.ShouldLog()
 		if expensiveLog {
 			if closedTS.IsEmpty() {
-				log.KvDistribution.Infof(ctx, "RangeFeed closed timestamp is empty")
+				log.KvExec.Infof(ctx, "RangeFeed closed timestamp is empty")
 			} else {
-				log.KvDistribution.Infof(ctx, "RangeFeed closed timestamp %s is behind by %s (%v)",
+				log.KvExec.Infof(ctx, "RangeFeed closed timestamp %s is behind by %s (%v)",
 					closedTS, signal.lag, signal)
 			}
 		}
@@ -901,7 +901,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 				}
 				defer func() { <-m.RangeFeedSlowClosedTimestampNudgeSem }()
 				if err := r.ensureClosedTimestampStarted(ctx); err != nil {
-					log.KvDistribution.Infof(ctx, `RangeFeed failed to nudge: %s`, err)
+					log.KvExec.Infof(ctx, `RangeFeed failed to nudge: %s`, err)
 				} else if signal.exceedsCancelLagThreshold {
 					// We have successfully nudged the leaseholder to make progress on
 					// the closed timestamp. If the lag was already persistently too
@@ -915,7 +915,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 					// prohibit us from cancelling the rangefeed in the current version,
 					// due to mixed version compatibility.
 					if expensiveLog {
-						log.KvDistribution.Infof(ctx,
+						log.KvExec.Infof(ctx,
 							`RangeFeed is too far behind, cancelling for replanning [%v]`, signal)
 					}
 					r.disconnectRangefeedWithReason(kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED)


### PR DESCRIPTION
Epic: none 
Release note: none 