### PR TITLE
kvserver: annotate engines in splitPreApply

### DIFF
--- a/pkg/kv/kvserver/kvstorage/storage.go
+++ b/pkg/kv/kvserver/kvstorage/storage.go
@@ -55,8 +55,14 @@ type ReadWriter struct {
 
 // TODOState interprets the provided storage accessor as the State engine.
 //
-// TODO(pav-kv): remove when all callers have clarified their access patterns.
+// TODO(pav-kv): remove when all callers have clarified their access patterns,
+// and switched to WrapState() or other explicitly defined engine types.
 func TODOState(rw storage.ReadWriter) State {
+	return State{RO: rw, WO: rw}
+}
+
+// WrapState interprets the provided storage accessor as the State engine.
+func WrapState(rw StateRW) State {
 	return State{RO: rw, WO: rw}
 }
 

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -321,7 +321,10 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// NB: another reason why we shouldn't write HardState at evaluation time is
 		// that it belongs to the log engine, whereas the evaluated batch must
 		// contain only state machine updates.
-		splitPreApply(ctx, b.r, b.batch, res.Split.SplitTrigger, cmd.Cmd.ClosedTimestamp)
+		splitPreApply(
+			ctx, b.r, kvstorage.StateRW(b.batch), kvstorage.TODORaft(b.batch),
+			res.Split.SplitTrigger, cmd.Cmd.ClosedTimestamp,
+		)
 
 		// The rangefeed processor will no longer be provided logical ops for
 		// its entire range, so it needs to be shut down and all registrations

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -122,7 +122,7 @@ func splitPreApply(
 			}
 		}
 		if err := kvstorage.RemoveStaleRHSFromSplit(
-			ctx, readWriter, readWriter, split.RightDesc.RangeID, split.RightDesc.RSpan(),
+			ctx, kvstorage.TODOState(readWriter), split.RightDesc.RangeID, split.RightDesc.RSpan(),
 		); err != nil {
 			log.KvExec.Fatalf(ctx, "failed to clear range data for removed rhs: %v", err)
 		}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -4043,12 +4043,10 @@ func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
 	}, &rightDesc.InternalReplicas[0])
 	require.NoError(t, err)
 
-	split := roachpb.SplitTrigger{
-		LeftDesc:  leftDesc,
-		RightDesc: rightDesc,
-	}
-
-	splitPreApply(ctx, lhsRepl, batch, split, nil)
+	splitPreApply(
+		ctx, lhsRepl, kvstorage.StateRW(batch), kvstorage.TODORaft(batch),
+		roachpb.SplitTrigger{LeftDesc: leftDesc, RightDesc: rightDesc}, nil,
+	)
 
 	// Verify that the RHS truncated state is initialized as expected.
 	rsl := kvstorage.MakeStateLoader(rightDesc.RangeID)


### PR DESCRIPTION
This PR annotates all storage operations with raft/state engine types, down the stack from `splitPreApply`.

Epic: CRDB-55220