### PR TITLE
*: remove stale skips of test tenant randomization

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -83,7 +83,7 @@ var (
 
 	testClusterBaseClusterArgs = base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(127241),
+			DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(127241),
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},

--- a/pkg/server/storage_api/nodes_test.go
+++ b/pkg/server/storage_api/nodes_test.go
@@ -216,9 +216,7 @@ func TestNodesGRPCResponse(t *testing.T) {
 
 	ctx := context.Background()
 
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110023),
-	})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 
 	if srv.DeploymentMode().IsExternal() {

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
@@ -327,7 +327,7 @@ func TestRefreshSession(t *testing.T) {
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109410),
+		DefaultTestTenant: base.TestDoesNotWorkWithExternalProcessMode(109410),
 		Locality: roachpb.Locality{
 			Tiers: []roachpb.Tier{
 				{Key: "abc", Value: "xyz"},


### PR DESCRIPTION
I've audited all places where we disable test tenants in some way and found a handful of places where an already closed issue was used as a reference for why a particular test disables test tenants. This commit removes those now-stale skips.

Epic: CRDB-48945
Release note: None