### PR TITLE
workload/schemachange: add INSPECT operation to random schema workload

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -145,6 +145,9 @@ const (
 	dropView     // DROP VIEW <view>
 	truncateTable
 
+	// INSPECT ...
+	inspect // INSPECT {TABLE|DATABASE} ...
+
 	// Unimplemented operations. TODO(sql-foundations): Audit and/or implement these operations.
 	// alterDatabaseOwner
 	// alterDatabasePlacement
@@ -206,7 +209,7 @@ const (
 )
 
 func isDMLOpType(t opType) bool {
-	return t == insertRow || t == selectStmt || t == validate
+	return t == insertRow || t == selectStmt || t == validate || t == inspect
 }
 
 var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, error){
@@ -214,6 +217,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	insertRow:  (*operationGenerator).insertRow,
 	selectStmt: (*operationGenerator).selectStmt,
 	validate:   (*operationGenerator).validate,
+	inspect:    (*operationGenerator).inspect,
 
 	// DDL Operations
 	alterDatabaseAddRegion:            (*operationGenerator).addRegion,
@@ -273,6 +277,7 @@ var opWeights = []int{
 	insertRow:  10,
 	selectStmt: 10,
 	validate:   2, // validate twice more often
+	inspect:    1,
 
 	// DDL Operations
 	alterDatabaseAddRegion:            1,
@@ -334,6 +339,7 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	insertRow:  clusterversion.MinSupported,
 	selectStmt: clusterversion.MinSupported,
 	validate:   clusterversion.MinSupported,
+	inspect:    clusterversion.V25_4,
 
 	alterPolicy:                       clusterversion.V25_2,
 	alterTableAddColumn:               clusterversion.MinSupported,

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -66,6 +66,7 @@ func _() {
 	_ = x[dropTrigger-50]
 	_ = x[dropView-51]
 	_ = x[truncateTable-52]
+	_ = x[inspect-53]
 }
 
 func (i opType) String() string {
@@ -176,6 +177,8 @@ func (i opType) String() string {
 		return "dropView"
 	case truncateTable:
 		return "truncateTable"
+	case inspect:
+		return "inspect"
 	default:
 		return "opType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
Adds a new inspect operation to the schema change workload, enabling random generation of INSPECT TABLE and INSPECT DATABASE statements.

Features:
- Support for TABLE/DB targets, AS OF SYSTEM TIME
- Always runs in DETACHED mode so that it can be run inside a transaciton
- Results checked post-run via SHOW INSPECT ERRORS

Errors reported in JSON, consistent with existing workload logs

Closes #155483
Epic: CRDB-55075
Release note: none