### PR TITLE
release-25.3: sql: disable vector index backfill in the legacy schema changer

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2917,7 +2917,12 @@ func indexBackfillInTxn(
 
 	var backfiller backfill.IndexBackfiller
 	if err := backfiller.InitForLocalUse(
-		ctx, evalCtx, semaCtx, tableDesc, indexBackfillerMon,
+		ctx,
+		evalCtx,
+		semaCtx,
+		tableDesc,
+		indexBackfillerMon,
+		evalCtx.Planner.ExecutorConfig().(*ExecutorConfig).VecIndexManager,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/vecindex/vecstore/vecstorepb",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/ctxgroup",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecencoding"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore/vecstorepb"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -605,6 +606,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 	semaCtx *tree.SemaContext,
 	desc catalog.TableDescriptor,
 	mon *mon.BytesMonitor,
+	vecIndexManager *vecindex.Manager,
 ) (retErr error) {
 	if mon == nil {
 		return errors.AssertionFailedf("memory monitor must be provided")
@@ -616,7 +618,8 @@ func (ib *IndexBackfiller) InitForLocalUse(
 	}()
 
 	// Initialize ib.added.
-	if err := ib.initIndexes(ctx, evalCtx, desc, nil /* allowList */, 0 /*sourceIndex*/, nil); err != nil {
+	// TODO(150163): Pass vecIndexManager once vector index build is supported with the legacy schema changer.
+	if err := ib.initIndexes(ctx, evalCtx, desc, nil /* allowList */, 0 /*sourceIndex*/, nil /*vecIndexManager*/); err != nil {
 		return err
 	}
 
@@ -919,6 +922,13 @@ func (ib *IndexBackfiller) initIndexes(
 		if idx.GetType() != idxtype.VECTOR {
 			ib.VectorOnly = false
 			continue
+		}
+
+		if vecIndexManager == nil {
+			return unimplemented.NewWithIssue(
+				150163,
+				"vector index build not supported with the legacy schema changer",
+			)
 		}
 
 		if ib.VectorIndexes == nil {

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -1141,3 +1141,25 @@ statement ok
 DROP TABLE composite_pk
 
 subtest end
+
+subtest test_backfill_149236
+
+statement ok
+set autocommit_before_ddl=off;
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE test_backfill_149236 (a INT PRIMARY KEY, b INT, vec1 VECTOR(3));
+
+statement error pgcode 0A000 vector index build not supported with the legacy schema changer
+CREATE VECTOR INDEX idx ON test_backfill_149236 (vec1);
+
+statement ok
+COMMIT;
+
+statement ok
+SET autocommit_before_ddl=on;
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #149812.

/cc @cockroachdb/release

---

Through an oversight, the legacy schema changer never received a copy of
the vector manager, required for backfilling vector indexes. In
practice, we always use the declarative schema changer for creating
vector indexes, so this wasn't caught in QA. Sentry caught the
oversight.

Completely fixing this problem is more complicated than what we have
time to do in 25.3, so for now the plan is to disable backfilling vector
indices with the legacy schema changer, which should be a corner case to
begin with.

Informs: https://github.com/cockroachdb/cockroach/issues/149236
Release note (bug fix): Attempting to create a vector index with the
legacy schema changer will now fail gracefully instead of crashing the
node.

Release Justification: Minor change to correct a sentry issue.