### PR TITLE
kvserver: simplify rewriteRaftState

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3241,15 +3241,18 @@ func TestRaftRemoveRace(t *testing.T) {
 	}
 	tc.AddVotersOrFatal(t, key, targets...)
 
+	sl := kvstorage.MakeStateLoader(desc.RangeID)
+	s2 := tc.GetFirstStoreFromServer(t, 2)
 	for i := 0; i < 10; i++ {
 		tc.RemoveVotersOrFatal(t, key, tc.Target(2))
 		tc.AddVotersOrFatal(t, key, tc.Target(2))
 
-		// Verify the tombstone key does not exist. See #12130.
-		ts, err := kvstorage.MakeStateLoader(desc.RangeID).LoadRangeTombstone(
-			ctx, tc.GetFirstStoreFromServer(t, 2).StateEngine())
+		replID, err := sl.LoadRaftReplicaID(ctx, s2.StateEngine())
 		require.NoError(t, err)
-		require.Equal(t, kvserverpb.RangeTombstone{}, ts)
+		ts, err := sl.LoadRangeTombstone(ctx, s2.StateEngine())
+		require.NoError(t, err)
+		// ReplicaID leads the RangeTombstone, which means a replica exists.
+		require.GreaterOrEqual(t, replID.ReplicaID, ts.NextReplicaID)
 	}
 }
 

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -81,12 +81,6 @@ func (s *snapWriteBuilder) rewriteRaftState(ctx context.Context, w storage.Write
 	if err := s.sl.SetRaftTruncatedState(ctx, w, &s.truncState); err != nil {
 		return errors.Wrapf(err, "unable to write RaftTruncatedState")
 	}
-	// TODO(pav-kv): consider not touching this key. We are not destroying the
-	// replica, and rather moving its state forward. Seemingly, there is no need
-	// in expediting replicaGC.
-	if err := w.ClearUnversioned(s.sl.RangeLastReplicaGCTimestampKey(), storage.ClearOptions{}); err != nil {
-		return errors.Wrapf(err, "unable to write LastReplicaGCTimestamp")
-	}
 
 	s.cleared = append(s.cleared, raftLog)
 	return nil

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -19,6 +19,8 @@ import (
 
 // snapWriteBuilder contains the data needed to prepare the on-disk state for a
 // snapshot.
+//
+// TODO(pav-kv): move this struct to kvstorage package.
 type snapWriteBuilder struct {
 	id roachpb.FullReplicaID
 
@@ -61,7 +63,8 @@ func (s *snapWriteBuilder) prepareSnapApply(ctx context.Context) error {
 // provided state. Specifically, it rewrites HardState and RaftTruncatedState,
 // and clears the raft log. All writes are generated in the engine keys order.
 func (s *snapWriteBuilder) rewriteRaftState(ctx context.Context, w storage.Writer) error {
-	cleared, err := kvstorage.RewriteRaftState(ctx, w, s.sl, s.hardState, s.truncState)
+	cleared, err := kvstorage.RewriteRaftState(
+		ctx, kvstorage.RaftWO(w), s.sl, s.hardState, s.truncState)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -63,13 +63,6 @@ func (s *snapWriteBuilder) prepareSnapApply(ctx context.Context) error {
 // snapshot entry ID, and that clearing the log is applied atomically with the
 // snapshot write, or after the latter is synced.
 func (s *snapWriteBuilder) rewriteRaftState(ctx context.Context, w storage.Writer) error {
-	// TODO(pav-kv): there is no harm in keeping RangeTombstone as long as it does
-	// not exceed the ReplicaID. Since the replica exists (can be uninitialized if
-	// this is an initial snapshot), this invariant holds. Don't touch either of
-	// ReplicaID / RangeTombstone keys, and it will retain the invariant.
-	if err := w.ClearUnversioned(s.sl.RangeTombstoneKey(), storage.ClearOptions{}); err != nil {
-		return errors.Wrapf(err, "unable to clear RangeTombstone")
-	}
 	// Update HardState.
 	if err := s.sl.SetHardState(ctx, w, s.hardState); err != nil {
 		return errors.Wrapf(err, "unable to write HardState")

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -3,7 +3,6 @@ echo
 >> sst:
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vote:0 commit:100 lead:0 lead_epoch:0 
 Delete Range: [0,0 /Local/RangeID/123/u/RaftLog (0x0169f67b757266746c00): , 0,0 /Local/RangeID/123/u"rftm" (0x0169f67b757266746d00): )
-Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:4 
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 Delete: 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
 >> sst:

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -1,7 +1,6 @@
 echo
 ----
 >> sst:
-Delete: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): 
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vote:0 commit:100 lead:0 lead_epoch:0 
 Delete Range: [0,0 /Local/RangeID/123/u/RaftLog (0x0169f67b757266746c00): , 0,0 /Local/RangeID/123/u"rftm" (0x0169f67b757266746d00): )
 Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:4 

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -4,7 +4,6 @@ echo
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vote:0 commit:100 lead:0 lead_epoch:0 
 Delete Range: [0,0 /Local/RangeID/123/u/RaftLog (0x0169f67b757266746c00): , 0,0 /Local/RangeID/123/u"rftm" (0x0169f67b757266746d00): )
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
-Delete: 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
 >> sst:
 Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
 Delete (Sized at 38): 0,0 /Local/RangeID/101/u/RaftHardState (0x0169ed757266746800): 

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -1,10 +1,12 @@
 echo
 ----
 >> sst:
-Delete Range: [0,0 /Local/RangeID/123/u"" (0x0169f67b7500): , 0,0 /Local/RangeID/123/v"" (0x0169f67b7600): )
+Delete: 0,0 /Local/RangeID/123/u/RangeTombstone (0x0169f67b757266746200): 
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vote:0 commit:100 lead:0 lead_epoch:0 
+Delete Range: [0,0 /Local/RangeID/123/u/RaftLog (0x0169f67b757266746c00): , 0,0 /Local/RangeID/123/u"rftm" (0x0169f67b757266746d00): )
 Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:4 
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
+Delete: 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
 >> sst:
 Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
 Delete (Sized at 38): 0,0 /Local/RangeID/101/u/RaftHardState (0x0169ed757266746800): 
@@ -30,7 +32,7 @@ Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109):
 >> repl: /Local/Lock/Local/Range"{a"-k"}
 >> repl: /Local/Lock"{a"-k"}
 >> repl: {a-k}
->> cleared: /Local/RangeID/123/{u""-v""}
+>> cleared: /Local/RangeID/123/u{/RaftLog-"rftm"}
 >> cleared: /Local/RangeID/101/{r""-s""}
 >> cleared: /Local/RangeID/101/{u""-v""}
 >> cleared: /Local/RangeID/102/{r""-s""}

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -7,10 +7,20 @@ Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 >> sst:
 Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
+Delete (Sized at 38): 0,0 /Local/RangeID/101/u/RaftHardState (0x0169ed757266746800): 
+Delete (Sized at 42): 0,0 /Local/RangeID/101/u/RaftLog/logIndex:11 (0x0169ed757266746c000000000000000b00): 
+Delete (Sized at 42): 0,0 /Local/RangeID/101/u/RaftLog/logIndex:12 (0x0169ed757266746c000000000000000c00): 
+Delete (Sized at 42): 0,0 /Local/RangeID/101/u/RaftLog/logIndex:13 (0x0169ed757266746c000000000000000d00): 
 Delete: 0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): 
+Delete (Sized at 32): 0,0 /Local/RangeID/101/u/RaftTruncatedState (0x0169ed757266747400): 
 >> sst:
 Put: 0,0 /Local/RangeID/102/u/RangeTombstone (0x0169ee757266746200): next_replica_id:2147483647 
+Delete (Sized at 38): 0,0 /Local/RangeID/102/u/RaftHardState (0x0169ee757266746800): 
+Delete (Sized at 42): 0,0 /Local/RangeID/102/u/RaftLog/logIndex:11 (0x0169ee757266746c000000000000000b00): 
+Delete (Sized at 42): 0,0 /Local/RangeID/102/u/RaftLog/logIndex:12 (0x0169ee757266746c000000000000000c00): 
+Delete (Sized at 42): 0,0 /Local/RangeID/102/u/RaftLog/logIndex:13 (0x0169ee757266746c000000000000000d00): 
 Delete: 0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): 
+Delete (Sized at 32): 0,0 /Local/RangeID/102/u/RaftTruncatedState (0x0169ee757266747400): 
 >> sst:
 Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
 >> sst:


### PR DESCRIPTION
Keys in the RangeID-local unreplicated space have both state machine and raft state. With separated engines, these will reside in different engines, and are also interleaved in an unfortunate way. So we can't use one `ClearRawRange` to cover them all, or even one per engine.

This PR clears all unreplicated keys in `rewriteRaftState` manually, so that we can control which goes to which engine/`Writer`. Additionally, this uncovers that half of these keys don't need to be cleared at all because they don't exist, or don't need to be changed.

The end effect of the PR is that `rewriteRaftState` now only mutates the raft engine state, which is very convenient. Incidentally, this function finally lives up to its name.

Part of #152845
Epic: CRDB-55220