### PR TITLE
release-25.2: kv: add debugging obs for TestFlowControlSendQueueRangeFeed

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -615,6 +615,7 @@ func newTransportForRange(
 		return nil, err
 	}
 	replicas.OptimizeReplicaOrder(ctx, ds.st, ds.nodeIDGetter(), ds.healthFunc, ds.latencyFunc, ds.locality)
+	log.VEventf(ctx, 2, "replica order for rangefeed transport is: %s", replicas)
 	opts := SendOptions{class: defRangefeedConnClass}
 	return ds.transportFactory(opts, replicas), nil
 }

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -3226,6 +3226,7 @@ func TestFlowControlSendQueueRangeSplitMerge(t *testing.T) {
 func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	testutils.SetVModule(t, "dist_sender_mux_rangefeed=2,dist_sender_rangefeed=2")
 
 	// rangeFeed will create a rangefeed suitable for testing. It will start a
 	// rangefeed and return a function that can be used to stop it.


### PR DESCRIPTION
Backport 1/1 commits from #156103 on behalf of @arulajmani.

----

I haven't been able to repro this. The test has failed twice in the last couple of days, so hopefully we'll be able to see why the rangefeed isn't ending up on n3 the next time this fails.

Closes https://github.com/cockroachdb/cockroach/issues/156064

Epic: none

Release note: None

----

Release justification: test only changes 