### PR TITLE
revert "sql: store bundle when TestStreamerTightBudget fails"

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -1053,7 +1053,9 @@ func findBundleDownloadURL(t *testing.T, runner *sqlutils.SQLRunner, id int) str
 	return urlTemplate[:prefixLength] + "/" + strconv.Itoa(id)
 }
 
-func downloadBundle(t *testing.T, url string, dest io.Writer) {
+func downloadAndUnzipBundle(t *testing.T, url string) *zip.Reader {
+
+	// Download the zip to a BytesBuffer.
 	httpClient := httputil.NewClientWithTimeout(30 * time.Second)
 	// Download the zip to a BytesBuffer.
 	resp, err := httpClient.Get(context.Background(), url)
@@ -1061,13 +1063,8 @@ func downloadBundle(t *testing.T, url string, dest io.Writer) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	_, _ = io.Copy(dest, resp.Body)
-}
-
-func downloadAndUnzipBundle(t *testing.T, url string) *zip.Reader {
-	// Download the zip to a BytesBuffer.
 	var buf bytes.Buffer
-	downloadBundle(t, url, &buf)
+	_, _ = io.Copy(&buf, resp.Body)
 
 	unzip, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	if err != nil {

--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -8,8 +8,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -19,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -159,7 +156,6 @@ func TestStreamerTightBudget(t *testing.T) {
 	// Streamer isn't hitting the root budget exceeded error.
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		SQLMemoryPoolSize: 1 << 30, /* 1GiB */
-		Insecure:          true,
 	})
 	defer s.Stopper().Stop(context.Background())
 	sqlDB := sqlutils.MakeSQLRunner(db)
@@ -184,9 +180,9 @@ func TestStreamerTightBudget(t *testing.T) {
 	sqlDB.Exec(t, fmt.Sprintf("SET distsql_workmem = '%dB'", blobSize))
 
 	// Perform an index join to read the blobs.
-	query := "SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"
+	query := "EXPLAIN ANALYZE SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"
 	maximumMemoryUsageRegex := regexp.MustCompile(`maximum memory usage: (\d+\.\d+) MiB`)
-	rows := sqlDB.QueryStr(t, "EXPLAIN ANALYZE (VERBOSE) "+query)
+	rows := sqlDB.QueryStr(t, query)
 	// Build pretty output for an error message in case we need it.
 	var sb strings.Builder
 	for _, row := range rows {
@@ -201,45 +197,9 @@ func TestStreamerTightBudget(t *testing.T) {
 			// by the ColIndexJoin when the blob is copied into the columnar
 			// batch). We allow for 0.1MiB for other memory usage in the query.
 			maxAllowed := 2.1
-			if maxAllowed >= usage {
-				return
-			}
-			// Get a stmt bundle for this query that might help in debugging the
-			// failure.
-			rows = sqlDB.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) "+query)
-			url := getBundleDownloadURL(t, fmt.Sprint(rows))
-			// First check whether the bundle experienced the elevated memory
-			// usage too.
-			unzip := downloadAndUnzipBundle(t, url)
-			for _, f := range unzip.File {
-				switch f.Name {
-				case "plan.txt":
-					contents := readUnzippedFile(t, f)
-					sb.WriteString("\n\n\nbundle plan.txt:\n\n\n")
-					sb.WriteString(contents)
-					// Check that the memory usage is still elevated.
-					if matches := maximumMemoryUsageRegex.FindStringSubmatch(contents); len(matches) == 0 {
-						t.Fatalf("unexpectedly didn't find a match for maximum memory usage\n%s", sb.String())
-					} else {
-						bundleUsage, err := strconv.ParseFloat(matches[1], 64)
-						require.NoError(t, err)
-						if maxAllowed >= bundleUsage {
-							// Memory usage is as expected in the bundle - do
-							// not fail the test since we don't have any
-							// information to help in understanding the original
-							// high memory usage.
-							return
-						}
-					}
-				}
-			}
-			// NB: we're not using t.TempDir() because we want these to survive
-			// on failure.
-			f, err := os.Create(filepath.Join(datapathutils.DebuggableTempDir(), "bundle.zip"))
-			require.NoError(t, err)
-			downloadBundle(t, url, f)
-			t.Fatalf("unexpectedly high memory usage\n----\n%s", sb.String())
+			require.GreaterOrEqualf(t, maxAllowed, usage, "unexpectedly high memory usage\n----\n%s", sb.String())
+			return
 		}
 	}
-	t.Fatalf("unexpectedly didn't find a match for maximum memory usage\n%s", sb.String())
+	t.Fatal("unexpectedly didn't find a match for maximum memory usage")
 }


### PR DESCRIPTION
This reverts commit 48f11d233313d292a8e5fe5a8bab2218a2405304.

The test hasn't failed in like year and a half and the captured stmt bundle didn't actually give any more insight into why it rarely failed.

Informs: #119675.
Release note: None