### PR TITLE
kv/bulk: enable test tenants

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -295,7 +296,7 @@ func TestPebbleEncryption(t *testing.T) {
 		require.NoError(t, batch.PutUnversioned(roachpb.Key("a"), []byte("a")))
 		require.NoError(t, batch.Commit(true))
 		require.NoError(t, db.Flush())
-		require.Equal(t, []byte("a"), storageutils.MVCCGetRaw(t, db, storageutils.PointKey("a", 0)))
+		require.Equal(t, []byte("a"), storageutils.MVCCGetRaw(t, db, storageutils.PointKey(keys.SystemSQLCodec, "a", 0)))
 	}()
 
 	func() {
@@ -320,7 +321,7 @@ func TestPebbleEncryption(t *testing.T) {
 		db, err := storage.Open(ctx, env, settings)
 		require.NoError(t, err)
 		defer db.Close()
-		require.Equal(t, []byte("a"), storageutils.MVCCGetRaw(t, db, storageutils.PointKey("a", 0)))
+		require.Equal(t, []byte("a"), storageutils.MVCCGetRaw(t, db, storageutils.PointKey(keys.SystemSQLCodec, "a", 0)))
 
 		// Flushing should've created a new sstable under the active key.
 		stats, err := db.GetEnvStats()

--- a/pkg/kv/bulk/buffering_adder_test.go
+++ b/pkg/kv/bulk/buffering_adder_test.go
@@ -28,8 +28,9 @@ func TestBufferingAdderMemoryExhaustion(t *testing.T) {
 	// sstbatcher if allocation failed due to memory exhaustion.
 
 	// Start a test server.
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	distSQLSrv := s.DistSQLServer().(*distsql.ServerImpl)
 	bulkAdderFactory := distSQLSrv.ServerConfig.BulkAdder

--- a/pkg/kv/bulk/main_test.go
+++ b/pkg/kv/bulk/main_test.go
@@ -28,15 +28,9 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 
-	defer serverutils.TestingSetDefaultTenantSelectionOverride(
-		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
-	)()
-
 	defer serverutils.TestingGlobalDRPCOption(
 		base.TestDRPCEnabledRandomly,
 	)()
 
-	code := m.Run()
-
-	os.Exit(code)
+	os.Exit(m.Run())
 }

--- a/pkg/testutils/storageutils/kv.go
+++ b/pkg/testutils/storageutils/kv.go
@@ -6,6 +6,7 @@
 package storageutils
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
@@ -26,8 +27,9 @@ func (kvs KVs) MVCCKeyValues() []storage.MVCCKeyValue {
 
 // PointKey creates an MVCCKey for the given string key and timestamp (walltime
 // seconds).
-func PointKey(key string, ts int) storage.MVCCKey {
-	return storage.MVCCKey{Key: roachpb.Key(key), Timestamp: WallTS(ts)}
+func PointKey(codec keys.SQLCodec, key string, ts int) storage.MVCCKey {
+	k := append(append(roachpb.Key(nil), codec.TenantPrefix()...), roachpb.Key(key)...)
+	return storage.MVCCKey{Key: k, Timestamp: WallTS(ts)}
 }
 
 // PointKV creates an MVCCKeyValue for the given string key/value and timestamp
@@ -50,7 +52,7 @@ func PointKVWithLocalTS(key string, ts int, localTS int, value string) storage.M
 		panic(err)
 	}
 	return storage.MVCCKeyValue{
-		Key:   PointKey(key, ts),
+		Key:   PointKey(keys.SystemSQLCodec, key, ts),
 		Value: v,
 	}
 }
@@ -70,7 +72,7 @@ func PointKVWithImportEpoch(
 		panic(err)
 	}
 	return storage.MVCCKeyValue{
-		Key:   PointKey(key, ts),
+		Key:   PointKey(keys.SystemSQLCodec, key, ts),
 		Value: v,
 	}
 }


### PR DESCRIPTION
There is one concerningly looking failure in external-process mode, and it's tracked separately.

Informs: #156329
Epic: None
Release note: None