### PR TITLE
backup: capture function descriptor changes in revision history backups

### DIFF
--- a/pkg/backup/backupinfo/manifest_handling.go
+++ b/pkg/backup/backupinfo/manifest_handling.go
@@ -1158,11 +1158,15 @@ func LoadSQLDescsFromBackupsAtTime(
 		asOf = lastBackupManifest.EndTime
 	}
 
-	for _, b := range backupManifests {
+	// TODO(msbutler): this logic can be removed because we already crop backup
+	// manifests that are too new. Keeping this around in case there is a bug
+	// upstream.
+	for i, b := range backupManifests {
 		if asOf.Less(b.StartTime) {
 			break
 		}
 		lastBackupManifest = b
+		lastIterFactory = layerToBackupManifestFileIterFactory[i]
 	}
 
 	// From this point on we try to load descriptors based on descriptor

--- a/pkg/backup/targets.go
+++ b/pkg/backup/targets.go
@@ -126,10 +126,12 @@ func getRelevantDescChanges(
 		}
 		for _, i := range starting {
 			switch desc := i.(type) {
-			case catalog.TableDescriptor, catalog.TypeDescriptor, catalog.SchemaDescriptor:
+			case catalog.TableDescriptor, catalog.TypeDescriptor, catalog.SchemaDescriptor, catalog.FunctionDescriptor:
 				// We need to add to interestingIDs so that if we later see a delete for
 				// this ID we still know it is interesting to us, even though we will not
 				// have a parentID at that point (since the delete is a nil desc).
+				//
+				// In other words, descriptor exists at start time, but not at end time.
 				if _, ok := interestingParents[desc.GetParentID()]; ok {
 					interestingIDs[desc.GetID()] = struct{}{}
 				}
@@ -159,7 +161,9 @@ func getRelevantDescChanges(
 		} else if change.Desc != nil {
 			desc := backupinfo.NewDescriptorForManifest(change.Desc)
 			switch desc := desc.(type) {
-			case catalog.TableDescriptor, catalog.TypeDescriptor, catalog.SchemaDescriptor:
+			case catalog.TableDescriptor, catalog.TypeDescriptor, catalog.SchemaDescriptor, catalog.FunctionDescriptor:
+				// In other words, does not exist at start or end time, but within the
+				// interval.
 				if _, ok := interestingParents[desc.GetParentID()]; ok {
 					interestingIDs[desc.GetID()] = struct{}{}
 					interestingChanges = append(interestingChanges, change)


### PR DESCRIPTION
Previously, backup would omit grabbing a function descriptor in revision history backups if the function did not exist at the end time or only within the interval. This patch fixes this bug.

Fixes #156206

Release note: none