### PR TITLE
spanconfig: clear invalid PTS targets on reconcile

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
@@ -63,9 +63,21 @@ protect record-id=2 ts=2
 tenants 1,10
 ----
 
+# We lay an invalid PTS before reconciliation to test that it is cleaned up by
+# the full reconciler.
+protect record-id=3 ts=4 tenant=10
+tenants 1
+----
+
 # Start the reconciliation loop for the secondary tenant.
 reconcile tenant=10
 ----
+
+# Verify that the full reconciler cleaned up the invalid PTS target.
+query-sql tenant=10
+SELECT count(*) FROM system.protected_ts_records;
+----
+0
 
 # We should see protected timestamp record mutations as the host tenant.
 mutations
@@ -158,7 +170,7 @@ upsert /Tenant/10/Table/10{6-7}            rangefeed_enabled=true
 upsert /Tenant/10/Table/10{7-8}            rangefeed_enabled=true
 
 # Write a protected timestamp record on the cluster as a secondary tenant.
-protect record-id=3 ts=3 cluster tenant=10
+protect record-id=4 ts=3 cluster tenant=10
 cluster
 ----
 
@@ -196,12 +208,26 @@ delete {source=1,target=1}
 delete {source=1,target=10}
 
 # Release all the protected timestamp records from the secondary tenant.
-release record-id=3 tenant=10
+release record-id=4 tenant=10
 ----
 
 mutations tenant=10
 ----
 delete {source=10,target=10}
+
+# Ensure that the incremental reconciler will ignore and drop invalid PTS
+# targets.
+protect record-id=5 ts=4 tenant=10
+tenants 1
+----
+
+mutations tenant=10
+----
+
+query-sql tenant=10
+SELECT count(*) FROM system.protected_ts_records;
+----
+0
 
 # All system span config targets should have been removed at this point.
 state limit=5

--- a/pkg/spanconfig/spanconfigreconciler/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigreconciler/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver/protectedts",
+        "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -36,6 +36,24 @@ type SQLTranslator struct {
 	txn      descs.Txn
 	pts      protectedts.Storage
 	settings *cluster.Settings
+	opts     sqlTranslatorOpts
+}
+
+// sqlTranslatorOpts captures options for a SQLTranslator.
+type sqlTranslatorOpts struct {
+	// ignoreInvalidPTSTargets teaches the translator to skip over any PTS with an
+	// invalid target.
+	ignoreInvalidPTSTargets bool
+}
+
+type SQLTranslatorOpt func(*sqlTranslatorOpts)
+
+// WithIgnoreInvalidPTSTargets configures the SQLTranslator to skip over any
+// PTS with an invalid target.
+func WithIgnoreInvalidPTSTargets() SQLTranslatorOpt {
+	return func(opts *sqlTranslatorOpts) {
+		opts.ignoreInvalidPTSTargets = true
+	}
 }
 
 // Factory is used to construct transaction-scoped SQLTranslators.
@@ -67,14 +85,18 @@ func NewFactory(
 // NewSQLTranslator constructs and returns a transaction-scoped
 // spanconfig.SQLTranslator. The caller must ensure that the collection and
 // internal executor and the transaction are associated with each other.
-func (f *Factory) NewSQLTranslator(txn descs.Txn) *SQLTranslator {
-	return &SQLTranslator{
+func (f *Factory) NewSQLTranslator(txn descs.Txn, opts ...SQLTranslatorOpt) *SQLTranslator {
+	translator := SQLTranslator{
 		codec:    f.codec,
 		knobs:    f.knobs,
 		txn:      txn,
 		pts:      f.ptsProvider.WithTxn(txn),
 		settings: f.settings,
 	}
+	for _, opt := range opts {
+		opt(&translator.opts)
+	}
+	return &translator
 }
 
 // Translate is part of the spanconfig.SQLTranslator interface.
@@ -168,17 +190,19 @@ func (s *SQLTranslator) generateSystemSpanConfigRecords(
 			systemTarget = spanconfig.MakeEntireKeyspaceTarget()
 		} else {
 			systemTarget, err = spanconfig.MakeTenantKeyspaceTarget(sourceTenantID, sourceTenantID)
+		}
+
+		if err == nil {
+			clusterSystemRecord, err := spanconfig.MakeRecord(
+				spanconfig.MakeTargetFromSystemTarget(systemTarget),
+				roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{ProtectionPolicies: clusterProtections}})
 			if err != nil {
 				return nil, err
 			}
-		}
-		clusterSystemRecord, err := spanconfig.MakeRecord(
-			spanconfig.MakeTargetFromSystemTarget(systemTarget),
-			roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{ProtectionPolicies: clusterProtections}})
-		if err != nil {
+			records = append(records, clusterSystemRecord)
+		} else if !s.opts.ignoreInvalidPTSTargets {
 			return nil, err
 		}
-		records = append(records, clusterSystemRecord)
 	}
 
 	// Aggregate tenant target protections.
@@ -187,6 +211,9 @@ func (s *SQLTranslator) generateSystemSpanConfigRecords(
 		tenantProtection := protection
 		systemTarget, err := spanconfig.MakeTenantKeyspaceTarget(sourceTenantID, tenantProtection.GetTenantID())
 		if err != nil {
+			if s.opts.ignoreInvalidPTSTargets {
+				continue
+			}
 			return nil, err
 		}
 		tenantSystemRecord, err := spanconfig.MakeRecord(


### PR DESCRIPTION
Previously, if a PTS with an invalid target (e.g. a secondary tenant attempting to lay a PTS on another tenant), the span config reconciler job would fail. As these types of PTSs are clearly invalid, this commit instead teaches the reconciler to drop these PTSs and continue.

Fixes: #155444

Release note: None