### PR TITLE
release-25.4: roachtest: more logging on deleted sst in OR recovery

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2383,9 +2383,11 @@ func (d *BackupRestoreTestDriver) deleteUserTableSST(
 	ctx context.Context, l *logger.Logger, db *gosql.DB, collection *backupCollection,
 ) error {
 	var sstPath string
+	var startPretty, endPretty string
+	var sizeBytes, numRows int
 	if err := db.QueryRowContext(
 		ctx,
-		`SELECT path FROM
+		`SELECT path, start_pretty, end_pretty, size_bytes, rows FROM
 		(
 			SELECT row_number() OVER (), * FROM
 			[SHOW BACKUP FILES FROM LATEST IN $1]
@@ -2394,14 +2396,17 @@ func (d *BackupRestoreTestDriver) deleteUserTableSST(
 		ORDER BY row_number DESC
 		LIMIT 1`,
 		collection.uri(),
-	).Scan(&sstPath); err != nil {
+	).Scan(&sstPath, &startPretty, &endPretty, &sizeBytes, &numRows); err != nil {
 		return errors.Wrapf(err, "failed to get SST path from %s", collection.uri())
 	}
 	uri, err := url.Parse(collection.uri())
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse backup collection URI %q", collection.uri())
 	}
-	l.Printf("deleting sst %s at %s", sstPath, uri)
+	l.Printf(
+		"deleting sst %s at %s: covering %d bytes and %d rows in [%s, %s)",
+		sstPath, uri, sizeBytes, numRows, startPretty, endPretty,
+	)
 	storage, err := cloud.ExternalStorageFromURI(
 		ctx,
 		collection.uri(),


### PR DESCRIPTION
Backport 1/1 commits from #155780 on behalf of @kev-cao.

----

This commit adds more logging on the SST that is deleted in the OR recovery roachtest to determine exactly what backed up span and data was deleted.

Epic: None

Release note: None

----

Release justification: Test-only change.