### PR TITLE
changefeedccl: changefeed-specific option for num of sink workers

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -51,6 +51,68 @@ func TestOptionsValidations(t *testing.T) {
 	}
 }
 
+func TestNumSinkWorkersOption(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name      string
+		input     map[string]string
+		expected  int64
+		expectErr bool
+	}{
+		{
+			name:      "positive value",
+			input:     map[string]string{"sink_io_workers": "5"},
+			expected:  5,
+			expectErr: false,
+		},
+		{
+			name:      "zero value (default)",
+			input:     map[string]string{"sink_io_workers": "0"},
+			expected:  0,
+			expectErr: false,
+		},
+		{
+			name:      "negative value (disable)",
+			input:     map[string]string{"sink_io_workers": "-1"},
+			expected:  -1,
+			expectErr: false,
+		},
+		{
+			name:      "not set",
+			input:     map[string]string{},
+			expected:  0,
+			expectErr: false,
+		},
+		{
+			name:      "invalid non-integer",
+			input:     map[string]string{"sink_io_workers": "abc"},
+			expected:  0,
+			expectErr: true,
+		},
+		{
+			name:      "invalid float",
+			input:     map[string]string{"sink_io_workers": "3.14"},
+			expected:  0,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			o := MakeStatementOptions(test.input)
+			val, err := o.GetNumSinkWorkers()
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, val)
+			}
+		})
+	}
+}
+
 func TestEncodingOptionsValidations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -258,8 +258,12 @@ func getSink(
 					return nil, err
 				}
 				if KafkaV2Enabled.Get(&serverCfg.Settings.SV) {
+					numWorkers, err := numSinkIOWorkers(serverCfg, opts)
+					if err != nil {
+						return nil, err
+					}
 					return makeKafkaSinkV2(ctx, &changefeedbase.SinkURL{URL: u}, targets, sinkOpts,
-						numSinkIOWorkers(serverCfg), newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
+						numWorkers, newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
 						serverCfg.Settings, metricsBuilder, kafkaSinkV2Knobs{})
 				} else {
 					return makeKafkaSink(ctx, &changefeedbase.SinkURL{URL: u}, targets, sinkOpts, serverCfg.Settings, metricsBuilder)
@@ -282,8 +286,12 @@ func getSink(
 				return nil, err
 			}
 			return validateOptionsAndMakeSink(changefeedbase.WebhookValidOptions, func() (Sink, error) {
+				numWorkers, err := numSinkIOWorkers(serverCfg, opts)
+				if err != nil {
+					return nil, err
+				}
 				return makeWebhookSink(ctx, &changefeedbase.SinkURL{URL: u}, encodingOpts, webhookOpts,
-					numSinkIOWorkers(serverCfg), newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
+					numWorkers, newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
 					metricsBuilder, serverCfg.Settings)
 			})
 		case isPubsubSink(u):
@@ -291,8 +299,12 @@ func getSink(
 			if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok {
 				testingKnobs = knobs
 			}
+			numWorkers, err := numSinkIOWorkers(serverCfg, opts)
+			if err != nil {
+				return nil, err
+			}
 			return makePubsubSink(ctx, u, encodingOpts, opts.GetPubsubConfigJSON(), targets,
-				opts.IsSet(changefeedbase.OptUnordered), numSinkIOWorkers(serverCfg),
+				opts.IsSet(changefeedbase.OptUnordered), numWorkers,
 				newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
 				metricsBuilder, serverCfg.Settings, testingKnobs)
 		case isCloudStorageSink(u):
@@ -446,9 +458,11 @@ type encDatumRowBuffer []rowenc.EncDatumRow
 func (b *encDatumRowBuffer) IsEmpty() bool {
 	return b == nil || len(*b) == 0
 }
+
 func (b *encDatumRowBuffer) Push(r rowenc.EncDatumRow) {
 	*b = append(*b, r)
 }
+
 func (b *encDatumRowBuffer) Pop() rowenc.EncDatumRow {
 	ret := (*b)[0]
 	*b = (*b)[1:]
@@ -745,7 +759,7 @@ func getSinkConfigFromJson(
 ) (batchCfg sinkBatchConfig, retryCfg retry.Options, err error) {
 	retryCfg = defaultRetryConfig()
 
-	var cfg = baseConfig
+	cfg := baseConfig
 	cfg.Retry.Max = jsonMaxRetries(retryCfg.MaxRetries)
 	cfg.Retry.Backoff = jsonDuration(retryCfg.InitialBackoff)
 	if jsonStr != `` {
@@ -802,20 +816,25 @@ func (j *jsonMaxRetries) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func numSinkIOWorkers(cfg *execinfra.ServerConfig) int {
-	numWorkers := changefeedbase.SinkIOWorkers.Get(&cfg.Settings.SV)
-	if numWorkers > 0 {
-		return int(numWorkers)
+func numSinkIOWorkers(
+	cfg *execinfra.ServerConfig, opts changefeedbase.StatementOptions,
+) (int, error) {
+	changefeedWorkers, err := opts.GetNumSinkWorkers()
+	if err != nil {
+		return 0, errors.Wrap(err, "Invalid sink config. num_sink_workers must be an integer")
 	}
 
-	idealNumber := runtime.GOMAXPROCS(0)
-	if idealNumber < 1 {
-		return 1
+	clusterWorkers := changefeedbase.SinkIOWorkers.Get(&cfg.Settings.SV)
+
+	value := int(clusterWorkers)
+	if changefeedWorkers != nil {
+		value = int(*changefeedWorkers)
 	}
-	if idealNumber > 32 {
-		return 32
+	if value <= 0 {
+		value = min(runtime.GOMAXPROCS(0), 32)
 	}
-	return idealNumber
+
+	return value, nil
 }
 
 func newCPUPacerFactory(ctx context.Context, cfg *execinfra.ServerConfig) func() *admission.Pacer {


### PR DESCRIPTION
Previously, the number of SinkIOWorkers could only be defined in cluster-wide setting.

This patch allows to set the number of SinkIOWorkers per changefeed.

If both (cluster-wide, per-changefeed) values are given, the min of the two will be used.

Release note (sql change): The CREATE CHANGEFEED statement was extended with an optional `num_sink_workers` setting that can be used to set the number of SinkIOWorkers per changefeed. Note that the number of workers is capped by the cluster-wide setting if present.

Fixes: #154546