### PR TITLE
sql/*: load external statement hints from the hints cache

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -574,6 +574,10 @@ func (ex *connExecutor) execStmtInOpenState(
 		ast = stmt.Statement.AST
 	}
 
+	if len(stmt.Hints) > 0 {
+		telemetry.Inc(sqltelemetry.StatementHintsCounter)
+	}
+
 	// This goroutine is the only one that can modify txnState.mu.priority and
 	// txnState.mu.autoRetryCounter, so we don't need to get a mutex here.
 	ctx = ih.Setup(ctx, ex, p, &stmt, os.ImplicitTxn.Get(),
@@ -1472,6 +1476,10 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 			ih.SetDiscardRows()
 		}
 		vars.ast = vars.stmt.Statement.AST
+	}
+
+	if len(vars.stmt.Hints) > 0 {
+		telemetry.Inc(sqltelemetry.StatementHintsCounter)
 	}
 
 	// For pausable portal, the instrumentation helper needs to be set up only

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/hints"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -383,12 +384,16 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	isExtendedProtocol := prepared != nil
 	stmtFingerprintFmtMask := tree.FmtHideConstants | tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV))
+	var statementHintsCache *hints.StatementHintsCache
+	if ex.executorType != executorTypeInternal {
+		statementHintsCache = ex.server.cfg.StatementHintsCache
+	}
 
 	var stmt Statement
 	if isExtendedProtocol {
-		stmt = makeStatementFromPrepared(prepared, queryID)
+		stmt = makeStatementFromPrepared(ctx, prepared, queryID, stmtFingerprintFmtMask, statementHintsCache)
 	} else {
-		stmt = makeStatement(parserStmt, queryID, stmtFingerprintFmtMask)
+		stmt = makeStatement(ctx, parserStmt, queryID, stmtFingerprintFmtMask, statementHintsCache)
 	}
 
 	if len(stmt.QueryTags) > 0 {
@@ -557,6 +562,10 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.ExpectedTypes = ps.Columns
 		stmt.StmtNoConstants = ps.StatementNoConstants
 		stmt.StmtSummary = ps.StatementSummary
+		stmt.Hints = ps.Hints
+		stmt.HintIDs = ps.HintIDs
+		stmt.HintsGeneration = ps.HintsGeneration
+		stmt.ReloadHintsIfStale(ctx, stmtFingerprintFmtMask, statementHintsCache)
 		res.ResetStmtType(ps.AST)
 
 		if e.DiscardRows {
@@ -888,7 +897,12 @@ func (ex *connExecutor) execStmtInOpenState(
 				typeHints[i] = resolved
 			}
 		}
+		var statementHintsCache *hints.StatementHintsCache
+		if ex.executorType != executorTypeInternal {
+			statementHintsCache = ex.server.cfg.StatementHintsCache
+		}
 		prepStmt := makeStatement(
+			ctx,
 			statements.Statement[tree.Statement]{
 				// We need the SQL string just for the part that comes after
 				// "PREPARE ... AS",
@@ -901,6 +915,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			},
 			ex.server.cfg.GenerateID(),
 			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV)),
+			statementHintsCache,
 		)
 		var rawTypeHints []oid.Oid
 
@@ -1252,11 +1267,15 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 	isExtendedProtocol := portal != nil && portal.Stmt != nil
 	stmtFingerprintFmtMask := tree.FmtHideConstants | tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV))
+	var statementHintsCache *hints.StatementHintsCache
+	if ex.executorType != executorTypeInternal {
+		statementHintsCache = ex.server.cfg.StatementHintsCache
+	}
 
 	if isExtendedProtocol {
-		vars.stmt = makeStatementFromPrepared(portal.Stmt, queryID)
+		vars.stmt = makeStatementFromPrepared(ctx, portal.Stmt, queryID, stmtFingerprintFmtMask, statementHintsCache)
 	} else {
-		vars.stmt = makeStatement(parserStmt, queryID, stmtFingerprintFmtMask)
+		vars.stmt = makeStatement(ctx, parserStmt, queryID, stmtFingerprintFmtMask, statementHintsCache)
 	}
 
 	var queryTimeoutTicker *time.Timer
@@ -1443,6 +1462,10 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		vars.stmt.ExpectedTypes = ps.Columns
 		vars.stmt.StmtNoConstants = ps.StatementNoConstants
 		vars.stmt.StmtSummary = ps.StatementSummary
+		vars.stmt.Hints = ps.Hints
+		vars.stmt.HintIDs = ps.HintIDs
+		vars.stmt.HintsGeneration = ps.HintsGeneration
+		vars.stmt.ReloadHintsIfStale(ctx, stmtFingerprintFmtMask, statementHintsCache)
 		res.ResetStmtType(ps.AST)
 
 		if e.DiscardRows {
@@ -1852,7 +1875,12 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 				typeHints[i] = resolved
 			}
 		}
+		var statementHintsCache *hints.StatementHintsCache
+		if ex.executorType != executorTypeInternal {
+			statementHintsCache = ex.server.cfg.StatementHintsCache
+		}
 		prepStmt := makeStatement(
+			ctx,
 			statements.Statement[tree.Statement]{
 				// We need the SQL string just for the part that comes after
 				// "PREPARE ... AS",
@@ -1865,6 +1893,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 			},
 			ex.server.cfg.GenerateID(),
 			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV)),
+			statementHintsCache,
 		)
 		var rawTypeHints []oid.Oid
 
@@ -3463,8 +3492,11 @@ func (ex *connExecutor) execStmtInNoTxnState(
 		}
 
 		p := &ex.planner
-		stmt := makeStatement(parserStmt, ex.server.cfg.GenerateID(),
-			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV)))
+		stmt := makeStatement(
+			ctx, parserStmt, ex.server.cfg.GenerateID(),
+			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV)),
+			nil, /* statementHintsCache */
+		)
 		p.stmt = stmt
 		p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 		p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -78,11 +78,14 @@ func PlanCDCExpression(
 		opt.apply(&cfg)
 	}
 
-	p.stmt = makeStatement(statements.Statement[tree.Statement]{
-		AST: cdcExpr,
-		SQL: tree.AsString(cdcExpr),
-	}, clusterunique.ID{}, /* queryID */
+	p.stmt = makeStatement(
+		ctx,
+		statements.Statement[tree.Statement]{
+			AST: cdcExpr,
+			SQL: tree.AsString(cdcExpr),
+		}, clusterunique.ID{}, /* queryID */
 		tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&p.execCfg.Settings.SV)),
+		nil, /* statementHintsCache */
 	)
 
 	p.curPlan.init(&p.stmt, &p.instrumentation)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -167,8 +167,11 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 		// We need to re-plan every time, since the plan is closed automatically
 		// by PlanAndRun() below making it unusable across retries.
-		p.stmt = makeStatement(stmt, clusterunique.ID{},
-			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&execCfg.Settings.SV)))
+		p.stmt = makeStatement(
+			ctx, stmt, clusterunique.ID{},
+			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&execCfg.Settings.SV)),
+			nil, /* statementHintsCache */
+		)
 		if err := p.makeOptimizerPlan(ctx); err != nil {
 			t.Fatal(err)
 		}
@@ -285,8 +288,11 @@ func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
 			p.ExtendedEvalContext().Tracing,
 		)
 
-		p.stmt = makeStatement(stmt, clusterunique.ID{},
-			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&s.ClusterSettings().SV)))
+		p.stmt = makeStatement(
+			ctx, stmt, clusterunique.ID{},
+			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&s.ClusterSettings().SV)),
+			nil, /* statementHintsCache */
+		)
 		if err := p.makeOptimizerPlan(ctx); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/explain_tree_test.go
+++ b/pkg/sql/explain_tree_test.go
@@ -71,8 +71,11 @@ func TestPlanToTreeAndPlanToString(t *testing.T) {
 			ih.codec = execCfg.Codec
 			ih.collectBundle = true
 
-			p.stmt = makeStatement(stmt, clusterunique.ID{},
-				tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&execCfg.Settings.SV)))
+			p.stmt = makeStatement(
+				ctx, stmt, clusterunique.ID{},
+				tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&execCfg.Settings.SV)),
+				nil, /* statementHintsCache */
+			)
 			if err := p.makeOptimizerPlan(ctx); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/security/username",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/hintpb",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/hintpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -577,6 +578,12 @@ func (ep *DummyEvalPlanner) ClearQueryPlanCache() {}
 
 // ClearTableStatsCache is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) ClearTableStatsCache() {}
+
+// ClearStatementHintsCache is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) ClearStatementHintsCache() {}
+
+// AwaitStatementHintsCache is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) AwaitStatementHintsCache(ctx context.Context, st *cluster.Settings) {}
 
 // RetryCounter is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) RetryCounter() int {

--- a/pkg/sql/hints/BUILD.bazel
+++ b/pkg/sql/hints/BUILD.bazel
@@ -14,6 +14,8 @@ go_library(
         "//pkg/kv/kvclient/rangefeed/rangefeedbuffer",
         "//pkg/kv/kvclient/rangefeed/rangefeedcache",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/sql/hints/hint_cache.go
+++ b/pkg/sql/hints/hint_cache.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedbuffer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -92,6 +94,10 @@ type StatementHintsCache struct {
 	// generation is incremented any time the hint cache is updated by the
 	// rangefeed.
 	generation atomic.Int64
+
+	// frontier is the walltime of the rangefeed watcher frontier time, which is
+	// polled by goroutines in Await.
+	frontier atomic.Int64
 }
 
 // cacheSize is the size of the entries to store in the cache.
@@ -137,6 +143,16 @@ func NewStatementHintsCache(
 	})
 	hintsCache.generation.Store(1)
 	return hintsCache
+}
+
+// Clear removes all entries from the StatementHintsCache.
+func (c *StatementHintsCache) Clear() {
+	defer c.generation.Add(1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.hintCache.Clear()
+	// TODO(michae2): Consider whether we should also delete hintedHashes and
+	// restart the rangefeed.
 }
 
 // ============================================================================
@@ -214,6 +230,7 @@ func (c *StatementHintsCache) onUpdate(
 		log.Dev.Info(ctx, "statement_hints rangefeed applying incremental update")
 		c.handleIncrementalUpdate(ctx, update)
 	}
+	c.frontier.Store(update.Timestamp.WallTime)
 }
 
 // handleInitialScan builds the hintedHashes map and adds it to
@@ -251,6 +268,7 @@ func (c *StatementHintsCache) handleIncrementalUpdate(
 	defer c.generation.Add(1)
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	for _, ev := range update.Events {
 		// Drop outdated entries from hintCache.
 		c.mu.hintCache.Del(ev.hash)
@@ -357,6 +375,30 @@ var _ rangefeedbuffer.Event = &bufferEvent{}
 // ============================================================================
 // Reading from the cache.
 // ============================================================================
+
+// Await blocks until the StatementHintsCache's rangefeed watcher catches up
+// with the present. After Await returns, MaybeGetStatementHints should
+// accurately reflect all hints that were modified before the call to Await
+// (assuming the ctx was not canceled).
+func (c *StatementHintsCache) Await(ctx context.Context, st *cluster.Settings) {
+	// The frontier timestamp comes from the rangefeed, and could be up to
+	// kv.closed_timestamp.target_duration +
+	// kv.rangefeed.closed_timestamp_refresh_interval behind the present.
+	targetDuration := closedts.TargetDuration.Get(&st.SV)
+	refreshInterval := kvserver.RangeFeedRefreshInterval.Get(&st.SV)
+	const fudge = 10 * time.Millisecond
+	waitUntil := c.clock.Now().AddDuration(targetDuration + refreshInterval + fudge).WallTime
+
+	// Await is only used for testing, so we don't need to wake up immediately. We
+	// can get away with polling the frontier time.
+	for frontier := c.frontier.Load(); frontier < waitUntil; frontier = c.frontier.Load() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(waitUntil-frontier) * time.Nanosecond):
+		}
+	}
+}
 
 // GetGeneration returns the current generation, which will change if any
 // modifications happen to the cache.

--- a/pkg/sql/hints/hint_cache.go
+++ b/pkg/sql/hints/hint_cache.go
@@ -135,6 +135,7 @@ func NewStatementHintsCache(
 			return s > int(cacheSize.Get(&st.SV))
 		},
 	})
+	hintsCache.generation.Store(1)
 	return hintsCache
 }
 

--- a/pkg/sql/hints/hint_cache_test.go
+++ b/pkg/sql/hints/hint_cache_test.go
@@ -416,7 +416,7 @@ func TestHintCacheGeneration(t *testing.T) {
 	}
 
 	// The initial scan should increment the generation.
-	waitForGenerationInc(0)
+	waitForGenerationInc(1)
 	generationAfterInitialScan := getGenerationAssertNoChange()
 
 	// Insert a hint - generation should increment.

--- a/pkg/sql/hints/hint_table.go
+++ b/pkg/sql/hints/hint_table.go
@@ -102,5 +102,8 @@ func InsertHintIntoDB(
 	if err != nil {
 		return 0, err
 	}
+	// TODO(michae2,drewk): Consider calling
+	// StatementHintsCache.handleIncrementalUpdate here to eagerly update the
+	// local node's cache.
 	return int64(tree.MustBeDInt(row[0])), nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -1,4 +1,4 @@
-# LogicTest: !local-mixed-25.2 !local-mixed-25.3
+# LogicTest: !local-mixed-25.2 !local-mixed-25.3 !local-prepared
 
 statement ok
 CREATE TABLE xy (x INT PRIMARY KEY, y INT, INDEX (y));
@@ -92,3 +92,89 @@ query I
 SELECT count(*) FROM system.statement_hints;
 ----
 0
+
+# Test that hints are loaded for matching statements.
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT * FROM xy WHERE x > y',
+  'SELECT * FROM xy WHERE x > y'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+statement ok
+SELECT * FROM xy WHERE x > y
+
+query I
+SELECT usage_count
+FROM crdb_internal.feature_usage
+WHERE feature_name = 'sql.session.statement-hints'
+----
+1
+
+statement ok
+EXPLAIN SELECT * FROM xy WHERE x > y
+
+query I
+SELECT usage_count
+FROM crdb_internal.feature_usage
+WHERE feature_name = 'sql.session.statement-hints'
+----
+2
+
+statement ok
+EXPLAIN ANALYZE SELECT * FROM xy WHERE x > y
+
+query I
+SELECT usage_count
+FROM crdb_internal.feature_usage
+WHERE feature_name = 'sql.session.statement-hints'
+----
+3
+
+statement ok
+PREPARE p AS SELECT * FROM xy WHERE x > y
+
+statement ok
+EXECUTE p
+
+query I
+SELECT usage_count
+FROM crdb_internal.feature_usage
+WHERE feature_name = 'sql.session.statement-hints'
+----
+5
+
+statement ok
+SELECT crdb_internal.clear_statement_hints_cache()
+
+statement ok
+SELECT * FROM xy WHERE x > y
+
+query I
+SELECT usage_count
+FROM crdb_internal.feature_usage
+WHERE feature_name = 'sql.session.statement-hints'
+----
+6
+
+statement ok
+DELETE FROM system.statement_hints WHERE true
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+statement ok
+SELECT * FROM xy WHERE x > y
+
+statement ok
+EXECUTE p
+
+query I
+SELECT usage_count
+FROM crdb_internal.feature_usage
+WHERE feature_name = 'sql.session.statement-hints'
+----
+6

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -1368,13 +1368,6 @@ func TestLogic_sqlsmith(
 	runLogicTest(t, "sqlsmith")
 }
 
-func TestLogic_statement_hint_builtins(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "statement_hint_builtins")
-}
-
 func TestLogic_statement_statistics_errors(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -450,6 +450,8 @@ func (b *Builder) buildRoutine(
 		bodyTags = make([]string, len(stmts))
 
 		for i := range stmts {
+			// TODO(michae2): We should be checking the statement hints cache here to
+			// find any external statement hints that could apply to this statement.
 			stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
 
 			// The last statement produces the output of the UDF.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -335,6 +335,8 @@ func (b *Builder) buildView(
 		if !ok {
 			panic(errors.AssertionFailedf("expected SELECT statement"))
 		}
+		// TODO(michae2): We should be checking the statement hints cache here to
+		// find any external statement hints that could apply to the view statement.
 
 		b.views[view] = sel
 

--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -652,7 +652,9 @@ func TestPlanGistControl(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.stmt = makeStatement(stmt, clusterunique.ID{}, fmtFingerprintMask)
+	p.stmt = makeStatement(
+		ctx, stmt, clusterunique.ID{}, fmtFingerprintMask, nil, /* statementHintsCache */
+	)
 	if err := p.makeOptimizerPlan(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +680,9 @@ func TestPlanGistControl(t *testing.T) {
 	p = internalPlanner.(*planner)
 	p.SessionData().DisablePlanGists = true
 
-	p.stmt = makeStatement(stmt, clusterunique.ID{}, fmtFingerprintMask)
+	p.stmt = makeStatement(
+		ctx, stmt, clusterunique.ID{}, fmtFingerprintMask, nil, /* statementHintsCache */
+	)
 	if err := p.makeOptimizerPlan(ctx); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -1087,6 +1088,20 @@ func (p *planner) ClearQueryPlanCache() {
 func (p *planner) ClearTableStatsCache() {
 	if p.execCfg.TableStatsCache != nil {
 		p.execCfg.TableStatsCache.Clear()
+	}
+}
+
+// ClearStatementHintsCache is part of the eval.Planner interface.
+func (p *planner) ClearStatementHintsCache() {
+	if p.execCfg.StatementHintsCache != nil {
+		p.execCfg.StatementHintsCache.Clear()
+	}
+}
+
+// AwaitStatementHintsCache is part of the eval.Planner interface.
+func (p *planner) AwaitStatementHintsCache(ctx context.Context, st *cluster.Settings) {
+	if p.execCfg.StatementHintsCache != nil {
+		p.execCfg.StatementHintsCache.Await(ctx, st)
 	}
 }
 

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -119,6 +119,8 @@ func (l *lexer) parseOne(sql string) (tree.Statement, error) {
 		return nil, err
 	}
 	l.numAnnotations = sqlStmt.NumAnnotations
+	// TODO(michae2): We should be checking the statement hints cache here to find
+	// any external statement hints that could apply to this statement.
 	return sqlStmt.AST, nil
 }
 

--- a/pkg/sql/prep/BUILD.bazel
+++ b/pkg/sql/prep/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/hintpb",
         "//pkg/sql/opt/memo",
         "//pkg/sql/parser/statements",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/querycache/query_cache_test.go
+++ b/pkg/sql/querycache/query_cache_test.go
@@ -44,7 +44,7 @@ func data(sql string, mem *memo.Memo, memEstimate int64) *CachedData {
 	cd := &CachedData{SQL: sql, Memo: mem, Metadata: &prep.Metadata{}}
 	n := memEstimate - cd.memoryEstimate()
 	if n < 0 {
-		panic(errors.AssertionFailedf("size %d too small", memEstimate))
+		panic(errors.AssertionFailedf("size %d too small %d", memEstimate, cd.memoryEstimate()))
 	}
 	// Add characters to AnonymizedStr which should increase the estimate.
 	s := make([]byte, n)
@@ -202,7 +202,7 @@ func TestSynchronization(t *testing.T) {
 					c.Purge(sql)
 				case r <= 35:
 					// 25% of the time, add an entry.
-					c.Add(&s, data(sql, &memo.Memo{}, int64(256+rng.Intn(10*avgCachedSize))))
+					c.Add(&s, data(sql, &memo.Memo{}, int64(288+rng.Intn(10*avgCachedSize))))
 				default:
 					// The rest of the time, find an entry.
 					_, _ = c.Find(&s, sql)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -451,8 +451,11 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 
 		localPlanner.MaybeReallocateAnnotations(stmt.NumAnnotations)
 		// Construct an optimized logical plan of the AS source stmt.
-		localPlanner.stmt = makeStatement(stmt, clusterunique.ID{}, /* queryID */
-			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&localPlanner.execCfg.Settings.SV)))
+		localPlanner.stmt = makeStatement(
+			ctx, stmt, clusterunique.ID{}, /* queryID */
+			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&localPlanner.execCfg.Settings.SV)),
+			nil, /* statementHintsCache */
+		)
 		localPlanner.optPlanningCtx.init(localPlanner)
 
 		localPlanner.runWithOptions(resolveFlags{skipCache: true}, func() {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9714,6 +9714,40 @@ WHERE object_id = table_descriptor_id
 			Volatility: volatility.Volatile,
 		},
 	),
+	"crdb_internal.clear_statement_hints_cache": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemRepair,
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				evalCtx.Planner.ClearStatementHintsCache()
+				return tree.DVoidDatum, nil
+			},
+			Info:       `This function is used to clear the statement hints cache on the gateway node`,
+			Volatility: volatility.Volatile,
+		},
+	),
+	"crdb_internal.await_statement_hints_cache": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemRepair,
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				evalCtx.Planner.AwaitStatementHintsCache(ctx, evalCtx.Settings)
+				return tree.DVoidDatum, nil
+			},
+			Info:       `This function is used to await the statement hints cache on the gateway node`,
+			Volatility: volatility.Volatile,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2861,6 +2861,8 @@ var builtinOidsArray = []string{
 	2906: `levenshtein_less_equal(source: string, target: string, ins_cost: int, del_cost: int, sub_cost: int, max_d: int) -> int`,
 	2907: `crdb_internal.request_transaction_bundle(transaction_fingerprint_id: string, sampling_probability: float, min_execution_latency: interval, expires_after: interval, redacted: bool) -> tuple{int AS request_id, bool AS created}`,
 	2908: `crdb_internal.inject_hint(statement_fingerprint: string, donor_sql: string) -> int`,
+	2909: `crdb_internal.clear_statement_hints_cache() -> void`,
+	2910: `crdb_internal.await_statement_hints_cache() -> void`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/hintpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -456,6 +457,14 @@ type Planner interface {
 
 	// ClearTableStatsCache removes all entries from the node's table stats cache.
 	ClearTableStatsCache()
+
+	// ClearStatementHintsCache removes all entries from the node's statement
+	// hints cache.
+	ClearStatementHintsCache()
+
+	// AwaitStatementHintsCache waits for the node's statement hints cache to
+	// catch up with recent hint injections.
+	AwaitStatementHintsCache(ctx context.Context, st *cluster.Settings)
 
 	// RetryCounter is the number of times this statement has been retried.
 	RetryCounter() int

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -161,7 +161,11 @@ func (p *planner) DeserializeSessionState(
 		}
 		// len(stmts) == 0 results in a nil (empty) statement.
 		id := clusterunique.GenerateID(evalCtx.ExecCfg.Clock.Now(), evalCtx.ExecCfg.NodeInfo.NodeID.SQLInstanceID())
-		stmt := makeStatement(parserStmt, id, tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&evalCtx.Settings.SV)))
+		stmt := makeStatement(
+			ctx, parserStmt, id,
+			tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&evalCtx.Settings.SV)),
+			evalCtx.ExecCfg.StatementHintsCache,
+		)
 
 		var placeholderTypes tree.PlaceholderTypes
 		if len(prepStmt.PlaceholderTypeHints) > 0 {

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -68,8 +68,11 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 			}
 
 			// Try to plan the cursor query to make sure that it's valid.
-			stmt := makeStatement(statements.Statement[tree.Statement]{AST: s.Select}, clusterunique.ID{},
-				tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&p.execCfg.Settings.SV)))
+			stmt := makeStatement(
+				ctx, statements.Statement[tree.Statement]{AST: s.Select}, clusterunique.ID{},
+				tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&p.execCfg.Settings.SV)),
+				nil, /* statementHintsCache */
+			)
 			pt := planTop{}
 			pt.init(&stmt, &p.instrumentation)
 			opc := &p.optPlanningCtx

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -234,6 +234,10 @@ var PlanClampedHistogramSelectivityCounter = telemetry.GetCounterOnce("sql.plan.
 // a histogram to a minimum value.
 var PlanClampedInequalitySelectivityCounter = telemetry.GetCounterOnce("sql.plan.clamped-inequality-selectivity")
 
+// StatementHintsCounter is to be incremented whenever external statement hints
+// are used.
+var StatementHintsCounter = telemetry.GetCounterOnce("sql.session.statement-hints")
+
 // We can't parameterize these telemetry counters, so just make a bunch of
 // buckets for setting the join reorder limit since the range of reasonable
 // values for the join reorder limit is quite small.

--- a/pkg/sql/statement_test.go
+++ b/pkg/sql/statement_test.go
@@ -6,6 +6,7 @@
 package sql
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
@@ -76,6 +77,7 @@ SELECT 1 /*action='%2Fparam*d',controller='index',framework='spring',
 	}
 
 	var p parser.Parser
+	ctx := context.Background()
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 
@@ -96,9 +98,13 @@ SELECT 1 /*action='%2Fparam*d',controller='index',framework='spring',
 									Statement: stmts[0],
 								},
 							}
-							stmt = makeStatementFromPrepared(ps, clusterunique.ID{})
+							stmt = makeStatementFromPrepared(
+								ctx, ps, clusterunique.ID{}, tree.FmtSimple, nil, /* statementHintsCache */
+							)
 						} else {
-							stmt = makeStatement(stmts[0], clusterunique.ID{}, tree.FmtSimple)
+							stmt = makeStatement(
+								ctx, stmts[0], clusterunique.ID{}, tree.FmtSimple, nil, /* statementHintsCache */
+							)
 						}
 						if withComments {
 							require.Equal(t, tc.expectedTags, stmt.QueryTags)

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -127,8 +127,11 @@ func (dsp *DistSQLPlanner) Exec(
 	distribute bool,
 ) error {
 	p := localPlanner.(*planner)
-	p.stmt = makeStatement(stmt, clusterunique.ID{}, /* queryID */
-		tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&p.execCfg.Settings.SV)))
+	p.stmt = makeStatement(
+		ctx, stmt, clusterunique.ID{}, /* queryID */
+		tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(&p.execCfg.Settings.SV)),
+		nil, /* statementHintsCache */
+	)
 	if err := p.makeOptimizerPlan(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
**sql/\*: load external statement hints from the hints cache**

When making a `sql.Statement`, call `MaybeGetStatementHints` to load any
applicable external statement hints from the hint cache. We don't yet do
anything with the hints once they're loaded, but we do save them in prepared
statements.

A few notable code paths are not yet loading hints from the hints cache:
- SQL statements within UDFs and SPs
- Views

Informs: #153633

Release note: None

---

**sql, sqltelemetry: add telemetry counter for external statement hints**

Informs: #153633

Release note: None

---

**sql/hints, builtins: add two more statement_hints_cache builtins**

Add new builtins `crdb_internal.clear_statement_hints_cache` and
`crdb_internal.await_statement_hints_cache` which will be useful for
testing.

The first builtin clears the hintCache, similar to
`clear_query_plan_cache` and `clear_table_stats_cache`. (I debated
whether this builtin should also set hintedHashes to nil and restart the
changefeed, but that seems too different from
`clear_table_stats_cache`.)

The second builtin blocks until the hints cache rangefeed watcher has
caught up with the present, which usually takes a couple of
seconds. This is handy when we want to test a statement using the hint
immediately after adding the hint to system.statement_hints.

Informs: #153633

Release note: None

---

**logictest: add tests for loading external statement hints**

Test that we're loading external statement hints correctly.

Informs: #153633

Release note: None