### PR TITLE
release-25.2: kv: deflake TestClosedTimestampFrozenAfterSubsumption

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -733,11 +733,16 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 			// Set up the closed timestamp timing such that, when we block a merge and
 			// transfer the RHS lease, the closed timestamp advances over the LHS
 			// lease but not over the RHS lease.
+			//
+			// NB: We want to ensure that the closed timestamp on the LHS is less than
+			// the lease start time for the RHS after the lease transfer. To ensure
+			// this holds and doesn't flake, we increase the target duration to 10
+			// seconds.
 			tc, _, _ := setupClusterForClosedTSTesting(ctx, t, 5*time.Second, 100*time.Millisecond, clusterArgs, "cttest", "kv")
 			defer tc.Stopper().Stop(ctx)
 			sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 			sqlDB.ExecMultiple(t, strings.Split(`
-SET CLUSTER SETTING kv.closed_timestamp.target_duration = '5s';
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10s';
 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '100ms';
 SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '100ms';
 SET CLUSTER SETTING kv.closed_timestamp.follower_reads.enabled = true;


### PR DESCRIPTION
Backport 1/1 commits from #155892 on behalf of @arulajmani.

----

In the RHS lease transfer while subsumed variant, this test wants to set things up such that the LHS range's closed timestamp is lower than the RHS range's lease start time. Closing timestamps 5 seconds in the past could sometimes cause the LHS range's CTS to advance beyond the RHS's lease start time, which could cause flakes. This patch deflakes things by closing timestamps 10 seconds in the past. I stressed this a bit under deadlock and this seems promising.

Closes https://github.com/cockroachdb/cockroach/issues/155517

Release note: None

----

Release justification: test-deflake.