### PR TITLE
sql/rowexec: enable tests under secondary tenants

### DIFF
--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -164,7 +164,6 @@ go_test(
     }),
     deps = [
         "//pkg/base",
-        "//pkg/gossip",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
@@ -173,6 +172,7 @@ go_test(
         "//pkg/kv/kvclient/rangecache",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -389,7 +389,15 @@ func TestAggregator(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	test := MakeProcessorTest(DefaultProcessorTestConfig())
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	test := MakeProcessorTest(ProcessorTestConfig{
+		FlowCtx: &execinfra.FlowCtx{
+			Cfg:     &execinfra.ServerConfig{Settings: st},
+			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
+		},
+	})
 	defer test.Close(ctx)
 	test.RunTestCases(ctx, t, testCases)
 }

--- a/pkg/sql/rowexec/backfiller_test.go
+++ b/pkg/sql/rowexec/backfiller_test.go
@@ -75,6 +75,7 @@ func TestWriteResumeSpan(t *testing.T) {
 				},
 			},
 		},
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(156127),
 	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -624,7 +623,7 @@ func TestInvertedJoiner(t *testing.T) {
 		testCases[i] = initCommonFields(c)
 	}
 
-	st := cluster.MakeTestingClusterSettings()
+	st := s.ClusterSettings()
 	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), nil /* statsCollector */)
 	if err != nil {
 		t.Fatal(err)
@@ -632,7 +631,7 @@ func TestInvertedJoiner(t *testing.T) {
 	defer tempEngine.Close()
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
+	evalCtx := eval.MakeTestingEvalContextWithCodec(s.Codec(), st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
@@ -764,13 +763,13 @@ func TestInvertedJoinerDrain(t *testing.T) {
 	tracer := s.TracerI().(*tracing.Tracer)
 	ctx, sp := tracer.StartSpanCtx(context.Background(), "test flow ctx", tracing.WithRecording(tracingpb.RecordingVerbose))
 	defer sp.Finish()
-	st := cluster.MakeTestingClusterSettings()
+	st := s.ClusterSettings()
 	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), nil /* statsCollector */)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tempEngine.Close()
-	evalCtx := eval.MakeTestingEvalContext(st)
+	evalCtx := eval.MakeTestingEvalContextWithCodec(s.Codec(), st)
 	defer evalCtx.Stop(context.Background())
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)

--- a/pkg/sql/rowexec/joinreader_blackbox_test.go
+++ b/pkg/sql/rowexec/joinreader_blackbox_test.go
@@ -100,5 +100,9 @@ func TestJoinReaderUsesBatchLimit(t *testing.T) {
 	tableID := desc.TableDesc().ID
 	sp, ok := rec.FindSpan("join reader")
 	require.True(t, ok)
-	require.Greater(t, tracing.CountLogMessages(sp, fmt.Sprintf("Scan /Table/%d", tableID)), 1)
+	var tenantPrefix string
+	if srv.StartedDefaultTestTenant() {
+		tenantPrefix = fmt.Sprintf("/Tenant/%s", serverutils.TestTenantID())
+	}
+	require.Greater(t, tracing.CountLogMessages(sp, fmt.Sprintf("Scan %s/Table/%d", tenantPrefix, tableID)), 1)
 }

--- a/pkg/sql/rowexec/main_test.go
+++ b/pkg/sql/rowexec/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -25,10 +24,6 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
-
-	defer serverutils.TestingSetDefaultTenantSelectionOverride(
-		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
-	)()
 
 	os.Exit(m.Run())
 }

--- a/pkg/sql/rowexec/processor_utils_test.go
+++ b/pkg/sql/rowexec/processor_utils_test.go
@@ -11,13 +11,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
@@ -31,18 +29,6 @@ type ProcessorTestConfig struct {
 
 	BeforeTestCase func(p execinfra.Processor, inputs []execinfra.RowSource, output execinfra.RowReceiver)
 	AfterTestCase  func(p execinfra.Processor, inputs []execinfra.RowSource, output execinfra.RowReceiver)
-}
-
-func DefaultProcessorTestConfig() ProcessorTestConfig {
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := eval.MakeTestingEvalContext(st)
-	return ProcessorTestConfig{
-		FlowCtx: &execinfra.FlowCtx{
-			Cfg:     &execinfra.ServerConfig{Settings: st},
-			EvalCtx: &evalCtx,
-			Mon:     evalCtx.TestingMon,
-		},
-	}
 }
 
 // ProcessorTestCaseRows is a number of rows of go values with an associated

--- a/pkg/sql/rowexec/project_set_test.go
+++ b/pkg/sql/rowexec/project_set_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -105,6 +106,7 @@ func TestProjectSet(t *testing.T) {
 		t.Run(c.description, func(t *testing.T) {
 			runProcessorTest(
 				t,
+				keys.SystemSQLCodec,
 				execinfrapb.ProcessorCoreUnion{ProjectSet: &c.spec},
 				execinfrapb.PostProcessSpec{},
 				c.inputTypes,

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -33,6 +33,7 @@ import (
 // with the given inputs, and asserts that the outputted rows are as expected.
 func runProcessorTest(
 	t *testing.T,
+	codec keys.SQLCodec,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
 	inputTypes []*types.T,
@@ -47,7 +48,7 @@ func runProcessorTest(
 	out := &distsqlutils.RowBuffer{}
 
 	st := cluster.MakeTestingClusterSettings()
-	evalCtx := eval.MakeTestingEvalContext(st)
+	evalCtx := eval.MakeTestingEvalContextWithCodec(codec, st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st, Stopper: stopper, DistSender: distSender},

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -41,7 +42,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 		Increment: 5000,
 		Settings:  st,
 	})
-	evalCtx := eval.MakeTestingEvalContextWithMon(st, monitor)
+	evalCtx := eval.MakeTestingEvalContextWithMon(keys.SystemSQLCodec, st, monitor)
 	defer evalCtx.Stop(ctx)
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -681,8 +680,8 @@ func TestZigzagJoiner(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.desc, func(t *testing.T) {
-			st := cluster.MakeTestingClusterSettings()
-			evalCtx := eval.MakeTestingEvalContext(st)
+			st := s.ClusterSettings()
+			evalCtx := eval.MakeTestingEvalContextWithCodec(s.Codec(), st)
 			defer evalCtx.Stop(ctx)
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
@@ -755,7 +754,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	tracer := s.TracerI().(*tracing.Tracer)
 	ctx, sp := tracer.StartSpanCtx(context.Background(), "test flow ctx", tracing.WithRecording(tracingpb.RecordingVerbose))
 	defer sp.Finish()
-	evalCtx := eval.MakeTestingEvalContext(s.ClusterSettings())
+	evalCtx := eval.MakeTestingEvalContextWithCodec(s.Codec(), s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), srv.NodeID())

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -789,7 +789,7 @@ func TestRouterDiskSpill(t *testing.T) {
 		Increment: 1,
 		Settings:  st,
 	})
-	evalCtx := eval.MakeTestingEvalContextWithMon(st, monitor)
+	evalCtx := eval.MakeTestingEvalContextWithMon(keys.SystemSQLCodec, st, monitor)
 	defer evalCtx.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -458,19 +458,31 @@ func MakeTestingEvalContext(st *cluster.Settings) Context {
 		Name:     mon.MakeName("test-monitor"),
 		Settings: st,
 	})
-	return MakeTestingEvalContextWithMon(st, monitor)
+	return MakeTestingEvalContextWithMon(keys.SystemSQLCodec, st, monitor)
+}
+
+// MakeTestingEvalContextWithCodec is the same as MakeTestingEvalContext but
+// allows overriding keys.SystemSQLCodec.
+func MakeTestingEvalContextWithCodec(codec keys.SQLCodec, st *cluster.Settings) Context {
+	monitor := mon.NewMonitor(mon.Options{
+		Name:     mon.MakeName("test-monitor"),
+		Settings: st,
+	})
+	return MakeTestingEvalContextWithMon(codec, st, monitor)
 }
 
 // MakeTestingEvalContextWithMon returns an EvalContext with the given
 // MemoryMonitor. Ownership of the memory monitor is transferred to the
 // EvalContext so do not start or close the memory monitor.
-func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonitor) Context {
+func MakeTestingEvalContextWithMon(
+	codec keys.SQLCodec, st *cluster.Settings, monitor *mon.BytesMonitor,
+) Context {
 	sessionData := &sessiondata.SessionData{}
 	// Set defaults that match what the session variables system expects.
 	// allow_unsafe_internals defaults to true.
 	sessionData.AllowUnsafeInternals = true
 	ctx := Context{
-		Codec:            keys.SystemSQLCodec,
+		Codec:            codec,
 		Txn:              &kv.Txn{},
 		SessionDataStack: sessiondata.NewStack(sessionData),
 		Settings:         st,


### PR DESCRIPTION
Given the modifications in recent commits, this mostly required plumbing the right codec into `eval.Context`. Additionally, a few tests needed some extra adjustments for the tenant prefix present in the spans. Only `TestWriteResumeSpan` is still skipped since it wasn't immediately clear what's wrong there.

Epic: CRDB-48945
Release note: None