### PR TITLE
sql: teach instanceResolver to (strictly) match multiple on localities

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -158,11 +158,13 @@ func backup(
 
 	oracle := physicalplan.DefaultReplicaChooser
 	if useBulkOracle.Get(&evalCtx.Settings.SV) {
-		oracle = kvfollowerreadsccl.NewBulkOracle(
+		oracle, err = kvfollowerreadsccl.NewLocalityFilteringBulkOracle(
 			dsp.ReplicaOracleConfig(evalCtx.Locality),
-			details.ExecutionLocality,
-			kvfollowerreadsccl.StreakConfig{},
+			sql.SingleLocalityFilter(details.ExecutionLocality),
 		)
+		if err != nil {
+			return roachpb.RowCount{}, 0, errors.Wrap(err, "failed to create locality filtering bulk oracle")
+		}
 	}
 
 	// We don't return the compatible nodes here since PartitionSpans will

--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -170,7 +170,7 @@ func backup(
 	// We don't return the compatible nodes here since PartitionSpans will
 	// filter out incompatible nodes.
 	planCtx, _, err := dsp.SetupAllNodesPlanningWithOracle(
-		ctx, evalCtx, execCtx.ExecCfg(), oracle, details.ExecutionLocality,
+		ctx, evalCtx, execCtx.ExecCfg(), oracle, sql.SingleLocalityFilter(details.ExecutionLocality), sql.NoStrictLocalityFiltering,
 	)
 	if err != nil {
 		return roachpb.RowCount{}, 0, errors.Wrap(err, "failed to determine nodes on which to run")

--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -155,7 +155,7 @@ func createCompactionPlan(
 	// TODO (kev-cao): Add support for execution locality.
 	planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanningWithOracle(
 		ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg(),
-		physicalplan.DefaultReplicaChooser, roachpb.Locality{},
+		physicalplan.DefaultReplicaChooser, []roachpb.Locality{}, sql.NoStrictLocalityFiltering,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/backup/restore_processor_planning.go
+++ b/pkg/backup/restore_processor_planning.go
@@ -93,7 +93,7 @@ func distRestore(
 
 		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanningWithOracle(
 			ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg(),
-			physicalplan.DefaultReplicaChooser, md.execLocality,
+			physicalplan.DefaultReplicaChooser, sql.SingleLocalityFilter(md.execLocality), sql.NoStrictLocalityFiltering,
 		)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -411,7 +411,11 @@ func makePlan(
 		oracle := replicaoracle.NewOracle(replicaOracleChoice, dsp.ReplicaOracleConfig(locFilter))
 		if useBulkOracle.Get(&evalCtx.Settings.SV) {
 			log.Changefeed.Infof(ctx, "using bulk oracle for DistSQL planning")
-			oracle = kvfollowerreadsccl.NewBulkOracle(dsp.ReplicaOracleConfig(evalCtx.Locality), locFilter, kvfollowerreadsccl.StreakConfig{})
+			var err error
+			oracle, err = kvfollowerreadsccl.NewLocalityFilteringBulkOracle(dsp.ReplicaOracleConfig(evalCtx.Locality), sql.SingleLocalityFilter(locFilter))
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 		planCtx := dsp.NewPlanningCtxWithOracle(ctx, execCtx.ExtendedEvalContext(), nil, /* planner */
 			blankTxn, sql.DistributionType(distMode), oracle, locFilter)

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -418,7 +418,7 @@ func makePlan(
 			}
 		}
 		planCtx := dsp.NewPlanningCtxWithOracle(ctx, execCtx.ExtendedEvalContext(), nil, /* planner */
-			blankTxn, sql.DistributionType(distMode), oracle, locFilter)
+			blankTxn, sql.DistributionType(distMode), oracle, sql.SingleLocalityFilter(locFilter), sql.NoStrictLocalityFiltering)
 		spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, trackedSpans, sql.PartitionSpansBoundDefault)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -691,32 +691,35 @@ func TestOracle(t *testing.T) {
 		}
 
 		t.Run("no-followers", func(t *testing.T) {
-			br := NewBulkOracle(cfg(stNoFollowers), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(stNoFollowers), sk)
 			leaseholder := &roachpb.ReplicaDescriptor{NodeID: 99}
 			picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, leaseholder, noCTPolicy, noQueryState)
 			require.NoError(t, err)
 			require.Equal(t, leaseholder.NodeID, picked.NodeID, "no follower reads means we pick the leaseholder")
 		})
 		t.Run("no-filter", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(st), sk)
 			picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, noLeaseholder, noCTPolicy, noQueryState)
 			require.NoError(t, err)
 			require.NotNil(t, picked, "no filter picks some node but could be any node")
 		})
 		t.Run("filter", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), region("b"), sk)
+			localites := []roachpb.Locality{region("z"), region("b"), region("y")}
+			br, err := NewLocalityFilteringBulkOracle(cfg(st), localites)
+			require.NoError(t, err)
 			picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, noLeaseholder, noCTPolicy, noQueryState)
 			require.NoError(t, err)
 			require.Equal(t, roachpb.NodeID(2), picked.NodeID, "filter means we pick the node that matches the filter")
 		})
 		t.Run("filter-no-match", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), region("z"), sk)
+			br, err := NewLocalityFilteringBulkOracle(cfg(st), sql.SingleLocalityFilter(region("z")))
+			require.NoError(t, err)
 			picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, noLeaseholder, noCTPolicy, noQueryState)
 			require.NoError(t, err)
 			require.NotNil(t, picked, "no match still picks some non-zero node")
 		})
 		t.Run("streak-short", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(st), sk)
 			for _, r := range replicas { // Check for each to show it isn't random.
 				picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, noLeaseholder, noCTPolicy, replicaoracle.QueryState{
 					NodeStreak:     1,
@@ -727,7 +730,7 @@ func TestOracle(t *testing.T) {
 			}
 		})
 		t.Run("streak-medium", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(st), sk)
 			for _, r := range replicas { // Check for each to show it isn't random.
 				picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, noLeaseholder, noCTPolicy, replicaoracle.QueryState{
 					NodeStreak:     9,
@@ -739,7 +742,7 @@ func TestOracle(t *testing.T) {
 			}
 		})
 		t.Run("streak-long-even", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(st), sk)
 			for _, r := range replicas { // Check for each to show it isn't random.
 				picked, _, err := br.ChoosePreferredReplica(ctx, noTxn, desc, noLeaseholder, noCTPolicy, replicaoracle.QueryState{
 					NodeStreak:     50,
@@ -751,7 +754,7 @@ func TestOracle(t *testing.T) {
 			}
 		})
 		t.Run("streak-long-skewed-to-other", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(st), sk)
 			for i := 0; i < 10; i++ { // Prove it isn't just randomly picking n2.
 				qs := replicaoracle.QueryState{
 					NodeStreak:     50,
@@ -764,7 +767,7 @@ func TestOracle(t *testing.T) {
 			}
 		})
 		t.Run("streak-long-skewed-randomizes", func(t *testing.T) {
-			br := NewBulkOracle(cfg(st), roachpb.Locality{}, sk)
+			br := NewStreakBulkOracle(cfg(st), sk)
 			qs := replicaoracle.QueryState{
 				NodeStreak:     50,
 				RangesPerNode:  intMap(1, 10, 2, 10, 3, 1005),

--- a/pkg/crosscluster/producer/stream_lifetime.go
+++ b/pkg/crosscluster/producer/stream_lifetime.go
@@ -295,8 +295,8 @@ func (r *replicationStreamManagerImpl) buildReplicationStreamSpec(
 			Min: 10, SmallPlanMin: 3, SmallPlanThreshold: 3, MaxSkew: 0.95,
 		}
 	}
-	oracle := kvfollowerreadsccl.NewBulkOracle(
-		dsp.ReplicaOracleConfig(evalCtx.Locality), noLoc, streaks,
+	oracle := kvfollowerreadsccl.NewStreakBulkOracle(
+		dsp.ReplicaOracleConfig(evalCtx.Locality), streaks,
 	)
 
 	planCtx := dsp.NewPlanningCtxWithOracle(

--- a/pkg/crosscluster/producer/stream_lifetime.go
+++ b/pkg/crosscluster/producer/stream_lifetime.go
@@ -288,7 +288,6 @@ func (r *replicationStreamManagerImpl) buildReplicationStreamSpec(
 
 	// Partition the spans with SQLPlanner
 	dsp := jobExecCtx.DistSQLPlanner()
-	noLoc := roachpb.Locality{}
 	var streaks kvfollowerreadsccl.StreakConfig
 	if useStreaks {
 		streaks = kvfollowerreadsccl.StreakConfig{
@@ -300,7 +299,7 @@ func (r *replicationStreamManagerImpl) buildReplicationStreamSpec(
 	)
 
 	planCtx := dsp.NewPlanningCtxWithOracle(
-		ctx, jobExecCtx.ExtendedEvalContext(), nil /* planner */, nil /* txn */, sql.FullDistribution, oracle, noLoc,
+		ctx, jobExecCtx.ExtendedEvalContext(), nil /* planner */, nil /* txn */, sql.FullDistribution, oracle, []roachpb.Locality{}, sql.NoStrictLocalityFiltering,
 	)
 
 	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, targetSpans, sql.PartitionSpansBoundDefault)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -5619,3 +5619,10 @@ func (dsp *DistSQLPlanner) createPlanForInsert(
 func (dsp *DistSQLPlanner) NodeDescStore() kvclient.NodeDescStore {
 	return dsp.nodeDescs
 }
+
+func SingleLocalityFilter(l roachpb.Locality) []roachpb.Locality {
+	if l.Empty() {
+		return nil
+	}
+	return []roachpb.Locality{l}
+}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -154,6 +154,8 @@ const (
 	FullDistribution
 )
 
+const NoStrictLocalityFiltering = false
+
 // ReplicaOraclePolicy controls which policy the physical planner uses to choose
 // a replica for a given range. It is exported so that it may be overwritten
 // during initialization by CCL code to enable follower reads.
@@ -961,7 +963,15 @@ func (p *spanPartitionState) update(
 type PlanningCtx struct {
 	ExtendedEvalCtx *extendedEvalContext
 
-	localityFilter roachpb.Locality
+	// localityFilters indicate that the sqlInstance resolver should attempt to
+	// map the passed in kv node to a sql instance that matches any of the
+	// locality filters.
+	localityFilters []roachpb.Locality
+
+	// strictFiltering, if specified, will fail planning if the instanceResolver
+	// cannot find a sql instance that matches the localityFilters. Further, the
+	// passed in kv node must also match the locality filters.
+	strictFiltering bool
 
 	// spanPartitionState captures information about the current state of the
 	// partitioning that has occurred during the planning process.
@@ -1319,6 +1329,9 @@ const (
 	// eligible but overloaded with other partitions. In this case we pick a
 	// random instance apart from the gateway.
 	SpanPartitionReason_LOCALITY_FILTERED_RANDOM_GATEWAY_OVERLOADED
+	// SpanPartitionReason_NO_VALID_INSTANCE is reported if no valid instance
+	// could be found.
+	SpanPartitionReason_NO_VALID_INSTANCE
 	// SpanPartitionReasonMax tracks the number of SpanPartitionReason objects.
 	SpanPartitionReasonMax
 )
@@ -1345,6 +1358,8 @@ func (r SpanPartitionReason) String() string {
 		return "round-robin"
 	case SpanPartitionReason_LOCALITY_FILTERED_RANDOM_GATEWAY_OVERLOADED:
 		return "locality-filtered-random-gateway-overloaded"
+	case SpanPartitionReason_NO_VALID_INSTANCE:
+		return "no-valid-instance"
 	default:
 		return "unknown"
 	}
@@ -1582,6 +1597,25 @@ func (dsp *DistSQLPlanner) partitionSpan(
 		}
 
 		sqlInstanceID, reason := getSQLInstanceIDForKVNodeID(replDesc.NodeID)
+		if reason == SpanPartitionReason_NO_VALID_INSTANCE {
+			return nil, 0, errors.Errorf("no valid SQL instance for KV node %d", replDesc.NodeID)
+		}
+		if planCtx.strictFiltering && !(reason == SpanPartitionReason_CLOSEST_LOCALITY_MATCH || reason == SpanPartitionReason_TARGET_HEALTHY) {
+			// TODO(msbutler): ideally we would error when
+			// SpanPartitionReason_CLOSEST_LOCALITY_MATCH is not returned, but the
+			// mixedProcessSameNodeResolver can return
+			// SpanPartitionReason_TARGET_HEALTHY on a valid match.
+			//
+			// As a follow up, we should remove the conditional use of the
+			// mixedProcessSameNodeResolver by either teaching the
+			// mixedProcessSameNodeResolver about locality filtering, or getting rid
+			// of it. To do this cleanly, I will need to grok
+			// https://github.com/cockroachdb/cockroach/pull/124986
+			return nil, 0, errors.Errorf(
+				"sql instance %d does not match locality filters %v, given partition reason %s",
+				sqlInstanceID, planCtx.localityFilters, reason,
+			)
+		}
 		planCtx.spanPartitionState.update(sqlInstanceID, reason)
 		partitionIdx, inNodeMap := nodeMap[sqlInstanceID]
 		if !inNodeMap {
@@ -1841,14 +1875,14 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 	ctx context.Context, planCtx *PlanningCtx,
 ) (func(roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason), error) {
 	_, mixedProcessMode := dsp.distSQLSrv.NodeID.OptionalNodeID()
-	locFilter := planCtx.localityFilter
+	locFilters := planCtx.localityFilters
 
 	var mixedProcessSameNodeResolver func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason)
 	if mixedProcessMode {
 		mixedProcessSameNodeResolver = dsp.healthySQLInstanceIDForKVNodeHostedInstanceResolver(ctx, planCtx)
 	}
 
-	if mixedProcessMode && locFilter.Empty() {
+	if mixedProcessMode && len(locFilters) == 0 {
 		return mixedProcessSameNodeResolver, nil
 	}
 
@@ -1865,7 +1899,7 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 		// instances (one example is someone explicitly removing the rows from
 		// the sql_instances table), but we always have the gateway pod to
 		// execute on, so we'll use it (unless we have a locality filter).
-		if locFilter.NonEmpty() {
+		if len(locFilters) > 0 {
 			return nil, noInstancesMatchingLocalityFilterErr
 		}
 		log.Dev.Warningf(ctx, "no healthy sql instances available for planning, only using the gateway")
@@ -1877,13 +1911,16 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 	instancesHaveLocality := false
 
 	var gatewayIsEligible bool
-	if locFilter.NonEmpty() {
+	if len(locFilters) > 0 {
 		eligible := make([]sqlinstance.InstanceInfo, 0, len(instances))
 		for i := range instances {
-			if ok, _ := instances[i].Locality.Matches(locFilter); ok {
-				eligible = append(eligible, instances[i])
-				if instances[i].InstanceID == dsp.gatewaySQLInstanceID {
-					gatewayIsEligible = true
+			for _, filter := range locFilters {
+				if ok, _ := instances[i].Locality.Matches(filter); ok {
+					eligible = append(eligible, instances[i])
+					if instances[i].InstanceID == dsp.gatewaySQLInstanceID {
+						gatewayIsEligible = true
+					}
+					break
 				}
 			}
 		}
@@ -1935,13 +1972,45 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 			// If we're in mixed-mode, check if the picked node already matches the
 			// locality filter in which case we can just use it.
 			if mixedProcessMode {
-				if ok, _ := nodeDesc.Locality.Matches(locFilter); ok {
-					return mixedProcessSameNodeResolver(nodeID)
-				} else {
-					log.VEventf(ctx, 2,
-						"node %d locality %s does not match locality filter %s, finding alternative placement...",
-						nodeID, nodeDesc.Locality, locFilter,
-					)
+				for _, filter := range locFilters {
+					if ok, _ := nodeDesc.Locality.Matches(filter); ok {
+						return mixedProcessSameNodeResolver(nodeID)
+					}
+				}
+				log.VEventf(ctx, 2,
+					"node %d locality %s does not match locality filter %s, finding alternative placement...",
+					nodeID, nodeDesc.Locality, locFilters)
+			}
+
+			// For strict mode to work, the nodeDesc must match the locality filter.
+			// This may have been checked earlier by certain oracles. Without this
+			// check, the ClosestInstances call below could return an instance that
+			// violates the locality filter. More specifically, if the locality filter
+			// contains a suffix and the current nodeDesc does not have an exact match
+			// to this suffix, it will match to a node with a common prefix.
+			//
+			// For example, suppose you want to filter on y=a and the eligible sql
+			// instances are 1:x=1,y=a and 2:x=2,y=a. If the picked kv node is
+			// x=1,y=b, ClosestInstances will choose node 1. Instead, in strict mode,
+			// this plan should fail, because we cannot have data in the kv node in
+			// x=1,y=b, get processed in by a sql instance with x=1,y=a. We need an
+			// exact match.
+			if planCtx.strictFiltering {
+				matched := false
+				for _, filter := range locFilters {
+					if ok, _ := nodeDesc.Locality.Matches(filter); ok {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					// The passed in node, which contains a replica for the span we are
+					// attempting to partition, does not satisfy the locality filters, so
+					// this plan should return an error. Return the gatewareInstanceID, as
+					// opposed to 0, just in case some downstream caller does not handle
+					// NO_VALID_INSTANCE properly. We'd rather have a bad plan than a node
+					// panic.
+					return dsp.gatewaySQLInstanceID, SpanPartitionReason_NO_VALID_INSTANCE
 				}
 			}
 
@@ -2079,6 +2148,9 @@ func (dsp *DistSQLPlanner) getInstanceIDForScan(
 		return 0, err
 	}
 	sqlInstanceID, reason := resolver(replDesc.NodeID)
+	if reason == SpanPartitionReason_NO_VALID_INSTANCE {
+		return 0, errors.Errorf("no valid SQL instance for KV node %d", replDesc.NodeID)
+	}
 	planCtx.spanPartitionState.update(sqlInstanceID, reason)
 	return sqlInstanceID, nil
 }
@@ -5378,7 +5450,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 	distributionType DistributionType,
 ) *PlanningCtx {
 	return dsp.NewPlanningCtxWithOracle(
-		ctx, evalCtx, planner, txn, distributionType, physicalplan.DefaultReplicaChooser, roachpb.Locality{},
+		ctx, evalCtx, planner, txn, distributionType, physicalplan.DefaultReplicaChooser, []roachpb.Locality{}, NoStrictLocalityFiltering,
 	)
 }
 
@@ -5391,7 +5463,8 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	txn *kv.Txn,
 	distributionType DistributionType,
 	oracle replicaoracle.Oracle,
-	localityFiler roachpb.Locality,
+	localityFilters []roachpb.Locality,
+	strictFiltering bool,
 ) *PlanningCtx {
 	distribute := distributionType == FullDistribution
 	// Note: infra.Release is not added to the planCtx's onFlowCleanup
@@ -5400,10 +5473,11 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	infra := physicalplan.NewPhysicalInfrastructure(uuid.MakeV4(), dsp.gatewaySQLInstanceID)
 	planCtx := &PlanningCtx{
 		ExtendedEvalCtx: evalCtx,
-		localityFilter:  localityFiler,
+		localityFilters: localityFilters,
 		infra:           infra,
 		isLocal:         !distribute,
 		planner:         planner,
+		strictFiltering: strictFiltering,
 	}
 	if !distribute {
 		if planner == nil ||


### PR DESCRIPTION
This patch teaches distSQL planning's instanceResolver (maps nodes to sql
instances) to match on multiple localities instead of just one. Further, if the
distsql planner is intialized with strict filtering, the distsql plan will
return an error if sql instance returned does not match the passed in
localities.

This work will enable data domiciled locality aware backups. For example,
suppose the user wants to back up an MR cluster spread over regions X, Y and Z.
With strict filtering, the user must pass 3 URIs each with a locality tag to X,
Y, Z. These locality pairs will then get plumbed to dist sql planning to ensure
that data stored in region X will get processed by a node in region X.
Downstream logic ensures a node in region X will send data to the bucket in
region X. So, suppose the user did not pass a bucket with locality Z, then
distsql planning would fail, as it could not return an instance that matches
the filters [X,Y] which contains data in Z.

Informs

Release note: none