### PR TITLE
sql/jsonpath: support index acceleration with AnyKey (`*`) at the chain end

### DIFF
--- a/pkg/sql/inverted/expression.go
+++ b/pkg/sql/inverted/expression.go
@@ -682,8 +682,8 @@ func intersectSpanExpressions(left, right *SpanExpression) *SpanExpression {
 		Right:              right,
 	}
 	if expr.FactoredUnionSpans != nil {
-		left.FactoredUnionSpans = subtractSpans(left.FactoredUnionSpans, expr.FactoredUnionSpans)
-		right.FactoredUnionSpans = subtractSpans(right.FactoredUnionSpans, expr.FactoredUnionSpans)
+		left.FactoredUnionSpans = SubtractSpans(left.FactoredUnionSpans, expr.FactoredUnionSpans)
+		right.FactoredUnionSpans = SubtractSpans(right.FactoredUnionSpans, expr.FactoredUnionSpans)
 	}
 	tryPruneChildren(expr)
 	return expr
@@ -910,9 +910,9 @@ func intersectSpans(left []Span, right []Span) []Span {
 	return spans
 }
 
-// subtractSpans subtracts right from left, under the assumption that right is a
+// SubtractSpans subtracts right from left, under the assumption that right is a
 // subset of left.
-func subtractSpans(left []Span, right []Span) []Span {
+func SubtractSpans(left []Span, right []Span) []Span {
 	if len(right) == 0 {
 		return left
 	}

--- a/pkg/sql/inverted/expression_test.go
+++ b/pkg/sql/inverted/expression_test.go
@@ -291,21 +291,21 @@ func TestSetIntersection(t *testing.T) {
 func TestSetSubtraction(t *testing.T) {
 	checkEqual(t,
 		nil,
-		subtractSpans(
+		SubtractSpans(
 			[]Span{single("b")},
 			[]Span{span("b", "c")},
 		),
 	)
 	checkEqual(t,
 		[]Span{span("b\x00", "d")},
-		subtractSpans(
+		SubtractSpans(
 			[]Span{span("b", "d")},
 			[]Span{span("b", "b\x00")},
 		),
 	)
 	checkEqual(t,
 		[]Span{span("b", "d"), span("e", "ea")},
-		subtractSpans(
+		SubtractSpans(
 			[]Span{span("b", "d"), span("e", "f")},
 			[]Span{span("ea", "f")},
 		),
@@ -313,7 +313,7 @@ func TestSetSubtraction(t *testing.T) {
 	checkEqual(t,
 		[]Span{span("d", "da"), span("db", "dc"),
 			span("dd", "df"), span("fa", "g")},
-		subtractSpans(
+		SubtractSpans(
 			[]Span{single("b"), span("d", "e"), span("f", "g")},
 			[]Span{span("b", "c"), span("da", "db"),
 				span("dc", "dd"), span("df", "e"), span("f", "fa")},

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists_index_acceleration
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists_index_acceleration
@@ -556,3 +556,50 @@ SELECT a FROM json_tab@primary WHERE jsonb_path_exists(b, '$.a ? (@.b == $x)', '
 
 statement error index "foo_inv" is inverted and cannot be used for this query
 SELECT a FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.a ? (@.b == $x)', '{"x": "c"}') ORDER BY a;
+
+subtest anykey
+
+statement ok
+DROP TABLE IF EXISTS anykey_json_tab;
+
+statement ok
+CREATE TABLE anykey_json_tab (
+  a INT PRIMARY KEY,
+  b JSONB
+);
+
+statement ok
+CREATE INVERTED INDEX anykey_inv ON anykey_json_tab(b)
+
+statement ok
+INSERT INTO anykey_json_tab VALUES
+(1, '{"a": {"b": {"c": "d"}}}'),
+(2, '{"a": {"b": {"c": {"d": "e"}}}}'),
+(3, '{"a": {"b": [{"c": {"d": "e"}}]}}'),
+(4, '{"a": {"b": ["c", "d"]}}'),
+(5, '{"a": {"b": "d"}}'),
+(6, '{"a": {"b1": "d"}}'),
+(7, '{"a": {"b1": {"c": {"d": "e"}}}}');
+
+query IT
+SELECT a, b FROM anykey_json_tab@primary WHERE jsonb_path_exists(b, '$.a.b.*') ORDER BY a;
+----
+1  {"a": {"b": {"c": "d"}}}
+2  {"a": {"b": {"c": {"d": "e"}}}}
+3  {"a": {"b": [{"c": {"d": "e"}}]}}
+
+query IT
+SELECT a, b FROM anykey_json_tab@anykey_inv WHERE jsonb_path_exists(b, '$.a.b.*') ORDER BY a;
+----
+1  {"a": {"b": {"c": "d"}}}
+2  {"a": {"b": {"c": {"d": "e"}}}}
+3  {"a": {"b": [{"c": {"d": "e"}}]}}
+
+# AnyKey should only be allowed at the end of the path chain.
+statement error index "anykey_inv" is inverted and cannot be used for this query
+SELECT a, b FROM anykey_json_tab@anykey_inv WHERE jsonb_path_exists(b, '$.a.*.b') ORDER BY a;
+
+statement error index "anykey_inv" is inverted and cannot be used for this query
+SELECT a, b FROM anykey_json_tab@anykey_inv WHERE jsonb_path_exists(b, '$.a.b.*.*') ORDER BY a;
+
+subtest end

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -13883,3 +13883,34 @@ project
                      ├── ["a"/Arr/"x"/Arr/False, "a"/Arr/"x"/Arr/False]
                      ├── ["a"/"x"/False, "a"/"x"/False]
                      └── ["a"/"x"/Arr/False, "a"/"x"/Arr/False]
+
+
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE jsonb_path_exists(j, '$.a.b.*')
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inverted-filter
+      ├── columns: k:1!null
+      ├── inverted expression: /9
+      │    ├── tight: true, unique: false
+      │    └── union spans
+      │         ├── [???, "a"/Arr/"b")
+      │         ├── ["a"/Arr/"b"/PrefixEnd, "a"/Arr/"b"/Arr)
+      │         ├── ["a"/Arr/"b"/Arr/PrefixEnd, "a"/Arr/Arr/)
+      │         ├── [???, "a"/"b")
+      │         ├── ["a"/"b"/PrefixEnd, "a"/"b"/Arr)
+      │         └── ["a"/"b"/Arr/PrefixEnd, "a"/Arr/)
+      ├── key: (1)
+      └── scan b@j_inv_idx,inverted
+           ├── columns: k:1!null j_inverted_key:9!null
+           └── inverted constraint: /9/1
+                └── spans
+                     ├── [???, "a"/Arr/"b")
+                     ├── ["a"/Arr/"b"/PrefixEnd, "a"/Arr/"b"/Arr)
+                     ├── ["a"/Arr/"b"/Arr/PrefixEnd, "a"/Arr/Arr/)
+                     ├── [???, "a"/"b")
+                     ├── ["a"/"b"/PrefixEnd, "a"/"b"/Arr)
+                     └── ["a"/"b"/Arr/PrefixEnd, "a"/Arr/)


### PR DESCRIPTION
fixes: #156340

We now support index accelerating `jsonb_path_exists` filters with json path expression that ends with an AnyKey (`*`).

Note that the AnyKey is allowed only at the end of the expression. I.e. the following are not allowed:

``` 
$.a.*.b 
$.a.b.*.* 
```

Release note (sql change): We now support index accelerating `jsonb_path_exists` filters with json path expression that ends with an AnyKey (`*`).