### PR TITLE
sql, sqlstats: Refactor Statement Recording

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1268,7 +1268,6 @@ func (s *Server) newConnExecutor(
 		s.sqlStatsIngester,
 		ex.phaseTimes,
 		s.localSqlStats.GetCounters(),
-		s.cfg.SQLStatsTestingKnobs,
 	)
 	ex.dataMutatorIterator.OnApplicationNameChange = func(newName string) {
 		ex.applicationName.Store(newName)

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlcommenter",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
+        "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/stop",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_ingester_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_ingester_test.go
@@ -412,7 +412,6 @@ func TestStatsCollectorIngester(t *testing.T) {
 		ingester,
 		phaseTimes,
 		uniqueServerCounts,
-		nil, // knobs
 	)
 
 	sessionID := clusterunique.IDFromBytes([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -471,7 +471,6 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		ingester,
 		sessionphase.NewTimes(),
 		sqlStats.GetCounters(),
-		nil, /* knobs */
 	)
 
 	recordStats := func(testCase *tc) {
@@ -595,7 +594,6 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			ingester,
 			sessionphase.NewTimes(),
 			sqlStats.GetCounters(),
-			nil, /* knobs */
 		)
 
 		ingester.Start(ctx, stopper)


### PR DESCRIPTION
A new RecordedStatementStatsBuilder was added to the sql package to make building a RecordedStmtStats struct easier.

New interfaces were also added to sqlstats to make make building RecordedStmtStats easier.

These new interfaces and builders should help to decouple Recording statement stats from the conn executor, allowing them to be recorded in other places as well 

Epic: None
Release note: None