### PR TITLE
acceptance: Add COCKROACH_ACCEPTANCE_ALLOW_UNSAFE env var

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -825,6 +825,9 @@ func (l *DockerCluster) PGUrl(ctx context.Context, i int) string {
 	options.Add("sslcert", filepath.Join(certsDir, certnames.EmbeddedRootCert))
 	options.Add("sslkey", filepath.Join(certsDir, certnames.EmbeddedRootKey))
 	options.Add("sslrootcert", filepath.Join(certsDir, certnames.EmbeddedCACert))
+	// Set allow_unsafe_internals=true for acceptance tests to allow access to
+	// crdb_internal and system tables.
+	options.Add("allow_unsafe_internals", "true")
 	pgURL := url.URL{
 		Scheme:   "postgres",
 		User:     url.User(certUser),

--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
     image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach
+    environment:
+      - COCKROACH_ACCEPTANCE_ALLOW_UNSAFE=true
     volumes:
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   flyway:

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -13,6 +13,7 @@ services:
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach
     environment:
       - KRB5_KTNAME=/keytab/crdb.keytab
+      - COCKROACH_ACCEPTANCE_ALLOW_UNSAFE=true
     volumes:
       - ${CERTS_DIR:-../../.localcluster.certs}:/certs
       - keytab:/keytab

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach
     environment:
       - KRB5_KTNAME=/keytab/crdb.keytab
+      - COCKROACH_ACCEPTANCE_ALLOW_UNSAFE=true
     volumes:
       - ${CERTS_DIR:-../../.localcluster.certs}:/certs
       - keytab:/keytab

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -9,6 +9,7 @@ system "mkdir -p logs"
 set histfile "cockroach_sql_history"
 
 set ::env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
+set ::env(COCKROACH_ACCEPTANCE_ALLOW_UNSAFE) "true"
 set ::env(COCKROACH_CONNECT_TIMEOUT) 15
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
 # Set client commands as insecure. The server uses --insecure.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionmutator"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -4388,7 +4389,13 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowUnsafeInternals), nil
 		},
-		GlobalDefault: globalTrue,
+		GlobalDefault: func(_ *settings.Values) string {
+			if envutil.EnvOrDefaultBool("COCKROACH_ACCEPTANCE_ALLOW_UNSAFE", false) {
+				return "on"
+			}
+			// In 26.1 we will change the default to false/off.
+			return "on"
+		},
 	},
 
 	`optimizer_use_improved_hoist_join_project`: {


### PR DESCRIPTION
Adding an environment variable to override the allow_unsafe_internals session variable is this simplest way to get the acceptance tests to pass when the default will turn to false in 26.1.

This was tested in #156398, and we see the CI acceptance job pass.

Fixes: #154663
Release note: None