### PR TITLE
release-24.3: kvnemesis: bump the timeout

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -58,7 +58,7 @@ go_library(
 
 go_test(
     name = "kvnemesis_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "applier_test.go",
         "engine_test.go",


### PR DESCRIPTION
Backport 1/1 commits from #156081 on behalf of @arulajmani.

----

Medium -> large.

Closes https://github.com/cockroachdb/cockroach/issues/155985 Closes https://github.com/cockroachdb/cockroach/issues/155852

Epic: none

Release note: None

----

Release justification: