### PR TITLE
roachtest: remove metamorphicBufferedSender

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1104,7 +1104,6 @@ func (r *testRunner) runWorker(
 						setting string
 						label   string
 					}{
-						{setting: "kv.rangefeed.buffered_sender.enabled", label: "metamorphicBufferedSender"},
 						{setting: "kv.transaction.write_buffering.enabled", label: "metamorphicWriteBuffering"},
 					} {
 						enable := prng.Intn(2) == 0


### PR DESCRIPTION
This setting is now enabled by default, so there is no need to enable this
metamorphically.

Epic: none 
Release note: none 