### PR TITLE
changfeedccl: add kafka client linger 

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -219,6 +219,7 @@ go_test(
         "event_processing_test.go",
         "fetch_table_bytes_test.go",
         "helpers_test.go",
+        "kafka_client_changefeed_bench_test.go",
         "main_test.go",
         "nemeses_test.go",
         "parquet_test.go",

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -204,6 +204,7 @@ go_test(
     size = "enormous",
     srcs = [
         "alter_changefeed_test.go",
+        "benchfeed_test.go",
         "changefeed_dist_test.go",
         "changefeed_job_info_test.go",
         "changefeed_memory_test.go",

--- a/pkg/ccl/changefeedccl/benchfeed_test.go
+++ b/pkg/ccl/changefeedccl/benchfeed_test.go
@@ -1,0 +1,360 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/mocks"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/golang/mock/gomock"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+var _ Sink = (*fakeKafkaSinkV2)(nil)
+var _ SinkWithTopics = (*fakeKafkaSinkV2)(nil)
+
+// Dial implements Sink interface. We use it to initialize the fake kafka sink,
+// since the test framework doesn't use constructors. We set up our mocks to
+// feed records into the channel that the wrapper can read from.
+func (s *fakeKafkaSinkV2Bench) Dial() error {
+	bs := s.batchingSink
+	kc := bs.client.(*kafkaSinkClientV2)
+	s.ctrl = gomock.NewController(s.t)
+	s.client = mocks.NewMockKafkaClientV2(s.ctrl)
+	s.client.EXPECT().ProduceSync(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msgs ...*kgo.Record) kgo.ProduceResults {
+		for _, m := range msgs {
+			var key sarama.Encoder
+			if m.Key != nil {
+				key = sarama.ByteEncoder(m.Key)
+			}
+
+			var headers []sarama.RecordHeader
+			for _, h := range m.Headers {
+				headers = append(headers, sarama.RecordHeader{
+					Key:   []byte(h.Key),
+					Value: h.Value,
+				})
+			}
+
+			select {
+			case <-ctx.Done():
+				return kgo.ProduceResults{kgo.ProduceResult{Err: ctx.Err()}}
+			case s.feedCh <- &sarama.ProducerMessage{
+				Topic:     m.Topic,
+				Key:       key,
+				Value:     sarama.ByteEncoder(m.Value),
+				Partition: m.Partition,
+				Headers:   headers,
+			}:
+			}
+		}
+		return nil
+	}).AnyTimes()
+	s.client.EXPECT().Close().AnyTimes()
+
+	kc.client.Close()
+	kc.client = s.client
+
+	s.adminClient = mocks.NewMockKafkaAdminClientV2(s.ctrl)
+	s.adminClient.EXPECT().ListTopics(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, topics ...string) (kadm.TopicDetails, error) {
+		// Say each topic has one partition and one replica.
+		td := kadm.TopicDetails{}
+		for _, topic := range topics {
+			td[topic] = kadm.TopicDetail{
+				Topic: topic,
+				Partitions: map[int32]kadm.PartitionDetail{
+					0: {Topic: topic, Partition: 0, Leader: 0, Replicas: []int32{0}, ISR: []int32{0}},
+				},
+			}
+		}
+		return td, nil
+	}).AnyTimes()
+	kc.adminClient = s.adminClient
+
+	return bs.Dial()
+}
+
+type fakeKafkaSinkV2Bench struct {
+	*batchingSink
+	// For compatibility with all the other fakeKafka test stuff, we convert kgo Records to sarama messages.
+	// TODO(#126991): clean this up when we remove the v1 sink.
+	feedCh      chan *sarama.ProducerMessage
+	t           *testing.B
+	ctrl        *gomock.Controller
+	client      *mocks.MockKafkaClientV2
+	adminClient *mocks.MockKafkaAdminClientV2
+}
+
+type benchmarkMetrics struct {
+	mu         syncutil.Mutex
+	latencies  []time.Duration
+	batchSizes []int
+	msgCount   int
+	startTime  time.Time
+
+	// Computed metrics
+	throughput float64
+	p50Latency time.Duration
+	p95Latency time.Duration
+	p99Latency time.Duration
+}
+
+func (m *benchmarkMetrics) updateMsgCount(count int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.msgCount += count
+}
+
+func (m *benchmarkMetrics) recordLatency(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.latencies = append(m.latencies, d)
+}
+
+var _ cdctest.TestFeedFactory = (*kafkaBenchFeedFactory)(nil)
+
+// Primary benchmark factory type
+type kafkaBenchFeedFactory struct {
+	enterpriseFeedFactory
+	knobs *sinkKnobs
+	b     *testing.B
+}
+
+var _ cdctest.TestFeed = (*kafkaFeed)(nil)
+
+// Benchmark-specific feed implementation
+type kafkaBenchFeed struct {
+	*jobFeed
+	seenTrackerMap
+	source   chan *sarama.ProducerMessage
+	tg       *teeGroup
+	registry *cdctest.SchemaRegistry
+	metrics  *benchmarkMetrics // Benchmark-specific
+}
+
+var _ cdctest.TestFeedFactory = (*kafkaFeedFactory)(nil)
+
+// makeKafkaFeedFactory returns a TestFeedFactory implementation using the `kafka` uri.
+func makeKafkaBenchFeedFactory(
+	t *testing.B, srvOrCluster interface{}, rootDB *gosql.DB,
+) cdctest.TestFeedFactory {
+	return makeKafkaFeedFactoryWithConnectionCheckForBench(t, srvOrCluster, rootDB, false)
+}
+
+func makeKafkaFeedFactoryWithConnectionCheckForBench(
+	t *testing.B, srvOrCluster interface{}, rootDB *gosql.DB, forceKafkaV1ConnectionCheck bool,
+) cdctest.TestFeedFactory {
+	s, injectables := getInjectables(srvOrCluster)
+	return &kafkaBenchFeedFactory{
+		knobs: &sinkKnobs{
+			bypassKafkaV1ConnectionCheck: !forceKafkaV1ConnectionCheck,
+		},
+		enterpriseFeedFactory: enterpriseFeedFactory{
+			s:      s,
+			db:     rootDB,
+			rootDB: rootDB,
+			di:     newDepInjector(injectables...),
+		},
+		b: t,
+	}
+}
+
+func (k *kafkaBenchFeedFactory) Feed(create string, args ...interface{}) (cdctest.TestFeed, error) {
+	parsed, err := parser.ParseOne(create)
+	if err != nil {
+		return nil, err
+	}
+	createStmt := parsed.AST.(*tree.CreateChangefeed)
+
+	// Set SinkURI if it wasn't provided.  It's okay if it is -- since we may
+	// want to set some kafka specific URI parameters.
+	defaultURI := fmt.Sprintf("%s://does.not.matter/", changefeedbase.SinkSchemeKafka)
+	if err := setURI(createStmt, defaultURI, true, &args); err != nil {
+		return nil, err
+	}
+
+	var registry *cdctest.SchemaRegistry
+	for _, opt := range createStmt.Options {
+		if opt.Key == changefeedbase.OptFormat {
+			format, err := exprAsString(opt.Value)
+			if err != nil {
+				return nil, err
+			}
+			if format == string(changefeedbase.OptFormatAvro) {
+				// Must use confluent schema registry so that we register our schema
+				// in order to be able to decode kafka messages.
+				registry = cdctest.StartTestSchemaRegistry()
+				registryOption := tree.KVOption{
+					Key:   changefeedbase.OptConfluentSchemaRegistry,
+					Value: tree.NewStrVal(registry.URL()),
+				}
+				createStmt.Options = append(createStmt.Options, registryOption)
+				break
+			}
+		}
+	}
+
+	tg := newTeeGroup()
+	// feedCh must have some buffer to hold the messages.
+	// basically, sarama is fully async, so we have to be async as well; otherwise, tests deadlock.
+	// Fixed sized buffer is probably okay at this point, but we should probably
+	// have  a proper fix.
+	feedCh := make(chan *sarama.ProducerMessage, 1024)
+	wrapSink := func(s Sink) Sink {
+		if KafkaV2Enabled.Get(&k.s.ClusterSettings().SV) {
+			return &fakeKafkaSinkV2Bench{
+				batchingSink: s.(*batchingSink),
+				feedCh:       feedCh,
+				t:            k.b,
+			}
+		}
+
+		return &fakeKafkaSink{
+			Sink:   s,
+			tg:     tg,
+			feedCh: feedCh,
+			knobs:  k.knobs,
+		}
+	}
+
+	c := &kafkaBenchFeed{
+		jobFeed:        newJobFeed(k.jobsTableConn(), wrapSink),
+		seenTrackerMap: make(map[string]struct{}),
+		source:         feedCh,
+		tg:             tg,
+		registry:       registry,
+		metrics: &benchmarkMetrics{
+			startTime:  timeutil.Now(),
+			latencies:  make([]time.Duration, 0),
+			batchSizes: make([]int, 0),
+		},
+	}
+
+	if err := k.startFeedJob(c.jobFeed, tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...); err != nil {
+		return nil, errors.CombineErrors(err, c.Close())
+	}
+	return c, nil
+}
+
+// Server implements TestFeedFactory
+func (k *kafkaBenchFeedFactory) Server() serverutils.ApplicationLayerInterface {
+	return k.s
+}
+
+// Next implements TestFeed
+func (k *kafkaBenchFeed) Next() (*cdctest.TestFeedMessage, error) {
+	start := timeutil.Now()
+	defer func() {
+		k.metrics.mu.Lock()
+		k.metrics.latencies = append(k.metrics.latencies, timeutil.Since(start))
+		k.metrics.msgCount++
+		k.metrics.mu.Unlock()
+	}()
+
+	for {
+		var msg *sarama.ProducerMessage
+		if err := timeutil.RunWithTimeout(
+			context.Background(), timeoutOp("kafka.Next", k.jobID), timeout(),
+			func(ctx context.Context) error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-k.shutdown:
+					return k.terminalJobError()
+				case msg = <-k.source:
+					return nil
+				}
+			},
+		); err != nil {
+			return nil, err
+		}
+
+		fm := &cdctest.TestFeedMessage{
+			Topic:     msg.Topic,
+			Partition: `kafka`, // TODO(yevgeniy): support multiple partitions.
+		}
+
+		decode := func(encoded sarama.Encoder, dest *[]byte) error {
+			// It's a bit weird to use encoder to get decoded bytes.
+			// But it's correct: we produce messages to sarama, and we set
+			// key/value to sarama.ByteEncoder(payload) -- and sarama ByteEncoder
+			// is just the type alias to []byte -- alas, we can't cast it, so just "encode"
+			// it to get back our original byte array.
+			decoded, err := encoded.Encode()
+			if err != nil {
+				return err
+			}
+			if k.registry == nil {
+				*dest = decoded
+			} else {
+				// Convert avro record to json.
+				jsonBytes, err := k.registry.AvroToJSON(decoded)
+				if err != nil {
+					return err
+				}
+				*dest = jsonBytes
+			}
+			return nil
+		}
+
+		if msg.Key == nil {
+			// It's a resolved timestamp
+			if err := decode(msg.Value, &fm.Resolved); err != nil {
+				return nil, err
+			}
+			return fm, nil
+		}
+		// It's a regular message
+		if err := decode(msg.Key, &fm.Key); err != nil {
+			return nil, err
+		}
+		if err := decode(msg.Value, &fm.Value); err != nil {
+			return nil, err
+		}
+
+		for _, h := range msg.Headers {
+			fm.Headers = append(fm.Headers, cdctest.Header{K: string(h.Key), V: h.Value})
+		}
+		slices.SortFunc(fm.Headers, func(a, b cdctest.Header) int { return strings.Compare(a.K, b.K) })
+
+		if isNew := k.markSeen(fm); isNew {
+			return fm, nil
+		}
+	}
+}
+func (k *kafkaBenchFeed) Partitions() []string {
+	// TODO(yevgeniy): Support multiple partitions.
+	return []string{`kafka`}
+}
+
+// Close implements TestFeed interface.
+// GetMetrics returns the current benchmark metrics
+func (k *kafkaBenchFeed) GetMetrics() *benchmarkMetrics {
+	return k.metrics
+}
+
+func (k *kafkaBenchFeed) Close() error {
+	if k.registry != nil {
+		defer k.registry.Close()
+	}
+	return errors.CombineErrors(k.jobFeed.Close(), k.tg.wait())
+}

--- a/pkg/ccl/changefeedccl/kafka_client_changefeed_bench_test.go
+++ b/pkg/ccl/changefeedccl/kafka_client_changefeed_bench_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"net/url"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/pgurlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/lib/pq"
+)
+
+func BenchmarkChangefeedKafkaLinger(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	// Setup test cluster with cleanup verification.
+	cluster, _, cleanup := startTestCluster(b)
+	defer cleanup()
+	s := cluster.Server(1)
+
+	pgURL, cleanup := pgurlutils.PGUrl(b, s.SQLAddr(), b.Name(), url.User(username.RootUser))
+	defer cleanup()
+	pgBase, err := pq.NewConnector(pgURL.String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	connector := pq.ConnectorWithNoticeHandler(pgBase, func(n *pq.Error) {
+	})
+
+	dbWithHandler := gosql.OpenDB(connector)
+	defer dbWithHandler.Close()
+
+	sqlDB := sqlutils.MakeSQLRunner(dbWithHandler)
+
+	sqlDB.Exec(b, `CREATE DATABASE a`)
+	sqlDB.Exec(b, `CREATE TABLE a.bench_table (
+		id INT PRIMARY KEY,
+		val STRING
+	)`)
+
+	// Enable the v2 Kafka sink which supports lingering.
+	sqlDB.Exec(b, `SET CLUSTER SETTING changefeed.new_kafka_sink.enabled = true`)
+
+	testCases := []struct {
+		name     string
+		lingerMs int
+		config   string
+	}{
+		{"NoLinger", 0, ``},
+		{"Linger10ms", 10, `kafka_sink_config='{"ProducerLinger": "1ms"}'`},
+		{"Linger50ms", 50, `kafka_sink_config='{"ProducerLinger": "5ms"}'`},
+		{"Linger100ms", 100, `kafka_sink_config='{"ProducerLinger": "10ms"}'`},
+		{"Linger150ms", 150, `kafka_sink_config='{"ProducerLinger": "50ms"}'`},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			// Reset table before every sub-benchmark run.
+			sqlDB.Exec(b, `DROP TABLE IF EXISTS a.bench_table CASCADE`)
+			sqlDB.Exec(b, `CREATE TABLE a.bench_table (
+				id INT PRIMARY KEY,
+				val STRING
+			)`)
+
+			f := makeKafkaBenchFeedFactory(b, s, dbWithHandler)
+
+			// Create the changefeed with specified linger setting.
+			var createStmt string
+			if tc.config == `` {
+				createStmt = `CREATE CHANGEFEED FOR a.bench_table`
+			} else {
+				createStmt = fmt.Sprintf(`CREATE CHANGEFEED FOR a.bench_table WITH %s`, tc.config)
+			}
+
+			feed := feed(b, f, createStmt)
+			defer closeFeed(b, feed)
+
+			benchFeed := feed.(*kafkaBenchFeed)
+
+			// Track the next ID to use across all iterations.
+			nextID := 1
+
+			b.ResetTimer()
+			const batchSize = 2000
+			for i := 0; i < b.N; i++ {
+				start := timeutil.Now()
+				// Use sequential IDs that never overlap
+				startID := nextID
+				endID := startID + batchSize - 1
+				nextID = endID + 1 // Update for next iteration
+
+				sqlDB.Exec(b, `
+					INSERT INTO a.bench_table (id, val)
+					SELECT generate_series($1, $2), 'test-value'
+				`, startID, endID)
+
+				benchFeed.metrics.recordLatency(timeutil.Since(start))
+				benchFeed.metrics.updateMsgCount(batchSize)
+			}
+
+			metrics := benchFeed.GetMetrics()
+			elapsed := timeutil.Since(metrics.startTime)
+			throughput := float64(metrics.msgCount) / elapsed.Seconds()
+			b.ReportMetric(throughput, "msgs/sec")
+
+			metrics.mu.Lock()
+			sortedLatencies := append([]time.Duration(nil), metrics.latencies...)
+			metrics.mu.Unlock()
+
+			if len(sortedLatencies) > 0 {
+				slices.Sort(sortedLatencies)
+				p50Idx := len(sortedLatencies) * 50 / 100
+				p95Idx := len(sortedLatencies) * 95 / 100
+				p99Idx := len(sortedLatencies) * 99 / 100
+
+				b.ReportMetric(float64(sortedLatencies[p50Idx].Microseconds()), "p50-latency-us")
+				b.ReportMetric(float64(sortedLatencies[p95Idx].Microseconds()), "p95-latency-us")
+				b.ReportMetric(float64(sortedLatencies[p99Idx].Microseconds()), "p99-latency-us")
+			}
+		})
+	}
+}

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -207,6 +207,8 @@ type saramaConfig struct {
 	RequiredAcks string `json:",omitempty"`
 
 	Version string `json:",omitempty"`
+
+	ProducerLinger jsonDuration `json:",omitempty"`
 }
 
 func (c saramaConfig) Validate() error {
@@ -257,6 +259,12 @@ func defaultSaramaConfig() *saramaConfig {
 	// to test this one more before changing it.
 	config.Flush.MaxMessages = 1000
 	config.ClientID = "CockroachDB"
+
+	// The default for ProducerLinger is 0ms. This means 0 latency when messages come in,
+	// but for clients with high througput, it could be beneficial to have some latency to
+	// reduce number of batches and increase performance.
+	config.ProducerLinger = jsonDuration(0)
+
 	return config
 }
 

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -506,6 +506,10 @@ func buildKgoConfig(
 		opts = append(opts, kgo.ClientID(sinkCfg.ClientID))
 	}
 
+	if time.Duration(sinkCfg.ProducerLinger) >= 0 {
+		opts = append(opts, kgo.ProducerLinger(time.Duration(sinkCfg.ProducerLinger)))
+	}
+
 	switch strings.ToUpper(sinkCfg.RequiredAcks) {
 	case ``, `ONE`, `1`: // This is our default.
 		opts = append(opts, kgo.RequiredAcks(kgo.LeaderAck()))

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -332,6 +332,24 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 			},
 		},
 		{
+			name: "producer linger",
+			jsonConfig: map[string]any{
+				"ProducerLinger": "100ms",
+			},
+			expectedOpts: map[string]any{
+				"ProducerLinger": time.Millisecond * 100,
+			},
+		},
+		{
+			name: "producer linger invalid",
+			jsonConfig: map[string]any{
+				"ProducerLinger": "-100ms",
+			},
+			expectedOpts: map[string]any{
+				"ProducerLinger": time.Duration(0),
+			},
+		},
+		{
 			name: "required acks",
 			jsonConfig: map[string]any{
 				"RequiredAcks": "0",

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -710,6 +710,22 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, sarama.KafkaVersion{}, saramaCfg.Version)
 	})
+
+	t.Run("apply parses ProducerLinger", func(t *testing.T) {
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"ProducerLinger": "10ms"}`)
+
+		cfg, err := getSaramaConfig(opts)
+		require.NoError(t, err)
+		require.Equal(t, time.Duration(cfg.ProducerLinger), 10*time.Millisecond)
+	})
+
+	t.Run("apply errors if ProducerLinger is invalid", func(t *testing.T) {
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"ProducerLinger": "invalid"}`)
+
+		_, err := getSaramaConfig(opts)
+		require.Error(t, err)
+	})
+
 	t.Run("apply errors if version is invalid", func(t *testing.T) {
 		opts := changefeedbase.SinkSpecificJSONConfig(`{"version": "invalid"}`)
 


### PR DESCRIPTION
Closes #154039 
**Summary**
Kafka changefeeds could be inefficient due to small batch sizes causing high overhead. 
Solution: Added a configurable ProducerLinger option to kafka_sink_config that allows the Kafka producer to wait and batch messages together before sending, trading slight individual message latency for significantly improved throughput.

**Testing**
Created comprehensive benchmarks (kafka_client_changefeed_bench_test.go) that measure throughput, latency percentiles (p50/p95/p99), and memory usage across different linger settings (0ms to 200ms). Results show significant performance enhancements on longer durations.