### PR TITLE
release-25.3: workload/schemachanger: disable CREATE TRIGGER operation

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -305,7 +305,7 @@ var opWeights = []int{
 	createSequence:                    1,
 	createTable:                       10,
 	createTableAs:                     1,
-	createTrigger:                     1,
+	createTrigger:                     0,
 	createTypeEnum:                    1,
 	createTypeComposite:               1,
 	createView:                        1,


### PR DESCRIPTION
Due to a bug in cascaded drops its possible for trigger functions to be cleaned up before the trigger. This can lead to DROP SCHEMA CASCADE failures in the workload (see #154248) . Since trigger support is not GA yet, we are going to disable coverage for CREATE TRIGGER in the random workload. The bug leads to either a user error or transient errors that can be worked around.

Fixes: #154223
Fixes: #154713

Release note: None
Release justification: test only change