### PR TITLE
sql/inspect: fix LTREE[] handling in query bounds

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_inspect
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_inspect
@@ -6,6 +6,19 @@ statement ok
 SET enable_scrub_job = true;
 
 statement ok
+SET enable_inspect_command = true;
+
+statement ok
+CREATE VIEW last_inspect_job AS
+SELECT status, COALESCE(jsonb_array_length(
+    crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload)->'inspectDetails'->'checks'
+  ), 0) AS num_checks
+FROM crdb_internal.system_jobs
+WHERE job_type = 'INSPECT'
+ORDER BY created DESC
+LIMIT 1
+
+statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, e BOOL, PRIMARY KEY (a, b, c, d), INDEX c_idx (c, d))
 
 # Split into ten parts.
@@ -53,6 +66,49 @@ query TTB
 SELECT description, status, finished IS NOT NULL AS finished FROM [SHOW JOBS] WHERE job_type = 'INSPECT' ORDER BY created DESC LIMIT 1
 ----
 EXPERIMENTAL SCRUB TABLE data AS OF SYSTEM TIME '-1us'  succeeded  true
+
+subtest end
+
+subtest ltree_array_pk_column
+
+statement ok
+CREATE TABLE table_ltree_array_leading (
+    pk_ltree_array LTREE[] NOT NULL,
+    pk_name NAME NOT NULL,
+    val INT,
+    PRIMARY KEY (pk_ltree_array, pk_name),
+    INDEX idx_val (val)
+);
+
+statement ok
+INSERT INTO table_ltree_array_leading VALUES
+    (ARRAY['a.b.c']::LTREE[], 'key1', 1),
+    (ARRAY['d.e.f']::LTREE[], 'key2', 2),
+    (ARRAY['g.h.i']::LTREE[], 'key3', 3),
+    (ARRAY['j.k.l']::LTREE[], 'key4', 4),
+    (ARRAY['m.n.o']::LTREE[], 'key5', 5),
+    (ARRAY['p.q.r']::LTREE[], 'key6', 6);
+
+# Split the table into multiple ranges to force distributed INSPECT queries.
+statement ok
+ALTER TABLE table_ltree_array_leading SPLIT AT VALUES (ARRAY['d.e.f']::LTREE[], 'key2');
+
+statement ok
+ALTER TABLE table_ltree_array_leading SPLIT AT VALUES (ARRAY['j.k.l']::LTREE[], 'key4');
+
+statement ok
+ALTER TABLE table_ltree_array_leading SCATTER;
+
+statement ok
+INSPECT TABLE table_ltree_array_leading;
+
+query TI
+SELECT * FROM last_inspect_job;
+----
+succeeded 1
+
+statement ok
+DROP TABLE table_ltree_array_leading;
 
 subtest end
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4273,7 +4273,7 @@ func (d *DLTree) Max(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
 }
 
 // AmbiguousFormat implements the Datum interface.
-func (*DLTree) AmbiguousFormat() bool { return false }
+func (*DLTree) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DLTree) Format(ctx *FmtCtx) {


### PR DESCRIPTION
INSPECT builds query bounds from primary key column types. When a table had an LTREE[] column, the bound datums could be interpreted as string[] by the query engine, causing errors like:
```
unsupported comparison operator: <ltree[]> >= <string[]>
```

This happened because the datum formatting omitted type information for array elements. For example, ['j.k.l']::LTREE[] was formatted as ARRAY['j.k.l'], which loses the cast. The fix marks the LTREE type as ambiguous so the formatter includes explicit type casts, avoiding mismatches in distributed queries.

While testing, I also added placeholder values to the logged query in inspect issues (previously only the query text was shown).

Informs: #155483
Closes: #156121
Epic: CRDB-55075

Release note: none
