### PR TITLE
kvserver: pass struct into SetRangeAppliedState

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/state.go
+++ b/pkg/kv/kvserver/kvserverpb/state.go
@@ -16,3 +16,18 @@ func (ms *MVCCPersistentStats) ToStats() enginepb.MVCCStats {
 func (ms *MVCCPersistentStats) ToStatsPtr() *enginepb.MVCCStats {
 	return (*enginepb.MVCCStats)(ms)
 }
+
+// ToRangeAppliedState converts the ReplicaState to a RangeAppliedState.
+func (m *ReplicaState) ToRangeAppliedState() RangeAppliedState {
+	// NB: RangeAppliedState materializes in the state machine on every raft
+	// commands batch application, and must be byte-to-byte consistent across
+	// replicas. If you need to change the returned fields here, most likely this
+	// needs to be accompanied by a below-raft migration.
+	return RangeAppliedState{
+		RaftAppliedIndex:     m.RaftAppliedIndex,
+		LeaseAppliedIndex:    m.LeaseAppliedIndex,
+		RangeStats:           MVCCPersistentStats(*m.Stats),
+		RaftClosedTimestamp:  m.RaftClosedTimestamp,
+		RaftAppliedIndexTerm: m.RaftAppliedIndexTerm,
+	}
+}

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -18,11 +18,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -181,8 +179,10 @@ func (r *replicaTruncatorTest) writeRaftStateToEngine(
 func (r *replicaTruncatorTest) writeRaftAppliedIndex(
 	t *testing.T, eng storage.Engine, raftAppliedIndex kvpb.RaftIndex, flush bool,
 ) {
-	require.NoError(t, r.stateLoader.SetRangeAppliedState(context.Background(), eng,
-		raftAppliedIndex, 0, 0, &enginepb.MVCCStats{}, hlc.Timestamp{}, nil))
+	require.NoError(t, r.stateLoader.SetRangeAppliedState(
+		context.Background(), eng,
+		&kvserverpb.RangeAppliedState{RaftAppliedIndex: raftAppliedIndex},
+	))
 	// Flush to make it satisfy the contract of OnlyReadGuaranteedDurable in
 	// Pebble.
 	if flush {


### PR DESCRIPTION
The signature of this method was error-prone and verbose. All the callers copy the `RangeAppliedState` from `ReplicaState` fields, or already have a fully populated `RangeAppliedState`.

Forked from the work in #156495

Epic: none
Release note: none