### PR TITLE
backup: remove schema field from backupTarget struct

### DIFF
--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -692,7 +692,6 @@ func (o RestoreOptions) IsDefault() bool {
 // Only one field may be non-nil.
 type BackupTargetList struct {
 	Databases NameList
-	Schemas   ObjectNamePrefixList
 	Tables    TableAttrs
 	TenantID  TenantID
 }
@@ -702,9 +701,6 @@ func (tl *BackupTargetList) Format(ctx *FmtCtx) {
 	if tl.Databases != nil {
 		ctx.WriteString("DATABASE ")
 		ctx.FormatNode(&tl.Databases)
-	} else if tl.Schemas != nil {
-		ctx.WriteString("SCHEMA ")
-		ctx.FormatNode(&tl.Schemas)
 	} else if tl.TenantID.Specified {
 		ctx.WriteString("VIRTUAL CLUSTER ")
 		ctx.FormatNode(&tl.TenantID)


### PR DESCRIPTION
It is not used by anything, so I'm removing it to prevent confusion.

Epic: none

Release note: none