### PR TITLE
drpc, server: add request counter telemetry in DRPC-gateway

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/security",
         "//pkg/security/certnames",
         "//pkg/security/username",
+        "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/ts/tspb",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -656,6 +656,12 @@ func NewContext(ctx context.Context, opts ContextOptions) *Context {
 		rpcCtx.clientStreamInterceptorsDRPC = append(rpcCtx.clientStreamInterceptorsDRPC,
 			drpcinterceptor.StreamClientInterceptor(tracer, tagger))
 	}
+
+	// Add the DRPC gateway request counter interceptor to track telemetry for
+	// HTTP gateway requests.
+	rpcCtx.clientUnaryInterceptorsDRPC = append(rpcCtx.clientUnaryInterceptorsDRPC,
+		drpcGatewayRequestCounterInterceptor)
+
 	// Note that we do not consult rpcCtx.Knobs.StreamClientInterceptor. That knob
 	// can add another interceptor, but it can only do it dynamically, based on
 	// a connection class. Only calls going over an actual gRPC connection will

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -220,7 +220,7 @@ func NewDRPCServer(_ context.Context, rpcCtx *Context, opts ...ServerOption) (DR
 	streamInterceptors = append(streamInterceptors, stopStream)
 
 	// Recover from any uncaught panics caused by DB Console requests.
-	unaryInterceptors = append(unaryInterceptors, DRPCGatewayRequestRecoveryInterceptor)
+	unaryInterceptors = append(unaryInterceptors, drpcGatewayRequestRecoveryInterceptor)
 
 	if !rpcCtx.ContextOptions.Insecure {
 		a := kvAuth{

--- a/pkg/rpc/drpc_test.go
+++ b/pkg/rpc/drpc_test.go
@@ -98,7 +98,7 @@ func TestGatewayRequestDRPCRecoveryInterceptor(t *testing.T) {
 			panic("test panic")
 		}
 
-		resp, err := DRPCGatewayRequestRecoveryInterceptor(ctx, nil, "test", handler)
+		resp, err := drpcGatewayRequestRecoveryInterceptor(ctx, nil, "test", handler)
 
 		require.Nil(t, resp)
 		require.ErrorContains(t, err, "unexpected error occurred")
@@ -118,7 +118,7 @@ func TestGatewayRequestDRPCRecoveryInterceptor(t *testing.T) {
 			}
 		}()
 
-		_, _ = DRPCGatewayRequestRecoveryInterceptor(ctx, nil, "test", handler)
+		_, _ = drpcGatewayRequestRecoveryInterceptor(ctx, nil, "test", handler)
 	})
 
 	// With gateway metadata but no panic - should pass through normally
@@ -131,7 +131,7 @@ func TestGatewayRequestDRPCRecoveryInterceptor(t *testing.T) {
 			return expectedResp, expectedErr
 		}
 
-		resp, err := DRPCGatewayRequestRecoveryInterceptor(ctx, nil, "test", handler)
+		resp, err := drpcGatewayRequestRecoveryInterceptor(ctx, nil, "test", handler)
 
 		require.Equal(t, expectedResp, resp)
 		require.ErrorIs(t, err, expectedErr)


### PR DESCRIPTION
gRPC-Gateway provides basic request counting via
https://github.com/cockroachdb/cockroach/blob/04f49359a573681a93d9724f37b6582b420eaf1b/pkg/server/grpc_gateway.go#L88

This patch adds support for request counting in drpc-gateway similar to how gRPC-Gateway provides and will help in production monitoring.

Epic: CRDB-48924
Fixes: #151399
Release note: None