### PR TITLE
release-25.4: changefeedccl: revert #152703, do not needlessly omit kafka

### DIFF
--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -157,8 +157,7 @@ func TestChangefeedUpdateProtectedTimestamp(t *testing.T) {
 		}
 	}
 
-	// Skip kafka sink because it's not compatible with s390x/IBM architecture
-	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks, feedTestOmitSinks("kafka"))
+	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks)
 }
 
 // TestChangefeedProtectedTimestamps asserts the state of changefeed PTS records


### PR DESCRIPTION
Backport 1/1 commits from #155244 on behalf of @aerfrei.

----

We were omitting kafka for this test in response to a failure
we saw on s390x, with which kafka is incompatible. That failure
was due to an unrelated issue.

Since these kafka sink tests do not run the kafka client,
they are not expected to fail on s390x.

Informs: https://github.com/cockroachdb/cockroach/pull/152703

Epic: none

Release note: None

----

Release justification: This is a test only fix.