### PR TITLE
dev-inf: Enable AI review for all PRs except backports

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   claude-code-pr-review:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'O-AI-Review')
+    if: "!startsWith(github.base_ref, 'release-') && !contains(github.event.pull_request.labels.*.name, 'O-No-AI-Review')"
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Changed the workflow trigger condition from opt-in (O-AI-Review label) to opt-out, with automatic exclusions for:
- Backport PRs (already reviewed when merged to master)
- PRs with O-No-AI-Review label (manual opt-out)

This enables broader AI review coverage while avoiding redundant reviews of backported changes and respecting explicit opt-outs.

**Before:**
- Only PRs with `O-AI-Review` label would get AI review

**After:**
- All PRs get AI review by default
- PRs with `backport` label are skipped (already reviewed)
- PRs with `O-No-AI-Review` label are skipped (explicit opt-out)

Release note: none

Epic: None