### PR TITLE
kvserver: consolidate SynthesizeRaftState

### DIFF
--- a/pkg/kv/kvserver/kvstorage/stateloader.go
+++ b/pkg/kv/kvserver/kvstorage/stateloader.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -386,22 +387,51 @@ func UninitializedReplicaState(rangeID roachpb.RangeID) kvserverpb.ReplicaState 
 	}
 }
 
-// The rest is not technically part of ReplicaState.
-
-// SynthesizeRaftState creates a Raft state which synthesizes HardState from
-// pre-seeded data in the engine: the state machine state created by
-// WriteInitialReplicaState on a split, and the existing HardState of an
-// uninitialized replica.
+// SynthesizeRaftState returns the initial raft state of an initialized replica,
+// taking into account the HardState of the uninitialized replica it replaces.
 //
-// TODO(sep-raft-log): this is now only used in splits, when initializing a
-// replica. Make the implementation straightforward, most of the stuff here is
-// constant except the existing HardState.
-func (s StateLoader) SynthesizeRaftState(
-	ctx context.Context, raftRW Raft, applied logstore.EntryID,
-) error {
-	hs, err := s.LoadHardState(ctx, raftRW.RO)
-	if err != nil {
-		return err
+// An uninitialized replica can have a non-empty HardState because such replicas
+// are able to update the Term, participate in raft elections (update Vote and
+// other supporting fields). When initializing the replica, we must not regress
+// this HardState.
+func SynthesizeRaftState(
+	oldHS raftpb.HardState, applied logstore.EntryID,
+) (_ raftpb.HardState, _ kvserverpb.RaftTruncatedState, err error) {
+	// Assert that the replica is uninitialized.
+	if commit := oldHS.Commit; commit != 0 {
+		err = errors.Newf("uninitialized replica with a non-zero commit index %d", commit)
+		return
 	}
-	return s.SynthesizeHardState(ctx, raftRW.WO, hs, applied)
+	// A raft log always starts at a fixed index/term of the virtual entry that
+	// represents the initial applied state of the range (populated upon the
+	// cluster bootstrap, or inherited by the range when it is split out).
+	initTS := kvserverpb.RaftTruncatedState{
+		Index: RaftInitialLogIndex,
+		Term:  RaftInitialLogTerm,
+	}
+	// Assert that the applied state is initialized correctly.
+	if applied != initTS {
+		err = errors.Newf("applied entry ID %+v mismatches %+v", applied, initTS)
+		return
+	}
+
+	// If the existing HardState is empty, or has an outdated term, we forget it,
+	// and install one with a newer term. This is a valid transition from raft's
+	// perspective.
+	if oldHS.Term < RaftInitialLogTerm {
+		return raftpb.HardState{
+			Term:   RaftInitialLogTerm,
+			Commit: RaftInitialLogIndex,
+		}, initTS, nil
+	}
+	// Otherwise, the uninitialized replica has already participated in the
+	// initial term or above. It might have voted, and might know the leader.
+	// Preserve this information, and only move the Commit index forward.
+	return raftpb.HardState{
+		Term:      oldHS.Term,
+		Commit:    RaftInitialLogIndex,
+		Vote:      oldHS.Vote,
+		Lead:      oldHS.Lead,
+		LeadEpoch: oldHS.LeadEpoch,
+	}, initTS, nil
 }

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//record",
         "@com_github_cockroachdb_pebble//vfs",
-        "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_time//rate",
     ],
 )

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -339,12 +339,15 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// NB: another reason why we shouldn't write HardState at evaluation time is
 		// that it belongs to the log engine, whereas the evaluated batch must
 		// contain only state machine updates.
-		in, err := validateAndPrepareSplit(ctx, b.r, res.Split.SplitTrigger, cmd.Cmd.ClosedTimestamp)
-		if err != nil {
+		if in, err := validateAndPrepareSplit(
+			ctx, b.r, res.Split.SplitTrigger, cmd.Cmd.ClosedTimestamp,
+		); err != nil {
 			log.KvExec.Fatalf(ctx, "unable to validate split: %s", err)
+		} else if err := splitPreApply(
+			ctx, kvstorage.StateRW(b.batch), kvstorage.WrapRaft(b.RaftBatch()), in,
+		); err != nil {
+			log.KvExec.Fatalf(ctx, "unable to apply split: %s", err)
 		}
-
-		splitPreApply(ctx, kvstorage.StateRW(b.batch), kvstorage.WrapRaft(b.RaftBatch()), in)
 
 		// The rangefeed processor will no longer be provided logical ops for
 		// its entire range, so it needs to be shut down and all registrations

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -337,7 +337,9 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 					// evaluation.
 					require.NoError(t, stateBatch.ApplyBatchRepr(ps.batchRepr, false /* sync */))
 					// Then run splitPreApply which does the apply-time tweaks.
-					splitPreApply(ctx, kvstorage.StateRW(stateBatch), kvstorage.WrapRaft(raftBatch), in)
+					require.NoError(t, splitPreApply(
+						ctx, kvstorage.StateRW(stateBatch), kvstorage.WrapRaft(raftBatch), in,
+					))
 					// If the RHS replica wasn't destroyed, it is now initialized.
 					// Update the in-memory state to reflect this.
 					if !destroyed {

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -120,7 +120,7 @@ func validateAndPrepareSplit(
 // split commit.
 func splitPreApply(
 	ctx context.Context, stateRW kvstorage.StateRW, raftRW kvstorage.Raft, in splitPreApplyInput,
-) {
+) error {
 	rsl := kvstorage.MakeStateLoader(in.rhsDesc.RangeID)
 	// After PR #149620, the split trigger batch may only contain replicated state
 	// machine keys, and never contains unreplicated / raft keys. One exception:
@@ -139,11 +139,11 @@ func splitPreApply(
 	// TODO(#152847): remove this workaround when there are no historical
 	// proposals with RaftTruncatedState, e.g. after a below-raft migration.
 	if ts, err := rsl.LoadRaftTruncatedState(ctx, stateRW); err != nil {
-		log.KvExec.Fatalf(ctx, "cannot load RaftTruncatedState: %v", err)
+		return errors.Wrapf(err, "cannot load RHS truncated state")
 	} else if ts == (kvserverpb.RaftTruncatedState{}) {
 		// Common case. Do nothing.
 	} else if err := rsl.ClearRaftTruncatedState(stateRW); err != nil {
-		log.KvExec.Fatalf(ctx, "cannot clear RaftTruncatedState: %v", err)
+		return errors.Wrapf(err, "cannot clear RaftTruncatedState")
 	}
 
 	if in.destroyed {
@@ -164,38 +164,39 @@ func splitPreApply(
 		if err := kvstorage.RemoveStaleRHSFromSplit(
 			ctx, kvstorage.WrapState(stateRW), in.rhsDesc.RangeID, in.rhsDesc.RSpan(),
 		); err != nil {
-			log.KvExec.Fatalf(ctx, "failed to clear range data for removed rhs: %v", err)
+			return errors.Wrapf(err, "failed to clear range data for removed RHS")
 		}
-		return
+		return nil
 	}
 
 	// The RHS replica exists and is uninitialized. We are initializing it here.
 	// This is the common case.
 	as, err := rsl.LoadRangeAppliedState(ctx, stateRW)
 	if err != nil {
-		log.KvExec.Fatalf(ctx, "%v", err)
+		return err
 	}
 	// Update the RHS applied state with the computed closed timestamp.
 	as.RaftClosedTimestamp = in.initClosedTimestamp
 	if err := rsl.SetRangeAppliedState(ctx, stateRW, as); err != nil {
-		log.KvExec.Fatalf(ctx, "%s", err)
+		return err
 	}
 
 	// Update raft HardState and truncated state to reflect the replica
 	// initialization. Take into account the existing HardState since the
 	// uninitialized replica could have already moved it forward.
 	if hs, err := rsl.LoadHardState(ctx, raftRW.RO); err != nil {
-		log.KvExec.Fatalf(ctx, "%v", err)
+		return err
 	} else if newHS, initTS, err := kvstorage.SynthesizeRaftState(hs, logstore.EntryID{
 		Index: as.RaftAppliedIndex,
 		Term:  as.RaftAppliedIndexTerm,
 	}); err != nil {
-		log.KvExec.Fatalf(ctx, "%v", err)
+		return err
 	} else if err := rsl.SetHardState(ctx, raftRW.WO, newHS); err != nil {
-		log.KvExec.Fatalf(ctx, "%v", err)
+		return err
 	} else if err := rsl.SetRaftTruncatedState(ctx, raftRW.WO, &initTS); err != nil {
-		log.KvExec.Fatalf(ctx, "%v", err)
+		return err
 	}
+	return nil
 }
 
 // splitPostApply is the part of the split trigger which coordinates the actual

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -175,6 +175,12 @@ func splitPreApply(
 	if err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
 	}
+	// Update the RHS applied state with the computed closed timestamp.
+	as.RaftClosedTimestamp = in.initClosedTimestamp
+	if err := rsl.SetRangeAppliedState(ctx, stateRW, as); err != nil {
+		log.KvExec.Fatalf(ctx, "%s", err)
+	}
+
 	// Update raft HardState and truncated state to reflect the replica
 	// initialization. Take into account the existing HardState since the
 	// uninitialized replica could have already moved it forward.
@@ -189,12 +195,6 @@ func splitPreApply(
 		log.KvExec.Fatalf(ctx, "%v", err)
 	} else if err := rsl.SetRaftTruncatedState(ctx, raftRW.WO, &initTS); err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
-	}
-
-	// Update the RHS applied state with the computed closed timestamp.
-	as.RaftClosedTimestamp = in.initClosedTimestamp
-	if err := rsl.SetRangeAppliedState(ctx, stateRW, as); err != nil {
-		log.KvExec.Fatalf(ctx, "%s", err)
 	}
 }
 

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -177,7 +178,15 @@ func splitPreApply(
 	//
 	// [*] Note that uninitialized replicas may cast votes, and if they have, we
 	// can't load the default Term and Vote values.
-	if err := rsl.SynthesizeRaftState(ctx, stateRW, raftRW); err != nil {
+	as, err := rsl.LoadRangeAppliedState(ctx, stateRW)
+	if err != nil {
+		log.KvExec.Fatalf(ctx, "%v", err)
+	}
+	// TODO(pav-kv): assert that the applied state == RaftInitialLog{Index,Term}.
+	if err := rsl.SynthesizeRaftState(ctx, raftRW, logstore.EntryID{
+		Index: as.RaftAppliedIndex,
+		Term:  as.RaftAppliedIndexTerm,
+	}); err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
 	}
 	if err := rsl.SetRaftTruncatedState(ctx, raftRW.WO, &kvserverpb.RaftTruncatedState{
@@ -186,8 +195,9 @@ func splitPreApply(
 	}); err != nil {
 		log.KvExec.Fatalf(ctx, "%v", err)
 	}
-	// Persist the closed timestamp.
-	if err := rsl.SetClosedTimestamp(ctx, stateRW, in.initClosedTimestamp); err != nil {
+	// Update the RHS applied state with the computed closed timestamp.
+	as.RaftClosedTimestamp = in.initClosedTimestamp
+	if err := rsl.SetRangeAppliedState(ctx, stateRW, as); err != nil {
 		log.KvExec.Fatalf(ctx, "%s", err)
 	}
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -4050,7 +4050,7 @@ func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
 	))
 	in, err := validateAndPrepareSplit(ctx, lhsRepl, roachpb.SplitTrigger{LeftDesc: leftDesc, RightDesc: rightDesc}, nil)
 	require.NoError(t, err)
-	splitPreApply(ctx, kvstorage.StateRW(batch), kvstorage.TODORaft(batch), in)
+	require.NoError(t, splitPreApply(ctx, kvstorage.StateRW(batch), kvstorage.TODORaft(batch), in))
 
 	// Verify that the RHS truncated state is initialized as expected.
 	rsl := kvstorage.MakeStateLoader(rightDesc.RangeID)
@@ -4097,7 +4097,9 @@ func TestSplitPreApplyWithSeparatedEngines(t *testing.T) {
 			RaftAppliedIndex:     kvstorage.RaftInitialLogIndex,
 			RaftAppliedIndexTerm: kvstorage.RaftInitialLogTerm,
 		}))
-	splitPreApply(ctx, kvstorage.StateRW(stateBatch), kvstorage.WrapRaft(raftBatch), in)
+	require.NoError(t, splitPreApply(
+		ctx, kvstorage.StateRW(stateBatch), kvstorage.WrapRaft(raftBatch), in,
+	))
 
 	require.NoError(t, stateBatch.Commit(false /* sync */))
 	require.NoError(t, raftBatch.Commit(false /* sync */))

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -4012,13 +4012,11 @@ func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
 
 	sl := kvstorage.MakeStateLoader(desc.RangeID)
 	// Write the range state that will be consulted and copied during the split.
-	lease := roachpb.Lease{
+	require.NoError(t, sl.SetLease(ctx, batch, nil, roachpb.Lease{
 		Replica:       desc.InternalReplicas[0],
 		Term:          10,
 		MinExpiration: hlc.Timestamp{WallTime: 100},
-	}
-	err := sl.SetLease(ctx, batch, nil, lease)
-	require.NoError(t, err)
+	}))
 
 	// Set up the store and LHS replica.
 	cfg := TestStoreConfig(clock)
@@ -4037,15 +4035,21 @@ func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
 	rightDesc.InternalReplicas[0].ReplicaID++
 
 	// Create an uninitialized replica for the RHS. splitPreApply expects this.
-	_, _, err = store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
+	_, _, err := store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID:   rightDesc.RangeID,
 		ReplicaID: rightDesc.InternalReplicas[0].ReplicaID,
 	}, &rightDesc.InternalReplicas[0])
 	require.NoError(t, err)
 
+	// Populate the RangeAppliedState of the RHS that splitPreApply asserts on.
+	require.NoError(t, kvstorage.MakeStateLoader(rightDesc.RangeID).SetRangeAppliedState(
+		ctx, batch, &kvserverpb.RangeAppliedState{
+			RaftAppliedIndex:     kvstorage.RaftInitialLogIndex,
+			RaftAppliedIndexTerm: kvstorage.RaftInitialLogTerm,
+		},
+	))
 	in, err := validateAndPrepareSplit(ctx, lhsRepl, roachpb.SplitTrigger{LeftDesc: leftDesc, RightDesc: rightDesc}, nil)
 	require.NoError(t, err)
-
 	splitPreApply(ctx, kvstorage.StateRW(batch), kvstorage.TODORaft(batch), in)
 
 	// Verify that the RHS truncated state is initialized as expected.
@@ -4087,12 +4091,16 @@ func TestSplitPreApplyWithSeparatedEngines(t *testing.T) {
 	raftBatch := e.LogEngine().NewBatch()
 	defer raftBatch.Close()
 
+	rsl := kvstorage.MakeStateLoader(rhsRangeID)
+	require.NoError(t, rsl.SetRangeAppliedState(ctx, stateBatch,
+		&kvserverpb.RangeAppliedState{
+			RaftAppliedIndex:     kvstorage.RaftInitialLogIndex,
+			RaftAppliedIndexTerm: kvstorage.RaftInitialLogTerm,
+		}))
 	splitPreApply(ctx, kvstorage.StateRW(stateBatch), kvstorage.WrapRaft(raftBatch), in)
 
 	require.NoError(t, stateBatch.Commit(false /* sync */))
 	require.NoError(t, raftBatch.Commit(false /* sync */))
-
-	rsl := kvstorage.MakeStateLoader(rhsRangeID)
 
 	// Check that the RaftTruncatedState is written to the raft engine.
 	truncState, err := rsl.LoadRaftTruncatedState(ctx, raftEng)


### PR DESCRIPTION
Previously, `splitPreApply` loaded the applied state of the RHS twice: in `SynthesizeRaftState` and `SetClosedTimestamp`. Additionally, `splitPreApply` was the only user of `SynthesizeRaftState` and `SetClosedTimestamp`. This PR removes this unnecessary duplication and indirection.

The logic of generating the initial raft state during a replica initialization in `splitPreApply` is consolidated and simplified. The assertions are made stronger, and the code is more straightforward due to the fact that all the initial values are mostly constants.

This change also decouples the logic from the physical write into the batch, and the latter is consolidated in `splitPreApply`. It is cleaner to plainly see all storage reads and writes in one place, rather than mix them with logic inside a helper.

Additionally, in the context of storage separation, it is better to avoid helpers that use both engines (which `SynthesizeRaftState` did before).

Epic: CRDB-55220