### PR TITLE
catalog/lease: fix queries against initial versions in locked mode

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_set.go
+++ b/pkg/sql/catalog/lease/descriptor_set.go
@@ -84,6 +84,13 @@ func (l *descriptorSet) findIndex(version descpb.DescriptorVersion) (int, bool) 
 	return i, false
 }
 
+func (l *descriptorSet) findOldest() *descriptorVersionState {
+	if len(l.data) == 0 {
+		return nil
+	}
+	return l.data[0]
+}
+
 func (l *descriptorSet) findNewest() *descriptorVersionState {
 	if len(l.data) == 0 {
 		return nil


### PR DESCRIPTION
Previously, all of our testing for locked timestamping included WaitForInitialVersion being enabled. This configuration ensured that we would always acquire the first version of leased descriptors in our tests. However, upon enabling locked leasing across the binary, we encountered issues because bootstrapped tables and other tests might not secure the initial version checkout. Consequently, we would incorrectly declare the object as non-existent if the lease timestamp precoded the object's creation.

Fixes: #156401

Release note: None