### PR TITLE
sql: enable test tenants

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -326,7 +326,8 @@ type DefaultTestTenantOptions struct {
 	// warn".
 	noWarnImplicitInterfaces bool
 
-	// If test tenant is disabled, issue and label to link in log message.
+	// If test tenant is disabled, issue and label to link in log message. These
+	// can be left unset if one of the tenant modes is explicitly skipped.
 	issueNum int
 	label    string
 }
@@ -573,6 +574,12 @@ func TestSkippedForExternalModeDueToPerformance(issueNumber int) DefaultTestTena
 // problem.
 func TestDoesNotWorkWithExternalProcessMode(issueNumber int) DefaultTestTenantOptions {
 	return testSkippedForExternalProcessMode(issueNumber)
+}
+
+// TestSkipForExternalProcessMode disables selecting the external process
+// virtual cluster for tests that are not applicable to that mode.
+func TestSkipForExternalProcessMode() DefaultTestTenantOptions {
+	return testSkippedForExternalProcessMode(0 /* issueNumber */)
 }
 
 func testSkippedForExternalProcessMode(issueNumber int) DefaultTestTenantOptions {

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -145,8 +145,7 @@ func FetchDescVersionModificationTime(
 	tableName string,
 	version int,
 ) hlc.Timestamp {
-	db := serverutils.OpenDBConn(
-		t, s.SQLAddr(), dbName, false, s.AppStopper())
+	db := s.SQLConn(t, serverutils.DBName(dbName))
 
 	tblKey := s.Codec().IndexPrefix(keys.DescriptorTableID, keys.DescriptorTablePrimaryKeyIndexID)
 	header := kvpb.RequestHeader{

--- a/pkg/ccl/testccl/sqlccl/gc_job_test.go
+++ b/pkg/ccl/testccl/sqlccl/gc_job_test.go
@@ -32,7 +32,7 @@ func TestGCJobGetsMarkedIdle(t *testing.T) {
 	s, mainDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
-	sqltestutils.SetShortRangeFeedIntervals(t, mainDB)
+	sqltestutils.SetShortRangeFeedIntervals(t, s)
 	defer s.Stopper().Stop(ctx)
 	tenant, tenantDB := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: serverutils.TestTenantID(),

--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -313,9 +312,6 @@ func TestAsOfRetry(t *testing.T) {
 
 			switch req := args.Req.(type) {
 			case *kvpb.GetRequest:
-				if kv.TestingIsRangeLookupRequest(req) {
-					return nil
-				}
 				for key, count := range magicVals.restartCounts {
 					if err := checkCorrectTxn(string(req.Key), magicVals, args.Hdr.Txn); err != nil {
 						return kvpb.NewError(err)

--- a/pkg/sql/authorization_test.go
+++ b/pkg/sql/authorization_test.go
@@ -98,8 +98,8 @@ func TestConcurrentGrants(t *testing.T) {
 
 	runConcurrentGrantsWithPriority := func(t *testing.T, priority string) {
 		ctx := context.Background()
-		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-		defer s.Stopper().Stop(ctx)
+		srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		defer srv.Stopper().Stop(ctx)
 		tdb := sqlutils.MakeSQLRunner(db)
 
 		// Shortening this cluster setting is essential for this test. A small value
@@ -107,7 +107,7 @@ func TestConcurrentGrants(t *testing.T) {
 		// commit. This is needed to force `txn2` to encounter a WriteTooOldError
 		// after being unblocked, and hence enter a retry, as retry in `txn2` is
 		// prerequisite for the potential deadlock described in #117144.
-		tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1ms'")
+		sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t)).Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1ms'")
 
 		tdb.Exec(t, "CREATE ROLE developer;")
 		tdb.Exec(t, "CREATE USER user1")

--- a/pkg/sql/backfill_protected_timestamp_test.go
+++ b/pkg/sql/backfill_protected_timestamp_test.go
@@ -241,6 +241,7 @@ func TestBackfillQueryWithProtectedTS(t *testing.T) {
 	var db *gosql.DB
 	var tableID uint32
 	s, db, _ = serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(156127),
 		Knobs: base.TestingKnobs{
 			SQLEvalContext: &eval.TestingKnobs{
 				ForceProductionValues: true,

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,6 +30,8 @@ import (
 func TestCreateAsVTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "too slow")
 
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -83,12 +86,17 @@ func TestCreateAsVTable(t *testing.T) {
 					`"".crdb_internal.gossip_liveness`:                {},
 					`"".crdb_internal.gossip_nodes`:                   {},
 					`"".crdb_internal.kv_flow_controller`:             {},
+					`"".crdb_internal.kv_flow_controller_v2`:          {},
 					`"".crdb_internal.kv_flow_control_handles`:        {},
+					`"".crdb_internal.kv_flow_control_handles_v2`:     {},
 					`"".crdb_internal.kv_flow_token_deductions`:       {},
+					`"".crdb_internal.kv_flow_token_deductions_v2`:    {},
 					`"".crdb_internal.kv_node_status`:                 {},
 					`"".crdb_internal.kv_node_liveness`:               {},
 					`"".crdb_internal.kv_store_status`:                {},
 					`"".crdb_internal.node_tenant_capabilities_cache`: {},
+					`"".crdb_internal.store_liveness_support_for`:     {},
+					`"".crdb_internal.store_liveness_support_from`:    {},
 					`"".crdb_internal.tenant_usage_details`:           {},
 				}
 				if _, ok := onlySystemTenant[fqName]; ok {

--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -59,6 +59,10 @@ func TestStatsWithLowTTL(t *testing.T) {
 				},
 			},
 		},
+		// In external-process mode the tenant doesn't have kvpb.GCRequest
+		// capability (and this capability can't be granted at the time of
+		// writing either), so we skip the external mode only.
+		DefaultTestTenant: base.TestSkipForExternalProcessMode(),
 	})
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -278,6 +278,10 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
 				UseDatabase: "test",
+				// Probably this test could work in shared-process mode, but
+				// it's occasionally flaking there and doesn't seem worth
+				// investigating since we're touching the ranges directly.
+				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 			},
 		})
 	defer tc.Stopper().Stop(context.Background())
@@ -298,7 +302,7 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	//
 	// TODO(andrei): This is super hacky. What this test really wants to do is to
 	// precisely control the contents of the range cache on node 4.
-	tc.Server(3).DistSenderI().(*kvcoord.DistSender).DisableFirstRangeUpdates()
+	tc.ApplicationLayer(3).DistSenderI().(*kvcoord.DistSender).DisableFirstRangeUpdates()
 	db3 := tc.ServerConn(3)
 	// Force the DistSQL on this connection.
 	_, err := db3.Exec(`SET CLUSTER SETTING sql.defaults.distsql = always;`)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -17,9 +17,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
@@ -47,6 +49,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeKey(codec keys.SQLCodec, key string) roachpb.Key {
+	return append(append(roachpb.Key(nil), codec.TenantPrefix()...), roachpb.Key(key)...)
+}
+
 // Test that we don't attempt to create flows in an aborted transaction.
 // Instead, a retryable error is created on the gateway. The point is to
 // simulate a race where the heartbeat loop finds out that the txn is aborted
@@ -63,21 +69,22 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	srv, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	if _, err := sqlDB.ExecContext(
 		ctx, "create database test; create table test.t(a int)"); err != nil {
 		t.Fatal(err)
 	}
-	key := roachpb.Key("a")
+	key := makeKey(s.Codec(), "a")
 
 	// Plan a statement.
 	execCfg := s.ExecutorConfig().(ExecutorConfig)
 	sd := NewInternalSessionData(ctx, execCfg.Settings, "test")
 	internalPlanner, cleanup := NewInternalPlanner(
 		"test",
-		kv.NewTxn(ctx, db, s.NodeID()),
+		kv.NewTxn(ctx, db, srv.NodeID()),
 		username.NodeUserName(),
 		&MemoryMetrics{},
 		&execCfg,
@@ -118,11 +125,11 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 			HeartbeatInterval: time.Millisecond,
 			Settings:          s.ClusterSettings(),
 			Clock:             s.Clock(),
-			Stopper:           s.Stopper(),
+			Stopper:           s.AppStopper(),
 		},
 		s.DistSenderI().(*kvcoord.DistSender),
 	)
-	shortDB := kv.NewDB(ambient, tsf, s.Clock(), s.Stopper())
+	shortDB := kv.NewDB(ambient, tsf, s.Clock(), s.AppStopper())
 
 	iter := 0
 	// We'll trace to make sure the test isn't fooling itself.
@@ -218,7 +225,7 @@ func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
 		abortTxn func(uuid uuid.UUID)
 	}{}
 
-	s, conn, db := serverutils.StartServer(t, base.TestServerArgs{
+	srv, conn, db := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			DistSQL: &execinfra.TestingKnobs{
 				RunBeforeCascadesAndChecks: func(txnID uuid.UUID) {
@@ -231,7 +238,8 @@ func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
 			},
 		},
 	})
-	defer s.Stopper().Stop(ctx)
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Set up schemas for the test. We want a construction that results in 2 FK
@@ -243,7 +251,7 @@ func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
 		t,
 		"create table test.child(a INT, b INT, FOREIGN KEY (a) REFERENCES test.parent1(a), FOREIGN KEY (b) REFERENCES test.parent2(b))",
 	)
-	key := roachpb.Key("a")
+	key := makeKey(s.Codec(), "a")
 
 	setupQueries := []string{
 		"insert into test.parent1 VALUES(1)",
@@ -341,11 +349,11 @@ func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
 			HeartbeatInterval: time.Millisecond,
 			Settings:          s.ClusterSettings(),
 			Clock:             s.Clock(),
-			Stopper:           s.Stopper(),
+			Stopper:           s.AppStopper(),
 		},
 		s.DistSenderI().(*kvcoord.DistSender),
 	)
-	shortDB := kv.NewDB(ambient, tsf, s.Clock(), s.Stopper())
+	shortDB := kv.NewDB(ambient, tsf, s.Clock(), s.AppStopper())
 
 	iter := 0
 	// We'll trace to make sure the test isn't fooling itself.
@@ -610,13 +618,15 @@ func TestDistSQLReceiverDrainsMeta(t *testing.T) {
 					},
 				},
 			},
-			Insecure: true,
+			Insecure:          true,
+			DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(112960),
 		}})
 	defer tc.Stopper().Stop(ctx)
+	s := tc.ApplicationLayer(0)
 
 	// Create a table with 30 rows, split them into 3 ranges with each node
 	// having one.
-	db := tc.ServerConn(0 /* idx */)
+	db := s.SQLConn(t, serverutils.DBName("test"))
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlutils.CreateTable(
 		t, db, "foo",
@@ -635,7 +645,7 @@ func TestDistSQLReceiverDrainsMeta(t *testing.T) {
 	)
 
 	// Connect to the cluster via the PGWire client.
-	p, err := pgtest.NewPGTest(ctx, tc.Server(0).AdvSQLAddr(), username.RootUser)
+	p, err := pgtest.NewPGTest(ctx, s.AdvSQLAddr(), username.RootUser)
 	require.NoError(t, err)
 
 	// We disable multiple active portals here as it only supports local-only plan.
@@ -839,6 +849,11 @@ func TestSetupFlowRPCError(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		tc.GrantTenantCapabilities(context.Background(), t, serverutils.TestTenantID(),
+			map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanAdminRelocateRange: "true"})
+	}
+
 	// Create a table with 30 rows, split them into 3 ranges with each node
 	// having one.
 	db := tc.ServerConn(0)
@@ -1012,7 +1027,8 @@ func TestDistributedQueryErrorIsRetriedLocally(t *testing.T) {
 					},
 				},
 			},
-			Insecure: true,
+			Insecure:          true,
+			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(155944),
 		},
 	})
 	defer tc.Stopper().Stop(context.Background())
@@ -1156,6 +1172,11 @@ SELECT id, details FROM jobs AS j INNER JOIN cte1 ON id = job_id WHERE id = 1;
 			},
 		}})
 	defer tc.Stopper().Stop(context.Background())
+
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		tc.GrantTenantCapabilities(context.Background(), t, serverutils.TestTenantID(),
+			map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanAdminRelocateRange: "true"})
+	}
 
 	db := tc.ServerConn(0 /* idx */)
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -202,7 +202,7 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `INSERT INTO t VALUES (3, false, repeat('x', 1024))`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/3/0›"`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/3/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -215,8 +215,8 @@ func TestPerfLogging(t *testing.T) {
 		},
 		{
 			query:       `INSERT INTO t VALUES (5, false, repeat('x', 2048))`,
-			errRe:       `row larger than max row size: table \d+ family 0 primary key /Table/\d+/1/5/0 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/5/0›"`,
+			errRe:       `row larger than max row size: table \d+ family 0 primary key (/Tenant/\d+)?/Table/\d+/1/5/0 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/5/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -244,14 +244,14 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `INSERT INTO t VALUES (2, false, 'x') ON CONFLICT (i) DO UPDATE SET s = repeat('x', 1024)`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/2/0›"`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `INSERT INTO t VALUES (2, false, 'x') ON CONFLICT (i) DO UPDATE SET s = repeat('x', 2048)`,
-			errRe:       `row larger than max row size: table \d+ family 0 primary key /Table/\d+/1/2/0 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/2/0›"`,
+			errRe:       `row larger than max row size: table \d+ family 0 primary key (/Tenant/\d+)?/Table/\d+/1/2/0 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -265,14 +265,14 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `UPSERT INTO t VALUES (2, false, repeat('x', 1024))`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/2/0›"`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `UPSERT INTO t VALUES (2, false, repeat('x', 2048))`,
-			errRe:       `row larger than max row size: table \d+ family 0 primary key /Table/\d+/1/2/0 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/2/0›"`,
+			errRe:       `row larger than max row size: table \d+ family 0 primary key (/Tenant/\d+)?/Table/\d+/1/2/0 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -286,14 +286,14 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `UPDATE t SET s = repeat('x', 1024) WHERE i = 2`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/2/0›"`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `UPDATE t SET s = repeat('x', 2048) WHERE i = 2`,
-			errRe:       `row larger than max row size: table \d+ family 0 primary key /Table/\d+/1/2/0 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/2/0›"`,
+			errRe:       `row larger than max row size: table \d+ family 0 primary key (/Tenant/\d+)?/Table/\d+/1/2/0 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -321,7 +321,7 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `ALTER TABLE t ADD COLUMN f FLOAT DEFAULT 99.999`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/4/0›"`,
+			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/4/0›"`,
 			logExpected: true,
 			breakHere:   true,
 			channel:     channel.SQL_INTERNAL_PERF,
@@ -329,14 +329,14 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `CREATE TABLE t2 (i, s, PRIMARY KEY (i)) AS SELECT i, s FROM t`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/4/0›"`,
+			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/4/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
 		{
 			query:       `ALTER TABLE t2 ADD COLUMN z STRING DEFAULT repeat('z', 2048)`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹/Table/\d+/1/4/0›"`,
+			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/4/0›"`,
 			logExpected: true,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
@@ -364,14 +364,14 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `INSERT INTO u VALUES (1, 1, repeat('x', 1024))`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹/Table/\d+/1/1/1/1›"`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/1/1/1›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `INSERT INTO u VALUES (2, 2, repeat('x', 2048))`,
-			errRe:       `pq: row larger than max row size: table \d+ family 1 primary key /Table/\d+/1/2/1/1 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹/Table/\d+/1/2/1/1›"`,
+			errRe:       `pq: row larger than max row size: table \d+ family 1 primary key (/Tenant/\d+)?/Table/\d+/1/2/1/1 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/1/1›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -385,7 +385,7 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `UPDATE u SET i = i + 1 WHERE i = 1`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹/Table/\d+/1/2/1/1›"`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/1/1›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -398,15 +398,15 @@ func TestPerfLogging(t *testing.T) {
 		},
 		{
 			query:       `UPDATE u SET s = repeat('x', 2048) WHERE i = 2`,
-			errRe:       `pq: row larger than max row size: table \d+ family 1 primary key /Table/\d+/1/2/1/1 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹/Table/\d+/1/2/1/1›"`,
+			errRe:       `pq: row larger than max row size: table \d+ family 1 primary key (/Tenant/\d+)?/Table/\d+/1/2/1/1 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/1/1›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `CREATE TABLE u2 (i, j, s, PRIMARY KEY (i), FAMILY f1 (i, j), FAMILY f2 (s)) AS SELECT i, j, repeat(s, 2048) FROM u`,
 			errRe:       ``,
-			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹/Table/\d+/1/2/1/1›"`,
+			logRe:       `"EventType":"large_row_internal","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/2/1/1›"`,
 			logExpected: true,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
@@ -419,8 +419,8 @@ func TestPerfLogging(t *testing.T) {
 		},
 		{
 			query:       `UPDATE u2 SET i = i + 1 WHERE i = 2`,
-			errRe:       `row larger than max row size: table \d+ family 1 primary key /Table/\d+/1/3/1/1 size \d+`,
-			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹/Table/\d+/1/3/1/1›"`,
+			errRe:       `row larger than max row size: table \d+ family 1 primary key (/Tenant/\d+)?/Table/\d+/1/3/1/1 size \d+`,
+			logRe:       `"EventType":"large_row","RowSize":\d+,"TableID":\d+,"FamilyID":1,"PrimaryKey":"‹(/Tenant/\d+)?/Table/\d+/1/3/1/1›"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -723,8 +723,9 @@ func TestPerfLogging(t *testing.T) {
 	defer cleanup()
 
 	// Start a SQL server.
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.ApplicationLayer()
 	// TODO(fqazi): Enable with MVCC back filler support, since max_row_size is
 	// not properly enforced right now.
 	_, err := sqlDB.Exec("SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer='off'")

--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -556,7 +556,7 @@ var LogicTestConfigs = []TestClusterConfig{
 		// local is the configuration where we run all tests which have bad
 		// interactions with the default test tenant.
 		//
-		// TODO(#76378): We should review this choice. Why can't we use "Random"
+		// TODO(#156124): We should review this choice. Why can't we use "Random"
 		// here? If there are specific tests that are incompatible, we can
 		// flag them to run only in a separate config.
 		UseSecondaryTenant:            Never,

--- a/pkg/sql/main_test.go
+++ b/pkg/sql/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -27,10 +26,6 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	kvtenant.InitTestConnectorFactory()
-
-	defer serverutils.TestingSetDefaultTenantSelectionOverride(
-		base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(76378),
-	)()
 
 	os.Exit(m.Run())
 }

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -49,10 +49,6 @@ func TestScatterRandomizeLeases(t *testing.T) {
 
 	r := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
-	// Even though we disabled merges via the store testing knob, we must also
-	// disable the setting in order for manual splits to be allowed.
-	r.Exec(t, "SET CLUSTER SETTING kv.range_merge.queue.enabled = false")
-
 	// Introduce 99 splits to get 100 ranges.
 	r.Exec(t, "ALTER TABLE test.t SPLIT AT (SELECT i*10 FROM generate_series(1, 99) AS g(i))")
 

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
@@ -7847,6 +7848,10 @@ func TestMemoryMonitorErrorsDuringBackfillAreRetried(t *testing.T) {
 		}
 		tc := testcluster.StartTestCluster(t, 2, tca)
 		defer tc.Stopper().Stop(ctx)
+		if tc.DefaultTenantDeploymentMode().IsExternal() {
+			tc.GrantTenantCapabilities(context.Background(), t, serverutils.TestTenantID(),
+				map[tenantcapabilitiespb.ID]string{tenantcapabilitiespb.CanAdminRelocateRange: "true"})
+		}
 		tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 		tdb.Exec(t, "CREATE TABLE foo (i INT PRIMARY KEY)")
 		tdb.Exec(t, "INSERT INTO foo VALUES (1)")

--- a/pkg/sql/session_migration_test.go
+++ b/pkg/sql/session_migration_test.go
@@ -198,6 +198,15 @@ WHERE dump.variable IS NULL OR dump2.variable IS NULL OR dump.variable != dump2.
 					return err.Error()
 				}
 				return ret
+			case "change_session_size":
+				// Only the system layer can change the session size cluster
+				// setting.
+				query := fmt.Sprintf("SET CLUSTER SETTING sql.session_transfer.max_session_size = '%s'", d.CmdArgs[0].Key)
+				_, err := srv.SystemLayer().SQLConn(t).Exec(query)
+				if err != nil {
+					return err.Error()
+				}
+				return ""
 
 			case "error":
 				var errorRE string

--- a/pkg/sql/show_fingerprints_test.go
+++ b/pkg/sql/show_fingerprints_test.go
@@ -137,8 +137,9 @@ func TestShowFingerprintsDuringSchemaChange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE DATABASE d`)

--- a/pkg/sql/show_trace_replica.go
+++ b/pkg/sql/show_trace_replica.go
@@ -98,7 +98,7 @@ func (n *showTraceReplicaNode) Close(ctx context.Context) {
 	n.input.Close(ctx)
 }
 
-var nodeStoreRangeRE = regexp.MustCompile(`^\[n(\d+),s(\d+),r(\d+)/`)
+var nodeStoreRangeRE = regexp.MustCompile(`^\[n(\d+),(?:tenant=\d+,)?s(\d+),r(\d+)/`)
 
 var replicaMsgRE = regexp.MustCompile(
 	strings.Join([]string{

--- a/pkg/sql/sqltestutils/sql_test_utils.go
+++ b/pkg/sql/sqltestutils/sql_test_utils.go
@@ -70,15 +70,15 @@ func DisableGCTTLStrictEnforcement(t *testing.T, db *gosql.DB) (cleanup func()) 
 // SetShortRangeFeedIntervals is a helper to set the cluster settings
 // pertaining to rangefeeds to short durations. This is helps tests which
 // rely on zone/span configuration changes to propagate.
-func SetShortRangeFeedIntervals(t *testing.T, db sqlutils.DBHandle) {
-	tdb := sqlutils.MakeSQLRunner(db)
+func SetShortRangeFeedIntervals(t *testing.T, srv serverutils.TestServerInterface) {
+	systemDB := sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t))
 	short := "'20ms'"
 	if util.RaceEnabled {
 		short = "'200ms'"
 	}
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = `+short)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = `+short)
-	tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = `+short)
+	systemDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = `+short)
+	systemDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = `+short)
+	systemDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = `+short)
 }
 
 // AddDefaultZoneConfig adds an entry for the given id into system.zones.

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -34,7 +34,9 @@ func TestDropTenantSynchronous(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("latest version", func(t *testing.T) {
-		s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+		s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		})
 		defer s.Stopper().Stop(ctx)
 		testDestroyTenantSynchronous(ctx, t, sqlDB, kvDB)
 	})
@@ -48,6 +50,7 @@ func TestDropTenantSynchronous(t *testing.T) {
 						ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 					},
 				},
+				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 			},
 		}
 		var (
@@ -91,7 +94,9 @@ func TestGetTenantIds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
 	defer s.Stopper().Stop(ctx)
 	idb := s.ExecutorConfig().(sql.ExecutorConfig).InternalDB
 	tdb := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/testdata/session_migration/max_size
+++ b/pkg/sql/testdata/session_migration/max_size
@@ -1,5 +1,4 @@
-exec
-SET CLUSTER SETTING sql.session_transfer.max_session_size = '2KB'
+change_session_size 2KB
 ----
 
 let $large_string

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -1252,7 +1251,8 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	}
 
 	testKey := []byte("test_key")
-	var s serverutils.TestServerInterface
+	var s serverutils.ApplicationLayerInterface
+	var nodeID roachpb.NodeID
 	var clockUpdate, restartDone int32
 	testingResponseFilter := func(
 		ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse,
@@ -1279,7 +1279,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 						txn := ba.Txn.Clone()
 						txn.ResetObservedTimestamps()
 						now := s.Clock().NowAsClockTimestamp()
-						txn.UpdateObservedTimestamp(s.NodeID(), now)
+						txn.UpdateObservedTimestamp(nodeID, now)
 						return kvpb.NewErrorWithTxn(kvpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp(), now), txn)
 					}
 				}
@@ -1297,9 +1297,11 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	params, _ := createTestServerParamsAllowTenants()
 	params.Knobs.Store = storeTestingKnobs
 	params.Knobs.KVClient = clientTestingKnobs
-	var sqlDB *gosql.DB
-	s, sqlDB, _ = serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	params.DefaultTestTenant = base.TestDoesNotWorkWithExternalProcessMode(156333)
+	srv, sqlDB, _ := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
+	s = srv.ApplicationLayer()
+	nodeID = srv.NodeID()
 
 	sqlDB.SetMaxOpenConns(1)
 	if _, err := sqlDB.Exec(`
@@ -1402,39 +1404,7 @@ func TestDistSQLRetryableError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	createTable := func(db *gosql.DB) {
-		sqlutils.CreateTable(t, db, "t",
-			"num INT PRIMARY KEY",
-			3, /* numRows */
-			sqlutils.ToRowFn(sqlutils.RowIdxFn))
-	}
-
-	// We can't programmatically get the targetKey since it's used before
-	// the test cluster is created.
-	// targetKey is represents one of the rows in the table.
-	// +2 since the first two available ids are allocated to the database and
-	// public schema.
-	var firstTableID uint32
-	var codec keys.SQLCodec
-	func() {
-		tc := serverutils.StartCluster(t, 3, /* numNodes */
-			base.TestClusterArgs{
-				ReplicationMode: base.ReplicationManual,
-				ServerArgs:      base.TestServerArgs{UseDatabase: "test"},
-			})
-		defer tc.Stopper().Stop(context.Background())
-		db := tc.ServerConn(0)
-		createTable(db)
-		row := db.QueryRow("SELECT 't'::REGCLASS::OID")
-		require.NotNil(t, row)
-		require.NoError(t, row.Scan(&firstTableID))
-		codec = tc.Server(0).Codec()
-	}()
-	indexID := uint32(1)
-	valInTable := uint64(2)
-	indexKey := codec.IndexPrefix(firstTableID, indexID)
-	targetKey := encoding.EncodeUvarintAscending(indexKey, valInTable)
-
+	var targetKey atomic.Value
 	restarted := true
 
 	tc := serverutils.StartCluster(t, 3, /* numNodes */
@@ -1447,7 +1417,14 @@ func TestDistSQLRetryableError(t *testing.T) {
 						EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
 							TestingEvalFilter: func(fArgs kvserverbase.FilterArgs) *kvpb.Error {
 								_, ok := fArgs.Req.(*kvpb.ScanRequest)
-								if ok && fArgs.Req.Header().Key.Equal(targetKey) && fArgs.Hdr.Txn.Epoch == 0 {
+								if !ok {
+									return nil
+								}
+								key, ok := targetKey.Load().([]byte)
+								if !ok {
+									return nil
+								}
+								if fArgs.Req.Header().Key.Equal(key) && fArgs.Hdr.Txn.Epoch == 0 {
 									restarted = true
 									err := kvpb.NewReadWithinUncertaintyIntervalError(
 										fArgs.Hdr.Timestamp, /* readTS */
@@ -1477,9 +1454,11 @@ func TestDistSQLRetryableError(t *testing.T) {
 	}
 
 	db := tc.ServerConn(0)
-	createTable(db)
+	sqlutils.CreateTable(t, db, "t",
+		"num INT PRIMARY KEY",
+		3, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
-	// We're going to split one of the tables, but node 4 is unaware of this.
 	_, err := db.Exec(fmt.Sprintf(`
 	ALTER TABLE "t" SPLIT AT VALUES (1), (2), (3);
 	ALTER TABLE "t" EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 1), (ARRAY[%d], 2), (ARRAY[%d], 3);
@@ -1490,6 +1469,13 @@ func TestDistSQLRetryableError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	var tableID uint32
+	row := db.QueryRow("SELECT 't'::REGCLASS::OID")
+	require.NotNil(t, row)
+	require.NoError(t, row.Scan(&tableID))
+	indexKey := tc.ApplicationLayer(0).Codec().IndexPrefix(tableID, 1 /* indexID */)
+	targetKey.Store(encoding.EncodeUvarintAscending(indexKey, 2 /* v */))
 
 	db.SetMaxOpenConns(1)
 
@@ -1519,7 +1505,7 @@ func TestDistSQLRetryableError(t *testing.T) {
 	}
 
 	// Let's make sure that DISTSQL will actually be used.
-	row := txn.QueryRow(`SELECT info FROM [EXPLAIN SELECT count(1) FROM t] WHERE info LIKE 'distribution%'`)
+	row = txn.QueryRow(`SELECT info FROM [EXPLAIN SELECT count(1) FROM t] WHERE info LIKE 'distribution%'`)
 	var automatic string
 	if err := row.Scan(&automatic); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -1212,7 +1211,7 @@ func TestNonRetryableError(t *testing.T) {
 	cleanupFilter := cmdFilters.AppendFilter(
 		func(args kvserverbase.FilterArgs) *kvpb.Error {
 			if req, ok := args.Req.(*kvpb.GetRequest); ok {
-				if bytes.Contains(req.Key, testKey) && !kv.TestingIsRangeLookupRequest(req) {
+				if bytes.Contains(req.Key, testKey) {
 					hitError = true
 					return kvpb.NewErrorWithTxn(fmt.Errorf("testError"), args.Hdr.Txn)
 				}
@@ -1260,7 +1259,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	) *kvpb.Error {
 		for _, ru := range ba.Requests {
 			if req := ru.GetGet(); req != nil {
-				if bytes.Contains(req.Key, testKey) && !kv.TestingIsRangeLookupRequest(req) {
+				if bytes.Contains(req.Key, testKey) {
 					if atomic.LoadInt32(&clockUpdate) == 0 {
 						atomic.AddInt32(&clockUpdate, 1)
 						// Hack to advance the transaction timestamp on a
@@ -1358,7 +1357,7 @@ func TestFlushUncommittedDescriptorCacheOnRestart(t *testing.T) {
 			}
 
 			if req, ok := args.Req.(*kvpb.GetRequest); ok {
-				if bytes.Contains(req.Key, testKey) && !kv.TestingIsRangeLookupRequest(req) {
+				if bytes.Contains(req.Key, testKey) {
 					atomic.AddInt32(&restartDone, 1)
 					// Return ReadWithinUncertaintyIntervalError.
 					txn := args.Hdr.Txn

--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -290,7 +290,7 @@ func TestUnsplitRanges(t *testing.T) {
 		s := srv.ApplicationLayer()
 
 		// Speed up how long it takes for the zone config changes to propagate.
-		sqltestutils.SetShortRangeFeedIntervals(t, sqlDB)
+		sqltestutils.SetShortRangeFeedIntervals(t, srv)
 
 		// Disable strict GC TTL enforcement because we're going to shove a zero-value
 		// TTL into the system with AddImmediateGCZoneConfig.

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -35,7 +35,12 @@ func TestUserLoginAfterGC(t *testing.T) {
 
 	ctx := context.Background()
 
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		// In external-process mode the tenant doesn't have kvpb.GCRequest
+		// capability (and this capability can't be granted at the time of
+		// writing either), so we skip the external mode only.
+		DefaultTestTenant: base.TestSkipForExternalProcessMode(),
+	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 


### PR DESCRIPTION
**sql: remove some redundant kv.TestingIsRangeLookupRequest calls in tests**

These were redundant because we have GetRequests in all call sites.

**sql: enable test tenants**

Some tests have been adjusted to work with test tenants, others have specific issues to investigate further.

Fixes: #143114
Epic: CRDB-48945