### PR TITLE
workload/tpch: add a couple of missed values for fixtures generation

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -295,7 +295,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xccfecd06eed59975,
-		`tpch`:       0xcd2abbd021ed895d,
+		`tpch`:       0x95bafd37ccb1eb7d,
 		`ycsb`:       0xa00a7efc9d3b8532,
 	}
 

--- a/pkg/workload/tpch/random.go
+++ b/pkg/workload/tpch/random.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload/faker"
 )
 
+// The spec can be found at https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf.
+
 const alphanumericLen64 = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890, `
 
 // randInt returns a random value between x and y inclusively, with a mean of
@@ -110,9 +112,9 @@ var randPartNames = [...]string{
 	"hot", "indian", "ivory", "khaki", "lace", "lavender", "lawn", "lemon", "light", "lime", "linen",
 	"magenta", "maroon", "medium", "metallic", "midnight", "mint", "misty", "moccasin", "navajo",
 	"navy", "olive", "orange", "orchid", "pale", "papaya", "peach", "peru", "pink", "plum", "powder",
-	"puff", "purple", "red", "rose", "rosy", "royal", "saddle", "salmon", "sandy", "seashell",
-	"sienna", "sky", "slate", "smoke", "snow", "spring", "steel", "tan", "thistle", "tomato",
-	"turquoise", "violet", "wheat", "white", "yellow",
+	"puff", "purple", "red", "rose", "rosy", "royal", "saddle", "salmon", "sandy", "seashell", "sienna",
+	"sky", "slate", "smoke", "snow", "spring", "steel", "tan", "thistle", "tomato", "turquoise", "violet",
+	"wheat", "white", "yellow",
 }
 
 const maxPartNameLen = 10
@@ -238,8 +240,8 @@ func randType(rng *rand.Rand, a *bufalloc.ByteAllocator) []byte {
 }
 
 var containerSyllables = [][]string{
-	{"SM", "MED", "JUMBO", "WRAP"},
-	{"BOX", "BAG", "JAR", "PKG", "PACK", "CAN", "DRUM"},
+	{"SM", "LG", "MED", "JUMBO", "WRAP"},
+	{"CASE", "BOX", "BAG", "JAR", "PKG", "PACK", "CAN", "DRUM"},
 }
 
 const maxContainerLen = 10
@@ -257,7 +259,7 @@ func randSegment(rng *rand.Rand) []byte {
 }
 
 var priorities = []string{
-	"1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED",
+	"1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED", "5-LOW",
 }
 
 func randPriority(rng *rand.Rand) []byte {
@@ -265,9 +267,7 @@ func randPriority(rng *rand.Rand) []byte {
 }
 
 var instructions = []string{
-	"DELIVER IN PERSON",
-	"COLLECT COD", "NONE",
-	"TAKE BACK RETURN",
+	"DELIVER IN PERSON", "COLLECT COD", "NONE", "TAKE BACK RETURN",
 }
 
 func randInstruction(rng *rand.Rand) []byte {

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -319,7 +319,7 @@ var numExpectedRowsByQueryNumber = map[int]int{
 	1:  4,
 	2:  100,
 	3:  10,
-	4:  4,
+	4:  5,
 	5:  5,
 	6:  1,
 	7:  4,


### PR DESCRIPTION
When we added the fixtures generation of TPCH spec, we forgot a couple of values - one for "priorities" and one for "containers". This commit fixes that omission. In particular, missing priority value made us return 4 rows instead of 5 for Q4, and the expectation has been adjusted accordingly.

Note that this omission was exposed via a roachtest that uses correctly generated fixtures of SF 100.

Fixes: #155834.

Release note: None