### PR TITLE
workload/changefeed: allow changefeed-cursor

### DIFF
--- a/pkg/workload/changefeeds/BUILD.bazel
+++ b/pkg/workload/changefeeds/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/hlc",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",

--- a/pkg/workload/changefeeds/changefeeds.go
+++ b/pkg/workload/changefeeds/changefeeds.go
@@ -27,6 +27,7 @@ func AddChangefeedToQueryLoad(
 	gen workload.ConnFlagser,
 	dbName string,
 	resolvedTarget time.Duration,
+	cursorStr string,
 	urls []string,
 	reg *histogram.Registry,
 	ql *workload.QueryLoad,
@@ -76,9 +77,10 @@ func AddChangefeedToQueryLoad(
 		return err
 	}
 
-	var cursorStr string
-	if err := conn.QueryRow(ctx, "SELECT cluster_logical_timestamp()").Scan(&cursorStr); err != nil {
-		return err
+	if cursorStr == "" {
+		if err := conn.QueryRow(ctx, "SELECT cluster_logical_timestamp()").Scan(&cursorStr); err != nil {
+			return err
+		}
 	}
 
 	tableNames := strings.Builder{}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -116,6 +116,8 @@ var (
 		"changefeed-max-rate", 0, "Maximum frequency of changefeed ingestion. If 0, no limit.")
 	changefeedResolvedTarget = runFlags.Duration("changefeed-resolved-target", 5*time.Second,
 		"The target frequency of resolved messages. O to disable resolved reporting and accept server defaults.")
+	changefeedCursor = runFlags.String("changefeed-cursor", "",
+		"The cursor to start the changefeed from. If empty, the changefeed will start from the current cluster logical timestamp.")
 )
 
 func init() {
@@ -507,7 +509,7 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 
 			if *changefeed {
 				log.Dev.Infof(ctx, "adding changefeed to query load...")
-				err = changefeeds.AddChangefeedToQueryLoad(ctx, gen.(workload.ConnFlagser), dbName, *changefeedResolvedTarget, urls, reg, &ops)
+				err = changefeeds.AddChangefeedToQueryLoad(ctx, gen.(workload.ConnFlagser), dbName, *changefeedResolvedTarget, *changefeedCursor, urls, reg, &ops)
 				if err != nil && !*tolerateErrors {
 					return errors.Wrapf(err, "failed to initialize changefeed")
 				}


### PR DESCRIPTION
Part of: https://cockroachlabs.atlassian.net/browse/CRDB-55203
Release note: none

---
**workload/changefeed: allow changefeed-cursor**

This commit adds a new option, changefeed-cursor, which allows specifying the
timestamp after which the changefeed should start emitting events and trigger a
catch-up scan. If not specified, the changefeed defaults to using the current
cluster logical timestamp. This helps tests specify catch-up scan behavior.

---
**workload/changefeed: add more logs**
