### PR TITLE
restore: fix retry revert stuck in reverting

### DIFF
--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -90,6 +90,10 @@ type BackupRestoreTestingKnobs struct {
 	// AfterAddRemoteSST is called after a remote SST is linked to pebble during
 	// the link phase of online restore.
 	AfterAddRemoteSST func() error
+
+	// AfterRevertRestoreDropDescriptors is called after a reverting restore
+	// drops its descriptors.
+	AfterRevertRestoreDropDescriptors func() error
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
Previously, if a reverting restore job was paused after dropping its descriptors and then resumed, the restore job would get stuck in a retry loop due to missing descriptors.

This commit adds a field in the restore details that can be set once descriptors have been dropped during restore cleanup. This allows us to avoid attempting to drop descriptors if they have already been dropped.

Fixes: #156019

Release note: Restore no longer gets stuck in a retry loop when reverts are attempted twice.