### PR TITLE
logictest: remove stale mixed-version skips

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/provisioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/provisioning
@@ -1,4 +1,4 @@
-# LogicTest: !local-mixed-24.3 !local-mixed-25.1 !local-mixed-25.2
+# LogicTest: !local-mixed-25.2
 # Tests for parsing/validation of the PROVISIONSRC role option.
 
 statement error role "root" cannot have a PROVISIONSRC

--- a/pkg/ccl/logictestccl/testdata/logic_test/show_create
+++ b/pkg/ccl/logictestccl/testdata/logic_test/show_create
@@ -91,7 +91,6 @@ r1  CREATE FUNCTION public.r1(i INT8)
       SELECT 1;
     $$
 
-skipif config local-mixed-23.1
 query TT
 SELECT * FROM [SHOW CREATE PROCEDURE r1] ORDER BY 2
 ----

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1592,7 +1592,6 @@ ALTER TABLE stored1 ALTER COLUMN comp1 SET DATA TYPE INT2 USING -1;
 statement ok
 INSERT INTO stored1 VALUES (-1000);
 
-skipif config local-mixed-24.3
 onlyif config schema-locked-disabled
 query TT
 SHOW CREATE TABLE stored1;
@@ -1980,7 +1979,6 @@ select * from t_multi_alter order by c1;
 10 10 2024-04-22 00:00:00 +0000 +0000
 20 20 2024-04-22 00:00:00 +0000 +0000
 
-skipif config local-mixed-24.3
 onlyif config schema-locked-disabled
 query TT colnames
 show create table t_multi_alter

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1,4 +1,4 @@
-# LogicTest: local 3node-tenant
+# LogicTest: local local-mixed-25.2 local-mixed-25.3 local-mixed-25.4 3node-tenant
 
 statement error a role/user named admin already exists
 CREATE ROLE admin
@@ -1532,25 +1532,31 @@ subtest end
 
 subtest validate_alter_provisioned_user_restrictions
 
+skipif config local-mixed-25.2
 # Changing PROVISIONSRC privilege for provisioned users is disallowed even for
 # ADMIN users, they can only be dropped.
 statement ok
 DROP ROLE testuser
 
+skipif config local-mixed-25.2
 statement ok
 CREATE USER testuser with PROVISIONSRC 'ldap:example.com'
 
+skipif config local-mixed-25.2
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER ROLE testuser WITH PROVISIONSRC 'ldap:example.com'
 
+skipif config local-mixed-25.2
 statement ok
 SET ROLE testuser
 
+skipif config local-mixed-25.2
 # Changing users with SET ROLE should now disallow self-password/provisionsrc
 # change as role has a PROVISIONSRC privilege.
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER testuser PASSWORD 'cat'
 
+skipif config local-mixed-25.2
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER testuser PROVISIONSRC 'ldap:example2.com'
 
@@ -1559,24 +1565,30 @@ RESET ROLE
 
 user testuser
 
+skipif config local-mixed-25.2
 # Verify that now provisioned testuser can't change its own password or provisionsrc.
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER testuser PASSWORD 'xyz'
 
+skipif config local-mixed-25.2
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER CURRENT_USER PASSWORD '123'
 
+skipif config local-mixed-25.2
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER testuser PROVISIONSRC 'ldap:example2.com'
 
+skipif config local-mixed-25.2
 # Verify that provisioned testuser still cannot *remove* its own password.
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER testuser PASSWORD NULL
 
+skipif config local-mixed-25.2
 # testuser still cannot change another user's password.
 statement error pq: user testuser does not have CREATEROLE privilege
 ALTER USER testuser2 WITH PASSWORD 'abc'
 
+skipif config local-mixed-25.2
 # Verify that testuser still cannot modify other role options of itself.
 statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
 ALTER USER testuser PASSWORD 'abc' VALID UNTIL '4044-10-31'
@@ -1951,24 +1963,20 @@ subtest provisionsrc
 
 skipif config 3node-tenant
 skipif config local-mixed-25.2
-skipif config local-mixed-25.1
-skipif config local-mixed-24.3
 statement ok
 CREATE ROLE role_with_provisioning PROVISIONSRC 'ldap:ldap.example.com'
 
 skipif config 3node-tenant
 skipif config local-mixed-25.2
-skipif config local-mixed-25.1
-skipif config local-mixed-24.3
 statement ok
 ALTER ROLE testuser PROVISIONSRC 'ldap:ldap.example.com'
 
-onlyif config local-mixed-24.3
-statement error SUBJECT role option is only supported after v25.3 upgrade is finalized
+onlyif config local-mixed-25.2
+statement error PROVISIONSRC role option is only supported after v25.3 upgrade is finalized
 CREATE ROLE role_with_provisioning PROVISIONSRC 'ldap:ldap.example.com'
 
-onlyif config local-mixed-24.3
-statement error SUBJECT role option is only supported after v25.3 upgrade is finalized
+onlyif config local-mixed-25.2
+statement error PROVISIONSRC role option is only supported after v25.3 upgrade is finalized
 ALTER ROLE testuser PROVISIONSRC 'ldap:ldap.example.com'
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -95,35 +95,19 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT, UNIQUE INDEX idx (j)) WITH (schema_loc
 statement ok
 INSERT INTO t SELECT i, i+1 FROM generate_series(1,10) AS tmp(i);
 
-onlyif config local-mixed-25.1 local-legacy-schema-changer
+onlyif config local-legacy-schema-changer
 statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE t ADD COLUMN k INT DEFAULT 30;
 
-onlyif config local-mixed-25.1 local-legacy-schema-changer
+onlyif config local-legacy-schema-changer
 statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE t DROP COLUMN j;
 
-onlyif config local-mixed-25.1
-statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
-ALTER TABLE t RENAME TO t2;
-
-onlyif config local-mixed-25.1
-statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
-ALTER TABLE t RENAME COLUMN j TO j2;
-
-onlyif config local-mixed-25.1
-statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
-ALTER INDEX idx RENAME TO idx2;
-
-onlyif config local-mixed-25.1
-statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
-ALTER INDEX idx INVISIBLE;
-
-onlyif config local-mixed-25.1 local-legacy-schema-changer
+onlyif config local-legacy-schema-changer
 statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 DROP INDEX idx;
 
-onlyif config local-mixed-25.1 local-legacy-schema-changer
+onlyif config local-legacy-schema-changer
 statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 CREATE INDEX idx2 ON t(j);
 
@@ -131,7 +115,7 @@ statement ok
 CREATE TABLE ref (a INT PRIMARY KEY, b INT)
 
 # Locked tables cannot be referenced by foreign keys.
-onlyif config local-mixed-25.1 local-legacy-schema-changer
+onlyif config local-legacy-schema-changer
 statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE ref ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES t(j);
 
@@ -151,23 +135,23 @@ subtest end
 # Declarative schema change can automatically unset and set schema locked.
 subtest declarative_allows_schema_changes
 
-skipif config local-mixed-25.1 local-legacy-schema-changer
+skipif config local-legacy-schema-changer
 statement ok
 ALTER TABLE t ADD COLUMN k INT DEFAULT 30;
 
-skipif config local-mixed-25.1 local-legacy-schema-changer
+skipif config local-legacy-schema-changer
 statement ok
 CREATE INDEX idx2 ON t(j);
 
-skipif config local-mixed-25.1 local-legacy-schema-changer
+skipif config local-legacy-schema-changer
 statement ok
 DROP INDEX idx2;
 
-skipif config local-mixed-25.1 local-legacy-schema-changer
+skipif config local-legacy-schema-changer
 statement ok
 ALTER TABLE ref ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES t(j);
 
-skipif config local-mixed-25.1 local-legacy-schema-changer
+skipif config local-legacy-schema-changer
 statement ok
 ALTER TABLE t DROP COLUMN j CASCADE;
 
@@ -177,7 +161,7 @@ SELECT count(create_statement) FROM [SHOW CREATE TABLE t] WHERE create_statement
 ----
 1
 
-onlyif config local-mixed-25.1 local-legacy-schema-changer
+onlyif config local-legacy-schema-changer
 statement ok
 ALTER TABLE t SET (schema_locked = false);
 
@@ -216,7 +200,6 @@ CREATE TABLE t_147993 (
 
 
 skipif config local-legacy-schema-changer
-skipif config local-mixed-25.1
 statement ok
 SELECT  AddGeometryColumn ('t_147993','geom7',4326,'POINT',2),
         AddGeometryColumn ('t_147993','geom8',4326,'POINT',2);

--- a/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
@@ -1648,6 +1648,13 @@ func TestLogic_returning(
 	runLogicTest(t, "returning")
 }
 
+func TestLogic_role(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "role")
+}
+
 func TestLogic_routine_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.3/generated_test.go
@@ -1655,6 +1655,13 @@ func TestLogic_returning(
 	runLogicTest(t, "returning")
 }
 
+func TestLogic_role(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "role")
+}
+
 func TestLogic_routine_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.4/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.4/generated_test.go
@@ -1669,6 +1669,13 @@ func TestLogic_returning(
 	runLogicTest(t, "returning")
 }
 
+func TestLogic_role(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "role")
+}
+
 func TestLogic_routine_schema_change(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Also adjust `role` test file to run with mixed versions.

Epic: None
Release note: None