### PR TITLE
catalog/lease: fix race condition with testing knob

### DIFF
--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -61,9 +61,6 @@ type ManagerTestingKnobs struct {
 	// To disable the deletion of orphaned leases at server startup.
 	DisableDeleteOrphanedLeases bool
 
-	// DisableRangeFeedCheckpoint is used to disable rangefeed checkpoints.
-	DisableRangeFeedCheckpoint bool
-
 	// RangeFeedReset channel is closed to indicate that the range feed
 	// has been reset.
 	RangeFeedResetChannel chan struct{}


### PR DESCRIPTION
Previously, the testing knob TestingDisableRangeFeedCheckpoint was read without any mutex, which could lead to a race condition in certain tests as detected by the race detector. To address this, this patch moves the field into the lease manager as an atomic, since testing knobs are copied, so they cannot store mutexes or atomics.

Fixes: #156182

Release note: None