### PR TITLE
sql: wrap CASE expressions with parenthesis within PLpgSQL context

### DIFF
--- a/pkg/internal/sqlsmith/plpgsql.go
+++ b/pkg/internal/sqlsmith/plpgsql.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var plpgsqlFlags = tree.FmtParsable | tree.FmtPLpgSQLParen
+
 func (s *Smither) makeRoutineBodyPLpgSQL(
 	params tree.ParamTypes, rTyp *types.T, vol tree.RoutineVolatility,
 ) string {
@@ -25,7 +27,7 @@ func (s *Smither) makeRoutineBodyPLpgSQL(
 	// errors.
 	block := s.makePLpgSQLBlock(scope)
 	block.Body = append(block.Body, s.makePLpgSQLReturn(scope))
-	return "\n" + tree.AsStringWithFlags(s.makePLpgSQLBlock(scope), tree.FmtParsable)
+	return "\n" + tree.AsStringWithFlags(s.makePLpgSQLBlock(scope), plpgsqlFlags, tree.FmtInPLpgSQL(true /* inPLpgSQL */))
 }
 
 func (s *Smither) makePLpgSQLBlock(scope plpgsqlBlockScope) *ast.Block {

--- a/pkg/internal/sqlsmith/setup_test.go
+++ b/pkg/internal/sqlsmith/setup_test.go
@@ -8,8 +8,6 @@ package sqlsmith_test
 import (
 	"context"
 	"flag"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -92,9 +90,7 @@ func TestGenerateParse(t *testing.T) {
 		t.Fatalf("unknown setting %s", settingName)
 	}
 	settings := setting(rnd)
-	t.Log("setting:", settingName, settings.Options)
 	setupSQL := setup(rnd)
-	t.Log(strings.Join(setupSQL, "\n"))
 	for _, stmt := range setupSQL {
 		db.Exec(t, stmt)
 	}
@@ -119,7 +115,6 @@ func TestGenerateParse(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		fmt.Print("STMT: ", i, "\n", stmt, ";\n\n")
 		if *flagExec {
 			_, err = conn.ExecContext(ctx, `SET statement_timeout = '9s'`)
 			if err != nil {
@@ -129,7 +124,7 @@ func TestGenerateParse(t *testing.T) {
 				es := err.Error()
 				if !seen[es] {
 					seen[es] = true
-					fmt.Printf("ERR (%d): %v\n", i, err)
+					t.Logf("ERR (%d): %v\n", i, err)
 				}
 			}
 		}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -192,6 +192,7 @@ var prettyCfg = func() tree.PrettyCfg {
 	cfg := tree.DefaultPrettyCfg()
 	cfg.LineWidth = 120
 	cfg.Simplify = false
+	cfg.FmtFlags = tree.FmtPLpgSQLParen
 	return cfg
 }()
 
@@ -213,10 +214,10 @@ func (s *Smither) Generate() string {
 		i = 0
 
 		printCfg := prettyCfg
-		fl := tree.FmtParsable
+		fl := plpgsqlFlags
 		if s.postgres {
-			printCfg.FmtFlags = tree.FmtPGCatalog
-			fl = tree.FmtPGCatalog
+			printCfg.FmtFlags = tree.FmtPGCatalog | tree.FmtPLpgSQLParen
+			fl = tree.FmtPGCatalog | tree.FmtPLpgSQLParen
 		}
 		p, err := printCfg.Pretty(stmt)
 		if err != nil {

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -1121,6 +1121,7 @@ func (s *DoBlock) Format(ctx *tree.FmtCtx) {
 		// Format the body of the DO block separately so that FormatStringDollarQuotes
 		// can examine the resulting string and determine how to quote the block.
 		bodyCtx := ctx.Clone()
+		tree.FmtInPLpgSQL(true /* inPLpgSQL */)(bodyCtx)
 		bodyCtx.FormatNode(s.Block)
 		bodyStr := "\n" + bodyCtx.CloseAndGetString()
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1438,6 +1438,13 @@ type CaseExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *CaseExpr) Format(ctx *FmtCtx) {
+	if ctx.HasFlags(FmtPLpgSQLParen) && ctx.inPLpgSQL {
+		// In some cases in PLpgSQL context we need to wrap the CASE expression
+		// in parenthesis to make it parsable. We do so only if the caller
+		// requested it.
+		ctx.WriteByte('(')
+		defer ctx.WriteByte(')')
+	}
 	ctx.WriteString("CASE ")
 	if node.Expr != nil {
 		ctx.FormatNode(node.Expr)


### PR DESCRIPTION
Currently, if we generate a CASE expression within the condition of the IF block in PLpgSQL, it cannot be parsed because it's unclear whether THEN belongs to CASE or to IF. In order to disambiguate this, we need to wrap CASE expressions in parenthesis, and we now do so in all sqlsmith-generated queries whenever we're in PLpgSQL context.

Fixes: #155200.
Release note: None