### PR TITLE
dev-inf: Add label when AI review detects potential bugs

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -236,3 +236,5 @@ jobs:
 
           **Next Steps:**
           Please review the detailed findings in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "o-AI-Review-Potential-Issue-Detected"


### PR DESCRIPTION
Previously, when the three-stage AI review process confirmed a potential bug in a PR, it would only post a comment. This made it difficult to track and filter PRs that had been flagged for issues.

This change adds automatic labeling with `o-AI-Review-Potential-Issue-Detected` when all three stages confirm a potential bug, making it easier to:
- Filter and search for flagged PRs
- Track the status of AI-detected issues
- Integrate with other workflows that monitor labeled PRs

Release note: none

Epic: None