### PR TITLE
roachtest: set allow_unsafe_internals=true for roachtests

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2986,6 +2986,7 @@ func (c *clusterImpl) ConnE(
 	for k, v := range connOptions.ConnectionOptions {
 		vals.Add(k, v)
 	}
+	vals["allow_unsafe_internals"] = []string{"true"}
 
 	if _, ok := vals["connect_timeout"]; !ok {
 		// connect_timeout is a libpq-specific parameter for the maximum

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -836,6 +836,7 @@ func (c *SyncedCluster) NodeURL(
 		v.Add("sslmode", "disable")
 	}
 
+	v.Add("allow_unsafe_internals", "true")
 	// We only want to pass an explicit `cluster` name if the user provided one.
 	if virtualClusterName != "" {
 		// We can only pass the cluster parameter for shared processes, as SQL server


### PR DESCRIPTION
This commit instruments the connections used by roachtests with the allow_unsafe_internals session variable set to true.

This is in preparation for when the default value of the session variable gets set to false in 26.1.

Fixes: #154674
Release note: None