### PR TITLE
release-25.3: sql: add read/write metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8905,9 +8905,25 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.bytes_read.count
+      exported_name: sql_statements_bytes_read_count
+      description: Number of bytes read by SQL statements
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.bytes_read.count.internal
+      exported_name: sql_statements_bytes_read_count_internal
+      description: Number of bytes read by SQL statements (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.statements.rows_read.count
       exported_name: sql_statements_rows_read_count
-      description: Number of rows read by SQL statements from primary and secondary indexes
+      description: Number of rows read by SQL statements
       y_axis_label: SQL Statements
       type: COUNTER
       unit: COUNT
@@ -8915,7 +8931,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.statements.rows_read.count.internal
       exported_name: sql_statements_rows_read_count_internal
-      description: Number of rows read by SQL statements from primary and secondary indexes (internal queries)
+      description: Number of rows read by SQL statements (internal queries)
       y_axis_label: SQL Internal Statements
       type: COUNTER
       unit: COUNT

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8908,7 +8908,7 @@ layers:
     - name: sql.statements.bytes_read.count
       exported_name: sql_statements_bytes_read_count
       description: Number of bytes read by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Bytes
       type: COUNTER
       unit: BYTES
       aggregation: AVG
@@ -8924,7 +8924,7 @@ layers:
     - name: sql.statements.index_bytes_written.count
       exported_name: sql_statements_index_bytes_written_count
       description: Number of primary and secondary index bytes modified by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Bytes
       type: COUNTER
       unit: BYTES
       aggregation: AVG
@@ -8940,7 +8940,7 @@ layers:
     - name: sql.statements.index_rows_written.count
       exported_name: sql_statements_index_rows_written_count
       description: Number of primary and secondary index rows modified by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Rows
       type: COUNTER
       unit: COUNT
       aggregation: AVG
@@ -8956,7 +8956,7 @@ layers:
     - name: sql.statements.rows_read.count
       exported_name: sql_statements_rows_read_count
       description: Number of rows read by SQL statements
-      y_axis_label: SQL Statements
+      y_axis_label: Rows
       type: COUNTER
       unit: COUNT
       aggregation: AVG

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8921,6 +8921,22 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.index_bytes_written.count
+      exported_name: sql_statements_index_bytes_written_count
+      description: Number of primary and secondary index bytes modified by SQL statements
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.index_bytes_written.count.internal
+      exported_name: sql_statements_index_bytes_written_count_internal
+      description: Number of primary and secondary index bytes modified by SQL statements (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.statements.index_rows_written.count
       exported_name: sql_statements_index_rows_written_count
       description: Number of primary and secondary index rows modified by SQL statements

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8905,6 +8905,22 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.rows_read.count
+      exported_name: sql_statements_rows_read_count
+      description: Number of rows read by SQL statements from primary and secondary indexes
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.rows_read.count.internal
+      exported_name: sql_statements_rows_read_count_internal
+      description: Number of rows read by SQL statements from primary and secondary indexes (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.stats.activity.update.latency
       exported_name: sql_stats_activity_update_latency
       description: The latency of updates made by the SQL activity updater job. Includes failed update attempts

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8921,6 +8921,22 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.index_rows_written.count
+      exported_name: sql_statements_index_rows_written_count
+      description: Number of primary and secondary index rows modified by SQL statements
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.index_rows_written.count.internal
+      exported_name: sql_statements_index_rows_written_count_internal
+      description: Number of primary and secondary index rows modified by SQL statements (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.statements.rows_read.count
       exported_name: sql_statements_rows_read_count
       description: Number of rows read by SQL statements

--- a/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
@@ -1889,6 +1889,8 @@ var cockroachdbMetrics = map[string]string{
 	"sql_service_latency_sum":                                     "sql.service.latency.sum",
 	"sql_statements_active":                                       "sql.statements.active",
 	"sql_statements_active_internal":                              "sql.statements.active.internal",
+	"sql_statements_rows_read_count":                              "sql.statements.rows_read.count",
+	"sql_statements_rows_read_count_internal":                     "sql.statements.rows_read.count.internal",
 	"sql_stats_activity_update_latency":                           "sql.stats.activity.update.latency",
 	"sql_stats_activity_update_latency_bucket":                    "sql.stats.activity.update.latency.bucket",
 	"sql_stats_activity_update_latency_count":                     "sql.stats.activity.update.latency.count",

--- a/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
@@ -1893,6 +1893,8 @@ var cockroachdbMetrics = map[string]string{
 	"sql_statements_rows_read_count_internal":                     "sql.statements.rows_read.count.internal",
 	"sql_statements_bytes_read_count":                             "sql.statements.bytes_read.count",
 	"sql_statements_bytes_read_count_internal":                    "sql.statements.bytes_read.count.internal",
+	"sql_statements_index_rows_written_count":                     "sql.statements.index_rows_written.count",
+	"sql_statements_index_rows_written_count_internal":            "sql.statements.index_rows_written.count.internal",
 	"sql_stats_activity_update_latency":                           "sql.stats.activity.update.latency",
 	"sql_stats_activity_update_latency_bucket":                    "sql.stats.activity.update.latency.bucket",
 	"sql_stats_activity_update_latency_count":                     "sql.stats.activity.update.latency.count",

--- a/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
@@ -1891,6 +1891,8 @@ var cockroachdbMetrics = map[string]string{
 	"sql_statements_active_internal":                              "sql.statements.active.internal",
 	"sql_statements_rows_read_count":                              "sql.statements.rows_read.count",
 	"sql_statements_rows_read_count_internal":                     "sql.statements.rows_read.count.internal",
+	"sql_statements_bytes_read_count":                             "sql.statements.bytes_read.count",
+	"sql_statements_bytes_read_count_internal":                    "sql.statements.bytes_read.count.internal",
 	"sql_stats_activity_update_latency":                           "sql.stats.activity.update.latency",
 	"sql_stats_activity_update_latency_bucket":                    "sql.stats.activity.update.latency.bucket",
 	"sql_stats_activity_update_latency_count":                     "sql.stats.activity.update.latency.count",

--- a/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
@@ -1895,6 +1895,8 @@ var cockroachdbMetrics = map[string]string{
 	"sql_statements_bytes_read_count_internal":                    "sql.statements.bytes_read.count.internal",
 	"sql_statements_index_rows_written_count":                     "sql.statements.index_rows_written.count",
 	"sql_statements_index_rows_written_count_internal":            "sql.statements.index_rows_written.count.internal",
+	"sql_statements_index_bytes_written_count":                    "sql.statements.index_bytes_written.count",
+	"sql_statements_index_bytes_written_count_internal":           "sql.statements.index_bytes_written.count.internal",
 	"sql_stats_activity_update_latency":                           "sql.stats.activity.update.latency",
 	"sql_stats_activity_update_latency_bucket":                    "sql.stats.activity.update.latency.bucket",
 	"sql_stats_activity_update_latency_count":                     "sql.stats.activity.update.latency.count",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -960,6 +960,7 @@ go_test(
         "//pkg/util/log/logconfig",
         "//pkg/util/log/logpb",
         "//pkg/util/log/logtestutils",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/protoutil",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -620,6 +620,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			TxnRetryCount:                     metric.NewCounter(getMetricMeta(MetaTxnRetry, internal)),
 			StatementRetryCount:               metric.NewCounter(getMetricMeta(MetaStatementRetry, internal)),
 			StatementRowsRead:                 metric.NewCounter(getMetricMeta(MetaStatementRowsRead, internal)),
+			StatementBytesRead:                metric.NewCounter(getMetricMeta(MetaStatementBytesRead, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -621,6 +621,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			StatementRetryCount:               metric.NewCounter(getMetricMeta(MetaStatementRetry, internal)),
 			StatementRowsRead:                 metric.NewCounter(getMetricMeta(MetaStatementRowsRead, internal)),
 			StatementBytesRead:                metric.NewCounter(getMetricMeta(MetaStatementBytesRead, internal)),
+			StatementIndexRowsWritten:         metric.NewCounter(getMetricMeta(MetaStatementIndexRowsWritten, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -622,6 +622,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			StatementRowsRead:                 metric.NewCounter(getMetricMeta(MetaStatementRowsRead, internal)),
 			StatementBytesRead:                metric.NewCounter(getMetricMeta(MetaStatementBytesRead, internal)),
 			StatementIndexRowsWritten:         metric.NewCounter(getMetricMeta(MetaStatementIndexRowsWritten, internal)),
+			StatementIndexBytesWritten:        metric.NewCounter(getMetricMeta(MetaStatementIndexBytesWritten, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -619,6 +619,7 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			FullTableOrIndexScanRejectedCount: metric.NewCounter(getMetricMeta(MetaFullTableOrIndexScanRejected, internal)),
 			TxnRetryCount:                     metric.NewCounter(getMetricMeta(MetaTxnRetry, internal)),
 			StatementRetryCount:               metric.NewCounter(getMetricMeta(MetaStatementRetry, internal)),
+			StatementRowsRead:                 metric.NewCounter(getMetricMeta(MetaStatementRowsRead, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3483,10 +3483,10 @@ func (ex *connExecutor) makeExecPlan(
 
 // topLevelQueryStats returns some basic statistics about the run of the query.
 type topLevelQueryStats struct {
-	// bytesRead is the number of bytes read from primary and secondary indexes.
-	bytesRead int64
 	// rowsRead is the number of rows read from primary and secondary indexes.
 	rowsRead int64
+	// bytesRead is the number of bytes read from primary and secondary indexes.
+	bytesRead int64
 	// rowsWritten is the number of rows written to the primary index. It does not
 	// include rows written to secondary indexes.
 	// NB: There is an asymmetry between rowsRead and rowsWritten - rowsRead
@@ -3497,6 +3497,9 @@ type topLevelQueryStats struct {
 	// indexRowsWritten is the number of rows written to primary and secondary
 	// indexes. It is always >= rowsWritten.
 	indexRowsWritten int64
+	// indexBytesWritten is the number of bytes written to primary and secondary
+	// indexes.
+	indexBytesWritten int64
 	// networkEgressEstimate is an estimate for the number of bytes sent to the
 	// client. It is used for estimating the number of RUs consumed by a query.
 	networkEgressEstimate int64
@@ -3510,6 +3513,7 @@ func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
 	s.bytesRead += other.bytesRead
 	s.rowsRead += other.rowsRead
 	s.rowsWritten += other.rowsWritten
+	s.indexBytesWritten += other.indexBytesWritten
 	s.indexRowsWritten += other.indexRowsWritten
 	s.networkEgressEstimate += other.networkEgressEstimate
 	s.clientTime += other.clientTime

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -259,6 +259,10 @@ func (d *deleteNode) rowsWritten() int64 {
 	return d.run.td.rowsWritten
 }
 
+func (d *deleteNode) indexRowsWritten() int64 {
+	return d.run.td.indexRowsWritten
+}
+
 func (d *deleteNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -263,6 +263,11 @@ func (d *deleteNode) indexRowsWritten() int64 {
 	return d.run.td.indexRowsWritten
 }
 
+func (d *deleteNode) indexBytesWritten() int64 {
+	// No bytes counted as written for a deletion.
+	return 0
+}
+
 func (d *deleteNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -84,6 +84,11 @@ func (d *deleteRangeNode) indexRowsWritten() int64 {
 	return int64(d.rowCount)
 }
 
+func (d *deleteRangeNode) indexBytesWritten() int64 {
+	// No bytes counted as written for a deletion.
+	return 0
+}
+
 // startExec implements the planNode interface.
 func (d *deleteRangeNode) startExec(params runParams) error {
 	if err := params.p.cancelChecker.Check(); err != nil {

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -78,6 +78,12 @@ func (d *deleteRangeNode) rowsWritten() int64 {
 	return int64(d.rowCount)
 }
 
+func (d *deleteRangeNode) indexRowsWritten() int64 {
+	// Same as rowsWritten, because deleteRangeNode only applies to primary index
+	// rows (it is not used if there's a secondary index on the table).
+	return int64(d.rowCount)
+}
+
 // startExec implements the planNode interface.
 func (d *deleteRangeNode) startExec(params runParams) error {
 	if err := params.p.cancelChecker.Check(); err != nil {

--- a/pkg/sql/delete_swap.go
+++ b/pkg/sql/delete_swap.go
@@ -143,6 +143,10 @@ func (d *deleteSwapNode) rowsWritten() int64 {
 	return d.run.td.rowsWritten
 }
 
+func (d *deleteSwapNode) indexRowsWritten() int64 {
+	return d.run.td.indexRowsWritten
+}
+
 func (d *deleteSwapNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/delete_swap.go
+++ b/pkg/sql/delete_swap.go
@@ -147,6 +147,11 @@ func (d *deleteSwapNode) indexRowsWritten() int64 {
 	return d.run.td.indexRowsWritten
 }
 
+func (d *deleteSwapNode) indexBytesWritten() int64 {
+	// No bytes counted as written for a deletion.
+	return 0
+}
+
 func (d *deleteSwapNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1539,6 +1539,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 		r.stats.bytesRead += meta.Metrics.BytesRead
 		r.stats.rowsRead += meta.Metrics.RowsRead
 		r.stats.rowsWritten += meta.Metrics.RowsWritten
+		r.stats.indexRowsWritten += meta.Metrics.IndexRowsWritten
 		if r.progressAtomic != nil && r.expectedRowsRead != 0 {
 			progress := float64(r.stats.rowsRead) / float64(r.expectedRowsRead)
 			atomic.StoreUint64(r.progressAtomic, math.Float64bits(progress))

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1540,6 +1540,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 		r.stats.rowsRead += meta.Metrics.RowsRead
 		r.stats.rowsWritten += meta.Metrics.RowsWritten
 		r.stats.indexRowsWritten += meta.Metrics.IndexRowsWritten
+		r.stats.indexBytesWritten += meta.Metrics.IndexBytesWritten
 		if r.progressAtomic != nil && r.expectedRowsRead != 0 {
 			progress := float64(r.stats.rowsRead) / float64(r.expectedRowsRead)
 			atomic.StoreUint64(r.progressAtomic, math.Float64bits(progress))

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1397,6 +1397,12 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaStatementIndexBytesWritten = metric.Metadata{
+		Name:        "sql.statements.index_bytes_written.count",
+		Help:        "Number of primary and secondary index bytes modified by SQL statements",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_BYTES,
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1391,6 +1391,12 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_BYTES,
 	}
+	MetaStatementIndexRowsWritten = metric.Metadata{
+		Name:        "sql.statements.index_rows_written.count",
+		Help:        "Number of primary and secondary index rows modified by SQL statements",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1382,25 +1382,25 @@ var (
 	MetaStatementRowsRead = metric.Metadata{
 		Name:        "sql.statements.rows_read.count",
 		Help:        "Number of rows read by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Rows",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaStatementBytesRead = metric.Metadata{
 		Name:        "sql.statements.bytes_read.count",
 		Help:        "Number of bytes read by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 	MetaStatementIndexRowsWritten = metric.Metadata{
 		Name:        "sql.statements.index_rows_written.count",
 		Help:        "Number of primary and secondary index rows modified by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Rows",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaStatementIndexBytesWritten = metric.Metadata{
 		Name:        "sql.statements.index_bytes_written.count",
 		Help:        "Number of primary and secondary index bytes modified by SQL statements",
-		Measurement: "SQL Statements",
+		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 )

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1381,9 +1381,15 @@ var (
 	}
 	MetaStatementRowsRead = metric.Metadata{
 		Name:        "sql.statements.rows_read.count",
-		Help:        "Number of rows read by SQL statements from primary and secondary indexes",
+		Help:        "Number of rows read by SQL statements",
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
+	}
+	MetaStatementBytesRead = metric.Metadata{
+		Name:        "sql.statements.bytes_read.count",
+		Help:        "Number of bytes read by SQL statements",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_BYTES,
 	}
 )
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1379,6 +1379,12 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaStatementRowsRead = metric.Metadata{
+		Name:        "sql.statements.rows_read.count",
+		Help:        "Number of rows read by SQL statements from primary and secondary indexes",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -333,12 +333,20 @@ message RemoteProducerMetadata {
   }
   // Metrics are unconditionally emitted by table readers.
   message Metrics {
-    // Total number of bytes read while executing a statement.
+    // BytesRead is the number of primary and secondary index bytes read while
+    // executing a statement.
     optional int64 bytes_read = 1 [(gogoproto.nullable) = false];
-    // Total number of rows read while executing a statement.
+    // RowsRead is the number of primary and secondary index rows read while
+    // executing a statement.
     optional int64 rows_read = 2 [(gogoproto.nullable) = false];
-    // Total number of rows modified while executing a statement.
+    // RowsWritten is the number of primary index rows modified while executing
+    // a statement. It does not include secondary index rows.
     optional int64 rows_written = 3 [(gogoproto.nullable) = false];
+    // IndexRowsWritten is the number of primary and secondary index rows
+    // modified while executing a statement. It is always >= RowsWritten.
+    optional int64 index_rows_written = 5 [(gogoproto.nullable) = false];
+    reserved 4;
+    // NEXT ID: 6
   }
   oneof value {
     RangeInfos range_info = 1;
@@ -353,7 +361,7 @@ message RemoteProducerMetadata {
     TracingAggregatorEvents tracing_aggregator_events= 12;
   }
   reserved 6, 10;
-  // NEXT ID: 13
+  // NEXT ID: 14
 }
 
 // DistSQLDrainingInfo represents the DistSQL draining state that gets gossiped

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -345,8 +345,11 @@ message RemoteProducerMetadata {
     // IndexRowsWritten is the number of primary and secondary index rows
     // modified while executing a statement. It is always >= RowsWritten.
     optional int64 index_rows_written = 5 [(gogoproto.nullable) = false];
+    // IndexBytesWritten is the number of primary and secondary index bytes
+    // modified while executing a statement.
+    optional int64 index_bytes_written = 6 [(gogoproto.nullable) = false];
     reserved 4;
-    // NEXT ID: 6
+    // NEXT ID: 7
   }
   oneof value {
     RangeInfos range_info = 1;
@@ -361,7 +364,7 @@ message RemoteProducerMetadata {
     TracingAggregatorEvents tracing_aggregator_events= 12;
   }
   reserved 6, 10;
-  // NEXT ID: 14
+  // NEXT ID: 13
 }
 
 // DistSQLDrainingInfo represents the DistSQL draining state that gets gossiped

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -88,6 +88,10 @@ type EngineMetrics struct {
 	// primary and secondary indexes. Note that some secondary indexes can have
 	// multiple index rows per primary index row (e.g. inverted and vector).
 	StatementRowsRead *metric.Counter
+
+	// StatementBytesRead counts the number of bytes scanned by SQL statements
+	// from primary and secondary indexes.
+	StatementBytesRead *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.
@@ -205,6 +209,7 @@ func (ex *connExecutor) recordStatementSummary(
 
 	// Update SQL statement metrics.
 	ex.metrics.EngineMetrics.StatementRowsRead.Inc(stats.rowsRead)
+	ex.metrics.EngineMetrics.StatementBytesRead.Inc(stats.bytesRead)
 
 	recordedStmtStats := &sqlstats.RecordedStmtStats{
 		FingerprintID:        stmtFingerprintID,

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -83,6 +83,11 @@ type EngineMetrics struct {
 	// StatementRetryCount counts the number of automatic statement retries that
 	// have occurred under READ COMMITTED isolation.
 	StatementRetryCount *metric.Counter
+
+	// StatementRowsRead counts the number of rows read by SQL statements from
+	// primary and secondary indexes. Note that some secondary indexes can have
+	// multiple index rows per primary index row (e.g. inverted and vector).
+	StatementRowsRead *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.
@@ -197,6 +202,10 @@ func (ex *connExecutor) recordStatementSummary(
 	if automaticRetryStmtCount > 0 {
 		autoRetryReason = planner.autoRetryStmtReason
 	}
+
+	// Update SQL statement metrics.
+	ex.metrics.EngineMetrics.StatementRowsRead.Inc(stats.rowsRead)
+
 	recordedStmtStats := &sqlstats.RecordedStmtStats{
 		FingerprintID:        stmtFingerprintID,
 		QuerySummary:         stmt.StmtSummary,

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -96,6 +96,10 @@ type EngineMetrics struct {
 	// StatementIndexRowsWritten counts the number of primary and secondary index
 	// rows modified by SQL statements.
 	StatementIndexRowsWritten *metric.Counter
+
+	// StatementIndexBytesWritten counts the number of primary and secondary index
+	// bytes modified by SQL statements.
+	StatementIndexBytesWritten *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.
@@ -215,6 +219,7 @@ func (ex *connExecutor) recordStatementSummary(
 	ex.metrics.EngineMetrics.StatementRowsRead.Inc(stats.rowsRead)
 	ex.metrics.EngineMetrics.StatementBytesRead.Inc(stats.bytesRead)
 	ex.metrics.EngineMetrics.StatementIndexRowsWritten.Inc(stats.indexRowsWritten)
+	ex.metrics.EngineMetrics.StatementIndexBytesWritten.Inc(stats.indexBytesWritten)
 
 	recordedStmtStats := &sqlstats.RecordedStmtStats{
 		FingerprintID:        stmtFingerprintID,

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -92,6 +92,10 @@ type EngineMetrics struct {
 	// StatementBytesRead counts the number of bytes scanned by SQL statements
 	// from primary and secondary indexes.
 	StatementBytesRead *metric.Counter
+
+	// StatementIndexRowsWritten counts the number of primary and secondary index
+	// rows modified by SQL statements.
+	StatementIndexRowsWritten *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.
@@ -210,6 +214,7 @@ func (ex *connExecutor) recordStatementSummary(
 	// Update SQL statement metrics.
 	ex.metrics.EngineMetrics.StatementRowsRead.Inc(stats.rowsRead)
 	ex.metrics.EngineMetrics.StatementBytesRead.Inc(stats.bytesRead)
+	ex.metrics.EngineMetrics.StatementIndexRowsWritten.Inc(stats.indexRowsWritten)
 
 	recordedStmtStats := &sqlstats.RecordedStmtStats{
 		FingerprintID:        stmtFingerprintID,

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -388,3 +388,7 @@ func (n *insertNode) enableAutoCommit() {
 func (n *insertNode) rowsWritten() int64 {
 	return n.run.ti.rowsWritten
 }
+
+func (n *insertNode) indexRowsWritten() int64 {
+	return n.run.ti.indexRowsWritten
+}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -392,3 +392,7 @@ func (n *insertNode) rowsWritten() int64 {
 func (n *insertNode) indexRowsWritten() int64 {
 	return n.run.ti.indexRowsWritten
 }
+
+func (n *insertNode) indexBytesWritten() int64 {
+	return n.run.ti.indexBytesWritten
+}

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -552,6 +552,10 @@ func (n *insertFastPathNode) indexRowsWritten() int64 {
 	return n.run.ti.indexRowsWritten
 }
 
+func (n *insertFastPathNode) indexBytesWritten() int64 {
+	return n.run.ti.indexBytesWritten
+}
+
 // See planner.autoCommit.
 func (n *insertFastPathNode) enableAutoCommit() {
 	n.run.ti.enableAutoCommit()

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -548,6 +548,10 @@ func (n *insertFastPathNode) rowsWritten() int64 {
 	return n.run.ti.rowsWritten
 }
 
+func (n *insertFastPathNode) indexRowsWritten() int64 {
+	return n.run.ti.indexRowsWritten
+}
+
 // See planner.autoCommit.
 func (n *insertFastPathNode) enableAutoCommit() {
 	n.run.ti.enableAutoCommit()

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -244,8 +244,6 @@ func TestStatementMetrics(t *testing.T) {
 		},
 	}
 
-	lastRowsRead := s.MustGetSQLCounter(sql.MetaStatementRowsRead.Name)
-
 	for _, tc := range testCases {
 		t.Run(tc.query, func(t *testing.T) {
 			for _, vectorized := range []string{"off", "on"} {
@@ -255,11 +253,23 @@ func TestStatementMetrics(t *testing.T) {
 						return
 					}
 
+					// Get initial values of the counters.
+					lastRowsRead := s.MustGetSQLCounter(sql.MetaStatementRowsRead.Name)
+					lastBytesRead := s.MustGetSQLCounter(sql.MetaStatementBytesRead.Name)
+
 					runner.Exec(t, tc.query)
+
+					// Test the rows read metric.
 					actual, err := checkCounterDelta(
 						s, sql.MetaStatementRowsRead, lastRowsRead, tc.rowsRead)
 					require.NoError(t, err)
 					lastRowsRead = actual
+
+					// If there were rows read, then expect bytes read to have
+					// increased. Don't check for a specific value, since there are
+					// too many factors that can change this.
+					currBytesRead := s.MustGetSQLCounter(sql.MetaStatementBytesRead.Name)
+					require.Greater(t, currBytesRead, lastBytesRead)
 				})
 			}
 		})

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -224,6 +224,9 @@ func TestStatementMetrics(t *testing.T) {
 		indexRowsWritten int64
 		// If true, then skip metamorphic testing for this query.
 		skipMetamorphic bool
+		// If true, then this is a deletion case, in which case indexBytesWritten
+		// is expected to be zero.
+		isDelete bool
 	}{
 		// Read-only statements.
 		{query: `SELECT * FROM db.t WHERE x = 1`, rowsRead: 1},
@@ -261,8 +264,15 @@ func TestStatementMetrics(t *testing.T) {
 			rowsRead:         1,
 			indexRowsWritten: 3,
 		},
-		{query: `DELETE FROM db.t WHERE x = 2`, rowsRead: 1, indexRowsWritten: 3},
-		{query: `DELETE FROM db.t WHERE a @> ARRAY['apple']`, rowsRead: 4, indexRowsWritten: 9},
+		{query: `DELETE FROM db.t WHERE x = 2`, rowsRead: 1, indexRowsWritten: 3, isDelete: true},
+		{
+			query:            `DELETE FROM db.t WHERE a @> ARRAY['apple']`,
+			rowsRead:         4,
+			indexRowsWritten: 9,
+			isDelete:         true,
+		},
+		// CREATE TABLE does not count rows or bytes written.
+		{query: `CREATE TABLE db.t2 (x, y) AS SELECT 1, 10 UNION SELECT 2, 20`},
 	}
 
 	for _, vectorized := range []string{"off", "on"} {
@@ -287,14 +297,14 @@ func TestStatementMetrics(t *testing.T) {
 					lastRowsRead := s.MustGetSQLCounter(sql.MetaStatementRowsRead.Name)
 					lastBytesRead := s.MustGetSQLCounter(sql.MetaStatementBytesRead.Name)
 					lastRowsWritten := s.MustGetSQLCounter(sql.MetaStatementIndexRowsWritten.Name)
+					lastBytesWritten := s.MustGetSQLCounter(sql.MetaStatementIndexBytesWritten.Name)
 
 					runner.Exec(t, tc.query)
 
 					// Test the rows read metric.
-					actual, err := checkCounterDelta(
+					_, err := checkCounterDelta(
 						s, sql.MetaStatementRowsRead, lastRowsRead, tc.rowsRead)
 					require.NoError(t, err)
-					lastRowsRead = actual
 
 					// If there were rows read, then expect bytes read to have
 					// increased. Don't check for a specific value, since there are
@@ -305,10 +315,22 @@ func TestStatementMetrics(t *testing.T) {
 					}
 
 					// Test the rows written metric.
-					actual, err = checkCounterDelta(
+					_, err = checkCounterDelta(
 						s, sql.MetaStatementIndexRowsWritten, lastRowsWritten, tc.indexRowsWritten)
 					require.NoError(t, err)
-					lastRowsWritten = actual
+
+					// If there were index rows written, then expect bytes written
+					// to have increased (or not in the delete case). Don't check
+					// for a specific value, since there are too many factors that
+					// can change this.
+					if tc.indexRowsWritten > 0 {
+						currBytesWritten := s.MustGetSQLCounter(sql.MetaStatementIndexBytesWritten.Name)
+						if !tc.isDelete {
+							require.Greater(t, currBytesWritten, lastBytesWritten)
+						} else {
+							require.Equal(t, currBytesWritten, lastBytesWritten)
+						}
+					}
 				})
 			}
 		})

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -8,6 +8,7 @@ package sql_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -18,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
@@ -200,6 +203,64 @@ func TestQueryCounts(t *testing.T) {
 			}
 			if accum.transactionTimeoutCount, err = checkCounterDelta(s, sql.MetaTransactionTimeout, accum.transactionTimeoutCount, tc.transactionTimeoutCount); err != nil {
 				t.Errorf("%q: %s", tc.query, err)
+			}
+		})
+	}
+}
+
+func TestStatementMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := createTestServerParamsAllowTenants()
+	srv, sqlDB, _ := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	s := srv.ApplicationLayer()
+
+	runner.Exec(t, `CREATE DATABASE db`)
+	runner.Exec(t, `CREATE TABLE db.t (x INT PRIMARY KEY, y INT, a STRING[], v VECTOR(2))`)
+	runner.Exec(t, `CREATE INDEX ON db.t (y)`)
+	runner.Exec(t, `CREATE INVERTED INDEX ON db.t (a)`)
+	runner.Exec(t, `INSERT INTO db.t VALUES (1, 10, ARRAY['apple', 'orange'], '[1, 2]')`)
+	runner.Exec(t, `INSERT INTO db.t VALUES (2, 20, ARRAY['banana'], '[3, 4]')`)
+	runner.Exec(t, `INSERT INTO db.t VALUES (3, 30, ARRAY['apple', 'pear', 'mango'], '[5, 6]')`)
+
+	testCases := []struct {
+		query    string
+		rowsRead int64
+		// If true, then skip metamorphic testing for this query.
+		skipMetamorphic bool
+	}{
+		{query: `SELECT * FROM db.t WHERE x = 1`, rowsRead: 1},
+		{query: `SELECT * FROM db.t WHERE x <= 2`, rowsRead: 2},
+		{query: `SELECT * FROM db.t WHERE a @> ARRAY['apple']`, rowsRead: 4},
+		{
+			query:    `SELECT * FROM db.t@t_a_idx t1, db.t t2 WHERE t1.a @> t2.a`,
+			rowsRead: 12,
+			// Skip this variation under metamorphic testing because the inverted
+			// joiner batch size can affect number of rows read.
+			skipMetamorphic: true,
+		},
+	}
+
+	lastRowsRead := s.MustGetSQLCounter(sql.MetaStatementRowsRead.Name)
+
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			for _, vectorized := range []string{"off", "on"} {
+				runner.Exec(t, "SET vectorize = $1", vectorized)
+				t.Run(fmt.Sprintf("vectorize = %s", vectorized), func(t *testing.T) {
+					if tc.skipMetamorphic && metamorphic.IsMetamorphicBuild() {
+						return
+					}
+
+					runner.Exec(t, tc.query)
+					actual, err := checkCounterDelta(
+						s, sql.MetaStatementRowsRead, lastRowsRead, tc.rowsRead)
+					require.NoError(t, err)
+					lastRowsRead = actual
+				})
 			}
 		})
 	}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -156,6 +156,11 @@ type mutationPlanNode interface {
 	// modified by this planNode. It is always >= rowsWritten. It should only be
 	// called once Next returns false.
 	indexRowsWritten() int64
+
+	// indexBytesWritten returns the number of primary and secondary index bytes
+	// modified by this planNode. It should only be called once Next returns
+	// false.
+	indexBytesWritten() int64
 }
 
 // planNodeFastPath is implemented by nodes that can perform all their

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -147,9 +147,15 @@ func (n *singleInputPlanNode) SetInput(i int, p planNode) error {
 type mutationPlanNode interface {
 	planNode
 
-	// rowsWritten returns the number of rows modified by this planNode. It
-	// should only be called once Next returns false.
+	// rowsWritten returns the number of table rows modified by this planNode.
+	// It does not include rows written to secondary indexes. It should only be
+	// called once Next returns false.
 	rowsWritten() int64
+
+	// indexRowsWritten returns the number of primary and secondary index rows
+	// modified by this planNode. It is always >= rowsWritten. It should only be
+	// called once Next returns false.
+	indexRowsWritten() int64
 }
 
 // planNodeFastPath is implemented by nodes that can perform all their

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -162,6 +162,14 @@ func (s *serializeNode) indexRowsWritten() int64 {
 	return m.indexRowsWritten()
 }
 
+func (s *serializeNode) indexBytesWritten() int64 {
+	m, ok := s.source.(mutationPlanNode)
+	if !ok {
+		return 0
+	}
+	return m.indexBytesWritten()
+}
+
 // requireSpool implements the planNodeRequireSpool interface.
 func (s *serializeNode) requireSpool() {}
 
@@ -238,4 +246,12 @@ func (r *rowCountNode) indexRowsWritten() int64 {
 		return 0
 	}
 	return m.indexRowsWritten()
+}
+
+func (r *rowCountNode) indexBytesWritten() int64 {
+	m, ok := r.source.(mutationPlanNode)
+	if !ok {
+		return 0
+	}
+	return m.indexBytesWritten()
 }

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -154,6 +154,14 @@ func (s *serializeNode) rowsWritten() int64 {
 	return m.rowsWritten()
 }
 
+func (s *serializeNode) indexRowsWritten() int64 {
+	m, ok := s.source.(mutationPlanNode)
+	if !ok {
+		return 0
+	}
+	return m.indexRowsWritten()
+}
+
 // requireSpool implements the planNodeRequireSpool interface.
 func (s *serializeNode) requireSpool() {}
 
@@ -222,4 +230,12 @@ func (r *rowCountNode) rowsWritten() int64 {
 		return 0
 	}
 	return m.rowsWritten()
+}
+
+func (r *rowCountNode) indexRowsWritten() int64 {
+	m, ok := r.source.(mutationPlanNode)
+	if !ok {
+		return 0
+	}
+	return m.indexRowsWritten()
 }

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -267,6 +267,7 @@ func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetad
 			metrics := execinfrapb.GetMetricsMeta()
 			metrics.RowsWritten = m.rowsWritten()
 			metrics.IndexRowsWritten = m.indexRowsWritten()
+			metrics.IndexBytesWritten = m.indexBytesWritten()
 			meta = []execinfrapb.ProducerMetadata{{Metrics: metrics}}
 		}
 	}

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -266,6 +266,7 @@ func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetad
 		if m, ok := p.node.(mutationPlanNode); ok {
 			metrics := execinfrapb.GetMetricsMeta()
 			metrics.RowsWritten = m.rowsWritten()
+			metrics.IndexRowsWritten = m.indexRowsWritten()
 			meta = []execinfrapb.ProducerMetadata{{Metrics: metrics}}
 		}
 	}

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -118,3 +118,11 @@ func (s *spoolNode) indexRowsWritten() int64 {
 	}
 	return m.indexRowsWritten()
 }
+
+func (s *spoolNode) indexBytesWritten() int64 {
+	m, ok := s.input.(mutationPlanNode)
+	if !ok {
+		return 0
+	}
+	return m.indexBytesWritten()
+}

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -110,3 +110,11 @@ func (s *spoolNode) rowsWritten() int64 {
 	}
 	return m.rowsWritten()
 }
+
+func (s *spoolNode) indexRowsWritten() int64 {
+	m, ok := s.input.(mutationPlanNode)
+	if !ok {
+		return 0
+	}
+	return m.indexRowsWritten()
+}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -71,6 +71,9 @@ type tableWriterBase struct {
 	// indexRowsWritten tracks the number of primary and secondary index rows
 	// written by this tableWriterBase so far. It is always >= rowsWritten.
 	indexRowsWritten int64
+	// indexBytesWritten tracks the number of primary and secondary index bytes
+	// written by this tableWriterBase so far.
+	indexBytesWritten int64
 	// rowsWrittenLimit if positive indicates that
 	// `transaction_rows_written_err` is enabled. The limit will be checked in
 	// finalize() before deciding whether it is safe to auto commit (if auto
@@ -151,11 +154,12 @@ func (tb *tableWriterBase) flushAndStartNewBatch(ctx context.Context) error {
 	if err := tb.tryDoResponseAdmission(ctx); err != nil {
 		return err
 	}
+	tb.rowsWritten += int64(tb.currentBatchSize)
+	tb.lastBatchSize = tb.currentBatchSize
 	// The mutation operators add one request to the KV batch for each index
 	// entry that's written.
 	tb.indexRowsWritten += int64(len(tb.b.Requests()))
-	tb.rowsWritten += int64(tb.currentBatchSize)
-	tb.lastBatchSize = tb.currentBatchSize
+	tb.indexBytesWritten += int64(tb.b.ApproximateMutationBytes())
 	tb.currentBatchSize = 0
 	tb.initNewBatch()
 	return nil
@@ -165,8 +169,9 @@ func (tb *tableWriterBase) flushAndStartNewBatch(ctx context.Context) error {
 func (tb *tableWriterBase) finalize(ctx context.Context) (err error) {
 	// NB: unlike flushAndStartNewBatch, we don't bother with admission control
 	// for response processing when finalizing.
-	tb.indexRowsWritten += int64(len(tb.b.Requests()))
 	tb.rowsWritten += int64(tb.currentBatchSize)
+	tb.indexRowsWritten += int64(len(tb.b.Requests()))
+	tb.indexBytesWritten += int64(tb.b.ApproximateMutationBytes())
 	if tb.autoCommit == autoCommitEnabled &&
 		// We can only auto commit if the rows written guardrail is disabled or
 		// we haven't exceeded the specified limit (the optimizer is responsible

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -57,15 +57,20 @@ type tableWriterBase struct {
 	// maxBatchByteSize determines the maximum number of key and value bytes in
 	// the KV batch for a mutation operation.
 	maxBatchByteSize int
-	// currentBatchSize is the size of the current batch. It is updated on
-	// every row() call and is reset once a new batch is started.
+	// currentBatchSize is the size of the current SQL-level batch (i.e. not the
+	// KV-level batch). It is updated on every row() call and is reset once a new
+	// batch is started.
 	currentBatchSize int
 	// lastBatchSize is the size of the last batch. It is set to the value of
 	// currentBatchSize once the batch is flushed or finalized.
 	lastBatchSize int
-	// rowsWritten tracks the number of rows written by this tableWriterBase so
-	// far.
+	// rowsWritten tracks the number of primary index rows written by this
+	// tableWriterBase so far. This counter includes unsuccessful writes (e.g.
+	// those performed by swap mutations in the event of a nonexistent row).
 	rowsWritten int64
+	// indexRowsWritten tracks the number of primary and secondary index rows
+	// written by this tableWriterBase so far. It is always >= rowsWritten.
+	indexRowsWritten int64
 	// rowsWrittenLimit if positive indicates that
 	// `transaction_rows_written_err` is enabled. The limit will be checked in
 	// finalize() before deciding whether it is safe to auto commit (if auto
@@ -146,10 +151,13 @@ func (tb *tableWriterBase) flushAndStartNewBatch(ctx context.Context) error {
 	if err := tb.tryDoResponseAdmission(ctx); err != nil {
 		return err
 	}
-	tb.initNewBatch()
+	// The mutation operators add one request to the KV batch for each index
+	// entry that's written.
+	tb.indexRowsWritten += int64(len(tb.b.Requests()))
 	tb.rowsWritten += int64(tb.currentBatchSize)
 	tb.lastBatchSize = tb.currentBatchSize
 	tb.currentBatchSize = 0
+	tb.initNewBatch()
 	return nil
 }
 
@@ -157,6 +165,7 @@ func (tb *tableWriterBase) flushAndStartNewBatch(ctx context.Context) error {
 func (tb *tableWriterBase) finalize(ctx context.Context) (err error) {
 	// NB: unlike flushAndStartNewBatch, we don't bother with admission control
 	// for response processing when finalizing.
+	tb.indexRowsWritten += int64(len(tb.b.Requests()))
 	tb.rowsWritten += int64(tb.currentBatchSize)
 	if tb.autoCommit == autoCommitEnabled &&
 		// We can only auto commit if the rows written guardrail is disabled or

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -305,6 +305,10 @@ func (u *updateNode) rowsWritten() int64 {
 	return u.run.tu.rowsWritten
 }
 
+func (u *updateNode) indexRowsWritten() int64 {
+	return u.run.tu.indexRowsWritten
+}
+
 func (u *updateNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -309,6 +309,10 @@ func (u *updateNode) indexRowsWritten() int64 {
 	return u.run.tu.indexRowsWritten
 }
 
+func (u *updateNode) indexBytesWritten() int64 {
+	return u.run.tu.indexBytesWritten
+}
+
 func (u *updateNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/update_swap.go
+++ b/pkg/sql/update_swap.go
@@ -143,6 +143,10 @@ func (u *updateSwapNode) rowsWritten() int64 {
 	return u.run.tu.rowsWritten
 }
 
+func (u *updateSwapNode) indexRowsWritten() int64 {
+	return u.run.tu.indexRowsWritten
+}
+
 func (u *updateSwapNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/update_swap.go
+++ b/pkg/sql/update_swap.go
@@ -147,6 +147,10 @@ func (u *updateSwapNode) indexRowsWritten() int64 {
 	return u.run.tu.indexRowsWritten
 }
 
+func (u *updateSwapNode) indexBytesWritten() int64 {
+	return u.run.tu.indexBytesWritten
+}
+
 func (u *updateSwapNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -233,6 +233,10 @@ func (n *upsertNode) rowsWritten() int64 {
 	return n.run.tw.rowsWritten
 }
 
+func (n *upsertNode) indexRowsWritten() int64 {
+	return n.run.tw.indexRowsWritten
+}
+
 func (n *upsertNode) enableAutoCommit() {
 	n.run.tw.enableAutoCommit()
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -237,6 +237,10 @@ func (n *upsertNode) indexRowsWritten() int64 {
 	return n.run.tw.indexRowsWritten
 }
 
+func (n *upsertNode) indexBytesWritten() int64 {
+	return n.run.tw.indexBytesWritten
+}
+
 func (n *upsertNode) enableAutoCommit() {
 	n.run.tw.enableAutoCommit()
 }


### PR DESCRIPTION
Backport 5/5 commits from #156459.

/cc @cockroachdb/release

---

### sql: add index_bytes_written metric
Add new sql.statements.index_bytes_written.count metric that counts the number
of primary and secondary index bytes modified by SQL statements.

### sql: add index_rows_written metric
Add new sql.statements.index_rows_written.count metric that counts the number
of primary and secondary index rows modified by SQL statements.

### sql: add bytes_read metric
Add new sql.statements.bytes_read.count metric that counts the number of
bytes scanned by SQL statements. This is the same value that's collected by
SQL stats for each statement and transaction, except in aggregated metric
form.

### sql: add rows_read metric
Add new `sql.statements.rows_read.count` metric that counts the number of index rows read by SQL statements. This is the same value that's collected by SQL stats for each statement and transaction, except in aggregated metric form.

Release Justification: This is needed as part of the Pricing and Packaging project, as part of evaluation of new potential billing metrics.
