### PR TITLE
kvserver: use Pebble snapshot for catchup scans

### DIFF
--- a/pkg/backup/backupsink/file_sst_sink.go
+++ b/pkg/backup/backupsink/file_sst_sink.go
@@ -361,7 +361,7 @@ func (s *FileSSTSink) copyPointKeys(ctx context.Context, dataSST []byte) (roachp
 
 	empty := true
 	for iter.SeekGE(storage.MVCCKey{Key: keys.MinKey}); ; iter.Next() {
-		if err := s.pacer.Pace(ctx); err != nil {
+		if _, err := s.pacer.Pace(ctx); err != nil {
 			return nil, err
 		}
 		if valid, err := iter.Valid(); !valid || err != nil {

--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -422,7 +422,7 @@ func compactSpanEntry(
 	scratch = append(scratch, prefix...)
 	iter := sstIter.iter
 	for iter.SeekGE(trimmedStart); ; iter.NextKey() {
-		if err := pacer.Pace(ctx); err != nil {
+		if _, err := pacer.Pace(ctx); err != nil {
 			return err
 		}
 		var key storage.MVCCKey

--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -476,7 +476,7 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 			// TODO(yevgeniy): rework this function: this function should simply
 			// return an error, and not rely on "handleError".
 			// It's hard to reason about this functions correctness otherwise.
-			_ = s.pacer.Pace(ctx)
+			_, _ = s.pacer.Pace(ctx)
 
 			switch r := req.(type) {
 			case *rowEvent:

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -343,7 +343,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 	// Request CPU time to use for event consumption, block if this time is
 	// unavailable. If there is unused CPU time left from the last call to
 	// Pace, then use that time instead of blocking.
-	if err := c.pacer.Pace(ctx); err != nil {
+	if _, err := c.pacer.Pace(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -444,7 +444,7 @@ func (b *SSTBatcher) AddMVCCKeyLDR(ctx context.Context, key storage.MVCCKey, val
 // Keys must be added in order.
 func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key storage.MVCCKey, value []byte) error {
 	// Pace based on admission control before adding the key.
-	if err := b.pacer.Pace(ctx); err != nil {
+	if _, err := b.pacer.Pace(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -841,6 +841,11 @@ func TestWithOnDeleteRange(t *testing.T) {
 		// should be visible, because catchup scans do emit tombstones. The range
 		// tombstone should be ordered after the initial point, but before the foo
 		// catchup point, and the previous values should respect the range tombstones.
+		//
+		// NB: When RaceEnabled=true, the range key will be emitted multiple
+		// times, since CatchUpSnapshot.CatchUpScan recreates the iterator at
+		// every step. These duplications are harmless and are de-duped by
+		// testEvents when printing.
 		require.NoError(t, db.Put(ctx, makeKey(srv.Codec(), "covered"), "covered"))
 		require.NoError(t, db.Put(ctx, makeKey(srv.Codec(), "foo"), "covered"))
 		require.NoError(t, db.DelRangeUsingTombstone(ctx, makeKey(srv.Codec(), "a"), makeKey(srv.Codec(), "z")))

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/bufalloc",
         "//pkg/util/buildutil",

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -244,7 +244,7 @@ func TestBufferedSenderOnOverflowMultiStream(t *testing.T) {
 
 	// Add our stream to the stream manager.
 	sm.RegisteringStream(streamID1)
-	registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+	registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 		sm.NewStream(streamID1, 1 /*rangeID*/))
 	require.True(t, registered)

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -8,20 +8,23 @@ package rangefeed
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 )
 
-// simpleCatchupIter is an extension of SimpleMVCCIterator that allows for the
+// SimpleCatchupIter is an extension of SimpleMVCCIterator that allows for the
 // primary iterator to be implemented using a regular MVCCIterator or a
 // (often) more efficient MVCCIncrementalIterator. When the caller wants to
 // iterate to see older versions of a key, the desire of the caller needs to
@@ -30,84 +33,101 @@ import (
 //     bounds.
 //   - NextIgnoringTime: when it wants to see the next older version even if it
 //     is not within the time bounds.
-type simpleCatchupIter interface {
+type SimpleCatchupIter interface {
 	storage.SimpleMVCCIterator
 	NextIgnoringTime()
 	RangeKeyChangedIgnoringTime() bool
 	RangeKeysIgnoringTime() storage.MVCCRangeKeyStack
 }
 
-type simpleCatchupIterAdapter struct {
-	storage.SimpleMVCCIterator
+// EngSnapshot abstracts an engine snapshot for testing.
+type EngSnapshot interface {
+	Close()
+	NewMVCCIncrementalIterator(
+		context.Context, storage.MVCCIncrementalIterOptions) (SimpleCatchupIter, error)
 }
 
-func (i simpleCatchupIterAdapter) NextIgnoringTime() {
-	i.SimpleMVCCIterator.Next()
+type EngSnapshotAdapter struct {
+	snap storage.Reader
 }
 
-func (i simpleCatchupIterAdapter) RangeKeyChangedIgnoringTime() bool {
-	return i.SimpleMVCCIterator.RangeKeyChanged()
+var _ EngSnapshot = EngSnapshotAdapter{}
+
+func (s EngSnapshotAdapter) Close() {
+	s.snap.Close()
 }
 
-func (i simpleCatchupIterAdapter) RangeKeysIgnoringTime() storage.MVCCRangeKeyStack {
-	return i.SimpleMVCCIterator.RangeKeys()
+func (s EngSnapshotAdapter) NewMVCCIncrementalIterator(
+	ctx context.Context, opts storage.MVCCIncrementalIterOptions,
+) (SimpleCatchupIter, error) {
+	iter, err := storage.NewMVCCIncrementalIterator(ctx, s.snap, opts)
+	if err != nil {
+		return nil, err
+	}
+	return iter, nil
 }
 
-var _ simpleCatchupIter = simpleCatchupIterAdapter{}
-
-// CatchUpIterator is an iterator for catchup-scans.
-type CatchUpIterator struct {
-	simpleCatchupIter
-	close     func()
-	span      roachpb.Span
-	startTime hlc.Timestamp // exclusive
-	pacer     *admission.Pacer
-	OnEmit    func(key, endKey roachpb.Key, ts hlc.Timestamp, vh enginepb.MVCCValueHeader)
+// CatchUpSnapshot is an engine snapshot for catchup-scans.
+type CatchUpSnapshot struct {
+	snap                 EngSnapshot
+	iterOpts             storage.MVCCIncrementalIterOptions
+	close                func()
+	span                 roachpb.Span
+	startTime            hlc.Timestamp // exclusive
+	pacer                *admission.Pacer
+	OnEmit               func(key, endKey roachpb.Key, ts hlc.Timestamp, vh enginepb.MVCCValueHeader)
+	iterRecreateDuration time.Duration
 }
 
-// NewCatchUpIterator returns a CatchUpIterator for the given Reader over the
-// given key/time span. startTime is exclusive.
+// NewCatchUpSnapshot returns a CatchUpSnapshot for the given Engine over the
+// given key/time span, where span represents a global key range. startTime is
+// exclusive.
 //
 // NB: startTime is exclusive, i.e. the first possible event will be emitted at
 // Timestamp.Next().
-func NewCatchUpIterator(
-	ctx context.Context,
-	reader storage.Reader,
+//
+// iterRecreateDuration, if > 0, is the duration after which the
+// MVCCIncrementalIterator should be closed and reopened (see the
+// storage.snapshot.recreate_iter_duration cluster setting for details).
+func NewCatchUpSnapshot(
+	eng storage.Engine,
 	span roachpb.Span,
 	startTime hlc.Timestamp,
 	closer func(),
 	pacer *admission.Pacer,
-) (*CatchUpIterator, error) {
-	iter, err := storage.NewMVCCIncrementalIterator(ctx, reader,
-		storage.MVCCIncrementalIterOptions{
-			KeyTypes:  storage.IterKeyTypePointsAndRanges,
-			StartKey:  span.Key,
-			EndKey:    span.EndKey,
-			StartTime: startTime,
-			EndTime:   hlc.MaxTimestamp,
-			// We want to emit intents rather than error
-			// (the default behavior) so that we can skip
-			// over the provisional values during
-			// iteration.
-			IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
-			ReadCategory: fs.RangefeedReadCategory,
-		})
-	if err != nil {
-		return nil, err
+	iterRecreateDuration time.Duration,
+) *CatchUpSnapshot {
+	iterOpts := storage.MVCCIncrementalIterOptions{
+		KeyTypes:  storage.IterKeyTypePointsAndRanges,
+		StartKey:  span.Key,
+		EndKey:    span.EndKey,
+		StartTime: startTime,
+		EndTime:   hlc.MaxTimestamp,
+		// We want to emit intents rather than error
+		// (the default behavior) so that we can skip
+		// over the provisional values during
+		// iteration.
+		IntentPolicy: storage.MVCCIncrementalIterIntentPolicyEmit,
+		ReadCategory: fs.RangefeedReadCategory,
 	}
-	return &CatchUpIterator{
-		simpleCatchupIter: iter,
-		close:             closer,
-		span:              span,
-		startTime:         startTime,
-		pacer:             pacer,
-	}, nil
+	// TODO(sumeer): create a snapshot over span and the lock table spans
+	// derived from it.
+	snap := eng.NewSnapshot()
+	return &CatchUpSnapshot{
+		snap:                 EngSnapshotAdapter{snap},
+		iterOpts:             iterOpts,
+		close:                closer,
+		span:                 span,
+		startTime:            startTime,
+		pacer:                pacer,
+		iterRecreateDuration: iterRecreateDuration,
+	}
 }
 
 // Close closes the iterator and calls the instantiator-supplied close
 // callback.
-func (i *CatchUpIterator) Close() {
-	i.simpleCatchupIter.Close()
+func (i *CatchUpSnapshot) Close() {
+	i.snap.Close()
 	i.pacer.Close()
 	if i.close != nil {
 		i.close()
@@ -133,9 +153,13 @@ type outputEventFn func(e *kvpb.RangeFeedEvent) error
 // keys a@6, a@4, and b@2, the emitted order is [a-f)@3,[a-f)@5,a@4,a@6,b@2 because
 // the start key "a" is ordered before all of the timestamped point keys.
 //
-// TODO(sumeer): ctx is not used for SeekGE and Next. Fix by adding a method
-// to SimpleMVCCIterator to replace the context.
-func (i *CatchUpIterator) CatchUpScan(
+// NB: When the iterator is recreated while positioned on a range key, the
+// same range key will be emitted multiple times. This is harmless. The range
+// key bounds are the same even when the seek key is higher than the start of
+// the range key. For example, with a range key [a, z), and iterator bound [d,
+// j), an iterator seeked to d observes range key [d, j), and an iterator
+// seeked to e also observes [d, j).
+func (i *CatchUpSnapshot) CatchUpScan(
 	ctx context.Context,
 	emitFn outputEventFn,
 	withDiff bool,
@@ -182,23 +206,101 @@ func (i *CatchUpIterator) CatchUpScan(
 		reorderBuf = reorderBuf[:0]
 		return nil
 	}
+	iter, err := i.snap.NewMVCCIncrementalIterator(ctx, i.iterOpts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
+	lastIterCreateTime := crtime.NowMono()
 	// Iterate though all keys using Next. We want to publish all committed
 	// versions of each key that are after the registration's startTS, so we
 	// can't use NextKey.
 	var lastKey roachpb.Key
 	var meta enginepb.MVCCMetadata
-	i.SeekGE(storage.MVCCKey{Key: i.span.Key})
+	iter.SeekGE(storage.MVCCKey{Key: i.span.Key})
 
 	for {
-		if ok, err := i.Valid(); err != nil {
+		if ok, err := iter.Valid(); err != nil {
 			return err
 		} else if !ok {
 			break
 		}
 
-		if err := i.pacer.Pace(ctx); err != nil {
+		readmitted, err := i.pacer.Pace(ctx)
+		if err != nil {
 			return err
 		}
+		// Determine whether the iterator moved to a new key.
+		unsafeKey := iter.UnsafeKey()
+		sameKey := bytes.Equal(unsafeKey.Key, lastKey)
+		if !sameKey {
+			// If so, output events for the last key encountered.
+			if err := outputEvents(); err != nil {
+				return err
+			}
+			a, lastKey = a.Copy(unsafeKey.Key)
+			// NB: we only recreate the iterator when we have moved to a new
+			// roachpb.Key. This is because we will need to reposition the new
+			// iterator using a seek, and the seek respects the time bounds.
+			// Repositioning the iterator using a seek within the different versions
+			// of a roachpb.Key is not desirable since we sometimes want to observe
+			// a version that is outside the time bounds (see the calls to
+			// NextIgnoringTime).
+			recreateIter := false
+			// recreateIter => now is initialized.
+			var now crtime.Mono
+			// We sample the current time only when readmitted is true, to avoid
+			// doing it in every iteration of the loop. In practice, readmitted is
+			// true after every 100ms of cpu time, and there is no wall time limit
+			// on how long one can wait in Pace. So there is a risk that the
+			// iterator recreation is arbitrarily delayed. But we accept that risk
+			// for now. The alternative would be to pass a context with a timeout to
+			// Pace. We also need to consider the CPU cost of recreating the
+			// iterator, and using the cpu time to amortize that cost seems
+			// reasonable.
+			if (readmitted && i.iterRecreateDuration > 0) || util.RaceEnabled {
+				// If enough walltime has elapsed, close iter and reopen. This
+				// prevents the iter from holding on to Pebble memtables for too long,
+				// which can cause OOMs.
+				now = crtime.NowMono()
+				recreateIter = now.Sub(lastIterCreateTime) > i.iterRecreateDuration || util.RaceEnabled
+			}
+			if recreateIter {
+				lastIterCreateTime = now
+				iter.Close()
+				iter = nil
+				iter, err = i.snap.NewMVCCIncrementalIterator(ctx, i.iterOpts)
+				if err != nil {
+					return err
+				}
+				// Resume from the same position. NB: we may have arrived at lastKey
+				// using NextIgnoringTime() in the previous iteration of this loop,
+				// and so lastKey may have a MVCC timestamp that is outside the time
+				// window. So the following seek (which does respect the time window)
+				// may land on a key > lastKey. Which is why we need to potentially
+				// replace lastKey below and to consider the case that the iterator is
+				// exhausted.
+				iter.SeekGE(storage.MVCCKey{Key: lastKey})
+				if ok, err := iter.Valid(); err != nil {
+					return err
+				} else if !ok {
+					break
+				}
+				unsafeKey = iter.UnsafeKey()
+				if !bytes.Equal(unsafeKey.Key, lastKey) {
+					// The seek moved past lastKey, so replace lastKey with the new key.
+					a, lastKey = a.Copy(unsafeKey.Key)
+				}
+			}
+		}
+		// Any stepping of the iterator below will immediately continue, i.e., key
+		// is what we will be processing in this iteration of the loop, and is a
+		// stable roachpb.Key.
+		key := lastKey
 
 		// Emit any new MVCC range tombstones when their start key is encountered.
 		// Range keys can currently only be MVCC range tombstones.
@@ -207,11 +309,11 @@ func (i *CatchUpIterator) CatchUpScan(
 		// NextIgnoringTime() call moved onto an MVCC range tombstone outside of the
 		// time bounds. In this case, HasPointAndRange() will return false,false and
 		// we step forward.
-		if i.RangeKeyChangedIgnoringTime() {
-			hasPoint, hasRange := i.HasPointAndRange()
+		if iter.RangeKeyChangedIgnoringTime() {
+			hasPoint, hasRange := iter.HasPointAndRange()
 			if hasRange {
 				// Emit events for these MVCC range tombstones, in chronological order.
-				rangeKeys := i.RangeKeys()
+				rangeKeys := iter.RangeKeys()
 				for j := rangeKeys.Len() - 1; j >= 0; j-- {
 					var span roachpb.Span
 					a, span.Key = a.Copy(rangeKeys.Bounds.Key)
@@ -239,13 +341,20 @@ func (i *CatchUpIterator) CatchUpScan(
 			// step onto the next key. This may be a point key version at the same key
 			// as the range key's start bound, or a later point/range key.
 			if !hasPoint {
-				i.Next()
+				iter.Next()
 				continue
 			}
 		}
+		// Else since !iter.RangekeyChangedIgnoringTime, we must have stepped to a
+		// new point key.
 
-		unsafeKey := i.UnsafeKey()
-		unsafeValRaw, err := i.UnsafeValue()
+		if util.RaceEnabled {
+			hasPoint, _ := iter.HasPointAndRange()
+			if !hasPoint {
+				return errors.AssertionFailedf("expected point key: %s", iter.UnsafeKey())
+			}
+		}
+		unsafeValRaw, err := iter.UnsafeValue()
 		if err != nil {
 			return err
 		}
@@ -270,23 +379,27 @@ func (i *CatchUpIterator) CatchUpScan(
 			// the time bounds. Using `NextIgnoringTime` on the next line makes sure
 			// that we are guaranteed to validate the version that belongs to the
 			// intent.
-			i.NextIgnoringTime()
+			iter.NextIgnoringTime()
 
-			if ok, err := i.Valid(); err != nil {
+			if ok, err := iter.Valid(); err != nil {
 				return errors.Wrap(err, "iterating to provisional value for intent")
 			} else if !ok {
 				return errors.Errorf("expected provisional value for intent")
 			}
-			if meta.Timestamp.ToTimestamp() != i.UnsafeKey().Timestamp {
+			if meta.Timestamp.ToTimestamp() != iter.UnsafeKey().Timestamp {
 				return errors.Errorf("expected provisional value for intent with ts %s, found %s",
-					meta.Timestamp, i.UnsafeKey().Timestamp)
+					meta.Timestamp, iter.UnsafeKey().Timestamp)
+			}
+			if util.RaceEnabled && !bytes.Equal(key, iter.UnsafeKey().Key) {
+				return errors.AssertionFailedf("expected key %s, and found %s",
+					key, iter.UnsafeKey().Key)
 			}
 			// Now move to the next key of interest. Note that if in the last
 			// iteration of the loop we called `NextIgnoringTime`, the fact that we
 			// hit an intent proves that there wasn't a previous value, so we can
 			// (in fact, have to, to avoid surfacing unwanted keys) unconditionally
 			// enforce time bounds.
-			i.Next()
+			iter.Next()
 			continue
 		}
 
@@ -303,20 +416,9 @@ func (i *CatchUpIterator) CatchUpScan(
 		if ignore && !withDiff {
 			// Skip all the way to the next key.
 			// NB: fast-path to avoid value copy when !r.withDiff.
-			i.NextKey()
+			iter.NextKey()
 			continue
 		}
-
-		// Determine whether the iterator moved to a new key.
-		sameKey := bytes.Equal(unsafeKey.Key, lastKey)
-		if !sameKey {
-			// If so, output events for the last key encountered.
-			if err := outputEvents(); err != nil {
-				return err
-			}
-			a, lastKey = a.Copy(unsafeKey.Key)
-		}
-		key := lastKey
 
 		// INVARIANT: !ignore || withDiff
 		//
@@ -345,7 +447,7 @@ func (i *CatchUpIterator) CatchUpScan(
 						// However, don't emit a value if an MVCC range tombstone existed
 						// between this value and the next one. The RangeKeysIgnoringTime()
 						// call is cheap, no need for caching.
-						rangeKeys := i.RangeKeysIgnoringTime()
+						rangeKeys := iter.RangeKeysIgnoringTime()
 						if rangeKeys.IsEmpty() || !rangeKeys.HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
 							// TODO(sumeer): find out if it is deliberate that we are not populating
 							// PrevValue.Timestamp.
@@ -361,7 +463,7 @@ func (i *CatchUpIterator) CatchUpScan(
 			// remote cluster (non zero originID), and the iterator has opted into
 			// omitting remote values.
 			if (mvccVal.OmitInRangefeeds && withFiltering) || (mvccVal.OriginID != 0 && withOmitRemote) {
-				i.Next()
+				iter.Next()
 				continue
 			}
 
@@ -384,16 +486,16 @@ func (i *CatchUpIterator) CatchUpScan(
 
 		if ignore {
 			// Skip all the way to the next key.
-			i.NextKey()
+			iter.NextKey()
 		} else {
 			// Move to the next version of this key (there may not be one, in which
 			// case it will move to the next key).
 			if withDiff {
 				// Need to see the next version even if it is older than the time
 				// bounds.
-				i.NextIgnoringTime()
+				iter.NextIgnoringTime()
 			} else {
-				i.Next()
+				iter.Next()
 			}
 		}
 	}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -47,13 +47,10 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		func() {
-			iter, err := rangefeed.NewCatchUpIterator(ctx, eng, span, opts.ts, nil, nil)
-			if err != nil {
-				b.Fatal(err)
-			}
-			defer iter.Close()
+			snap := rangefeed.NewCatchUpSnapshot(eng, span, opts.ts, nil, nil, 0)
+			defer snap.Close()
 			counter := 0
-			err = iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
+			err := snap.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
 				counter++
 				return nil
 			}, opts.withDiff, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery)

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -154,12 +154,11 @@ func TestCatchupScan(t *testing.T) {
 		testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
 			testutils.RunTrueAndFalse(t, "withFiltering", func(t *testing.T, withFiltering bool) {
 				span := roachpb.Span{Key: testKey1, EndKey: roachpb.KeyMax}
-				iter, err := NewCatchUpIterator(ctx, eng, span, ts1, nil, nil)
-				require.NoError(t, err)
-				defer iter.Close()
+				snap := NewCatchUpSnapshot(eng, span, ts1, nil, nil, 0)
+				defer snap.Close()
 				var events []kvpb.RangeFeedValue
 				// ts1 here is exclusive, so we do not want the versions at ts1.
-				require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+				require.NoError(t, snap.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 					events = append(events, *e.Val)
 					return nil
 				}, withDiff, withFiltering, false /* withOmitRemote */, noBulkDelivery))
@@ -232,12 +231,12 @@ func TestCatchupScanOriginID(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "withOmitRmote", func(t *testing.T, omitRemote bool) {
 		span := roachpb.Span{Key: a1.Key.Key, EndKey: roachpb.KeyMax}
-		iter, err := NewCatchUpIterator(ctx, eng, span, exclusiveStartTime, nil, nil)
+		snap := NewCatchUpSnapshot(eng, span, exclusiveStartTime, nil, nil, 0)
 		require.NoError(t, err)
-		defer iter.Close()
+		defer snap.Close()
 		var events []kvpb.RangeFeedValue
 		// ts1 here is exclusive, so we do not want the versions at ts1.
-		require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+		require.NoError(t, snap.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 			events = append(events, *e.Val)
 			return nil
 		}, false /* withDiff */, false /* withFiltering */, omitRemote, noBulkDelivery))
@@ -267,11 +266,11 @@ func TestCatchupScanInlineError(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it error.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter, err := NewCatchUpIterator(ctx, eng, span, hlc.Timestamp{}, nil, nil)
+	snap := NewCatchUpSnapshot(eng, span, hlc.Timestamp{}, nil, nil, 0)
 	require.NoError(t, err)
-	defer iter.Close()
+	defer snap.Close()
 
-	err = iter.CatchUpScan(ctx, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery)
+	err = snap.CatchUpScan(ctx, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected inline value")
 }
@@ -313,12 +312,12 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 
 	// Run a catchup scan across the span and watch it succeed.
 	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
-	iter, err := NewCatchUpIterator(ctx, eng, span, tsCutoff, nil, nil)
+	snap := NewCatchUpSnapshot(eng, span, tsCutoff, nil, nil, 0)
 	require.NoError(t, err)
-	defer iter.Close()
+	defer snap.Close()
 
 	keys := map[string]struct{}{}
-	require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+	require.NoError(t, snap.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 		keys[string(e.Val.Key)] = struct{}{}
 		return nil
 	}, true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery))

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -175,10 +175,10 @@ type Processor interface {
 	// events that are consumed concurrently with this call. The channel will be
 	// provided an error when the registration closes.
 	//
-	// The optionally provided "catch-up" iterator is used to read changes from the
+	// The optionally provided "catch-up" snapshot is used to read changes from the
 	// engine which occurred after the provided start timestamp (exclusive). If
-	// this method succeeds, registration must take ownership of iterator and
-	// subsequently close it. If method fails, iterator must be kept intact and
+	// this method succeeds, registration must take ownership of snapshot and
+	// subsequently close it. If method fails, snapshot must be kept intact and
 	// would be closed by caller.
 	//
 	// If the method returns false, the processor will have been stopped, so calling
@@ -191,7 +191,7 @@ type Processor interface {
 		streamCtx context.Context,
 		span roachpb.RSpan,
 		startTS hlc.Timestamp, // exclusive
-		catchUpIter *CatchUpIterator,
+		catchUpSnap *CatchUpSnapshot,
 		withDiff bool,
 		withFiltering bool,
 		withOmitRemote bool,

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -69,7 +69,7 @@ func TestProcessorBasic(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -204,7 +204,7 @@ func TestProcessorBasic(t *testing.T) {
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			true,  /* withDiff */
 			true,  /* withFiltering */
 			false, /* withOmitRemote */
@@ -317,7 +317,7 @@ func TestProcessorBasic(t *testing.T) {
 			r3Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -339,7 +339,7 @@ func TestProcessorBasic(t *testing.T) {
 			r4Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -367,7 +367,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -393,7 +393,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			true,  /* withOmitRemote */
@@ -453,7 +453,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 				r1Stream.ctx,
 				roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 				hlc.Timestamp{WallTime: 1},
-				nil,   /* catchUpIter */
+				nil,   /* catchUpSnap */
 				false, /* withDiff */
 				false, /* withFiltering */
 				false, /* withOmitRemote */
@@ -465,7 +465,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 				r2Stream.ctx,
 				roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
 				hlc.Timestamp{WallTime: 1},
-				nil,   /* catchUpIter */
+				nil,   /* catchUpSnap */
 				false, /* withDiff */
 				false, /* withFiltering */
 				false, /* withOmitRemote */
@@ -563,7 +563,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -621,7 +621,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -704,7 +704,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1020,7 +1020,7 @@ func TestProcessorConcurrentStop(t *testing.T) {
 				defer wg.Done()
 				runtime.Gosched()
 				s := newTestStream()
-				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 					noBulkDelivery,
 					h.toBufferedStreamIfNeeded(s))
@@ -1096,7 +1096,7 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 				// operation is should see is firstIdx.
 				s := newTestStream()
 				regs[s] = firstIdx
-				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 					noBulkDelivery,
 					h.toBufferedStreamIfNeeded(s))
@@ -1157,7 +1157,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 			rStream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1239,7 +1239,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 			rStream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1311,7 +1311,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false, /* withOmitRemote */
@@ -1325,7 +1325,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
-			nil,   /* catchUpIter */
+			nil,   /* catchUpSnap */
 			false, /* withDiff */
 			false, /* withFiltering */
 			false /* withOmitRemote */, noBulkDelivery,
@@ -1497,7 +1497,7 @@ func TestProcessorBackpressure(t *testing.T) {
 
 		// Add a registration.
 		stream := newTestStream()
-		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpIter */
+		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpSnap */
 			false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
 			noBulkDelivery,
 			h.toBufferedStreamIfNeeded(stream))

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -225,7 +225,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 				defer stopper.Stop(ctx)
 				stream := sm.NewStream(sID, rID)
 				sm.RegisteringStream(sID)
-				registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 					stream)
 				require.True(t, registered)
@@ -240,7 +240,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			p, h, stopper := newTestProcessor(t, withRangefeedTestType(rt))
 			defer stopper.Stop(ctx)
 			sm.RegisteringStream(sID)
-			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 				stream)
 			require.True(t, registered)
@@ -256,7 +256,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			p, h, stopper := newTestProcessor(t, withRangefeedTestType(rt))
 			defer stopper.Stop(ctx)
 			sm.RegisteringStream(sID)
-			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 				stream)
 			require.True(t, registered)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -49,7 +49,7 @@ func TestUnbufferedRegWithStreamManager(t *testing.T) {
 	t.Run("register 50 streams", func(t *testing.T) {
 		for id := int64(0); id < 50; id++ {
 			sm.RegisteringStream(id)
-			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpSnap */
 				false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 				sm.NewStream(id, r1))
 			require.True(t, registered)
@@ -145,7 +145,7 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	// Register one stream.
 	sm.RegisteringStream(s1)
 	registered, d, _ := p.Register(ctx, h.span, startTs,
-		makeCatchUpIterator(catchUpIter, span, startTs), /* catchUpIter */
+		makeCatchUpSnap(catchUpIter, span, startTs), /* catchUpSnap */
 		true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, noBulkDelivery,
 		sm.NewStream(s1, r1))
 	sm.AddStream(s1, d)
@@ -258,11 +258,11 @@ func TestUnbufferedRegOnCatchUpSwitchOver(t *testing.T) {
 			withCatchUpIter(iter)).(*unbufferedRegistration)
 		catchUpReg.publish(ctx, ev1, nil /* alloc */)
 		catchUpReg.Disconnect(kvpb.NewError(nil))
-		require.Nil(t, catchUpReg.mu.catchUpIter)
+		require.Nil(t, catchUpReg.mu.catchUpSnap)
 		// Catch up scan should not be initiated.
 		go catchUpReg.runOutputLoop(ctx, 0)
 		require.NoError(t, catchUpReg.waitForCaughtUp(ctx))
-		require.Nil(t, catchUpReg.mu.catchUpIter)
+		require.Nil(t, catchUpReg.mu.catchUpSnap)
 		// No events should be sent since the registration has catch up buffer and
 		// is disconnected before catch up scan starts.
 		require.Nil(t, s.GetAndClearEvents())

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -756,7 +756,7 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		// reflect our prior determination of the scan's priority, so this call to
 		// Pace() should be explicitly conditional on Pacer's non-nilness.
 		if cf.pacer != nil {
-			if err := cf.pacer.Pace(ctx); err != nil {
+			if _, err := cf.pacer.Pace(ctx); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -594,7 +594,7 @@ func runParallelImport(
 		var numSkipped int64
 		var count int64
 		for producer.Scan() {
-			if err := pacer.Pace(ctx); err != nil {
+			if _, err := pacer.Pace(ctx); err != nil {
 				return err
 			}
 			// Skip rows if needed.
@@ -712,7 +712,7 @@ func (p *parallelImporter) importWorker(
 		for batchIdx, record := range batch.data {
 			rowNum = batch.startPos + int64(batchIdx)
 			// Pace the admission control before processing each row.
-			if err := pacer.Pace(ctx); err != nil {
+			if _, err := pacer.Pace(ctx); err != nil {
 				return err
 			}
 

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -275,7 +275,7 @@ func (w *WorkloadKVConverter) Worker(
 		a = a.Truncate()
 		w.rows.FillBatch(batchIdx, cb, &a)
 		for rowIdx, numRows := 0, cb.Length(); rowIdx < numRows; rowIdx++ {
-			if err := pacer.Pace(ctx); err != nil {
+			if _, err := pacer.Pace(ctx); err != nil {
 				return err
 			}
 			for colIdx, col := range cb.ColVecs() {

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -751,7 +751,7 @@ func (f *txnKVFetcher) maybeAdmitBatchResponse(ctx context.Context, br *kvpb.Bat
 		// TODO(irfansharif): Add tests for the SELECT queries issued by the TTL
 		// to ensure that they have local plans with a single TableReader
 		// processor in multi-node clusters.
-		if err := f.admissionPacer.Pace(ctx); err != nil {
+		if _, err := f.admissionPacer.Pace(ctx); err != nil {
 			return err
 		}
 	} else if f.responseAdmissionQ != nil {

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -345,7 +345,7 @@ func (ib *indexBackfiller) ingestIndexEntries(
 			addedToVectorIndex := false
 			for _, indexEntry := range indexBatch.indexEntries {
 				// Pace the admission control before processing each index entry.
-				if err := pacer.Pace(ctx); err != nil {
+				if _, err := pacer.Pace(ctx); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
The snapshot is used to create an iterator, which is recreated based on the storage.snapshot.recreate_iter_duration cluster setting, which defaults to 20s.

This is mostly plumbing changes, except for catchup_scan.go.

Fixes #133851

Epic: none

Release note (ops change): The cluster setting
storage.snapshot.recreate_iter_duration (default 20s) controls how frequently a long-lived engine iterator, backed by an engine snapshot, will be closed and recreated. Currently, it is only used for iterators used in rangefeed catchup scans.