### PR TITLE
release-25.4: kvcoord: hard-code seed in BenchmarkTruncateLoop

### DIFF
--- a/pkg/kv/kvclient/kvcoord/batch_test.go
+++ b/pkg/kv/kvclient/kvcoord/batch_test.go
@@ -642,7 +642,6 @@ func BenchmarkTruncateLoop(b *testing.B) {
 	defer leaktest.AfterTest(b)()
 	defer log.Scope(b).Close(b)
 
-	rng, _ := randutil.NewTestRand()
 	const keyLength = 8
 	for _, scanDir := range []ScanDirection{Ascending, Descending} {
 		for _, mustPreserveOrder := range []bool{false, true} {
@@ -650,6 +649,7 @@ func BenchmarkTruncateLoop(b *testing.B) {
 				for _, numRanges := range []int{4, 64} {
 					// We'll split the whole key space into numRanges ranges
 					// using random numRanges-1 split points.
+					rng := randutil.NewTestRandWithSeed(51)
 					rangeSpans := makeRanges(rng, numRanges, keyLength)
 					if scanDir == Descending {
 						// Reverse all the range spans for the Descending scan


### PR DESCRIPTION
Backport 1/3 commits from #156405.

/cc @cockroachdb/release

---

#### kvcoord: hard-code seed in BenchmarkTruncateLoop

Hard-coding the seed in `BenchmarkTruncateLoop` ensures fair comparisons
across multiple benchmark runs.

---

Release justification: Test-only change.

