### PR TITLE
sql: harden DistSQL interactions with routines

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1020,11 +1020,11 @@ type PlanningCtx struct {
 	// query).
 	subOrPostQuery bool
 
-	// mustUseLeafTxn, if set, indicates that this PlanningCtx is used to handle
+	// flowConcurrency will be non-zero when this PlanningCtx is used to handle
 	// one of the plans that will run in parallel with other plans. As such, the
 	// DistSQL planner will need to use the LeafTxn (even if it's not needed
 	// based on other "regular" factors).
-	mustUseLeafTxn bool
+	flowConcurrency distsql.ConcurrencyKind
 
 	// onFlowCleanup contains non-nil functions that will be called after the
 	// local flow finished running and is being cleaned up. It allows us to

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -977,7 +977,8 @@ type PlanningCtx struct {
 	// isLocal is set to true if we're planning this query on a single node.
 	isLocal bool
 	// distSQLProhibitedErr, if set, indicates why the plan couldn't be
-	// distributed.
+	// distributed. If any part of the plan isn't distributable, then this is
+	// guaranteed to be non-nil.
 	distSQLProhibitedErr error
 	planner              *planner
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -754,7 +754,7 @@ func (dsp *DistSQLPlanner) Run(
 	// the line.
 	localState.EvalContext = evalCtx
 	localState.IsLocal = planCtx.isLocal
-	localState.MustUseLeaf = planCtx.mustUseLeafTxn
+	localState.AddConcurrency(planCtx.flowConcurrency)
 	localState.Txn = txn
 	localState.LocalProcs = plan.LocalProcessors
 	localState.LocalVectorSources = plan.LocalVectorSources
@@ -777,7 +777,9 @@ func (dsp *DistSQLPlanner) Run(
 		// cannot create a LeafTxn, so we cannot parallelize scans.
 		planCtx.parallelizeScansIfLocal = false
 		for _, flow := range flows {
-			localState.HasConcurrency = localState.HasConcurrency || execinfra.HasParallelProcessors(flow)
+			if execinfra.HasParallelProcessors(flow) {
+				localState.AddConcurrency(distsql.ConcurrencyHasParallelProcessors)
+			}
 		}
 	} else {
 		if planCtx.isLocal && noMutations && planCtx.parallelizeScansIfLocal {
@@ -785,7 +787,9 @@ func (dsp *DistSQLPlanner) Run(
 			// have decided to parallelize the scans. If that's the case, we
 			// will need to use the Leaf txn.
 			for _, flow := range flows {
-				localState.HasConcurrency = localState.HasConcurrency || execinfra.HasParallelProcessors(flow)
+				if execinfra.HasParallelProcessors(flow) {
+					localState.AddConcurrency(distsql.ConcurrencyHasParallelProcessors)
+				}
 			}
 		}
 		if noMutations {
@@ -886,7 +890,7 @@ func (dsp *DistSQLPlanner) Run(
 							// Both index and lookup joins, with and without
 							// ordering, are executed via the Streamer API that has
 							// concurrency.
-							localState.HasConcurrency = true
+							localState.AddConcurrency(distsql.ConcurrencyStreamer)
 							break
 						}
 					}
@@ -1009,11 +1013,37 @@ func (dsp *DistSQLPlanner) Run(
 		return
 	}
 
-	if len(flows) == 1 && evalCtx.Txn != nil && evalCtx.Txn.Type() == kv.RootTxn {
-		// If we have a fully local plan and a RootTxn, we don't expect any
-		// concurrency, so it's safe to use the DistSQLReceiver to push the
-		// metadata into directly from routines.
-		if planCtx.planner != nil {
+	if len(flows) == 1 && planCtx.planner != nil {
+		// We have a fully local plan, so check whether it'll be safe to use the
+		// DistSQLReceiver to push the metadata into directly from routines
+		// (which is the case when we don't have any concurrency between
+		// routines themselves as well as a routine and the "head" processor -
+		// the one pushing into the DistSQLReceiver).
+		var safe bool
+		if evalCtx.Txn != nil && evalCtx.Txn.Type() == kv.RootTxn {
+			// We have a RootTxn, so we don't expect any concurrency whatsoever.
+			safe = true
+		} else {
+			// We have a LeafTxn, so we need to examine what kind of concurrency
+			// is present in the flow.
+			var safeConcurrency distsql.ConcurrencyKind
+			// We don't care whether we use the Streamer API - it has
+			// concurrency only at the KV client level and below.
+			safeConcurrency |= distsql.ConcurrencyStreamer
+			// If we have "outer plan" concurrency, the "inner" and the
+			// "outer" plans have their own DistSQLReceivers.
+			//
+			// Note that the same is the case with parallel CHECKs concurrency,
+			// but then planCtx.planner is shared between goroutines, so we'll
+			// avoid mutating it. (We can't have routines in post-query CHECKs
+			// since only FK and UNIQUE checks are run in parallel.)
+			safeConcurrency |= distsql.ConcurrencyWithOuterPlan
+			unsafeConcurrency := ^safeConcurrency
+			if localState.GetConcurrency()&unsafeConcurrency == 0 {
+				safe = true
+			}
+		}
+		if safe {
 			planCtx.planner.routineMetadataForwarder = recv
 		}
 	}
@@ -1989,7 +2019,7 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 			// Skip the diagram generation since on this "main" query path we
 			// can get it via the statement bundle.
 			true,  /* skipDistSQLDiagramGeneration */
-			false, /* mustUseLeafTxn */
+			false, /* innerPlansMustUseLeafTxn */
 		) {
 			return recv.commErr
 		}
@@ -2056,7 +2086,7 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 	recv *DistSQLReceiver,
 	subqueryResultMemAcc *mon.BoundAccount,
 	skipDistSQLDiagramGeneration bool,
-	mustUseLeafTxn bool,
+	innerPlansMustUseLeafTxn bool,
 ) bool {
 	for planIdx, subqueryPlan := range subqueryPlans {
 		if err := dsp.planAndRunSubquery(
@@ -2069,7 +2099,7 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 			recv,
 			subqueryResultMemAcc,
 			skipDistSQLDiagramGeneration,
-			mustUseLeafTxn,
+			innerPlansMustUseLeafTxn,
 		); err != nil {
 			recv.SetError(err)
 			return false
@@ -2093,7 +2123,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	recv *DistSQLReceiver,
 	subqueryResultMemAcc *mon.BoundAccount,
 	skipDistSQLDiagramGeneration bool,
-	mustUseLeafTxn bool,
+	innerPlansMustUseLeafTxn bool,
 ) error {
 	subqueryDistribution, distSQLProhibitedErr := planner.getPlanDistribution(ctx, subqueryPlan.plan)
 	distribute := DistributionType(LocalDistribution)
@@ -2105,7 +2135,9 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	subqueryPlanCtx.stmtType = tree.Rows
 	subqueryPlanCtx.skipDistSQLDiagramGeneration = skipDistSQLDiagramGeneration
 	subqueryPlanCtx.subOrPostQuery = true
-	subqueryPlanCtx.mustUseLeafTxn = mustUseLeafTxn
+	if innerPlansMustUseLeafTxn {
+		subqueryPlanCtx.flowConcurrency = distsql.ConcurrencyWithOuterPlan
+	}
 	if planner.instrumentation.ShouldSaveFlows() {
 		subqueryPlanCtx.saveFlows = getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeSubquery)
 	}
@@ -2724,7 +2756,9 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	}
 	postqueryPlanCtx.associateNodeWithComponents = associateNodeWithComponents
 	postqueryPlanCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
-	postqueryPlanCtx.mustUseLeafTxn = parallelCheck
+	if parallelCheck {
+		postqueryPlanCtx.flowConcurrency = distsql.ConcurrencyParallelChecks
+	}
 
 	postqueryPhysPlan, physPlanCleanup, err := dsp.createPhysPlan(ctx, postqueryPlanCtx, postqueryPlan)
 	defer physPlanCleanup()

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -875,15 +875,10 @@ func (dsp *DistSQLPlanner) Run(
 			// that we might have a plan where some expression (e.g. a cast to
 			// an Oid type) uses the planner's txn (which is the RootTxn), so
 			// it'd be illegal to use LeafTxns for a part of such plan.
-			// TODO(yuzefovich): this check is both excessive and insufficient.
-			// For example:
-			// - it disables the usage of the Streamer when a subquery has an
-			// Oid type, but that would have no impact on usage of the Streamer
-			// in the main query;
-			// - it might allow the usage of the Streamer even when the internal
-			// executor is used by a part of the plan, and the IE would use the
-			// RootTxn. Arguably, this would be a bug in not prohibiting the
-			// DistSQL altogether.
+			// TODO(yuzefovich): this check could be excessive. For example, it
+			// disables the usage of the Streamer when a subquery has an Oid
+			// type (due to a serialization issue), but that would have no
+			// impact on usage of the Streamer in the main query.
 			if !containsLocking && !mustUseRootTxn && planCtx.distSQLProhibitedErr == nil {
 				if evalCtx.SessionData().StreamerEnabled {
 					for _, proc := range plan.Processors {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2225,8 +2225,10 @@ func shouldDistributeGivenRecAndMode(
 // the plan.
 //
 // The returned error, if any, indicates why we couldn't distribute the plan.
-// Note that it's possible that we choose to not distribute the plan while
-// nil error is returned.
+// Note that it's possible that we choose to not distribute the plan while nil
+// error is returned (but it's guaranteed that if some part of the plan isn't
+// distributable, then non-nil error is returned).
+//
 // WARNING: in some cases when this method returns
 // physicalplan.FullyDistributedPlan, the plan might actually run locally. This
 // is the case when
@@ -2245,23 +2247,9 @@ func (p *planner) getPlanDistribution(
 		return plan.physPlan.Distribution, nil
 	}
 
-	// If this transaction has modified or created any types, it is not safe to
-	// distribute due to limitations around leasing descriptors modified in the
-	// current transaction.
-	if p.Descriptors().HasUncommittedDescriptors() {
-		return physicalplan.LocalPlan, nil
-	}
-
+	// Check DistSQL-supportability as the first order of business in order to
+	// find whether usage of DistSQL is prohibited by features of the plan.
 	sd := p.SessionData()
-	if sd.DistSQLMode == sessiondatapb.DistSQLOff {
-		return physicalplan.LocalPlan, nil
-	}
-
-	// Don't try to run empty nodes (e.g. SET commands) with distSQL.
-	if _, ok := plan.planNode.(*zeroNode); ok {
-		return physicalplan.LocalPlan, nil
-	}
-
 	// Determine whether the txn has buffered some writes.
 	txnHasBufferedWrites := p.txn.HasBufferedWrites()
 	if sd.BufferedWritesEnabled && p.curPlan.main == plan {
@@ -2277,9 +2265,24 @@ func (p *planner) getPlanDistribution(
 	}
 	rec, err := checkSupportForPlanNode(ctx, plan.planNode, &p.distSQLVisitor, sd, txnHasBufferedWrites)
 	if err != nil {
-		// Don't use distSQL for this request.
 		log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
 		return physicalplan.LocalPlan, err
+	}
+
+	// If this transaction has modified or created any types, it is not safe to
+	// distribute due to limitations around leasing descriptors modified in the
+	// current transaction.
+	if p.Descriptors().HasUncommittedDescriptors() {
+		return physicalplan.LocalPlan, nil
+	}
+
+	if sd.DistSQLMode == sessiondatapb.DistSQLOff {
+		return physicalplan.LocalPlan, nil
+	}
+
+	// Don't try to run empty nodes (e.g. SET commands) with distSQL.
+	if _, ok := plan.planNode.(*zeroNode); ok {
+		return physicalplan.LocalPlan, nil
 	}
 
 	if shouldDistributeGivenRecAndMode(rec, sd.DistSQLMode) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -336,7 +336,7 @@ quality of service: regular
 │       │ estimated max sql temp disk usage: 0 B
 │       │ group by: lk
 │       │
-│       └── • lookup join (left outer) (streamer)
+│       └── • lookup join (left outer)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0

--- a/pkg/sql/opt/exec/execbuilder/testdata/jsonb_path_query
+++ b/pkg/sql/opt/exec/execbuilder/testdata/jsonb_path_query
@@ -153,19 +153,19 @@ query T kvtrace
 SELECT jsonb_path_query(b, '$.a.b') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a.b') ORDER BY a;
 ----
 Scan /Table/106/2/{???-"a"/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/}
-Scan /Table/106/1/7/0, /Table/106/1/11/0, /Table/106/1/8/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0, /Table/106/1/12/0, /Table/106/1/3/0, /Table/106/1/9/0, /Table/106/1/4/0, /Table/106/1/6/0
+Scan /Table/106/1/3/0, /Table/106/1/4/0, /Table/106/1/6/0, /Table/106/1/7/0, /Table/106/1/8/0, /Table/106/1/9/0, /Table/106/1/11/0, /Table/106/1/12/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0
 
 query T kvtrace
 SELECT jsonb_path_query(b, '$.a[*].b') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a[*].b') ORDER BY a;
 ----
 Scan /Table/106/2/{???-"a"/Arr/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/}
-Scan /Table/106/1/7/0, /Table/106/1/11/0, /Table/106/1/8/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0, /Table/106/1/12/0, /Table/106/1/3/0, /Table/106/1/9/0, /Table/106/1/4/0, /Table/106/1/6/0
+Scan /Table/106/1/3/0, /Table/106/1/4/0, /Table/106/1/6/0, /Table/106/1/7/0, /Table/106/1/8/0, /Table/106/1/9/0, /Table/106/1/11/0, /Table/106/1/12/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0
 
 query T kvtrace
 SELECT jsonb_path_query(b, '$.a[*][*].b') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a[*][*].b') ORDER BY a;
 ----
 Scan /Table/106/2/{???-"a"/Arr/Arr/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/}
-Scan /Table/106/1/7/0, /Table/106/1/11/0, /Table/106/1/8/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0, /Table/106/1/12/0, /Table/106/1/3/0, /Table/106/1/9/0, /Table/106/1/4/0, /Table/106/1/6/0
+Scan /Table/106/1/3/0, /Table/106/1/4/0, /Table/106/1/6/0, /Table/106/1/7/0, /Table/106/1/8/0, /Table/106/1/9/0, /Table/106/1/11/0, /Table/106/1/12/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0
 
 query T kvtrace
 SELECT jsonb_path_query(b, '$.a.b[*].c') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a.b[*].c') ORDER BY a;
@@ -234,7 +234,7 @@ query T kvtrace
 SELECT a, jsonb_path_query(b, '$.a.b') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a.b') ORDER BY a;
 ----
 Scan /Table/106/2/{???-"a"/Arr/Arr/}, /Table/106/2/{???-"a"/Arr/}
-Scan /Table/106/1/7/0, /Table/106/1/11/0, /Table/106/1/8/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0, /Table/106/1/12/0, /Table/106/1/3/0, /Table/106/1/9/0, /Table/106/1/4/0, /Table/106/1/6/0
+Scan /Table/106/1/3/0, /Table/106/1/4/0, /Table/106/1/6/0, /Table/106/1/7/0, /Table/106/1/8/0, /Table/106/1/9/0, /Table/106/1/11/0, /Table/106/1/12/0, /Table/106/1/13/0, /Table/106/1/14/0, /Table/106/1/15/0, /Table/106/1/16/0
 
 query T kvtrace
 SELECT a, jsonb_path_query(b, '$.a.b'), jsonb_path_query(b, '$.a.d') FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a.b') AND jsonb_path_exists(b, '$.a.d') ORDER BY a;

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -1077,8 +1077,9 @@ func (p *planner) ClearTableStatsCache() {
 	}
 }
 
-// mustUseLeafTxn returns true if inner plans must use a leaf transaction.
-func (p *planner) mustUseLeafTxn() bool {
+// innerPlansMustUseLeafTxn returns true if inner plans must use a leaf
+// transaction.
+func (p *planner) innerPlansMustUseLeafTxn() bool {
 	return atomic.LoadInt32(&p.atomic.innerPlansMustUseLeafTxn) >= 1
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -521,7 +521,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 					ctx, localPlanner, localPlanner.ExtendedEvalContextCopy,
 					localPlanner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
 					false, /* skipDistSQLDiagramGeneration */
-					false, /* mustUseLeafTxn */
+					false, /* innerPlansMustUseLeafTxn */
 				) {
 					if planAndRunErr = rw.Err(); planAndRunErr != nil {
 						return


### PR DESCRIPTION
**sql: unconditionally check DistSQL supportability**

This commit hardens c17591e. In
particular, in that change we disabled the usage of the Streamer
whenever some part of the plan isn't distributable. However, population
of `distSQLProhibitedErr` was left on a best-effort basis. In
particular, if we have `distsql=off` (as well as a couple of other
conditions), we'd skip the supportability check. This meant that we
could still end up using the Streamer in some illegal cases - one
example that I came up with is if we have a routine (which currently
prohibits distsql), it might access the RootTxn concurrently with the
LeafTxn access by the Streamer, which is no bueno. This commit makes it
so that we do DistSQL supportability check unconditionally. Note that
this shouldn't really have a performance impact - after all, we do
expect this check to be done pretty much all the time (unless someone
runs with `distsql=off`).

Additionally, this change happens to fix a nil pointer error around the
recent fix to top-level query stats in presence of routines. Namely,
that patch only set the metadata forwarder for local plans if we end up
using the RootTxn, but in a query where we happened to use the streamer
with routines, (before this patch) we'd end up with LeafTxn and unset
metadata forwarder. Now we'll have streamer disabled, so we'll have the
RootTxn and the forwarder will be set.

Fixes: #155955.

**sql: harden recent fix to top-level query stats with routines**

This commit relaxes the requirements for when it's safe to set the
routine metadata forwarder. Previously, we only set it when we end up
using the RootTxn in a local plan, but now we examine all possible kinds
of concurrency within the local plan to see whether it's actually safe
to set the metadata forwarder. This seems like a nice cleanup as well.

Note that this commit independently fixes the issue mentioned in the
previous commit.

Release note: None