### PR TITLE
WORKSPACE: update pgo profile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -641,8 +641,8 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
+    sha256 = "1a51d220e533c2e1bd79920e28909cc8c58a95690f96a266b44248bb4674162a",
+    url = "https://storage.googleapis.com/cockroach-profiles/20251022205135-b077a4e9887e8182f8f1997ba10b1fe5d708a7a0.pb.gz",
 )
 
 # Download and register the FIPS enabled Go toolchain at the end to avoid toolchain conflicts for gazelle.


### PR DESCRIPTION
```
                                                           │ benchstat_old.txt │             benchstat.txt             │
                                                           │      ops/sec      │   ops/sec    vs base                  │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery             133.4 ± 3%    131.4 ± 2%       ~ (p=0.156 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder            1.334k ± 3%   1.314k ± 2%       ~ (p=0.156 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus          133.4 ± 3%    131.4 ± 2%       ~ (p=0.147 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment             1.334k ± 3%   1.314k ± 2%       ~ (p=0.158 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel           133.4 ± 3%    131.4 ± 2%       ~ (p=0.147 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total               3.068k ± 3%   3.023k ± 2%       ~ (p=0.158 n=18+20)
geomean                                                             484.6         477.5       -1.48%

                                                           │ benchstat_old.txt │            benchstat.txt             │
                                                           │      ms/avg       │   ms/avg    vs base                  │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery             68.35 ± 4%   68.20 ± 3%       ~ (p=0.691 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder             108.3 ± 4%   111.0 ± 2%       ~ (p=0.169 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus          14.70 ± 3%   14.85 ± 4%       ~ (p=0.500 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment              30.75 ± 3%   31.35 ± 4%       ~ (p=0.097 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel           20.20 ± 2%   20.45 ± 2%       ~ (p=0.223 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                65.20 ± 3%   66.20 ± 2%       ~ (p=0.151 n=18+20)
geomean                                                             40.49        41.03       +1.34%

                                                           │ benchstat_old.txt │             benchstat.txt             │
                                                           │      ms/p50       │   ms/p50     vs base                  │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery             65.00 ± 3%    65.00 ± 3%       ~ (p=0.784 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder             104.9 ± 4%    104.9 ± 4%       ~ (p=0.297 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus          9.400 ± 6%   10.000 ± 6%       ~ (p=0.493 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment              26.75 ± 2%    27.30 ± 4%       ~ (p=0.193 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel           16.30 ± 4%    16.30 ± 4%       ~ (p=0.572 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                52.40 ± 4%    52.40 ± 4%       ~ (p=0.301 n=18+20)
geomean                                                             33.70         34.16       +1.38%

                                                           │ benchstat_old.txt │            benchstat.txt             │
                                                           │      ms/p95       │   ms/p95    vs base                  │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery             113.2 ± 4%   113.2 ± 4%       ~ (p=0.485 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder             192.9 ± 4%   192.9 ± 4%       ~ (p=0.209 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus          44.00 ± 5%   44.00 ± 5%       ~ (p=0.378 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment              62.90 ± 3%   62.90 ± 3%   0.00% (p=0.031 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel           48.20 ± 4%   48.20 ± 4%       ~ (p=0.309 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                167.8 ± 5%   167.8 ± 5%       ~ (p=0.141 n=18+20)
geomean                                                             88.75        88.75       +0.00%

                                                           │ benchstat_old.txt │            benchstat.txt             │
                                                           │      ms/p99       │   ms/p99    vs base                  │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery             142.6 ± 6%   151.0 ± 6%       ~ (p=0.222 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder             234.9 ± 4%   243.3 ± 3%       ~ (p=0.073 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus          65.00 ± 3%   67.10 ± 6%       ~ (p=0.258 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment              88.10 ± 5%   88.10 ± 5%       ~ (p=0.163 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel           71.30 ± 6%   73.40 ± 3%       ~ (p=0.147 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                209.7 ± 4%   218.1 ± 4%  +4.01% (p=0.040 n=18+20)
geomean                                                             119.2        123.1       +3.26%

                                                           │ benchstat_old.txt │             benchstat.txt             │
                                                           │      ms/max       │   ms/max     vs base                  │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery            264.2 ±  8%   276.8 ±  9%       ~ (p=0.316 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder            419.4 ±  8%   419.4 ± 20%       ~ (p=0.272 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus         176.2 ± 10%   188.7 ±  7%  +7.09% (p=0.039 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment             218.1 ±  8%   234.9 ± 21%  +7.70% (p=0.023 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel          184.5 ±  9%   197.1 ± 15%       ~ (p=0.089 n=18+20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total               419.4 ±  8%   419.4 ± 20%       ~ (p=0.253 n=18+20)
geomean                                                            262.8         274.2        +4.35%

```
Epic: none
Release note: None