### PR TITLE
scbuild: update stub method for isV261Active

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -229,6 +229,5 @@ var isV254Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMo
 }
 
 var isV261Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
-	// change the cluster version once V26_1 is created
-	return activeVersion.IsActive(clusterversion.V25_4)
+	return activeVersion.IsActive(clusterversion.V26_1)
 }


### PR DESCRIPTION
The version has been created, so we can fix this function now.

Epic: None
Release note: None