### PR TITLE
[dnm] repro script for #155734

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -145,7 +145,7 @@ func (o *OverrideStorePool) GetStoreListForTargets(
 func (o *OverrideStorePool) LiveAndDeadReplicas(
 	repls []roachpb.ReplicaDescriptor, includeSuspectAndDrainingStores bool,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
-	return o.sp.liveAndDeadReplicasWithLiveness(repls, o.overrideNodeLivenessFn, includeSuspectAndDrainingStores)
+	return o.sp.liveAndDeadReplicasWithLiveness(repls, o.overrideNodeLivenessFn, includeSuspectAndDrainingStores, nil)
 }
 
 // ClusterNodeCount implements the AllocatorStorePool interface.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euxo pipefail
+
+roachprod destroy local-oxide
+roachprod create -n 5 local-oxide
+roachprod put local-oxide ~/crdb/cockroach ./cockroach
+roachprod start local-oxide
+roachprod sql local-oxide:1 -- -e ' 
+CREATE DATABASE d;
+CREATE TABLE d.t (i INT PRIMARY KEY);
+ALTER RANGE DEFAULT CONFIGURE ZONE USING num_replicas = 5, num_voters = 5;
+'
+
+# Wait for 5x replication.
+while ! roachprod sql local-oxide:1 -- -e "
+WITH bad AS (
+  SELECT range_id
+  FROM crdb_internal.ranges_no_leases
+  WHERE cardinality(replicas) != 5
+  ORDER BY range_id
+  LIMIT 10
+),
+agg AS (
+  SELECT coalesce(string_agg(range_id::string, ', '), '') AS ids,
+         count(*) AS n
+  FROM bad
+)
+SELECT CASE
+         WHEN n > 0 THEN crdb_internal.force_error(
+           '22000',
+           'Some ranges do not have 5 replicas: ' || ids
+         )
+       END
+FROM agg;
+"; do
+  echo "waiting for replication..."
+  sleep 5
+done
+
+# Create some ranges.
+roachprod sql local-oxide:1 -- -e '
+INSERT INTO d.t(i) SELECT generate_series(1,100);
+ALTER TABLE d.t SPLIT AT SELECT i FROM d.t ORDER by i DESC;
+'
+
+echo "stopping n4 and n5"
+date
+# Stop n4 and n5.
+roachprod stop local-oxide:4-5
+
+# After 20 seconds, nodes should be known not to be live. Decommission.
+sleep 20
+echo "decommission n4 and n5"
+date
+roachprod run local-oxide:1 -- ./cockroach node decommission --insecure --port {pgport:1} 4 5
+
+roachprod adminui local-oxide:1
+
+for i in $(seq 1 10); do
+roachprod sql local-oxide:1 -- -e '
+SELECT count(*) FROM d.t;
+'
+sleep 10
+done
+


### PR DESCRIPTION
This reproduces the problem in #155734:

- start 5 node cluster
- set replication factor to 5
- stop n4 and n5
- decommission n4 and n5

The allocator will attempt to remove live voters, which due to the bug fixed in #156464 it manages to do:

```
I251029 15:47:08.438137 22553 13@kv/kvserver/allocator/plan/replicate.go:625 ⋮ [T1,Vsystem,n1,replicate,s1,r80/1:/Table/106{-/1/‹1›}] 2673  removing voting replica n2,s2 due to over-replication: [1*:346, 2:346, 3:346, 4:346, 5:346]
I251029 15:47:08.438275 22553 13@kv/kvserver/replica_command.go:2540 ⋮ [T1,Vsystem,n1,replicate,s1,r80/1:/Table/106{-/1/‹1›}] 2674  change replicas (add [] remove [(n2,s2):4VOTER_DEMOTING_LEARNER]): existing descriptor r80:/Table/106{-/1/‹1›
} [(n1,s1):1, (n5,s5):2, (n4,s4):3, (n2,s2):4, (n3,s3):5, next=6, gen=109]

[T1,Vsystem,n1,replicate,s1,r80/1:/Table/106{-/1/‹1›}] 388  ‹range r80:/Table/106{-/1/1} [(n1,s1):1, (n5,s5):2, (n4,s4):3, (n2,s2):4VOTER_DEMOTING_LEARNER, (n3,s3):5, next=6 , gen=110] cannot make progress with proposed changes add=[] del=[(n2,s2):4VOTER_DEMOTING_LEARNER] based on live replicas [(n1,s1):1 (n2,s2):4VOTER_DEMOTING_LEARNER (n3,s3):5]›
[T1,Vsystem,n1,replicate,s1,r80/1:/Table/106{-/1/‹1›}] 391  ‹range r80:/Table/106{-/1/1} [(n1,s1):1, (n5,s5):2, (n4,s4):3, (n2,s2):4VOTER_DEMOTING_LEARNER, (n3,s3):5, next=6 , gen=110] cannot make progress with proposed changes add=[] del=[(n2,s2):4VOTER_DEMOTING_LEARNER] based on live replicas [(n1,s1):1 (n2,s2):4VOTER_DEMOTING_LEARNER (n3,s3):5]›
[repeats a few more times]

// does the removal anyway due to the bug:
I251029 15:47:18.539099 22553 13@kv/kvserver/replica_raft.go:421 ⋮ [T1,Vsystem,n1,s1,r80/1:/Table/106{-/1/‹1›}] 2683  proposing ENTER_JOINT(r4 l4) [(n2,s2):4VOTER_DEMOTING_LEARNER]: after=[(n1,s1):1 (n5,s5):2 (n4,s4):3 (n2,s2):4VOTER_DEMOTIN
G_LEARNER (n3,s3):5] next=6
```

This demonstrates that #156464 is likely going to "fix" this problem. Of course
the second layer of the problem is that the allocator really shouldn't try to
remove live voters in this situatoin.

Epic: none

