### PR TITLE
kvnemesis: add follower reads

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -122,6 +122,16 @@ func exceptContextCanceled(err error) bool {
 		strings.Contains(err.Error(), "query execution canceled")
 }
 
+const followerReadsOffset = 2 * time.Second
+
+func makeFollowerReadTimestamp(ts hlc.Timestamp) hlc.Timestamp {
+	return ts.Add(-followerReadsOffset.Nanoseconds(), 0)
+}
+func configureBatchForFollowerReads(b *kv.Batch, ts hlc.Timestamp) {
+	b.Header.Timestamp = makeFollowerReadTimestamp(ts)
+	b.Header.RoutingPolicy = kvpb.RoutingPolicy_NEAREST
+}
+
 func (a *Applier) applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 	switch o := op.GetValue().(type) {
 	case *GetOperation,
@@ -188,6 +198,15 @@ func (a *Applier) applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 		})
 		var savedTxn *kv.Txn
 		txnErr := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			// Attempt to set a follower reads timestamp only on the first iteration.
+			// Setting it again and again on retries can lead to starvation.
+			if o.FollowerReadEligible && savedTxn == nil {
+				followerReadTs := makeFollowerReadTimestamp(db.Clock().Now())
+				err := txn.SetFixedTimestamp(ctx, followerReadTs)
+				if err != nil {
+					panic(err)
+				}
+			}
 			if err := txn.SetIsoLevel(o.IsoLevel); err != nil {
 				panic(err)
 			}
@@ -251,7 +270,7 @@ func (a *Applier) applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 			}
 			if o.CommitInBatch != nil {
 				b := txn.NewBatch()
-				applyBatchOp(ctx, b, txn.CommitInBatch, o.CommitInBatch)
+				applyBatchOp(ctx, b, txn.CommitInBatch, o.CommitInBatch, nil /* clock */)
 				// The KV api disallows use of a txn after an operation on it errors.
 				if r := o.CommitInBatch.Result; r.Type == ResultType_Error {
 					return errors.DecodeError(ctx, *r.Err)
@@ -349,6 +368,13 @@ func applyClientOp(
 			} else {
 				b.Get(o.Key)
 			}
+			if !inTxn && o.FollowerReadEligible {
+				kvDB, ok := db.(*kv.DB)
+				if !ok {
+					panic(errors.AssertionFailedf("unexpected transactional interface"))
+				}
+				configureBatchForFollowerReads(b, kvDB.Clock().Now())
+			}
 		})
 		o.Result = resultInit(ctx, err)
 		if err != nil {
@@ -421,6 +447,13 @@ func applyClientOp(
 				} else {
 					b.Scan(o.Key, o.EndKey)
 				}
+			}
+			if !inTxn && o.FollowerReadEligible {
+				kvDB, ok := db.(*kv.DB)
+				if !ok {
+					panic(errors.AssertionFailedf("unexpected transactional interface"))
+				}
+				configureBatchForFollowerReads(b, kvDB.Clock().Now())
 			}
 		})
 		o.Result = resultInit(ctx, err)
@@ -531,7 +564,15 @@ func applyClientOp(
 		o.Result = resultInit(ctx, err)
 	case *BatchOperation:
 		b := &kv.Batch{}
-		applyBatchOp(ctx, b, db.Run, o)
+		if inTxn {
+			applyBatchOp(ctx, b, db.Run, o, nil /* clock */)
+		} else {
+			kvDB, ok := db.(*kv.DB)
+			if !ok {
+				panic(errors.AssertionFailedf("unexpected transactional interface"))
+			}
+			applyBatchOp(ctx, b, db.Run, o, kvDB.Clock())
+		}
 	case *SavepointCreateOperation:
 		txn, ok := db.(*kv.Txn) // savepoints are only allowed with transactions
 		if !ok {
@@ -589,7 +630,11 @@ func setLastReqSeq(b *kv.Batch, seq kvnemesisutil.Seq) {
 }
 
 func applyBatchOp(
-	ctx context.Context, b *kv.Batch, run func(context.Context, *kv.Batch) error, o *BatchOperation,
+	ctx context.Context,
+	b *kv.Batch,
+	run func(context.Context, *kv.Batch) error,
+	o *BatchOperation,
+	clock *hlc.Clock,
 ) {
 	for i := range o.Ops {
 		switch subO := o.Ops[i].GetValue().(type) {
@@ -673,6 +718,9 @@ func applyBatchOp(
 		default:
 			panic(errors.AssertionFailedf(`unknown batch operation type: %T %v`, subO, subO))
 		}
+	}
+	if clock != nil && o.FollowerReadEligible {
+		configureBatchForFollowerReads(b, clock.Now())
 	}
 	ts, err := batchRun(ctx, run, b)
 	o.Result = resultInit(ctx, err)

--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -138,6 +138,8 @@ func TestRandStep(t *testing.T) {
 						} else {
 							client.GetExistingForShare++
 						}
+					} else if o.FollowerReadEligible {
+						client.GetExistingFollowerRead++
 					} else {
 						client.GetExisting++
 					}
@@ -168,6 +170,8 @@ func TestRandStep(t *testing.T) {
 						} else {
 							client.GetMissingForShare++
 						}
+					} else if o.FollowerReadEligible {
+						client.GetMissingFollowerRead++
 					} else {
 						client.GetMissing++
 					}
@@ -226,6 +230,8 @@ func TestRandStep(t *testing.T) {
 						} else {
 							client.ReverseScanForShare++
 						}
+					} else if o.FollowerReadEligible {
+						client.ReverseScanFollowerRead++
 					} else {
 						client.ReverseScan++
 					}
@@ -257,6 +263,8 @@ func TestRandStep(t *testing.T) {
 						} else {
 							client.ScanForShare++
 						}
+					} else if o.FollowerReadEligible {
+						client.ScanFollowerRead++
 					} else {
 						client.Scan++
 					}

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -629,6 +629,8 @@ func testKVNemesisImpl(t testing.TB, cfg kvnemesisTestCfg) {
 	// Turn net/trace on, which results in real trace spans created throughout.
 	// This gives kvnemesis a chance to hit NPEs related to tracing.
 	sqlutils.MakeSQLRunner(sqlDBs[0]).Exec(t, `SET CLUSTER SETTING trace.debug_http_endpoint.enabled = true`)
+	// This allows more operations to be eligible for follower reads.
+	sqlutils.MakeSQLRunner(sqlDBs[0]).Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
 
 	// In liveness mode, set up zone config constraints to ensure all ranges
 	// have a voter on nodes 1 and 2, the nodes guaranteed to be available.
@@ -665,6 +667,7 @@ func testKVNemesisImpl(t testing.TB, cfg kvnemesisTestCfg) {
 
 func logMetricsReport(t testing.TB, tc *testcluster.TestCluster) {
 	metricsOfInterest := []string{
+		"follower_reads.success_count",
 		// Raft command metrics
 		"raft.commands.proposed",
 		"raft.commands.reproposed.new-lai",

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -17,6 +17,7 @@ import "util/hlc/timestamp.proto";
 message BatchOperation {
   repeated Operation ops = 1 [(gogoproto.nullable) = false];
   Result result = 2 [(gogoproto.nullable) = false];
+  bool follower_read_eligible = 3;
 }
 
 enum ClosureTxnType {
@@ -35,6 +36,7 @@ message ClosureTxnOperation {
   roachpb.Transaction txn = 6;
   bool buffered_writes = 8;
   double user_priority = 9 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.UserPriority"];
+  bool follower_read_eligible = 10;
 }
 
 message GetOperation {
@@ -44,6 +46,7 @@ message GetOperation {
   bool guaranteed_durability = 4;
   bool skip_locked = 5;
   Result result = 6 [(gogoproto.nullable) = false];
+  bool follower_read_eligible = 7;
 }
 
 message ScanOperation {
@@ -55,6 +58,7 @@ message ScanOperation {
   bool skip_locked = 6;
   bool reverse = 7;
   Result result = 8 [(gogoproto.nullable) = false];
+  bool follower_read_eligible = 9;
 }
 
 message PutOperation {

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1051,14 +1051,14 @@ func (v *validator) checkAtomic(atomicType string, result Result) {
 		// of writing, checkAtomicCommitted doesn't capitalize on this unconditional
 		// presence yet, and most unit tests don't specify it for reads.
 		if !result.OptionalTimestamp.IsSet() {
-			err := errors.AssertionFailedf("operation has no execution timestamp: %s", result)
+			err := errors.AssertionFailedf("operation has no execution timestamp: %v", result)
 			v.failures = append(v.failures, err)
 		}
 		v.checkAtomicCommitted(`committed `+atomicType, observations, result.OptionalTimestamp)
 	} else if resultIsAmbiguous(result) {
 		// An ambiguous result shouldn't have an execution timestamp.
 		if result.OptionalTimestamp.IsSet() {
-			err := errors.AssertionFailedf("OptionalTimestamp set for ambiguous result: %s", result)
+			err := errors.AssertionFailedf("OptionalTimestamp set for ambiguous result: %v", result)
 			v.failures = append(v.failures, err)
 		}
 		v.checkAtomicAmbiguous(`ambiguous `+atomicType, observations)


### PR DESCRIPTION
This commit adds follower reads support to kvnemesis. The target closed timestamp is set to 1s, and select read-only non-locking operations run in batches with a timestamp of now - 3s. Multi-request batches and transactions are also eligible for follower reads as long as they consist only of eligible operations.

Fixes: #59061

Release note: None