### PR TITLE
release-25.3: kvserver: don't proceed with unsafe replication changes after 10s

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2402,6 +2402,9 @@ func within10s(ctx context.Context, fn func() error) error {
 			return nil
 		}
 	}
+	if err != nil {
+		return err
+	}
 	return ctx.Err()
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #156464 on behalf of @tbg.

----

See https://github.com/cockroachdb/cockroach/issues/152604#issuecomment-3462036667.

`within10s` is called from within the change replicas txn as a last layer
of defense against replication changes that would lose quorum. While looking
into cases in which precisely this happened, I wondered why this last line
of defense couldn't block these ill-advised changes.

It turns out that within10s had a bug: it would return without an error.
In effect, it wasn't doing anything except delay the problematic change.

The bug is fixed here. In follow-up https://github.com/cockroachdb/cockroach/pull/156463 (not for backporting),
we completely remove this bespoke helper and "just" use `retry`.

This bug is mine - introduced almost five years ago in #57564. Consequently,
it's present in "all" versions of CockroachDB.

Closes #156466.

Epic: none
Release note(bug fix): A mechanism that blocks replication changes that would
result in a loss of quorum was ineffective. It now works as intended.


----

Release justification: fixes a backstop that prevents known cases of CockroachDB trying to remove live voters from resulting in loss of quorum.