### PR TITLE
sql: increase timeout for inspect tests

### DIFF
--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
 
 go_test(
     name = "inspect_test",
+    size = "large",
     srcs = [
         "index_consistency_check_test.go",
         "inspect_job_test.go",


### PR DESCRIPTION
The `sql/inspect.TestInspectMetrics` test was flaking in CI. Increasing
the size will increase the timeout.

Epic: none
Fixes: #156197
Fixes: #156082
Fixes: https://github.com/cockroachdb/cockroach/issues/156238

Release note: None
