### PR TITLE
opt/props: make MinSelectivity variadic

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -4729,7 +4729,7 @@ func (sb *statisticsBuilder) selectivityFromConstrainedCols(
 
 	// Find the minimum upper bound selectivity.
 	selectivityUpperBound =
-		props.MinSelectivity3(selectivityUpperBound, selectivityUpperBound2, selectivityUpperBound3)
+		props.MinSelectivity(selectivityUpperBound, selectivityUpperBound2, selectivityUpperBound3)
 
 	selectivity.Add(props.MakeSelectivity(
 		correlation * (selectivityUpperBound.AsFloat() - selectivity.AsFloat()),

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -87,18 +87,16 @@ func (s *Selectivity) Divide(other Selectivity) {
 	s.selectivity = selectivityInRange(s.selectivity / other.selectivity)
 }
 
-// MinSelectivity returns the smaller value of two selectivities.
-func MinSelectivity(a, b Selectivity) Selectivity {
-	return Selectivity{
-		selectivity: min(a.selectivity, b.selectivity),
+// MinSelectivity returns the smallest of the given selectivities (most
+// selective).
+func MinSelectivity(a Selectivity, others ...Selectivity) Selectivity {
+	m := a.selectivity
+	for _, o := range others {
+		if o.selectivity < m {
+			m = o.selectivity
+		}
 	}
-}
-
-// MinSelectivity3 returns the smallest value of three selectivities.
-func MinSelectivity3(a, b, c Selectivity) Selectivity {
-	return Selectivity{
-		selectivity: min(a.selectivity, b.selectivity, c.selectivity),
-	}
+	return Selectivity{m}
 }
 
 // MaxSelectivity returns the larger value of two selectivities.

--- a/pkg/sql/opt/props/selectivity_test.go
+++ b/pkg/sql/opt/props/selectivity_test.go
@@ -64,6 +64,8 @@ func TestSelectivity(t *testing.T) {
 	// MinSelectivity variations.
 	test(MinSelectivity(s(0.4), s(0.5)), s(0.4))
 	test(MinSelectivity(s(0.5), s(0.4)), s(0.4))
+	test(MinSelectivity(s(0.5), s(0.4), s(0.3)), s(0.3))
+	test(MinSelectivity(s(0.3), s(0.4), s(0.5)), s(0.3))
 	test(MinSelectivity(ZeroSelectivity, OneSelectivity), ZeroSelectivity)
 	test(MinSelectivity(ZeroSelectivity, s(epsilon)), ZeroSelectivity)
 	test(MinSelectivity(s(0), s(epsilon)), s(epsilon))


### PR DESCRIPTION
`MinSelectivity` is now variadic. `MinSelectivity3` is obsolete and has
been removed.

Release note: None
