### PR TITLE
rangefeed: enable more unit tests with buffered sender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
@@ -253,27 +253,16 @@ func (h *processorTestHelper) triggerTxnPushUntilPushed(t *testing.T, pushedC <-
 	}
 }
 
-type rangefeedTestType bool
+type rangefeedTestType string
 
-var (
-	scheduledProcessorWithUnbufferedSender rangefeedTestType
-	scheduledProcessorWithBufferedSender   rangefeedTestType
+const (
+	scheduledProcessorWithUnbufferedSender rangefeedTestType = "unbuffered_sender"
+	scheduledProcessorWithBufferedSender   rangefeedTestType = "buffered_sender"
 )
 
 var testTypes = []rangefeedTestType{
 	scheduledProcessorWithUnbufferedSender,
 	scheduledProcessorWithBufferedSender,
-}
-
-func (t rangefeedTestType) String() string {
-	switch t {
-	case scheduledProcessorWithUnbufferedSender:
-		return "scheduled"
-	case scheduledProcessorWithBufferedSender:
-		return "scheduled/registration=buffered"
-	default:
-		panic("unknown rangefeed test type")
-	}
 }
 
 type testConfig struct {
@@ -422,6 +411,7 @@ func newTestProcessor(
 			EventChanCap:     testProcessorEventCCap,
 			Metrics:          NewMetrics(),
 		},
+		feedType: scheduledProcessorWithUnbufferedSender,
 	}
 	for _, o := range opts {
 		o(&cfg)

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1526,7 +1526,7 @@ func TestProcessorBackpressure(t *testing.T) {
 		// The sender should be blocked for at least 3 seconds.
 		select {
 		case <-doneC:
-			t.Fatal("send unexpectely succeeded")
+			t.Fatal("send unexpectedly succeeded")
 		case <-time.After(3 * time.Second):
 		case <-ctx.Done():
 		}


### PR DESCRIPTION
It looks like a previous refactor resulted in a few tests not actually
running with the buffered sender. Luckily, all of these tests appear to
pass (at least under normal non-stress, non-deadlock runs). This isn't
so unexpected because many of the tests that this impacted are testing
the processor and the stream manager which largely behave the same
regardless of registration. That said, I found it somewhat confusing so
I've fixed it.

Epic: none
Release note: None