### PR TITLE
release-25.2: roachtest: skip node distribution check in c2c/disconnect

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1766,17 +1766,18 @@ func registerClusterReplicationResilience(r registry.Registry) {
 // reconnects the nodes.
 func registerClusterReplicationDisconnect(r registry.Registry) {
 	sp := replicationSpec{
-		name:               "c2c/disconnect",
-		srcNodes:           3,
-		dstNodes:           3,
-		cpus:               4,
-		workload:           replicateKV{readPercent: 0, initRows: 1000000, maxBlockBytes: 1024, initWithSplitAndScatter: true, tolerateErrors: true},
-		timeout:            20 * time.Minute,
-		additionalDuration: 10 * time.Minute,
-		cutover:            2 * time.Minute,
-		maxAcceptedLatency: 12 * time.Minute,
-		clouds:             registry.OnlyGCE,
-		suites:             registry.Suites(registry.Nightly),
+		name:                      "c2c/disconnect",
+		srcNodes:                  3,
+		dstNodes:                  3,
+		cpus:                      4,
+		workload:                  replicateKV{readPercent: 0, initRows: 1000000, maxBlockBytes: 1024, initWithSplitAndScatter: true, tolerateErrors: true},
+		timeout:                   20 * time.Minute,
+		additionalDuration:        10 * time.Minute,
+		cutover:                   2 * time.Minute,
+		maxAcceptedLatency:        12 * time.Minute,
+		skipNodeDistributionCheck: true,
+		clouds:                    registry.OnlyGCE,
+		suites:                    registry.Suites(registry.Nightly),
 	}
 	c2cRegisterWrapper(r, sp, func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		rd := makeReplicationDriver(t, c, sp)


### PR DESCRIPTION
Backport 1/1 commits from #155994 on behalf of @msbutler.

----

The check flakes during the test and isn't necessary for the test.

Informs #155753
Informs #152248
Informs #152248

Release note: none

----

Release justification: