### PR TITLE
cmd/reduce: fix parsing of DO blocks

### DIFF
--- a/pkg/cmd/reduce/reduce/reducesql/BUILD.bazel
+++ b/pkg/cmd/reduce/reduce/reducesql/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/cmd/reduce/reduce",
         "//pkg/sql/parser",
         "//pkg/sql/parser/statements",
+        "//pkg/sql/plpgsql/parser",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
     ],

--- a/pkg/cmd/reduce/reduce/reducesql/reducesql.go
+++ b/pkg/cmd/reduce/reduce/reducesql/reducesql.go
@@ -14,6 +14,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/reduce/reduce"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
+	// Ensure that sql/parser.ParseDoBlockFn is injected from the PLpgSQL
+	// parser.
+	_ "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
 	// Import builtins.
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"


### PR DESCRIPTION
Parsing DO blocks requires that plpgsql be initialized, which reduce previously failed to do, causing it to SEGV upon encountering a DO block in the file being reduced. This change imports the plpgsql parser to hit its init() function, which resolves the issue.

Epic: none
Release note: None