### PR TITLE
rangefeed: fix BenchmarkRangefeedBudget

### DIFF
--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -63,17 +63,20 @@ func BenchmarkRangefeed(b *testing.B) {
 // processes a set of events.
 func BenchmarkRangefeedBudget(b *testing.B) {
 	for _, budget := range []bool{false, true} {
-		b.Run(fmt.Sprintf("budget=%t", budget), func(b *testing.B) {
-			var budgetSize int64
-			if budget {
-				budgetSize = math.MaxInt64
-			}
-			runBenchmarkRangefeed(b, benchmarkRangefeedOpts{
-				opType:           writeOpType,
-				numRegistrations: 1,
-				budget:           budgetSize,
+		for _, procType := range testTypes {
+			b.Run(fmt.Sprintf("budget=%t/proc=%s", budget, procType), func(b *testing.B) {
+				var budgetSize int64
+				if budget {
+					budgetSize = math.MaxInt64
+				}
+				runBenchmarkRangefeed(b, benchmarkRangefeedOpts{
+					rangefeedTestType: procType,
+					opType:            writeOpType,
+					numRegistrations:  1,
+					budget:            budgetSize,
+				})
 			})
-		})
+		}
 	}
 }
 


### PR DESCRIPTION
This benchmark was broken in f4d1c07f1bed85346051197e414e71941c7c2015 but was not noticed becuase benchmarks aren't run in CI.

Fixes #156748
Release note: none