### PR TITLE
logical: support array primary keys in the crud writer

### DIFF
--- a/pkg/crosscluster/logical/replication_statements_test.go
+++ b/pkg/crosscluster/logical/replication_statements_test.go
@@ -131,6 +131,18 @@ func TestReplicationStatements(t *testing.T) {
 				prepareStatement(t, sqlDB, types, stmt)
 
 				return stmt.SQL
+			case "show-point-select":
+				var tableName string
+				d.ScanArgs(t, "table", &tableName)
+
+				desc := getTableDesc(tableName)
+
+				stmt, types, err := newPointSelectStatement(desc)
+				require.NoError(t, err)
+
+				prepareStatement(t, sqlDB, types, stmt)
+
+				return stmt.SQL
 			default:
 				return "unknown command: " + d.Cmd
 			}

--- a/pkg/crosscluster/logical/sql_row_reader_test.go
+++ b/pkg/crosscluster/logical/sql_row_reader_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -69,7 +70,7 @@ func TestSQLRowReader(t *testing.T) {
 	// Use sqlRowReader to get prior rows from both tables
 	db := s.InternalDB().(isql.DB)
 
-	readRows := func(t *testing.T, db isql.DB, rows []tree.Datums, reader *sqlRowReader) map[int]priorRow {
+	readRows := func(t *testing.T, db isql.DB, rows []tree.Datums, reader sqlRowReader) map[int]priorRow {
 		var result map[int]priorRow
 		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			result, err = reader.ReadRows(ctx, rows)
@@ -139,4 +140,55 @@ func TestSQLRowReader(t *testing.T) {
 		readRows(t, db, testRows, dstReader),
 		readRowsSql(t, dbDest, primaryKeys),
 		"reading destination did not yield expected rows")
+}
+
+func TestSQLRowReaderWithArrayColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create tables with array column
+	createStmt := `CREATE TABLE tab_array (pk int[] primary key, value int)`
+	runner.Exec(t, createStmt)
+
+	// Insert test data
+	runner.Exec(t, "INSERT INTO tab_array VALUES (ARRAY['1', '2'], 10), (ARRAY['1'], 20)")
+
+	// Create sqlRowReader for source table
+	desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", "tab_array")
+	session := newInternalSession(t, s)
+	defer session.Close(ctx)
+	reader, err := newSQLRowReader(ctx, desc, session)
+	require.NoError(t, err)
+
+	db := s.InternalDB().(isql.DB)
+
+	testRows := []tree.Datums{
+		{
+			tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.NewDInt(1), tree.NewDInt(2)}),
+			tree.NewDInt(0),
+		},
+		{
+			tree.NewDArrayFromDatums(types.Int, tree.Datums{tree.NewDInt(1)}),
+			tree.NewDInt(0),
+		},
+	}
+
+	var result map[int]priorRow
+	require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		result, err = reader.ReadRows(ctx, testRows)
+		return err
+	}))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result, 2)
+	require.Equal(t, result[0].row[1], tree.NewDInt(10))
+	require.Equal(t, result[1].row[1], tree.NewDInt(20))
 }

--- a/pkg/crosscluster/logical/table_batch_handler.go
+++ b/pkg/crosscluster/logical/table_batch_handler.go
@@ -26,7 +26,7 @@ import (
 // tableHandler applies batches of replication events that are destined for a
 // sinlgle table.
 type tableHandler struct {
-	sqlReader        *sqlRowReader
+	sqlReader        sqlRowReader
 	sqlWriter        *sqlRowWriter
 	session          isql.Session
 	db               descs.DB

--- a/pkg/crosscluster/logical/testdata/ldr_statements
+++ b/pkg/crosscluster/logical/testdata/ldr_statements
@@ -176,3 +176,29 @@ DELETE FROM [112 AS replication_target] WHERE (((((id = $1::UUID) AND (user_id I
 show-select table=user_events
 ----
 SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.user_id, replication_target.event_type, replication_target.event_data, replication_target.created_at, replication_target.region FROM ROWS FROM (unnest($1::UUID[], $2::@100111)) WITH ORDINALITY AS key_list (key1, key2, index) INNER LOOKUP JOIN [112 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.region = key_list.key2)
+
+# Test table with array primary key - this requires point select due to array-of-arrays limitations
+exec
+CREATE TABLE array_pk_table (
+  arr_col INT[] PRIMARY KEY,
+  name STRING,
+  value INT
+);
+----
+ok
+
+show-insert table=array_pk_table
+----
+INSERT INTO [113 AS replication_target](arr_col, name, value) VALUES ($1::INT8[], $2::STRING, $3::INT8)
+
+show-update table=array_pk_table
+----
+UPDATE [113 AS replication_target] SET arr_col = $4::INT8[], name = $5::STRING, value = $6::INT8 WHERE ((arr_col = $1::INT8[]) AND (name IS NOT DISTINCT FROM $2::STRING)) AND (value IS NOT DISTINCT FROM $3::INT8)
+
+show-delete table=array_pk_table
+----
+DELETE FROM [113 AS replication_target] WHERE ((arr_col = $1::INT8[]) AND (name IS NOT DISTINCT FROM $2::STRING)) AND (value IS NOT DISTINCT FROM $3::INT8) RETURNING *
+
+show-point-select table=array_pk_table
+----
+SELECT replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.arr_col, replication_target.name, replication_target.value FROM [113 AS replication_target] WHERE replication_target.arr_col = $1::INT8[]


### PR DESCRIPTION
This adds a second point select row reader to the LDR crud writer. This is a work around for #32552.

This change also includes a small fix to the batch row reader. It now initializes the array parameter with the canonical type. This is required because the arguments come from the cdc event decoder and the event decoder always returns canonical datums.

Release note: none
Fixes: #148303