### PR TITLE
telemetryccl: unskip and simplify TestTelemetry

### DIFF
--- a/pkg/ccl/telemetryccl/telemetry_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_test.go
@@ -22,8 +22,6 @@ func TestTelemetry(t *testing.T) {
 	skip.UnderRace(t, "takes >1min under race")
 	skip.UnderDeadlock(t, "takes >1min under deadlock")
 
-	skip.WithIssue(t, 152123)
-
 	sqltestutils.TelemetryTest(
 		t,
 		[]base.TestServerArgs{

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_row
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_row
@@ -12,165 +12,61 @@ USE d;
 ALTER DATABASE d ADD REGION "ap-southeast-2"
 ----
 
+#####################################################################
+# CREATE TABLE: Test each locality type once
+#####################################################################
+
 feature-usage
-CREATE TABLE t4 () WITH (schema_locked=false) LOCALITY GLOBAL
+CREATE TABLE t_global () WITH (schema_locked=false) LOCALITY GLOBAL
 ----
 sql.multiregion.create_table.locality.global
 
 feature-usage
-CREATE TABLE t5 () WITH (schema_locked=false) LOCALITY REGIONAL BY ROW
+CREATE TABLE t_row () WITH (schema_locked=false) LOCALITY REGIONAL BY ROW
 ----
 sql.multiregion.create_table.locality.regional_by_row
 
 feature-usage
-CREATE TABLE t6 (cr crdb_internal_region) WITH (schema_locked=false) LOCALITY REGIONAL BY ROW AS cr
+CREATE TABLE t_row_as (cr crdb_internal_region) WITH (schema_locked=false) LOCALITY REGIONAL BY ROW AS cr
 ----
 sql.multiregion.create_table.locality.regional_by_row_as
 
-#
-# GLOBAL -> the others
-#
+#####################################################################
+# ALTER TABLE: Test representative transitions (not exhaustive)
+#####################################################################
 
+# Test GLOBAL -> REGIONAL BY ROW transition
 feature-usage
-ALTER TABLE t4 SET LOCALITY REGIONAL BY ROW
+ALTER TABLE t_global SET LOCALITY REGIONAL BY ROW
 ----
 sql.multiregion.alter_table.locality.from.global.to.regional_by_row
 
 exec
-ALTER TABLE t4 SET LOCALITY GLOBAL
+ALTER TABLE t_global SET LOCALITY GLOBAL
 ----
 
+# Test REGIONAL BY ROW -> GLOBAL transition
 feature-usage
-ALTER TABLE t4 SET LOCALITY GLOBAL
-----
-sql.multiregion.alter_table.locality.from.global.to.global
-
-exec
-ALTER TABLE t4 SET LOCALITY GLOBAL
-----
-
-feature-usage
-ALTER TABLE t4 SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
-----
-sql.multiregion.alter_table.locality.from.global.to.regional_by_table_in
-
-exec
-ALTER TABLE t4 SET LOCALITY GLOBAL;
-ALTER TABLE t4 ADD COLUMN cr crdb_internal_region NOT NULL
-----
-
-feature-usage
-ALTER TABLE t4 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-sql.multiregion.alter_table.locality.from.global.to.regional_by_row_as
-
-exec
-ALTER TABLE t4 SET LOCALITY GLOBAL
-----
-
-feature-usage
-ALTER TABLE t4 SET LOCALITY REGIONAL BY TABLE
-----
-sql.multiregion.alter_table.locality.from.global.to.regional_by_table
-
-exec
-ALTER TABLE t4 SET LOCALITY GLOBAL
-----
-
-#
-# REGIONAL BY ROW -> the others
-#
-
-feature-usage
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW
-----
-sql.multiregion.alter_table.locality.from.regional_by_row.to.regional_by_row
-
-exec
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW
-----
-
-feature-usage
-ALTER TABLE t5 SET LOCALITY GLOBAL
+ALTER TABLE t_row SET LOCALITY GLOBAL
 ----
 sql.multiregion.alter_table.locality.from.regional_by_row.to.global
 
 exec
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW
+ALTER TABLE t_row SET LOCALITY REGIONAL BY ROW
 ----
 
+# Test REGIONAL BY ROW AS -> REGIONAL BY TABLE transition
 feature-usage
-ALTER TABLE t5 SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
-----
-sql.multiregion.alter_table.locality.from.regional_by_row.to.regional_by_table_in
-
-exec
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW;
-----
-
-exec
-ALTER TABLE t5 ADD COLUMN cr crdb_internal_region NOT NULL
-----
-
-feature-usage
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-sql.multiregion.alter_table.locality.from.regional_by_row.to.regional_by_row_as
-
-exec
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW
-----
-
-feature-usage
-ALTER TABLE t5 SET LOCALITY REGIONAL BY TABLE
-----
-sql.multiregion.alter_table.locality.from.regional_by_row.to.regional_by_table
-
-exec
-ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW
-----
-
-#
-# REGIONAL BY TABLE -> the others
-#
-
-feature-usage
-ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW
-----
-sql.multiregion.alter_table.locality.from.regional_by_row_as.to.regional_by_row
-
-exec
-ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-
-feature-usage
-ALTER TABLE t6 SET LOCALITY GLOBAL
-----
-sql.multiregion.alter_table.locality.from.regional_by_row_as.to.global
-
-exec
-ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-
-feature-usage
-ALTER TABLE t6 SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
-----
-sql.multiregion.alter_table.locality.from.regional_by_row_as.to.regional_by_table_in
-
-exec
-ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-
-feature-usage
-ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-sql.multiregion.alter_table.locality.from.regional_by_row_as.to.regional_by_row_as
-
-exec
-ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-
-feature-usage
-ALTER TABLE t6 SET LOCALITY REGIONAL BY TABLE
+ALTER TABLE t_row_as SET LOCALITY REGIONAL BY TABLE
 ----
 sql.multiregion.alter_table.locality.from.regional_by_row_as.to.regional_by_table
+
+exec
+ALTER TABLE t_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
+----
+
+# Test a self-transition case
+feature-usage
+ALTER TABLE t_row SET LOCALITY REGIONAL BY ROW
+----
+sql.multiregion.alter_table.locality.from.regional_by_row.to.regional_by_row

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_table
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_table
@@ -13,122 +13,61 @@ ALTER DATABASE d ADD REGION "ap-southeast-2"
 ----
 
 #####################################################################
-# CREATE TABLE: Test initial table creation with different localities
+# CREATE TABLE: Test each locality type once
 #####################################################################
 
 feature-usage
-CREATE TABLE t0 () 
+CREATE TABLE t_unspecified ()
 ----
 sql.multiregion.create_table.locality.unspecified
 
 feature-usage
-CREATE TABLE t1 () LOCALITY REGIONAL BY TABLE
+CREATE TABLE t_regional () LOCALITY REGIONAL BY TABLE
 ----
 sql.multiregion.create_table.locality.regional_by_table
 
 feature-usage
-CREATE TABLE t2 () LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+CREATE TABLE t_regional_in () LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 ----
 sql.multiregion.create_table.locality.regional_by_table_in
 
 feature-usage
-CREATE TABLE t3 () LOCALITY GLOBAL
+CREATE TABLE t_global () LOCALITY GLOBAL
 ----
 sql.multiregion.create_table.locality.global
 
 #####################################################################
-# ALTER TABLE from REGIONAL BY TABLE
+# ALTER TABLE: Test representative transitions (not exhaustive)
 #####################################################################
 
 exec
-CREATE TABLE t1_to_row () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE;
-CREATE TABLE t1_to_global () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE;
-CREATE TABLE t1_to_table_in () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE;
-CREATE TABLE t1_to_row_as () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE;
-ALTER TABLE t1_to_row_as ADD COLUMN cr crdb_internal_region NOT NULL;
+CREATE TABLE t_alter1 () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE;
+CREATE TABLE t_alter2 () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2";
+CREATE TABLE t_alter3 () WITH (schema_locked=false) LOCALITY GLOBAL;
+CREATE TABLE t_alter4 () WITH (schema_locked=false) LOCALITY REGIONAL BY TABLE;
+ALTER TABLE t_alter4 ADD COLUMN cr crdb_internal_region NOT NULL;
 ----
 
+# Test REGIONAL BY TABLE -> REGIONAL BY ROW
 feature-usage
-ALTER TABLE t1_to_row SET LOCALITY REGIONAL BY ROW
+ALTER TABLE t_alter1 SET LOCALITY REGIONAL BY ROW
 ----
 sql.multiregion.alter_table.locality.from.regional_by_table.to.regional_by_row
 
+# Test REGIONAL BY TABLE IN -> GLOBAL
 feature-usage
-ALTER TABLE t1_to_global SET LOCALITY GLOBAL
-----
-sql.multiregion.alter_table.locality.from.regional_by_table.to.global
-
-feature-usage
-ALTER TABLE t1_to_table_in SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
-----
-sql.multiregion.alter_table.locality.from.regional_by_table.to.regional_by_table_in
-
-feature-usage
-ALTER TABLE t1_to_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-sql.multiregion.alter_table.locality.from.regional_by_table.to.regional_by_row_as
-
-#####################################################################
-# ALTER TABLE from REGIONAL BY TABLE IN
-#####################################################################
-
-exec
-CREATE TABLE t2_to_row () WITH (schema_locked = false) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2";
-CREATE TABLE t2_to_global () WITH (schema_locked = false) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2";
-CREATE TABLE t2_to_table () WITH (schema_locked = false) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2";
-CREATE TABLE t2_to_row_as () WITH (schema_locked = false) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2";
-ALTER TABLE t2_to_row_as ADD COLUMN cr crdb_internal_region NOT NULL;
-----
-
-feature-usage
-ALTER TABLE t2_to_row SET LOCALITY REGIONAL BY ROW
-----
-sql.multiregion.alter_table.locality.from.regional_by_table_in.to.regional_by_row
-
-feature-usage
-ALTER TABLE t2_to_global SET LOCALITY GLOBAL
+ALTER TABLE t_alter2 SET LOCALITY GLOBAL
 ----
 sql.multiregion.alter_table.locality.from.regional_by_table_in.to.global
 
+# Test GLOBAL -> REGIONAL BY TABLE IN
 feature-usage
-ALTER TABLE t2_to_table SET LOCALITY REGIONAL BY TABLE
-----
-sql.multiregion.alter_table.locality.from.regional_by_table_in.to.regional_by_table
-
-feature-usage
-ALTER TABLE t2_to_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
-----
-sql.multiregion.alter_table.locality.from.regional_by_table_in.to.regional_by_row_as
-
-
-#####################################################################
-# ALTER TABLE from GLOBAL
-#####################################################################exec
-
-exec
-CREATE TABLE t3_to_row () WITH (schema_locked = false) LOCALITY GLOBAL;
-CREATE TABLE t3_to_table () WITH (schema_locked = false) LOCALITY GLOBAL;
-CREATE TABLE t3_to_table_in () WITH (schema_locked = false) LOCALITY GLOBAL;
-CREATE TABLE t3_to_row_as () WITH (schema_locked = false) LOCALITY GLOBAL;
-ALTER TABLE t3_to_row_as ADD COLUMN cr crdb_internal_region NOT NULL;
-----
-
-feature-usage
-ALTER TABLE t3_to_row SET LOCALITY REGIONAL BY ROW
-----
-sql.multiregion.alter_table.locality.from.global.to.regional_by_row
-
-feature-usage
-ALTER TABLE t3_to_table SET LOCALITY REGIONAL BY TABLE
-----
-sql.multiregion.alter_table.locality.from.global.to.regional_by_table
-
-feature-usage
-ALTER TABLE t3_to_table_in SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+ALTER TABLE t_alter3 SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 ----
 sql.multiregion.alter_table.locality.from.global.to.regional_by_table_in
 
+# Test REGIONAL BY TABLE -> REGIONAL BY ROW AS
 feature-usage
-ALTER TABLE t3_to_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
+ALTER TABLE t_alter4 SET LOCALITY REGIONAL BY ROW AS "cr"
 ----
-sql.multiregion.alter_table.locality.from.global.to.regional_by_row_as
+sql.multiregion.alter_table.locality.from.regional_by_table.to.regional_by_row_as


### PR DESCRIPTION
Previously, we would often get test flakes for TestTelemetry because it exercised many different multi-region features for the sole purpose of checking whether telemetry counters would get incremented. This is not very useful because the logic for the different counters is mostly identical and runs through the same functions in multiregion/telemetry.go. As long as these integration tests verify that those functions get called, we don't need an exhaustive set of cases.

Resolves: #152123
Epic: None

Release note: none