### PR TITLE
release-25.4: opt: fix LTREE <@ index constraint spans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ltree
+++ b/pkg/sql/logictest/testdata/logic_test/ltree
@@ -350,4 +350,21 @@ SELECT lca(''::LTREE, 'A.B.C'::LTREE)
 ----
 NULL
 
+# Regression test for #156478. Correct constraint spans should be built for the
+# <@ (contained-by) operator.
+statement ok
+CREATE TABLE t156478 (
+  k INT PRIMARY KEY,
+  l LTREE,
+  INDEX idx (l),
+  INDEX idx_desc (l DESC)
+)
 
+statement ok
+INSERT INTO t156478 VALUES (1, 'foo.bar_'::LTREE)
+
+query empty
+SELECT * FROM t156478@idx WHERE l <@ 'foo.bar'::LTREE
+
+query empty
+SELECT * FROM t156478@idx_desc WHERE l <@ 'foo.bar'::LTREE

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1943,4 +1943,4 @@ vectorized: true
 • scan
   missing stats
   table: t5@t5_a_idx
-  spans: [/'A.B.C' - /'A.B.D')
+  spans: [/'A.B.C' - /'A.B.C-')

--- a/pkg/sql/opt/idxconstraint/testdata/ltree
+++ b/pkg/sql/opt/idxconstraint/testdata/ltree
@@ -25,7 +25,7 @@ a @> NULL
 index-constraints vars=(a ltree) index=a
 a <@ 'A.B.C'
 ----
-[/'A.B.C' - /'A.B.D')
+[/'A.B.C' - /'A.B.C-')
 
 index-constraints vars=(a ltree) index=a
 a <@ 'z'
@@ -53,8 +53,8 @@ a @> '-' OR a @> 'foo.bar'
 index-constraints vars=(a ltree) index=a
 a <@ '-' OR a <@ 'foo.bar'
 ----
-[/'-' - /'0')
-[/'foo.bar' - /'foo.bas')
+[/'-' - /'--')
+[/'foo.bar' - /'foo.bar-')
 
 index-constraints vars=(a ltree) index=a
 a <@ 'A.B.C' OR a @> 'A.B'
@@ -62,14 +62,14 @@ a <@ 'A.B.C' OR a @> 'A.B'
 [/'' - /'']
 [/'A' - /'A']
 [/'A.B' - /'A.B']
-[/'A.B.C' - /'A.B.D')
+[/'A.B.C' - /'A.B.C-')
 
 index-constraints vars=(a ltree) index=a
 a @> 'A.B.C' OR a <@ 'A.B'
 ----
 [/'' - /'']
 [/'A' - /'A']
-[/'A.B' - /'A.C')
+[/'A.B' - /'A.B-')
 
 index-constraints vars=(a ltree) index=a
 a <@ 'A.B.C' AND a @> 'A.B.C.D.E'

--- a/pkg/util/ltree/ltree_test.go
+++ b/pkg/util/ltree/ltree_test.go
@@ -153,18 +153,20 @@ func TestCompare(t *testing.T) {
 	}
 }
 
-func TestNext(t *testing.T) {
+func TestNextSibling(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
+		ok       bool
 	}{
-		{"a", "b"},
-		{"a.b", "a.c"},
-		{"a.z", "a.z-"},
-		{"-", "0"},
-		{"9", "A"},
-		{"Z", "_"},
-		{"_", "a"},
+		{"", "", false},
+		{"a", "a-", true},
+		{"a.b", "a.b-", true},
+		{"a.z", "a.z-", true},
+		{"-", "--", true},
+		{"9", "9-", true},
+		{"Z", "Z-", true},
+		{"_", "_-", true},
 	}
 
 	for _, tc := range tests {
@@ -172,9 +174,12 @@ func TestNext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error parsing %q: %v", tc.input, err)
 		}
-		next := a.NextSibling()
-		if next.String() != tc.expected {
-			t.Errorf("expected next of %q to be %q, got %q", tc.input, tc.expected, next.String())
+		next, ok := a.NextSibling()
+		if ok != tc.ok {
+			t.Errorf("expected ok=%v for input %q, got %v", tc.ok, tc.input, ok)
+		}
+		if n := next.String(); n != tc.expected {
+			t.Errorf("expected %q for input %q, got %q", tc.expected, tc.input, n)
 		}
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #156573.

/cc @cockroachdb/release

---

Fixes #156478

Release note (bug fix): A bug has been fixed that caused incorrect
results for queries that filter indexed `LTREE` columns with the `<@`
(contained-by) operator. This bug has been present since v25.4.0.

Co-authored-by: Yahor Yuzefovich <yahor@cockroachlabs.com>
Co-authored-by: Michael Erickson <michae2@cockroachlabs.com>

---

Release justification: Bug fix for incorrect results with new LTREE
data type.

