### PR TITLE
sql/inspect: record spans processed metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -5137,6 +5137,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: jobs.inspect.spans_processed
+      exported_name: jobs_inspect_spans_processed
+      description: Number of spans processed by INSPECT jobs
+      y_axis_label: Spans
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: jobs.key_visualizer.currently_idle
       exported_name: jobs_key_visualizer_currently_idle
       labeled_name: 'jobs{type: key_visualizer, status: currently_idle}'

--- a/pkg/roachprod/agents/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/agents/opentelemetry/cockroachdb_metrics.go
@@ -902,6 +902,7 @@ var cockroachdbMetrics = map[string]string{
     "jobs_inspect_resume_retry_error": "jobs.inspect.resume_retry_error",
     "jobs_inspect_runs": "jobs.inspect.runs",
     "jobs_inspect_runs_with_issues": "jobs.inspect.runs_with_issues",
+    "jobs_inspect_spans_processed": "jobs.inspect.spans_processed",
     "jobs_key_visualizer_currently_idle": "jobs.key_visualizer.currently_idle",
     "jobs_key_visualizer_currently_paused": "jobs.key_visualizer.currently_paused",
     "jobs_key_visualizer_currently_running": "jobs.key_visualizer.currently_running",

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "large"},
         "//conditions:default": {"test.Pool": "default"},
     }),
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/jobs",

--- a/pkg/sql/inspect/inspect_metrics.go
+++ b/pkg/sql/inspect/inspect_metrics.go
@@ -17,6 +17,7 @@ type InspectMetrics struct {
 	Runs           *metric.Counter
 	RunsWithIssues *metric.Counter
 	IssuesFound    *metric.Counter
+	SpansProcessed *metric.Counter
 }
 
 var _ metric.Struct = (*InspectMetrics)(nil)
@@ -43,6 +44,12 @@ var (
 		Measurement: "Issues",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaInspectSpansProcessed = metric.Metadata{
+		Name:        "jobs.inspect.spans_processed",
+		Help:        "Number of spans processed by INSPECT jobs",
+		Measurement: "Spans",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // MakeInspectMetrics instantiates the metrics for INSPECT jobs.
@@ -51,6 +58,7 @@ func MakeInspectMetrics(histogramWindow time.Duration) metric.Struct {
 		Runs:           metric.NewCounter(metaInspectRuns),
 		RunsWithIssues: metric.NewCounter(metaInspectRunsWithIssues),
 		IssuesFound:    metric.NewCounter(metaInspectIssuesFound),
+		SpansProcessed: metric.NewCounter(metaInspectSpansProcessed),
 	}
 }
 


### PR DESCRIPTION
This add a new INSPECT metric to track a counter of the number spans completed. This will be useful to see the rate of progress for INSPECT.

Closes #155484
Epic: CRDB-55075
Release note: none