### PR TITLE
rowenc, flowinfra: enable a couple test for secondary tenants

### DIFF
--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/trigram"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
@@ -1076,7 +1077,6 @@ func TestEncodeTrigramInvertedIndexSpans(t *testing.T) {
 
 	runTest := func(indexedValue, value string, searchType trigramSearchType,
 		expectContainsKeys, expected, expectUnique bool) {
-		t.Logf("test case: %s %s %v %t %t %t", indexedValue, value, searchType, expectContainsKeys, expected, expectUnique)
 		keys, err := EncodeInvertedIndexTableKeys(tree.NewDString(indexedValue), nil, descpb.LatestIndexDescriptorVersion)
 		require.NoError(t, err)
 
@@ -1285,6 +1285,7 @@ func TestDecodeKeyVals(t *testing.T) {
 // write leaf keys, so that's what's tested here.
 func TestVectorEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -1376,6 +1377,7 @@ func TestVectorEncoding(t *testing.T) {
 
 func TestVectorCompositeEncoding(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})


### PR DESCRIPTION
**rowenc: adjust TestInitIndexFetchSpec to work with test tenants**

With test tenants we have extra 2 bytes (the tenant prefix) included
into the "key prefix length" of the spec, so we need to make an
adjustment to the test. Also add a couple of log scopes in this package.

Fixes: #109390

**flowinfra: enable TestDistSQLReadsFillGatewayID for secondary tenants**

This required only a minor adjustment to the request filter.

Fixes: #109392.
Epic: CRDB-48945