### PR TITLE
release-25.4: storage: don't use global rand in test configs

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -85,6 +85,7 @@ go_library(
         "//pkg/util/metamorphic",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/sysutil",
         "//pkg/util/timeutil",

--- a/pkg/storage/pebbleiter/BUILD.bazel
+++ b/pkg/storage/pebbleiter/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util",
+        "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",
     ],


### PR DESCRIPTION
Backport 1/1 commits from #155787 on behalf of @yuzefovich.

----

I was looking into a test timeout under race and saw one spot where we use the global rand under race. We have a few spots like this in the storage folder, so this commit fixes them.

Epic: None
Release note: None

----

Release justification: effectively test-only change.