### PR TITLE
sql: update metrics description

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8750,7 +8750,7 @@ layers:
     - name: sql.statements.bytes_read.count
       exported_name: sql_statements_bytes_read_count
       description: Number of bytes read by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Bytes
       type: COUNTER
       unit: BYTES
       aggregation: AVG
@@ -8766,7 +8766,7 @@ layers:
     - name: sql.statements.index_bytes_written.count
       exported_name: sql_statements_index_bytes_written_count
       description: Number of primary and secondary index bytes modified by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Bytes
       type: COUNTER
       unit: BYTES
       aggregation: AVG
@@ -8782,7 +8782,7 @@ layers:
     - name: sql.statements.index_rows_written.count
       exported_name: sql_statements_index_rows_written_count
       description: Number of primary and secondary index rows modified by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Rows
       type: COUNTER
       unit: COUNT
       aggregation: AVG
@@ -8798,7 +8798,7 @@ layers:
     - name: sql.statements.rows_read.count
       exported_name: sql_statements_rows_read_count
       description: Number of rows read by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Rows
       type: COUNTER
       unit: COUNT
       aggregation: AVG

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1517,25 +1517,25 @@ var (
 	MetaStatementRowsRead = metric.Metadata{
 		Name:        "sql.statements.rows_read.count",
 		Help:        "Number of rows read by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Rows",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaStatementBytesRead = metric.Metadata{
 		Name:        "sql.statements.bytes_read.count",
 		Help:        "Number of bytes read by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 	MetaStatementIndexRowsWritten = metric.Metadata{
 		Name:        "sql.statements.index_rows_written.count",
 		Help:        "Number of primary and secondary index rows modified by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Rows",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaStatementIndexBytesWritten = metric.Metadata{
 		Name:        "sql.statements.index_bytes_written.count",
 		Help:        "Number of primary and secondary index bytes modified by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 )


### PR DESCRIPTION
Small update to metrics descriptions that change the caption that's shown for the y-axis for the bytes/rows read/written metrics.

Epic: AOP-30

Release note: None