### PR TITLE
release-25.4: sql: remove wrapping single quotes in output of  ltree2text

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ltree
+++ b/pkg/sql/logictest/testdata/logic_test/ltree
@@ -203,7 +203,7 @@ SELECT subpath(NULL::LTREE, 99, 99);
 ----
 NULL
 
-# An overflow has occurred 
+# An overflow has occurred
 query error invalid positions
 SELECT subpath('A.B.C'::LTREE, 1, 9223372036854775807::INT8)
 
@@ -284,10 +284,12 @@ foo_bar-baz.baz
 query error could not parse ltree
 SELECT text2ltree('foo..bar');
 
-query T
-SELECT ltree2text('foo_bar-baz.baz'::LTREE);
+query TBB
+SELECT ltree2text('foo_bar-baz.baz'::LTREE),
+    ltree2text('foo'::LTREE) = 'foo'::TEXT,
+    ltree2text(NULL::LTREE) IS NULL;
 ----
-'foo_bar-baz.baz'
+foo_bar-baz.baz  true  true
 
 query T
 SELECT lca('A.B.C'::LTREE, 'A.B.C.D'::LTREE, 'A.B.C.E'::LTREE);

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9629,7 +9629,7 @@ WHERE object_id = table_descriptor_id
 			Volatility: volatility.Immutable,
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ltree := tree.MustBeDLTree(args[0])
-				return tree.NewDString(ltree.String()), nil
+				return tree.NewDString(ltree.LTree.String()), nil
 			},
 		},
 	),


### PR DESCRIPTION
Backport 1/1 commits from #156485.

/cc @cockroachdb/release

---

Fixes #156479

Release note (bug fix): A bug has been fix with the `ltree2text`
built-in function in which the returned `TEXT` value was incorrectly
wrapped with single quotes. This bug has been present since the
`ltree2text` built-in was introduced in v25.4.0.

---

Release justification: Low-risk fix to a newly introduced built-in.

