### PR TITLE
testutils: introduce datadriven test helpers

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2473,6 +2473,7 @@ GO_TARGETS = [
     "//pkg/testutils/bazelcodecover:bazelcodecover",
     "//pkg/testutils/colcontainerutils:colcontainerutils",
     "//pkg/testutils/datapathutils:datapathutils",
+    "//pkg/testutils/dd:dd",
     "//pkg/testutils/diagutils:diagutils",
     "//pkg/testutils/distsqlutils:distsqlutils",
     "//pkg/testutils/docker/docker-fsnotify:docker-fsnotify",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -517,6 +517,7 @@ go_test(
         "//pkg/storage/storageconfig",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/echotest",
         "//pkg/testutils/gossiputil",
         "//pkg/testutils/jobutils",

--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
@@ -99,23 +100,21 @@ func TestConstraintMatcher(t *testing.T) {
 				return b.String()
 
 			case "remove-store":
-				var storeID int
-				d.ScanArgs(t, "store-id", &storeID)
-				cm.removeStore(roachpb.StoreID(storeID))
+				storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")
+				cm.removeStore(storeID)
 				var b strings.Builder
 				printMatcher(&b)
 				return b.String()
 
 			case "store-matches":
-				var storeID int
-				d.ScanArgs(t, "store-id", &storeID)
+				storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")
 				lines := strings.Split(d.Input, "\n")
 				require.Greater(t, 2, len(lines))
 				var cc []roachpb.Constraint
 				if len(lines) == 1 {
 					cc = parseConstraints(t, strings.Fields(strings.TrimSpace(lines[0])))
 				}
-				matches := cm.storeMatches(roachpb.StoreID(storeID), interner.internConstraintsConj(cc))
+				matches := cm.storeMatches(storeID, interner.internConstraintsConj(cc))
 				return fmt.Sprintf("%t", matches)
 
 			case "match-stores":

--- a/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -75,28 +76,26 @@ func TestMeansMemo(t *testing.T) {
 				return ""
 
 			case "store-load":
-				var storeID int
-				d.ScanArgs(t, "store-id", &storeID)
-				sal, ok := storeMap[roachpb.StoreID(storeID)]
+				storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")
+				sal, ok := storeMap[storeID]
 				require.True(t, ok)
 				var cpuLoad, wbLoad, bsLoad int64
 				d.ScanArgs(t, "load", &cpuLoad, &wbLoad, &bsLoad)
 				var cpuCapacity, wbCapacity, bsCapacity int64
 				d.ScanArgs(t, "capacity", &cpuCapacity, &wbCapacity, &bsCapacity)
-				var leaseCountLoad int64
-				d.ScanArgs(t, "secondary-load", &leaseCountLoad)
+				leaseCountLoad := dd.ScanArg[LoadValue](t, d, "secondary-load")
 				sLoad := &storeLoad{
 					reportedLoad: LoadVector{LoadValue(cpuLoad), LoadValue(wbLoad), LoadValue(bsLoad)},
 					capacity: LoadVector{
 						LoadValue(cpuCapacity), LoadValue(wbCapacity), LoadValue(bsCapacity)},
-					reportedSecondaryLoad: SecondaryLoadVector{LoadValue(leaseCountLoad)},
+					reportedSecondaryLoad: SecondaryLoadVector{leaseCountLoad},
 				}
 				for i := range sLoad.capacity {
 					if sLoad.capacity[i] < 0 {
 						sLoad.capacity[i] = UnknownCapacity
 					}
 				}
-				loadProvider.sloads[roachpb.StoreID(storeID)] = storeLoadAndNodeID{
+				loadProvider.sloads[storeID] = storeLoadAndNodeID{
 					nodeID:    sal.NodeID,
 					storeLoad: sLoad,
 				}
@@ -104,15 +103,10 @@ func TestMeansMemo(t *testing.T) {
 				return ""
 
 			case "node-load":
-				var nodeID int
-				d.ScanArgs(t, "node-id", &nodeID)
-				var cpuLoad, cpuCapacity int64
-				d.ScanArgs(t, "cpu-load", &cpuLoad)
-				d.ScanArgs(t, "cpu-capacity", &cpuCapacity)
 				nLoad := &NodeLoad{
-					NodeID:      roachpb.NodeID(nodeID),
-					ReportedCPU: LoadValue(cpuLoad),
-					CapacityCPU: LoadValue(cpuCapacity),
+					NodeID:      dd.ScanArg[roachpb.NodeID](t, d, "node-id"),
+					ReportedCPU: dd.ScanArg[LoadValue](t, d, "cpu-load"),
+					CapacityCPU: dd.ScanArg[LoadValue](t, d, "cpu-capacity"),
 				}
 				loadProvider.nloads[nLoad.NodeID] = nLoad
 				return ""
@@ -157,12 +151,10 @@ func TestMeansMemo(t *testing.T) {
 				return b.String()
 
 			case "get-store-summary":
-				var storeID int
-				d.ScanArgs(t, "store-id", &storeID)
-				var loadSeqNum uint64
-				d.ScanArgs(t, "load-seq-num", &loadSeqNum)
+				storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")
+				loadSeqNum := dd.ScanArg[uint64](t, d, "load-seq-num")
 				loadProvider.returnedLoadSeqNum = loadSeqNum
-				_ = mm.getStoreLoadSummary(context.Background(), mss, roachpb.StoreID(storeID), loadSeqNum)
+				_ = mm.getStoreLoadSummary(context.Background(), mss, storeID, loadSeqNum)
 				rv := loadProvider.b.String()
 				loadProvider.b.Reset()
 				return rv

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/diversity_scoring_memo
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/diversity_scoring_memo
@@ -34,7 +34,7 @@ score-sums:
   locality-str 1:3:: 0.500000
   locality-str 4:5:: 1.000000
 
-existing-replica-localities store-ids=1,2
+existing-replica-localities store-ids=(1,2)
 ----
 replicas:
   =a,=a1
@@ -61,7 +61,7 @@ score-sums:
   locality-str 1:3:: 0.500000
   locality-str 4:5:: 2.000000
 
-existing-replica-localities store-ids=1,3
+existing-replica-localities store-ids=(1,3)
 ----
 replicas:
   =a,=a1

--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/skip",
         "//pkg/util",
         "//pkg/util/allstacks",

--- a/pkg/kv/kvserver/kvflowcontrol/node_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/node_rac2/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/echotest",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/asciitsdb",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -440,8 +441,7 @@ func TestSendTokenWatcher(t *testing.T) {
 				return makeStateString()
 
 			case "cancel":
-				var name string
-				d.ScanArgs(t, "name", &name)
+				name := dd.ScanArg[string](t, d, "name")
 				handle, ok := notifications[name]
 				require.True(t, ok)
 				watcher.CancelHandle(ctx, handle.handle)
@@ -449,8 +449,7 @@ func TestSendTokenWatcher(t *testing.T) {
 				return makeStateString()
 
 			case "tick":
-				var seconds int
-				d.ScanArgs(t, "seconds", &seconds)
+				seconds := dd.ScanArg[int](t, d, "seconds")
 				clock.Advance(time.Duration(seconds) * time.Second)
 				// Sleep to ensure that the tick is processed before proceeding.
 				time.Sleep(20 * time.Millisecond)

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
@@ -64,8 +65,7 @@ func TestTokenTracker(t *testing.T) {
 	datadriven.RunTest(t, "testdata/token_tracker", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "init":
-			var term uint64
-			d.ScanArgs(t, "term", &term)
+			term := dd.ScanArg[uint64](t, d, "term")
 			tracker.Init(term, kvflowcontrol.Stream{})
 			return "ok"
 
@@ -109,8 +109,7 @@ func TestTokenTracker(t *testing.T) {
 		case "untrack":
 			var av AdmittedVector
 			d.ScanArgs(t, "term", &av.Term)
-			var evalTokensGEIndex uint64
-			d.ScanArgs(t, "eval-tokens-ge-index", &evalTokensGEIndex)
+			evalTokensGEIndex := dd.ScanArg[uint64](t, d, "eval-tokens-ge-index")
 			for _, line := range strings.Split(d.Input, "\n") {
 				line = strings.TrimSpace(line)
 				if line == "" {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/server/serverpb",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/close_scheduler_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/close_scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -119,10 +120,7 @@ func TestStreamCloseScheduler(t *testing.T) {
 			return buf.String()
 
 		case "tick":
-			var durationStr string
-			d.ScanArgs(t, "duration", &durationStr)
-			duration, err := time.ParseDuration(durationStr)
-			require.NoError(t, err)
+			duration := dd.ScanArg[time.Duration](t, d, "duration")
 			clock.Advance(duration)
 			// Delay to allow the channel selects to fire.
 			time.Sleep(20 * time.Millisecond)

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/echotest",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/kv/kvserver/split/BUILD.bazel
+++ b/pkg/kv/kvserver/split/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/metric",

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/dd",
         "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -1,4 +1,4 @@
-create-descriptor start=a end=d replicas=[1,2,3]
+create-descriptor start=a end=d replicas=(1,2,3)
 ----
 created descriptor: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 
@@ -8,7 +8,7 @@ created replica: (n1,s1):1
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
 
 # Create an initialized replica this time around.
-create-descriptor start=d end=k replicas=[1,2,3]
+create-descriptor start=d end=k replicas=(1,2,3)
 ----
 created descriptor: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 

--- a/pkg/testutils/dd/BUILD.bazel
+++ b/pkg/testutils/dd/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "dd",
+    srcs = ["dd.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/dd",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_cockroachdb_datadriven//:datadriven"],
+)

--- a/pkg/testutils/dd/dd.go
+++ b/pkg/testutils/dd/dd.go
@@ -1,0 +1,42 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package dd contains utilities enhancing the experience of using the
+// datadriven testing package.
+//
+// TODO(pav-kv): migrate to the datadriven package when widely used.
+package dd
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+// ScanArg is like TestData.ScanArgs, but for a single argument. Requires the
+// argument to be present.
+func ScanArg[T any](t testing.TB, d *datadriven.TestData, key string) T {
+	t.Helper()
+	var val T
+	d.ScanArgs(t, key, &val)
+	return val
+}
+
+// ScanArgOpt is like ScanArg, but it allows the argument to be missing. The
+// returned bool indicates whether it is present.
+func ScanArgOpt[T any](t testing.TB, d *datadriven.TestData, key string) (T, bool) {
+	t.Helper()
+	var val T
+	found := d.MaybeScanArgs(t, key, &val)
+	return val, found
+}
+
+// ScanArgOr is like ScanArg, but it returns the provided default value when the
+// argument is not present.
+func ScanArgOr[T any](t testing.TB, d *datadriven.TestData, key string, def T) T {
+	t.Helper()
+	d.MaybeScanArgs(t, key, &def)
+	return def
+}


### PR DESCRIPTION
This PR introduces 3 trivial helpers for parsing arguments in `datadriven` tests. These cover the vast majority of use-cases and cut the parsing boilerplate in half. See individual commits, separated by package (only sub-packages of `kvserver` at this point).

Examples:

```golang
var (
	rangeID = dd.ScanArg[roachpb.RangeID](t, d, "id") // required
	flag    = dd.ScanArgOr(t, d, "flag", false)       // optional flag
	param   = dd.ScanArgOr[uint32](t, d, "param", 10) // optional, with a default
	ids     = dd.ScanArgOr[[]roachpb.NodeID](t, d, "nodes", nil)  // slice
)

// Optional argument with explicit presence handling.
if str, ok := dd.ScanArgOpt[string](t, d, "key"); ok {
	// do something with str, e.g. parse further
}
```

This PR also simplifies a few places in tests where manual parsing was unnecessary because `datadriven` supports the corresponding types natively (e.g. `time.Duration` and slices).

In many cases, it also removes redundant type conversions, since the right type can be used as the generic parameter from the beginning.

Epic: none
Release note: none