### PR TITLE
kvclient: log internal rangefeed errors if no handler is present

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -396,9 +396,10 @@ func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier, resumeWithF
 			errors.HasType(err, &kvpb.MVCCHistoryMutationError{}) {
 			if errCallback := f.onUnrecoverableError; errCallback != nil {
 				errCallback(ctx, err)
+				log.VEventf(ctx, 1, "exiting rangefeed due to internal error: %v", err)
+			} else {
+				log.Dev.Warningf(ctx, "exiting rangefeed because of internal error with no OnInternalError callback: %s", err.Error())
 			}
-
-			log.VEventf(ctx, 1, "exiting rangefeed due to internal error: %v", err)
 			return
 		}
 		if err != nil && ctx.Err() == nil && restartLogEvery.ShouldLog() {


### PR DESCRIPTION
Because of #75610, I find myself occasionally suspicious that some behavior is the result of a failed rangefeed client. This log line may help diagnose such issues.

Informs #75610
Release note: None