### PR TITLE
release-25.2: kvserver: deflake TestPromoteNonVoterInAddVoter

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -2160,6 +2161,12 @@ func TestPromoteNonVoterInAddVoter(t *testing.T) {
 	defer testutils.StartExecTrace(t, scope.GetDirectory()).Finish(t)
 
 	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	// NB: Ensure that tables created by the test start off on their own range.
+	// This ensures that any span config changes made by the test don't have to
+	// first induce a split, which is a known source of flakiness.
+	spanconfigstore.StorageCoalesceAdjacentSetting.Override(ctx, &st.SV, false)
+	spanconfigstore.TenantCoalesceAdjacentSetting.Override(ctx, &st.SV, false)
 
 	// Create 7 stores: 3 in Region 1, 2 in Region 2, and 2 in Region 3.
 	const numNodes = 7
@@ -2167,6 +2174,7 @@ func TestPromoteNonVoterInAddVoter(t *testing.T) {
 	regions := [numNodes]int{1, 1, 1, 2, 2, 3, 3}
 	for i := 0; i < numNodes; i++ {
 		serverArgs[i] = base.TestServerArgs{
+			Settings: st,
 			Locality: roachpb.Locality{
 				Tiers: []roachpb.Tier{
 					{

--- a/pkg/spanconfig/spanconfigstore/span_store.go
+++ b/pkg/spanconfig/spanconfigstore/span_store.go
@@ -19,10 +19,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// tenantCoalesceAdjacentSetting is a public cluster setting that
+// TenantCoalesceAdjacentSetting is a public cluster setting that
 // controls whether we coalesce adjacent ranges across all secondary
 // tenant keyspaces if they have the same span config.
-var tenantCoalesceAdjacentSetting = settings.RegisterBoolSetting(
+var TenantCoalesceAdjacentSetting = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"spanconfig.tenant_coalesce_adjacent.enabled",
 	`collapse adjacent ranges with the same span configs across all secondary tenant keyspaces`,
@@ -157,7 +157,7 @@ func (s *spanConfigStore) computeSplitKey(
 				return roachpb.RKey(match.span.Key), nil
 			}
 		} else {
-			if !tenantCoalesceAdjacentSetting.Get(&s.settings.SV) {
+			if !TenantCoalesceAdjacentSetting.Get(&s.settings.SV) {
 				return roachpb.RKey(match.span.Key), nil
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #155861 on behalf of @arulajmani.

----

This test could previously fail because a lease transfer could race with a split. Without the split, the effects of the span config (that the test asserts on) will not apply. We sidestep this problem by removing the need of a split entirely -- by tuning some cluster settings to ensure that every table is on its own range to begin with.

H/t to @pav-kv for the analysis on this one.

Closes https://github.com/cockroachdb/cockroach/issues/155828 
Closes https://github.com/cockroachdb/cockroach/issues/155747 
Closes https://github.com/cockroachdb/cockroach/issues/155316 
Closes https://github.com/cockroachdb/cockroach/issues/154773 
Closes https://github.com/cockroachdb/cockroach/issues/134383

Release note: None

----

Release justification: test-only change