### PR TITLE
sql: introduce canary full stats rollout and `stats_as_of` session var

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -7,6 +7,7 @@ package catalog
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -878,6 +879,9 @@ type TableDescriptor interface {
 	// security for the table and false if it is no force. When forced is
 	// set the table's RLS policies are enforced even on the table owner.
 	IsRowLevelSecurityForced() bool
+	// GetStatsCanaryWindow returns the canary statistics rollout duration.
+	// See TableDescriptor.StatsCanaryWindow for details.
+	GetStatsCanaryWindow() time.Duration
 }
 
 // MutableTableDescriptor is both a MutableDescriptor and a TableDescriptor.

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -7,6 +7,8 @@
 package tabledesc
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -739,4 +741,9 @@ func (desc *wrapper) IsRowLevelSecurityEnabled() bool {
 // IsRowLevelSecurityForced implements the TableDescriptor interface.
 func (desc *wrapper) IsRowLevelSecurityForced() bool {
 	return desc.RowLevelSecurityForced
+}
+
+// GetStatsCanaryWindow implements the TableDescriptor interface.
+func (desc *wrapper) GetStatsCanaryWindow() time.Duration {
+	return desc.StatsCanaryWindow
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4255,6 +4255,7 @@ sql_safe_updates                                                 off
 ssl                                                              on
 standard_conforming_strings                                      on
 statement_timeout                                                0
+stats_as_of                                                      ·
 streamer_always_maintain_ordering                                off
 streamer_enabled                                                 on
 streamer_head_of_line_only_fraction                              0.8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3207,6 +3207,7 @@ sql_safe_updates                                                 off            
 ssl                                                              on                  NULL      NULL        NULL        string
 standard_conforming_strings                                      on                  NULL      NULL        NULL        string
 statement_timeout                                                0                   NULL      NULL        NULL        string
+stats_as_of                                                      ·                   NULL      NULL        NULL        string
 streamer_always_maintain_ordering                                off                 NULL      NULL        NULL        string
 streamer_enabled                                                 on                  NULL      NULL        NULL        string
 streamer_head_of_line_only_fraction                              0.8                 NULL      NULL        NULL        string
@@ -3456,6 +3457,7 @@ sql_safe_updates                                                 off            
 ssl                                                              on                  NULL  user     NULL      on                  on
 standard_conforming_strings                                      on                  NULL  user     NULL      on                  on
 statement_timeout                                                0                   ms    user     NULL      0s                  0s
+stats_as_of                                                      ·                   NULL  user     NULL      ·                   ·
 streamer_always_maintain_ordering                                off                 NULL  user     NULL      off                 off
 streamer_enabled                                                 on                  NULL  user     NULL      on                  on
 streamer_head_of_line_only_fraction                              0.8                 NULL  user     NULL      0.8                 0.8
@@ -3697,6 +3699,7 @@ sql_safe_updates                                                 NULL    NULL   
 ssl                                                              NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings                                      NULL    NULL     NULL     NULL        NULL
 statement_timeout                                                NULL    NULL     NULL     NULL        NULL
+stats_as_of                                                      NULL    NULL     NULL     NULL        NULL
 streamer_always_maintain_ordering                                NULL    NULL     NULL     NULL        NULL
 streamer_enabled                                                 NULL    NULL     NULL     NULL        NULL
 streamer_head_of_line_only_fraction                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -224,6 +224,7 @@ sql_safe_updates                                                 off
 ssl                                                              on
 standard_conforming_strings                                      on
 statement_timeout                                                0
+stats_as_of                                                      ·
 streamer_always_maintain_ordering                                off
 streamer_enabled                                                 on
 streamer_head_of_line_only_fraction                              0.8

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/util/encoding",
+        "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -205,6 +205,9 @@ type Table interface {
 
 	// Policies returns all the policies defined for this table.
 	Policies() *Policies
+
+	// StatsCanaryWindow returns the canary window size for the table.
+	StatsCanaryWindow() time.Duration
 }
 
 // CheckConstraint represents a check constraint on a table. Check constraints

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",
         "//pkg/util/metamorphic",

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"encoding/binary"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -667,6 +668,9 @@ func (u *unknownTable) IsRowLevelSecurityEnabled() bool { return false }
 
 // IsRowLevelSecurityForced is part of the cat.Table interface
 func (u *unknownTable) IsRowLevelSecurityForced() bool { return false }
+
+// StatsCanaryWindow is part of the cat.Table interface
+func (u *unknownTable) StatsCanaryWindow() time.Duration { return 0 }
 
 // Policies is part of the cat.Table interface.
 func (u *unknownTable) Policies() *cat.Policies { return nil }

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/iterutil",
         "//pkg/util/json",

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -685,8 +685,12 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 
 	statsCanaryWindow := tabMeta.StatsCanaryWindow
 	sd := sb.evalCtx.SessionData()
+	olderThanTs := hlc.MaxTimestamp
+	if asOf := sb.evalCtx.SessionData().StatsAsOf; !asOf.IsEmpty() {
+		olderThanTs = asOf
+	}
 
-	first := cat.FindLatestFullStat(0 /* start */, tab, sd, hlc.MaxTimestamp, true /* inclusive */)
+	first := cat.FindLatestFullStat(0 /* start */, tab, sd, olderThanTs, true /* inclusive */)
 	// If we are going to select the stable stat and there are still more stats,
 	// try to see if we should skip the current full stats and look for the second
 	// most recent full stat.

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -659,6 +661,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 	}
 
 	tab := sb.md.Table(tabID)
+	tabMeta := sb.md.TableMeta(tabID)
 	// Create a mapping from table column ordinals to inverted index column
 	// ordinals. This allows us to do a fast lookup while iterating over all
 	// stats from a statistic's column to any associated inverted columns.
@@ -680,7 +683,27 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 	// Make now and annotate the metadata table with it for next time.
 	stats = &props.Statistics{}
 
-	first := cat.FindLatestFullStat(tab, sb.evalCtx.SessionData())
+	statsCanaryWindow := tabMeta.StatsCanaryWindow
+	sd := sb.evalCtx.SessionData()
+
+	first := cat.FindLatestFullStat(0 /* start */, tab, sd, hlc.MaxTimestamp, true /* inclusive */)
+	// If we are going to select the stable stat and there are still more stats,
+	// try to see if we should skip the current full stats and look for the second
+	// most recent full stat.
+	if statsCanaryWindow > 0 && !sb.evalCtx.UseCanaryStats && first < tab.StatisticCount() {
+		stat := tab.Statistic(first)
+		createdAtTS := hlc.Timestamp{WallTime: stat.CreatedAt().UnixNano()}
+		// If the most recent full stat is within the canary window, try look for the
+		// second most recent full stat who is created strictly earlier than the
+		// current one.
+		if createdAtTS.AddDuration(statsCanaryWindow).After(hlc.Timestamp{WallTime: time.Now().UnixNano()}) {
+			nextFullStatsIdx := cat.FindLatestFullStat(first+1, tab, sd, createdAtTS, false /* inclusive */)
+			if nextFullStatsIdx < tab.StatisticCount() {
+				first = nextFullStatsIdx
+			}
+		}
+	}
+
 	if first >= tab.StatisticCount() {
 		// No statistics.
 		stats.Available = false
@@ -699,13 +722,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 	EachStat:
 		for i := first; i < tab.StatisticCount(); i++ {
 			stat := tab.Statistic(i)
-			if stat.IsPartial() {
-				continue
-			}
-			if stat.IsMerged() && !sb.evalCtx.SessionData().OptimizerUseMergedPartialStatistics {
-				continue
-			}
-			if stat.IsForecast() && !sb.evalCtx.SessionData().OptimizerUseForecasts {
+			if !cat.IsEligibleFullStats(stat, sb.evalCtx.SessionData(), hlc.MaxTimestamp, true /* inclusive */) {
 				continue
 			}
 			if stat.ColumnCount() > 1 && !sb.evalCtx.SessionData().OptimizerUseMultiColStats {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"math"
 	"reflect"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -700,7 +699,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 		// If the most recent full stat is within the canary window, try look for the
 		// second most recent full stat who is created strictly earlier than the
 		// current one.
-		if createdAtTS.AddDuration(statsCanaryWindow).After(hlc.Timestamp{WallTime: time.Now().UnixNano()}) {
+		if createdAtTS.AddDuration(statsCanaryWindow).After(olderThanTs) {
 			nextFullStatsIdx := cat.FindLatestFullStat(first+1, tab, sd, createdAtTS, false /* inclusive */)
 			if nextFullStatsIdx < tab.StatisticCount() {
 				first = nextFullStatsIdx

--- a/pkg/sql/opt/memo/testdata/stats/canary-stats
+++ b/pkg/sql/opt/memo/testdata/stats/canary-stats
@@ -1,0 +1,365 @@
+exec-ddl
+CREATE TABLE sel (a INT PRIMARY KEY) WITH (canary_window = '30s')
+----
+
+# Single stats case: both canary and stable path should use the same stats.
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:00.00000+00:00",
+      "row_count": 20,
+      "distinct_count": 20
+    }
+	]'
+----
+
+opt stats-as-of=(2018-01-01 11:00:10.00000+00:00) canary-stats=true
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=20]
+ ├── key: (1)
+ └── ordering: +1
+
+opt stats-as-of=(2018-01-01 11:00:10.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=20]
+ ├── key: (1)
+ └── ordering: +1
+
+# More than 2 stats available: should only consider the latest 2 stats with different created_at
+# as possible candidates.
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 30
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:00.00000+00:00",
+      "row_count": 20,
+      "distinct_count": 20
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 10:59:40.00000+00:00",
+      "row_count": 10,
+      "distinct_count": 10
+    }
+	]'
+----
+
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=true
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── ordering: +1
+
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=20]
+ ├── key: (1)
+ └── ordering: +1
+
+# Skip over stats with same created_at timestamp when picking for stable stats.
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 30
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 20
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 20
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 10:59:40.00000+00:00",
+      "row_count": 5,
+      "distinct_count": 5
+    }
+	]'
+----
+
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=true
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── ordering: +1
+
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=5]
+ ├── key: (1)
+ └── ordering: +1
+
+# When the only remaining stats is not an eligible full stats, use the latest stats as the stable stats.
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 30
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 20
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 20
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 10:59:40.00000+00:00",
+      "row_count": 5,
+      "distinct_count": 5,
+      "partial_predicate": "(a < 0:::INT8) OR ((a > 8:::INT8) OR (a IS NULL))"
+    }
+	]'
+----
+
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── ordering: +1
+
+# Optimize as of a later timestamp, so that latest stats is out of the
+# canary window, and canary stats has been promoted to stable stats.
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 30
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:00.00000+00:00",
+      "row_count": 20,
+      "distinct_count": 20
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 10:59:40.00000+00:00",
+      "row_count": 10,
+      "distinct_count": 10
+    }
+	]'
+----
+
+opt stats-as-of=(2018-01-01 11:01:30.00000+00:00) canary-stats=true
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── ordering: +1
+
+opt stats-as-of=(2018-01-01 11:01:30.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── ordering: +1
+
+# Test time traveling of stats_as_of.
+opt stats-as-of=(2018-01-01 11:00:20.00000+00:00) canary-stats=true
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=20]
+ ├── key: (1)
+ └── ordering: +1
+
+opt stats-as-of=(2018-01-01 11:00:20.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=10]
+ ├── key: (1)
+ └── ordering: +1
+
+# If travelling way too back in the past so that no stats are valid,
+# both paths should use the fake stats (with rows = 1000).
+opt stats-as-of=(2018-01-01 10:00:00.00000+00:00) canary-stats=true
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=1000]
+ ├── key: (1)
+ └── ordering: +1
+
+opt stats-as-of=(2018-01-01 10:00:00.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=1000]
+ ├── key: (1)
+ └── ordering: +1
+
+# Test that for stable stats, we always pick the last available *full* stats.
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:00.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 30
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 10:00:30.00000+00:00",
+      "row_count": 40,
+      "distinct_count": 40,
+      "partial_predicate": "(a < 0:::INT8) OR ((a > 8:::INT8) OR (a IS NULL))"
+    }
+	]'
+----
+
+opt stats-as-of=(2018-01-01 11:00:20.00000+00:00) canary-stats=false
+SELECT a FROM sel ORDER BY a
+----
+scan sel
+ ├── columns: a:1(int!null)
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── ordering: +1
+
+# Test with a query with multiple tables, with one having canary_window defined but the other not.
+exec-ddl
+CREATE TABLE sel2 (a INT PRIMARY KEY)
+----
+
+exec-ddl
+ALTER TABLE sel2 INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 10,
+      "distinct_count": 10
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:30.00000+00:00",
+      "row_count": 5,
+      "distinct_count": 5
+    }
+	]'
+----
+
+exec-ddl
+ALTER TABLE sel INJECT STATISTICS '[
+    {
+    	"columns": ["a"],
+      "created_at": "2018-01-01 11:00:40.00000+00:00",
+      "row_count": 30,
+      "distinct_count": 30
+    },
+    {
+      "columns": ["a"],
+      "created_at": "2018-01-01 11:00:30.00000+00:00",
+      "row_count": 20,
+      "distinct_count": 20
+    }
+	]'
+----
+
+# Table sel2 doesn't have canary window defined, so we should always use
+# the most recent stats for it, which has 10 rows for sel2.
+# So with canary-stats=false, we should pick stable stats for table sel (rowCount = 20)
+# and the latest stats for table sel2 (rowCount=10).
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=false
+SELECT * FROM sel JOIN sel2 ON sel.a = sel2.a ORDER BY sel.a
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) a:4(int!null)
+ ├── left ordering: +1
+ ├── right ordering: +4
+ ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0]
+ ├── key: (4)
+ ├── fd: (1)==(4), (4)==(1)
+ ├── ordering: +(1|4) [actual: +1]
+ ├── scan sel
+ │    ├── columns: sel.a:1(int!null)
+ │    ├── stats: [rows=20, distinct(1)=20, null(1)=0]
+ │    ├── key: (1)
+ │    └── ordering: +1
+ ├── scan sel2
+ │    ├── columns: sel2.a:4(int!null)
+ │    ├── stats: [rows=10, distinct(4)=10, null(4)=0]
+ │    ├── key: (4)
+ │    └── ordering: +4
+ └── filters (true)
+
+# With canary-stats=true, we should pick the canary stats for table sel
+# (rowCount = 30) and the latest stats for table sel2 (rowCount=10).
+opt stats-as-of=(2018-01-01 11:00:50.00000+00:00) canary-stats=true
+SELECT * FROM sel JOIN sel2 ON sel.a = sel2.a ORDER BY sel.a
+----
+inner-join (merge)
+ ├── columns: a:1(int!null) a:4(int!null)
+ ├── left ordering: +1
+ ├── right ordering: +4
+ ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(4)=10, null(4)=0]
+ ├── key: (4)
+ ├── fd: (1)==(4), (4)==(1)
+ ├── ordering: +(1|4) [actual: +1]
+ ├── scan sel
+ │    ├── columns: sel.a:1(int!null)
+ │    ├── stats: [rows=30, distinct(1)=30, null(1)=0]
+ │    ├── key: (1)
+ │    └── ordering: +1
+ ├── scan sel2
+ │    ├── columns: sel2.a:4(int!null)
+ │    ├── stats: [rows=10, distinct(4)=10, null(4)=0]
+ │    ├── key: (4)
+ │    └── ordering: +4
+ └── filters (true)

--- a/pkg/sql/opt/memo/testdata/stats/histogram-canary-stats
+++ b/pkg/sql/opt/memo/testdata/stats/histogram-canary-stats
@@ -1,0 +1,410 @@
+# Test histogram statistics with canary selection
+exec-ddl
+CREATE TABLE hist_tbl (id INT PRIMARY KEY, score INT, category STRING, price DECIMAL) WITH (canary_window = '25s')
+----
+
+exec-ddl
+ALTER TABLE hist_tbl INJECT STATISTICS '[
+		{
+		  "columns": ["score"],
+			"created_at": "2018-01-01 13:00:20.00000+00:00",
+			"row_count": 2000,
+			"distinct_count": 100,
+			"null_count": 0,
+			"avg_size": 8,
+			"histo_col_type": "INT8",
+			"histo_version": 3,
+			"histo_buckets": [
+				{
+					"num_eq": 20,
+					"num_range": 0,
+					"distinct_range": 0,
+					"upper_bound": "10"
+				},
+				{
+					"num_eq": 50,
+					"num_range": 180,
+					"distinct_range": 18,
+					"upper_bound": "100"
+				},
+				{
+					"num_eq": 30,
+					"num_range": 200,
+					"distinct_range": 20,
+					"upper_bound": "500"
+				},
+				{
+					"num_eq": 40,
+					"num_range": 300,
+					"distinct_range": 30,
+					"upper_bound": "1000"
+				}
+			]
+		},
+		{
+		  "columns": ["category"],
+			"created_at": "2018-01-01 13:00:20.00000+00:00",
+			"row_count": 2000,
+			"distinct_count": 8,
+			"null_count": 5,
+			"avg_size": 20,
+			"histo_col_type": "STRING",
+			"histo_version": 3,
+			"histo_buckets": [
+				{
+					"num_eq": 250,
+					"num_range": 0,
+					"distinct_range": 0,
+					"upper_bound": "electronics"
+				},
+				{
+					"num_eq": 200,
+					"num_range": 300,
+					"distinct_range": 3,
+					"upper_bound": "home"
+				},
+				{
+					"num_eq": 180,
+					"num_range": 150,
+					"distinct_range": 2,
+					"upper_bound": "sports"
+				},
+				{
+					"num_eq": 160,
+					"num_range": 100,
+					"distinct_range": 1,
+					"upper_bound": "toys"
+				}
+			]
+		},
+		{
+		  "columns": ["price"],
+			"created_at": "2018-01-01 13:00:20.00000+00:00",
+			"row_count": 2000,
+			"distinct_count": 500,
+			"null_count": 10,
+			"avg_size": 12,
+			"histo_col_type": "DECIMAL",
+			"histo_version": 3,
+			"histo_buckets": [
+				{
+					"num_eq": 100,
+					"num_range": 0,
+					"distinct_range": 0,
+					"upper_bound": "9.99"
+				},
+				{
+					"num_eq": 80,
+					"num_range": 400,
+					"distinct_range": 100,
+					"upper_bound": "99.99"
+				},
+				{
+					"num_eq": 60,
+					"num_range": 300,
+					"distinct_range": 150,
+					"upper_bound": "999.99"
+				}
+			]
+		},
+    {
+		  "columns": ["score"],
+			"created_at": "2018-01-01 13:00:00.00000+00:00",
+			"row_count": 1800,
+			"distinct_count": 90,
+			"null_count": 0,
+			"avg_size": 8,
+			"histo_col_type": "INT8",
+			"histo_version": 3,
+			"histo_buckets": [
+				{
+					"num_eq": 18,
+					"num_range": 0,
+					"distinct_range": 0,
+					"upper_bound": "10"
+				},
+				{
+					"num_eq": 45,
+					"num_range": 162,
+					"distinct_range": 16,
+					"upper_bound": "100"
+				},
+				{
+					"num_eq": 27,
+					"num_range": 180,
+					"distinct_range": 18,
+					"upper_bound": "500"
+				},
+				{
+					"num_eq": 36,
+					"num_range": 270,
+					"distinct_range": 27,
+					"upper_bound": "1000"
+				}
+			]
+		},
+		{
+		  "columns": ["category"],
+			"created_at": "2018-01-01 13:00:00.00000+00:00",
+			"row_count": 1800,
+			"distinct_count": 7,
+			"null_count": 4,
+			"avg_size": 18,
+			"histo_col_type": "STRING",
+			"histo_version": 3,
+			"histo_buckets": [
+				{
+					"num_eq": 225,
+					"num_range": 0,
+					"distinct_range": 0,
+					"upper_bound": "electronics"
+				},
+				{
+					"num_eq": 180,
+					"num_range": 270,
+					"distinct_range": 3,
+					"upper_bound": "home"
+				},
+				{
+					"num_eq": 162,
+					"num_range": 135,
+					"distinct_range": 2,
+					"upper_bound": "sports"
+				},
+				{
+					"num_eq": 144,
+					"num_range": 90,
+					"distinct_range": 1,
+					"upper_bound": "toys"
+				}
+			]
+		},
+		{
+		  "columns": ["price"],
+			"created_at": "2018-01-01 13:00:00.00000+00:00",
+			"row_count": 1800,
+			"distinct_count": 450,
+			"null_count": 9,
+			"avg_size": 12,
+			"histo_col_type": "DECIMAL",
+			"histo_version": 3,
+			"histo_buckets": [
+				{
+					"num_eq": 90,
+					"num_range": 0,
+					"distinct_range": 0,
+					"upper_bound": "9.99"
+				},
+				{
+					"num_eq": 72,
+					"num_range": 360,
+					"distinct_range": 90,
+					"upper_bound": "99.99"
+				},
+				{
+					"num_eq": 54,
+					"num_range": 270,
+					"distinct_range": 135,
+					"upper_bound": "999.99"
+				}
+			]
+		}
+	]'
+----
+
+# Test histogram-based range queries with canary stats
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=true
+SELECT score FROM hist_tbl WHERE score BETWEEN 50 AND 200
+----
+select
+ ├── columns: score:2(int!null)
+ ├── stats: [rows=490.851, distinct(2)=16.576, null(2)=0]
+ │   histogram(2)=  0  0   101.12  50   49.624 0.50125
+ │                <--- 49 -------- 100 --------- 200 -
+ ├── scan hist_tbl
+ │    ├── columns: score:2(int)
+ │    └── stats: [rows=2000, distinct(2)=100, null(2)=0]
+ │        histogram(2)=  0  20  180  50   200  30   300   40
+ │                     <--- 10 ----- 100 ----- 500 ----- 1000
+ └── filters
+      └── (score:2 >= 50) AND (score:2 <= 200) [type=bool, outer=(2), constraints=(/2: [/50 - /200]; tight)]
+
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=false
+SELECT score FROM hist_tbl WHERE score BETWEEN 50 AND 200
+----
+select
+ ├── columns: score:2(int!null)
+ ├── stats: [rows=441.766, distinct(2)=14.9061, null(2)=0]
+ │   histogram(2)=  0  0   91.011  45   44.662 0.45113
+ │                <--- 49 -------- 100 --------- 200 -
+ ├── scan hist_tbl
+ │    ├── columns: score:2(int)
+ │    └── stats: [rows=1800, distinct(2)=90, null(2)=0]
+ │        histogram(2)=  0  18  162  45   180  27   270   36
+ │                     <--- 10 ----- 100 ----- 500 ----- 1000
+ └── filters
+      └── (score:2 >= 50) AND (score:2 <= 200) [type=bool, outer=(2), constraints=(/2: [/50 - /200]; tight)]
+
+# Test string histogram with equality predicates
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=true
+SELECT category FROM hist_tbl WHERE category = 'electronics'
+----
+select
+ ├── columns: category:3(string!null)
+ ├── stats: [rows=371.747, distinct(3)=1, null(3)=0]
+ │   histogram(3)=  0       250
+ │                <--- 'electronics'
+ ├── fd: ()-->(3)
+ ├── scan hist_tbl
+ │    ├── columns: category:3(string)
+ │    └── stats: [rows=2000, distinct(3)=8, null(3)=5]
+ │        histogram(3)=  0   5    0       250       300   200    150    180     100   160
+ │                     <--- NULL --- 'electronics' ----- 'home' ----- 'sports' ----- 'toys'
+ └── filters
+      └── category:3 = 'electronics' [type=bool, outer=(3), constraints=(/3: [/'electronics' - /'electronics']; tight), fd=()-->(3)]
+
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=false
+SELECT category FROM hist_tbl WHERE category = 'electronics'
+----
+select
+ ├── columns: category:3(string!null)
+ ├── stats: [rows=334.711, distinct(3)=1, null(3)=0]
+ │   histogram(3)=  0       225
+ │                <--- 'electronics'
+ ├── fd: ()-->(3)
+ ├── scan hist_tbl
+ │    ├── columns: category:3(string)
+ │    └── stats: [rows=1800, distinct(3)=7, null(3)=4]
+ │        histogram(3)=  0   4    0       225       270   180    135    162     90   144
+ │                     <--- NULL --- 'electronics' ----- 'home' ----- 'sports' ---- 'toys'
+ └── filters
+      └── category:3 = 'electronics' [type=bool, outer=(3), constraints=(/3: [/'electronics' - /'electronics']; tight), fd=()-->(3)]
+
+# Test decimal histogram with range queries
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=true
+SELECT price FROM hist_tbl WHERE price > 50.0 AND price <= 500.0
+----
+select
+ ├── columns: price:4(decimal!null)
+ ├── immutable
+ ├── stats: [rows=916.873, distinct(4)=123.213, null(4)=0]
+ │   histogram(4)=  0   0    222.18   80    133.34    0
+ │                <--- 50.0 -------- 99.99 -------- 500.0
+ ├── scan hist_tbl
+ │    ├── columns: price:4(decimal)
+ │    └── stats: [rows=2000, distinct(4)=500, null(4)=10]
+ │        histogram(4)=  0   10   0  100   400   80    300    60
+ │                     <--- NULL --- 9.99 ----- 99.99 ----- 999.99
+ └── filters
+      └── (price:4 > 50.0) AND (price:4 <= 500.0) [type=bool, outer=(4), immutable, constraints=(/4: (/50.0 - /500.0]; tight)]
+
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=false
+SELECT price FROM hist_tbl WHERE price > 50.0 AND price <= 500.0
+----
+select
+ ├── columns: price:4(decimal!null)
+ ├── immutable
+ ├── stats: [rows=825.185, distinct(4)=110.992, null(4)=0]
+ │   histogram(4)=  0   0    199.96   72    120    0
+ │                <--- 50.0 -------- 99.99 ----- 500.0
+ ├── scan hist_tbl
+ │    ├── columns: price:4(decimal)
+ │    └── stats: [rows=1800, distinct(4)=450, null(4)=9]
+ │        histogram(4)=  0   9    0   90   360   72    270    54
+ │                     <--- NULL --- 9.99 ----- 99.99 ----- 999.99
+ └── filters
+      └── (price:4 > 50.0) AND (price:4 <= 500.0) [type=bool, outer=(4), immutable, constraints=(/4: (/50.0 - /500.0]; tight)]
+
+# Test combined histogram and non-histogram columns
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=true
+SELECT * FROM hist_tbl WHERE score > 100 AND category LIKE 'h%'
+----
+select
+ ├── columns: id:1(int!null) score:2(int!null) category:3(string!null) price:4(decimal)
+ ├── stats: [rows=259.497, distinct(2)=52, null(2)=0, distinct(3)=1.53618, null(3)=0, distinct(2,3)=79.8815, null(2,3)=0]
+ │   histogram(2)=  0   0   91.052 13.658 136.58 18.21
+ │                <--- 100 -------- 500 --------- 1000
+ │   histogram(3)=  0   0   43.354   200    7.6984   0
+ │                <--- 'h' -------- 'home' -------- 'i'
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan hist_tbl
+ │    ├── columns: id:1(int!null) score:2(int) category:3(string) price:4(decimal)
+ │    ├── stats: [rows=2000, distinct(1)=2000, null(1)=0, distinct(2)=100, null(2)=0, distinct(3)=8, null(3)=5, distinct(2,3)=800, null(2,3)=0]
+ │    │   histogram(2)=  0  20  180  50   200  30   300   40
+ │    │                <--- 10 ----- 100 ----- 500 ----- 1000
+ │    │   histogram(3)=  0   5    0       250       300   200    150    180     100   160
+ │    │                <--- NULL --- 'electronics' ----- 'home' ----- 'sports' ----- 'toys'
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── score:2 > 100 [type=bool, outer=(2), constraints=(/2: [/101 - ]; tight)]
+      └── category:3 LIKE 'h%' [type=bool, outer=(3), constraints=(/3: [/'h' - /'i'); tight)]
+
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=false
+SELECT * FROM hist_tbl WHERE score > 100 AND category LIKE 'h%'
+----
+select
+ ├── columns: id:1(int!null) score:2(int!null) category:3(string!null) price:4(decimal)
+ ├── stats: [rows=233.644, distinct(2)=47, null(2)=0, distinct(3)=1.53618, null(3)=0, distinct(2,3)=72.2006, null(2,3)=0]
+ │   histogram(2)=  0   0   81.98 12.297 122.97 16.396
+ │                <--- 100 ------- 500 --------- 1000
+ │   histogram(3)=  0   0   39.018   180    6.9286   0
+ │                <--- 'h' -------- 'home' -------- 'i'
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── scan hist_tbl
+ │    ├── columns: id:1(int!null) score:2(int) category:3(string) price:4(decimal)
+ │    ├── stats: [rows=1800, distinct(1)=1800, null(1)=0, distinct(2)=90, null(2)=0, distinct(3)=7, null(3)=4, distinct(2,3)=630, null(2,3)=0]
+ │    │   histogram(2)=  0  18  162  45   180  27   270   36
+ │    │                <--- 10 ----- 100 ----- 500 ----- 1000
+ │    │   histogram(3)=  0   4    0       225       270   180    135    162     90   144
+ │    │                <--- NULL --- 'electronics' ----- 'home' ----- 'sports' ---- 'toys'
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4)
+ └── filters
+      ├── score:2 > 100 [type=bool, outer=(2), constraints=(/2: [/101 - ]; tight)]
+      └── category:3 LIKE 'h%' [type=bool, outer=(3), constraints=(/3: [/'h' - /'i'); tight)]
+
+# Test histogram with aggregations
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=true
+SELECT category, count(*), avg(score), max(price) FROM hist_tbl GROUP BY category
+----
+group-by (hash)
+ ├── columns: category:3(string) count:7(int!null) avg:8(decimal) max:9(decimal)
+ ├── grouping columns: category:3(string)
+ ├── stats: [rows=8, distinct(3)=8, null(3)=1]
+ ├── key: (3)
+ ├── fd: (3)-->(7-9)
+ ├── scan hist_tbl
+ │    ├── columns: score:2(int) category:3(string) price:4(decimal)
+ │    └── stats: [rows=2000, distinct(3)=8, null(3)=5]
+ │        histogram(3)=  0   5    0       250       300   200    150    180     100   160
+ │                     <--- NULL --- 'electronics' ----- 'home' ----- 'sports' ----- 'toys'
+ └── aggregations
+      ├── count-rows [as=count_rows:7, type=int]
+      ├── avg [as=avg:8, type=decimal, outer=(2)]
+      │    └── score:2 [type=int]
+      └── max [as=max:9, type=decimal, outer=(4)]
+           └── price:4 [type=decimal]
+
+opt stats-as-of=(2018-01-01 13:00:30.00000+00:00) canary-stats=false
+SELECT category, count(*), avg(score), max(price) FROM hist_tbl GROUP BY category
+----
+group-by (hash)
+ ├── columns: category:3(string) count:7(int!null) avg:8(decimal) max:9(decimal)
+ ├── grouping columns: category:3(string)
+ ├── stats: [rows=7, distinct(3)=7, null(3)=1]
+ ├── key: (3)
+ ├── fd: (3)-->(7-9)
+ ├── scan hist_tbl
+ │    ├── columns: score:2(int) category:3(string) price:4(decimal)
+ │    └── stats: [rows=1800, distinct(3)=7, null(3)=4]
+ │        histogram(3)=  0   4    0       225       270   180    135    162     90   144
+ │                     <--- NULL --- 'electronics' ----- 'home' ----- 'sports' ---- 'toys'
+ └── aggregations
+      ├── count-rows [as=count_rows:7, type=int]
+      ├── avg [as=avg:8, type=decimal, outer=(2)]
+      │    └── score:2 [type=int]
+      └── max [as=max:9, type=decimal, outer=(4)]
+           └── price:4 [type=decimal]

--- a/pkg/sql/opt/memo/testdata/stats/multicol-canary-stats
+++ b/pkg/sql/opt/memo/testdata/stats/multicol-canary-stats
@@ -1,0 +1,237 @@
+# Test multi-column statistics with canary selection
+exec-ddl
+CREATE TABLE multi_col (a INT PRIMARY KEY, b INT, c STRING, d DECIMAL, e BOOL, INDEX ab (a, b)) WITH (canary_window = '20s')
+----
+
+exec-ddl
+ALTER TABLE multi_col INJECT STATISTICS '[
+		{
+		  "columns": ["a"],
+			"created_at": "2018-01-01 12:00:20.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 500,
+			"null_count": 10,
+			"avg_size": 8
+		},
+		{
+		  "columns": ["b"],
+			"created_at": "2018-01-01 12:00:20.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 300,
+			"null_count": 20,
+			"avg_size": 8
+		},
+		{
+		  "columns": ["a", "b"],
+			"created_at": "2018-01-01 12:00:20.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 750,
+			"null_count": 25
+		},
+		{
+		  "columns": ["c"],
+			"created_at": "2018-01-01 12:00:20.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 400,
+			"null_count": 5,
+			"avg_size": 15
+		},
+		{
+		  "columns": ["d"],
+			"created_at": "2018-01-01 12:00:20.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 600,
+			"null_count": 15,
+			"avg_size": 16
+		},
+		{
+		  "columns": ["e"],
+			"created_at": "2018-01-01 12:00:20.00000+00:00",
+			"row_count": 1000,
+			"distinct_count": 2,
+			"null_count": 50,
+			"avg_size": 1
+		},
+    {
+		  "columns": ["a"],
+			"created_at": "2018-01-01 12:00:00.00000+00:00",
+			"row_count": 800,
+			"distinct_count": 400,
+			"null_count": 8,
+			"avg_size": 8
+		},
+		{
+		  "columns": ["b"],
+			"created_at": "2018-01-01 12:00:00.00000+00:00",
+			"row_count": 800,
+			"distinct_count": 240,
+			"null_count": 16,
+			"avg_size": 8
+		},
+		{
+		  "columns": ["a", "b"],
+			"created_at": "2018-01-01 12:00:00.00000+00:00",
+			"row_count": 800,
+			"distinct_count": 600,
+			"null_count": 20
+		},
+		{
+		  "columns": ["c"],
+			"created_at": "2018-01-01 12:00:00.00000+00:00",
+			"row_count": 800,
+			"distinct_count": 320,
+			"null_count": 4,
+			"avg_size": 15
+		},
+		{
+		  "columns": ["d"],
+			"created_at": "2018-01-01 12:00:00.00000+00:00",
+			"row_count": 800,
+			"distinct_count": 480,
+			"null_count": 12,
+			"avg_size": 16
+		},
+		{
+		  "columns": ["e"],
+			"created_at": "2018-01-01 12:00:00.00000+00:00",
+			"row_count": 800,
+			"distinct_count": 2,
+			"null_count": 40,
+			"avg_size": 1
+		}
+	]'
+----
+
+# Test canary stats with single column queries
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=true
+SELECT a FROM multi_col WHERE a > 10
+----
+scan multi_col@ab
+ ├── columns: a:1(int!null)
+ ├── constraint: /1/2: [/11 - ]
+ ├── stats: [rows=333.333, distinct(1)=166.667, null(1)=0]
+ └── key: (1)
+
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=false
+SELECT a FROM multi_col WHERE a > 10
+----
+scan multi_col@ab
+ ├── columns: a:1(int!null)
+ ├── constraint: /1/2: [/11 - ]
+ ├── stats: [rows=266.667, distinct(1)=133.333, null(1)=0]
+ └── key: (1)
+
+# Test canary stats with multi-column queries
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=true
+SELECT a, b FROM multi_col WHERE a > 10 AND b < 100
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── stats: [rows=299.141, distinct(1)=166.667, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=299.141, null(1,2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan multi_col@ab
+ │    ├── columns: a:1(int!null) b:2(int)
+ │    ├── constraint: /1/2: (/11/NULL - ]
+ │    ├── stats: [rows=330.661, distinct(1)=166.667, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── b:2 < 100 [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
+
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=false
+SELECT a, b FROM multi_col WHERE a > 10 AND b < 100
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── stats: [rows=239.53, distinct(1)=133.333, null(1)=0, distinct(2)=80, null(2)=0, distinct(1,2)=239.53, null(1,2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan multi_col@ab
+ │    ├── columns: a:1(int!null) b:2(int)
+ │    ├── constraint: /1/2: (/11/NULL - ]
+ │    ├── stats: [rows=264.662, distinct(1)=133.333, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── b:2 < 100 [type=bool, outer=(2), constraints=(/2: (/NULL - /99]; tight)]
+
+# Test with different data types
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=true
+SELECT c, d, e FROM multi_col WHERE e = true
+----
+select
+ ├── columns: c:3(string) d:4(decimal) e:5(bool!null)
+ ├── stats: [rows=950, distinct(5)=1, null(5)=0]
+ ├── fd: ()-->(5)
+ ├── scan multi_col
+ │    ├── columns: c:3(string) d:4(decimal) e:5(bool)
+ │    └── stats: [rows=1000, distinct(5)=2, null(5)=50]
+ └── filters
+      └── e:5 [type=bool, outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
+
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=false
+SELECT c, d, e FROM multi_col WHERE e = true
+----
+select
+ ├── columns: c:3(string) d:4(decimal) e:5(bool!null)
+ ├── stats: [rows=760, distinct(5)=1, null(5)=0]
+ ├── fd: ()-->(5)
+ ├── scan multi_col
+ │    ├── columns: c:3(string) d:4(decimal) e:5(bool)
+ │    └── stats: [rows=800, distinct(5)=2, null(5)=40]
+ └── filters
+      └── e:5 [type=bool, outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
+
+# Test aggregate operations with multi-column stats
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=true
+SELECT count(*), sum(a), avg(d) FROM multi_col GROUP BY e
+----
+project
+ ├── columns: count:8(int!null) sum:9(decimal!null) avg:10(decimal)
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=2]
+ └── group-by (hash)
+      ├── columns: e:5(bool) count_rows:8(int!null) sum:9(decimal!null) avg:10(decimal)
+      ├── grouping columns: e:5(bool)
+      ├── cardinality: [0 - 3]
+      ├── stats: [rows=2, distinct(5)=2, null(5)=1]
+      ├── key: (5)
+      ├── fd: (5)-->(8-10)
+      ├── scan multi_col
+      │    ├── columns: a:1(int!null) d:4(decimal) e:5(bool)
+      │    ├── stats: [rows=1000, distinct(5)=2, null(5)=50]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4,5)
+      └── aggregations
+           ├── count-rows [as=count_rows:8, type=int]
+           ├── sum [as=sum:9, type=decimal, outer=(1)]
+           │    └── a:1 [type=int]
+           └── avg [as=avg:10, type=decimal, outer=(4)]
+                └── d:4 [type=decimal]
+
+opt stats-as-of=(2018-01-01 12:00:30.00000+00:00) canary-stats=false
+SELECT count(*), sum(a), avg(d) FROM multi_col GROUP BY e
+----
+project
+ ├── columns: count:8(int!null) sum:9(decimal!null) avg:10(decimal)
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=2]
+ └── group-by (hash)
+      ├── columns: e:5(bool) count_rows:8(int!null) sum:9(decimal!null) avg:10(decimal)
+      ├── grouping columns: e:5(bool)
+      ├── cardinality: [0 - 3]
+      ├── stats: [rows=2, distinct(5)=2, null(5)=1]
+      ├── key: (5)
+      ├── fd: (5)-->(8-10)
+      ├── scan multi_col
+      │    ├── columns: a:1(int!null) d:4(decimal) e:5(bool)
+      │    ├── stats: [rows=800, distinct(5)=2, null(5)=40]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4,5)
+      └── aggregations
+           ├── count-rows [as=count_rows:8, type=int]
+           ├── sum [as=sum:9, type=decimal, outer=(1)]
+           │    └── a:1 [type=int]
+           └── avg [as=avg:10, type=decimal, outer=(4)]
+                └── d:4 [type=decimal]

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -788,7 +788,7 @@ func (md *Metadata) AddTable(tab cat.Table, alias *tree.TableName) TableID {
 	if md.tables == nil {
 		md.tables = make([]TableMeta, 0, 4)
 	}
-	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab, Alias: *alias})
+	md.tables = append(md.tables, TableMeta{MetaID: tabID, Table: tab, Alias: *alias, StatsCanaryWindow: tab.StatsCanaryWindow()})
 
 	colCount := tab.ColumnCount()
 	if md.cols == nil {
@@ -909,6 +909,7 @@ func (md *Metadata) DuplicateTable(
 		partialIndexPredicates:        partialIndexPredicates,
 		indexPartitionLocalities:      tabMeta.indexPartitionLocalities,
 		checkConstraintsStats:         checkConstraintsStats,
+		StatsCanaryWindow:             tabMeta.StatsCanaryWindow,
 	}
 	newTabMeta.indexVisibility.cached = tabMeta.indexVisibility.cached
 	newTabMeta.indexVisibility.notVisible = tabMeta.indexVisibility.notVisible

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -8,6 +8,7 @@ package opt
 import (
 	"context"
 	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -214,6 +215,11 @@ type TableMeta struct {
 		cached     *intsets.Fast
 		notVisible *intsets.Fast
 	}
+
+	// StatsCanaryWindow determines the time duration for which a newly collected
+	// stats is in a "canary" state before it is promoted to a stable state.
+	// See TableDescriptor.StatsCanaryWindow for details.
+	StatsCanaryWindow time.Duration
 }
 
 // IsIndexNotVisible returns true if the given index is not visible, and false
@@ -293,6 +299,7 @@ func (tm *TableMeta) copyFrom(from *TableMeta, copyScalarFn func(Expr) Expr) {
 		Alias:                        from.Alias,
 		IgnoreForeignKeys:            from.IgnoreForeignKeys,
 		IgnoreUniqueWithoutIndexKeys: from.IgnoreUniqueWithoutIndexKeys,
+		StatsCanaryWindow:            from.StatsCanaryWindow,
 		// Annotations are not copied.
 	}
 

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/asof",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/volatility",

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/sql/vtable",
+        "//pkg/util/duration",
         "//pkg/util/intsets",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -47,7 +47,12 @@ func (tc *Catalog) AlterTable(stmt *tree.AlterTable) {
 			default:
 				panic(errors.AssertionFailedf("unsupported constraint type %v", d))
 			}
-
+		case *tree.AlterTableSetStorageParams:
+			if canaryWindowExpr := t.StorageParams.GetVal(canaryWindowStorageParamKey); canaryWindowExpr != nil {
+				tab.statsCanaryWindow = getDurationFromStrExpr(canaryWindowExpr)
+			} else {
+				panic(errors.AssertionFailedf("unsupported AlterTableSetStorageParams stmt with storage params: %v", t.StorageParams))
+			}
 		default:
 			panic(errors.AssertionFailedf("unsupported ALTER TABLE command %T", t))
 		}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -922,6 +922,8 @@ type Table struct {
 	rlsForced    bool
 	policies     cat.Policies
 	nextPolicyID descpb.PolicyID
+
+	statsCanaryWindow time.Duration
 }
 
 var _ cat.Table = &Table{}
@@ -1231,6 +1233,9 @@ func (tt *Table) IsRowLevelSecurityEnabled() bool { return tt.rlsEnabled }
 
 // IsRowLevelSecurityForced is part of the cat.Table interface.
 func (tt *Table) IsRowLevelSecurityForced() bool { return tt.rlsForced }
+
+// StatsCanaryWindow is part of the cat.Table interface.
+func (tt *Table) StatsCanaryWindow() time.Duration { return tt.statsCanaryWindow }
 
 // Policies is part of the cat.Table interface.
 func (tt *Table) Policies() *cat.Policies {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -937,6 +937,9 @@ type optTable struct {
 	rlsForced  bool
 	policies   cat.Policies
 
+	// Canary statistics rollout duration.
+	statsCanaryWindow time.Duration
+
 	// colMap is a mapping from unique ColumnID to column ordinal within the
 	// table. This is a common lookup that needs to be fast.
 	colMap catalog.TableColMap
@@ -1219,6 +1222,9 @@ func newOptTable(
 	ot.rlsEnabled = desc.IsRowLevelSecurityEnabled()
 	ot.rlsForced = desc.IsRowLevelSecurityForced()
 	ot.policies = getOptPolicies(desc.GetPolicies())
+
+	// Store canary stats rollout duration.
+	ot.statsCanaryWindow = desc.GetStatsCanaryWindow()
 
 	// Synthesize any check constraints for user defined types.
 	var synthesizedChecks []optCheckConstraint
@@ -1625,6 +1631,11 @@ func (ot *optTable) IsRowLevelSecurityEnabled() bool { return ot.rlsEnabled }
 
 // IsRowLevelSecurityForced is part of the cat.Table interface.
 func (ot *optTable) IsRowLevelSecurityForced() bool { return ot.rlsForced }
+
+// StatsCanaryWindow is part of the cat.Table interface.
+func (ot *optTable) StatsCanaryWindow() time.Duration {
+	return ot.statsCanaryWindow
+}
 
 // Policies is part of the cat.Table interface.
 func (ot *optTable) Policies() *cat.Policies {
@@ -2772,6 +2783,11 @@ func (ot *optVirtualTable) IsRowLevelSecurityEnabled() bool { return false }
 
 // IsRowLevelSecurityForced is part of the cat.Table interface.
 func (ot *optVirtualTable) IsRowLevelSecurityForced() bool { return false }
+
+// StatsCanaryWindow is part of the cat.Table interface.
+func (ot *optVirtualTable) StatsCanaryWindow() time.Duration {
+	return 0
+}
 
 // Policies is part of the cat.Table interface.
 func (ot *optVirtualTable) Policies() *cat.Policies { return nil }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -759,6 +759,10 @@ message LocalOnlySessionData {
   // canary statistics (mode == on), stable statistics (mode == off), or
   // let the system decide based on random selection (mode == auto).
   int64 canary_stats_mode = 193 [(gogoproto.casttype) = "CanaryStatsMode"];
+  // StatsAsOf is an optional timestamp that, when set, stats selection
+  // will be based on the age gap between the stats creation timestamp and
+  // the StatsAsOf timestamp, rather than the current time.
+  util.hlc.Timestamp stats_as_of = 194 [(gogoproto.nullable) = false];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/BUILD.bazel
+++ b/pkg/sql/sessionmutator/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/util/duration",
+        "//pkg/util/hlc",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/redact"
@@ -1109,4 +1110,8 @@ func (m *SessionDataMutator) SetDisableWaitForJobsNotice(val bool) {
 
 func (m *SessionDataMutator) SetCanaryStatsMode(val sessiondatapb.CanaryStatsMode) {
 	m.Data.CanaryStatsMode = val
+}
+
+func (m *SessionDataMutator) SetStatsAsOf(val hlc.Timestamp) {
+	m.Data.StatsAsOf = val
 }


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/150015

Rebased from #156307

Release note: TBD