### PR TITLE
kvnemesis: address fault mode todos

### DIFF
--- a/pkg/kv/kvserver/idalloc/BUILD.bazel
+++ b/pkg/kv/kvserver/idalloc/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/kv",
+        "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/util/log",
         "//pkg/util/retry",
@@ -28,6 +29,7 @@ go_test(
     deps = [
         "//pkg/keys",
         "//pkg/kv/kvclient/kvcoord",
+        "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -84,7 +85,7 @@ func (ia *Allocator) Allocate(ctx context.Context) (int64, error) {
 	case id := <-ia.ids:
 		// when the channel is closed, the zero value is returned.
 		if id == 0 {
-			return id, errors.Errorf("could not allocate ID; system is draining")
+			return id, &kvpb.NodeUnavailableError{}
 		}
 		return id, nil
 	case <-ctx.Done():

--- a/pkg/kv/kvserver/idalloc/id_alloc_test.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/idalloc"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	// Import to set ZoneConfigHook.
@@ -232,9 +233,9 @@ func TestAllocateWithStopper(t *testing.T) {
 	s, idAlloc := newTestAllocator(t)
 	s.Stop() // not deferred.
 
-	if _, err := idAlloc.Allocate(context.Background()); !testutils.IsError(err, "system is draining") {
-		t.Errorf("unexpected error: %+v", err)
-	}
+	_, err := idAlloc.Allocate(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, &kvpb.NodeUnavailableError{})
 }
 
 // TestLostWriteAssertion makes sure that the Allocator performs a best-effort


### PR DESCRIPTION
This commit addresses TODOs left after introducing network partitions and node restarts to kvnemesis:

- All fault mode tests run with 4 nodes to ensure that liveness tests can always maintain a majority quorum of replicas on nodes 1 and 2. If the tests run with 5 nodes, we need to take extra care to ensure 3 replicas are healthy for all RF=5 ranges (e.g. the systems ranges).

- Splits are now allowed in both partition and restart liveness modes. Previously, if r3 was unavailable, the range ID allocator would get stuck retrying the increment operation that generates a new range ID. This commit ensures all systems ranges are available in liveness mode.

- Lease transafers are now allowed in partition liveness mode. It's not clear what changed but the failure doesn't repro anymore. Will investigate more if it fails in CI.

Part of: #64828
Part of: #114814

Release note: None