### PR TITLE
kv: deflake TestCheckConsistencyInconsistent

### DIFF
--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -418,13 +418,14 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 		// Find the problematic range in the storage.
 		var desc *roachpb.RangeDescriptor
-		require.NoError(t, kvstorage.IterateRangeDescriptorsFromDisk(context.Background(), cpEng,
+		require.NoError(t, kvstorage.IterateRangeDescriptorsFromCheckpoint(context.Background(), cpEng,
 			func(rd roachpb.RangeDescriptor) error {
 				if rd.RangeID == resp.Result[0].RangeID {
 					desc = &rd
 				}
 				return nil
-			}))
+			},
+		))
 		require.NotNil(t, desc)
 
 		// Compute a checksum over the content of the problematic range.


### PR DESCRIPTION
This patch skips invariant checks when iterating through range descriptors from a checkpoint to prevent spurious assertion failures. These assertion failures did not hold because checkpoints are not complete stores, so anything beyond the checkpoints span may not be considered a consistent snapshot.

Closes https://github.com/cockroachdb/cockroach/issues/155680

Epic: none

Release note: None