### PR TITLE
release-25.2: cloud/amazon: disable s3.client_retry_token_bucket.enabled by default

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -172,9 +172,7 @@ var enableClientRetryTokenBucket = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"cloudstorage.s3.client_retry_token_bucket.enabled",
 	"enable the client side retry token bucket in the AWS S3 client",
-	// TODO(jeffswenson): change this to false in a seperate PR. This is false in
-	// the backports to stay true to the backport policy.
-	true)
+	false)
 
 // roleProvider contains fields about the role that needs to be assumed
 // in order to access the external storage.


### PR DESCRIPTION
Backport 1/1 commits from #156496 on behalf of @msbutler.

----

Disabling the client side retry token bucket has made s3 backups at scale more stable.

Epic: none

Release note: none

----

Release justification: