### PR TITLE
release-25.4: rangefeed: deflake TestUnbufferedRegWithStreamManager

### DIFF
--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -62,13 +62,14 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 		})
 	})
 	testServerStream.reset()
-	t.Run("publish 20 logical ops to 50 registrations", func(t *testing.T) {
-		for i := 0; i < 20; i++ {
+	eventCount := testProcessorEventCCap - 1
+	t.Run(fmt.Sprintf("publish %d logical ops to 50 registrations", eventCount), func(t *testing.T) {
+		for range eventCount {
 			p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: 1}))
 		}
-		testServerStream.waitForEventCount(t, 20*50)
+		testServerStream.waitForEventCount(t, eventCount*50)
 		testServerStream.iterateEventsByStreamID(func(_ int64, events []*kvpb.MuxRangeFeedEvent) {
-			require.Equal(t, 20, len(events))
+			require.Equal(t, eventCount, len(events))
 			require.NotNil(t, events[0].RangeFeedEvent.Val)
 		})
 	})


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/155823

Backport 1/5 commits from #153740.

Release justification: Test-only change.

/cc @cockroachdb/release

---

**rangefeed: deflake TestUnbufferedRegWithStreamManager**

Under stress, this test would fail because attempting to publish 20
events in a tight loop would overwhelm the processor's event buffer
(which has a capacity of 16).

Epic: none
Release note: None


