### PR TITLE
kv: add observability for TestDelegateSnapshot

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2954,6 +2954,19 @@ func (r *Replica) sendSnapshotUsingDelegate(
 	senderQueuePriority float64,
 ) (retErr error) {
 
+	// Enable verbose tracing for delegated snapshots if configured by the testing
+	// knob.
+	if traceChan := r.store.cfg.TestingKnobs.DelegatedSnapshotTraceChan; traceChan != nil {
+		var sp *tracing.Span
+		ctx, sp = r.store.cfg.Tracer().StartSpanCtx(
+			ctx, "send-snapshot-using-delegate", tracing.WithRecording(tracingpb.RecordingVerbose),
+		)
+		defer func() {
+			recording := sp.FinishAndGetConfiguredRecording()
+			traceChan <- recording
+		}()
+	}
+
 	defer func() {
 		// Report the snapshot status to Raft, which expects us to do this once we
 		// finish sending the snapshot.

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -377,6 +377,9 @@ func TestDelegateSnapshot(t *testing.T) {
 
 	// Record snapshots as they are sent on this channel for later analysis.
 	requestChannel := make(chan *kvserverpb.DelegateSendSnapshotRequest, 2)
+	// Capture snapshot traces for debugging via this channel.
+	traceChannel := make(chan tracingpb.Recording, 2)
+
 	knobs, ltk := makeReplicationTestKnobs()
 	ltk.storeKnobs.SendSnapshot = func(request *kvserverpb.DelegateSendSnapshotRequest) {
 		// TODO(abaptist): Remove this condition once 96841 is fixed. This
@@ -386,6 +389,8 @@ func TestDelegateSnapshot(t *testing.T) {
 			requestChannel <- request
 		}
 	}
+	// Enable tracing for delegated snapshots by providing a trace channel.
+	ltk.storeKnobs.DelegatedSnapshotTraceChan = traceChannel
 
 	localityA := roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "a"}}}
 	localityB := roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "b"}}}
@@ -415,7 +420,9 @@ func TestDelegateSnapshot(t *testing.T) {
 	{
 		_ = tc.AddVotersOrFatal(t, scratchKey, tc.Targets(2)...)
 		request := <-requestChannel
-		require.Equalf(t, request.DelegatedSender.StoreID, roachpb.StoreID(1), "Wrong sender for request %+v", request)
+		trace := <-traceChannel
+		require.Equalf(t, roachpb.StoreID(1), request.DelegatedSender.StoreID,
+			"Wrong sender for request %+v.\nSnapshot trace:\n%s", request, trace)
 	}
 
 	verifySnapshotMetrics(t, tc, map[int]expectedMetric{
@@ -442,7 +449,9 @@ func TestDelegateSnapshot(t *testing.T) {
 		})
 
 		request := <-requestChannel
-		require.Equalf(t, request.DelegatedSender.StoreID, roachpb.StoreID(3), "Wrong type of request %+v", request)
+		trace := <-traceChannel
+		require.Equalf(t, roachpb.StoreID(3), request.DelegatedSender.StoreID,
+			"Wrong sender for request %+v.\nSnapshot trace:\n%s", request, trace)
 		// TODO(abaptist): Remove this loop. Sometimes the delegated request fails
 		// due to Raft updating the generation before we can delegate. Even with the
 		// loop above to get the delegate on the correct generation, this is racy if
@@ -451,6 +460,7 @@ func TestDelegateSnapshot(t *testing.T) {
 		// leaseholder.
 		for len(requestChannel) > 0 {
 			<-requestChannel
+			<-traceChannel
 		}
 
 		verifySnapshotMetrics(t, tc, map[int]expectedMetric{
@@ -465,7 +475,9 @@ func TestDelegateSnapshot(t *testing.T) {
 	{
 		_ = tc.AddVotersOrFatal(t, scratchKey, tc.Targets(1)...)
 		request := <-requestChannel
-		require.Equalf(t, request.DelegatedSender.StoreID, roachpb.StoreID(1), "Wrong type of request %+v", request)
+		trace := <-traceChannel
+		require.Equalf(t, roachpb.StoreID(1), request.DelegatedSender.StoreID,
+			"Wrong sender for request %+v.\nSnapshot trace:\n%s", request, trace)
 	}
 	verifySnapshotMetrics(t, tc, map[int]expectedMetric{
 		0: {1, 0, 0, 0},

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 )
 
 // StoreTestingKnobs is a part of the context used to control parts of
@@ -332,6 +333,9 @@ type StoreTestingKnobs struct {
 	// SendSnapshot is run after receiving a DelegateRaftSnapshot request but
 	// before any throttling or sending logic.
 	SendSnapshot func(*kvserverpb.DelegateSendSnapshotRequest)
+	// DelegatedSnapshotTraceChan, if set, enables verbose tracing when sending
+	// snapshots and sends the trace recording on the channel.
+	DelegatedSnapshotTraceChan chan tracingpb.Recording
 	// ReceiveSnapshot is run after receiving a snapshot header but before
 	// acquiring snapshot quota or doing shouldAcceptSnapshotData checks. If an
 	// error is returned from the hook, it's sent as an ERROR SnapshotResponse.


### PR DESCRIPTION
It's impossible to say why a snapshot wasn't sent from the delegate replica the test was expecting. This configures tracing for sending snapshots which, upon failure, should prove illuminating.

Closes https://github.com/cockroachdb/cockroach/issues/155382

Release note: None