### PR TITLE
release-25.4: sql/schemachanger: clean up triggers before their references

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.explain
@@ -20,7 +20,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │         │    ├── ABSENT → PUBLIC TriggerTiming:{DescID: 104 (t), TriggerID: 1}
  │         │    ├── ABSENT → PUBLIC TriggerEvents:{DescID: 104 (t), TriggerID: 1}
  │         │    ├── ABSENT → PUBLIC TriggerFunctionCall:{DescID: 104 (t), TriggerID: 1}
- │         │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+ │         │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
  │         └── 10 Mutation operations
@@ -43,7 +43,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │    │    │    ├── PUBLIC → ABSENT TriggerTiming:{DescID: 104 (t), TriggerID: 1}
  │    │    │    ├── PUBLIC → ABSENT TriggerEvents:{DescID: 104 (t), TriggerID: 1}
  │    │    │    ├── PUBLIC → ABSENT TriggerFunctionCall:{DescID: 104 (t), TriggerID: 1}
- │    │    │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+ │    │    │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │    │    ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │    │    │    └── ABSENT → PUBLIC TableSchemaLocked:{DescID: 104 (t)}
  │    │    └── 1 Mutation operation
@@ -56,7 +56,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │         │    ├── ABSENT → PUBLIC TriggerTiming:{DescID: 104 (t), TriggerID: 1}
  │         │    ├── ABSENT → PUBLIC TriggerEvents:{DescID: 104 (t), TriggerID: 1}
  │         │    ├── ABSENT → PUBLIC TriggerFunctionCall:{DescID: 104 (t), TriggerID: 1}
- │         │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+ │         │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
  │         └── 13 Mutation operations

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger__rollback_1_of_1.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger__rollback_1_of_1.explain
@@ -21,7 +21,7 @@ Schema change plan for rolling back CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR
       │    │    ├── PUBLIC → ABSENT TriggerTiming:{DescID: 104 (t), TriggerID: 1}
       │    │    ├── PUBLIC → ABSENT TriggerEvents:{DescID: 104 (t), TriggerID: 1}
       │    │    ├── PUBLIC → ABSENT TriggerFunctionCall:{DescID: 104 (t), TriggerID: 1}
-      │    │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+      │    │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
       │    └── 11 Mutation operations
       │         ├── RemoveTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
       │         ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerName","TriggerID":1}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.explain
@@ -48,7 +48,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │         │    ├── PUBLIC → ABSENT  TriggerTiming:{DescID: 104 (t-), TriggerID: 1}
  │         │    ├── PUBLIC → ABSENT  TriggerEvents:{DescID: 104 (t-), TriggerID: 1}
  │         │    ├── PUBLIC → ABSENT  TriggerFunctionCall:{DescID: 104 (t-), TriggerID: 1}
- │         │    ├── PUBLIC → ABSENT  TriggerDeps:{DescID: 104 (t-), TriggerID: 1}
+ │         │    ├── PUBLIC → ABSENT  TriggerDeps:{DescID: 104 (t-), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 104 (t-)}
  │         └── 53 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}
@@ -147,7 +147,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │    │    │    ├── ABSENT  → PUBLIC TriggerTiming:{DescID: 104 (t-), TriggerID: 1}
  │    │    │    ├── ABSENT  → PUBLIC TriggerEvents:{DescID: 104 (t-), TriggerID: 1}
  │    │    │    ├── ABSENT  → PUBLIC TriggerFunctionCall:{DescID: 104 (t-), TriggerID: 1}
- │    │    │    ├── ABSENT  → PUBLIC TriggerDeps:{DescID: 104 (t-), TriggerID: 1}
+ │    │    │    ├── ABSENT  → PUBLIC TriggerDeps:{DescID: 104 (t-), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │    │    │    └── ABSENT  → PUBLIC TableSchemaLocked:{DescID: 104 (t-)}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
@@ -193,7 +193,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │         │    ├── PUBLIC → ABSENT  TriggerTiming:{DescID: 104 (t-), TriggerID: 1}
  │         │    ├── PUBLIC → ABSENT  TriggerEvents:{DescID: 104 (t-), TriggerID: 1}
  │         │    ├── PUBLIC → ABSENT  TriggerFunctionCall:{DescID: 104 (t-), TriggerID: 1}
- │         │    ├── PUBLIC → ABSENT  TriggerDeps:{DescID: 104 (t-), TriggerID: 1}
+ │         │    ├── PUBLIC → ABSENT  TriggerDeps:{DescID: 104 (t-), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 104 (t-)}
  │         └── 56 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.explain
@@ -9,7 +9,7 @@ Schema change plan for DROP TRIGGER ‹tr› ON ‹defaultdb›.‹t›;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 2 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT Trigger:{DescID: 104 (t), TriggerID: 1}
- │         │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+ │         │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
  │         └── 3 Mutation operations
  │              ├── RemoveTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
  │              ├── UpdateTableBackReferencesInRelations {"TableID":104}
@@ -18,13 +18,13 @@ Schema change plan for DROP TRIGGER ‹tr› ON ‹defaultdb›.‹t›;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── ABSENT → PUBLIC Trigger:{DescID: 104 (t), TriggerID: 1}
-      │    │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+      │    │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
       │    └── 1 Mutation operation
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── PUBLIC → ABSENT Trigger:{DescID: 104 (t), TriggerID: 1}
-           │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
+           │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1, ReferencedFunctionIDs: [105 (f)]}
            └── 3 Mutation operations
                 ├── RemoveTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
                 ├── UpdateTableBackReferencesInRelations {"TableID":104}

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1517,3 +1517,48 @@ statement error pgcode 42601 pq: .*empty schema name
 CREATE SCHEMA "";
 
 subtest end
+
+
+# Regression test for #154248, which ensures that during cascade drops of schemas,
+# we will clean up triggers before functions that reference them.
+subtest drop_schema_with_triggers
+
+statement ok
+CREATE SCHEMA drop_schema_with_triggers;
+
+statement ok
+CREATE TYPE drop_schema_with_triggers.typ_1 AS ENUM ('foo');
+
+statement ok
+CREATE TYPE typ_2_drop_schema_with_triggers AS ENUM ('foo');
+
+statement ok
+CREATE TABLE drop_schema_with_triggers.t1 (
+	n INT8 PRIMARY KEY, j INT8 UNIQUE
+);
+
+statement ok
+CREATE TABLE t2_drop_schema_with_triggers (
+	n
+		INT8 PRIMARY KEY,
+	j
+		INT8 REFERENCES drop_schema_with_triggers.t1 (j)
+);
+
+statement ok
+CREATE FUNCTION drop_schema_with_triggers.trigger_function_w4_520()
+	RETURNS TRIGGER
+	LANGUAGE plpgsql
+	AS $$ BEGIN SELECT 'foo'::drop_schema_with_triggers.typ_1, 'foo'::public.typ_2_drop_schema_with_triggers FROM drop_schema_with_triggers.t1;RETURN NEW;END; $$;
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE TRIGGER trigger_w4_521 BEFORE UPDATE OR DELETE ON drop_schema_with_triggers.t1 FOR EACH ROW EXECUTE FUNCTION drop_schema_with_triggers.trigger_function_w4_520();
+
+skipif config local-mixed-25.2
+skipif config local-mixed-25.3
+skipif config local-legacy-schema-changer
+statement ok
+DROP SCHEMA drop_schema_with_triggers CASCADE;
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_trigger
@@ -34,7 +34,7 @@ CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f(
   {events: [{columnNames: [], type: INSERT}, {columnNames: [], type: UPDATE}], tableId: 104, triggerId: 1}
 - [[TriggerFunctionCall:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
   {funcArgs: [], funcBody: "DECLARE\nfoo @100106 := 'a';\nBEGIN\nINSERT INTO defaultdb.public.ab VALUES ((new).x, (new).y);\nRAISE NOTICE '% %', public.g(), nextval(108:::REGCLASS);\nRETURN new;\nEND;\n", funcId: 110, tableId: 104, triggerId: 1}
-- [[TriggerDeps:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
+- [[TriggerDeps:{DescID: 104, ReferencedTypeIDs: [106 107], TriggerID: 1, ReferencedFunctionIDs: [109 110]}, PUBLIC], ABSENT]
   {tableId: 104, triggerId: 1, usesRelations: [{columnIds: [1, 2], id: 105}, {id: 108}], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
 
 # TODO(#126362, #135655): uncomment this test case.

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_object.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_object.go
@@ -129,7 +129,7 @@ func init() {
 				from.TypeFilter(rulesVersionKey, isTypeDescriptor),
 				from.DescIDEq(fromDescID),
 				to.ReferencedTypeDescIDsContain(fromDescID),
-				to.TypeFilter(rulesVersionKey, isSimpleDependent, isWithTypeT),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent, isWithTypeTOrHasReferences),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
 		},
@@ -168,7 +168,7 @@ func init() {
 	)
 
 	registerDepRule(
-		"descriptor drop right before removing dependent with function refs in columns",
+		"descriptor drop right before removing dependent with function refs in columns / triggers",
 		scgraph.SameStagePrecedence,
 		"referenced-descriptor", "referencing-via-function",
 		func(from, to NodeVars) rel.Clauses {
@@ -177,12 +177,11 @@ func init() {
 				from.Type((*scpb.Function)(nil)),
 				from.DescIDEq(fromDescID),
 				to.ReferencedFunctionIDsContains(fromDescID),
-				to.TypeFilter(rulesVersionKey, isSimpleDependent, isWithExpression),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent, isWithExpressionOrHasReferences),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
 		},
 	)
-
 }
 
 // These rules ensure that descriptor, back-reference in parent descriptor,

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
@@ -146,6 +146,19 @@ func isWithTypeT(element scpb.Element) bool {
 	return err == nil
 }
 
+// isWithExpressionOrHasReferences returns true if `element` has an embedded
+// type or has references to types inside.
+func isWithTypeTOrHasReferences(element scpb.Element) bool {
+	if isWithTypeT(element) {
+		return true
+	}
+	switch element.(type) {
+	case *scpb.TriggerDeps:
+		return true
+	}
+	return false
+}
+
 func getExpression(element scpb.Element) (*scpb.Expression, error) {
 	switch e := element.(type) {
 	case *scpb.ColumnType:
@@ -210,6 +223,19 @@ func getExpression(element scpb.Element) (*scpb.Expression, error) {
 func isWithExpression(element scpb.Element) bool {
 	_, err := getExpression(element)
 	return err == nil
+}
+
+// isWithExpressionOrHasReferences returns true if `element` has an embedded
+// expression or has references to either types, functions or relations.
+func isWithExpressionOrHasReferences(element scpb.Element) bool {
+	if isWithExpression(element) {
+		return true
+	}
+	switch element.(type) {
+	case *scpb.TriggerDeps:
+		return true
+	}
+	return false
 }
 
 func isTypeDescriptor(element scpb.Element) bool {

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3532,7 +3532,7 @@ deprules
     - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
-    - $referencing-via-type[Type] = '*scpb.ColumnType'
+    - $referencing-via-type[Type] IN ['*scpb.ColumnType', '*scpb.TriggerDeps']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -3565,7 +3565,7 @@ deprules
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-Target, $referenced-descriptor-Node)
     - joinTargetNode($referencing-via-expr, $referencing-via-expr-Target, $referencing-via-expr-Node)
-- name: descriptor drop right before removing dependent with function refs in columns
+- name: descriptor drop right before removing dependent with function refs in columns / triggers
   from: referenced-descriptor-Node
   kind: SameStagePrecedence
   to: referencing-via-function-Node
@@ -3573,7 +3573,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Function'
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-function[ReferencedFunctionIDs] CONTAINS $fromDescID
-    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
+    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr', '*scpb.TriggerDeps', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - toAbsent($referenced-descriptor-Target, $referencing-via-function-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-function-Node[CurrentStatus] = ABSENT
@@ -5025,6 +5025,60 @@ deprules
     - $dependent-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($trigger, $trigger-Target, $trigger-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - toAbsent($trigger dependency-Target, $column-Target)
+    - $trigger dependency-Node[CurrentStatus] = ABSENT
+    - $column-Node[CurrentStatus] = WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - transient($trigger dependency-Target, $column-Target)
+    - $trigger dependency-Node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - $trigger dependency-Target[TargetStatus] = TRANSIENT_ABSENT
+    - $trigger dependency-Node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-Target[TargetStatus] = ABSENT
+    - $column-Node[CurrentStatus] = WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - $trigger dependency-Target[TargetStatus] = ABSENT
+    - $trigger dependency-Node[CurrentStatus] = ABSENT
+    - $column-Target[TargetStatus] = TRANSIENT_ABSENT
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
 - name: trigger removed before dependents
   from: trigger-Node
   kind: Precedence
@@ -8614,7 +8668,7 @@ deprules
     - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.EnumType']
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
-    - $referencing-via-type[Type] = '*scpb.ColumnType'
+    - $referencing-via-type[Type] IN ['*scpb.ColumnType', '*scpb.TriggerDeps']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -8647,7 +8701,7 @@ deprules
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-Target, $referenced-descriptor-Node)
     - joinTargetNode($referencing-via-expr, $referencing-via-expr-Target, $referencing-via-expr-Node)
-- name: descriptor drop right before removing dependent with function refs in columns
+- name: descriptor drop right before removing dependent with function refs in columns / triggers
   from: referenced-descriptor-Node
   kind: SameStagePrecedence
   to: referencing-via-function-Node
@@ -8655,7 +8709,7 @@ deprules
     - $referenced-descriptor[Type] = '*scpb.Function'
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-function[ReferencedFunctionIDs] CONTAINS $fromDescID
-    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
+    - $referencing-via-function[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr', '*scpb.TriggerDeps', '*scpb.UniqueWithoutIndexConstraintUnvalidated']
     - toAbsent($referenced-descriptor-Target, $referencing-via-function-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-function-Node[CurrentStatus] = ABSENT
@@ -10107,6 +10161,60 @@ deprules
     - $dependent-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($trigger, $trigger-Target, $trigger-Node)
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - toAbsent($trigger dependency-Target, $column-Target)
+    - $trigger dependency-Node[CurrentStatus] = ABSENT
+    - $column-Node[CurrentStatus] = WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - transient($trigger dependency-Target, $column-Target)
+    - $trigger dependency-Node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - $trigger dependency-Target[TargetStatus] = TRANSIENT_ABSENT
+    - $trigger dependency-Node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-Target[TargetStatus] = ABSENT
+    - $column-Node[CurrentStatus] = WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
+- name: trigger references cleaned before columns
+  from: trigger dependency-Node
+  kind: Precedence
+  to: column-Node
+  query:
+    - $trigger dependency[Type] = '*scpb.TriggerDeps'
+    - $column[Type] = '*scpb.Column'
+    - trigger refers to column(*scpb.TriggerDeps, *scpb.Column)($trigger dependency, $column)
+    - $trigger dependency-Target[TargetStatus] = ABSENT
+    - $trigger dependency-Node[CurrentStatus] = ABSENT
+    - $column-Target[TargetStatus] = TRANSIENT_ABSENT
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - joinTargetNode($trigger dependency, $trigger dependency-Target, $trigger dependency-Node)
+    - joinTargetNode($column, $column-Target, $column-Node)
 - name: trigger removed before dependents
   from: trigger-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scplan/testdata/create_trigger
@@ -19,7 +19,7 @@ StatementPhase stage 1 of 1 with 9 MutationType ops
     [[TriggerTiming:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
     [[TriggerEvents:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
     [[TriggerFunctionCall:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
-    [[TriggerDeps:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.AddTrigger
       Trigger:
@@ -92,7 +92,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[TriggerTiming:{DescID: 104, TriggerID: 1}, PUBLIC], PUBLIC] -> ABSENT
     [[TriggerEvents:{DescID: 104, TriggerID: 1}, PUBLIC], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 104, TriggerID: 1}, PUBLIC], PUBLIC] -> ABSENT
-    [[TriggerDeps:{DescID: 104, TriggerID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, PUBLIC], PUBLIC] -> ABSENT
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
@@ -104,7 +104,7 @@ PreCommitPhase stage 2 of 2 with 9 MutationType ops
     [[TriggerTiming:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
     [[TriggerEvents:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
     [[TriggerFunctionCall:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
-    [[TriggerDeps:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.AddTrigger
       Trigger:
@@ -174,7 +174,7 @@ deps
 CREATE TRIGGER t1_tg BEFORE INSERT OR UPDATE OR DELETE ON defaultdb.t1 FOR EACH ROW EXECUTE FUNCTION g();
 ----
 - from: [Trigger:{DescID: 104, TriggerID: 1}, PUBLIC]
-  to:   [TriggerDeps:{DescID: 104, TriggerID: 1}, PUBLIC]
+  to:   [TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, PUBLIC]
   kind: Precedence
   rule: trigger public before its dependents
 - from: [Trigger:{DescID: 104, TriggerID: 1}, PUBLIC]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -117,7 +117,7 @@ StatementPhase stage 1 of 1 with 142 MutationType ops
     [[TriggerTiming:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[TriggerDeps:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
@@ -723,7 +723,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[TriggerTiming:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[TriggerDeps:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], ABSENT] -> PUBLIC
     [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
@@ -832,7 +832,7 @@ PreCommitPhase stage 2 of 2 with 153 MutationType ops
     [[TriggerTiming:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[TriggerDeps:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
@@ -2704,7 +2704,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [TriggerDeps:{DescID: 109, TriggerID: 1}, ABSENT]
+  to:   [TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -2751,11 +2751,11 @@ DROP TABLE defaultdb.shipments CASCADE;
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [TriggerDeps:{DescID: 109, TriggerID: 1}, ABSENT]
+- from: [TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [TriggerDeps:{DescID: 109, TriggerID: 1}, ABSENT]
+- from: [TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT]
   to:   [Trigger:{DescID: 109, TriggerID: 1}, PUBLIC]
   kind: Precedence
   rule: trigger removed before dependents

--- a/pkg/sql/schemachanger/scplan/testdata/drop_trigger
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_trigger
@@ -16,7 +16,7 @@ DROP TRIGGER t1_tg ON defaultdb.t1;
 StatementPhase stage 1 of 1 with 3 MutationType ops
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[TriggerDeps:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.RemoveTrigger
       Trigger:
@@ -36,14 +36,14 @@ StatementPhase stage 1 of 1 with 3 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[TriggerDeps:{DescID: 104, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
 PreCommitPhase stage 2 of 2 with 3 MutationType ops
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[TriggerDeps:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.RemoveTrigger
       Trigger:
@@ -64,7 +64,7 @@ PreCommitPhase stage 2 of 2 with 3 MutationType ops
 deps
 DROP TRIGGER t1_tg ON defaultdb.t1;
 ----
-- from: [TriggerDeps:{DescID: 104, TriggerID: 1}, ABSENT]
+- from: [TriggerDeps:{DescID: 104, TriggerID: 1, ReferencedFunctionIDs: [105]}, ABSENT]
   to:   [Trigger:{DescID: 104, TriggerID: 1}, PUBLIC]
   kind: Precedence
   rule: trigger removed before dependents

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -370,6 +370,8 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.TriggerDeps)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(TriggerID, "TriggerID"),
+		rel.EntityAttr(ReferencedFunctionIDs, "UsesRoutineIDs"),
+		rel.EntityAttr(ReferencedTypeIDs, "UsesTypeIDs"),
 	),
 	// Policy elements
 	rel.EntityMapping(t((*scpb.Policy)(nil)),


### PR DESCRIPTION
Backport 1/1 commits from #155777 on behalf of @fqazi.

----

Previously, when cascaded drops occurred in the declarative schema changer it was possible for a function, columns, and types to be cleaned up before triggers that referenced them. This could lead to failed DROP SCHEMA CASCADE operations. To address this, this patch adds a rule for enforcing that function references are cleaned up first in the case of triggers.

Fixes: #154248
Fixes: #154133

Release note (bug fix): Addresses a bug where DROP SCHEMA CASCADE could run into an error with complex references from triggers.

----

Release justification: low risk fix that updates a schema changer rule to ensure that trigger functions are dropped after a trigger.