### PR TITLE
kvstorage: partially fix CreateUninitializedReplica

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5248,8 +5248,8 @@ func TestAckWriteBeforeApplication(t *testing.T) {
 // It may learn about a newer replica ID than the split without ever hearing
 // about the split replica. If it does not crash (3) it will know that the
 // split replica is too old and will not initialize it. If the node does
-// crash (4) it will forget it had learned about the higher replica ID and
-// will initialize the RHS as the split replica.
+// crash (4) it will not forget that it had learned about the higher replica ID
+// and will likewise not initialize the RHS as the split replica.
 //
 // Starting in 19.2 if a replica discovers from a raft message that it is an
 // old replica then it knows that it has been removed and re-added to the range.
@@ -5294,17 +5294,14 @@ func TestAckWriteBeforeApplication(t *testing.T) {
 //     with a higher replica ID (but without a tombstone). This case is very
 //     similar to (1)
 //
-//     (4) s1 crashes still before processing the split, forgetting that it had
-//     known about r21/4. When it reboots r21/4 is totally partitioned and
-//     r20 becomes unpartitioned.
+//     (4) s1 crashes still before processing the split, and does not forget
+//     that it had known about r21/4. When it reboots r21/4 is totally
+//     partitioned and r20 becomes unpartitioned.
 //
-//   - r20 processes the split successfully and initialized r21/3.
+//   - r20 processes the split and does not initialize r21/3.
 //
-// In the 4th case we find that until we unpartition r21/4 (the RHS) and let it
-// learn about its removal with a ReplicaTooOldError that it will be initialized
-// with a CommitIndex at 10 as r21/3, the split's value. After r21/4 becomes
-// unpartitioned it will learn it is removed by either catching up on its
-// its log or receiving a ReplicaTooOldError which will lead to a tombstone.
+// In the 4th case when we unpartition r21/4 (the RHS), the replica will not be
+// resurrected because it has already been destroyed.
 func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5675,9 +5672,9 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			tc.WaitForValues(t, keyB, []int64{6, 6, 6})
 		})
 
-		// This case is set up like the previous one except after the RHS learns about
-		// its higher replica ID the store crashes and forgets. The RHS replica gets
-		// initialized by the split.
+		// This case is set up like the previous one except after the RHS learns
+		// about its higher replica ID the store crashes. However, it doesn't forget
+		// this ID, so the RHS replica is still not initialized by the split.
 		t.Run("(4) initial replica RHS partition, with restart", func(t *testing.T) {
 			tc, db, keyA, keyB, _, lhsPartition := setup(t)
 			defer tc.Stopper().Stop(ctx)
@@ -5758,22 +5755,16 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 			require.NoError(t, tc.RestartServer(0))
 
 			tc.WaitForValues(t, keyA, []int64{8, 8, 8})
-			// In this case the store has forgotten that it knew the RHS of the split
-			// could not exist. We ensure that it has been initialized to the initial
-			// commit value, which is 10.
-			testutils.SucceedsSoon(t, func() error {
-				hs := getHardState(t, tc.GetFirstStoreFromServer(t, 0), rhsID)
-				if hs.Commit != uint64(10) {
-					return errors.Errorf("hard state not yet initialized: got %v, expected %v",
-						hs.Commit, uint64(10))
-				}
-				return nil
-			})
+			// The store has not forgotten that it knew the RHS of the split could not
+			// exist. Ensure that the RHS replica is not initialized.
+			hs := getHardState(t, tc.GetFirstStoreFromServer(t, 0), rhsID)
+			require.Equal(t, uint64(0), hs.Commit)
+
 			log.KvExec.Infof(ctx, "deactivate RHS partition: %s", rhsPartition)
 			rhsPartition.deactivate()
 			log.KvExec.Infof(ctx, "adding voter: %v", target)
 			testutils.SucceedsSoon(t, func() error {
-				_, err := tc.AddVoters(keyB, tc.Target(0))
+				_, err := tc.AddVoters(keyB, target)
 				return err
 			})
 			tc.WaitForValues(t, keyB, []int64{curB, curB, curB})

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -148,13 +147,16 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 
 			case "create-replica":
 				rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
+				replicaID := dd.ScanArgOr[roachpb.ReplicaID](t, d, "replica-id", 0)
 				initialized := d.HasArg("initialized")
 
 				rs := tc.mustGetRangeState(t, rangeID)
-				if rs.replica != nil {
-					return errors.New("initialized replica already exists on n1/s1").Error()
+				require.Nil(t, rs.replica, "replica already exists on n1/s1")
+				repl := *rs.mustGetReplicaDescriptor(t, roachpb.NodeID(1))
+				if replicaID != 0 {
+					require.False(t, initialized, "custom ReplicaID not supported for initialized replicas")
+					repl.ReplicaID = replicaID
 				}
-				repl := rs.mustGetReplicaDescriptor(t, roachpb.NodeID(1))
 
 				output := tc.mutate(t, func(batch storage.Batch) {
 					if initialized {

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -49,13 +49,13 @@ import (
 // The test has a single storage engine that corresponds to n1/s1, and all batch
 // operations to storage are printed out. It uses the following format:
 //
-// create-descriptor start=<key> end=<key> replicas=[<int>,<int>,...]
+// create-descriptor start=<key> end=<key> replicas=[<int>,<int>,...] [replica-id=<int>]
 // ----
 //
 //	Creates a range descriptor with the specified start and end keys and
 //	optional replica list. The range ID is auto-assigned. If provided,
-//	replicas specify NodeIDs for replicas of the range. Note that ReplicaIDs
-//	are assigned incrementally starting from 1.
+//	replicas specify NodeIDs for replicas of the range. ReplicaIDs are
+//	assigned incrementally starting from replica-id (default=1).
 //
 // create-replica range-id=<int> [initialized]
 // ----
@@ -138,7 +138,8 @@ func TestReplicaLifecycleDataDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "create-descriptor":
-				desc := tc.createRangeDesc(t, roachpb.RSpan{
+				replicaID := dd.ScanArgOr[roachpb.ReplicaID](t, d, "replica-id", 1)
+				desc := tc.createRangeDesc(t, replicaID, roachpb.RSpan{
 					Key:    roachpb.RKey(dd.ScanArg[string](t, d, "start")),
 					EndKey: roachpb.RKey(dd.ScanArg[string](t, d, "end")),
 				}, dd.ScanArg[[]roachpb.NodeID](t, d, "replicas"))
@@ -471,7 +472,7 @@ func (tc *testCtx) mutate(t *testing.T, write func(storage.Batch)) string {
 // createRangeDesc creates a new RangeDescriptor for the given keys span and list
 // of replica locations, assigned to the next unused RangeID.
 func (tc *testCtx) createRangeDesc(
-	t *testing.T, span roachpb.RSpan, replicasOn []roachpb.NodeID,
+	t *testing.T, replicaID roachpb.ReplicaID, span roachpb.RSpan, replicasOn []roachpb.NodeID,
 ) roachpb.RangeDescriptor {
 	require.True(t, span.EndKey.Compare(span.Key) > 0)
 	require.True(t, slices.Contains(replicasOn, 1), "replica list must contain n1")
@@ -492,12 +493,12 @@ func (tc *testCtx) createRangeDesc(
 		StartKey:         span.Key,
 		EndKey:           span.EndKey,
 		InternalReplicas: make([]roachpb.ReplicaDescriptor, len(replicasOn)),
-		NextReplicaID:    roachpb.ReplicaID(len(replicasOn) + 1),
+		NextReplicaID:    replicaID + roachpb.ReplicaID(len(replicasOn)),
 	}
 	tc.nextRangeID++
 	for i, id := range replicasOn {
 		desc.InternalReplicas[i] = roachpb.ReplicaDescriptor{
-			ReplicaID: roachpb.ReplicaID(i + 1),
+			ReplicaID: replicaID + roachpb.ReplicaID(i),
 			NodeID:    id,
 			StoreID:   roachpb.StoreID(id),
 			Type:      roachpb.VOTER_FULL,

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -24,9 +24,21 @@ Put: 0,0 /Local/RangeID/2/u/RaftReplicaID (0x01698a757266747200): replica_id:1
 Put: 0,0 /Local/RangeID/2/u/RaftHardState (0x01698a757266746800): term:5 vote:0 commit:10 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 term:5 
 
+# Replica for r1 is uninitialized, r2 is initialized.
 print-range-state
 ----
 range desc: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 		replica (n1/s1): id=1 [uninitialized] HardState={Term:0,Vote:0,Commit:0}
+range desc: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10
+
+restart
+----
+ok
+
+# After restart, the uninitialized replica for r1 is not loaded.
+print-range-state
+----
+range desc: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 range desc: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -7,6 +7,11 @@ create-replica range-id=1
 created replica: (n1,s1):1
 Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
 
+# Make the uninitialized replica vote.
+update-hard-state range-id=1 term=10 vote=2
+----
+HardState {Term:10 Vote:2 Commit:0 Lead:0 LeadEpoch:0}
+
 # Create an initialized replica this time around.
 create-descriptor start=d end=k replicas=(1,2,3)
 ----
@@ -28,7 +33,7 @@ Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 
 print-range-state
 ----
 range desc: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
-		replica (n1/s1): id=1 [uninitialized] HardState={Term:0,Vote:0,Commit:0}
+		replica (n1/s1): id=1 [uninitialized] HardState={Term:10,Vote:2,Commit:0}
 range desc: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10
 

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -1,11 +1,11 @@
-create-descriptor start=a end=d replicas=(1,2,3)
+create-descriptor start=a end=d replicas=(1,2,3) replica-id=3
 ----
-created descriptor: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+created descriptor: r1:{a-d} [(n1,s1):3, (n2,s2):4, (n3,s3):5, next=6, gen=0]
 
 create-replica range-id=1
 ----
-created replica: (n1,s1):1
-Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+created replica: (n1,s1):3
+Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:3 
 
 # Make the uninitialized replica vote.
 update-hard-state range-id=1 term=10 vote=2
@@ -32,8 +32,8 @@ Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 
 # Replica for r1 is uninitialized, r2 is initialized.
 print-range-state
 ----
-range desc: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
-		replica (n1/s1): id=1 [uninitialized] HardState={Term:10,Vote:2,Commit:0}
+range desc: r1:{a-d} [(n1,s1):3, (n2,s2):4, (n3,s3):5, next=6, gen=0]
+		replica (n1/s1): id=3 [uninitialized] HardState={Term:10,Vote:2,Commit:0}
 range desc: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10
 
@@ -44,6 +44,6 @@ ok
 # After restart, the uninitialized replica for r1 is not loaded.
 print-range-state
 ----
-range desc: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
+range desc: r1:{a-d} [(n1,s1):3, (n2,s2):4, (n3,s3):5, next=6, gen=0]
 range desc: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/create_replica.txt
@@ -27,6 +27,6 @@ Put: 0,0 /Local/RangeID/2/u/RaftTruncatedState (0x01698a757266747400): index:10 
 print-range-state
 ----
 range desc: r1:{a-d} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
-		replica (n1/s1): id=1 uninitialized
+		replica (n1/s1): id=1 [uninitialized] HardState={Term:0,Vote:0,Commit:0}
 range desc: r2:{d-k} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=0]
 		replica (n1/s1): id=1 HardState={Term:5,Vote:0,Commit:10} TruncatedState={Index:10,Term:5} LastIdx=10

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
@@ -1,0 +1,40 @@
+create-descriptor start=a end=d replicas=(1,2,3) replica-id=5
+----
+created descriptor: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
+
+create-replica range-id=1
+----
+created replica: (n1,s1):5
+Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:5 
+
+# Make the uninitialized replica vote.
+update-hard-state range-id=1 term=10 vote=2
+----
+HardState {Term:10 Vote:2 Commit:0 Lead:0 LeadEpoch:0}
+
+# Replica for r1 is uninitialized.
+print-range-state
+----
+range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
+		replica (n1/s1): id=5 [uninitialized] HardState={Term:10,Vote:2,Commit:0}
+
+restart
+----
+ok
+
+# After restart, the uninitialized replica for r1 is not loaded.
+print-range-state
+----
+range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
+
+# TODO(pav-kv): must not be allowed because there is already ReplicaID=5.
+create-replica range-id=1 replica-id=1
+----
+created replica: (n1,s1):1
+Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+
+# TODO(pav-kv): the new replica must not inherit the old replica's HardState.
+print-range-state
+----
+range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
+		replica (n1/s1): id=1 [uninitialized] HardState={Term:10,Vote:2,Commit:0}

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
@@ -27,14 +27,13 @@ print-range-state
 ----
 range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
 
-# TODO(pav-kv): must not be allowed because there is already ReplicaID=5.
+# ReplicaID is already destroyed, so this returns an error.
 create-replica range-id=1 replica-id=1
 ----
-created replica: (n1,s1):1
-Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:1 
+raft group deleted
 
-# TODO(pav-kv): the new replica must not inherit the old replica's HardState.
+# The already existing newer replica state remains correct.
 print-range-state
 ----
 range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
-		replica (n1/s1): id=1 [uninitialized] HardState={Term:10,Vote:2,Commit:0}
+		replica (n1/s1): id=5 [uninitialized] HardState={Term:10,Vote:2,Commit:0}

--- a/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
+++ b/pkg/kv/kvserver/testdata/replica_lifecycle/uninitialized_replica_restart.txt
@@ -37,3 +37,18 @@ print-range-state
 ----
 range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
 		replica (n1/s1): id=5 [uninitialized] HardState={Term:10,Vote:2,Commit:0}
+
+restart
+----
+ok
+
+create-replica range-id=1 replica-id=10
+----
+created replica: (n1,s1):10
+Put: 0,0 /Local/RangeID/1/u/RaftReplicaID (0x016989757266747200): replica_id:10 
+
+# TODO(pav-kv): HardState of the previous replica should not be inherited.
+print-range-state
+----
+range desc: r1:{a-d} [(n1,s1):5, (n2,s2):6, (n3,s3):7, next=8, gen=0]
+		replica (n1/s1): id=10 [uninitialized] HardState={Term:10,Vote:2,Commit:0}


### PR DESCRIPTION
Since we [don’t instantiate](https://github.com/cockroachdb/cockroach/blob/c1b788a68f6bdff0440cc8061c669919eaf40efe/pkg/kv/kvserver/store.go#L2336-L2339) uninitialized replicas on server startup, it is possible that we have a valid uninitialized replica only in storage, with a non-empty `HardState` that voted. In [getOrCreateReplica](https://github.com/cockroachdb/cockroach/blob/24bd59b71d63fd07f258673811b4b39a6e61f1bc/pkg/kv/kvserver/store_create_replica.go#L53), when we see that there is no in-memory replica, we proceed to [calling](https://github.com/cockroachdb/cockroach/blob/24bd59b71d63fd07f258673811b4b39a6e61f1bc/pkg/kv/kvserver/store_create_replica.go#L189-L193) `CreateUninitializedReplica`, which then almost unconditionally writes the `ReplicaID`.

The bug is: we can change the `ReplicaID` here in storage. And the resulting replica will inherit a non-empty `HardState` that belongs to a different `ReplicaID`.

The PR partially fixes the bug. `CreateUninitializedReplica` now also loads the `ReplicaID` and compares it against the given one. We can then easily handle the case when the `ReplicaID` matches or exceeds the requested one.

When the existing replica is old, we should destroy it. This is to be done in follow-up commits.

Related to #152845
Epic: CRDB-55220