### PR TITLE
rangefeed: drop messages for overflowed streams

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -59,6 +59,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -182,7 +182,7 @@ func (bs *BufferedSender) sendBuffered(
 	if !ok {
 		return errNoSuchStream
 	}
-	nextState, err := bs.nextPerQueueStateLocked(status, ev)
+	nextState, err := bs.nextPerStreamStateLocked(status, ev)
 	if nextState == streamErrored {
 		// We will be admitting this event but no events after this.
 		assertTrue(err == nil, "expected error event to be admitted")
@@ -209,11 +209,11 @@ func (bs *BufferedSender) sendBuffered(
 	return nil
 }
 
-// nextPerQueueStateLocked returns the next state that should be stored for the
+// nextPerStreamStateLocked returns the next state that should be stored for the
 // stream related to the given rangefeed event. If an error is returned, the
 // event should not be admitted and the given error should be returned to the
 // client.
-func (bs *BufferedSender) nextPerQueueStateLocked(
+func (bs *BufferedSender) nextPerStreamStateLocked(
 	status streamStatus, ev *kvpb.MuxRangeFeedEvent,
 ) (streamState, error) {
 	// An error should always put us into stateErrored, so let's do that first.

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -177,8 +177,8 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 
 	t.Log(bs.TestingBufferSummary())
 	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
-	require.NoError(t, bs.sendBuffered(muxEv, nil))
-	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	require.ErrorIs(t, bs.sendBuffered(muxEv, nil), errNoSuchStream)
+	require.ErrorIs(t, bs.sendBuffered(muxErrEvent, nil), errNoSuchStream)
 	t.Log(bs.TestingBufferSummary())
 
 	testServerStream.waitForEvent(t, muxErrEvent)
@@ -193,8 +193,8 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 	muxEv2.StreamID = 2
 	sm.RegisteringStream(2)
 	testServerStream.reset()
-	require.NoError(t, bs.sendBuffered(muxEv, nil))
-	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	require.ErrorIs(t, bs.sendBuffered(muxEv, nil), errNoSuchStream)
+	require.ErrorIs(t, bs.sendBuffered(muxErrEvent, nil), errNoSuchStream)
 	require.NoError(t, bs.sendBuffered(&muxEv2, nil))
 	testServerStream.waitForEvent(t, &muxEv2)
 	require.Equal(t, 1, testServerStream.totalEventsSent())
@@ -257,8 +257,8 @@ func TestBufferedSenderOnOverflowWithErrorEvent(t *testing.T) {
 	muxEv2.StreamID = 2
 	sm.RegisteringStream(2)
 	testServerStream.reset()
-	require.NoError(t, bs.sendBuffered(muxEv, nil))
-	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	require.ErrorIs(t, bs.sendBuffered(muxEv, nil), errNoSuchStream)
+	require.ErrorIs(t, bs.sendBuffered(muxErrEvent, nil), errNoSuchStream)
 	require.NoError(t, bs.sendBuffered(&muxEv2, nil))
 	testServerStream.waitForEvent(t, &muxEv2)
 	require.Equal(t, 1, testServerStream.totalEventsSent())

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -46,6 +46,7 @@ func TestBufferedSenderDisconnectStream(t *testing.T) {
 
 	t.Run("basic operation", func(t *testing.T) {
 		var num atomic.Int32
+		sm.RegisteringStream(streamID)
 		sm.AddStream(int64(streamID), &cancelCtxDisconnector{
 			cancel: func() {
 				num.Add(1)
@@ -62,6 +63,7 @@ func TestBufferedSenderDisconnectStream(t *testing.T) {
 		testServerStream.reset()
 	})
 	t.Run("disconnect stream on the same stream is idempotent", func(t *testing.T) {
+		sm.RegisteringStream(streamID)
 		sm.AddStream(int64(streamID), &cancelCtxDisconnector{
 			cancel: func() {
 				require.NoError(t, sm.sender.sendBuffered(errEvent, nil))
@@ -120,7 +122,10 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 
 	RangefeedSingleBufferedSenderQueueMaxPerReg.Override(ctx, &st.SV, queueCap)
 	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
-	bs.addStream(streamID)
+	smMetrics := NewStreamManagerMetrics()
+	sm := NewStreamManager(bs, smMetrics)
+	sm.RegisteringStream(streamID)
+
 	require.Equal(t, queueCap, bs.queueMu.perStreamCapacity)
 
 	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
@@ -143,8 +148,109 @@ func TestBufferedSenderOnOverflow(t *testing.T) {
 	require.Equal(t, queueCap, int64(bs.len()))
 
 	// Overflow now.
+	t.Log(bs.TestingBufferSummary())
 	err := bs.sendBuffered(muxEv, nil)
 	require.EqualError(t, err, newRetryErrBufferCapacityExceeded().Error())
+	t.Log(bs.TestingBufferSummary())
+
+	// Start the stream manager now, which will start to drain the overflowed stream.
+	require.NoError(t, sm.Start(ctx, stopper))
+	defer sm.Stop(ctx)
+
+	testServerStream.waitForEventCount(t, int(queueCap))
+	testServerStream.reset()
+
+	// The stream should now be in state overflowing. Any non-error events are
+	// silently dropped, but the next error event is delivered to the client.
+	ev2 := kvpb.RangeFeedEvent{Error: &kvpb.RangeFeedError{Error: *newErrBufferCapacityExceeded()}}
+	muxErrEvent := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: ev2, RangeID: 0, StreamID: streamID}
+
+	t.Log(bs.TestingBufferSummary())
+	require.NoError(t, bs.sendBuffered(muxEv, nil))
+	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	t.Log(bs.TestingBufferSummary())
+
+	testServerStream.waitForEvent(t, muxErrEvent)
+	require.Equal(t, 1, testServerStream.totalEventsSent())
+
+	// Once the error event has been delivered to the client, all additional
+	// requests should be dropped.
+	//
+	// We use a second stream "flush" the buffer and assert we don't see these
+	// events. This assumes buffered sender orders unrelated streams.
+	muxEv2 := *muxEv
+	muxEv2.StreamID = 2
+	sm.RegisteringStream(2)
+	testServerStream.reset()
+	require.NoError(t, bs.sendBuffered(muxEv, nil))
+	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	require.NoError(t, bs.sendBuffered(&muxEv2, nil))
+	testServerStream.waitForEvent(t, &muxEv2)
+	require.Equal(t, 1, testServerStream.totalEventsSent())
+}
+
+// TestBufferedSenderOnOverflowWithErrorEvent tests the special case of a stream
+// hitting an overflow on an event that is itself an error.
+func TestBufferedSenderOnOverflowWithErrorEvent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	testServerStream := newTestServerStream()
+	st := cluster.MakeTestingClusterSettings()
+
+	queueCap := int64(24)
+	streamID := int64(1)
+
+	RangefeedSingleBufferedSenderQueueMaxPerReg.Override(ctx, &st.SV, queueCap)
+	bs := NewBufferedSender(testServerStream, st, NewBufferedSenderMetrics())
+	smMetrics := NewStreamManagerMetrics()
+	sm := NewStreamManager(bs, smMetrics)
+	sm.RegisteringStream(streamID)
+
+	require.Equal(t, queueCap, bs.queueMu.perStreamCapacity)
+
+	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	ev1 := new(kvpb.RangeFeedEvent)
+	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})
+	muxEv := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: *ev1, RangeID: 0, StreamID: streamID}
+
+	for range queueCap {
+		require.NoError(t, bs.sendBuffered(muxEv, nil))
+	}
+
+	// Overflow now.
+	ev2 := kvpb.RangeFeedEvent{Error: &kvpb.RangeFeedError{Error: *newErrBufferCapacityExceeded()}}
+	muxErrEvent := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: ev2, RangeID: 0, StreamID: streamID}
+	// We admit the error event.
+	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	t.Log(bs.TestingBufferSummary())
+
+	// Start the stream manager now, which will start to drain the overflowed stream.
+	require.NoError(t, sm.Start(ctx, stopper))
+	defer sm.Stop(ctx)
+
+	testServerStream.waitForEventCount(t, int(queueCap+1))
+	// We should see the event we sent to the stream.
+	require.True(t, testServerStream.hasEvent(muxErrEvent))
+	testServerStream.reset()
+
+	// All additional requests should be dropped, including errors because the
+	// first error should have moved us to overflowed.
+	//
+	// We use a second stream "flush" the buffer and assert we don't see these
+	// events. This assumes buffered sender orders unrelated streams.
+	muxEv2 := *muxEv
+	muxEv2.StreamID = 2
+	sm.RegisteringStream(2)
+	testServerStream.reset()
+	require.NoError(t, bs.sendBuffered(muxEv, nil))
+	require.NoError(t, bs.sendBuffered(muxErrEvent, nil))
+	require.NoError(t, bs.sendBuffered(&muxEv2, nil))
+	testServerStream.waitForEvent(t, &muxEv2)
+	require.Equal(t, 1, testServerStream.totalEventsSent())
 }
 
 // TestBufferedSenderOnOverflowMultiStream tests that BufferedSender and

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -278,6 +278,8 @@ func TestCatchupScanInlineError(t *testing.T) {
 
 func TestCatchupScanSeesOldIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	// Regression test for [#85886]. When with-diff is specified, the iterator may
 	// be positioned on an intent that is outside the time bounds. When we read
 	// the intent and want to load the version, we must make sure to ignore time

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1200,7 +1200,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 		// after flushing the queue, but couldn't determine when main processor loop
 		// is actually closed.
 		testutils.SucceedsSoon(t, func() error {
-			fmt.Printf("Budget now: %d bytes remained, %d events processed\n",
+			t.Logf("budget: %d bytes remained, %d events processed",
 				m.AllocBytes(), rStream.Consumed())
 			if m.AllocBytes() != 0 {
 				return errors.Errorf(
@@ -1367,7 +1367,7 @@ func requireBudgetDrainedSoon(t *testing.T, b *FeedBudget, stream *consumer) {
 		b.mu.Lock()
 		used := b.mu.memBudget.Used()
 		b.mu.Unlock()
-		fmt.Printf("Budget used: %d bytes, %d events processed\n",
+		t.Logf("budget used: %d bytes, %d events processed",
 			used, stream.Consumed())
 		if used != 0 {
 			return errors.Errorf(

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -45,37 +45,48 @@ func TestStreamManagerDisconnectStream(t *testing.T) {
 		require.NoError(t, sm.Start(ctx, stopper))
 		defer sm.Stop(ctx)
 
-		const streamID = 0
+		var sid int64
+		nextStreamID := func() int64 {
+			sid++
+			return sid
+		}
+
 		err := kvpb.NewError(kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_NO_LEASEHOLDER))
-		errEvent := makeMuxRangefeedErrorEvent(int64(streamID), 1, err)
+		errEvent := func(streamID int64) *kvpb.MuxRangeFeedEvent {
+			return makeMuxRangefeedErrorEvent(streamID, 1, err)
+		}
 
 		t.Run("basic operation", func(t *testing.T) {
 			var num atomic.Int32
-			sm.AddStream(int64(streamID), &cancelCtxDisconnector{
+			streamID := nextStreamID()
+			sm.RegisteringStream(streamID)
+			sm.AddStream(streamID, &cancelCtxDisconnector{
 				cancel: func() {
 					num.Add(1)
-					require.NoError(t, sm.sender.sendBuffered(errEvent, nil))
+					require.NoError(t, sm.sender.sendBuffered(errEvent(streamID), nil))
 				},
 			})
 			require.Equal(t, int64(1), smMetrics.ActiveMuxRangeFeed.Value())
 			require.Equal(t, 0, testServerStream.totalEventsSent())
-			sm.DisconnectStream(int64(streamID), err)
-			testServerStream.waitForEvent(t, errEvent)
+			sm.DisconnectStream(streamID, err)
+			testServerStream.waitForEvent(t, errEvent(streamID))
 			require.Equal(t, int32(1), num.Load())
 			require.Equal(t, 1, testServerStream.totalEventsSent())
 			waitForRangefeedCount(t, smMetrics, 0)
 			testServerStream.reset()
 		})
 		t.Run("disconnect stream on the same stream is idempotent", func(t *testing.T) {
-			sm.AddStream(int64(streamID), &cancelCtxDisconnector{
+			streamID := nextStreamID()
+			sm.RegisteringStream(streamID)
+			sm.AddStream(streamID, &cancelCtxDisconnector{
 				cancel: func() {
-					require.NoError(t, sm.sender.sendBuffered(errEvent, nil))
+					require.NoError(t, sm.sender.sendBuffered(errEvent(streamID), nil))
 				},
 			})
 			require.Equal(t, int64(1), smMetrics.ActiveMuxRangeFeed.Value())
-			sm.DisconnectStream(int64(streamID), err)
-			sm.DisconnectStream(int64(streamID), err)
-			testServerStream.waitForEvent(t, errEvent)
+			sm.DisconnectStream(streamID, err)
+			sm.DisconnectStream(streamID, err)
+			testServerStream.waitForEvent(t, errEvent(streamID))
 			require.Equalf(t, 1, testServerStream.totalEventsSent(),
 				"expected only 1 error event but got %s", testServerStream.String())
 			waitForRangefeedCount(t, smMetrics, 0)

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
@@ -243,6 +244,7 @@ func (s *testIterator) RangeKeyChanged() bool {
 
 func TestInitResolvedTSScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
 	startKey := roachpb.RKey("d")

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -7,6 +7,7 @@ package rangefeed
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -444,5 +445,11 @@ func (ubr *unbufferedRegistration) waitForCaughtUp(ctx context.Context) error {
 func assertTrue(cond bool, msg string) {
 	if buildutil.CrdbTestBuild && !cond {
 		panic(msg)
+	}
+}
+
+func assumedUnreachable(msg string) {
+	if buildutil.CrdbTestBuild {
+		panic(fmt.Sprintf("assumed unreachable code reached: %s", msg))
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -135,9 +135,6 @@ func (ubs *UnbufferedSender) sendUnbuffered(event *kvpb.MuxRangeFeedEvent) error
 // addStream implements sender.
 func (ubs *UnbufferedSender) addStream(int64) {}
 
-// removeStream implements sender.
-func (ubs *UnbufferedSender) removeStream(int64) {}
-
 // cleanup implements sender.
 func (ubs *UnbufferedSender) cleanup(context.Context) {}
 


### PR DESCRIPTION
This PR fixes some bugs discovered when trying to increase the test coverage of the buffered sender unit tests:

- A stream would actually never move into the "overflowing" state. Rather it would stay in the "active" state and keep returning a buffer capacity error until the registration sent the error back to us, in which case it would go straight to overflowed.

- This was papering over another bug in which the overflowing state could produce an invalid stream of events.

Here, I add test coverage for the expected state transitions and fix these bugs by:

  - Dropping buffered messages for streams not in the stream map. This works because the stream will be in the stream map from the point of the RegisteringStream call and is only removed when the stream finally sends the error. Thus any message for a stream not in map represents either (1) a message sent to a StreamID before RegisteringStream has been called or (2) a message sent to a StreamID after an Error. (1) would be a programming error and (2) would be messages that are dropped server-side anyway.

  - Re-organizing the code such that it is harder to miss saving the stream status back to the status map.

Note any potential bug here only existed on master and thus no release note is needed.

Epic: CRDB-55217

Release note: None