### PR TITLE
sql: enable pessimistic histogram estimate settings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4188,8 +4188,8 @@ opt_split_scan_limit                                             2048
 optimizer                                                        on
 optimizer_always_use_histograms                                  on
 optimizer_check_input_min_row_count                              1
-optimizer_clamp_inequality_selectivity                           off
-optimizer_clamp_low_histogram_selectivity                        off
+optimizer_clamp_inequality_selectivity                           on
+optimizer_clamp_low_histogram_selectivity                        on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3137,8 +3137,8 @@ on_update_rehome_row_enabled                                     on             
 opt_split_scan_limit                                             2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                                  on                  NULL      NULL        NULL        string
 optimizer_check_input_min_row_count                              1                   NULL      NULL        NULL        string
-optimizer_clamp_inequality_selectivity                           off                 NULL      NULL        NULL        string
-optimizer_clamp_low_histogram_selectivity                        off                 NULL      NULL        NULL        string
+optimizer_clamp_inequality_selectivity                           on                  NULL      NULL        NULL        string
+optimizer_clamp_low_histogram_selectivity                        on                  NULL      NULL        NULL        string
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL      NULL        NULL        string
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
@@ -3383,8 +3383,8 @@ on_update_rehome_row_enabled                                     on             
 opt_split_scan_limit                                             2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                                  on                  NULL  user     NULL      on                  on
 optimizer_check_input_min_row_count                              1                   NULL  user     NULL      1                   1
-optimizer_clamp_inequality_selectivity                           off                 NULL  user     NULL      off                 off
-optimizer_clamp_low_histogram_selectivity                        off                 NULL  user     NULL      off                 off
+optimizer_clamp_inequality_selectivity                           on                  NULL  user     NULL      on                  on
+optimizer_clamp_low_histogram_selectivity                        on                  NULL  user     NULL      on                  on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on                  NULL  user     NULL      on                  on
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -154,8 +154,8 @@ on_update_rehome_row_enabled                                     on
 opt_split_scan_limit                                             2048
 optimizer_always_use_histograms                                  on
 optimizer_check_input_min_row_count                              1
-optimizer_clamp_inequality_selectivity                           off
-optimizer_clamp_low_histogram_selectivity                        off
+optimizer_clamp_inequality_selectivity                           on
+optimizer_clamp_low_histogram_selectivity                        on
 optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
@@ -18390,7 +18390,9 @@ __forecast__  {e}    2022-02-06 18:39:47.938163 +0000 UTC  6550920018  160520885
 __forecast__  {f}    2022-02-06 18:39:47.938163 +0000 UTC  6550920018  8977521     25263499    0
 
 statement ok
-SET optimizer_use_forecasts = off
+SET optimizer_use_forecasts = off;
+SET optimizer_clamp_low_histogram_selectivity = off;
+SET optimizer_clamp_inequality_selectivity = off;
 
 # Without forecasts, we estimate 1 row with c newer than 2022-01-25.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3097,14 +3097,14 @@ vectorized: true
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 1
+    │ estimated row count: 10
     │ table: d@d_pkey
     │ key columns: a
     │ parallel
     │
     └── • scan
           columns: (a)
-          estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+          estimated row count: 10 (0.01% of the table; stats collected <hidden> ago)
           table: d@foo_inv
           spans: /[]-/{}
 
@@ -3140,14 +3140,14 @@ vectorized: true
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 1
+    │ estimated row count: 10
     │ table: d@d_pkey
     │ key columns: a
     │ parallel
     │
     └── • scan
           columns: (a)
-          estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+          estimated row count: 10 (0.01% of the table; stats collected <hidden> ago)
           table: d@foo_inv
           spans: /{}-/{}/PrefixEnd
 
@@ -3164,7 +3164,7 @@ vectorized: true
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 1
+    │ estimated row count: 3
     │ table: d@d_pkey
     │ key columns: a
     │ parallel
@@ -3174,13 +3174,13 @@ vectorized: true
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
-            │ estimated row count: 1
+            │ estimated row count: 3
             │ inverted column: b_inverted_key
             │ num spans: 2
             │
             └── • scan
                   columns: (a, b_inverted_key)
-                  estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                  estimated row count: 10 (0.01% of the table; stats collected <hidden> ago)
                   table: d@foo_inv
                   spans: /{}-/{}/PrefixEnd /"a"/"b"-/"a"/"b"/PrefixEnd
 
@@ -3197,7 +3197,7 @@ vectorized: true
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 1
+    │ estimated row count: 3
     │ table: d@d_pkey
     │ key columns: a
     │ parallel
@@ -3207,13 +3207,13 @@ vectorized: true
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
-            │ estimated row count: 1
+            │ estimated row count: 3
             │ inverted column: b_inverted_key
             │ num spans: 8
             │
             └── • scan
                   columns: (a, b_inverted_key)
-                  estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+                  estimated row count: 10 (0.01% of the table; stats collected <hidden> ago)
                   table: d@foo_inv
                   spans: /"f"-/"f"/PrefixEnd /[]-/{} /Arr/"f"-/Arr/"f"/PrefixEnd /Arr/{}-/Arr/{}/PrefixEnd /Arr/"a"/"b"-/Arr/"a"/"b"/PrefixEnd /Arr/"c"/{}-/Arr/"c"/{}/PrefixEnd /Arr/"c"/"d"/[]-/Arr/"c"/"d"/{} /Arr/"c"/"d"/Arr/"e"-/Arr/"c"/"d"/Arr/"e"/PrefixEnd
 

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
@@ -195,7 +195,7 @@ project
       ├── fd: (1)-->(2,3)
       ├── index-join t
       │    ├── columns: k:1(int!null) g:2(geometry) s:3(string)
-      │    ├── stats: [rows=33.9305]
+      │    ├── stats: [rows=33.9402]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2,3)
       │    └── inverted-filter
@@ -208,7 +208,7 @@ project
       │         │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │         ├── pre-filterer expression
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
-      │         ├── stats: [rows=33.9305]
+      │         ├── stats: [rows=33.9402]
       │         ├── key: (1)
       │         └── scan t@m,inverted
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
@@ -222,11 +222,11 @@ project
       │              │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x01", "B\xfd\x12\x00\x00\x00\x00\x00\x00\x00")
       │              │         └── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
       │              ├── flags: force-index=m
-      │              └── stats: [rows=118.757, distinct(1)=33.9305, null(1)=0, distinct(3)=2, null(3)=0, distinct(7)=1.18757, null(7)=0, distinct(3,7)=2.37514, null(3,7)=0]
-      │                  histogram(3)=  0   59.378   0   59.378
+      │              └── stats: [rows=118.791, distinct(1)=33.9402, null(1)=0, distinct(3)=2, null(3)=0, distinct(7)=1.18757, null(7)=0, distinct(3,7)=2.37514, null(3,7)=0]
+      │                  histogram(3)=  0   59.395   0   59.395
       │                               <--- 'banana' --- 'cherry'
-      │                  histogram(7)=  0             0              1.8225e-10            100             18.757             0              0             0
-      │                               <--- '\x42fd1000000000000001' ------------ '\x42fd1000000100000000' -------- '\x42fd1200000000000000' --- '\x42fd1400000000000001'
+      │                  histogram(7)=  0             0              1.823e-10           100.03           18.762             0              0             0
+      │                               <--- '\x42fd1000000000000001' ----------- '\x42fd1000000100000000' -------- '\x42fd1200000000000000' --- '\x42fd1400000000000001'
       └── filters
            └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool, outer=(2), immutable, constraints=(/2: (/NULL - ])]
 

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -3409,18 +3409,18 @@ limit
  │    ├── limit hint: 1.00
  │    ├── index-join stale
  │    │    ├── columns: w:1(string!null) x:2(string) y:3(string) z:4(string)
- │    │    ├── stats: [rows=2.2e-08]
+ │    │    ├── stats: [rows=0.011]
  │    │    ├── key: (1)
  │    │    ├── fd: ()-->(2), (1)-->(3,4), (2,3)~~>(1,4)
- │    │    ├── limit hint: 0.00
+ │    │    ├── limit hint: 0.01
  │    │    └── scan stale@stale_x_z_idx
  │    │         ├── columns: w:1(string!null) x:2(string!null) z:4(string)
  │    │         ├── constraint: /2/4/1: [/'bar1' - /'bar1']
- │    │         ├── stats: [rows=2.2e-08, distinct(2)=2.2e-08, null(2)=0]
+ │    │         ├── stats: [rows=0.011, distinct(2)=0.011, null(2)=0]
  │    │         │   histogram(2)=
  │    │         ├── key: (1)
  │    │         ├── fd: ()-->(2), (1)-->(4)
- │    │         └── limit hint: 0.00
+ │    │         └── limit hint: 0.01
  │    └── filters
  │         └── (y:3 = 'bar1000') OR (y:3 = 'bar1001') [type=bool, outer=(3), constraints=(/3: [/'bar1000' - /'bar1000'] [/'bar1001' - /'bar1001']; tight)]
  └── 1 [type=int]
@@ -3463,6 +3463,6 @@ index-join stale
       │    ├── [/'bar1'/'bar1000' - /'bar1'/'bar1000']
       │    └── [/'bar1'/'bar1001' - /'bar1'/'bar1001']
       ├── limit: 1
-      ├── stats: [rows=4.4e-08]
+      ├── stats: [rows=0.00200002]
       ├── key: ()
       └── fd: ()-->(1-3)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -4067,7 +4067,7 @@ WHERE
 left-join (hash)
  ├── columns: col1:10(string) col2:11(string) col3:12(int) col1:1(string!null) col2:2(string!null) col3:3(int!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
  ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
- ├── stats: [rows=2623.02, distinct(10)=1, null(10)=2123.01, distinct(11)=500.011, null(11)=2123.01]
+ ├── stats: [rows=2623.02, distinct(10)=1, null(10)=2122.76, distinct(11)=500.261, null(11)=2122.76]
  ├── key: (2,4,5)
  ├── fd: ()-->(1,6,7), (2,4,5)-->(3,10-12), (11)-->(12)
  ├── select
@@ -4095,7 +4095,7 @@ left-join (hash)
  ├── scan table1
  │    ├── columns: table1.col1:10(string!null) table1.col2:11(string!null) table1.col3:12(int!null)
  │    ├── constraint: /10/11: [/'e' - /'e']
- │    ├── stats: [rows=2000, distinct(10)=1, null(10)=0, distinct(11)=2000, null(11)=0]
+ │    ├── stats: [rows=2001, distinct(10)=1, null(10)=0, distinct(11)=2001, null(11)=0]
  │    │   histogram(10)=  0 2000
  │    │                 <--- 'e'
  │    ├── key: (11)
@@ -4462,10 +4462,10 @@ SELECT c0 FROM t00 WHERE (c0 = 1) OR (c1 = 3) OR
 ----
 project
  ├── columns: c0:1(int)
- ├── stats: [rows=1.9]
+ ├── stats: [rows=1.90162]
  └── select
       ├── columns: c0:1(int) c1:2(int)
-      ├── stats: [rows=1.9]
+      ├── stats: [rows=1.90162]
       ├── scan t00
       │    ├── columns: c0:1(int) c1:2(int)
       │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -154,7 +154,7 @@ project
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── cardinality: [0 - 5]
  ├── volatile
- ├── stats: [rows=4.54855, distinct(1)=4.54855, null(1)=0, distinct(3)=4.43676, null(3)=0, distinct(8)=4.38572, null(8)=0, distinct(14)=0.989418, null(14)=0, distinct(15)=0.989418, null(15)=0, distinct(16)=0.989418, null(16)=0, distinct(17)=4.54833, null(17)=0]
+ ├── stats: [rows=4.95204, distinct(1)=4.95204, null(1)=0, distinct(3)=4.81972, null(3)=0, distinct(8)=4.75945, null(8)=0, distinct(14)=0.992931, null(14)=0, distinct(15)=0.992931, null(15)=0, distinct(16)=0.992931, null(16)=0, distinct(17)=4.95177, null(17)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -170,11 +170,11 @@ project
       ├── locking: for-update
       ├── cardinality: [0 - 5]
       ├── volatile
-      ├── stats: [rows=4.54855, distinct(1)=4.54855, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.43676, null(3)=0, distinct(8)=4.38572, null(8)=0, distinct(14)=0.989418, null(14)=0, distinct(15)=0.989418, null(15)=0, distinct(16)=0.989418, null(16)=0, distinct(17)=4.54833, null(17)=0, distinct(1,2)=4.54855, null(1,2)=0]
-      │   histogram(1)=  0 0.966 0 0.966  0 0.966  0 0.82528 0 0.82528
-      │                <--- 900 --- 1000 --- 1100 --- 1400 ---- 1500 -
-      │   histogram(2)=  0 4.5486
-      │                <---- 4 --
+      ├── stats: [rows=4.95204, distinct(1)=4.95204, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.81972, null(3)=0, distinct(8)=4.75945, null(8)=0, distinct(14)=0.992931, null(14)=0, distinct(15)=0.992931, null(15)=0, distinct(16)=0.992931, null(16)=0, distinct(17)=4.95177, null(17)=0, distinct(1,2)=4.95204, null(1,2)=0]
+      │   histogram(1)=  0 1.0517 0 1.0517 0 1.0517 0 0.89848 0 0.89848
+      │                <--- 900 ---- 1000 --- 1100 --- 1400 ---- 1500 -
+      │   histogram(2)=  0 4.952
+      │                <---- 4 -
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       └── ordering: +1 opt(2) [actual: +1]
@@ -192,10 +192,10 @@ column_names    row_count  distinct_count  null_count
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {s_data}        5.00           1.00           5.00                1.00                0.00            1.00
-{s_dist_05}     5.00           1.00           4.00                1.25                0.00            1.00
+{s_dist_05}     5.00           1.00           5.00                1.00                0.00            1.00
 {s_i_id}        5.00           1.00           5.00                1.00                0.00            1.00
 {s_order_cnt}   5.00           1.00           1.00                1.00                0.00            1.00
-{s_quantity}    5.00           1.00           4.00                1.00                0.00            1.00
+{s_quantity}    5.00           1.00           5.00                1.25                0.00            1.00
 {s_remote_cnt}  5.00           1.00           1.00                1.00                0.00            1.00
 {s_w_id}        5.00           1.00           1.00                1.00                0.00            1.00
 {s_ytd}         5.00           1.00           1.00                1.00                0.00            1.00

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -731,7 +731,7 @@ SELECT * FROM t@{FORCE_INVERTED_INDEX} WHERE b = 0
 ----
 select
  ├── columns: k:1!null a:2 b:3!null c:4
- ├── stats: [rows=1, distinct(3)=1, null(3)=0]
+ ├── stats: [rows=10, distinct(3)=1, null(3)=0]
  │   histogram(3)=  0  0
  │                <--- 0
  ├── cost: 1e+100

--- a/pkg/sql/opt/xform/testdata/external/fittings
+++ b/pkg/sql/opt/xform/testdata/external/fittings
@@ -2623,13 +2623,13 @@ project
            ├── internal-ordering: -1
            ├── k: 100
            ├── cardinality: [0 - 100]
-           ├── stats: [rows=1]
+           ├── stats: [rows=100]
            ├── key: (1)
            ├── ordering: -1
            └── scan fits@fits_items_idx,inverted
                 ├── columns: killmail:1!null
                 ├── inverted constraint: /13/1
                 │    └── spans: [Arr/54731, Arr/54731]
-                ├── stats: [rows=1, distinct(13)=1, null(13)=0]
+                ├── stats: [rows=218.76, distinct(13)=1, null(13)=0]
                 │   histogram(13)=
                 └── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -838,37 +838,37 @@ project
  │    │    ├── inner-join (cross)
  │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null wl_c_id:6!null dm_date:10!null dm_s_symb:11!null dm_close:12!null lt_s_symb:18!null lt_price:20!null s_symb:25!null s_num_out:31!null
  │    │    │    ├── fd: ()-->(1,6,10), (11)-->(12), (18)-->(20), (25)-->(31), (2)==(11,18,25), (11)==(2,18,25), (18)==(2,11,25), (25)==(2,11,18)
- │    │    │    ├── inner-join (lookup last_trade)
+ │    │    │    ├── inner-join (lookup daily_market)
  │    │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null dm_date:10!null dm_s_symb:11!null dm_close:12!null lt_s_symb:18!null lt_price:20!null s_symb:25!null s_num_out:31!null
- │    │    │    │    ├── key columns: [25] = [18]
+ │    │    │    │    ├── key columns: [68 18] = [10 11]
  │    │    │    │    ├── lookup columns are key
  │    │    │    │    ├── key: (25)
  │    │    │    │    ├── fd: ()-->(1,10), (11)-->(12), (18)-->(20), (25)-->(31), (2)==(11,18,25), (11)==(2,18,25), (18)==(2,11,25), (25)==(2,11,18)
- │    │    │    │    ├── inner-join (lookup security)
- │    │    │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null dm_date:10!null dm_s_symb:11!null dm_close:12!null s_symb:25!null s_num_out:31!null
- │    │    │    │    │    ├── key columns: [2] = [25]
- │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: "lookup_join_const_col_@10":68!null wi_wl_id:1!null wi_s_symb:2!null lt_s_symb:18!null lt_price:20!null s_symb:25!null s_num_out:31!null
  │    │    │    │    │    ├── key: (25)
- │    │    │    │    │    ├── fd: ()-->(1,10), (11)-->(12), (25)-->(31), (2)==(11,25), (11)==(2,25), (25)==(2,11)
- │    │    │    │    │    ├── inner-join (lookup daily_market)
- │    │    │    │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null dm_date:10!null dm_s_symb:11!null dm_close:12!null
- │    │    │    │    │    │    ├── key columns: [58 2] = [10 11]
+ │    │    │    │    │    ├── fd: ()-->(1,68), (18)-->(20), (25)-->(31), (2)==(18,25), (18)==(2,25), (25)==(2,18)
+ │    │    │    │    │    ├── inner-join (lookup last_trade)
+ │    │    │    │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null lt_s_symb:18!null lt_price:20!null s_symb:25!null s_num_out:31!null
+ │    │    │    │    │    │    ├── key columns: [25] = [18]
  │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │    │    ├── key: (11)
- │    │    │    │    │    │    ├── fd: ()-->(1,10), (11)-->(12), (2)==(11), (11)==(2)
- │    │    │    │    │    │    ├── project
- │    │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@10":58!null wi_wl_id:1!null wi_s_symb:2!null
- │    │    │    │    │    │    │    ├── key: (2)
- │    │    │    │    │    │    │    ├── fd: ()-->(1,58)
+ │    │    │    │    │    │    ├── key: (25)
+ │    │    │    │    │    │    ├── fd: ()-->(1), (18)-->(20), (25)-->(31), (2)==(18,25), (18)==(2,25), (25)==(2,18)
+ │    │    │    │    │    │    ├── inner-join (lookup security)
+ │    │    │    │    │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null s_symb:25!null s_num_out:31!null
+ │    │    │    │    │    │    │    ├── key columns: [2] = [25]
+ │    │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    ├── key: (25)
+ │    │    │    │    │    │    │    ├── fd: ()-->(1), (25)-->(31), (2)==(25), (25)==(2)
  │    │    │    │    │    │    │    ├── scan watch_item
  │    │    │    │    │    │    │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null
  │    │    │    │    │    │    │    │    ├── constraint: /1/2: [/0 - /0]
  │    │    │    │    │    │    │    │    ├── key: (2)
  │    │    │    │    │    │    │    │    └── fd: ()-->(1)
- │    │    │    │    │    │    │    └── projections
- │    │    │    │    │    │    │         └── '2020-06-17' [as="lookup_join_const_col_@10":58]
+ │    │    │    │    │    │    │    └── filters (true)
  │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── '2020-06-17' [as="lookup_join_const_col_@10":68]
  │    │    │    │    └── filters (true)
  │    │    │    ├── scan watch_list@watch_list_wl_c_id_idx
  │    │    │    │    ├── columns: wl_c_id:6!null
@@ -1008,58 +1008,58 @@ project
  │    ├── project
  │    │    ├── columns: column69:69!null column71:71!null
  │    │    ├── immutable
- │    │    ├── inner-join (lookup last_trade)
+ │    │    ├── inner-join (lookup daily_market)
  │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null dm_date:36!null dm_s_symb:37!null dm_close:38!null lt_s_symb:44!null lt_price:46!null s_symb:51!null s_num_out:57!null
- │    │    │    ├── key columns: [51] = [44]
+ │    │    │    ├── key columns: [112 44] = [36 37]
  │    │    │    ├── lookup columns are key
  │    │    │    ├── key: (51)
  │    │    │    ├── fd: ()-->(1,2,9,36), (17)-->(22), (37)-->(38), (44)-->(46), (51)-->(57), (6)==(22), (22)==(6), (1)==(9), (9)==(1), (17)==(37,44,51), (37)==(17,44,51), (44)==(17,37,51), (51)==(17,37,44)
- │    │    │    ├── inner-join (lookup security)
- │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null dm_date:36!null dm_s_symb:37!null dm_close:38!null s_symb:51!null s_num_out:57!null
- │    │    │    │    ├── key columns: [17] = [51]
- │    │    │    │    ├── lookup columns are key
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "lookup_join_const_col_@36":112!null in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null lt_s_symb:44!null lt_price:46!null s_symb:51!null s_num_out:57!null
  │    │    │    │    ├── key: (51)
- │    │    │    │    ├── fd: ()-->(1,2,9,36), (17)-->(22), (37)-->(38), (51)-->(57), (17)==(37,51), (37)==(17,51), (51)==(17,37), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
- │    │    │    │    ├── inner-join (hash)
- │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null dm_date:36!null dm_s_symb:37!null dm_close:38!null
- │    │    │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
- │    │    │    │    │    ├── key: (37)
- │    │    │    │    │    ├── fd: ()-->(1,2,9,36), (17)-->(22), (37)-->(38), (17)==(37), (37)==(17), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
- │    │    │    │    │    ├── scan industry@industry_in_name_key
- │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null
- │    │    │    │    │    │    ├── constraint: /2: [/'Software' - /'Software']
- │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │    │    └── fd: ()-->(1,2)
- │    │    │    │    │    ├── inner-join (lookup company)
- │    │    │    │    │    │    ├── columns: co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null dm_date:36!null dm_s_symb:37!null dm_close:38!null
- │    │    │    │    │    │    ├── key columns: [22] = [6]
+ │    │    │    │    ├── fd: ()-->(1,2,9,112), (17)-->(22), (44)-->(46), (51)-->(57), (17)==(44,51), (44)==(17,51), (51)==(17,44), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
+ │    │    │    │    ├── inner-join (lookup last_trade)
+ │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null lt_s_symb:44!null lt_price:46!null s_symb:51!null s_num_out:57!null
+ │    │    │    │    │    ├── key columns: [51] = [44]
+ │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    ├── key: (51)
+ │    │    │    │    │    ├── fd: ()-->(1,2,9), (17)-->(22), (44)-->(46), (51)-->(57), (17)==(44,51), (44)==(17,51), (51)==(17,44), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
+ │    │    │    │    │    ├── inner-join (lookup security)
+ │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null s_symb:51!null s_num_out:57!null
+ │    │    │    │    │    │    ├── key columns: [17] = [51]
  │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │    │    ├── key: (37)
- │    │    │    │    │    │    ├── fd: ()-->(36), (6)-->(9), (17)-->(22), (37)-->(38), (17)==(37), (37)==(17), (6)==(22), (22)==(6)
- │    │    │    │    │    │    ├── inner-join (lookup daily_market)
- │    │    │    │    │    │    │    ├── columns: s_symb:17!null s_co_id:22!null dm_date:36!null dm_s_symb:37!null dm_close:38!null
- │    │    │    │    │    │    │    ├── key columns: [83 17] = [36 37]
- │    │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │    │    │    ├── key: (37)
- │    │    │    │    │    │    │    ├── fd: ()-->(36), (17)-->(22), (37)-->(38), (17)==(37), (37)==(17)
- │    │    │    │    │    │    │    ├── project
- │    │    │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@36":83!null s_symb:17!null s_co_id:22!null
+ │    │    │    │    │    │    ├── key: (51)
+ │    │    │    │    │    │    ├── fd: ()-->(1,2,9), (17)-->(22), (51)-->(57), (17)==(51), (51)==(17), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
+ │    │    │    │    │    │    ├── inner-join (hash)
+ │    │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null
+ │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    │    │    │    │    │    │    ├── key: (17)
+ │    │    │    │    │    │    │    ├── fd: ()-->(1,2,9), (17)-->(22), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
+ │    │    │    │    │    │    │    ├── scan industry@industry_in_name_key
+ │    │    │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null
+ │    │    │    │    │    │    │    │    ├── constraint: /2: [/'Software' - /'Software']
+ │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │    └── fd: ()-->(1,2)
+ │    │    │    │    │    │    │    ├── inner-join (lookup company)
+ │    │    │    │    │    │    │    │    ├── columns: co_id:6!null co_in_id:9!null s_symb:17!null s_co_id:22!null
+ │    │    │    │    │    │    │    │    ├── key columns: [22] = [6]
+ │    │    │    │    │    │    │    │    ├── lookup columns are key
  │    │    │    │    │    │    │    │    ├── key: (17)
- │    │    │    │    │    │    │    │    ├── fd: ()-->(83), (17)-->(22)
+ │    │    │    │    │    │    │    │    ├── fd: (6)-->(9), (17)-->(22), (6)==(22), (22)==(6)
  │    │    │    │    │    │    │    │    ├── scan security@security_s_co_id_s_issue_key
  │    │    │    │    │    │    │    │    │    ├── columns: s_symb:17!null s_co_id:22!null
  │    │    │    │    │    │    │    │    │    ├── constraint: /22/18: [/1 - /5000]
  │    │    │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    │    │    └── fd: (17)-->(22)
- │    │    │    │    │    │    │    │    └── projections
- │    │    │    │    │    │    │    │         └── '2020-06-17' [as="lookup_join_const_col_@36":83]
- │    │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │    │    └── filters
- │    │    │    │    │    │         └── (co_id:6 >= 1) AND (co_id:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
- │    │    │    │    │    └── filters
- │    │    │    │    │         └── co_in_id:9 = in_id:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
- │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │    │         └── (co_id:6 >= 1) AND (co_id:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
+ │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │         └── co_in_id:9 = in_id:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    └── filters (true)
+ │    │    │    │    └── projections
+ │    │    │    │         └── '2020-06-17' [as="lookup_join_const_col_@36":112]
  │    │    │    └── filters (true)
  │    │    └── projections
  │    │         ├── s_num_out:57 * dm_close:38 [as=column69:69, outer=(38,57), immutable]
@@ -1204,37 +1204,37 @@ project
  │    ├── project
  │    │    ├── columns: column40:40!null column42:42!null
  │    │    ├── immutable
- │    │    ├── inner-join (lookup last_trade)
+ │    │    ├── inner-join (lookup daily_market)
  │    │    │    ├── columns: hs_ca_id:1!null hs_s_symb:2!null dm_date:7!null dm_s_symb:8!null dm_close:9!null lt_s_symb:15!null lt_price:17!null s_symb:22!null s_num_out:28!null
- │    │    │    ├── key columns: [22] = [15]
+ │    │    │    ├── key columns: [72 15] = [7 8]
  │    │    │    ├── lookup columns are key
  │    │    │    ├── key: (22)
  │    │    │    ├── fd: ()-->(1,7), (8)-->(9), (15)-->(17), (22)-->(28), (2)==(8,15,22), (8)==(2,15,22), (15)==(2,8,22), (22)==(2,8,15)
- │    │    │    ├── inner-join (lookup security)
- │    │    │    │    ├── columns: hs_ca_id:1!null hs_s_symb:2!null dm_date:7!null dm_s_symb:8!null dm_close:9!null s_symb:22!null s_num_out:28!null
- │    │    │    │    ├── key columns: [2] = [22]
- │    │    │    │    ├── lookup columns are key
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "lookup_join_const_col_@7":72!null hs_ca_id:1!null hs_s_symb:2!null lt_s_symb:15!null lt_price:17!null s_symb:22!null s_num_out:28!null
  │    │    │    │    ├── key: (22)
- │    │    │    │    ├── fd: ()-->(1,7), (8)-->(9), (22)-->(28), (2)==(8,22), (8)==(2,22), (22)==(2,8)
- │    │    │    │    ├── inner-join (lookup daily_market)
- │    │    │    │    │    ├── columns: hs_ca_id:1!null hs_s_symb:2!null dm_date:7!null dm_s_symb:8!null dm_close:9!null
- │    │    │    │    │    ├── key columns: [58 2] = [7 8]
+ │    │    │    │    ├── fd: ()-->(1,72), (15)-->(17), (22)-->(28), (2)==(15,22), (15)==(2,22), (22)==(2,15)
+ │    │    │    │    ├── inner-join (lookup last_trade)
+ │    │    │    │    │    ├── columns: hs_ca_id:1!null hs_s_symb:2!null lt_s_symb:15!null lt_price:17!null s_symb:22!null s_num_out:28!null
+ │    │    │    │    │    ├── key columns: [22] = [15]
  │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │    ├── key: (8)
- │    │    │    │    │    ├── fd: ()-->(1,7), (8)-->(9), (2)==(8), (8)==(2)
- │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@7":58!null hs_ca_id:1!null hs_s_symb:2!null
- │    │    │    │    │    │    ├── key: (2)
- │    │    │    │    │    │    ├── fd: ()-->(1,58)
+ │    │    │    │    │    ├── key: (22)
+ │    │    │    │    │    ├── fd: ()-->(1), (15)-->(17), (22)-->(28), (2)==(15,22), (15)==(2,22), (22)==(2,15)
+ │    │    │    │    │    ├── inner-join (lookup security)
+ │    │    │    │    │    │    ├── columns: hs_ca_id:1!null hs_s_symb:2!null s_symb:22!null s_num_out:28!null
+ │    │    │    │    │    │    ├── key columns: [2] = [22]
+ │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    ├── key: (22)
+ │    │    │    │    │    │    ├── fd: ()-->(1), (22)-->(28), (2)==(22), (22)==(2)
  │    │    │    │    │    │    ├── scan holding_summary
  │    │    │    │    │    │    │    ├── columns: hs_ca_id:1!null hs_s_symb:2!null
  │    │    │    │    │    │    │    ├── constraint: /1/2: [/0 - /0]
  │    │    │    │    │    │    │    ├── key: (2)
  │    │    │    │    │    │    │    └── fd: ()-->(1)
- │    │    │    │    │    │    └── projections
- │    │    │    │    │    │         └── '2020-06-17' [as="lookup_join_const_col_@7":58]
+ │    │    │    │    │    │    └── filters (true)
  │    │    │    │    │    └── filters (true)
- │    │    │    │    └── filters (true)
+ │    │    │    │    └── projections
+ │    │    │    │         └── '2020-06-17' [as="lookup_join_const_col_@7":72]
  │    │    │    └── filters (true)
  │    │    └── projections
  │    │         ├── s_num_out:28 * dm_close:9 [as=column40:40, outer=(9,28), immutable]

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -550,7 +550,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:11!null sellprice:12!null desiredinventory:14!null actualinventory:15!null version:17!null discount:13!null maxinventory:16!null
  ├── immutable
- ├── stats: [rows=1]
+ ├── stats: [rows=5.8334]
  ├── key: (17)
  ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
  └── inner-join (lookup cards)
@@ -558,13 +558,13 @@ project
       ├── key columns: [10] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=0.999992, null(1)=0, distinct(10)=0.999992, null(10)=0]
+      ├── stats: [rows=5.8334, distinct(1)=5.83313, null(1)=0, distinct(10)=5.83313, null(10)=0]
       ├── key: (10)
       ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=1, distinct(9)=1, null(9)=0, distinct(10)=0.999992, null(10)=0, distinct(17)=0.0221969, null(17)=0, distinct(9,17)=1, null(9,17)=0]
+      │    ├── stats: [rows=5.8334, distinct(9)=1, null(9)=0, distinct(10)=5.83313, null(10)=0, distinct(17)=0.0221969, null(17)=0, distinct(9,17)=1, null(9,17)=0]
       │    │   histogram(17)=  0                0                 0.022197           0
       │    │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
       │    ├── key: (10)
@@ -572,7 +572,7 @@ project
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:9!null cardid:10!null version:17!null
       │         ├── constraint: /9/17: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=1, distinct(9)=1, null(9)=0, distinct(10)=0.999992, null(10)=0, distinct(17)=0.0221969, null(17)=0, distinct(9,17)=1, null(9,17)=0]
+      │         ├── stats: [rows=5.8334, distinct(9)=1, null(9)=0, distinct(10)=5.83313, null(10)=0, distinct(17)=0.0221969, null(17)=0, distinct(9,17)=1, null(9,17)=0]
       │         │   histogram(17)=  0                0                 0.022197           0
       │         │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
       │         ├── key: (10)

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -558,7 +558,7 @@ FROM CardsView WHERE Version > 1584421773604892000.0000000000
 project
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:11!null sellprice:12!null desiredinventory:14!null actualinventory:15!null version:17!null discount:13!null maxinventory:16!null
  ├── immutable
- ├── stats: [rows=1]
+ ├── stats: [rows=5.8334]
  ├── key: (17)
  ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
  └── inner-join (lookup cards)
@@ -566,20 +566,20 @@ project
       ├── key columns: [10] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── stats: [rows=1, distinct(1)=0.999992, null(1)=0, distinct(10)=0.999992, null(10)=0]
+      ├── stats: [rows=5.8334, distinct(1)=5.83313, null(1)=0, distinct(10)=5.83313, null(10)=0]
       ├── key: (10)
       ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=1, distinct(9)=1, null(9)=0, distinct(10)=0.999992, null(10)=0, distinct(17)=1, null(17)=0, distinct(9,17)=1, null(9,17)=0]
+      │    ├── stats: [rows=5.8334, distinct(9)=1, null(9)=0, distinct(10)=5.83313, null(10)=0, distinct(17)=1, null(17)=0, distinct(9,17)=1, null(9,17)=0]
       │    │   histogram(17)=
       │    ├── key: (10)
       │    ├── fd: ()-->(9), (10)-->(11-17), (17)-->(10-16)
       │    └── scan cardsinfo@cardsinfoversionindex
       │         ├── columns: dealerid:9!null cardid:10!null version:17!null
       │         ├── constraint: /9/17: (/1/1584421773604892000.0000000000 - /1]
-      │         ├── stats: [rows=1, distinct(9)=1, null(9)=0, distinct(10)=0.999992, null(10)=0, distinct(17)=1, null(17)=0, distinct(9,17)=1, null(9,17)=0]
+      │         ├── stats: [rows=5.8334, distinct(9)=1, null(9)=0, distinct(10)=5.83313, null(10)=0, distinct(17)=1, null(17)=0, distinct(9,17)=1, null(9,17)=0]
       │         │   histogram(17)=
       │         ├── key: (10)
       │         └── fd: ()-->(9), (10)-->(17), (17)-->(10)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4413,7 +4413,7 @@ var varGen = map[string]sessionVar{
 				evalCtx.SessionData().OptimizerClampLowHistogramSelectivity,
 			), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 
 	`optimizer_clamp_inequality_selectivity`: {
@@ -4431,7 +4431,7 @@ var varGen = map[string]sessionVar{
 				evalCtx.SessionData().OptimizerClampInequalitySelectivity,
 			), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 


### PR DESCRIPTION
This commit turns on `optimizer_clamp_low_histogram_selectivity` and `optimizer_clamp_inequality_selectivity`. See also #153067.

Informs #130201

Release note (sql change): The `optimizer_clamp_low_histogram_selectivity` setting is now on by default. This will cause the optimizer to assume that at least one distinct value "passes" each filter in a query. This reduces the chances of a catastrophic underestimate.