### PR TITLE
release-25.3: insights: skip contention test under duress

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -780,6 +780,8 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuress(t)
+
 	// Start the cluster. (One node is sufficient; the outliers system is currently in-memory only.)
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettings()


### PR DESCRIPTION
Backport 1/1 commits from #156317 on behalf of @dhartunian.

----

Resolves: #155838
Resolves: #155962

Epic: None

Release note: None

----

Release justification: test-only change