### PR TITLE
kvserver: add storeRaftDequeuePacer and changes to raftReceiveQueue

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -260,6 +260,7 @@ go_library(
         "@com_github_cockroachdb_pebble//sstable/block",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//proto",
         "@com_github_kr_pretty//:pretty",
         "@com_github_prometheus_client_golang//prometheus",

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -6,9 +6,12 @@
 package kvserver
 
 import (
+	"cmp"
 	"context"
+	"maps"
 	"math"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,8 +33,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/taskpacer"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/dustin/go-humanize"
 )
+
+var RaftMsgAppDequeuePacingEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly, "kv.raft.msg_app_dequeue_pacing.enabled",
+	"enables pacing of dequeueing of MsgApps from the raftReceiveQueue, to reduce the "+
+		"probability of store write stalls", true)
 
 var (
 	logRaftRecvQueueFullEvery = log.Every(1 * time.Second)
@@ -42,26 +55,137 @@ type raftRequestInfo struct {
 	respStream RaftMessageResponseStream
 }
 
+// raftReceiveQueue contains the received RaftMessageRequests for a range,
+// that are waiting to be processed on the raft scheduler. It separates the
+// stream of MsgApp messages from the rest, where the rest are labeled as
+// "other" messages in the code. This is acceptable since Raft does not suffer
+// from performance hiccups (e.g. retransmits) in the absence of total
+// ordering of MsgApps with respect to other messages, so we can narrow the in
+// order delivery to within each stream. Of course, not delivering the MsgApp
+// stream can delay quorum.
+//
+// Other messages are always dequeued when Drain is called from the raft
+// scheduler (after which the caller processes the drained messages).
+//
+// MsgApp messages may not be drained if the MsgApp processing is being paced
+// to avoid store write stalls. MsgApp draining can be arbitrarily delayed,
+// but since there is a bounded volume of queued MsgApps (because of quorum
+// replication flow control (QRFC) pacing at the sender), we do not run the
+// risk of OOMs. Additionally, due to the existence of the QRFC, we constrain
+// MsgApp pacing only to when all the queued MsgApps have LowPriorityOverride
+// set to true. This covers the case of the sender doing force-flush of a QRFC
+// send-queue, which is the primary case where we run the risk of write
+// stalls. We could expand the scope of the pacing in the future, if
+// necessary, but we want to be very careful about adding more cases where
+// queueing can delay quorum.
+//
+// NB: In the default case of QRFC applying to all work (regular and elastic),
+// the enforceMaxLen bool is false, so one doesn't need to worry about
+// queueing increasing the probability of overflow.
 type raftReceiveQueue struct {
+	rangeID      roachpb.RangeID
+	dequeuePacer *storeRaftDequeuePacer
+
 	mu struct { // not to be locked directly
-		destroyed bool
 		syncutil.Mutex
-		infos         []raftRequestInfo
+		destroyed bool
+		// The queued MsgApps.
+		msgAppInfos []raftRequestInfo
+		// Memory accounting for the queued MsgApp requests. The used bytes
+		// represents the total size in bytes of the msgAppInfos. This is read by
+		// the storeRaftDequeuePacer.
+		msgAppAcc mon.BoundAccount
+
+		// The queued non-MsgApp (other) messages.
+		otherMsgInfos []raftRequestInfo
+		// Memory accounting for the qeueued non-MsgApp (other) requests.
+		otherAcc mon.BoundAccount
+
+		// Whether to enforce maxLen on append. Typically, it will be false, and
+		// only exists because it was needed pre-QRFC.
 		enforceMaxLen bool
+
+		// lastDrainedFromOtherMsgs is used for reusing the msgAppInfos or
+		// otherMsgInfos slice.
+		lastDrainedFromOtherMsgs bool
+
+		// When the queue is non-empty, someone must be responsible for draining
+		// it. This happens either by the (a) range being queued for processing at
+		// the raft scheduler, or (b) pacerDequeueDecision==raftDequeueOtherMsgs,
+		// in which case the storeRaftDequeuePacer is responsible for eventually
+		// transitioning to raftDequeueAllMsgs, and queuing the range for
+		// processing at the raft scheduler. Both (a) and (b) can be true at the
+		// same time, since when pacerDequeueDecision==raftDequeueOtherMsgs, the
+		// drain will only drain the otherMsgInfos.
+		//
+		// queuedAtRaftScheduler is true if raftReceiveQueue believes it is queued
+		// at the raft scheduler. It is ok for this to be false when it is
+		// actually queued, but the reverse would be a serious bug leading to
+		// indefinitely queued messages.
+		queuedAtRaftScheduler bool
+
+		// State managed by the storeRaftDequeuePacer.
+		//
+		// The raftReceiveQueue and storeRaftDequeuePacer interact via three
+		// fields in the raftReceiveQueue. One of these is msgAppAcc which is read
+		// by storeRaftDequeuePacer and modified by raftReceiveQueue (also
+		// mentioned above). The other two are the following pacerDequeue* fields
+		// that are read and modified by the pacer. The pacerDequeueDecision is
+		// read by raftReceiveQueue to decide on its actions. The
+		// pacerDequeueAccountingBytes is used for bookkeeping by the pacer, and
+		// set to 0 when the MsgApps are drained (it is distinct from
+		// msgAppAcc.Used() as more MsgApps can be queued after the pacer switches
+		// the decision to raftDequeueAllMsgs).
+		//
+		// INVARIANTS:
+		//
+		// pacerDequeueDecision == raftDequeueOtherMsgs <=>
+		//   pacerDequeueAccountingBytes == 0
+		//
+		// pacerDequeueDecision == raftDequeueOtherMsgs <=>
+		//   the raftReceiveQueue is enqueued in the pacer
+		//
+		// The first invariant is trivially maintained by ensuring that any
+		// transition from raftDequeueAllMsgs => raftDequeueOtherMsgs only happens
+		// when the enqueued msgAppInfos are transitioning from non-empty to
+		// empty.
+		//
+		// The transition from raftDequeueOtherMsgs => raftDequeueAllMsgs happens
+		// when the store is healthy enough (decided by the storeRaftDequeuePacer)
+		// for them to be dequeued.
+		//
+		// See the declaration of storeRaftDequeuePacer for the methods called on
+		// the pacer by the raftReceiveQueue.
+		pacerDequeueDecision        raftDequeueDecision
+		pacerDequeueAccountingBytes int64
 	}
 	maxLen int
-	acc    mon.BoundAccount
+}
+
+func newRaftReceiveQueue(
+	rangeID roachpb.RangeID, pacer *storeRaftDequeuePacer, monitor *mon.BytesMonitor, maxLen int,
+) *raftReceiveQueue {
+	q := &raftReceiveQueue{rangeID: rangeID, dequeuePacer: pacer, maxLen: maxLen}
+	q.mu.msgAppAcc.Init(context.Background(), monitor)
+	q.mu.otherAcc.Init(context.Background(), monitor)
+	return q
 }
 
 // Len returns the number of requests in the queue.
 func (q *raftReceiveQueue) Len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.mu.infos)
+	return q.lenLocked()
 }
 
-// Drain moves the stored requests out of the queue, returning them to
-// the caller. Returns true if the returned slice was not empty.
+func (q *raftReceiveQueue) lenLocked() int {
+	return len(q.mu.msgAppInfos) + len(q.mu.otherMsgInfos)
+}
+
+// Drain moves the stored requests out of the queue, returning them to the
+// caller. Returns true if the returned slice was not empty. It will always
+// drain the non-MsgApp requests, and will also drain the MsgApp requests if
+// the (internal) raftDequeueDecision permits.
 func (q *raftReceiveQueue) Drain() ([]raftRequestInfo, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -69,20 +193,44 @@ func (q *raftReceiveQueue) Drain() ([]raftRequestInfo, bool) {
 }
 
 func (q *raftReceiveQueue) drainLocked() ([]raftRequestInfo, bool) {
-	if len(q.mu.infos) == 0 {
-		return nil, false
+	var infos []raftRequestInfo
+	if len(q.mu.otherMsgInfos) == 0 {
+		if len(q.mu.msgAppInfos) != 0 && q.mu.pacerDequeueDecision == raftDequeueAllMsgs {
+			// Common case on followers: only MsgApps in the queue.
+			q.dequeuePacer.DrainingMsgAppsQLocked(q)
+			infos = q.mu.msgAppInfos
+			q.mu.msgAppInfos = nil
+			q.mu.lastDrainedFromOtherMsgs = false
+			q.mu.msgAppAcc.Clear(context.Background())
+		}
+	} else {
+		infos = q.mu.otherMsgInfos
+		q.mu.otherMsgInfos = nil
+		q.mu.lastDrainedFromOtherMsgs = true
+		q.mu.otherAcc.Clear(context.Background())
+		if len(q.mu.msgAppInfos) != 0 && q.mu.pacerDequeueDecision == raftDequeueAllMsgs {
+			q.dequeuePacer.DrainingMsgAppsQLocked(q)
+			infos = append(infos, q.mu.msgAppInfos...)
+			q.mu.msgAppInfos = q.mu.msgAppInfos[:0]
+			q.mu.msgAppAcc.Clear(context.Background())
+		}
+		// Else, common case on leader: only non-MsgApps in the queue.
 	}
-	infos := q.mu.infos
-	q.mu.infos = nil
-	q.acc.Clear(context.Background())
-	return infos, true
+	q.mu.queuedAtRaftScheduler = false
+	return infos, len(infos) > 0
 }
 
 func (q *raftReceiveQueue) Delete() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	q.dequeuePacer.DeregisterQLocked(q)
 	q.drainLocked()
-	if err := q.acc.ResizeTo(context.Background(), 0); err != nil {
+	q.mu.msgAppInfos = nil
+	q.mu.otherMsgInfos = nil
+	if err := q.mu.msgAppAcc.ResizeTo(context.Background(), 0); err != nil {
+		panic(err) // ResizeTo(., 0) always returns nil
+	}
+	if err := q.mu.otherAcc.ResizeTo(context.Background(), 0); err != nil {
 		panic(err) // ResizeTo(., 0) always returns nil
 	}
 	q.mu.destroyed = true
@@ -91,39 +239,89 @@ func (q *raftReceiveQueue) Delete() {
 // Recycle makes a slice that the caller knows will no longer be accessed
 // available for reuse.
 func (q *raftReceiveQueue) Recycle(processed []raftRequestInfo) {
-	if cap(processed) > 4 {
+	if cap(processed) > 8 {
 		return // cap recycled slice lengths
 	}
+	// Optimistically set it up for reuse.
+	for i := range processed {
+		processed[i] = raftRequestInfo{}
+	}
+	processed = processed[:0]
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.mu.infos == nil {
-		for i := range processed {
-			processed[i] = raftRequestInfo{}
+	if q.mu.lastDrainedFromOtherMsgs {
+		if q.mu.otherMsgInfos == nil {
+			q.mu.otherMsgInfos = processed
 		}
-		q.mu.infos = processed[:0]
+	} else if q.mu.msgAppInfos == nil {
+		q.mu.msgAppInfos = processed
 	}
 }
 
+// Append adds the request to the queue. The return value
+// shouldQueueAtRaftScheduler is true if the range should be enqueued in the
+// raftScheduler.
 func (q *raftReceiveQueue) Append(
 	req *kvserverpb.RaftMessageRequest, s RaftMessageResponseStream,
-) (shouldQueue bool, size int64, appended bool) {
+) (shouldQueueAtRaftScheduler bool, size int64, appended bool) {
 	size = int64(req.Size())
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.mu.destroyed || (q.mu.enforceMaxLen && len(q.mu.infos) >= q.maxLen) {
+	if q.mu.destroyed || (q.mu.enforceMaxLen && q.lenLocked() >= q.maxLen) {
 		return false, size, false
 	}
-	if q.acc.Grow(context.Background(), size) != nil {
+	// Do the append.
+	isOther := req.Message.Type != raftpb.MsgApp
+	var acc *mon.BoundAccount
+	var infos *[]raftRequestInfo
+	if isOther {
+		acc = &q.mu.otherAcc
+		infos = &q.mu.otherMsgInfos
+	} else {
+		acc = &q.mu.msgAppAcc
+		infos = &q.mu.msgAppInfos
+	}
+	if acc.Grow(context.Background(), size) != nil {
 		return false, size, false
 	}
-	q.mu.infos = append(q.mu.infos, raftRequestInfo{
+	*infos = append(*infos, raftRequestInfo{
 		req:        req,
 		respStream: s,
 		size:       size,
 	})
-	// The operation that enqueues the first message will
-	// be put in charge of triggering a drain of the queue.
-	return len(q.mu.infos) == 1, size, true
+	if isOther {
+		if !q.mu.queuedAtRaftScheduler {
+			q.mu.queuedAtRaftScheduler = true
+			shouldQueueAtRaftScheduler = true
+		}
+		return shouldQueueAtRaftScheduler, size, true
+	}
+	// MsgApp.
+	wasEmpty := len(q.mu.msgAppInfos) == 1
+	// Note that if the MsgApp queue was empty, the
+	// current decision must be raftDequeueAllMsgs because we only transition to
+	// raftDequeueOtherMsgs when the MsgApp queue becomes non-empty, and it must
+	// transition to raftDequeueAllMsgs before it is drained.
+	if wasEmpty && q.mu.pacerDequeueDecision == raftDequeueOtherMsgs {
+		panic(errors.AssertionFailedf("pacerDequeueDecision inconsistent with empty MsgApp queue"))
+	}
+	if wasEmpty && req.LowPriorityOverride {
+		// Transitioned from empty MsgApps to non-empty with low-pri-override.
+		q.dequeuePacer.MaybePauseMsgAppDequeueOnTransitionToNonEmptyQLocked(q)
+	}
+	// Else use the current decision. NB: if the first message in the queue was
+	// LowPriOverride, and we transitioned to raftDequeueOtherMsgs, we will stay
+	// in that state even if later messages are !LowPriOverride. We deem this
+	// acceptable since the send-queue has been recently emptied, and even if
+	// this replica is needed for quorum (because it was emptied due to a
+	// force-flush), the burst may be large enough that we need to pace it to
+	// prevent engine write stalls.
+
+	if q.mu.pacerDequeueDecision == raftDequeueAllMsgs && !q.mu.queuedAtRaftScheduler {
+		shouldQueueAtRaftScheduler = true
+		q.mu.queuedAtRaftScheduler = true
+	}
+	return shouldQueueAtRaftScheduler, size, true
 }
 
 func (q *raftReceiveQueue) SetEnforceMaxLen(enforceMaxLen bool) {
@@ -138,10 +336,17 @@ func (q *raftReceiveQueue) getEnforceMaxLenForTesting() bool {
 	return q.mu.enforceMaxLen
 }
 
+func (q *raftReceiveQueue) memoryUsedForTesting() int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.mu.msgAppAcc.Used() + q.mu.otherAcc.Used()
+}
+
 type raftReceiveQueues struct {
 	mon           *mon.BytesMonitor
 	m             syncutil.Map[roachpb.RangeID, raftReceiveQueue]
 	enforceMaxLen atomic.Bool
+	dequeuePacer  *storeRaftDequeuePacer
 }
 
 func (qs *raftReceiveQueues) Load(rangeID roachpb.RangeID) (*raftReceiveQueue, bool) {
@@ -154,8 +359,7 @@ func (qs *raftReceiveQueues) LoadOrCreate(
 	if q, ok := qs.Load(rangeID); ok {
 		return q, ok // fast path
 	}
-	q := &raftReceiveQueue{maxLen: maxLen}
-	q.acc.Init(context.Background(), qs.mon)
+	q := newRaftReceiveQueue(rangeID, qs.dequeuePacer, qs.mon, maxLen)
 	q, loaded = qs.m.LoadOrStore(rangeID, q)
 	if loaded {
 		return q, true
@@ -1138,3 +1342,369 @@ func (s *Store) updateCapacityGauges(ctx context.Context) error {
 
 	return nil
 }
+
+// raftSchedulerForDequeuePacer abstracts raftScheduler for the
+// storeRaftDequeuePacer.
+type raftSchedulerForDequeuePacer interface {
+	EnqueueRaftRequest(id roachpb.RangeID)
+}
+
+// engineForDequeuePacer abstracts storage.Engine for the
+// storeRaftDequeuePacer.
+type engineForDequeuePacer interface {
+	// TryWaitForMemTableStallHeadroom returns true if the number of engine
+	// memtables is small enough to have some headroom to avoid write stalls, in
+	// which case it also returns the allowedBurst in bytes (which must be
+	// greater than zero). Otherwise, it returns false and allowedBurst is zero.
+	//
+	// If doWait is true, it waits until there is headroom before returning, in
+	// which case the return value is guaranteed to be true.
+	//
+	// This is not optimized to be very efficient, so it is preferable that it
+	// is only called by a few callers, who cache the result for a short
+	// duration (say 10ms).
+	TryWaitForMemTableStallHeadroom(doWait bool) (ok bool, allowedBurst int64)
+}
+
+// TODO(sumeer): remove when the implementation is complete.
+type noopEngineForDequeuePacer struct{}
+
+func (n noopEngineForDequeuePacer) TryWaitForMemTableStallHeadroom(doWait bool) (bool, int64) {
+	return true, math.MaxInt64
+}
+
+// storeRaftDequeuePacer paces dequeueing of MsgApps for a set of
+// raftReceiveQueues. Roughly, it needs to perform a number of tasks:
+//   - queue raftReceiveQueues that need to be paced
+//   - block in the storage.Engine waiting for an allowedBurst
+//   - track the burst granted by the engine and how it is distributed to some
+//     of the waiting raftReceiveQueues, and when those raftReceiveQueues have
+//     used those grants
+//   - enqueue granted raftReceiveQueues in the raftScheduler.
+//
+// Additionally, we don't always want to run in the mode of blocking in the
+// storage.Engine and distributing bursts among raftReceiveQueues, since
+// waiting for those bursts to be consumed can slow down raftReceiveQueue
+// processing needlessly when the Engine is fully healthy.
+//
+// To satisfy the above functionality, the pacer tightly integrates with the
+// raftReceiveQueue internals as documented in the field declarations in the
+// raftReceiveQueue (i.e., we choose not to unnecessarily abstract). The
+// invariants are documented and enforced via numerous assertions.
+//
+// The methods called by the raftReceiveQueue are:
+//   - MaybePauseMsgAppDequeueOnTransitionToNonEmptyQLocked: to ask the pacer
+//     to update the pacerDequeueDecision.
+//   - DrainingMsgAppsQLocked: whenever the raftReceiveQueue drains all the
+//     MsgApps. This is needed for bookkeeping inside the pacer.
+//   - DeregisterQLocked: when the queue is being deleted.
+//
+// Concurrency: The pacer's mutex is ordered after raftReceiveQueue.mu. The
+// raftReceiveQueue calls all methods on storeRaftDequeuePacer while holding
+// its own mutex (indicated by the "QLocked" suffix on the methods).
+type storeRaftDequeuePacer struct {
+	eng       engineForDequeuePacer
+	scheduler raftSchedulerForDequeuePacer
+	st        *cluster.Settings
+	nowMono   func() crtime.Mono
+	every     log.EveryN
+	mu        struct {
+		syncutil.Mutex
+		// waiting is the set of raftReceiveQueues that have
+		// raftReceiveQueue.mu.pacerDequeueDecision set to raftDequeueOtherMsgs.
+		//
+		// NB: for simplicity, we don't bother with FIFO ordering this queue.
+		waiting map[*raftReceiveQueue]struct{}
+		// Used to sample headroom availability no frequently than every
+		// engineHeadroomPollingInterval when waiting is empty.
+		lastHeadroomAvailableSampleTime crtime.Mono
+
+		// When dequeueBurst has granted bytes to various raftReceiveQueues, this
+		// captures how much was granted in total but has not yet been drained by
+		// the raftReceiveQueues (since draining happens on the raftScheduler).
+		// Another burst will not be requested from the engine until this is zero.
+		burstBytesToDrain int64
+		queueCond         *sync.Cond
+		closed            bool
+	}
+	testingMaybePauseCh   chan *raftReceiveQueue
+	testingDrainingCh     chan *raftReceiveQueue
+	testingDeregisterCh   chan *raftReceiveQueue
+	testingDequeueBurstCh chan struct{}
+}
+
+func newStoreRaftDequeuePacer(
+	eng engineForDequeuePacer, scheduler raftSchedulerForDequeuePacer, st *cluster.Settings,
+) *storeRaftDequeuePacer {
+	w := &storeRaftDequeuePacer{
+		eng:       eng,
+		scheduler: scheduler,
+		st:        st,
+		nowMono:   crtime.NowMono,
+		every:     log.Every(time.Minute),
+	}
+	w.mu.waiting = map[*raftReceiveQueue]struct{}{}
+	w.mu.queueCond = sync.NewCond(&w.mu.Mutex)
+	return w
+}
+
+// Start must be called once to start the pacer.
+func (w *storeRaftDequeuePacer) Start() {
+	go w.waiter()
+}
+
+func (w *storeRaftDequeuePacer) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.mu.closed = true
+	w.mu.queueCond.Signal()
+}
+
+// engineHeadroomPollingInterval is the minimum duration between sampling
+// engine headroom availability when there are no waiting raftReceiveQueues.
+const engineHeadroomPollingInterval = 10 * time.Millisecond
+
+// MaybePauseMsgAppDequeueOnTransitionToNonEmptyQLocked is called by a
+// raftReceiveQueue to request an update to its pacerDequeueDecision, when it
+// is transitioning from empty to non-empty queued MsgApps, with a
+// low-priority-override MsgApp. The current pacerDequeueDecision must be
+// raftDequeueAllMsgs.
+func (w *storeRaftDequeuePacer) MaybePauseMsgAppDequeueOnTransitionToNonEmptyQLocked(
+	q *raftReceiveQueue,
+) {
+	if w.testingMaybePauseCh != nil {
+		w.testingMaybePauseCh <- q
+	}
+	if q.mu.pacerDequeueAccountingBytes != 0 {
+		panic(errors.AssertionFailedf(
+			"pacerDequeueAccountingBytes %d are non zero", q.mu.pacerDequeueAccountingBytes))
+	}
+	if q.mu.pacerDequeueDecision != raftDequeueAllMsgs {
+		panic(errors.AssertionFailedf("pacerDequeueDecision is raftDequeueOtherMsgs"))
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.mu.waiting) == 0 {
+		now := w.nowMono()
+		haveHeadroom := true
+		if now.Sub(w.mu.lastHeadroomAvailableSampleTime) >= engineHeadroomPollingInterval &&
+			RaftMsgAppDequeuePacingEnabled.Get(&w.st.SV) {
+			w.mu.lastHeadroomAvailableSampleTime = now
+			haveHeadroom, _ = w.eng.TryWaitForMemTableStallHeadroom(false)
+		}
+		if haveHeadroom {
+			// Common case.
+			return
+		}
+	}
+	// Enqueue.
+	w.mu.waiting[q] = struct{}{}
+	q.mu.pacerDequeueDecision = raftDequeueOtherMsgs
+	if len(w.mu.waiting) == 1 {
+		// The waiting queue is transitioning to non-empty, so tell the waiter
+		// goroutine, so it can request an allowedBurst from the engine.
+		w.mu.queueCond.Signal()
+	}
+}
+
+// DrainingMsgAppsQLocked is called by a raftReceiveQueue whenever it drains
+// all its MsgApps.
+func (w *storeRaftDequeuePacer) DrainingMsgAppsQLocked(q *raftReceiveQueue) {
+	if w.testingDrainingCh != nil {
+		w.testingDrainingCh <- q
+	}
+	if q.mu.pacerDequeueAccountingBytes == 0 {
+		// Common case.
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.deductBurstBytesQLockedPacerLocked(q)
+}
+
+// DeregisterQLocked is called by a raftReceiveQueue when it is being deleted.
+func (w *storeRaftDequeuePacer) DeregisterQLocked(q *raftReceiveQueue) {
+	if w.testingDeregisterCh != nil {
+		w.testingDeregisterCh <- q
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	switch q.mu.pacerDequeueDecision {
+	case raftDequeueAllMsgs:
+		_, ok := w.mu.waiting[q]
+		if ok {
+			panic(errors.AssertionFailedf("raftReceiveQueue should not be in waiting"))
+		}
+		if q.mu.pacerDequeueAccountingBytes != 0 {
+			w.deductBurstBytesQLockedPacerLocked(q)
+		}
+	case raftDequeueOtherMsgs:
+		// Ensure everything is drained.
+		q.mu.pacerDequeueDecision = raftDequeueAllMsgs
+		_, ok := w.mu.waiting[q]
+		if !ok {
+			panic(errors.AssertionFailedf("raftReceiveQueue should be in waiting"))
+		}
+		delete(w.mu.waiting, q)
+		if q.mu.pacerDequeueAccountingBytes != 0 {
+			panic(errors.AssertionFailedf(
+				"pacerDequeueAccountingBytes %d are non zero", q.mu.pacerDequeueAccountingBytes))
+		}
+	default:
+		panic(errors.AssertionFailedf("unknown pacerDequeueDecision %v", q.mu.pacerDequeueDecision))
+	}
+}
+
+func (w *storeRaftDequeuePacer) deductBurstBytesQLockedPacerLocked(q *raftReceiveQueue) {
+	// NB: the raftReceiveQueue may have drained more than this, because there
+	// is a lag between the transition to raftDequeueAllMsgs and the actual
+	// draining of MsgApps during which more MsgApps could have been queued. We
+	// are ok with that error. We just need our accounting to be accurate in the
+	// sense that what we added is what we deduct.
+	w.mu.burstBytesToDrain -= q.mu.pacerDequeueAccountingBytes
+	if w.mu.burstBytesToDrain < 0 {
+		panic(errors.AssertionFailedf("negative burstBytesToDrain: %d", w.mu.burstBytesToDrain))
+	}
+	q.mu.pacerDequeueAccountingBytes = 0
+	if w.mu.burstBytesToDrain == 0 {
+		// There may be more waiters, that the waiter goroutine can now try to
+		// process.
+		w.mu.queueCond.Signal()
+	}
+}
+
+// waiter runs in a goroutine waiting for the waiting raftReceiveQueues to
+// become non-empty, or the existing burstBytesToDrain to be consumed. At that
+// point it has some work to do, which involves asking the engine for an
+// allowedBurst and dequeueing some raftReceiveQueues accordingly.
+func (w *storeRaftDequeuePacer) waiter() {
+	// queueBuf is used to avoid allocations in dequeueBurst.
+	var queueBuf []*raftReceiveQueue
+	for {
+		closed := w.waitUntilTryWaitAtEng()
+		if closed {
+			break
+		}
+		// Allow another burst. TryWaitForMemTableStallHeadroom will return if
+		// the engine is closed.
+		ok, allowedBurst := w.eng.TryWaitForMemTableStallHeadroom(true)
+		if !ok {
+			panic(errors.AssertionFailedf("unexpected !ok"))
+		}
+		if allowedBurst <= 0 {
+			panic(errors.AssertionFailedf("allowedBurst must be > 0"))
+		}
+		queueBuf = w.dequeueBurst(allowedBurst, queueBuf)
+		// Queue may be empty. Or there may be more waiting, but we need to wait
+		// until all the burst is consumed. Or there may be waiters that got
+		// added immediately after dequeueBurst finished. Loop around to wait
+		// for the next event.
+	}
+	w.dequeueBurst(math.MaxInt64, queueBuf)
+}
+
+func (w *storeRaftDequeuePacer) waitUntilTryWaitAtEng() (closed bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for (len(w.mu.waiting) == 0 || w.mu.burstBytesToDrain > 0) && !w.mu.closed {
+		// Nothing to do, so wait.
+		w.mu.queueCond.Wait()
+	}
+	return w.mu.closed
+}
+
+// dequeueBurst dequeues raftReceiveQueues up to allowedBurst. It stops after
+// the first raftReceiveQueue that causes the allowedBurst to be exceeded. The
+// queueBuf is scratch space to avoid allocations, and the returned queueBuf2
+// is also scratch space.
+func (w *storeRaftDequeuePacer) dequeueBurst(
+	allowedBurst int64, queueBuf []*raftReceiveQueue,
+) (queueBuf2 []*raftReceiveQueue) {
+	consumedSize := int64(0)
+	for consumedSize < allowedBurst {
+		// Collect all the current waiters. A subset of those will get dequeued
+		// later. We can't decide that subset in this loop as it requires
+		// examining raftReceiveQueue.mu.msgAppAcc, which requires acquiring
+		// raftReceiveQueue.mu, which precedes w.mu in the lock ordering.
+		w.mu.Lock()
+		queueBuf = slices.AppendSeq(queueBuf[:0], maps.Keys(w.mu.waiting))
+		w.mu.Unlock()
+		if len(queueBuf) == 0 {
+			break
+		}
+		if w.testingDequeueBurstCh != nil {
+			// Determinism for testing.
+			slices.SortFunc(queueBuf, func(a, b *raftReceiveQueue) int {
+				return cmp.Compare(a.rangeID, b.rangeID)
+			})
+		}
+		// Iterate over queueBuf, granting a prefix of the queues, and updating
+		// their state to raftDequeueAllMsgs, and telling the raftScheduler to
+		// schedule them.
+		for _, q := range queueBuf {
+			q.mu.Lock()
+			if q.mu.pacerDequeueDecision == raftDequeueAllMsgs {
+				// Changed to raftQDequeueAll before we reacquired the lock. This
+				// can happen when the raftReceiveQueue got closed.
+				q.mu.Unlock()
+				continue
+			}
+			size := q.mu.msgAppAcc.Used()
+			consumedSize += size
+			// NB: it may dequeue more, but we record what we have granted, so we
+			// can correctly deduct from w.burstBytesToDrain.
+			if q.mu.pacerDequeueAccountingBytes != 0 {
+				panic(errors.AssertionFailedf("pacerDequeueAccountingBytes was not zero"))
+			}
+			q.mu.pacerDequeueAccountingBytes = size
+			q.mu.pacerDequeueDecision = raftDequeueAllMsgs
+			w.mu.Lock()
+			delete(w.mu.waiting, q)
+			w.mu.burstBytesToDrain += q.mu.pacerDequeueAccountingBytes
+			w.mu.Unlock()
+			q.mu.Unlock()
+			w.scheduler.EnqueueRaftRequest(q.rangeID)
+			if consumedSize >= allowedBurst {
+				break
+			}
+		}
+		// More queues could have been added to waiting, so loop.
+	}
+	if consumedSize > 0 && log.V(1) {
+		log.KvExec.Infof(context.TODO(), "storeRaftDequeuePacer: allowed burst=%s consumed=%s",
+			redact.SafeString(humanize.Bytes(uint64(allowedBurst))),
+			redact.SafeString(humanize.Bytes(uint64(consumedSize))))
+	}
+	if consumedSize > 0 && w.testingDequeueBurstCh != nil {
+		w.testingDequeueBurstCh <- struct{}{}
+	}
+	return queueBuf
+}
+
+// TryLog is called periodically by the store during metrics collection, and
+// allows the pacer to log its internal state if interesting.
+func (w *storeRaftDequeuePacer) TryLog(ctx context.Context) {
+	var lenWaiting int
+	var burstBytesToDrain int64
+	func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		lenWaiting = len(w.mu.waiting)
+		burstBytesToDrain = w.mu.burstBytesToDrain
+	}()
+	if lenWaiting == 0 && burstBytesToDrain == 0 {
+		return
+	}
+	if !w.every.ShouldLog() {
+		return
+	}
+	log.KvExec.Infof(ctx, "storeRaftDequeuePacer: waiting: %d, burstBytesToDrain: %s",
+		lenWaiting, redact.SafeString(humanize.Bytes(uint64(burstBytesToDrain))))
+}
+
+type raftDequeueDecision uint8
+
+const (
+	raftDequeueAllMsgs raftDequeueDecision = iota
+	raftDequeueOtherMsgs
+)

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -7,8 +7,12 @@
 package kvserver
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -32,8 +37,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/crlib/crtime"
+	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
+
+type noopRaftSchedulerForDequeuePacer struct{}
+
+func (n noopRaftSchedulerForDequeuePacer) EnqueueRaftRequest(id roachpb.RangeID) {}
 
 func TestRaftReceiveQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -45,7 +56,8 @@ func TestRaftReceiveQueue(t *testing.T) {
 		CurCount: g,
 		Settings: st,
 	})
-	qs := raftReceiveQueues{mon: m}
+	qs := raftReceiveQueues{mon: m, dequeuePacer: newStoreRaftDequeuePacer(
+		noopEngineForDequeuePacer{}, noopRaftSchedulerForDequeuePacer{}, st)}
 
 	const r1 = roachpb.RangeID(1)
 	const r5 = roachpb.RangeID(5)
@@ -77,7 +89,7 @@ func TestRaftReceiveQueue(t *testing.T) {
 		require.True(t, appended)
 		require.True(t, shouldQ)
 		require.Equal(t, n1, size)
-		require.Equal(t, n1, q1.acc.Used())
+		require.Equal(t, n1, q1.memoryUsedForTesting())
 		// NB: the monitor allocates in chunks so it will have allocated more than n1.
 		// We don't check these going forward, as we've now verified that they're hooked up.
 		require.GreaterOrEqual(t, m.AllocBytes(), n1)
@@ -89,7 +101,7 @@ func TestRaftReceiveQueue(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, sl, 1)
 		require.Equal(t, e1, sl[0].req)
-		require.Zero(t, q1.acc.Used())
+		require.Zero(t, q1.memoryUsedForTesting())
 	}
 
 	// Append a first element (again).
@@ -97,7 +109,7 @@ func TestRaftReceiveQueue(t *testing.T) {
 		shouldQ, _, appended := q1.Append(e1, nil /* stream */)
 		require.True(t, shouldQ)
 		require.True(t, appended)
-		require.Equal(t, n1, q1.acc.Used())
+		require.Equal(t, n1, q1.memoryUsedForTesting())
 	}
 
 	// Add a second element.
@@ -105,21 +117,21 @@ func TestRaftReceiveQueue(t *testing.T) {
 		shouldQ, _, appended := q1.Append(e1, nil /* stream */)
 		require.False(t, shouldQ) // not first entry in queue
 		require.True(t, appended)
-		require.Equal(t, 2*n1, q1.acc.Used())
+		require.Equal(t, 2*n1, q1.memoryUsedForTesting())
 	}
 
 	// Now interleave creation of a second queue.
 	q5, loaded := qs.LoadOrCreate(r5, 1 /* maxLen */)
 	{
 		require.False(t, loaded)
-		require.Zero(t, q5.acc.Used())
+		require.Zero(t, q5.memoryUsedForTesting())
 		shouldQ, _, appended := q5.Append(e5, nil /* stream */)
 		require.True(t, appended)
 		require.True(t, shouldQ)
 
 		// No accidental misattribution of bytes between the queues.
-		require.Equal(t, 2*n1, q1.acc.Used())
-		require.Equal(t, n5, q5.acc.Used())
+		require.Equal(t, 2*n1, q1.memoryUsedForTesting())
+		require.Equal(t, n5, q5.memoryUsedForTesting())
 	}
 
 	// Delete the queue. Post deletion, even if someone still has a handle
@@ -130,8 +142,8 @@ func TestRaftReceiveQueue(t *testing.T) {
 		shouldQ, _, appended := q1.Append(e1, nil /* stream */)
 		require.False(t, appended)
 		require.False(t, shouldQ)
-		require.Zero(t, q1.acc.Used())
-		require.Equal(t, n5, q5.acc.Used()) // we didn't touch q5
+		require.Zero(t, q1.memoryUsedForTesting())
+		require.Equal(t, n5, q5.memoryUsedForTesting()) // we didn't touch q5
 	}
 }
 
@@ -238,7 +250,8 @@ func TestRaftReceiveQueuesEnforceMaxLenConcurrency(t *testing.T) {
 		CurCount: g,
 		Settings: st,
 	})
-	qs := raftReceiveQueues{mon: m}
+	qs := raftReceiveQueues{mon: m, dequeuePacer: newStoreRaftDequeuePacer(
+		noopEngineForDequeuePacer{}, noopRaftSchedulerForDequeuePacer{}, st)}
 	// checkingMu is locked in write mode when checking that the values of
 	// enforceMaxLen across all the queues is the expected value.
 	var checkingMu syncutil.RWMutex
@@ -301,7 +314,8 @@ func TestRaftReceiveQueuesEnforceMaxLen(t *testing.T) {
 		CurCount: g,
 		Settings: st,
 	})
-	qs := raftReceiveQueues{mon: m}
+	qs := raftReceiveQueues{mon: m, dequeuePacer: newStoreRaftDequeuePacer(
+		noopEngineForDequeuePacer{}, noopRaftSchedulerForDequeuePacer{}, st)}
 	qs.SetEnforceMaxLen(false)
 	q, _ := qs.LoadOrCreate(1, 2)
 	var s RaftMessageResponseStream
@@ -312,4 +326,408 @@ func TestRaftReceiveQueuesEnforceMaxLen(t *testing.T) {
 	qs.SetEnforceMaxLen(true)
 	_, _, appended := q.Append(&kvserverpb.RaftMessageRequest{}, s)
 	require.False(t, appended)
+}
+
+func decisionStr(d raftDequeueDecision) string {
+	switch d {
+	case raftDequeueAllMsgs:
+		return "all"
+	case raftDequeueOtherMsgs:
+		return "other"
+	}
+	panic("unknown decision")
+}
+
+// TestRaftReceiveDequeue verifies raftReceiveQueue's enqueueing and selective
+// dequeueing behavior. It does not test storeRaftDequeuePacer itself.
+func TestRaftReceiveDequeue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	st := cluster.MakeTestingClusterSettings()
+	g := metric.NewGauge(metric.Metadata{})
+	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
+		Name:     mon.MakeName("test"),
+		CurCount: g,
+		Settings: st,
+	})
+	pacer := newStoreRaftDequeuePacer(noopEngineForDequeuePacer{}, noopRaftSchedulerForDequeuePacer{}, st)
+	pacer.testingMaybePauseCh = make(chan *raftReceiveQueue, 100)
+	pacer.testingDrainingCh = make(chan *raftReceiveQueue, 100)
+	pacer.testingDeregisterCh = make(chan *raftReceiveQueue, 100)
+	qs := raftReceiveQueues{mon: m, dequeuePacer: pacer}
+	qs.SetEnforceMaxLen(false)
+
+	const r1 = roachpb.RangeID(1)
+	var q *raftReceiveQueue
+
+	// ma1 is a MsgApp.
+	ma1 := &kvserverpb.RaftMessageRequest{Message: raftpb.Message{
+		Type: raftpb.MsgApp,
+		Entries: []raftpb.Entry{
+			{Data: []byte("foo bar baz")}}}}
+	sizeMA1 := int64(ma1.Size())
+	// ma2 is a MsgApp with LowPriorityOverride.
+	ma2 := &kvserverpb.RaftMessageRequest{
+		Message: raftpb.Message{
+			Type: raftpb.MsgApp,
+			Entries: []raftpb.Entry{
+				{Data: []byte("xxxxlxlxlxlxllxlxlxlxlxxlxllxlxlxlxlxl")}}},
+		LowPriorityOverride: true,
+	}
+	sizeMA2 := int64(ma2.Size())
+	// o1 is some other message type.
+	o1 := &kvserverpb.RaftMessageRequest{Message: raftpb.Message{
+		Type: raftpb.MsgHeartbeat,
+	}}
+	sizeO1 := int64(o1.Size())
+	o2 := &kvserverpb.RaftMessageRequest{Message: raftpb.Message{
+		Type: raftpb.MsgVote,
+	}}
+	sizeO2 := int64(o2.Size())
+	type msgAndSize struct {
+		msg  *kvserverpb.RaftMessageRequest
+		size int64
+	}
+	msgsByName := map[string]msgAndSize{}
+	msgsByName["ma1"] = msgAndSize{msg: ma1, size: sizeMA1}
+	msgsByName["ma2"] = msgAndSize{msg: ma2, size: sizeMA2}
+	msgsByName["o1"] = msgAndSize{msg: o1, size: sizeO1}
+	msgsByName["o2"] = msgAndSize{msg: o2, size: sizeO2}
+	msgsByPointer := map[*kvserverpb.RaftMessageRequest]string{}
+	msgsByPointer[ma1] = "ma1"
+	msgsByPointer[ma2] = "ma2"
+	msgsByPointer[o1] = "o1"
+	msgsByPointer[o2] = "o2"
+	printMsgSliceAndSize := func(t *testing.T, infos []raftRequestInfo) (_ string, totalSize int64) {
+		var b strings.Builder
+		fmt.Fprintf(&b, "[")
+		for i, info := range infos {
+			if i > 0 {
+				fmt.Fprintf(&b, " ")
+			}
+			name, ok := msgsByPointer[info.req]
+			if !ok {
+				t.Fatalf("unknown msg")
+			}
+			fmt.Fprintf(&b, "%s", name)
+			require.Equal(t, infos[i].size, msgsByName[name].size)
+			totalSize += msgsByName[name].size
+		}
+		fmt.Fprintf(&b, "]")
+		return b.String(), totalSize
+	}
+	countAndEmptyCh := func(ch chan *raftReceiveQueue) (count int) {
+		for {
+			select {
+			case <-ch:
+				count++
+			default:
+				return count
+			}
+		}
+	}
+	var b strings.Builder
+	builderStr := func(t *testing.T) string {
+		if count := countAndEmptyCh(pacer.testingMaybePauseCh); count > 0 {
+			fmt.Fprintf(&b, "pacer.MaybePause calls %d\n", count)
+		}
+		if count := countAndEmptyCh(pacer.testingDrainingCh); count > 0 {
+			fmt.Fprintf(&b, "pacer.DrainingMsgApps calls %d\n", count)
+		}
+		if count := countAndEmptyCh(pacer.testingDeregisterCh); count > 0 {
+			fmt.Fprintf(&b, "pacer.Deregister calls %d\n", count)
+		}
+		fmt.Fprintf(&b, "queue state:\n")
+		q.mu.Lock()
+		if q.mu.destroyed {
+			fmt.Fprintf(&b, " destroyed\n")
+		}
+		msgsStr, size := printMsgSliceAndSize(t, q.mu.msgAppInfos)
+		require.Equal(t, size, q.mu.msgAppAcc.Used())
+		fmt.Fprintf(&b, " msgApps: %s\n", msgsStr)
+		msgsStr, size = printMsgSliceAndSize(t, q.mu.otherMsgInfos)
+		require.Equal(t, size, q.mu.otherAcc.Used())
+		fmt.Fprintf(&b, " otherMsgs: %s\n", msgsStr)
+		fmt.Fprintf(&b, " queuedAtRaftScheduler: %t\n", q.mu.queuedAtRaftScheduler)
+		fmt.Fprintf(&b, " lastDrainedFromOtherMsgs: %t\n", q.mu.lastDrainedFromOtherMsgs)
+		fmt.Fprintf(&b, " pacer: decision: %s, accountingBytes: %d\n",
+			decisionStr(q.mu.pacerDequeueDecision), q.mu.pacerDequeueAccountingBytes)
+		q.mu.Unlock()
+		str := b.String()
+		b.Reset()
+		return str
+	}
+	var lastDrain []raftRequestInfo
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "raft_receive_dequeue"),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "init":
+				q, _ = qs.LoadOrCreate(r1, 10 /* maxLen */)
+				return builderStr(t)
+
+			case "append":
+				var msgStr string
+				d.ScanArgs(t, "msg", &msgStr)
+				msg, ok := msgsByName[msgStr]
+				if !ok {
+					t.Fatalf("unknown msg %s", msgStr)
+				}
+				shouldQ, size, appended := q.Append(msg.msg, nil /* stream */)
+				fmt.Fprintf(&b, "shouldQ=%t size=%d appended=%t\n", shouldQ, size, appended)
+				return builderStr(t)
+
+			case "drain":
+				var ok bool
+				lastDrain, ok = q.Drain()
+				require.Equal(t, ok, len(lastDrain) > 0)
+				msgsStr, _ := printMsgSliceAndSize(t, lastDrain)
+				fmt.Fprintf(&b, "drained msgs: %s\n", msgsStr)
+				return builderStr(t)
+
+			case "recycle":
+				q.Recycle(lastDrain)
+				lastDrain = nil
+				return builderStr(t)
+
+			case "destroy":
+				qs.Delete(r1)
+				return builderStr(t)
+
+			case "overwrite-decision":
+				var decisionStr string
+				d.ScanArgs(t, "decision", &decisionStr)
+				var decision raftDequeueDecision
+				switch decisionStr {
+				case "all":
+					decision = raftDequeueAllMsgs
+				case "other":
+					decision = raftDequeueOtherMsgs
+				default:
+					t.Fatalf("unknown decision %s", decisionStr)
+				}
+				q.mu.Lock()
+				q.mu.pacerDequeueDecision = decision
+				// Fix up the pacer state so invariant checking doesn't panic.
+				pacer.mu.Lock()
+				if decision == raftDequeueOtherMsgs {
+					pacer.mu.waiting[q] = struct{}{}
+				} else {
+					delete(pacer.mu.waiting, q)
+				}
+				pacer.mu.Unlock()
+				q.mu.Unlock()
+				return builderStr(t)
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+}
+
+type testRaftScheduler struct {
+	b *strings.Builder
+}
+
+func (t *testRaftScheduler) EnqueueRaftRequest(rangeID roachpb.RangeID) {
+	fmt.Fprintf(t.b, "raftScheduler.EnqueueRaftRequest(r%d)\n", rangeID)
+}
+
+type testEngineForDequeuePacer struct {
+	b                     *strings.Builder
+	returnValueWhenNoWait bool
+	allowedBurst          int64
+	startWaitCh           chan struct{}
+	endWaitCh             chan struct{}
+}
+
+func (t *testEngineForDequeuePacer) TryWaitForMemTableStallHeadroom(
+	doWait bool,
+) (ok bool, allowedBurst int64) {
+	if !doWait {
+		if t.returnValueWhenNoWait {
+			allowedBurst = t.allowedBurst
+		}
+		fmt.Fprintf(t.b,
+			"engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=%t, allowedBurst=%d\n",
+			t.returnValueWhenNoWait, allowedBurst)
+		return t.returnValueWhenNoWait, allowedBurst
+	}
+	fmt.Fprintf(t.b, "start engine.TryWaitForMemTableStallHeadroom(doWait=true)\n")
+	t.startWaitCh <- struct{}{}
+	<-t.endWaitCh
+	fmt.Fprintf(t.b,
+		"end engine.TryWaitForMemTableStallHeadroom(doWait=true) => ok=true, allowedBurst=%d\n",
+		t.allowedBurst)
+	return true, t.allowedBurst
+}
+
+func TestStoreRaftDequeuePacer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var now time.Duration
+	crtimeNow := func() crtime.Mono {
+		return crtime.Mono(now)
+	}
+	var scheduler *testRaftScheduler
+	var eng *testEngineForDequeuePacer
+	var p *storeRaftDequeuePacer
+	var qs *raftReceiveQueues
+	var b strings.Builder
+	var st *cluster.Settings
+	init := func() {
+		b.Reset()
+		scheduler = &testRaftScheduler{b: &b}
+		eng = &testEngineForDequeuePacer{
+			b:                     &b,
+			returnValueWhenNoWait: true,
+			allowedBurst:          100,
+			startWaitCh:           make(chan struct{}, 1),
+			endWaitCh:             make(chan struct{}, 1),
+		}
+		st = cluster.MakeTestingClusterSettings()
+		p = newStoreRaftDequeuePacer(eng, scheduler, st)
+		now = engineHeadroomPollingInterval
+		p.nowMono = crtimeNow
+		p.testingDequeueBurstCh = make(chan struct{})
+		g := metric.NewGauge(metric.Metadata{})
+		m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
+			Name:     mon.MakeName("test"),
+			CurCount: g,
+			Settings: st,
+		})
+		qs = &raftReceiveQueues{mon: m, dequeuePacer: p}
+		qs.SetEnforceMaxLen(false)
+		p.Start()
+	}
+	ma1 := &kvserverpb.RaftMessageRequest{
+		Message: raftpb.Message{
+			Type: raftpb.MsgApp,
+			Entries: []raftpb.Entry{
+				{Data: []byte("foo bar baz")}}},
+		LowPriorityOverride: true,
+	}
+	sizeMA1 := int64(ma1.Size())
+	require.Greater(t, int64(100), sizeMA1)
+	ma2 := &kvserverpb.RaftMessageRequest{
+		Message: raftpb.Message{
+			Type: raftpb.MsgApp,
+			Entries: []raftpb.Entry{
+				{Data: []byte("xxxxlxlxlxlxllxlxlxlxlxxlxllxlxlxlxlxlxlxlxlxlxlxl")}}},
+		LowPriorityOverride: true,
+	}
+	sizeMA2 := int64(ma2.Size())
+	require.Less(t, int64(100), sizeMA2)
+	msgsByName := map[string]*kvserverpb.RaftMessageRequest{}
+	msgsByName["ma1"] = ma1
+	msgsByName["ma2"] = ma2
+	printQueueState := func(q *raftReceiveQueue) string {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		return fmt.Sprintf("r%s %s %d", q.rangeID, decisionStr(q.mu.pacerDequeueDecision),
+			q.mu.pacerDequeueAccountingBytes)
+	}
+	builderStr := func() string {
+		var queues []*raftReceiveQueue
+		p.mu.Lock()
+		queues = slices.AppendSeq(queues[:0], maps.Keys(p.mu.waiting))
+		fmt.Fprintf(&b, "pacer state:\n")
+		fmt.Fprintf(&b, " lastHeadroomSampleTime: %v\n",
+			time.Duration(p.mu.lastHeadroomAvailableSampleTime))
+		if p.mu.burstBytesToDrain > 0 {
+			fmt.Fprintf(&b, " burstBytesToDrain: %d\n", p.mu.burstBytesToDrain)
+		}
+		p.mu.Unlock()
+		if len(queues) > 0 {
+			slices.SortFunc(queues, func(a, b *raftReceiveQueue) int {
+				return cmp.Compare(a.rangeID, b.rangeID)
+			})
+			fmt.Fprintf(&b, " waiting queues (rangeID, decision, accounting-bytes):")
+			for _, q := range queues {
+				fmt.Fprintf(&b, " (%s)", printQueueState(q))
+			}
+			fmt.Fprintf(&b, "\n")
+		}
+		str := b.String()
+		b.Reset()
+		return str
+	}
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "raft_dequeue_pacer"),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "init":
+				init()
+				return builderStr()
+
+			case "enqueue":
+				var rangeID int
+				d.ScanArgs(t, "range", &rangeID)
+				q, _ := qs.LoadOrCreate(roachpb.RangeID(rangeID), 10 /* maxLen */)
+				var msgStr string
+				d.ScanArgs(t, "msg", &msgStr)
+				msg, ok := msgsByName[msgStr]
+				if !ok {
+					t.Fatalf("unknown msg %s", msgStr)
+				}
+				shouldQ, size, appended := q.Append(msg, nil /* stream */)
+				if d.HasArg("wait-for-start-wait") {
+					<-eng.startWaitCh
+				}
+				fmt.Fprintf(&b, "raftReceiveQueue.Append() => shouldQ=%t size=%d appended=%t\n",
+					shouldQ, size, appended)
+				fmt.Fprintf(&b, "queue state: %s\n", printQueueState(q))
+				return builderStr()
+
+			case "drain":
+				var rangeID int
+				d.ScanArgs(t, "range", &rangeID)
+				q, _ := qs.LoadOrCreate(roachpb.RangeID(rangeID), 10 /* maxLen */)
+				msgs, _ := q.Drain()
+				if d.HasArg("wait-for-start-wait") {
+					<-eng.startWaitCh
+				}
+				fmt.Fprintf(&b, "raftReceiveQueue.Drain() => msgs=%d\n", len(msgs))
+				fmt.Fprintf(&b, "queue state: %s\n", printQueueState(q))
+				return builderStr()
+
+			case "delete":
+				var rangeID int
+				d.ScanArgs(t, "range", &rangeID)
+				q, _ := qs.LoadOrCreate(roachpb.RangeID(rangeID), 10 /* maxLen */)
+				qs.Delete(roachpb.RangeID(rangeID))
+				q.mu.Lock()
+				require.Equal(t, raftDequeueAllMsgs, q.mu.pacerDequeueDecision)
+				require.Zero(t, q.mu.pacerDequeueAccountingBytes)
+				q.mu.Unlock()
+				if d.HasArg("wait-for-start-wait") {
+					<-eng.startWaitCh
+				}
+				fmt.Fprintf(&b, "raftReceiveQueues.Delete()\n")
+				return builderStr()
+
+			case "advance-time":
+				now += engineHeadroomPollingInterval
+				return ""
+
+			case "close":
+				p.Close()
+				return builderStr()
+
+			case "set-engine-overload":
+				var overload bool
+				d.ScanArgs(t, "overload", &overload)
+				eng.returnValueWhenNoWait = !overload
+				return ""
+
+			case "end-wait":
+				eng.endWaitCh <- struct{}{}
+				<-p.testingDequeueBurstCh
+				if d.HasArg("wait-for-start-wait") {
+					<-eng.startWaitCh
+				}
+				return builderStr()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
 }

--- a/pkg/kv/kvserver/testdata/raft_dequeue_pacer
+++ b/pkg/kv/kvserver/testdata/raft_dequeue_pacer
@@ -1,0 +1,222 @@
+# Basic behavior of draining after engine becomes overloaded and then recovers.
+init
+----
+pacer state:
+ lastHeadroomSampleTime: 0s
+
+# Engine not overloaded.
+enqueue range=1 msg=ma1
+----
+engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=true, allowedBurst=100
+raftReceiveQueue.Append() => shouldQ=true size=70 appended=true
+queue state: r1 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+drain range=1
+----
+raftReceiveQueue.Drain() => msgs=1
+queue state: r1 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+set-engine-overload overload=true
+----
+
+# Engine is overloaded, but we recently sampled headroom, so we don't sample
+# overload.
+enqueue range=1 msg=ma1
+----
+raftReceiveQueue.Append() => shouldQ=true size=70 appended=true
+queue state: r1 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+drain range=1
+----
+raftReceiveQueue.Drain() => msgs=1
+queue state: r1 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+# Advance time so that we will sample headroom again.
+advance-time
+----
+
+# Range gets queued in the pacer.
+enqueue range=1 msg=ma1 wait-for-start-wait
+----
+engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
+start engine.TryWaitForMemTableStallHeadroom(doWait=true)
+raftReceiveQueue.Append() => shouldQ=false size=70 appended=true
+queue state: r1 other 0
+pacer state:
+ lastHeadroomSampleTime: 20ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+
+# Drain does not drain anything.
+drain range=1
+----
+raftReceiveQueue.Drain() => msgs=0
+queue state: r1 other 0
+pacer state:
+ lastHeadroomSampleTime: 20ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+
+# Engine recovers, allowing the range to be dequeued. The pacer's
+# burstBytesToDrain is positive.
+end-wait
+----
+end engine.TryWaitForMemTableStallHeadroom(doWait=true) => ok=true, allowedBurst=100
+raftScheduler.EnqueueRaftRequest(r1)
+pacer state:
+ lastHeadroomSampleTime: 20ms
+ burstBytesToDrain: 70
+
+# Deletion causes the range to be removed from the pacer and its burst bytes
+# returned.
+delete range=1
+----
+raftReceiveQueues.Delete()
+pacer state:
+ lastHeadroomSampleTime: 20ms
+
+close
+----
+pacer state:
+ lastHeadroomSampleTime: 20ms
+
+# Multiple ranges being paced. The first one has < 100 bytes, and the engine
+# allows a burst of 100 bytes, so both ranges get dequeued when the engine
+# recovers.
+init
+----
+pacer state:
+ lastHeadroomSampleTime: 0s
+
+set-engine-overload overload=true
+----
+
+# Range r1 gets queued in the pacer.
+enqueue range=1 msg=ma1 wait-for-start-wait
+----
+engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
+start engine.TryWaitForMemTableStallHeadroom(doWait=true)
+raftReceiveQueue.Append() => shouldQ=false size=70 appended=true
+queue state: r1 other 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+
+# Range r2 gets queued in the pacer.
+enqueue range=2 msg=ma2
+----
+raftReceiveQueue.Append() => shouldQ=false size=109 appended=true
+queue state: r2 other 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 other 0) (r2 other 0)
+
+# Both ranges dequeued. Both are accounted for in the burstBytesToDrain.
+end-wait
+----
+end engine.TryWaitForMemTableStallHeadroom(doWait=true) => ok=true, allowedBurst=100
+raftScheduler.EnqueueRaftRequest(r1)
+raftScheduler.EnqueueRaftRequest(r2)
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ burstBytesToDrain: 179
+
+# The drain of range r1 reduces burstBytesToDrain.
+drain range=1
+----
+raftReceiveQueue.Drain() => msgs=1
+queue state: r1 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ burstBytesToDrain: 109
+
+# Deletion of range r2 causes its burst bytes to be returned.
+delete range=2
+----
+raftReceiveQueues.Delete()
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+close
+----
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+# Multiple ranges being paced. Each has > 100 bytes, and the engine allows a
+# burst of 100 bytes, so one range gets dequeued at a time when the engine
+# recovers.
+init
+----
+pacer state:
+ lastHeadroomSampleTime: 0s
+
+set-engine-overload overload=true
+----
+
+# Range r1 gets queued in the pacer.
+enqueue range=1 msg=ma2 wait-for-start-wait
+----
+engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
+start engine.TryWaitForMemTableStallHeadroom(doWait=true)
+raftReceiveQueue.Append() => shouldQ=false size=109 appended=true
+queue state: r1 other 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+
+# Range r2 gets queued in the pacer.
+enqueue range=2 msg=ma2
+----
+raftReceiveQueue.Append() => shouldQ=false size=109 appended=true
+queue state: r2 other 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 other 0) (r2 other 0)
+
+# Range r1 is dequeued. Its bytes are accounted for in burstBytesToDrain
+end-wait
+----
+end engine.TryWaitForMemTableStallHeadroom(doWait=true) => ok=true, allowedBurst=100
+raftScheduler.EnqueueRaftRequest(r1)
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ burstBytesToDrain: 109
+ waiting queues (rangeID, decision, accounting-bytes): (r2 other 0)
+
+# Deletion of range r1 causes its bytes to be removed from accounting, and
+# another TryWait to start.
+delete range=1 wait-for-start-wait
+----
+start engine.TryWaitForMemTableStallHeadroom(doWait=true)
+raftReceiveQueues.Delete()
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r2 other 0)
+
+# Range r2 is dequeued. Its bytes are accounted for in burstBytesToDrain.
+end-wait
+----
+end engine.TryWaitForMemTableStallHeadroom(doWait=true) => ok=true, allowedBurst=100
+raftScheduler.EnqueueRaftRequest(r2)
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ burstBytesToDrain: 109
+
+# Range r2 is drained. Its bytes are removed from accounting.
+drain range=2
+----
+raftReceiveQueue.Drain() => msgs=1
+queue state: r2 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+close
+----
+pacer state:
+ lastHeadroomSampleTime: 10ms

--- a/pkg/kv/kvserver/testdata/raft_dequeue_pacer
+++ b/pkg/kv/kvserver/testdata/raft_dequeue_pacer
@@ -49,19 +49,19 @@ enqueue range=1 msg=ma1 wait-for-start-wait
 engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
 start engine.TryWaitForMemTableStallHeadroom(doWait=true)
 raftReceiveQueue.Append() => shouldQ=false size=70 appended=true
-queue state: r1 other 0
+queue state: r1 skip-paused 0
 pacer state:
  lastHeadroomSampleTime: 20ms
- waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0)
 
 # Drain does not drain anything.
 drain range=1
 ----
 raftReceiveQueue.Drain() => msgs=0
-queue state: r1 other 0
+queue state: r1 skip-paused 0
 pacer state:
  lastHeadroomSampleTime: 20ms
- waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0)
 
 # Engine recovers, allowing the range to be dequeued. The pacer's
 # burstBytesToDrain is positive.
@@ -78,6 +78,7 @@ pacer state:
 delete range=1
 ----
 raftReceiveQueues.Delete()
+queue state: r1 all 0
 pacer state:
  lastHeadroomSampleTime: 20ms
 
@@ -85,6 +86,54 @@ close
 ----
 pacer state:
  lastHeadroomSampleTime: 20ms
+
+# Queue in state raftDequeueSkipPaused is deregistered.
+init
+----
+pacer state:
+ lastHeadroomSampleTime: 0s
+
+set-engine-overload overload=true
+----
+
+# Range gets queued in the pacer.
+enqueue range=1 msg=ma1 wait-for-start-wait
+----
+engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
+start engine.TryWaitForMemTableStallHeadroom(doWait=true)
+raftReceiveQueue.Append() => shouldQ=false size=70 appended=true
+queue state: r1 skip-paused 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0)
+
+# Drain does not drain anything.
+drain range=1
+----
+raftReceiveQueue.Drain() => msgs=0
+queue state: r1 skip-paused 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0)
+
+# Deletion causes the range to be removed from waiting in the pacer.
+delete range=1
+----
+raftReceiveQueues.Delete()
+queue state: r1 all 0
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+end-wait do-not-wait-for-dequeue-burst
+----
+end engine.TryWaitForMemTableStallHeadroom(doWait=true) => ok=true, allowedBurst=100
+pacer state:
+ lastHeadroomSampleTime: 10ms
+
+close
+----
+pacer state:
+ lastHeadroomSampleTime: 10ms
 
 # Multiple ranges being paced. The first one has < 100 bytes, and the engine
 # allows a burst of 100 bytes, so both ranges get dequeued when the engine
@@ -103,19 +152,19 @@ enqueue range=1 msg=ma1 wait-for-start-wait
 engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
 start engine.TryWaitForMemTableStallHeadroom(doWait=true)
 raftReceiveQueue.Append() => shouldQ=false size=70 appended=true
-queue state: r1 other 0
+queue state: r1 skip-paused 0
 pacer state:
  lastHeadroomSampleTime: 10ms
- waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0)
 
 # Range r2 gets queued in the pacer.
 enqueue range=2 msg=ma2
 ----
 raftReceiveQueue.Append() => shouldQ=false size=109 appended=true
-queue state: r2 other 0
+queue state: r2 skip-paused 0
 pacer state:
  lastHeadroomSampleTime: 10ms
- waiting queues (rangeID, decision, accounting-bytes): (r1 other 0) (r2 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0) (r2 skip-paused 0)
 
 # Both ranges dequeued. Both are accounted for in the burstBytesToDrain.
 end-wait
@@ -140,6 +189,7 @@ pacer state:
 delete range=2
 ----
 raftReceiveQueues.Delete()
+queue state: r2 all 0
 pacer state:
  lastHeadroomSampleTime: 10ms
 
@@ -165,19 +215,19 @@ enqueue range=1 msg=ma2 wait-for-start-wait
 engine.TryWaitForMemTableStallHeadroom(doWait=false) => ok=false, allowedBurst=0
 start engine.TryWaitForMemTableStallHeadroom(doWait=true)
 raftReceiveQueue.Append() => shouldQ=false size=109 appended=true
-queue state: r1 other 0
+queue state: r1 skip-paused 0
 pacer state:
  lastHeadroomSampleTime: 10ms
- waiting queues (rangeID, decision, accounting-bytes): (r1 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0)
 
 # Range r2 gets queued in the pacer.
 enqueue range=2 msg=ma2
 ----
 raftReceiveQueue.Append() => shouldQ=false size=109 appended=true
-queue state: r2 other 0
+queue state: r2 skip-paused 0
 pacer state:
  lastHeadroomSampleTime: 10ms
- waiting queues (rangeID, decision, accounting-bytes): (r1 other 0) (r2 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r1 skip-paused 0) (r2 skip-paused 0)
 
 # Range r1 is dequeued. Its bytes are accounted for in burstBytesToDrain
 end-wait
@@ -187,7 +237,7 @@ raftScheduler.EnqueueRaftRequest(r1)
 pacer state:
  lastHeadroomSampleTime: 10ms
  burstBytesToDrain: 109
- waiting queues (rangeID, decision, accounting-bytes): (r2 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r2 skip-paused 0)
 
 # Deletion of range r1 causes its bytes to be removed from accounting, and
 # another TryWait to start.
@@ -195,9 +245,10 @@ delete range=1 wait-for-start-wait
 ----
 start engine.TryWaitForMemTableStallHeadroom(doWait=true)
 raftReceiveQueues.Delete()
+queue state: r1 all 0
 pacer state:
  lastHeadroomSampleTime: 10ms
- waiting queues (rangeID, decision, accounting-bytes): (r2 other 0)
+ waiting queues (rangeID, decision, accounting-bytes): (r2 skip-paused 0)
 
 # Range r2 is dequeued. Its bytes are accounted for in burstBytesToDrain.
 end-wait

--- a/pkg/kv/kvserver/testdata/raft_receive_dequeue
+++ b/pkg/kv/kvserver/testdata/raft_receive_dequeue
@@ -1,0 +1,436 @@
+# Test case that queues ma1 (MsgApp) followed by o1 (non-MsgApp), then drains.
+init
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+append msg=ma1
+----
+shouldQ=true size=68 appended=true
+queue state:
+ msgApps: [ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+append msg=o1
+----
+shouldQ=false size=47 appended=true
+queue state:
+ msgApps: [ma1]
+ otherMsgs: [o1]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+drain
+----
+drained msgs: [o1 ma1]
+pacer.DrainingMsgApps calls 1
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+destroy
+----
+pacer.Deregister calls 1
+queue state:
+ destroyed
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+# Test case that queues ma1 (MsgApp) drains and queues ma2 (MsgApp) and o1
+# (non-MsgApp) and checks o1, ma2 are not clobbered by recycle.
+init
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+append msg=ma1
+----
+shouldQ=true size=68 appended=true
+queue state:
+ msgApps: [ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+drain
+----
+drained msgs: [ma1]
+pacer.DrainingMsgApps calls 1
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+# Transitioning from empty to non-empty with low-priority-override, hence the
+# MaybePause call.
+append msg=ma2
+----
+shouldQ=true size=97 appended=true
+pacer.MaybePause calls 1
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+append msg=o1
+----
+shouldQ=false size=47 appended=true
+queue state:
+ msgApps: [ma2]
+ otherMsgs: [o1]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: [ma2]
+ otherMsgs: [o1]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+destroy
+----
+pacer.DrainingMsgApps calls 1
+pacer.Deregister calls 1
+queue state:
+ destroyed
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+# Test case that queues o1 (non-MsgApp) drains and queues o2 (non-MsgApp) and
+# ma1, and checks ma1 and o2 are not clobbered by recycle.
+init
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+append msg=o1
+----
+shouldQ=true size=47 appended=true
+queue state:
+ msgApps: []
+ otherMsgs: [o1]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+drain
+----
+drained msgs: [o1]
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+append msg=o2
+----
+shouldQ=true size=47 appended=true
+queue state:
+ msgApps: []
+ otherMsgs: [o2]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+append msg=ma1
+----
+shouldQ=false size=68 appended=true
+queue state:
+ msgApps: [ma1]
+ otherMsgs: [o2]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: [ma1]
+ otherMsgs: [o2]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+destroy
+----
+pacer.DrainingMsgApps calls 1
+pacer.Deregister calls 1
+queue state:
+ destroyed
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+# Test case that drains only non-MsgApps and drains MsgApps on destroy.
+init
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+# Transitioning from empty to non-empty with low-priority-override, hence the
+# MaybePause call.
+append msg=ma2
+----
+shouldQ=true size=97 appended=true
+pacer.MaybePause calls 1
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+append msg=ma1
+----
+shouldQ=false size=68 appended=true
+queue state:
+ msgApps: [ma2 ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+overwrite-decision decision=other
+----
+queue state:
+ msgApps: [ma2 ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: other, accountingBytes: 0
+
+append msg=o1
+----
+shouldQ=false size=47 appended=true
+queue state:
+ msgApps: [ma2 ma1]
+ otherMsgs: [o1]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: other, accountingBytes: 0
+
+# Only o1 drains.
+drain
+----
+drained msgs: [o1]
+queue state:
+ msgApps: [ma2 ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: other, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: [ma2 ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: other, accountingBytes: 0
+
+# The MsgApps are drained because queue is being destroyed.
+destroy
+----
+pacer.DrainingMsgApps calls 1
+pacer.Deregister calls 1
+queue state:
+ destroyed
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+# Test case that drains only non-MsgApps and drains MsgApps when the decision
+# changes.
+init
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+# Transitioning from empty to non-empty with low-priority-override, hence the
+# MaybePause call.
+append msg=ma2
+----
+shouldQ=true size=97 appended=true
+pacer.MaybePause calls 1
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+overwrite-decision decision=other
+----
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: other, accountingBytes: 0
+
+append msg=o1
+----
+shouldQ=false size=47 appended=true
+queue state:
+ msgApps: [ma2]
+ otherMsgs: [o1]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: other, accountingBytes: 0
+
+# Only o1 drains.
+drain
+----
+drained msgs: [o1]
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: other, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: other, accountingBytes: 0
+
+overwrite-decision decision=all
+----
+queue state:
+ msgApps: [ma2]
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+append msg=o2
+----
+shouldQ=true size=47 appended=true
+queue state:
+ msgApps: [ma2]
+ otherMsgs: [o2]
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+drain
+----
+drained msgs: [o2 ma2]
+pacer.DrainingMsgApps calls 1
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+append msg=ma1
+----
+shouldQ=true size=68 appended=true
+queue state:
+ msgApps: [ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: [ma1]
+ otherMsgs: []
+ queuedAtRaftScheduler: true
+ lastDrainedFromOtherMsgs: true
+ pacer: decision: all, accountingBytes: 0
+
+drain
+----
+drained msgs: [ma1]
+pacer.DrainingMsgApps calls 1
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+recycle
+----
+queue state:
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+destroy
+----
+pacer.Deregister calls 1
+queue state:
+ destroyed
+ msgApps: []
+ otherMsgs: []
+ queuedAtRaftScheduler: false
+ lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0

--- a/pkg/kv/kvserver/testdata/raft_receive_dequeue
+++ b/pkg/kv/kvserver/testdata/raft_receive_dequeue
@@ -2,50 +2,44 @@
 init
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 append msg=ma1
 ----
 shouldQ=true size=68 appended=true
 queue state:
- msgApps: [ma1]
- otherMsgs: []
+ normal-stream: [ma1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 append msg=o1
 ----
 shouldQ=false size=47 appended=true
 queue state:
- msgApps: [ma1]
- otherMsgs: [o1]
+ normal-stream: [ma1 o1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 drain
 ----
-drained msgs: [o1 ma1]
-pacer.DrainingMsgApps calls 1
+drained msgs: [ma1 o1]
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 destroy
@@ -53,147 +47,158 @@ destroy
 pacer.Deregister calls 1
 queue state:
  destroyed
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
-# Test case that queues ma1 (MsgApp) drains and queues ma2 (MsgApp) and o1
-# (non-MsgApp) and checks o1, ma2 are not clobbered by recycle.
+# Test case that queues ma2 (MsgApp) drains and queues ma1 (MsgApp) and o1
+# (non-MsgApp) and checks o1, ma1 are not clobbered by recycle.
 init
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
+ pacer: decision: all, accountingBytes: 0
+
+next-should-pause-says-yes
+----
+
+# Empty paused stream and message is low-priority-override, and will pause,
+# hence the Pause call.
+append msg=ma2
+----
+shouldQ=false size=97 appended=true
+pacer.Pause calls 1
+queue state:
+ normal-stream: []
+ paused-stream: [ma2]
+ queuedAtRaftScheduler: false
+ pacer: decision: skip-paused, accountingBytes: 0
+
+# Nothing drain, since ma2 is in the paused stream.
+drain
+----
+drained msgs: []
+queue state:
+ normal-stream: []
+ paused-stream: [ma2]
+ queuedAtRaftScheduler: false
+ pacer: decision: skip-paused, accountingBytes: 0
+
+transition-to-dequeue-all
+----
+queue state:
+ normal-stream: []
+ paused-stream: [ma2]
+ queuedAtRaftScheduler: false
+ pacer: decision: all, accountingBytes: 0
+
+# Message ma2 drains.
+drain
+----
+drained msgs: [ma2]
+pacer.DrainingMsgApps calls 1
+queue state:
+ normal-stream: []
+ paused-stream: []
+ queuedAtRaftScheduler: false
  pacer: decision: all, accountingBytes: 0
 
 append msg=ma1
 ----
 shouldQ=true size=68 appended=true
 queue state:
- msgApps: [ma1]
- otherMsgs: []
+ normal-stream: [ma1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: all, accountingBytes: 0
-
-drain
-----
-drained msgs: [ma1]
-pacer.DrainingMsgApps calls 1
-queue state:
- msgApps: []
- otherMsgs: []
- queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
- pacer: decision: all, accountingBytes: 0
-
-# Transitioning from empty to non-empty with low-priority-override, hence the
-# MaybePause call.
-append msg=ma2
-----
-shouldQ=true size=97 appended=true
-pacer.MaybePause calls 1
-queue state:
- msgApps: [ma2]
- otherMsgs: []
- queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 append msg=o1
 ----
 shouldQ=false size=47 appended=true
 queue state:
- msgApps: [ma2]
- otherMsgs: [o1]
+ normal-stream: [ma1 o1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: [ma2]
- otherMsgs: [o1]
+ normal-stream: [ma1 o1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 destroy
 ----
-pacer.DrainingMsgApps calls 1
 pacer.Deregister calls 1
 queue state:
  destroyed
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 # Test case that queues o1 (non-MsgApp) drains and queues o2 (non-MsgApp) and
-# ma1, and checks ma1 and o2 are not clobbered by recycle.
+# ma2, and checks ma2 and o2 are not clobbered by recycle.
 init
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 append msg=o1
 ----
 shouldQ=true size=47 appended=true
 queue state:
- msgApps: []
- otherMsgs: [o1]
+ normal-stream: [o1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 drain
 ----
 drained msgs: [o1]
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 append msg=o2
 ----
 shouldQ=true size=47 appended=true
 queue state:
- msgApps: []
- otherMsgs: [o2]
+ normal-stream: [o2]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
-append msg=ma1
+next-should-pause-says-yes
 ----
-shouldQ=false size=68 appended=true
+
+append msg=ma2
+----
+shouldQ=false size=97 appended=true
+pacer.Pause calls 1
 queue state:
- msgApps: [ma1]
- otherMsgs: [o2]
+ normal-stream: [o2]
+ paused-stream: [ma2]
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: true
- pacer: decision: all, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: [ma1]
- otherMsgs: [o2]
+ normal-stream: [o2]
+ paused-stream: [ma2]
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: true
- pacer: decision: all, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 destroy
 ----
@@ -201,83 +206,70 @@ pacer.DrainingMsgApps calls 1
 pacer.Deregister calls 1
 queue state:
  destroyed
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 # Test case that drains only non-MsgApps and drains MsgApps on destroy.
 init
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
+next-should-pause-says-yes
+----
+
 # Transitioning from empty to non-empty with low-priority-override, hence the
-# MaybePause call.
+# Pause call.
 append msg=ma2
 ----
-shouldQ=true size=97 appended=true
-pacer.MaybePause calls 1
+shouldQ=false size=97 appended=true
+pacer.Pause calls 1
 queue state:
- msgApps: [ma2]
- otherMsgs: []
- queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: all, accountingBytes: 0
+ normal-stream: []
+ paused-stream: [ma2]
+ queuedAtRaftScheduler: false
+ pacer: decision: skip-paused, accountingBytes: 0
 
 append msg=ma1
 ----
 shouldQ=false size=68 appended=true
 queue state:
- msgApps: [ma2 ma1]
- otherMsgs: []
- queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: all, accountingBytes: 0
-
-overwrite-decision decision=other
-----
-queue state:
- msgApps: [ma2 ma1]
- otherMsgs: []
- queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: other, accountingBytes: 0
+ normal-stream: []
+ paused-stream: [ma2 ma1]
+ queuedAtRaftScheduler: false
+ pacer: decision: skip-paused, accountingBytes: 0
 
 append msg=o1
 ----
-shouldQ=false size=47 appended=true
+shouldQ=true size=47 appended=true
 queue state:
- msgApps: [ma2 ma1]
- otherMsgs: [o1]
+ normal-stream: [o1]
+ paused-stream: [ma2 ma1]
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: other, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 # Only o1 drains.
 drain
 ----
 drained msgs: [o1]
 queue state:
- msgApps: [ma2 ma1]
- otherMsgs: []
+ normal-stream: []
+ paused-stream: [ma2 ma1]
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
- pacer: decision: other, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: [ma2 ma1]
- otherMsgs: []
+ normal-stream: []
+ paused-stream: [ma2 ma1]
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
- pacer: decision: other, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 # The MsgApps are drained because queue is being destroyed.
 destroy
@@ -286,10 +278,9 @@ pacer.DrainingMsgApps calls 1
 pacer.Deregister calls 1
 queue state:
  destroyed
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 # Test case that drains only non-MsgApps and drains MsgApps when the decision
@@ -297,81 +288,68 @@ queue state:
 init
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
+
+next-should-pause-says-yes
+----
 
 # Transitioning from empty to non-empty with low-priority-override, hence the
 # MaybePause call.
 append msg=ma2
 ----
-shouldQ=true size=97 appended=true
-pacer.MaybePause calls 1
+shouldQ=false size=97 appended=true
+pacer.Pause calls 1
 queue state:
- msgApps: [ma2]
- otherMsgs: []
- queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: all, accountingBytes: 0
-
-overwrite-decision decision=other
-----
-queue state:
- msgApps: [ma2]
- otherMsgs: []
- queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: other, accountingBytes: 0
+ normal-stream: []
+ paused-stream: [ma2]
+ queuedAtRaftScheduler: false
+ pacer: decision: skip-paused, accountingBytes: 0
 
 append msg=o1
 ----
-shouldQ=false size=47 appended=true
+shouldQ=true size=47 appended=true
 queue state:
- msgApps: [ma2]
- otherMsgs: [o1]
+ normal-stream: [o1]
+ paused-stream: [ma2]
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: false
- pacer: decision: other, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 # Only o1 drains.
 drain
 ----
 drained msgs: [o1]
 queue state:
- msgApps: [ma2]
- otherMsgs: []
+ normal-stream: []
+ paused-stream: [ma2]
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
- pacer: decision: other, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: [ma2]
- otherMsgs: []
+ normal-stream: []
+ paused-stream: [ma2]
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
- pacer: decision: other, accountingBytes: 0
+ pacer: decision: skip-paused, accountingBytes: 0
 
-overwrite-decision decision=all
+transition-to-dequeue-all
 ----
 queue state:
- msgApps: [ma2]
- otherMsgs: []
+ normal-stream: []
+ paused-stream: [ma2]
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 append msg=o2
 ----
 shouldQ=true size=47 appended=true
 queue state:
- msgApps: [ma2]
- otherMsgs: [o2]
+ normal-stream: [o2]
+ paused-stream: [ma2]
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 drain
@@ -379,49 +357,43 @@ drain
 drained msgs: [o2 ma2]
 pacer.DrainingMsgApps calls 1
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 append msg=ma1
 ----
 shouldQ=true size=68 appended=true
 queue state:
- msgApps: [ma1]
- otherMsgs: []
+ normal-stream: [ma1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: [ma1]
- otherMsgs: []
+ normal-stream: [ma1]
+ paused-stream: []
  queuedAtRaftScheduler: true
- lastDrainedFromOtherMsgs: true
  pacer: decision: all, accountingBytes: 0
 
 drain
 ----
 drained msgs: [ma1]
-pacer.DrainingMsgApps calls 1
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 recycle
 ----
 queue state:
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0
 
 destroy
@@ -429,8 +401,7 @@ destroy
 pacer.Deregister calls 1
 queue state:
  destroyed
- msgApps: []
- otherMsgs: []
+ normal-stream: []
+ paused-stream: []
  queuedAtRaftScheduler: false
- lastDrainedFromOtherMsgs: false
  pacer: decision: all, accountingBytes: 0


### PR DESCRIPTION
The raftReceiveQueues now separate the stream of MsgApp messages from the non-MsgApp messages. Dequeueing of the MsgApp message streams can be paced by the storeRaftDequeuePacer to reduce the probability of a write stall due to too many memtables in the engine.

The code currently uses a noop engine, which always indicates that it is healthy.

Informs #155183

Epic: none

Release note (ops change): The cluster setting
kv.raft.msg_app_dequeue_pacing.enabled (default is true) controls whether MsgApp dequeueing can be paced to reduce the probability of engine write stalls.