### PR TITLE
sql: fix MatchBatchSize to use KV batch size

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -598,7 +598,7 @@ func (n *createTableNode) startExec(params runParams) error {
 
 				// Periodically flush out the batches, so that we don't issue gigantic
 				// raft commands.
-				if ti.currentBatchSize >= ti.maxBatchSize ||
+				if len(ti.b.Requests()) >= ti.maxBatchSize ||
 					ti.b.ApproximateMutationBytes() >= ti.maxBatchByteSize {
 					if err := ti.flushAndStartNewBatch(params.ctx); err != nil {
 						return err

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -139,13 +139,13 @@ func (d *deleteNode) processBatch(params runParams) (lastBatch bool, err error) 
 		}
 
 		// Are we done yet with the current batch?
-		if d.run.td.currentBatchSize >= d.run.td.maxBatchSize ||
+		if len(d.run.td.b.Requests()) >= d.run.td.maxBatchSize ||
 			d.run.td.b.ApproximateMutationBytes() >= d.run.td.maxBatchByteSize {
 			break
 		}
 	}
 
-	if d.run.td.currentBatchSize > 0 {
+	if len(d.run.td.b.Requests()) > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -336,13 +336,13 @@ func (n *insertNode) processBatch(params runParams) (lastBatch bool, err error) 
 		}
 
 		// Are we done yet with the current batch?
-		if n.run.ti.currentBatchSize >= n.run.ti.maxBatchSize ||
+		if len(n.run.ti.b.Requests()) >= n.run.ti.maxBatchSize ||
 			n.run.ti.b.ApproximateMutationBytes() >= n.run.ti.maxBatchByteSize {
 			break
 		}
 	}
 
-	if n.run.ti.currentBatchSize > 0 {
+	if len(n.run.ti.b.Requests()) > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -59,7 +59,7 @@ func (td *tableDeleter) row(
 	mustValidateOldPKValues bool,
 	traceKV bool,
 ) error {
-	td.currentBatchSize++
+	td.rowsWritten++
 	return td.rd.DeleteRow(ctx, td.b, values, pm, vh, oth, mustValidateOldPKValues, traceKV)
 }
 

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -51,7 +51,7 @@ func (ti *tableInserter) row(
 	oth row.OriginTimestampCPutHelper,
 	traceKV bool,
 ) error {
-	ti.currentBatchSize++
+	ti.rowsWritten++
 	return ti.ri.InsertRow(ctx, &ti.putter, values, pm, vh, oth, row.CPutOp, traceKV)
 }
 

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -55,7 +55,7 @@ func (tu *tableUpdater) rowForUpdate(
 	mustValidateOldPKValues bool,
 	traceKV bool,
 ) (tree.Datums, error) {
-	tu.currentBatchSize++
+	tu.rowsWritten++
 	return tu.ru.UpdateRow(
 		ctx, tu.b, oldValues, updateValues, pm, vh, oth, mustValidateOldPKValues, traceKV,
 	)

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -172,7 +172,7 @@ func (tu *tableUpserter) row(
 	oth row.OriginTimestampCPutHelper,
 	traceKV bool,
 ) error {
-	tu.currentBatchSize++
+	tu.rowsWritten++
 	tu.onModifiedRow()
 
 	// Consult the canary column to determine whether to insert or update. For

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -147,13 +147,13 @@ func (u *updateNode) processBatch(params runParams) (lastBatch bool, err error) 
 		}
 
 		// Are we done yet with the current batch?
-		if u.run.tu.currentBatchSize >= u.run.tu.maxBatchSize ||
+		if len(u.run.tu.b.Requests()) >= u.run.tu.maxBatchSize ||
 			u.run.tu.b.ApproximateMutationBytes() >= u.run.tu.maxBatchByteSize {
 			break
 		}
 	}
 
-	if u.run.tu.currentBatchSize > 0 {
+	if len(u.run.tu.b.Requests()) > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -107,13 +107,13 @@ func (n *upsertNode) processBatch(params runParams) (lastBatch bool, err error) 
 		}
 
 		// Are we done yet with the current batch?
-		if n.run.tw.currentBatchSize >= n.run.tw.maxBatchSize ||
+		if len(n.run.tw.b.Requests()) >= n.run.tw.maxBatchSize ||
 			n.run.tw.b.ApproximateMutationBytes() >= n.run.tw.maxBatchByteSize {
 			break
 		}
 	}
 
-	if n.run.tw.currentBatchSize > 0 {
+	if len(n.run.tw.b.Requests()) > 0 {
 		if !lastBatch {
 			// We only run/commit the batch if there were some rows processed
 			// in this batch.


### PR DESCRIPTION
The comment for MaxBatchSize indicates it limits the max number of entries in KV batches used for mutations. However, it's actually coded to limit the max number of logical SQL rows that are modified in a KV batch. This can be much smaller than the max number of KV entries, depending on the number of indexes on the mutated table.

This commit updates the code to match the comment, limiting the max number of KV entries rather than the number of logical SQL rows. This also makes the code consistent with MaxBatchByteSize, which limits the max number of bytes in KV batches.

Epic: None

Release note: None