### PR TITLE
logical: do not allow the REFCURSOR type

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2833,6 +2833,11 @@ func TestLogicalReplicationCreationChecks(t *testing.T) {
 	jobutils.WaitForJobToCancel(t, dbA, jobAID)
 	replicationtestutils.WaitForAllProducerJobsToFail(t, dbB)
 
+	// Check that REFCURSOR columns are not allowed.
+	dbA.Exec(t, "CREATE TABLE tab_with_refcursor (pk INT PRIMARY KEY, curs REFCURSOR)")
+	dbB.Exec(t, "CREATE TABLE b.tab_with_refcursor (pk INT PRIMARY KEY, curs REFCURSOR)")
+	expectErr(t, "tab_with_refcursor", "cannot create logical replication stream: column curs is a RefCursor")
+
 	// Add different default values to to the source and dest, verify the stream
 	// can be created, and that the default value is sent over the wire.
 	dbA.Exec(t, "CREATE TABLE tab2 (pk INT PRIMARY KEY, payload STRING DEFAULT 'cat')")


### PR DESCRIPTION
This removes LDR support for the REFCURSOR type. The crud writer does not support it because REFCURSOR does not support the equality SQL operator.

This removal is unlikely to impact any users. The REFCURSOR is a weird type that should not show up in a durable table. If the user really needs this type for some reason, they could store they type as a STRING and convert it back to a REFCURSOR when reading from the table.

Epic: CRDB-48647
Release note: none