### PR TITLE
release-25.2: kvserver: deflake TestFlowControlSendQueueRangeFeed

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -3361,7 +3361,7 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
 	h.resetV2TokenMetrics(ctx)
 	h.waitForConnectedStreams(ctx, desc.RangeID, 3, 0 /* serverIdx */)
 
-	ts := tc.Server(2)
+	srv2 := tc.Server(2)
 	span := desc.KeySpan().AsRawSpanWithNoLocals()
 	ignoreValues := func(event kvcoord.RangeFeedMessage) {}
 
@@ -3402,17 +3402,26 @@ func TestFlowControlSendQueueRangeFeed(t *testing.T) {
   WHERE name LIKE 'kv.rangefeed.closed_timestamp.slow_ranges.cancelled'
   ORDER BY name ASC;
 `
-
-	closeFeed := rangeFeed(
-		ctx,
-		ts.DistSenderI(),
-		span,
-		tc.Server(0).Clock().Now(),
-		ignoreValues,
-		kvcoord.WithRangeObserver(observer),
-	)
+	// The rangefeed is supposed to live on n3, since that's srv2 and it is
+	// supposed to prefer the local replica. However, it can happen that n3
+	// doesn't see itself in the gossip network yet. Retry until the rangefeed
+	// does get planned on n3.
+	var closeFeed func()
+	testutils.SucceedsSoon(t, func() error {
+		if closeFeed != nil {
+			closeFeed()
+		}
+		closeFeed = rangeFeed(
+			ctx,
+			srv2.DistSenderI(),
+			span,
+			tc.Server(0).Clock().Now(),
+			ignoreValues,
+			kvcoord.WithRangeObserver(observer),
+		)
+		return checkRangeFeedNodeID(3, true /* include */)
+	})
 	defer closeFeed()
-	testutils.SucceedsSoon(t, func() error { return checkRangeFeedNodeID(3, true /* include */) })
 	h.comment(`(Rangefeed on n3)`)
 
 	h.comment(`


### PR DESCRIPTION
Backport 1/1 commits from #156616 on behalf of @tbg.

----

The recently added logging showed that n2 and n3 just weren't even considered
for starting the rangefeed. Likely this was because the descriptors weren't
gossiped yet (this was corroborated by gossip logging).

Rather than waiting for specific preconditions that "likely" fix
the problem for the particular version of the code, widen the scope
of the retry loop to re-establish the rangefeed until it does get
scheduled were it needs to for the test to succeed.

Closes https://github.com/cockroachdb/cockroach/issues/156341.

Epic: none



----

Release justification: