### PR TITLE
Add grpc connection closing error to allowlist

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -340,6 +340,7 @@ go_test(
         "//pkg/util/ctxgroup",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/ioctx",

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -941,7 +942,7 @@ func requireNoFeedsFail(t *testing.T) (fn updateKnobsFn) {
 		`context canceled`,
 	}
 	shouldIgnoreErr := func(err error) bool {
-		if err == nil || errors.Is(err, context.Canceled) {
+		if err == nil || errors.Is(err, context.Canceled) || grpcutil.IsClosedConnection(err) {
 			return true
 		}
 		for _, ignoreErr := range ignoreErrs {


### PR DESCRIPTION
## Fix TestChangefeedFlushesSinkToReleaseMemory test flake

Fixes #156078

The test was failing on grpc connection closing errors that weren't being ignored. Using `grpcutil.IsClosedConnection()` to properly handle all connection closing scenarios including the specific "grpc: the client connection is closing" error.

**Changed:**
- `pkg/ccl/changefeedccl/helpers_test.go`: Use `grpcutil.IsClosedConnection()` in error handling