### PR TITLE
release-25.3: sql: skip row-level TTL tests under race

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -449,6 +449,8 @@ func TestRowLevelTTLJobMultipleNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t, "the test times out under race")
+
 	testCases := []struct {
 		desc     string
 		splitAts []int


### PR DESCRIPTION
Backport 1/1 commits from #156473 on behalf of @bghal.

----

The overhead from the race detector is causing this test to time out.\

Epic: none
Fixes: #156073

Release note: None


----

Release justification: test only change