### PR TITLE
release-25.4: logictest: reduce data set in cursor test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -655,7 +655,7 @@ subtest holdable
 
 statement ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT);
-INSERT INTO t (SELECT t, t%123 FROM generate_series(1, 10000) g(t));
+INSERT INTO t (SELECT t, t%7 FROM generate_series(1, 10) g(t));
 
 # A holdable cursor can be declared in an implicit transaction.
 statement ok


### PR DESCRIPTION
Backport 1/1 commits from #156565 on behalf of @yuzefovich.

----

We've seen a few failures on `cursor` logic test under race which seems to be due to node overload / timeout. My hypothesis is it's due to metamorphic randomization, and I found one spot where we use 10k rows in the table, but I don't think we need this much. This commit reduces the row count to just 10 in hopes of eliminating the flake under race.

Fixes: #155609.
Release note: None

----

Release justification: test-only change.