### PR TITLE
kvstorage: separate engines in replica destruction

### DIFF
--- a/pkg/kv/kvserver/kvstorage/destroy_test.go
+++ b/pkg/kv/kvserver/kvstorage/destroy_test.go
@@ -68,7 +68,8 @@ func TestDestroyReplica(t *testing.T) {
 	})
 	mutate("destroy", func(rw storage.ReadWriter) {
 		require.NoError(t, DestroyReplica(
-			ctx, rw, rw, DestroyReplicaInfo{FullReplicaID: r.id, Keys: r.keys}, r.id.ReplicaID+1,
+			ctx, TODOReadWriter(rw),
+			DestroyReplicaInfo{FullReplicaID: r.id, Keys: r.keys}, r.id.ReplicaID+1,
 		))
 	})
 

--- a/pkg/kv/kvserver/kvstorage/stateloader.go
+++ b/pkg/kv/kvserver/kvstorage/stateloader.go
@@ -352,6 +352,11 @@ func (s StateLoader) SetRaftReplicaID(
 	)
 }
 
+// ClearRaftReplicaID clears the RaftReplicaID key.
+func (s StateLoader) ClearRaftReplicaID(stateWO StateWO) error {
+	return stateWO.ClearUnversioned(s.RaftReplicaIDKey(), storage.ClearOptions{})
+}
+
 // LoadRangeTombstone loads the RangeTombstone of the range.
 func (s StateLoader) LoadRangeTombstone(
 	ctx context.Context, stateRO StateRO,

--- a/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica.txt
+++ b/pkg/kv/kvserver/kvstorage/testdata/TestDestroyReplica.txt
@@ -26,7 +26,7 @@ Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b75
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:13 (0x0169f67b757266746c000000000000000d00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:14 (0x0169f67b757266746c000000000000000e00): 
 Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:15 (0x0169f67b757266746c000000000000000f00): 
-Delete (Sized at 31): 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 
+Delete: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): 
 Delete (Sized at 33): 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): 
 Delete (Sized at 34): 0,0 /Local/RangeID/123/u/RangeLastReplicaGCTimestamp (0x0169f67b75726c727400): 
 Delete (Sized at 20): 0.000000001,0 /Local/Range"a"/RangeDescriptor (0x016b126100017264736300000000000000000109): 

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -364,7 +364,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		rhsRepl.readOnlyCmdMu.Unlock()
 
 		if _, err := kvstorage.SubsumeReplica(
-			ctx, b.batch, b.batch, rhsRepl.destroyInfoRaftMuLocked(),
+			ctx, kvstorage.TODOReadWriter(b.batch), rhsRepl.destroyInfoRaftMuLocked(),
 		); err != nil {
 			return errors.Wrapf(err, "unable to subsume replica before merge")
 		}
@@ -453,7 +453,8 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// above, and DestroyReplica will also add a range tombstone to the
 		// batch, so that when we commit it, the removal is finalized.
 		if err := kvstorage.DestroyReplica(
-			ctx, b.batch, b.batch, b.r.destroyInfoRaftMuLocked(), change.NextReplicaID(),
+			ctx, kvstorage.TODOReadWriter(b.batch),
+			b.r.destroyInfoRaftMuLocked(), change.NextReplicaID(),
 		); err != nil {
 			return errors.Wrapf(err, "unable to destroy replica before removal")
 		}

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -91,7 +91,8 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 
 	// TODO(sep-raft-log): need both engines separately here.
 	if err := kvstorage.DestroyReplica(
-		ctx, r.store.TODOEngine(), batch, r.destroyInfoRaftMuLocked(), nextReplicaID,
+		ctx, kvstorage.TODOReaderWriter(r.store.TODOEngine(), batch),
+		r.destroyInfoRaftMuLocked(), nextReplicaID,
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -149,7 +149,9 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(ctx context.Context) err
 	for _, sub := range s.subsume {
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		if err := s.writeSST(ctx, func(ctx context.Context, w storage.Writer) error {
-			opts, err := kvstorage.SubsumeReplica(ctx, reader, w, sub)
+			opts, err := kvstorage.SubsumeReplica(
+				ctx, kvstorage.TODOReaderWriter(reader, w), sub,
+			)
 			s.cleared = append(s.cleared, rditer.Select(sub.RangeID, opts)...)
 			return err
 		}); err != nil {

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -7,10 +7,10 @@ Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 >> sst:
 Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
-Delete (Sized at 30): 0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): 
+Delete: 0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): 
 >> sst:
 Put: 0,0 /Local/RangeID/102/u/RangeTombstone (0x0169ee757266746200): next_replica_id:2147483647 
-Delete (Sized at 30): 0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): 
+Delete: 0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): 
 >> sst:
 Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
 >> sst:


### PR DESCRIPTION
This PR decomposes clearing the unreplicated RangeID-local span in replica destruction funcs, and annotates them with the raft/state engine types.

Part of #152845
Epic: CRDB-55220