### PR TITLE
release-25.2: sqlccl: ignore known bug in TestExplainGist

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -200,6 +200,7 @@ func TestExplainGist(t *testing.T) {
 				// Ignore all errors except the internal ones.
 				for _, knownErr := range []string{
 					"expected equivalence dependants to be its closure",                  // #119045
+					"type check failed while initializing stat",                          // #125620
 					"argument expression has type RECORD, need type USER DEFINED RECORD", // #139910
 					"not in index", // #148405
 				} {


### PR DESCRIPTION
Backport 1/1 commits from #155988 on behalf of @yuzefovich.

----

See: #125620
Informs: #155948

Release note: None



----

Release justification: test-only change.