### PR TITLE
mmaprototype: improve modeling of pending changes

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
@@ -59,6 +59,8 @@ type Allocator interface {
 	// Calls to AdjustPendingChangesDisposition must be correctly sequenced with
 	// full state updates from the local node provided in
 	// ProcessNodeLoadResponse.
+	//
+	// REQUIRES: len(changes) > 0 and all changes are to the same range.
 	AdjustPendingChangesDisposition(changes []ChangeID, success bool)
 
 	// RegisterExternalChanges informs this allocator about yet to complete

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -818,7 +818,12 @@ func (a *allocatorState) ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoad
 func (a *allocatorState) AdjustPendingChangesDisposition(changeIDs []ChangeID, success bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	// NB: It is possible that some of the changeIDs have already been enacted
+	// via StoreLeaseholderMsg, and even been garbage collected. So no
+	// assumption can be made about whether these changeIDs will be found in the
+	// allocator's state.
 	if !success {
+		// Gather the changes that are found and need to be undone.
 		replicaChanges := make([]ReplicaChange, 0, len(changeIDs))
 		for _, changeID := range changeIDs {
 			change, ok := a.cs.pendingChanges[changeID]
@@ -834,25 +839,35 @@ func (a *allocatorState) AdjustPendingChangesDisposition(changeIDs []ChangeID, s
 				return
 			}
 			replicaChanges = append(replicaChanges, change.ReplicaChange)
-			// Else ignore this change. We don't want to pass this change to
-			// pre-check since it will likely violate an invariant and cause us to
-			// emit a noisy log message.
 		}
 		if len(replicaChanges) == 0 {
 			return
 		}
+		// Check that we can undo these changes. If not, log and return.
 		if err := a.cs.preCheckOnUndoReplicaChanges(replicaChanges); err != nil {
+			// TODO(sumeer): we should be able to panic here, once the interface
+			// contract says that all the proposed changes must be included in
+			// changeIDs. Without that contract, there may be a pair of changes
+			// (remove replica and lease from s1), (add replica and lease to s2),
+			// and the caller can provide the first changeID only, and the undo
+			// would cause two leaseholders. The pre-check would catch that here.
 			log.KvDistribution.Infof(context.Background(), "did not undo change %v: due to %v", changeIDs, err)
 			return
 		}
 	}
 
 	for _, changeID := range changeIDs {
-		// We set !requireFound, since a StoreLeaseholderMsg that happened after
-		// the pending change was created and before this call to
+		// We set !requireFound, since some of these pending changes may no longer
+		// exist in the allocator's state. For example, a StoreLeaseholderMsg that
+		// happened after the pending change was created and before this call to
 		// AdjustPendingChangesDisposition may have already removed the pending
 		// change.
 		if success {
+			// TODO(sumeer): this code is implicitly assuming that all the changes
+			// on the rangeState are being enacted. And that is true of the current
+			// callers. We should explicitly state the assumption in the interface.
+			// Because if only some are being enacted, we ought to set
+			// pendingChangeNoRollback, and we don't bother to.
 			a.cs.pendingChangeEnacted(changeID, a.cs.ts.Now(), false)
 		} else {
 			a.cs.undoPendingChange(changeID, false)

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -546,9 +546,8 @@ func (a *allocatorState) rebalanceStores(
 				}
 				leaseChanges := MakeLeaseTransferChanges(
 					rangeID, rstate.replicas, rstate.load, addTarget, removeTarget)
-				if valid, reason := a.cs.preCheckOnApplyReplicaChanges(leaseChanges[:]); !valid {
-					panic(fmt.Sprintf("pre-check failed for lease transfer %v: due to %v",
-						leaseChanges, reason))
+				if err := a.cs.preCheckOnApplyReplicaChanges(leaseChanges[:]); err != nil {
+					panic(errors.Wrapf(err, "pre-check failed for lease transfer %v", leaseChanges))
 				}
 				pendingChanges := a.cs.createPendingChanges(leaseChanges[:]...)
 				changes = append(changes, PendingRangeChange{
@@ -764,9 +763,9 @@ func (a *allocatorState) rebalanceStores(
 			}
 			replicaChanges := makeRebalanceReplicaChanges(
 				rangeID, rstate.replicas, rstate.load, addTarget, removeTarget)
-			if valid, reason := a.cs.preCheckOnApplyReplicaChanges(replicaChanges[:]); !valid {
-				panic(fmt.Sprintf("pre-check failed for replica changes: %v due to %v for %v",
-					replicaChanges, reason, rangeID))
+			if err = a.cs.preCheckOnApplyReplicaChanges(replicaChanges[:]); err != nil {
+				panic(errors.Wrapf(err, "pre-check failed for replica changes: %v for %v",
+					replicaChanges, rangeID))
 			}
 			pendingChanges := a.cs.createPendingChanges(replicaChanges[:]...)
 			changes = append(changes, PendingRangeChange{
@@ -824,12 +823,26 @@ func (a *allocatorState) AdjustPendingChangesDisposition(changeIDs []ChangeID, s
 		for _, changeID := range changeIDs {
 			change, ok := a.cs.pendingChanges[changeID]
 			if !ok {
+				continue
+			}
+			rs, ok := a.cs.ranges[change.rangeID]
+			if !ok {
+				panic(errors.AssertionFailedf("range %v not found in cluster state", change.rangeID))
+			}
+			if rs.pendingChangeNoRollback {
+				// All the changes are to the same range, so return.
 				return
 			}
 			replicaChanges = append(replicaChanges, change.ReplicaChange)
+			// Else ignore this change. We don't want to pass this change to
+			// pre-check since it will likely violate an invariant and cause us to
+			// emit a noisy log message.
 		}
-		if valid, reason := a.cs.preCheckOnUndoReplicaChanges(replicaChanges); !valid {
-			log.KvDistribution.Infof(context.Background(), "did not undo change %v: due to %v", changeIDs, reason)
+		if len(replicaChanges) == 0 {
+			return
+		}
+		if err := a.cs.preCheckOnUndoReplicaChanges(replicaChanges); err != nil {
+			log.KvDistribution.Infof(context.Background(), "did not undo change %v: due to %v", changeIDs, err)
 			return
 		}
 	}
@@ -852,10 +865,10 @@ func (a *allocatorState) AdjustPendingChangesDisposition(changeIDs []ChangeID, s
 func (a *allocatorState) RegisterExternalChanges(changes []ReplicaChange) []ChangeID {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if valid, reason := a.cs.preCheckOnApplyReplicaChanges(changes); !valid {
+	if err := a.cs.preCheckOnApplyReplicaChanges(changes); err != nil {
 		a.mmaMetrics.ExternalFailedToRegister.Inc(1)
 		log.KvDistribution.Infof(context.Background(),
-			"did not register external changes: due to %v", reason)
+			"did not register external changes: due to %v", err)
 		return nil
 	} else {
 		a.mmaMetrics.ExternaRegisterSuccess.Inc(1)

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1076,12 +1076,12 @@ type clusterState struct {
 	stores map[roachpb.StoreID]*storeState
 	// A range is present in the ranges map if any of the local stores is the
 	// leaseholder for that range according to the StoreLeaseholderMsgs from the
-	// local stores. If a local store is shedding the lease for the range, this
-	// map will continue to contain that range until that change is enacted
-	// according to a StoreLeaseholderMsg. However, rangeState internally
-	// maintains adjusted state, along with the pending changes, so that
-	// adjustment will already be reflected in that adjusted state (i.e., a
-	// local store will not be the leaseholder in the adjusted rangeState).
+	// local stores, or if the local leaseholder is transferring the lease to
+	// a non-local store. In the latter case, there is a pending change reflecting
+	// the lease transfer, and the adjusted range state (which already reflects
+	// that transfer) will show the lease on a non-local store. If/once this
+	// change gets enacted via a StoreLeaseholderMsg, range state is
+	// dropped.
 	//
 	// Of course, if the lease shedding was done as part of moving the replica
 	// from one local store to another local store, then the rangeState will

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -870,9 +870,9 @@ type rangeState struct {
 	// see a new RangeMsg.Replicas, and have an existing list of pending
 	// changes, we can individually compare each pending change to the state in
 	// RangeMsg.Replicas and decide whether it is (a) already incorporated or
-	// (b) can still apply in the future or (c) is inconsistent. This simplifies
-	// the code. It also allows composition of many simple pendingReplicaChanges
-	// to represent a complex decision.
+	// (b) can still apply in the future or (c) is inconsistent. Even complex
+	// decisions don't need to refer to a replica multiple times, so this is
+	// not a problematic restriction.
 	//
 	// This separability per replica allows for observing intermediate states
 	// representing partial application (case (a) in the previous paragraph),

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1335,7 +1335,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 			// changes, and these are the changes that are pending. This is hacky
 			// and should be cleaned up.
 			var valid bool
-			var reason string
+			var reason redact.RedactableString
 			if gcRemainingChanges {
 				reason = "GCing remaining changes after partial enactment"
 			} else {
@@ -1346,7 +1346,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 				err := cs.preCheckOnApplyReplicaChanges(remainingReplicaChanges)
 				valid = err == nil
 				if err != nil {
-					reason = err.Error()
+					reason = redact.Sprint(err)
 				}
 				// Restore it.
 				rs.pendingChanges = rc

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -47,30 +47,33 @@ type ReplicaIDAndType struct {
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
-func (rt ReplicaIDAndType) SafeFormat(w redact.SafePrinter, _ rune) {
+func (rit ReplicaIDAndType) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Print("replica-id=")
-	switch rt.ReplicaID {
+	switch rit.ReplicaID {
 	case unknownReplicaID:
 		w.Print("unknown")
 	case noReplicaID:
 		w.Print("none")
 	default:
-		w.Print(rt.ReplicaID)
+		w.Print(rit.ReplicaID)
 	}
-	w.Printf(" type=%v", rt.ReplicaType.ReplicaType)
-	if rt.IsLeaseholder {
+	w.Printf(" type=%v", rit.ReplicaType.ReplicaType)
+	if rit.IsLeaseholder {
 		w.Print(" leaseholder=true")
 	}
 }
 
-func (rt ReplicaIDAndType) String() string {
-	return redact.StringWithoutMarkers(rt)
+func (rit ReplicaIDAndType) String() string {
+	return redact.StringWithoutMarkers(rit)
 }
 
 // subsumesChange returns true if rit subsumes prev and next. prev is the state
 // before the proposed change and next is the state after the proposed change.
 // rit is the current observed state.
-func (rit *ReplicaIDAndType) subsumesChange(prev, next ReplicaIDAndType) bool {
+//
+// NB: this method uses a value receiver since it mutates the value as part of
+// its computation.
+func (rit ReplicaIDAndType) subsumesChange(prev, next ReplicaIDAndType) bool {
 	if rit.ReplicaID == noReplicaID && next.ReplicaID == noReplicaID {
 		// Removal has happened.
 		return true
@@ -90,11 +93,23 @@ func (rit *ReplicaIDAndType) subsumesChange(prev, next ReplicaIDAndType) bool {
 		// Already seeing the load, so consider the change done.
 		rit.ReplicaType.ReplicaType = roachpb.VOTER_FULL
 	}
-	// rit.replicaId equal to LEARNER, VOTER_DEMOTING* are left as-is. If next
-	// is trying to remove a replica, this change has not finished yet, and the
-	// store is still seeing the load corresponding to the state it is exiting.
-	if rit.ReplicaType == next.ReplicaType && (prev.IsLeaseholder == next.IsLeaseholder ||
-		rit.IsLeaseholder == next.IsLeaseholder) {
+	// rit.replicaType.ReplicaType equal to LEARNER, VOTER_DEMOTING* are left
+	// as-is. If next is trying to remove a replica, this change has not
+	// finished yet, and the store is still seeing the load corresponding to the
+	// state it is exiting.
+
+	// TODO: the prev.IsLeaseholder == next.IsLeaseholder check originates in
+	// the notion that if we were changing some aspect of ReplicaType, but not
+	// whether it was the leaseholder, we could leave IsLeaseholder false in
+	// both prev and next (signifying no change in this replica's leaseholder
+	// bit). I think this is not actually true, and if it is, we should make it
+	// not true. That is, we should populate all fields in prev and next,
+	// regardless of whether they are changing or not. Additionally, it is hard
+	// to fathom a change in the ReplicaType when it was a leaseholder and is
+	// staying a leaseholder.
+	if rit.ReplicaType.ReplicaType == next.ReplicaType.ReplicaType &&
+		(prev.IsLeaseholder == next.IsLeaseholder ||
+			rit.IsLeaseholder == next.IsLeaseholder) {
 		return true
 	}
 	return false
@@ -172,8 +187,11 @@ type ReplicaChange struct {
 	// - prev.replicaID >= 0 && next.replicaID >= 0: can be a change to
 	//   IsLeaseholder, or ReplicaType. next.ReplicaType must be VOTER_FULL or
 	//   NON_VOTER.
-	prev              ReplicaState
-	next              ReplicaIDAndType
+	prev ReplicaState
+	next ReplicaIDAndType
+
+	// replicaChangeType is derived from (prev, next) and is a convenience for
+	// logging.
 	replicaChangeType ReplicaChangeType
 }
 
@@ -518,64 +536,16 @@ func (prc PendingRangeChange) LeaseTransferFrom() roachpb.StoreID {
 	panic("unreachable")
 }
 
-// TODO: we need to rethink how to model pending changes. pendingReplicaChange
-// was developed to allow us to have a simple way of representing all changes,
-// by composing one or more pendingReplicaChanges (each of which only touches
-// one store). For replica moves and lease transfers this results in a pair of
-// changes. For replica moves the pair is an addition at one store and a
-// removal at another store. These can be enacted separately, and noticed as
-// enacted separately, so having them become non-pending separately is useful.
-//
-// Lease transfers create a hazard with this modeling approach which can
-// result in no leaseholder or two leaseholders in the internal state of MMA.
-// As a reminder, we don't care if internal state of MMA is out-of-sync with
-// the real world: the StoreLeaseholderMsgs will eventually correct the state.
-// But we care about internal consistency. Also, as a reminder we want a
-// single rangeState for a range, regardless of the number of local stores.
-// This helps in having a single reality inside MMA, even if it is currently
-// incorrect.
-//
-// Example of the hazard: Consider a node with two stores s1 and s2, and range
-// r1, where s1 is the leaseholder. Say we decide to move the replica from s1
-// to s2 -- this is permitted since they are never in the same quorum. As part
-// of this move, the lease will also be transferred from s1 to s2. We
-// currently produce two pendingReplicaChanges, c1 removes the replica and
-// lease from s1, and c2 adds the replica and lease to s2. Say we receive a
-// StoreLeaseholderMsg from s2, which says that it is the leaseholder and has
-// a replica. This will cause us to mark c2 as done (no longer pending). But
-// we can't mark c1 as done since both the lease loss and replica loss are in
-// a single change. And then something causes c2 to be undone, e.g., GC or a
-// spurious error on the transfer path which causes the enacter to say that
-// the change was not successful. Now we will undo c1 and have s1 also as the
-// leaseholder, which is incorrect.
-//
-// To avoid this hazard, we need to model this as 3 pending changes, c1 for
-// removing the replica from s1, c2 for adding the replica to s2, and c3 for
-// transferring the lease from s1 to s2. c3 has to model load changes to two
-// stores. Having a single change c3 model the lease transfer means it is
-// either consider enacted or failed as a whole, so there will be exactly one
-// leaseholder.
-//
-// TODO(wenyi): For the prototype we are keeping this old modeling approach,
-// since we think it will suffice for single store roachtests. We have
-// discussed checking that a pending change is consistent with the current
-// rangeState. In the hazard example above, when c2 is enacted, because of a
-// StoreLeaseholderMsg from s2, we will check that c1 is still valid for the
-// current rangeState. From a replica loss perspective, it is valid, but from
-// a lease loss perspective, it is no longer valid since the lease is already
-// lost. We may have to relax the consistency checking to only check that the
-// replica loss is valid.
-
 // pendingReplicaChange is a proposed change to a single replica. Some
 // external entity (the leaseholder of the range) may choose to enact this
 // change. It may not be enacted if it will cause some invariant (like the
 // number of replicas, or having a leaseholder) to be violated. If not
 // enacted, the allocator will either be told about the lack of enactment, or
 // will eventually expire from the allocator's state after
-// pendingChangeExpiryDuration. Such expiration without enactment should be
-// rare. pendingReplicaChanges can be paired, when a range is being moved from
-// one store to another -- that pairing is not captured here, and captured in
-// the changes suggested by the allocator to the external entity.
+// pendingChangeGCDuration or revisedGCTime. Such expiration without enactment
+// should be rare. pendingReplicaChanges can be paired, when a range is being
+// moved from one store to another -- that pairing is not captured here, and
+// captured in the changes suggested by the allocator to the external entity.
 type pendingReplicaChange struct {
 	ChangeID
 	ReplicaChange
@@ -583,6 +553,13 @@ type pendingReplicaChange struct {
 	// The wall time at which this pending change was initiated. Used for
 	// expiry.
 	startTime time.Time
+	// revisedGCTime is optionally populated (the zero value represents no
+	// revision). When populated, it represents a time, which, if earlier than
+	// the GC time decided by startTime + pendingChangeGCDuration, will cause an
+	// earlier GC. It is used to hasten GC (for the remaining changes) when some
+	// subset of changes corresponding to the same complex change have been
+	// observed to be enacted.
+	revisedGCTime time.Time
 
 	// TODO(kvoli,sumeerbhola): Consider adopting an explicit expiration time,
 	// after which the change is considered to have been rejected. This would
@@ -604,6 +581,10 @@ type storeState struct {
 	storeLoad
 	StoreAttributesAndLocality
 	adjusted struct {
+		// TODO: these adjusted load values can become negative due to applying
+		// pending changes. We need to let them be negative to retain the ability
+		// to undo pending changes. Audit the mean computation and rebalancing
+		// code to ensure that we bump up to a lower bound of zero.
 		load          LoadVector
 		secondaryLoad SecondaryLoadVector
 		// Pending changes for computing loadReplicas and load.
@@ -834,7 +815,7 @@ func (s StoreIDAndReplicaState) SafeFormat(w redact.SafePrinter, _ rune) {
 
 // rangeState is periodically updated based on reporting by the leaseholder.
 type rangeState struct {
-	// localRangOwner is used for rangeState GC. The StoreID mentioned here is
+	// localRangeOwner is used for rangeState GC. The StoreID mentioned here is
 	// the local store that last included that range in its StoreLeaseholderMsg,
 	// and therefore is considered the "owner" of the rangeState.
 	//
@@ -847,42 +828,127 @@ type rangeState struct {
 	// store s2, the localRangeOwner will initially be s1. If a
 	// StoreLeaseholderMsg from s2 arrives with the range before the
 	// StoreLeaseholderMsg from s1 without the range, the localRangeOwner will
-	// be updated to s2. If the opposite happens, the rangeState will be garbage
-	// collected, and later the StoreLeaseholderMsg from s2 will recreate it.
+	// be updated to s2. If the reverse ordering happens, the rangeState will be
+	// garbage collected, and later the StoreLeaseholderMsg from s2 will
+	// recreate it.
 	localRangeOwner roachpb.StoreID
-	// replicas is the adjusted replicas. It is always consistent with
-	// the storeState.adjusted.replicas in the corresponding stores.
+	// replicas is the adjusted replicas after applying pendingChanges. It is
+	// always consistent with the storeState.adjusted.replicas in the
+	// corresponding stores.
 	//
-	// NB: Because pendingReplicaChange individually represents the change to a
-	// single store, a lease transfer or replica movement is represented using
-	// two pendingReplicaChanges. This is convenient since it allows composition
-	// of the simple pendingReplicaChange to represent various changes. And it
-	// allows for the enactment to be decoupled e.g. a new replica is added
-	// during the joint config and starts experiencing load before the old
-	// replica is removed. One unintended side-effect of this data-structural
-	// choice is that we could undo the effect of a lease transfer change on the
-	// lease shedding store before undoing the effect of the lease addition on
-	// the new leaseholder store (e.g. when doing time based GC -- though
-	// currently time-based GC is done for the whole clusterState so unclear if
-	// this is really possible). This allows multiple leaseholders, or no
-	// leaseholder, but only when there are still some pendingReplicaChanges for
-	// the rangeState. We consider this harmless for the prototype since we will
-	// not make changes to a range that has pending changes. However, we cannot
-	// continue with this weakness in multi-store setting -- see the hazard
-	// discussed where pendingReplicaChange is declared, and how we plan to fix
-	// it.
+	// INVARIANT: There must be exactly one replica marked as the leaseholder in
+	// this slice. Additionally, the leaseholder replica in the slice may not be
+	// a local store when there are pending changes that transfer the lease
+	// away, since replicas contains the final state after applying pending
+	// changes (we continue to track the rangeState in clusterState.ranges until
+	// it is wiped out by a StoreLeaseholderMsg from the current localRangeOwner
+	// that no longer mentions the range (we've discussed this above).
+	//
+	// A Note about Pending Changes:
+	//
+	// 1. Overview
+	//
+	// One should think of pendingChanges as a transient override of the
+	// authoritative state provided by the leaseholder in a RangeMsg.Replicas
+	// (i.e., eventually, RangeMsg.Replicas wins). The allocator wants to track
+	// the effect of the ongoing changes, to prevent itself from making more
+	// changes that overshoot a goal, which is why these changes are
+	// incorporated into replicas (and storeState.adjusted.load etc.). It also
+	// wants to know exactly what is pending, so when it sees RangeMsg.Replicas
+	// that are still at the initial state, or an intermediate state, it can
+	// continue anticipating that these pending changes will happen. Tracking
+	// what is pending also allows for undo in the case of explicit failure,
+	// notified by AdjustPendingChangesDisposition.
+	//
+	// 2. Modeling
+	//
+	// The slice of pendingChanges represent one decision. However, this
+	// decision is not always executed atomically by the external system.
+	//
+	// The decision is modeled using at most one pendingReplicaChange per
+	// replica in the pre-change rangeState.replicas. This means that when we
+	// see a new RangeMsg.Replicas, and have an existing list of pending
+	// changes, we can individually compare each pending change to the state in
+	// RangeMsg.Replicas and decide whether it is (a) already incorporated or
+	// (b) can still apply in the future or (c) is inconsistent. This simplifies
+	// the code. It also allows composition of many simple pendingReplicaChanges
+	// to represent a complex decision.
+	//
+	// This separability per replica allows for observing intermediate states
+	// representing partial application (case (a) in the previous paragraph),
+	// and leaving other changes as pending. A simple example of this is a range
+	// move where replicas are at stores {s1, s2, s3} and a replica is moved
+	// from s3 to s4. There will be two pending changes, for addition of s4, and
+	// removal of s3, and replicas field will represent the final state {s1, s2,
+	// s4}. If the leaseholder (say s1) provides a RangeMsg that lists replicas
+	// {s1, s2, s3, s4}, the allocator realizes that the addition of s4 is done,
+	// marks it as enacted and removes it from the pendingChanges slice. Note
+	// that this capability to mark some pending changes as enacted is in some
+	// ways overly lenient, but we don't try to narrow this leniency: e.g. if
+	// one sees {s1, s2}, one will mark the removal pending change as enacted,
+	// and keep the addition pending change. But the external system does not
+	// make a replica change in this manner, and there was probably some kind of
+	// other event that happened (e.g. some other component made a change
+	// without the allocator's knowledge), and it is likely that s4 will never
+	// be added (we will GC it after partiallyEnactedGCDuration).
+	//
+	// The modeling of intermediate states is not perfect. Say that in the above
+	// example s3 was the local leaseholder. And say that the decision is
+	// removing both the leaseholder and replica from s3, and adding a replica
+	// and leaseholder to s4. This will be modeled with two pending changes, one
+	// that removes the replica and leaseholder from s3, and another that adds
+	// the replica and leaseholder to s4. An intermediate state that can be
+	// observed is {s1, s2, s3, s4} with the lease still at s3. But the pending
+	// change for adding s4 includes both that it has a replica, and it has the
+	// lease, so we will not mark it done, and keep pretending that the whole
+	// change is pending. Since lease transfers are fast, we accept this
+	// imperfect modeling fidelity.
+	//
+	// 3. Non Atomicity Hazard
+	//
+	// Since a decision is represented with multiple pending changes, and we
+	// allow for individual changes to be considered enacted or failed, we have
+	// to contend with the hazard of having two leaseholders or no leaseholders.
+	// In the earlier example, say s3 and s4 were both local stores (a
+	// multi-store node), it may be possible to observe an intermediate state
+	// {s1, s2, s3, s4} where s4 is the leaseholder. If we subsequently get a
+	// spurious AdjustPendingChangesDisposition(success=false) call, or
+	// time-based GC causes the s3 removal to be undone, there will be two
+	// replicas marked as the leaseholder. The other extreme is believing that
+	// the s3 transfer is done and the s4 incoming replica (and lease) failed
+	// (this may not actually be possible because of the surrounding code).
+	//
+	// We deal with this hazard by observing that we've constructed multiple
+	// pending changes in order to observe intermediate changes in the common
+	// case of success. Once one change in the set of changes is considered
+	// enacted, we mark the whole remaining group as no-rollback. In the above
+	// case, if we see s4 has become the leaseholder, the s1 removal can't undo
+	// itself -- it can be dropped if it is considered subsumed when processing
+	// a RangeMsg, or it can be GC'd.
+	//
+	// Additionally, when processing a RangeMsg, if any of the pending changes
+	// is considered inconsistent, all the pending changes are discarded. This
+	// avoids a situation where the RangeMsg presents a state that causes the
+	// addition of s4 to be thrown away while keeping the removal of s1. This is
+	// mostly being defensive to avoid any chance of internal inconsistency.
 	replicas []StoreIDAndReplicaState
 	conf     *normalizedSpanConfig
 
 	load RangeLoad
 
-	// Only 1 or 2 changes (latter represents a least transfer or rebalance that
+	// Only 1 or 2 changes (latter represents a lease transfer or rebalance that
 	// adds and removes replicas).
 	//
 	// Life-cycle matches clusterState.pendingChanges. The consolidated
 	// rangeState.pendingChanges across all ranges in clusterState.ranges will
 	// be identical to clusterState.pendingChanges.
 	pendingChanges []*pendingReplicaChange
+	// When set, the pendingChanges can not be rolled back anymore. They have
+	// to be enacted, or discarded wholesale in favor of the latest RangeMsg
+	// from the leaseholder. It is reset to false when pendingChanges
+	// transitions from empty to non-empty.
+	pendingChangeNoRollback bool
+
 	// If non-nil, it is up-to-date. Typically, non-nil for a range that has no
 	// pendingChanges and is not satisfying some constraint, since we don't want
 	// to repeat the analysis work every time we consider it.
@@ -946,32 +1012,34 @@ func (rs *rangeState) setReplica(repl StoreIDAndReplicaState) {
 	rs.replicas = append(rs.replicas, repl)
 }
 
-func (rs *rangeState) removeReplica(storeID roachpb.StoreID) {
+func (rs *rangeState) removeReplica(storeID roachpb.StoreID) error {
 	var i, n int
 	n = len(rs.replicas)
 	for ; i < n; i++ {
 		if rs.replicas[i].StoreID == storeID {
 			rs.replicas[i], rs.replicas[n-1] = rs.replicas[n-1], rs.replicas[i]
 			rs.replicas = rs.replicas[:n-1]
-			return
+			return nil
 		}
 	}
-	// TODO(sumeer): uncomment once we fix the external change problem.
-	// panic(errors.AssertionFailedf("store %v has no replica", storeID))
+	return errors.Errorf("store %v has no replica", storeID)
 }
 
-func replicaSetIsValid(replicas []StoreIDAndReplicaState) (bool, string) {
+func replicaSetIsValid(replicas []StoreIDAndReplicaState) error {
 	hasSeenLeaseholder := false
 	for _, repl := range replicas {
 		if repl.ReplicaState.IsLeaseholder {
 			if hasSeenLeaseholder {
 				// More than one leaseholder.
-				return false, "more than one leaseholder"
+				return errors.Errorf("more than one leaseholder")
 			}
 			hasSeenLeaseholder = true
 		}
 	}
-	return hasSeenLeaseholder, "no leaseholder"
+	if hasSeenLeaseholder {
+		return nil
+	}
+	return errors.Errorf("no leaseholder")
 }
 
 func (rs *rangeState) removePendingChangeTracking(changeID ChangeID) {
@@ -1007,11 +1075,13 @@ type clusterState struct {
 	nodes  map[roachpb.NodeID]*nodeState
 	stores map[roachpb.StoreID]*storeState
 	// A range is present in the ranges map if any of the local stores is the
-	// leaseholder for that range. If a local store is shedding the lease for
-	// the range, this map will continue to contain that range until that change
-	// is enacted according to a StoreLeaseholderMsg. However, rangeState
-	// internally maintains adjusted state, along with the pending changes, so
-	// that adjustment will already be reflected in that adjusted state.
+	// leaseholder for that range according to the StoreLeaseholderMsgs from the
+	// local stores. If a local store is shedding the lease for the range, this
+	// map will continue to contain that range until that change is enacted
+	// according to a StoreLeaseholderMsg. However, rangeState internally
+	// maintains adjusted state, along with the pending changes, so that
+	// adjustment will already be reflected in that adjusted state (i.e., a
+	// local store will not be the leaseholder in the adjusted rangeState).
 	//
 	// Of course, if the lease shedding was done as part of moving the replica
 	// from one local store to another local store, then the rangeState will
@@ -1028,11 +1098,6 @@ type clusterState struct {
 	// the leaseholder would allow for more efficient gc when receiving a
 	// StoreLeaseholderMsg. For now, we avoid denormalizing and taking the
 	// efficiency hit.
-	//
-	// TODO(sumeer): we use StoreLeaseholderMsg as the fully authoritative
-	// source of truth. But clusterState.pendingChangesEnacted also marks things
-	// as enacted, but doesn't remove ranges from this map. This could be made
-	// cleaner.
 	ranges map[roachpb.RangeID]*rangeState
 
 	scratchRangeMap map[roachpb.RangeID]struct{}
@@ -1145,15 +1210,14 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		} else if rs.localRangeOwner != msg.StoreID {
 			rs.localRangeOwner = msg.StoreID
 		}
-		if !rangeMsg.MaybeSpanConfIsPopulated {
-			// When there are no pending changes, confirm that the membership state
-			// is consistent. If not, fall through and make it consistent. We have
-			// seen an example where AdjustPendingChangesDisposition lied about
-			// being successful, and have not been able to find the root cause. So
-			// we'd rather force eventual consistency here.
-			if len(rs.pendingChanges) > 0 {
-				continue
-			}
+		if !rangeMsg.MaybeSpanConfIsPopulated && len(rs.pendingChanges) == 0 {
+			// Common case: no pending changes, and span config not provided.
+			//
+			// Confirm that the membership state is consistent. If not, fall through
+			// and make it consistent. We have seen an example where
+			// AdjustPendingChangesDisposition lied about being successful, and have
+			// not been able to find the root cause. So we'd rather force eventual
+			// consistency here.
 			mayHaveDiverged := false
 			if len(rs.replicas) == len(rangeMsg.Replicas) {
 				for i := range rs.replicas {
@@ -1175,6 +1239,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 			if !mayHaveDiverged {
 				continue
 			}
+			// Else fall through and do the expensive work.
 		}
 		// Set the range state and store state to match the range message state
 		// initially. The pending changes which are not enacted in the range
@@ -1195,7 +1260,8 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		}
 
 		// Find any pending changes which are now enacted, according to the
-		// leaseholder.
+		// leaseholder. Note that this is the only code path where a subset of
+		// pending changes for a replica can be considered enacted.
 		var remainingChanges, enactedChanges []*pendingReplicaChange
 		var remainingReplicaChanges []ReplicaChange
 		for _, change := range rs.pendingChanges {
@@ -1210,6 +1276,29 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 			} else {
 				remainingChanges = append(remainingChanges, change)
 				remainingReplicaChanges = append(remainingReplicaChanges, change.ReplicaChange)
+			}
+		}
+		gcRemainingChanges := false
+		if rs.pendingChangeNoRollback {
+			// A previous StoreLeaseholderMsg has enacted some changes, so the
+			// remainingChanges may be GC'able. All of them share the same GC time.
+			// Note that normal GC will not GC these, since normal GC needs to undo,
+			// and we are not allowed to undo these.
+			if len(remainingChanges) > 0 {
+				startTime := remainingChanges[0].startTime
+				revisedGCTime := remainingChanges[0].revisedGCTime
+				if startTime.Add(pendingChangeGCDuration).Before(now) || revisedGCTime.Before(now) {
+					gcRemainingChanges = true
+				}
+			}
+		} else if len(enactedChanges) > 0 {
+			// First time this set of changes is seeing something enacted.
+			//
+			// No longer permitted to rollback.
+			rs.pendingChangeNoRollback = true
+			for _, change := range remainingChanges {
+				// Potentially shorten when the GC happens.
+				change.revisedGCTime = now.Add(partiallyEnactedGCDuration)
 			}
 		}
 		// rs.pendingChanges is the union of remainingChanges and enactedChanges.
@@ -1232,6 +1321,9 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 			// made by the replicate and lease queues.
 			cs.pendingChangeEnacted(change.ChangeID, now, true)
 		}
+		// INVARIANT: remainingChanges and rs.pendingChanges contain the same set
+		// of changes, though possibly in different order.
+
 		// rs.pendingChanges only contains remainingChanges, and these are also in
 		// cs.pendingChanges and storeState's loadPendingChanges. Their load
 		// effect is also incorporated into the storeStates, but not in the range
@@ -1242,10 +1334,23 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 			// preCheckOnApplyReplicaChanges returns false if there are any pending
 			// changes, and these are the changes that are pending. This is hacky
 			// and should be cleaned up.
-			rs.pendingChanges = nil
-			valid, reason := cs.preCheckOnApplyReplicaChanges(remainingReplicaChanges)
-			// Restore it.
-			rs.pendingChanges = remainingChanges
+			var valid bool
+			var reason string
+			if gcRemainingChanges {
+				reason = "GCing remaining changes after partial enactment"
+			} else {
+				// NB: rs.pendingChanges contains the same changes as
+				// remainingChanges, but they are not the same slice.
+				rc := rs.pendingChanges
+				rs.pendingChanges = nil
+				err := cs.preCheckOnApplyReplicaChanges(remainingReplicaChanges)
+				valid = err == nil
+				if err != nil {
+					reason = err.Error()
+				}
+				// Restore it.
+				rs.pendingChanges = rc
+			}
 			if valid {
 				// Re-apply the remaining changes. Note that the load change was not
 				// undone above, so we pass !applyLoadChange, to avoid applying it
@@ -1479,24 +1584,55 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 // forget it in the data-structure.
 const pendingChangeGCDuration = 5 * time.Minute
 
+// partiallyEnactedGCDuration is the duration after which a pending change is
+// GC'd if some other change that was part of the same decision has been
+// enacted, and this duration has elapsed since that enactment. This is
+// shorter than the normal pendingChangeGCDuration, since we want to clean up
+// such partially enacted changes faster. Long-running decisions are those
+// that involve a new range snapshot being sent, and that is the first change
+// that is seen as enacted. Subsequent ones should be fast.
+const partiallyEnactedGCDuration = 30 * time.Second
+
 // Called periodically by allocator.
 func (cs *clusterState) gcPendingChanges(now time.Time) {
-	gcBeforeTime := now.Add(-pendingChangeGCDuration)
-	var removeChangeIds []ChangeID
-	var replicaChanges []ReplicaChange
+	var rangesWithChanges map[roachpb.RangeID]struct{}
 	for _, pendingChange := range cs.pendingChanges {
-		if !pendingChange.startTime.After(gcBeforeTime) {
-			removeChangeIds = append(removeChangeIds, pendingChange.ChangeID)
-			replicaChanges = append(replicaChanges, pendingChange.ReplicaChange)
+		if rangesWithChanges == nil {
+			rangesWithChanges = make(map[roachpb.RangeID]struct{})
 		}
+		rangesWithChanges[pendingChange.rangeID] = struct{}{}
 	}
-	if len(replicaChanges) > 0 {
-		if valid, reason := cs.preCheckOnUndoReplicaChanges(replicaChanges); !valid {
-			log.KvDistribution.Infof(context.Background(), "did not undo change %v: due to %v", removeChangeIds, reason)
-			return
+	for rangeID := range rangesWithChanges {
+		rs, ok := cs.ranges[rangeID]
+		if !ok {
+			panic(errors.AssertionFailedf("range %v not found in cluster state", rangeID))
 		}
-		for _, rmChange := range removeChangeIds {
-			cs.undoPendingChange(rmChange, true)
+		if rs.pendingChangeNoRollback {
+			continue
+		}
+		if len(rs.pendingChanges) == 0 {
+			panic(errors.AssertionFailedf("no pending changes in range %v", rangeID))
+		}
+		startTime := rs.pendingChanges[0].startTime
+		// NB: we don't bother looking at revisedGCTime, since in that case
+		// rangeState.pendingChangeNoRollback is set to true, so we can't do GC
+		// here (since it requires undo).
+		if !startTime.Add(pendingChangeGCDuration).Before(now) {
+			continue
+		}
+		var replicaChanges []ReplicaChange
+		var changeIDs []ChangeID
+		for _, pendingChange := range rs.pendingChanges {
+			replicaChanges = append(replicaChanges, pendingChange.ReplicaChange)
+			changeIDs = append(changeIDs, pendingChange.ChangeID)
+		}
+		if err := cs.preCheckOnUndoReplicaChanges(replicaChanges); err != nil {
+			log.KvDistribution.Infof(context.Background(),
+				"did not undo changes to range %v: due to %v", rangeID, err)
+			continue
+		}
+		for _, changeID := range changeIDs {
+			cs.undoPendingChange(changeID, true)
 		}
 	}
 }
@@ -1520,19 +1656,26 @@ func (cs *clusterState) pendingChangeEnacted(cid ChangeID, enactedAt time.Time, 
 	delete(cs.pendingChanges, change.ChangeID)
 }
 
-// undoPendingChange reverses the change with ID cid.
+// undoPendingChange reverses the change with ID cid, if it exists.
+//
+// REQUIRES: if requireFound, the change exists; the change is not marked as
+// no-rollback.
 func (cs *clusterState) undoPendingChange(cid ChangeID, requireFound bool) {
 	change, ok := cs.pendingChanges[cid]
 	if !ok {
 		if requireFound {
-			panic(fmt.Sprintf("change %v not found %v", cid, printMapPendingChanges(cs.pendingChanges)))
+			panic(errors.AssertionFailedf("change %v not found %v", cid, printMapPendingChanges(cs.pendingChanges)))
 		} else {
 			return
 		}
 	}
 	rs, ok := cs.ranges[change.rangeID]
 	if !ok {
-		panic(fmt.Sprintf("range %v not found in cluster state", change.rangeID))
+		panic(errors.AssertionFailedf("range %v not found in cluster state", change.rangeID))
+	}
+	if rs.pendingChangeNoRollback {
+		// One cannot undo changes once no-rollback is true.
+		panic(errors.AssertionFailedf("pending change is marked as no-rollback"))
 	}
 	// Wipe the analyzed constraints, as the range has changed.
 	rs.constraints = nil
@@ -1582,7 +1725,28 @@ func printPendingChanges(changes []*pendingReplicaChange) string {
 // createPendingChanges takes a set of changes applies the changes as pending.
 // The application updates the adjusted load, tracked pending changes and
 // changeID to reflect the pending application.
+//
+// REQUIRES: all the changes are to the same range, and that the range has no
+// pending changes.
 func (cs *clusterState) createPendingChanges(changes ...ReplicaChange) []*pendingReplicaChange {
+	if len(changes) == 0 {
+		return nil
+	}
+	rangeID := changes[0].rangeID
+	for i := 1; i < len(changes); i++ {
+		if changes[i].rangeID != rangeID {
+			panic(errors.AssertionFailedf("all changes must be to the same range %d != %d",
+				changes[i].rangeID, rangeID))
+		}
+	}
+	rs := cs.ranges[rangeID]
+	if rs != nil && len(rs.pendingChanges) > 0 {
+		panic(errors.AssertionFailedf("range r%v already has pending changes: %d",
+			rangeID, len(rs.pendingChanges)))
+	}
+	// NB: rs != nil is also required, but we also check that in a method called
+	// below.
+
 	var pendingChanges []*pendingReplicaChange
 	now := cs.ts.Now()
 	for _, change := range changes {
@@ -1600,22 +1764,30 @@ func (cs *clusterState) createPendingChanges(changes ...ReplicaChange) []*pendin
 		cs.pendingChanges[cid] = pendingChange
 		storeState.adjusted.loadPendingChanges[cid] = pendingChange
 		rangeState.pendingChanges = append(rangeState.pendingChanges, pendingChange)
+		rangeState.pendingChangeNoRollback = false
 		log.KvDistribution.VInfof(context.Background(), 3, "createPendingChanges: change_id=%v, range_id=%v, change=%v", cid, change.rangeID, change)
 		pendingChanges = append(pendingChanges, pendingChange)
 	}
 	return pendingChanges
 }
 
-func (cs *clusterState) preCheckOnApplyReplicaChanges(
-	changes []ReplicaChange,
-) (valid bool, reason string) {
-	if len(changes) == 0 {
-		return false, "no changes to apply"
-	}
+// preCheckOnApplyReplicaChanges does some validation of the changes being
+// proposed. It ensures the range is known and has no pending changes already.
+// For a removal, it validates that the replica exists. For non-removal, it
+// blind applies the change without validating whether the current state is
+// ReplicaChange.prev -- this blind application allows this pre-check to
+// succeed when a ReplicaChange has been partially applied e.g. a replica has
+// been added at a store, but it has not yet received the lease. Finally, it
+// checks that after the changes are applied there is exactly one leaseholder.
+// It returns a non-nil error if any of these checks fail.
+//
+// REQUIRES: all the changes are to the same range; there are 1, 2 or 4
+// changes.
+func (cs *clusterState) preCheckOnApplyReplicaChanges(changes []ReplicaChange) error {
 	// preApplyReplicaChange is called before applying a change to the cluster
 	// state.
 	if len(changes) != 1 && len(changes) != 2 && len(changes) != 4 {
-		panic(fmt.Sprintf(
+		panic(errors.AssertionFailedf(
 			"applying replica changes must be of length 1, 2, or 4 but got %v in %v",
 			len(changes), changes))
 	}
@@ -1624,12 +1796,11 @@ func (cs *clusterState) preCheckOnApplyReplicaChanges(
 	curr, ok := cs.ranges[rangeID]
 	// Return early if range already has some pending changes or the range does not exist.
 	if !ok {
-		return false, "range does not exist in cluster state"
+		return errors.Errorf("range does not exist in cluster state")
 	}
 	if len(curr.pendingChanges) > 0 {
-		log.KvDistribution.VInfof(context.Background(), 2, "range %d has pending changes: %v",
+		return errors.Errorf("range %d has pending changes: %v",
 			rangeID, curr.pendingChanges)
-		return false, "range has pending changes"
 	}
 
 	// Make a deep copy of the range state
@@ -1639,15 +1810,14 @@ func (cs *clusterState) preCheckOnApplyReplicaChanges(
 	for _, change := range changes {
 		// Check that all changes correspond to the same range. Panic otherwise.
 		if change.rangeID != rangeID {
-			panic(fmt.Sprintf("unexpected change rangeID %d != %d", change.rangeID, rangeID))
+			panic(errors.AssertionFailedf("unexpected change rangeID %d != %d", change.rangeID, rangeID))
 		}
 		if change.isRemoval() {
-			// TODO: why are we not confirming that the replica actually exists in
-			// copiedCurr?
-			copiedCurr.removeReplica(change.target.StoreID)
+			if err := copiedCurr.removeReplica(change.target.StoreID); err != nil {
+				return err
+			}
 		} else if change.isAddition() || change.isUpdate() {
-			// TODO: shouldn't isAddition case check that the replica does not exist
-			// in copiedCurr?
+			// NB: see the blind apply comment on the method declaration.
 			pendingRepl := StoreIDAndReplicaState{
 				StoreID: change.target.StoreID,
 				ReplicaState: ReplicaState{
@@ -1656,7 +1826,7 @@ func (cs *clusterState) preCheckOnApplyReplicaChanges(
 			}
 			copiedCurr.setReplica(pendingRepl)
 		} else {
-			panic(fmt.Sprintf("unknown replica change %+v", change))
+			panic(errors.AssertionFailedf("unknown replica change %+v", change))
 		}
 	}
 	// check on the final state of currCopy and whether it is valid
@@ -1675,20 +1845,28 @@ func (cs *clusterState) preCheckOnApplyReplicaChanges(
 // latter is trivial since it is just subtraction of numbers. But it can't
 // undo the membership changes. So we presumably have left membership in an
 // inconsistent state.
-func (cs *clusterState) preCheckOnUndoReplicaChanges(changes []ReplicaChange) (bool, string) {
+
+// preCheckOnUndoReplicaChanges does some validation of the changes being
+// proposed for undo.
+//
+// REQUIRES: changes is non-empty, and all changes are to the same range.
+func (cs *clusterState) preCheckOnUndoReplicaChanges(changes []ReplicaChange) error {
 	if len(changes) == 0 {
-		return false, "no changes to apply"
+		panic(errors.AssertionFailedf("no changes to undo"))
 	}
 	rangeID := changes[0].rangeID
 	curr, ok := cs.ranges[rangeID]
 	if !ok {
-		return false, "range does not exist in cluster state"
+		return errors.Errorf("range %v does not exist in cluster state", rangeID)
 	}
 
 	copiedCurr := &rangeState{
 		replicas: append([]StoreIDAndReplicaState{}, curr.replicas...),
 	}
 	for _, change := range changes {
+		if change.rangeID != rangeID {
+			panic(errors.AssertionFailedf("unexpected change rangeID %d != %d", change.rangeID, rangeID))
+		}
 		// TODO: for isRemoval it should check that the replica does not exist in
 		// copiedCurr. for isUpdate it should check that the replica exists in
 		// copiedCurr.
@@ -1699,17 +1877,17 @@ func (cs *clusterState) preCheckOnUndoReplicaChanges(changes []ReplicaChange) (b
 			}
 			copiedCurr.setReplica(prevRepl)
 		} else if change.isAddition() {
-			// TODO: for isAddition it should check that the replica exists in
-			// copiedCurr.
-			copiedCurr.removeReplica(change.target.StoreID)
+			if err := copiedCurr.removeReplica(change.target.StoreID); err != nil {
+				return err
+			}
 		} else {
-			panic(fmt.Sprintf("unknown replica change %+v", change))
+			panic(errors.AssertionFailedf("unknown replica change %+v", change))
 		}
 	}
-	if ok, reason := replicaSetIsValid(copiedCurr.replicas); !ok {
-		panic(fmt.Sprintf("undo should always be valid: %s", reason))
+	if err := replicaSetIsValid(copiedCurr.replicas); err != nil {
+		return err
 	}
-	return true, ""
+	return nil
 }
 
 func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange bool) {
@@ -1732,7 +1910,9 @@ func (cs *clusterState) applyReplicaChange(change ReplicaChange, applyLoadChange
 		change, change.rangeID, change.target.StoreID)
 	if change.isRemoval() {
 		delete(storeState.adjusted.replicas, change.rangeID)
-		rangeState.removeReplica(change.target.StoreID)
+		if err := rangeState.removeReplica(change.target.StoreID); err != nil {
+			panic(err)
+		}
 	} else if change.isAddition() {
 		pendingRepl := StoreIDAndReplicaState{
 			StoreID: change.target.StoreID,
@@ -1772,7 +1952,9 @@ func (cs *clusterState) undoReplicaChange(change ReplicaChange) {
 		storeState.adjusted.replicas[change.rangeID] = prevRepl.ReplicaState
 	} else if change.isAddition() {
 		delete(storeState.adjusted.replicas, change.rangeID)
-		rangeState.removeReplica(change.target.StoreID)
+		if err := rangeState.removeReplica(change.target.StoreID); err != nil {
+			panic(err)
+		}
 	} else {
 		panic(fmt.Sprintf("unknown replica change %+v", change))
 	}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -8,6 +8,7 @@ package mmaprototype
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -364,7 +365,8 @@ func TestClusterState(t *testing.T) {
 					var buf strings.Builder
 					for _, rangeID := range rangeIDs {
 						rs := cs.ranges[roachpb.RangeID(rangeID)]
-						fmt.Fprintf(&buf, "range-id=%v load=%v raft-cpu=%v\n", rangeID, rs.load.Load, rs.load.RaftCPU)
+						fmt.Fprintf(&buf, "range-id=%v local-store=%v load=%v raft-cpu=%v\n", rangeID,
+							rs.localRangeOwner, rs.load.Load, rs.load.RaftCPU)
 						for _, repl := range rs.replicas {
 							fmt.Fprintf(&buf, "  store-id=%v %v\n",
 								repl.StoreID, repl.ReplicaIDAndType,
@@ -385,7 +387,13 @@ func TestClusterState(t *testing.T) {
 							ss.StoreID, ss.NodeID, ss.status, ss.reportedLoad, ss.adjusted.load, ns.ReportedCPU, ns.adjustedCPU,
 							ss.loadSeqNum,
 						)
-						for ls, topk := range ss.adjusted.topKRanges {
+						var localStores []roachpb.StoreID
+						for ls := range ss.adjusted.topKRanges {
+							localStores = append(localStores, ls)
+						}
+						slices.Sort(localStores)
+						for _, ls := range localStores {
+							topk := ss.adjusted.topKRanges[ls]
 							n := topk.len()
 							if n == 0 {
 								continue
@@ -482,8 +490,18 @@ func TestClusterState(t *testing.T) {
 
 				case "reject-pending-changes":
 					changeIDsInt := dd.ScanArg[[]ChangeID](t, d, "change-ids")
+					expectPanic := false
+					if d.HasArg("expect-panic") {
+						expectPanic = true
+					}
 					for _, id := range changeIDsInt {
-						cs.undoPendingChange(id, true)
+						if expectPanic {
+							require.Panics(t, func() {
+								cs.undoPendingChange(id, true)
+							})
+						} else {
+							cs.undoPendingChange(id, true)
+						}
 					}
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -428,6 +428,11 @@ func TestClusterState(t *testing.T) {
 					return ss.status.String()
 
 				case "store-load-msg":
+					// TODO(sumeer): the load-time is passed as an argument, and is
+					// independent of ts. This is by necessity, since the load-time can
+					// be in the past, indicating gossip delay. However, having it be
+					// some arbitrary value can be confusing for the test reader.
+					// Consider making it relative to ts.
 					msg := parseStoreLoadMsg(t, d.Input)
 					cs.processStoreLoadMsg(context.Background(), &msg)
 					return ""

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
@@ -90,3 +90,31 @@ store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2
 store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r2 r3
+
+ranges
+----
+range-id=2 local-store=1 load=[cpu:20, write-bandwidth:10, byte-size:15] raft-cpu=10
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+  store-id=2 replica-id=2 type=VOTER_FULL
+range-id=3 local-store=1 load=[cpu:30, write-bandwidth:10, byte-size:10] raft-cpu=25
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+  store-id=2 replica-id=2 type=VOTER_FULL
+
+# Exercise the path that ensures consistency even though not-populated is
+# true.
+store-leaseholder-msg
+store-id=1
+  range-id=2 not-populated
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+  range-id=3 not-populated
+    store-id=2 replica-id=5 type=VOTER_FULL
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+----
+
+ranges
+----
+range-id=2 local-store=1 load=[cpu:20, write-bandwidth:10, byte-size:15] raft-cpu=10
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+range-id=3 local-store=1 load=[cpu:30, write-bandwidth:10, byte-size:10] raft-cpu=25
+  store-id=2 replica-id=5 type=VOTER_FULL
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
@@ -100,8 +100,9 @@ range-id=3 local-store=1 load=[cpu:30, write-bandwidth:10, byte-size:10] raft-cp
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 
-# Exercise the path that ensures consistency even though not-populated is
-# true.
+# Change the membership, while MaybeSpanConfIsPopulated=false, to ensure that
+# we notice the change in replicas. One of these ranges has changed the number
+# of replicas, and the other the replica-id of one of the store's replicas.
 store-leaseholder-msg
 store-id=1
   range-id=2 not-populated
@@ -111,6 +112,7 @@ store-id=1
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 ----
 
+# The ranges reflect the latest state from the StoreLeaseholderMsg.
 ranges
 ----
 range-id=2 local-store=1 load=[cpu:20, write-bandwidth:10, byte-size:15] raft-cpu=10

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
@@ -2,10 +2,10 @@ set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
-node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
-node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 membership=full attrs=purple locality-code=1:2:3:
+node-id=2 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=2
+  store-id=2 membership=full attrs=yellow locality-code=4:5:6:
 
 store-load-msg
   store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s
@@ -13,10 +13,10 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
-store-leaseholder-msg
+store-leaseholder-msg 
 store-id=1
   range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
@@ -24,15 +24,15 @@ store-id=1
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
@@ -47,70 +47,119 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=2 replica-id=unknown type=VOTER_FULL leaseholder=true
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
-# TODO: this test is confusing since it is sending StoreLeaseholderMsgs from
-# s1 and s2 to the same clusterState, but s1 and s2 are not on the same node.
-store-leaseholder-msg
-store-id=2
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
-    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+# Same store load from s1. Results in no change.
+store-load-msg
+  store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s
 ----
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
+# Store leaseholder msg from s1 showing that s2 has a replica but not the lease.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=2 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+----
+
+# Neither change is considered enacted.
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s enacted=0s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s enacted=0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
-store-load-msg
-  store-id=2 node-id=2 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=15s
+tick seconds=5
+----
+t=5s
+
+# Store leaseholder msg from s1 showing that s1 no longer has the lease.
+store-leaseholder-msg
+store-id=1
 ----
 
+# Both changes are considered enacted at t=5s.
 get-pending-changes
 ----
-pending(1)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s enacted=0s
+pending(2)
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s enacted=5s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
+ranges
+----
+
+# The enacted changes are still adjusting the load.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
-  top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
+store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
-
+# Store load msg from s2 showing updated load.
 store-load-msg
-  store-id=1 node-id=1 load=[0,0,0] capacity=[100,100,100] secondary-load=1 load-time=15s
+  store-id=2 node-id=2 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=14s
 ----
 
+# Store load msg from s1 showing updated load.
+store-load-msg
+  store-id=1 node-id=2 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=14s
+----
+
+# Neither load is recent enough to be considered as accounting for the enacted
+# changes. So s2 adjusted load appears very high and s1 adjusted load becomes
+# negative.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:-75, write-bandwidth:-75, byte-size:-75] node-reported-cpu=80 node-adjusted-cpu=-80 seq=6
+store-id=2 node-id=2 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=5 node-adjusted-cpu=173 seq=3
+
+# The enacted changes are still adjusting the load.
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s enacted=5s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Store load msg from s2 showing updated load.
+store-load-msg
+  store-id=2 node-id=2 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=16s
+----
+
+# Store load msg from s1 showing updated load.
+store-load-msg
+  store-id=1 node-id=2 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=16s
+----
+
+# The enacted changes are no longer adjusting the load.
 get-pending-changes
 ----
 pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
-  top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
-  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=80 node-adjusted-cpu=-80 seq=7
+store-id=2 node-id=2 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=5 node-adjusted-cpu=165 seq=4

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
@@ -21,10 +21,10 @@ set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
-node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 membership=full attrs=purple locality-code=1:2:3:
-node-id=2 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 membership=full attrs=yellow locality-code=4:5:6:
+node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 attrs=purple locality-code=1:2:3:
+node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
+  store-id=2 attrs=yellow locality-code=4:5:6:
 
 store-load-msg
   store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s
@@ -32,8 +32,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 store-leaseholder-msg 
 store-id=1
@@ -49,9 +49,9 @@ range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
@@ -71,9 +71,9 @@ range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # Same store load from s1. Results in no change.
 store-load-msg
@@ -82,9 +82,9 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # Store leaseholder msg from s1 showing that s2 has a replica but not the lease.
 store-leaseholder-msg
@@ -105,6 +105,7 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
+# Advance just to simulate some passage of time.
 tick seconds=5
 ----
 t=5s
@@ -131,8 +132,8 @@ ranges
 # The enacted changes are still adjusting the load.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # Store load msg from s2 showing updated load.
 store-load-msg
@@ -141,16 +142,18 @@ store-load-msg
 
 # Store load msg from s1 showing updated load.
 store-load-msg
-  store-id=1 node-id=2 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=14s
+  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=14s
 ----
 
-# Neither load is recent enough (computePendingChangesReflectedInLatestLoad
-# timeout) to be considered as accounting for the enacted changes. So s2
-# adjusted load appears very high and s1 adjusted load becomes negative.
+# Both of the load msgs had load-time=14s, while the enacted time was 5s.
+# Neither is recent enough, since lagForChangeReflectedInLoad is 10s (see
+# computePendingChangesReflectedInLatestLoad) to be considered as accounting
+# for the enacted changes. So s2 adjusted load appears very high and s1
+# adjusted load becomes negative.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:-75, write-bandwidth:-75, byte-size:-75] node-reported-cpu=80 node-adjusted-cpu=-80 seq=6
-store-id=2 node-id=2 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=5 node-adjusted-cpu=173 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:-75, write-bandwidth:-75, byte-size:-75] node-reported-cpu=5 node-adjusted-cpu=-75 seq=6
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=80 node-adjusted-cpu=168 seq=3
 
 # The enacted changes are still adjusting the load.
 get-pending-changes
@@ -170,15 +173,17 @@ store-load-msg
 
 # Store load msg from s1 showing updated load.
 store-load-msg
-  store-id=1 node-id=2 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=16s
+  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=16s
 ----
 
-# The enacted changes are no longer adjusting the load.
+# Both of the load msgs had load-time=16s, while the enacted time was 5s. So
+# they are recent enough to be considered as accounting for the enacted
+# changes. The enacted changes are no longer adjusting the load.
 get-pending-changes
 ----
 pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=80 node-adjusted-cpu=-80 seq=7
-store-id=2 node-id=2 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=5 node-adjusted-cpu=165 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=5 node-adjusted-cpu=5 seq=7
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=4

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
@@ -1,3 +1,22 @@
+# Tests rebalancing a replica from a local store to a remote store (stores on
+# different nodes).
+#
+# Scenario: Store s1 on node 1 initially holds the replica and lease for range 1.
+# The test rebalances the replica (and lease) from s1 to s2 on node 2.
+#
+# Steps and expectations:
+# 1. Creates pending changes for the rebalance, verifying load adjustments
+#    immediately reflect the pending state.
+# 2. Simulates enactment: when s1's leaseholder message arrives without the
+#    range (indicating s1 no longer has the lease), both changes are considered
+#    enacted simultaneously. The range state is removed since the lease moved to
+#    a non-local store.
+# 3. Tracks load adjustments: pending changes adjust load until store-reported
+#    load reflects the change (after >10s of enactment). Load messages arriving
+#    too early (<10s after enactment) result in incorrect adjusted loads (negative
+#    for s1, inflated for s2) until later load messages arrive.
+# 4. Verifies changes are removed from load tracking once store-reported load
+#    reflects the change.
 set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
@@ -125,9 +144,9 @@ store-load-msg
   store-id=1 node-id=2 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=14s
 ----
 
-# Neither load is recent enough to be considered as accounting for the enacted
-# changes. So s2 adjusted load appears very high and s1 adjusted load becomes
-# negative.
+# Neither load is recent enough (computePendingChangesReflectedInLatestLoad
+# timeout) to be considered as accounting for the enacted changes. So s2
+# adjusted load appears very high and s1 adjusted load becomes negative.
 get-load-info
 ----
 store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:-75, write-bandwidth:-75, byte-size:-75] node-reported-cpu=80 node-adjusted-cpu=-80 seq=6

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores
@@ -1,0 +1,282 @@
+# Two stores on the same node.
+set-store
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+  store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 membership=full attrs=purple locality-code=1:2:3:
+  store-id=2 membership=full attrs=yellow locality-code=4:5:3:
+
+store-load-msg
+  store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s
+----
+
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
+
+# Store s1 has the single replica and lease for r1.
+store-leaseholder-msg 
+store-id=1
+  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+----
+
+ranges
+----
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+
+# The top-k uses CPURate, with r1 as the only range.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
+
+# Transfer the replica from s1 to s2. The lease will also be transferred.
+make-pending-changes range-id=1
+  rebalance-replica: remove-store-id=1 add-store-id=2
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Range r1 reflects the pending change as if it has already been applied. Note
+# that the local-store representing the "range owner" is still s1.
+ranges
+----
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=2 replica-id=unknown type=VOTER_FULL leaseholder=true
+
+# The adjusted load is post transfer.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
+
+tick seconds=5
+----
+t=5s
+
+# Store leaseholder msg from s1, showing that s2 has a replica, but not the
+# lease.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=2 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+----
+
+# Neither change is considered enacted.
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Store leaseholder msg from s2, showing that s2 is now the leaseholder.
+store-leaseholder-msg
+store-id=2
+  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=2 type=VOTER_FULL
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+# The local-store representing the "range owner" is now s2.
+ranges
+----
+range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+
+# The addition of replica and lease on s2 is considered enacted. The removal
+# of replica and lease from s1 is not yet enacted.
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+tick seconds=5
+----
+t=10s
+
+# Change 1 will not be found, so can't be rejected.
+reject-pending-changes change-ids=(1) expect-panic
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Change 2 is found, but is no-rollback, so can't be rejected.
+reject-pending-changes change-ids=(2) expect-panic
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Store load msg from s2, showing its new load.
+store-load-msg
+  store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=15s
+----
+
+# The adjusted load on s2 reflects both the reported load and the addition of
+# the replica and lease, since the load-time is not more than 10s after the
+# enactment time of change 1.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=168 seq=2
+store-id=2 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=160 node-adjusted-cpu=168 seq=3
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+
+# Store load msg from s2 at time 16s, which is 11s after the enactment of
+# change 1.
+store-load-msg
+  store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=16s
+----
+
+# We are no longer tracking change 1 for the sake of load.
+get-pending-changes
+----
+pending(1)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# The adjusted load on s2 no longer reflects the addition of the replica and
+# lease, since the load-time is more than 10s after the enactment time of
+# change 1.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+
+# Advance time enough for change 2 to be eligible for GC.
+tick seconds=300
+----
+t=5m10s
+
+# Even after the GC time has elapsed change 2 cannot be undone since it is
+# no-rollback.
+gc-pending-changes
+----
+pending(1)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Store leaseholder msg from s2, showing that s1 is no longer a replica.
+store-leaseholder-msg
+store-id=2
+  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+# Now change 2 is considered enacted.
+get-pending-changes
+----
+pending(1)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s enacted=5m10s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Change 2 is still serving the purpose of adjusting the load on s1.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+# Store load msg from s2, showing its new load.
+store-load-msg
+  store-id=2 node-id=1 load=[85,85,85] capacity=[100,100,100] secondary-load=1 load-time=310s
+----
+
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=165 node-adjusted-cpu=85 seq=2
+store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=165 node-adjusted-cpu=85 seq=5
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+tick seconds=20
+----
+t=5m30s
+
+# Store load msg from s1, showing its new load.
+store-load-msg
+  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=330s
+----
+
+# No longer tracking change 2 for the sake of load.
+get-pending-changes
+----
+pending(0)
+
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=3
+store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+# Transfer the replica from s2 back to s1. The lease will also be transferred.
+make-pending-changes range-id=1
+  rebalance-replica: remove-store-id=2 add-store-id=1
+----
+pending(2)
+change-id=3 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m30s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=4 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m30s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Adjusted load shows the change.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=4
+store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+# Enough time elapses to GC the changes.
+tick seconds=310
+----
+t=10m40s
+
+gc-pending-changes
+----
+pending(0)
+
+# No more pending changes.
+get-pending-changes
+----
+pending(0)
+
+# Adjusted load no longer reflects the changes.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
+store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=7
+  top-k-ranges (local-store-id=2) dim=CPURate: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores
@@ -28,9 +28,9 @@ set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
-node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 membership=full attrs=purple locality-code=1:2:3:
-  store-id=2 membership=full attrs=yellow locality-code=4:5:3:
+node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=2 attrs=yellow locality-code=4:5:3:
 
 store-load-msg
   store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s
@@ -38,8 +38,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
 
 # Store s1 has the single replica and lease for r1.
 store-leaseholder-msg 
@@ -56,9 +56,9 @@ range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
 # The top-k uses CPURate, with r1 as the only range.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
 
 # Transfer the replica from s1 to s2. The lease will also be transferred.
 make-pending-changes range-id=1
@@ -82,9 +82,9 @@ range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
 # The adjusted load is post transfer.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
 
 tick seconds=5
 ----
@@ -169,15 +169,15 @@ store-load-msg
 
 # The adjusted load on s2 reflects both the reported load and the addition of
 # the replica and lease, since the load-time is not more than 10s after the
-# enactment time of change 1.
+# enactment time of change 1 (see lagForChangeReflectedInLoad).
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=168 seq=2
-store-id=2 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=160 node-adjusted-cpu=168 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=168 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=160 node-adjusted-cpu=168 seq=3
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 # Store load msg from s2 at time 16s, which is 11s after the enactment of
-# change 1.
+# change 1. So the change is no longer needed for load adjustment.
 store-load-msg
   store-id=2 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=16s
 ----
@@ -191,12 +191,12 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
   next=(replica-id=none type=VOTER_FULL)
 
 # The adjusted load on s2 no longer reflects the addition of the replica and
-# lease, since the load-time is more than 10s after the enactment time of
+# lease, since the load-time was more than 10s after the enactment time of
 # change 1.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
-store-id=2 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 # Advance time enough for change 2 to be eligible for GC.
@@ -231,26 +231,29 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # Change 2 is still serving the purpose of adjusting the load on s1.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
-store-id=2 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
-# Store load msg from s2, showing its new load.
+# Store load msg from s2, showing its new load. The enacted change is still
+# needed because the enactment time is equal to the load-time.
 store-load-msg
   store-id=2 node-id=1 load=[85,85,85] capacity=[100,100,100] secondary-load=1 load-time=310s
 ----
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=165 node-adjusted-cpu=85 seq=2
-store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=165 node-adjusted-cpu=85 seq=5
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=165 node-adjusted-cpu=85 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=165 node-adjusted-cpu=85 seq=5
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 tick seconds=20
 ----
 t=5m30s
 
-# Store load msg from s1, showing its new load.
+# Store load msg from s1, showing its new load. The enacted change is no
+# longer needed for load adjustment since load-time is 20s after the enactment
+# time (and lagForChangeReflectedInLoad is 10s).
 store-load-msg
   store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=330s
 ----
@@ -262,8 +265,8 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=3
-store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=3
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Transfer the replica from s2 back to s1. The lease will also be transferred.
@@ -281,8 +284,8 @@ change-id=4 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # Adjusted load shows the change.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=4
-store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=4
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Enough time elapses to GC the changes.
@@ -302,6 +305,6 @@ pending(0)
 # Adjusted load no longer reflects the changes.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
-store-id=2 node-id=1 reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=7
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=7
   top-k-ranges (local-store-id=2) dim=CPURate: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores
@@ -1,3 +1,28 @@
+# Tests rebalancing a replica between two local stores (stores on the same node).
+#
+# Scenario: Two stores (s1, s2) on node 1. Initially, s1 holds the replica and
+# lease for range 1. The test rebalances the replica (and lease) from s1 to s2,
+# then back from s2 to s1.
+#
+# Steps and expectations:
+# 1. Creates pending changes for the rebalance, verifying load adjustments
+#    immediately reflect the pending state.
+# 2. Simulates enactment: when s2's leaseholder message arrives showing it has
+#    the lease, change 1 (add to s2) is marked enacted. Change 2 (remove from
+#    s1) remains pending until s1 is removed from the replica set.
+# 3. Verifies enacted changes cannot be rejected (they're removed from
+#    pendingChanges).
+# 4. Verifies no-rollback changes cannot be rejected once any change in the
+#    set is enacted.
+# 5. Tracks load adjustments: pending changes adjust load until store-reported
+#    load reflects the change (after 10s of enactment). After that, the change
+#    is removed from load tracking but may remain for GC.
+# 6. Tests GC: changes marked no-rollback cannot be GC'd via normal GC (which
+#    requires undo). They're only removed once store-reported load reflects the
+#    change.
+# 7. Rebalances back from s2 to s1 and verifies changes are GC'd after the
+#    normal GC duration.
+#
 # Two stores on the same node.
 set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc
@@ -16,22 +16,22 @@ set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
-node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 membership=full attrs=purple locality-code=1:2:3:
-  store-id=2 membership=full attrs=yellow locality-code=4:5:3:
+node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=2 attrs=yellow locality-code=4:5:3:
 
 # Two other stores.
 set-store
   store-id=3 node-id=3 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=4 node-id=4 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
-node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 membership=full attrs=purple locality-code=1:2:3:
-  store-id=2 membership=full attrs=yellow locality-code=4:5:3:
-node-id=3 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=3
-  store-id=3 membership=full attrs=purple locality-code=1:2:6:
-node-id=4 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=4
-  store-id=4 membership=full attrs=yellow locality-code=4:5:7:
+node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=2 attrs=yellow locality-code=4:5:3:
+node-id=3 locality-tiers=region=us-west-1,zone=us-west-1a,node=3
+  store-id=3 attrs=purple locality-code=1:2:6:
+node-id=4 locality-tiers=region=us-east-1,zone=us-east-1a,node=4
+  store-id=4 attrs=yellow locality-code=4:5:7:
 
 # Store s1 is the leaseholder for range r1.
 store-leaseholder-msg 
@@ -70,12 +70,12 @@ range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
 # The adjusted load is post transfer.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
-store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
-store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 tick seconds=5
 ----
@@ -149,15 +149,15 @@ change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 # Make another pending change to transfer from s3 to s4.
 make-pending-changes range-id=1
@@ -180,15 +180,15 @@ t=45s
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-3, byte-size:-3] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-3, byte-size:-3] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
 
 # Store leaseholder msg from s2, showing that s4 has the replica, and s3
 # replica has not been removed.
@@ -253,13 +253,13 @@ change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc
@@ -1,0 +1,250 @@
+# Two stores on the same node.
+set-store
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+  store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 membership=full attrs=purple locality-code=1:2:3:
+  store-id=2 membership=full attrs=yellow locality-code=4:5:3:
+
+# Two other stores.
+set-store
+  store-id=3 node-id=3 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+  store-id=4 node-id=4 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+----
+node-id=1 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 membership=full attrs=purple locality-code=1:2:3:
+  store-id=2 membership=full attrs=yellow locality-code=4:5:3:
+node-id=3 failure-summary=ok locality-tiers=region=us-west-1,zone=us-west-1a,node=3
+  store-id=3 membership=full attrs=purple locality-code=1:2:6:
+node-id=4 failure-summary=ok locality-tiers=region=us-east-1,zone=us-east-1a,node=4
+  store-id=4 membership=full attrs=yellow locality-code=4:5:7:
+
+# Store s1 is the leaseholder for range r1.
+store-leaseholder-msg 
+store-id=1
+  range-id=1 load=[2,2,2] raft-cpu=1 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=3 replica-id=3 type=VOTER_FULL
+----
+
+ranges
+----
+range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+  store-id=3 replica-id=3 type=VOTER_FULL
+
+# Transfer the replica from s1 to s2. The lease will also be transferred.
+make-pending-changes range-id=1
+  rebalance-replica: remove-store-id=1 add-store-id=2
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Range r1 reflects the pending change as if it has already been applied. Note
+# that the local-store representing the "range owner" is still s1.
+ranges
+----
+range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
+  store-id=2 replica-id=unknown type=VOTER_FULL leaseholder=true
+  store-id=3 replica-id=3 type=VOTER_FULL
+
+# The adjusted load is post transfer.
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+
+tick seconds=5
+----
+t=5s
+
+# Store leaseholder msg from s2, showing that s2 has the replica and lease,
+# and s1 still has a replica.
+store-leaseholder-msg
+store-id=2
+  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+# One change is considered enacted.
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+ranges
+----
+range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+  store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+  store-id=3 replica-id=3 type=VOTER_FULL
+
+tick seconds=35
+----
+t=40s
+
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Same store leaseholder msg from s2. The pending change for s1 is gc'd.
+store-leaseholder-msg
+store-id=2
+  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+ranges
+----
+range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+  store-id=1 replica-id=1 type=VOTER_FULL
+  store-id=3 replica-id=3 type=VOTER_FULL
+  store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+
+get-pending-changes
+----
+pending(1)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+
+# Make another pending change to transfer from s3 to s4.
+make-pending-changes range-id=1
+  rebalance-replica: remove-store-id=3 add-store-id=4
+----
+pending(3)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL)
+change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:-3, byte-size:-3] start=40s
+  prev=(replica-id=3 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+tick seconds=5
+----
+t=45s
+
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-3, byte-size:-3] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+
+# Store leaseholder msg from s2, showing that s4 has the replica, and s3
+# replica has not been removed.
+store-leaseholder-msg
+store-id=2
+  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    store-id=4 replica-id=4 type=VOTER_FULL
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+get-pending-changes
+----
+pending(3)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s enacted=45s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL)
+change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:-3, byte-size:-3] start=40s
+  prev=(replica-id=3 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+tick seconds=35
+----
+t=1m20s
+
+get-pending-changes
+----
+pending(3)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s enacted=45s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL)
+change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:-3, byte-size:-3] start=40s
+  prev=(replica-id=3 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Same store leaseholder msg from s2. The pending change for s3 is gc'd.
+store-leaseholder-msg
+store-id=2
+  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    store-id=4 replica-id=4 type=VOTER_FULL
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+----
+
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s enacted=5s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s enacted=45s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=2 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=3 node-id=3 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=4 node-id=4 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc
@@ -1,4 +1,17 @@
-# Two stores on the same node.
+# Tests GC of partially enacted changes when rebalancing between local stores.
+# This is a variation of rebalance_replica_local_stores in which a rebalancing
+# operation is partially enacted but the remainder is ultimately garbage collected.
+#
+# - The range initially initially sits on (n1s1,n3s3), and is then rebalanced to
+#   (n1s2,n3s4), i.e. moved between n1's two stores.
+# - The second half of the pending change (removal of s1) never gets enacted.
+# - That change is pending is no-rollback due to the first half having been enacted.
+#   After 30s (partiallyEnactedGCDuration) has elapsed since the partial
+#   enactment, the removal is GC'd with the next leaseholder message. In
+#   particular, this change does not have to wait for the much longer regular GC
+#   timeout.
+# - A second rebalance is carried out on the same range, while an enacted remnant
+#   of the first operation remains.
 set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
@@ -109,7 +122,9 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
-# Same store leaseholder msg from s2. The pending change for s1 is gc'd.
+# Same store leaseholder msg from s2. The pending change for s1 is gc'd because
+# the more aggressive partiallyEnactedGCDuration (30s) applies. It is immaterial
+# that the message originates from s2 and not s1.
 store-leaseholder-msg
 store-id=2
   range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica
@@ -32,7 +32,7 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 
@@ -48,7 +48,7 @@ change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:-20, write-bandwidth
 # store 1 remaining.
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 # The load info for s2 should also reflect the load delta [-20,-80,-80] being

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges
@@ -18,7 +18,7 @@ store-id=1
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 make-pending-changes range-id=1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease
@@ -36,7 +36,7 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 
@@ -60,7 +60,7 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 
@@ -77,7 +77,7 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 ranges
 ----
-range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 


### PR DESCRIPTION
The goal was to fix a known bug where in a multi-store setting where a range (and lease) is being moved from one local store to another local store, under a partial undo case we could end up with 2 leaseholders in the internal state of the allocator.

As part of fixing this, we elaborate on why we are modeling a single "decision" as a set of pending pendingReplicaChanges, one per replica, and the modeling deficiencies. To address the bug, we sacrifice the universal undo behavior of a pendingReplicaChange. Instead, once some subset of changes on a range are seen to be enacted, we set a no-rollback bit on the rangeState for the remaining set of pendingReplicaChanges. These can no longer be undone, and must only be discarded or considered subsumed. This discarding behavior happens when processing a new StoreLeaseholderMsg.

As part of this change, we also shorten the GC duration of the remaining pending changes once some subset has been observed to be enacted. This should be generally beneficial, since for range moves it is the first change (replica addition) that is time consuming, and is what caused us to have a slow (5min) GC duration.

Informs #156754

Epic: CRDB-55052

Release note: None