### PR TITLE
changefeedccl: fix timestamp for desc fetches during planning

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -448,7 +448,11 @@ func generateAndValidateNewTargets(
 		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 
-	prevTargets, err := AllTargets(ctx, prevDetails, p.ExecCfg())
+	targetTS := prevProgress.GetHighWater()
+	if targetTS == nil || targetTS.IsEmpty() {
+		targetTS = &prevDetails.StatementTime
+	}
+	prevTargets, err := AllTargets(ctx, prevDetails, p.ExecCfg(), *targetTS)
 	if err != nil {
 		return nil, nil, hlc.Timestamp{}, nil, err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -378,7 +378,8 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	if ca.knobs.OverrideExecCfg != nil {
 		execCfg = ca.knobs.OverrideExecCfg(execCfg)
 	}
-	ca.targets, err = AllTargets(ctx, ca.spec.Feed, execCfg)
+	targetTS := ca.spec.GetSchemaTS()
+	ca.targets, err = AllTargets(ctx, ca.spec.Feed, execCfg, targetTS)
 	if err != nil {
 		log.Changefeed.Warningf(ca.Ctx(), "moving to draining due to error getting targets: %v", err)
 		ca.MoveToDraining(err)
@@ -1352,7 +1353,8 @@ func newChangeFrontierProcessor(
 	if cf.knobs.OverrideExecCfg != nil {
 		execCfg = cf.knobs.OverrideExecCfg(execCfg)
 	}
-	targets, err := AllTargets(ctx, spec.Feed, execCfg)
+	targetTS := cf.spec.GetSchemaTS()
+	targets, err := AllTargets(ctx, cf.spec.Feed, execCfg, targetTS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 	"github.com/linkedin/goavro/v2"
@@ -54,13 +55,16 @@ type enrichedSourceProvider struct {
 }
 
 func GetTableSchemaInfo(
-	ctx context.Context, cfg *execinfra.ServerConfig, targets changefeedbase.Targets,
+	ctx context.Context,
+	cfg *execinfra.ServerConfig,
+	targets changefeedbase.Targets,
+	schemaTS hlc.Timestamp,
 ) (map[descpb.ID]tableSchemaInfo, error) {
 	schemaInfo := make(map[descpb.ID]tableSchemaInfo)
 	execCfg := cfg.ExecutorConfig.(*sql.ExecutorConfig)
 	err := targets.EachTarget(func(target changefeedbase.Target) error {
 		id := target.DescID
-		td, dbd, sd, err := getDescriptors(ctx, execCfg, id)
+		td, dbd, sd, err := getDescriptors(ctx, execCfg, id, schemaTS)
 		if err != nil {
 			return err
 		}
@@ -548,13 +552,16 @@ func init() {
 const originCockroachDB = "cockroachdb"
 
 func getDescriptors(
-	ctx context.Context, execCfg *sql.ExecutorConfig, tableID descpb.ID,
+	ctx context.Context, execCfg *sql.ExecutorConfig, tableID descpb.ID, schemaTS hlc.Timestamp,
 ) (catalog.TableDescriptor, catalog.DatabaseDescriptor, catalog.SchemaDescriptor, error) {
 	var tableDescriptor catalog.TableDescriptor
 	var dbDescriptor catalog.DatabaseDescriptor
 	var schemaDescriptor catalog.SchemaDescriptor
 	var err error
 	f := func(ctx context.Context, txn descs.Txn) error {
+		if err := txn.KV().SetFixedTimestamp(ctx, schemaTS); err != nil {
+			return err
+		}
 		byIDGetter := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get()
 		tableDescriptor, err = byIDGetter.Table(ctx, tableID)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -109,7 +109,8 @@ func newEventConsumer(
 		if encodingOpts.Envelope == changefeedbase.OptEnvelopeEnriched {
 			var schemaInfo map[descpb.ID]tableSchemaInfo
 			if inSet(changefeedbase.EnrichedPropertySource, encodingOpts.EnrichedProperties) {
-				schemaInfo, err = GetTableSchemaInfo(ctx, cfg, feed.Targets)
+				targetTS := spec.GetSchemaTS()
+				schemaInfo, err = GetTableSchemaInfo(ctx, cfg, feed.Targets, targetTS)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/ccl/changefeedccl/event_processing_test.go
+++ b/pkg/ccl/changefeedccl/event_processing_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -155,7 +156,7 @@ func TestTopicForEvent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Can pass in nil for execCfg to AllTargets because we're not testing
 			// database-level targets.
-			targets, err := AllTargets(context.Background(), tc.details, nil)
+			targets, err := AllTargets(context.Background(), tc.details, nil, hlc.Timestamp{})
 			require.NoError(t, err)
 			cfg, err := makeChangefeedConfigFromJobDetails(tc.details, targets)
 			require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -128,6 +128,11 @@ type TestingKnobs struct {
 	// MakeKVFeedToAggregatorBufferKnobs is used to make a fresh set of testing knobs
 	// to pass to the constructor of the kv feed to change aggregator buffer.
 	MakeKVFeedToAggregatorBufferKnobs func() kvevent.BlockingBufferTestingKnobs
+
+	// AfterComputeDistChangefeedTimestamps is called when a changefeed is starting, after
+	// the initial timestamps are computed and before the changefeed targets'
+	// descriptors are fetched.
+	AfterComputeDistChangefeedTimestamps func(context.Context)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
+        "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/optional",
         "//pkg/util/protoutil",

--- a/pkg/sql/execinfrapb/api.go
+++ b/pkg/sql/execinfrapb/api.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -60,9 +61,29 @@ func (m *ChangeAggregatorSpec) User() username.SQLUsername {
 	return m.UserProto.Decode()
 }
 
+// GetSchemaTS returns the schema timestamp to use. If the spec has a valid
+// SchemaTS, it returns the value of SchemaTS. Otherwise, it returns the
+// statement time of the changefeed.
+func (m *ChangeAggregatorSpec) GetSchemaTS() hlc.Timestamp {
+	if m.SchemaTS != nil && !m.SchemaTS.IsEmpty() {
+		return *m.SchemaTS
+	}
+	return m.Feed.StatementTime
+}
+
 // User accesses the user field.
 func (m *ChangeFrontierSpec) User() username.SQLUsername {
 	return m.UserProto.Decode()
+}
+
+// GetSchemaTS returns the schema timestamp to use. If the spec has a valid
+// SchemaTS, it returns the value of SchemaTS. Otherwise, it returns the
+// statement time of the changefeed.
+func (m *ChangeFrontierSpec) GetSchemaTS() hlc.Timestamp {
+	if m.SchemaTS != nil && !m.SchemaTS.IsEmpty() {
+		return *m.SchemaTS
+	}
+	return m.Feed.StatementTime
 }
 
 func (m *GenerativeSplitAndScatterSpec) User() username.SQLUsername {

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -68,6 +68,10 @@ message ChangeAggregatorSpec {
   // ResolvedSpans contains the resolved spans that should be restored
   // when the changefeed resumes.
   repeated cockroach.sql.jobs.jobspb.ResolvedSpan resolved_spans = 11 [(gogoproto.nullable) = false];
+
+  // SchemaTS is, during changefeed startup or resumption, the time at which the
+  // aggregator's targets' schemas should be used from.
+  optional util.hlc.Timestamp schema_ts = 12 [(gogoproto.customname) = "SchemaTS"];
 }
 
 // ChangeFrontierSpec is the specification for a processor that receives
@@ -106,6 +110,10 @@ message ChangeFrontierSpec {
   // ResolvedSpans contains the resolved spans that should be restored
   // when the changefeed resumes.
   repeated cockroach.sql.jobs.jobspb.ResolvedSpan resolved_spans = 8 [(gogoproto.nullable) = false];
+
+  // SchemaTS is, during changefeed startup or resumption, the time at which the
+  // change frontier's targets' schemas should be used from.
+  optional util.hlc.Timestamp schema_ts = 9 [(gogoproto.customname) = "SchemaTS"];
 }
 
 // ChangefeedProgressConfig is the configuration for the changefeed's progress tracking.


### PR DESCRIPTION
When a changefeed is planned and executed, there are several places where target table descriptors are fetched. With a db-level changefeed, the set of tables can change during changefeed startup. Now, the timestamp is set to the schema timestamp for retrieving table descriptors.

Adding a schema_ts to the protobuf for ChangeAggregatorSpec and ChangeFrontierSpec.

Fixes: #154549
Epic: CRDB-1421

Release note: None