### PR TITLE
roachtest : log for failed provider init & fail build when no tests are executed

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -62,6 +62,12 @@ go_test(
     embed = [":roachtestutil"],
     deps = [
         "//pkg/cmd/roachtest/option",
+        "//pkg/roachprod",
+        "//pkg/roachprod/vm/aws",
+        "//pkg/roachprod/vm/azure",
+        "//pkg/roachprod/vm/gce",
+        "//pkg/roachprod/vm/ibm",
+        "//pkg/roachprod/vm/local",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -336,3 +336,14 @@ func SimulateMultiRegionCluster(
 
 	return cleanupFunc, nil
 }
+
+// PrintProvidersErrors prints error messages from a map of provider names to
+// errors from roachprod.
+func PrintProvidersErrors(w io.Writer, providersState map[string]string) {
+	for provider, s := range providersState {
+		if s == "Active" || strings.Contains(s, roachprod.RoachprodDisabledProviderMessage) {
+			continue
+		}
+		fmt.Fprintf(w, "Error from cloud provider %s: %s\n", provider, s)
+	}
+}

--- a/pkg/cmd/roachtest/roachtestutil/utils_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils_test.go
@@ -6,11 +6,22 @@
 package roachtestutil
 
 import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/ibm"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCmdLogFileName(t *testing.T) {
@@ -26,4 +37,132 @@ func TestCmdLogFileName(t *testing.T) {
 		exp,
 		cmdLogFileName(ts, nodes, "./cockroach bla --foo bar"),
 	)
+}
+
+func TestPrintProvidersErrors(t *testing.T) {
+	testCases := []struct {
+		name           string
+		providersState map[string]string
+		expectedLines  []string
+	}{
+		{
+			name: "No errors",
+			providersState: map[string]string{
+				aws.ProviderName:   "Active",
+				gce.ProviderName:   "Active",
+				azure.ProviderName: "Active",
+				ibm.ProviderName:   "Active",
+				local.ProviderName: "Active",
+			},
+		},
+		{
+			name: "Single error",
+			providersState: map[string]string{
+				aws.ProviderName:   "Active",
+				gce.ProviderName:   "Inactive - failed to authenticate",
+				azure.ProviderName: "Active",
+				ibm.ProviderName:   "Active",
+				local.ProviderName: "Active",
+			},
+			expectedLines: []string{
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", gce.ProviderName),
+			},
+		},
+		{
+			name: "Multiple errors",
+			providersState: map[string]string{
+				aws.ProviderName:   "Active",
+				gce.ProviderName:   "Inactive - failed to authenticate",
+				azure.ProviderName: "Inactive - failed to authenticate",
+				ibm.ProviderName:   "Active",
+				local.ProviderName: "Active",
+			},
+			expectedLines: []string{
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", gce.ProviderName),
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", azure.ProviderName),
+			},
+		},
+		{
+			name: "No errors with disabled provider",
+			providersState: map[string]string{
+				aws.ProviderName:   "Active",
+				gce.ProviderName:   fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				azure.ProviderName: "Active",
+				ibm.ProviderName:   "Active",
+				local.ProviderName: "Active",
+			},
+		},
+		{
+			name: "No errors with multiple disabled providers",
+			providersState: map[string]string{
+				aws.ProviderName:   "Active",
+				gce.ProviderName:   fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				azure.ProviderName: fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				ibm.ProviderName:   "Active",
+				local.ProviderName: "Active",
+			},
+		},
+		{
+			name: "Errors with multiple disabled providers",
+			providersState: map[string]string{
+				aws.ProviderName:   "Inactive - failed to authenticate",
+				gce.ProviderName:   fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				azure.ProviderName: fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				ibm.ProviderName:   "Inactive - failed to authenticate",
+				local.ProviderName: "Active",
+			},
+			expectedLines: []string{
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", aws.ProviderName),
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", ibm.ProviderName),
+			},
+		},
+		{
+			name: "All Errors",
+			providersState: map[string]string{
+				aws.ProviderName:   "Inactive - failed to authenticate",
+				gce.ProviderName:   "Inactive - failed to authenticate",
+				azure.ProviderName: "Inactive - failed to authenticate",
+				ibm.ProviderName:   "Inactive - failed to authenticate",
+				local.ProviderName: "Inactive - failed to authenticate",
+			},
+			expectedLines: []string{
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", aws.ProviderName),
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", gce.ProviderName),
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", azure.ProviderName),
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", ibm.ProviderName),
+				fmt.Sprintf("Error from cloud provider %s: Inactive - failed to authenticate", local.ProviderName),
+			},
+		},
+		{
+			name: "All Disabled",
+			providersState: map[string]string{
+				aws.ProviderName:   fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				gce.ProviderName:   fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				azure.ProviderName: fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				ibm.ProviderName:   fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+				local.ProviderName: fmt.Sprintf("Inactive - %s", roachprod.RoachprodDisabledProviderMessage),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintProvidersErrors(&buf, tc.providersState)
+			var outputLines []string
+			if buf.String() != "" {
+				// if buffer is empty, then buf.String() will return an empty string
+				// passing an empty string into strings.Split will return a slice with
+				// a single element
+				// for length assertion later, if buffer is empty, outputLines should
+				// be nil
+
+				outputLines = strings.Split(strings.TrimSpace(buf.String()), "\n")
+			}
+			require.Len(t, outputLines, len(tc.expectedLines))
+			for _, line := range outputLines {
+				require.True(t, slices.Contains(tc.expectedLines, line))
+			}
+		})
+	}
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -73,6 +73,10 @@ var (
 	// worker encountered an error when trying to POST to GitHub
 	errGithubPostFailed = fmt.Errorf("failed to POST to GitHub")
 
+	// errNoTestsExecuted error returned when an invocation of roachtest does not
+	// execute any tests i.e., if no clusters were provisioned
+	errNoTestsExecuted = fmt.Errorf("no tests executed")
+
 	prometheusNameSpace = "roachtest"
 	// prometheusScrapeInterval should be consistent with the scrape interval defined in
 	// https://grafana.testeng.crdb.io/prometheus/config
@@ -591,6 +595,10 @@ func (r *testRunner) Run(
 	if len(r.status.fail) > 0 {
 		shout(ctx, l, lopt.stdout, "%d tests failed", len(r.status.fail))
 		err = errors.Join(err, errTestsFailed)
+	}
+	if len(r.status.pass) == 0 && len(r.status.fail) == 0 {
+		shout(ctx, l, lopt.stdout, "No tests ran. Skip count: %d", len(r.status.skip))
+		err = errors.Join(err, errNoTestsExecuted)
 	}
 	if err != nil {
 		return err

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1959,6 +1959,10 @@ func StageURL(
 	return urls, nil
 }
 
+// RoachprodDisabledProviderMessage is set as the provider state if a provider
+// is included in ROACHPROD_DISABLED_PROVIDERS
+const RoachprodDisabledProviderMessage = "disabled via ROACHPROD_DISABLED_PROVIDERS"
+
 var disabledProviders = func() map[string]struct{} {
 	disabled := make(map[string]struct{})
 	for _, p := range strings.Split(os.Getenv("ROACHPROD_DISABLED_PROVIDERS"), ",") {
@@ -2006,11 +2010,10 @@ func InitProviders() map[string]string {
 		},
 	} {
 		if _, dis := disabledProviders[prov.name]; dis {
-			reason := "disabled via ROACHPROD_DISABLED_PROVIDERS"
-			providersState[prov.name] = "Inactive - " + reason
+			providersState[prov.name] = "Inactive - " + RoachprodDisabledProviderMessage
 			// We need an empty provider that emits errors or we'll
 			// crash as roachprod expects all providers to be present.
-			vm.Providers[prov.name] = flagstub.New(prov.empty, reason)
+			vm.Providers[prov.name] = flagstub.New(prov.empty, RoachprodDisabledProviderMessage)
 		} else if err := prov.init(); err != nil {
 			providersState[prov.name] = "Inactive - " + err.Error()
 		} else {


### PR DESCRIPTION
Motivation: Prevent noop'ing builds from going unnoticed and improve triaging provider auth issues

2 Changes
* previously an auth error was never written to stdout / the logs. Let's just surface all provider failures.  It might slightly increase noise if people have misconfigured providers, but we're already overly verbose in that area when that happens anyways i.e. AWS and IBM 
* fail the build when 0 tests pass and 0 tests fail i.e. no tests were executed
  * currently we aren't "running" Azure on release branches. These release branch builds won't ping our channel because that logic is handled in the TC scripts, see here for more details https://cockroachlabs.slack.com/archives/C026MSSL926/p1761687043215529  
* Also changed the exit code condition check to use a switch case statement becasue the if else logic (that I added previously) was confusing me

Notes: 
* For verification, the current preemption polling unit test cases as a side effect test these changes, can add a dedicated case though if wanted, it would look very similar assuming there's some cluster creation hook or something like that
* TC Invocation & pass / fail status https://github.com/cockroachdb/cockroach/blob/ed7cf72dabdae9d7901e4f0592063d6b52b431ca/build/teamcity-roachtest-invoke.sh

Verification 

GCE Nightly: 
https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel?branch=156400&buildTypeTab=overview&mode=builds 
* Just a smoke test, expecting this to run and complete as expected

Azure Nightly:
https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyAzureBazel/20668546?buildTab=overview&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true
* Expecting the build status to fail as the azure secret is currently not valid 