### PR TITLE
kv/bulk: turn on bulkio.ingest.compute_stats_diff_in_stream_batcher.enabled

### DIFF
--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -784,7 +784,7 @@ func (sip *streamIngestionProcessor) handleEvent(event PartitionEvent) error {
 	}
 
 	if sip.logBufferEvery.ShouldLog() {
-		log.Dev.Infof(sip.Ctx(), "current KV batch size %d (%d items)", sip.buffer.curKVBatchSize, len(sip.buffer.curKVBatch))
+		log.VEventf(sip.Ctx(), 2, "current KV batch size %d (%d items)", sip.buffer.curKVBatchSize, len(sip.buffer.curKVBatch))
 	}
 
 	if sip.buffer.shouldFlushOnSize(sip.Ctx(), sv) {

--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//pkg/util/humanizeutil",
         "//pkg/util/limit",
         "//pkg/util/log",
-        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/retry",


### PR DESCRIPTION
We figured out the current cause of ComputeStatsDiff violations were due mid
key sized based flushes, which are unavoidable and rare. Therefore, we feel
good turning on accurate stats computing for PCR.

This patch also adds logging every time we conduct a mid key flush.

Fixes #152536

Release note: none