### PR TITLE
sql/inspect: skip indexes with virtual columns during INSPECT

### DIFF
--- a/pkg/sql/inspect_job.go
+++ b/pkg/sql/inspect_job.go
@@ -197,6 +197,16 @@ func isUnsupportedIndexForIndexConsistencyCheck(
 		return true
 	}
 
+	// Check if any of the index key columns are virtual columns.
+	// TODO(155841): add support for indexes on virtual columns.
+	for i := 0; i < index.NumKeyColumns(); i++ {
+		colID := index.GetKeyColumnID(i)
+		col := catalog.FindColumnByID(table, colID)
+		if col != nil && col.IsVirtual() {
+			return true
+		}
+	}
+
 	switch t := index.GetType(); t {
 	case idxtype.VECTOR:
 		return true

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -297,6 +297,81 @@ DROP TABLE t2;
 
 subtest end
 
+subtest inspect_virtual_column_indexes
+
+user root
+
+# Test that indexes on virtual columns are not supported for INSPECT.
+statement ok
+CREATE TABLE t_virtual (
+    c1 INT,
+    c2 INT AS (c1 + 1) VIRTUAL,
+    c3 INT,
+    INDEX idx_c2 (c2),
+    INDEX idx_c3 (c3)
+);
+
+statement ok
+INSERT INTO t_virtual (c1, c3) VALUES (1, 10), (2, 20), (3, 30);
+
+# INSPECT TABLE should skip the virtual column index and only check the regular index.
+statement ok
+INSPECT TABLE t_virtual AS OF SYSTEM TIME '-1us';
+
+# Verify only one check was created (for idx_c3, the regular index).
+query TI
+SELECT * FROM last_inspect_job;
+----
+succeeded  1
+
+# Explicitly specifying the virtual column index should fail.
+statement error pq: index "idx_c2" on table "t_virtual" is not supported for index consistency checking
+INSPECT TABLE t_virtual WITH OPTIONS INDEX (idx_c2);
+
+# Explicitly specifying the regular index should succeed.
+statement ok
+INSPECT TABLE t_virtual WITH OPTIONS INDEX (idx_c3);
+
+query TI
+SELECT * FROM last_inspect_job;
+----
+succeeded  1
+
+# Test with multiple virtual columns in the same index.
+statement ok
+CREATE TABLE t_multi_virtual (
+    c1 INT,
+    c2 INT AS (c1 + 1) VIRTUAL,
+    c3 INT AS (c1 * 2) VIRTUAL,
+    c4 INT,
+    INDEX idx_virtual_combo (c2, c3),
+    INDEX idx_regular (c4)
+);
+
+statement ok
+INSERT INTO t_multi_virtual (c1, c4) VALUES (1, 100);
+
+# Should skip the index with virtual columns and only check the regular index.
+statement ok
+INSPECT TABLE t_multi_virtual AS OF SYSTEM TIME '-1us';
+
+query TI
+SELECT * FROM last_inspect_job;
+----
+succeeded  1
+
+# Explicitly specifying the index with virtual columns should fail.
+statement error pq: index "idx_virtual_combo" on table "t_multi_virtual" is not supported for index consistency checking
+INSPECT TABLE t_multi_virtual WITH OPTIONS INDEX (idx_virtual_combo);
+
+statement ok
+DROP TABLE t_virtual;
+
+statement ok
+DROP TABLE t_multi_virtual;
+
+subtest end
+
 subtest database_resolve_indexes
 
 statement ok


### PR DESCRIPTION
INSPECT previously attempted to verify index consistency on indexes containing virtual columns, which would result in internal errors. This occurred because INSPECT relies on LEFT LOOKUP JOIN ... @{FORCE_INDEX=[...]} constructs, which require all participating columns to be stored. Virtual columns are not compatible with this constraint, leading to a parser rejection.

This change modifies the behavior of INSPECT to skip any index that has a key column over a virtual column, thereby avoiding the internal error. A follow-up task has been opened to add proper support for virtual columns in INSPECT.

Informs: #155676
Informs: #155483
Epic: CRDB-55075

Release note (bug fix): INSPECT no longer fails when checking index consistency on indexes with virtual key columns. Such indexes will now be skipped.