### PR TITLE
release-25.4: sem/tree: mark LTREE as ambiguous type for proper casting

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4273,7 +4273,7 @@ func (d *DLTree) Max(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
 }
 
 // AmbiguousFormat implements the Datum interface.
-func (*DLTree) AmbiguousFormat() bool { return false }
+func (*DLTree) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DLTree) Format(ctx *FmtCtx) {


### PR DESCRIPTION
Backport 1/2 commits from #156122.

/cc @cockroachdb/release

---

LTREE datums need explicit type casts when formatted to avoid being misinterpreted as strings by the query engine. Previously, LTREE[] arrays were formatted as ARRAY['j.k.l'] which loses type information, causing the query engine to interpret them as string[] and resulting in errors like:
```
unsupported comparison operator: <ltree[]> >= <string[]>
```

Marking LTREE as an ambiguous type ensures the formatter includes explicit type casts (e.g., ARRAY['j.k.l']::LTREE[]), preventing type mismatches in distributed queries.

Release note: none
Release justification: low risk fix for new datatype
