### PR TITLE
release-25.3: roachtest: skip kv/quiescence/nodes=3 in prep for deletion

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -460,6 +460,7 @@ func registerKVContention(r registry.Registry) {
 func registerKVQuiescenceDead(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                "kv/quiescence/nodes=3",
+		Skip:                "https://github.com/cockroachdb/cockroach/issues/156357",
 		Owner:               registry.OwnerKV,
 		Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds:    registry.AllExceptAWS,


### PR DESCRIPTION
Backport 1/1 commits from #156370 on behalf of @tbg.

----

This test is flaky on multiple branches, but the flakes are not actionable (dozens of them got closed out without progress over time). Rather than adding "the works" (statement bundles, etc), we are going to remove this test and rely on `kv/gracefuldraining` and (weekly test) `kv/restart`. Similar functionality is also covered through the perturbation/full/restart test, though we have issues with the perturbation test harness as well.

This PR only skips the test and is suitable for backporting. A follow-up PR on master will fully remove the test (and there is no need to backport that).

Closes https://github.com/cockroachdb/cockroach/issues/156357.
Closes https://github.com/cockroachdb/cockroach/issues/152052.
Closes https://github.com/cockroachdb/cockroach/issues/154238.

Epic: none

----

Release justification: