### PR TITLE
*: address a couple of nits

### DIFF
--- a/pkg/crosscluster/settings.go
+++ b/pkg/crosscluster/settings.go
@@ -59,7 +59,7 @@ var ReplanThreshold = settings.RegisterFloatSetting(
 	"fraction of nodes in the producer or consumer job that would need to change to refresh the"+
 		" physical execution plan. If set to 0, the physical plan will not automatically refresh.",
 	0.1,
-	settings.NonNegativeFloatWithMaximum(1),
+	settings.Fraction,
 	settings.WithName("physical_replication.consumer.replan_flow_threshold"),
 )
 
@@ -116,7 +116,7 @@ var LogicalReplanThreshold = settings.RegisterFloatSetting(
 	"fraction of nodes in the producer or consumer job that would need to change to refresh the"+
 		" physical execution plan. If set to 0, the physical plan will not automatically refresh.",
 	0.1,
-	settings.NonNegativeFloatWithMaximum(1),
+	settings.Fraction,
 )
 
 var LogicalReplanFrequency = settings.RegisterDurationSetting(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -295,7 +295,7 @@ var TraceTxnSampleRate = settings.RegisterFloatSetting(
 		"will have tracing enabled, and only those which exceed the configured "+
 		"threshold will be logged.",
 	1.0,
-	settings.NonNegativeFloatWithMaximum(1.0),
+	settings.Fraction,
 	settings.WithPublic)
 
 // TraceTxnOutputJaegerJSON sets the output format of transaction trace logs.

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -63,7 +63,7 @@ var MaxFractionHistogramMCVs = settings.RegisterFloatSetting(
 	"sql.stats.histogram_buckets.max_fraction_most_common_values",
 	"maximum fraction of histogram buckets to use for most common values",
 	0.1,
-	settings.NonNegativeFloatWithMaximum(1),
+	settings.Fraction,
 	settings.WithPublic)
 
 // HistogramVersion identifies histogram versions.

--- a/pkg/util/log/logtestutils/log_spy.go
+++ b/pkg/util/log/logtestutils/log_spy.go
@@ -86,7 +86,7 @@ func (s *LogSpy) Reset() {
 	s.mu.logs = []logpb.Entry{}
 }
 
-// ReadAll consumes the specified number of logs contained within
+// Read consumes the specified number of logs contained within
 // the spy and returns them as a list. Once the logs are consumed
 // they cannot be read again.
 func (s *LogSpy) Read(n int) []logpb.Entry {


### PR DESCRIPTION
We can use `settings.Fraction` for non-negative float with max 1.0. Also fix up one comment. (Noticed this while reviewing the probabilistic transaction tracing backport.)

Epic: None
Release note: None