### PR TITLE
sql: remove wrapping single quotes in output of  ltree2text

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ltree
+++ b/pkg/sql/logictest/testdata/logic_test/ltree
@@ -263,7 +263,7 @@ SELECT subpath(NULL::LTREE, 99, 99);
 ----
 NULL
 
-# An overflow has occurred 
+# An overflow has occurred
 query error invalid positions
 SELECT subpath('A.B.C'::LTREE, 1, 9223372036854775807::INT8)
 
@@ -344,10 +344,12 @@ foo_bar-baz.baz
 query error could not parse ltree
 SELECT text2ltree('foo..bar');
 
-query T
-SELECT ltree2text('foo_bar-baz.baz'::LTREE);
+query TBB
+SELECT ltree2text('foo_bar-baz.baz'::LTREE),
+    ltree2text('foo'::LTREE) = 'foo'::TEXT,
+    ltree2text(NULL::LTREE) IS NULL;
 ----
-'foo_bar-baz.baz'
+foo_bar-baz.baz  true  true
 
 query T
 SELECT lca('A.B.C'::LTREE, 'A.B.C.D'::LTREE, 'A.B.C.E'::LTREE);

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9630,7 +9630,7 @@ WHERE object_id = table_descriptor_id
 			Volatility: volatility.Immutable,
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ltree := tree.MustBeDLTree(args[0])
-				return tree.NewDString(ltree.String()), nil
+				return tree.NewDString(ltree.LTree.String()), nil
 			},
 		},
 	),


### PR DESCRIPTION
Fixes #156479

Release note (bug fix): A bug has been fix with the `ltree2text`
built-in function in which the returned `TEXT` value was incorrectly
wrapped with single quotes. This bug has been present since the
`ltree2text` built-in was introduced in v25.4.0.
