### PR TITLE
release-24.3: roachtest: relax split test

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -359,7 +359,7 @@ func registerLoadSplits(r registry.Registry) {
 				// The number of splits should be similar to YCSB/A.
 				cpuThreshold:      100 * time.Millisecond, // 1/10th of a CPU per second.
 				minimumRanges:     15,
-				maximumRanges:     40,
+				maximumRanges:     60, // see #156261
 				initialRangeCount: 2,
 				load: ycsbSplitLoad{
 					workload:     "b",


### PR DESCRIPTION
Backport 1/1 commits from #156272 on behalf of @tbg.

----

We can see more splits than the test expected.

Closes https://github.com/cockroachdb/cockroach/issues/156261.

Epic: none

----

Release justification: