### PR TITLE
roachtest: Fix the kerberos roachtest to AMD64 arch

### DIFF
--- a/pkg/cmd/roachtest/tests/kerberos_connection_stress.go
+++ b/pkg/cmd/roachtest/tests/kerberos_connection_stress.go
@@ -38,7 +38,7 @@ func registerKerberosConnectionStressTest(r registry.Registry) {
 		Name:      "kerberos_connection_stress_test",
 		Owner:     registry.OwnerProductSecurity,
 		Benchmark: true,
-		Cluster:   r.MakeClusterSpec(numNodes, spec.GCEZones(regionUsCentral)),
+		Cluster:   r.MakeClusterSpec(numNodes, spec.GCEZones(regionUsCentral), spec.Arch(spec.OnlyAMD64)),
 		// Cannot be run locally as it is dependent on Linux.
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
* Due to a recent change in #153964, roachtest were run on a randomly chosen architecture.
* However kerberos is not enabled on FIPS arch, hence limiting the arch to only AMD64
* Roachtest was run to validate the success by specifying the arch of the GCE worker.

Fixes: #155631
Epic: CRDB-55521

Release note: None