### PR TITLE
workload: increase burst for changefeed limiter

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -441,7 +441,9 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 	}
 	var changefeedLimiter *rate.Limiter
 	if *changefeedMaxRate > 0 {
-		changefeedLimiter = rate.NewLimiter(rate.Limit(*changefeedMaxRate), 1)
+		ratePerSecond := *changefeedMaxRate
+		burst := max(int(ratePerSecond), 1)
+		changefeedLimiter = rate.NewLimiter(rate.Limit(ratePerSecond), burst)
 	}
 
 	maybeLogRandomSeed(ctx, gen)


### PR DESCRIPTION
The inbound work from the rangefeed is not evenly distributed over a 1s interval. For changefeeds, we mostly care about whether the configured rate is or is not sufficient for the given write rate over rather long time intervals.

Using a large burst helps make we get the desired rate over those longer time horizons.

Epic: CRDB-55203
Release note: none