### PR TITLE
sql/inspect: exclude REFCURSOR[] from index consistency comparisons

### DIFF
--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/spanutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -149,9 +148,8 @@ func (c *indexConsistencyCheck) Start(
 		}
 		col := c.tableDesc.PublicColumns()[pos]
 		otherColumns = append(otherColumns, col)
-		if col.GetType().Family() == types.RefCursorFamily {
-			// Refcursor values do not support equality comparison, so we cannot use
-			// them in the join predicates that detect inconsistencies.
+		if !tree.EqCmpAllowedForEquivalentTypes(col.GetType(), col.GetType()) {
+			// We cannot use types in join predicates that don't allow for equality comparisons.
 			return
 		}
 		joinColumns = append(joinColumns, col)

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -514,10 +514,12 @@ subtest end
 subtest refcursor_stored_column
 
 statement ok
-CREATE TABLE refcursor_tbl (id INT PRIMARY KEY, a INT, c REFCURSOR);
+CREATE TABLE refcursor_tbl (id INT PRIMARY KEY, a INT, c REFCURSOR, d REFCURSOR[]);
 
 statement ok
-INSERT INTO refcursor_tbl VALUES (1, 10, 'cursor1'), (2, 20, 'cursor2');
+INSERT INTO refcursor_tbl VALUES
+  (1, 10, 'cursor1', ARRAY['c1a', 'c1b']::REFCURSOR[]),
+  (2, 20, 'cursor2', ARRAY['c2a', 'c2b']::REFCURSOR[]);
 
 # Verify that we cannot index the refcursor. They can only be included
 # in an index as stored columns.
@@ -525,7 +527,10 @@ statement error pq: unimplemented: column c has type refcursor, which is not ind
 CREATE INDEX idx_refcursor ON refcursor_tbl (c);
 
 statement ok
-CREATE INDEX idx_refcursor ON refcursor_tbl (a) STORING (c);
+CREATE INDEX idx_a_c ON refcursor_tbl (a) STORING (c);
+
+statement ok
+CREATE INDEX idx_a_d ON refcursor_tbl (a) STORING (d);
 
 statement ok
 INSPECT TABLE refcursor_tbl WITH OPTIONS INDEX ALL;
@@ -533,7 +538,23 @@ INSPECT TABLE refcursor_tbl WITH OPTIONS INDEX ALL;
 query TI
 SELECT * FROM last_inspect_job;
 ----
-succeeded  1
+succeeded  2
+
+# Test with hash optimization disabled to ensure JOIN-based consistency check works.
+statement ok
+SET CLUSTER SETTING sql.inspect.index_consistency_hash.enabled = false;
+
+statement ok
+INSPECT TABLE refcursor_tbl WITH OPTIONS INDEX ALL;
+
+query TI
+SELECT * FROM last_inspect_job;
+----
+succeeded  2
+
+# Re-enable hash optimization.
+statement ok
+SET CLUSTER SETTING sql.inspect.index_consistency_hash.enabled = true;
 
 statement ok
 DROP TABLE refcursor_tbl;


### PR DESCRIPTION
The index consistency check previously filtered out REFCURSOR columns when constructing join predicates, but failed to do the same for REFCURSOR[] (arrays of cursors). Like REFCURSOR, these cannot be used in comparison operations.

This change ensures that both REFCURSOR and REFCURSOR[] columns are properly excluded from such comparisons.

Informs: #155483
Epic: CRDB-55075
Release note: none