### PR TITLE
kvserver: deflake TestPromoteNonVoterInAddVoter

### DIFF
--- a/pkg/spanconfig/spanconfigstore/span_store.go
+++ b/pkg/spanconfig/spanconfigstore/span_store.go
@@ -19,10 +19,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// tenantCoalesceAdjacentSetting is a public cluster setting that
+// TenantCoalesceAdjacentSetting is a public cluster setting that
 // controls whether we coalesce adjacent ranges across all secondary
 // tenant keyspaces if they have the same span config.
-var tenantCoalesceAdjacentSetting = settings.RegisterBoolSetting(
+var TenantCoalesceAdjacentSetting = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"spanconfig.tenant_coalesce_adjacent.enabled",
 	`collapse adjacent ranges with the same span configs across all secondary tenant keyspaces`,
@@ -157,7 +157,7 @@ func (s *spanConfigStore) computeSplitKey(
 				return roachpb.RKey(match.span.Key), nil
 			}
 		} else {
-			if !tenantCoalesceAdjacentSetting.Get(&s.settings.SV) {
+			if !TenantCoalesceAdjacentSetting.Get(&s.settings.SV) {
 				return roachpb.RKey(match.span.Key), nil
 			}
 		}


### PR DESCRIPTION
This test could previously fail because a lease transfer could race with a split. Without the split, the effects of the span config (that the test asserts on) will not apply. We sidestep this problem by removing the need of a split entirely -- by tuning some cluster settings to ensure that every table is on its own range to begin with.

H/t to @pav-kv for the analysis on this one.

Closes https://github.com/cockroachdb/cockroach/issues/155828 
Closes https://github.com/cockroachdb/cockroach/issues/155747 
Closes https://github.com/cockroachdb/cockroach/issues/155316 
Closes https://github.com/cockroachdb/cockroach/issues/154773 
Closes https://github.com/cockroachdb/cockroach/issues/134383

Release note: None