### PR TITLE
release-25.4: copy: fix vectorized auto commit behavior

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -148,16 +148,7 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	// Enable the verbose logging on relevant files to have better understanding
 	// in case the test fails.
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=copy_from=2,insert=2")
-	// The roachtest frequently runs on overloaded instances and can timeout as
-	// a result. We've seen cases where the atomic COPY takes about 2 minutes to
-	// complete, so we set the closed TS and SQL liveness TTL to 5 minutes (to
-	// give enough safety gap, otherwise the closed TS system and lease system
-	// expireation might continuously push the COPY txn not allowing it ever to
-	// complete).
-	clusterSettings := install.MakeClusterSettings(install.ClusterSettingsOption{
-		"kv.closed_timestamp.target_duration": "300s",
-		"server.sqlliveness.ttl":              "300s",
-	})
+	clusterSettings := install.MakeClusterSettings()
 	c.Start(ctx, t.L(), startOpts, clusterSettings, c.All())
 	initTest(ctx, t, c, sf)
 	db, err := c.ConnE(ctx, t.L(), 1)


### PR DESCRIPTION
Backport 1/1 commits from #156584 on behalf of @yuzefovich.

----

When we implemented the vectorized INSERT which supports COPY in some cases, we missed one condition for auto-committing the txn that is present in the regular `tableWriterBase` path. Namely, we need to check whether the deadline that might be set on the txn hasn't expired yet, and if it has, we shouldn't be auto-committing and should be leaving it up to the connExecutor (which will try to refresh the deadline). The impact of the bug is that often if COPY took longer than 40s (controlled via `server.sqlliveness.ttl`), we'd hit the txn retry error and propagate it to the client.

Fixes: #155300.

Release note (bug fix): Previously, the "atomic" COPY command (controlled via `copy_from_atomic_enabled`, which is `true` by default) could encounter RETRY_COMMIT_DEADLINE_EXCEEDED txn errors if the whole command took 1 minute or more. This was the case only when the vectorized engine was used for COPY and is now fixed.

----

Release justification: low-risk bug fix.