### PR TITLE
roachtest: require workload disk for snapshots

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -29,6 +29,9 @@ func registerDatabaseDrop(r registry.Registry) {
 		spec.CPU(8),
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
+		// The use of snapshots requires workload nodes to also have an attached disk.
+		// See: https://github.com/cockroachdb/cockroach/issues/156760
+		spec.WorkloadRequiresDisk(),
 		// The dataset uses above 4TiB of data, and if we have to create the dataset
 		// via IMPORT we need some buffer. 500GiB per node (4.5TiB total) has been
 		// found to fail regularly in the past since the IMPORT job fails when any

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -29,6 +29,9 @@ func registerIndexBackfill(r registry.Registry) {
 		10, /* nodeCount */
 		spec.CPU(8),
 		spec.WorkloadNode(),
+		// The use of snapshots requires workload nodes to also have an attached disk.
+		// See: https://github.com/cockroachdb/cockroach/issues/156760
+		spec.WorkloadRequiresDisk(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(500),
 		spec.GCEVolumeType("pd-ssd"),


### PR DESCRIPTION
Previously, an optimization was made to workload nodes to not include any data disks [1]. This breaks the snapshot functionality provided by roachprod. A different issue has been created to make the snapshot functionality compatible with VMs without data disks [2].

[1] https://github.com/cockroachdb/cockroach/pull/153952
[2] https://github.com/cockroachdb/cockroach/issues/156760

Fixes: #156713
Epic: None