### PR TITLE
util,log: make util.EveryN generic

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -318,7 +318,7 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 			Alloc:             &c.a,
 			Spec:              &spec,
 			TraceKV:           c.rfArgs.traceKV,
-			TraceKVEvery:      &util.EveryN{N: c.rfArgs.traceKVLogFrequency},
+			TraceKVEvery:      &util.EveryN[time.Time]{N: c.rfArgs.traceKVLogFrequency},
 		},
 	); err != nil {
 		return nil, nil, err

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1115,7 +1115,7 @@ const (
 )
 
 // slowLogEveryN rate-limits the logging of slow spans
-var slowLogEveryN = log.Every(slowSpanMaxFrequency)
+var slowLogEveryN = util.Every(slowSpanMaxFrequency)
 
 // jobState encapsulates changefeed job state.
 type jobState struct {
@@ -2349,7 +2349,7 @@ type saveRateConfig struct {
 // duration it takes to save progress.
 type saveRateLimiter struct {
 	config     saveRateConfig
-	warnEveryN util.EveryN
+	warnEveryN util.EveryN[time.Time]
 
 	clock timeutil.TimeSource
 

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -58,7 +58,7 @@ func SetDefaultAdminUIPort(c cluster.Cluster, opts *install.StartOpts) {
 // recently a given log message has been emitted so that it can determine
 // whether it's worth logging again.
 type EveryN struct {
-	util.EveryN
+	util.EveryN[time.Time]
 }
 
 // Every is a convenience constructor for an EveryN object that allows a log

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -147,7 +148,7 @@ type raftLogQueue struct {
 	*baseQueue
 	db *kv.DB
 
-	logSnapshots util.EveryN
+	logSnapshots util.EveryN[crtime.Mono]
 }
 
 var _ queueImpl = &raftLogQueue{}
@@ -162,7 +163,7 @@ var _ queueImpl = &raftLogQueue{}
 func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 	rlq := &raftLogQueue{
 		db:           db,
-		logSnapshots: util.Every(10 * time.Second),
+		logSnapshots: util.EveryMono(10 * time.Second),
 	}
 	rlq.baseQueue = newBaseQueue(
 		"raftlog", rlq, store,
@@ -689,7 +690,7 @@ func (rlq *raftLogQueue) process(
 		return false, nil
 	}
 
-	if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
+	if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(crtime.NowMono()) {
 		log.KvExec.Infof(ctx, "%v", redact.Safe(decision.String()))
 		log.KvDistribution.Infof(ctx, "%v", redact.Safe(decision.String()))
 	} else {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1056,7 +1056,7 @@ type Replica struct {
 	// information and without explicit throttling some replicas will offer once
 	// per applied Raft command, which is silly and also clogs up the queues'
 	// semaphores.
-	splitQueueThrottle, mergeQueueThrottle util.EveryN
+	splitQueueThrottle, mergeQueueThrottle util.EveryN[time.Time]
 
 	// loadBasedSplitter keeps information about load-based splitting.
 	loadBasedSplitter split.Decider

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -101,7 +101,7 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 	settingValues := &execCtx.ExecCfg().Settings.SV
 	persistCheckpointsMu := struct {
 		syncutil.Mutex
-		util.EveryN
+		util.EveryN[time.Time]
 	}{}
 	persistCheckpointsMu.EveryN = util.Every(ReconciliationJobCheckpointInterval.Get(settingValues))
 

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -339,7 +339,7 @@ type FetcherInitArgs struct {
 	TraceKV bool
 	// TraceKVEvery controls how often KVs are sampled for logging with traceKV
 	// enabled.
-	TraceKVEvery               *util.EveryN
+	TraceKVEvery               *util.EveryN[time.Time]
 	ForceProductionKVBatchSize bool
 	// SpansCanOverlap indicates whether the spans in a given batch can overlap
 	// with one another. If it is true, spans that correspond to the same row must

--- a/pkg/sql/unsafesql/BUILD.bazel
+++ b/pkg/sql/unsafesql/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/severity",
-        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_redact//:redact",
     ],
 )

--- a/pkg/sql/unsafesql/unsafesql.go
+++ b/pkg/sql/unsafesql/unsafesql.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/redact"
 )
 
@@ -58,14 +58,14 @@ func CheckInternalsAccess(
 	// If an override is set, allow access to this virtual table.
 	if sd.AllowUnsafeInternals {
 		// Log this access to the SENSITIVE_ACCESS channel since the override condition bypassed normal access controls.
-		if accessedLogLimiter.ShouldProcess(timeutil.Now()) {
+		if accessedLogLimiter.ShouldProcess(crtime.NowMono()) {
 			log.StructuredEvent(ctx, severity.WARNING, &eventpb.UnsafeInternalsAccessed{Query: q})
 		}
 		return nil
 	}
 
 	// Log this access to the SENSITIVE_ACCESS channel to show where failing internals accesses are happening.
-	if deniedLogLimiter.ShouldProcess(timeutil.Now()) {
+	if deniedLogLimiter.ShouldProcess(crtime.NowMono()) {
 		log.StructuredEvent(ctx, severity.WARNING, &eventpb.UnsafeInternalsDenied{Query: q})
 	}
 	return sqlerrors.ErrUnsafeTableAccess

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     deps = [
         "//pkg/util/netutil/addr",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ] + select({

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//:pebble",

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/tokenbucket"
 )
 
@@ -236,7 +237,7 @@ func (e *elasticCPUGranter) hasWaitingRequests() bool {
 
 // computeUtilizationMetric is part of the elasticCPULimiter interface.
 func (e *elasticCPUGranter) computeUtilizationMetric() {
-	if !e.metrics.everyInterval.ShouldProcess(timeutil.Now()) {
+	if !e.metrics.everyInterval.ShouldProcess(crtime.NowMono()) {
 		return // nothing to do
 	}
 
@@ -343,7 +344,7 @@ type elasticCPUGranterMetrics struct {
 	OverLimitDuration      metric.IHistogram
 
 	Utilization      *metric.GaugeFloat64 // updated every elasticCPUUtilizationMetricInterval, using fields below
-	everyInterval    util.EveryN
+	everyInterval    util.EveryN[crtime.Mono]
 	lastCumUsedNanos int64
 }
 
@@ -365,7 +366,7 @@ func makeElasticCPUGranterMetrics() *elasticCPUGranterMetrics {
 		}),
 		Utilization:      metric.NewGaugeFloat64(elasticCPUGranterUtilization),
 		UtilizationLimit: metric.NewGaugeFloat64(elasticCPUGranterUtilizationLimit),
-		everyInterval:    util.Every(elasticCPUUtilizationMetricInterval),
+		everyInterval:    util.EveryMono(elasticCPUUtilizationMetricInterval),
 	}
 
 	metrics.MaxAvailableNanos.Inc(int64(runtime.GOMAXPROCS(0)) * time.Second.Nanoseconds())

--- a/pkg/util/every_n.go
+++ b/pkg/util/every_n.go
@@ -9,7 +9,12 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/crlib/crtime"
 )
+
+type clockReading[T any] interface {
+	Sub(T) time.Duration
+}
 
 // EveryN provides a way to rate limit spammy events. It tracks how recently a
 // given event has occurred so that it can determine whether it's worth
@@ -21,22 +26,28 @@ import (
 // NOTE: If you specifically care about log messages, you should use the
 // version of this in the log package, as it integrates with the verbosity
 // flags.
-type EveryN struct {
+type EveryN[T clockReading[T]] struct {
 	// N is the minimum duration of time between log messages.
 	N time.Duration
 
 	syncutil.Mutex
-	lastProcessed time.Time
+	lastProcessed T
 }
 
 // Every is a convenience constructor for an EveryN object that allows a log
 // message every n duration.
-func Every(n time.Duration) EveryN {
-	return EveryN{N: n}
+func Every(n time.Duration) EveryN[time.Time] {
+	return EveryN[time.Time]{N: n}
+}
+
+// EveryMono is a convenience constructor for an EveryN object that allows a log
+// message every n duration, expecting crtime.Mono as input.
+func EveryMono(n time.Duration) EveryN[crtime.Mono] {
+	return EveryN[crtime.Mono]{N: n}
 }
 
 // ShouldProcess returns whether it's been more than N time since the last event.
-func (e *EveryN) ShouldProcess(now time.Time) bool {
+func (e *EveryN[T]) ShouldProcess(now T) bool {
 	var shouldProcess bool
 	e.Lock()
 	if now.Sub(e.lastProcessed) >= e.N {

--- a/pkg/util/every_n_test.go
+++ b/pkg/util/every_n_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestEveryN(t *testing.T) {
 	start := timeutil.Now()
-	en := EveryN{N: time.Minute}
+	en := EveryN[time.Time]{N: time.Minute}
 	testCases := []struct {
 		t        time.Duration // time since start
 		expected bool

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/util/log/every_n.go
+++ b/pkg/util/log/every_n.go
@@ -9,28 +9,28 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 )
 
 // EveryN provides a way to rate limit spammy log messages. It tracks how
 // recently a given log message has been emitted so that it can determine
 // whether it's worth logging again.
 type EveryN struct {
-	util.EveryN
+	util.EveryN[crtime.Mono]
 }
 
 // Every is a convenience constructor for an EveryN object that allows a log
 // message every n duration.
 func Every(n time.Duration) EveryN {
-	return EveryN{EveryN: util.Every(n)}
+	return EveryN{EveryN: util.EveryMono(n)}
 }
 
 // ShouldLog returns whether it's been more than N time since the last event.
 func (e *EveryN) ShouldLog() bool {
-	return e.shouldLog(timeutil.Now())
+	return e.shouldLog(crtime.NowMono())
 }
 
-func (e *EveryN) shouldLog(now time.Time) bool {
+func (e *EveryN) shouldLog(now crtime.Mono) bool {
 	if VDepth(2 /* level */, 2 /* depth */) {
 		// Always log when high verbosity is desired.
 		return true


### PR DESCRIPTION
This changes util.EveryN to a generic function and then modifies log.EveryN to allow use a crtime.Mono instead of a time.Time.

Epic: none
Release note: None