### PR TITLE
server: fix admin v1 health endpoint

### DIFF
--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -237,7 +237,7 @@ func (s *httpServer) setupRoutes(
 
 	// Exempt the 2nd health check endpoint from authentication.
 	// (This simply mirrors /health and exists for backward compatibility.)
-	s.mux.Handle(apiconstants.AdminHealth, authenticatedAPIInternalServer)
+	s.mux.Handle(apiconstants.AdminHealth, unauthenticatedAPIInternalServer)
 	// The /_status/vars and /metrics endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(apiconstants.StatusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings, false /* useStaticLabels */}.handleVars))
 	s.mux.Handle(apiconstants.MetricsPath, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings, true /* useStaticLabels */}.handleVars))

--- a/pkg/server/storage_api/health_test.go
+++ b/pkg/server/storage_api/health_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -30,7 +29,6 @@ func TestHealthAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 155052)
 	ctx := context.Background()
 
 	t.Run("sql", func(t *testing.T) {


### PR DESCRIPTION
PR #153929 migrated admin RPC use DRPC http instead of the grpc-gateway. This introduced a bug that made the
admin/v1/health endpoint require authentication when it previously did not require this.

This PR changes it to use an unauthenticated internal server.

Fixes: #155052
Epic: None
Release note: None