### PR TITLE
sql: append copies of system column descriptors

### DIFF
--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -334,8 +334,9 @@ func newColumnCache(desc *descpb.TableDescriptor, mutations *mutationCache) *col
 	numMutations := len(mutations.columns)
 	numDeletable := numPublic + numMutations
 	for i := range colinfo.AllSystemColumnDescs {
+		desc := colinfo.AllSystemColumnDescs[i]
 		col := column{
-			desc:    &colinfo.AllSystemColumnDescs[i],
+			desc:    &desc,
 			ordinal: numDeletable + i,
 		}
 		backingStructs = append(backingStructs, col)


### PR DESCRIPTION
Previously, the shared descriptors common to system columns meant
changes in one could cause side-effects in another. This was of
particular concern for the schema changer removing the `ColumnHidden`
element during a table drop and consequently exposing the column in
other tables. This change appends copies to avoid that side-effect.

Part of: #139605

Release note: None
