### PR TITLE
roachtest: bump jepsen version

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -77,7 +77,7 @@ const jepsenRepo = "https://github.com/cockroachdb/jepsen"
 const repoBranch = "tc-nightly-main"
 
 const gcpPath = "https://storage.googleapis.com/cockroach-jepsen"
-const binaryVersion = "0.1.0-6699eb4-standalone"
+const binaryVersion = "0.1.0-bd82e2e-standalone"
 
 var jepsenNemeses = []struct {
 	name, config string


### PR DESCRIPTION
This patch bumps the jepsen version used in jepsen tests to include a backported fix to prevent a potential deadlock during worker setup in crdb's Jepsen fork.

Epic: none
Fixes: #152140
Release note: None