### PR TITLE
release-25.4: kvserver: deflake and improve obs in TestPromoteNonVoterInAddVoter

### DIFF
--- a/pkg/kv/kvserver/lease_queue.go
+++ b/pkg/kv/kvserver/lease_queue.go
@@ -137,7 +137,7 @@ func (lq *leaseQueue) process(
 
 	if transferOp, ok := change.Op.(plan.AllocationTransferLeaseOp); ok {
 		lease, _ := repl.GetLease()
-		log.KvDistribution.Infof(ctx, "transferring lease to s%d usage=%v, lease=[%v type=%v]", transferOp.Target, transferOp.Usage, lease, lease.Type())
+		log.KvDistribution.Infof(ctx, "transferring lease to %d usage=%v, lease=[%v type=%v]", transferOp.Target, transferOp.Usage, lease, lease.Type())
 		lq.lastLeaseTransfer.Store(timeutil.Now())
 		changeID := lq.as.NonMMAPreTransferLease(
 			desc,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -2189,12 +2188,6 @@ func TestPromoteNonVoterInAddVoter(t *testing.T) {
 	defer testutils.StartExecTrace(t, scope.GetDirectory()).Finish(t)
 
 	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	// NB: Ensure that tables created by the test start off on their own range.
-	// This ensures that any span config changes made by the test don't have to
-	// first induce a split, which is a known source of flakiness.
-	spanconfigstore.StorageCoalesceAdjacentSetting.Override(ctx, &st.SV, false)
-	spanconfigstore.TenantCoalesceAdjacentSetting.Override(ctx, &st.SV, false)
 
 	// Create 7 stores: 3 in Region 1, 2 in Region 2, and 2 in Region 3.
 	const numNodes = 7
@@ -2202,7 +2195,6 @@ func TestPromoteNonVoterInAddVoter(t *testing.T) {
 	regions := [numNodes]int{1, 1, 1, 2, 2, 3, 3}
 	for i := 0; i < numNodes; i++ {
 		serverArgs[i] = base.TestServerArgs{
-			Settings: st,
 			Locality: roachpb.Locality{
 				Tiers: []roachpb.Tier{
 					{

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1786,11 +1786,13 @@ func toggleReplicationQueues(tc *testcluster.TestCluster, active bool) {
 
 func forceScanOnAllReplicationQueues(tc *testcluster.TestCluster) (err error) {
 	for _, s := range tc.Servers {
-		err = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
+		if err := s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
 			return store.ForceReplicationScanAndProcess()
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 func toggleSplitQueues(tc *testcluster.TestCluster, active bool) {

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2304,6 +2304,7 @@ SELECT * FROM (
 		if numNonVoters != 2 {
 			return errors.Newf("expected 2 non-voters for r%d; got %v", rangeID, numNonVoters)
 		}
+		t.Logf("success: %d has %d voters and %d non-voters", rangeID, numVoters, numNonVoters)
 		return nil
 	})
 

--- a/pkg/spanconfig/spanconfigstore/span_store.go
+++ b/pkg/spanconfig/spanconfigstore/span_store.go
@@ -19,10 +19,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// TenantCoalesceAdjacentSetting is a public cluster setting that
+// tenantCoalesceAdjacentSetting is a public cluster setting that
 // controls whether we coalesce adjacent ranges across all secondary
 // tenant keyspaces if they have the same span config.
-var TenantCoalesceAdjacentSetting = settings.RegisterBoolSetting(
+var tenantCoalesceAdjacentSetting = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"spanconfig.tenant_coalesce_adjacent.enabled",
 	`collapse adjacent ranges with the same span configs across all secondary tenant keyspaces`,
@@ -157,7 +157,7 @@ func (s *spanConfigStore) computeSplitKey(
 				return roachpb.RKey(match.span.Key), nil
 			}
 		} else {
-			if !TenantCoalesceAdjacentSetting.Get(&s.settings.SV) {
+			if !tenantCoalesceAdjacentSetting.Get(&s.settings.SV) {
 				return roachpb.RKey(match.span.Key), nil
 			}
 		}


### PR DESCRIPTION
Backport 7/7 commits from #156540 on behalf of @tbg.

----

This attempts to finally put #156530 to rest. See individual commits, but broad stokes are that we repeatedly force-process the split queue (and not only the replicate queue), to make sure the range can quickly have the span config applied to it. I also added a bunch of span config and descriptor related debug output that should make it clear where the problem is should this test fail again.
Unfortunately, reproducing failures in this test seems to be difficult, though others seem to have managed.

Closes #156530.

Epic: none

----

Release justification: test flake fix