### PR TITLE
logical: feature flag off UDF support

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -117,6 +117,12 @@ func createLogicalReplicationStreamPlanHook(
 
 		hasUDF := len(options.userFunctions) > 0 || options.defaultFunction != nil && options.defaultFunction.FunctionId != 0
 
+		if hasUDF && !crosscluster.LogicalReplicationUDFWriterEnabled.Get(&p.ExecCfg().Settings.SV) {
+			return pgerror.Newf(pgcode.FeatureNotSupported,
+				"UDF-based logical replication is disabled and will be deleted in a future CockroachDB release. "+
+					"Enable with SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+		}
+
 		mode := jobspb.LogicalReplicationDetails_Immediate
 		if m, ok := options.GetMode(); ok {
 			switch m {

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -1024,6 +1024,9 @@ func TestPreviouslyInterestingTables(t *testing.T) {
 	tc, s, runnerA, runnerB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer tc.Stopper().Stop(ctx)
 
+	runnerA.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+	runnerB.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+
 	sqlA := s.SQLConn(t, serverutils.DBName("a"))
 
 	type testCase struct {
@@ -1837,6 +1840,9 @@ func TestLogicalStreamIngestionJobWithFallbackUDF(t *testing.T) {
 	ctx := context.Background()
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
+
+	dbA.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+	dbB.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
 
 	lwwFunc := `CREATE OR REPLACE FUNCTION repl_apply(action STRING, proposed tab, existing tab, prev tab, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL, proposed_mvcc_timestamp DECIMAL)
 	RETURNS string

--- a/pkg/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/crosscluster/logical/udf_row_processor_test.go
@@ -53,6 +53,9 @@ func TestUDFWithRandomTables(t *testing.T) {
 	tc, s, runnerA, runnerB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer tc.Stopper().Stop(ctx)
 
+	runnerA.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+	runnerB.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+
 	tableName := "rand_table"
 	rng, _ := randutil.NewPseudoRand()
 	createStmt := randgen.RandCreateTableWithName(
@@ -108,6 +111,9 @@ func TestUDFInsertOnly(t *testing.T) {
 	tc, s, runnerA, runnerB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer tc.Stopper().Stop(ctx)
 
+	runnerA.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+	runnerB.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+
 	tableName := "tallies"
 	stmt := "CREATE TABLE tallies(pk INT PRIMARY KEY, v INT)"
 	runnerA.Exec(t, stmt)
@@ -156,6 +162,9 @@ func TestUDFPreviousValue(t *testing.T) {
 	ctx := context.Background()
 	tc, s, runnerA, runnerB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer tc.Stopper().Stop(ctx)
+
+	runnerA.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
+	runnerB.Exec(t, "SET CLUSTER SETTING logical_replication.deprecated_udf_writer.enabled = true")
 
 	tableName := "tallies"
 	stmt := "CREATE TABLE tallies(pk INT PRIMARY KEY, v INT)"

--- a/pkg/crosscluster/settings.go
+++ b/pkg/crosscluster/settings.go
@@ -126,3 +126,13 @@ var LogicalReplanFrequency = settings.RegisterDurationSetting(
 	10*time.Minute,
 	settings.PositiveDuration,
 )
+
+// LogicalReplicationUDFWriterEnabled controls whether the UDF-based logical
+// data replication writer is enabled. When disabled, existing UDF writer jobs
+// will be paused and new UDF LDR jobs cannot be created.
+var LogicalReplicationUDFWriterEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"logical_replication.deprecated_udf_writer.enabled",
+	"enables the UDF-based logical data replication writer (deprecated, will be removed)",
+	false,
+)


### PR DESCRIPTION
This adds a logical_replication.deprecated_udf_writer.enabled feature flag that turns off LDR UDF support. The UDF writer will be permanently deleted after a full upgrade cycle.

Fixes: #148312
Release note: none