### PR TITLE
release-25.3: rpc: skip clock offset tests under duress

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -190,6 +190,7 @@ func TestClockOffsetInClientPingRequest(t *testing.T) {
 }
 
 func testClockOffsetInPingRequestInternal(t *testing.T, clientOnly bool) {
+	skip.UnderDuress(t, "https://github.com/cockroachdb/cockroach/issues/154839")
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #156637 on behalf of @tbg.

----

Closes https://github.com/cockroachdb/cockroach/issues/154839.

Reviewers: please bors on LGTM.

Epic: none

----

Release justification: test flake improvement