### PR TITLE
roachprod/roachtest: uniform storage capabilities

### DIFF
--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -137,8 +137,8 @@ func initCreateCmdFlags(createCmd *cobra.Command) {
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
-	createCmd.Flags().StringVar(&createVMOpts.SSDOpts.FileSystem,
-		"filesystem", vm.Ext4, "The underlying file system(ext4/zfs). ext4 is used by default.")
+	createCmd.Flags().StringVar((*string)(&createVMOpts.SSDOpts.FileSystem),
+		"filesystem", string(vm.Ext4), "The underlying file system(ext4/zfs/xfs/f2fs/btrfs). ext4 is used by default.")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
 		"local-ssd-no-ext4-barrier", true,
 		`Mount the local SSD with the "-o nobarrier" flag. Ignored if --local-ssd=false is specified.`)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1909,7 +1909,7 @@ func (c *clusterImpl) CreateSnapshot(
 func (c *clusterImpl) ApplySnapshots(ctx context.Context, snapshots []vm.VolumeSnapshot) error {
 	opts := vm.VolumeCreateOpts{
 		Size: c.spec.VolumeSize,
-		Type: c.spec.GCE.VolumeType, // TODO(irfansharif): This is only applicable to GCE. Change that.
+		Type: c.spec.VolumeType,
 		Labels: map[string]string{
 			vm.TagUsage: "roachtest",
 		},

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -523,10 +523,10 @@ var (
 		Usage: `Override use of local SSD`,
 	})
 
-	OverrideFilesystem string
+	OverrideFilesystem vm.Filesystem
 	_                  = registerRunFlag(&OverrideFilesystem, FlagInfo{
 		Name:  "filesystem",
-		Usage: `Override the underlying file system(ext4/zfs)`,
+		Usage: `Override the underlying file system(ext4/zfs/xfs/f2fs/btrfs)`,
 	})
 
 	OverrideNoExt4Barrier bool

--- a/pkg/cmd/roachtest/roachtestflags/manager.go
+++ b/pkg/cmd/roachtest/roachtestflags/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 )
@@ -74,6 +75,8 @@ func (m *manager) AddFlagsToCommand(cmd cmdID, cmdFlags *pflag.FlagSet) {
 			cmdFlags.StringToStringVarP(p, f.Name, f.Shorthand, *p, usage)
 		case *spec.Cloud:
 			cmdFlags.VarP(&cloudValue{val: p}, f.Name, f.Shorthand, usage)
+		case *vm.Filesystem:
+			cmdFlags.VarP(&filesystemValue{val: p}, f.Name, f.Shorthand, usage)
 		default:
 			panic(fmt.Sprintf("unsupported pointer type %T", p))
 		}
@@ -144,5 +147,28 @@ func (cv *cloudValue) Set(str string) error {
 		return errors.Errorf("invalid cloud %q", str)
 	}
 	*cv.val = val
+	return nil
+}
+
+type filesystemValue struct {
+	val *vm.Filesystem
+}
+
+var _ pflag.Value = (*filesystemValue)(nil)
+
+func (fv *filesystemValue) String() string {
+	return string(*fv.val)
+}
+
+func (fv *filesystemValue) Type() string {
+	return "string"
+}
+
+func (fv *filesystemValue) Set(str string) error {
+	val, err := vm.ParseFilesystemString(str)
+	if err != nil {
+		return err
+	}
+	*fv.val = val
 	return nil
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -25,13 +25,11 @@ import (
 type fileSystemType int
 
 const (
-	// Since ext4 is the default of 0, it isn't being
-	// used anywhere in the code. Therefore, it isn't
-	// added as a const here since it is unused, and
-	// leads to a lint error.
-
-	// Zfs file system.
-	Zfs fileSystemType = 1
+	Ext4 fileSystemType = iota
+	Zfs
+	Xfs
+	F2fs
+	Btrfs
 
 	// Extra labels added by roachtest
 	RoachtestBranch = "roachtest-branch"
@@ -205,6 +203,8 @@ type ClusterSpec struct {
 	SSDs                 int
 	RAID0                bool
 	VolumeSize           int
+	VolumeType           string
+	VolumeCount          int
 	LocalSSD             LocalSSDSetting
 	Geo                  bool
 	Lifetime             time.Duration
@@ -224,8 +224,6 @@ type ClusterSpec struct {
 	GCE struct {
 		MachineType    string
 		MinCPUPlatform string
-		VolumeType     string
-		VolumeCount    int // volume count is only supported for GCE. This can be moved up if we start supporting other clouds
 		Zones          string
 	} `cloud:"gce"`
 
@@ -242,13 +240,13 @@ type ClusterSpec struct {
 	// Azure-specific arguments. These values apply only on clusters instantiated on Azure.
 	Azure struct {
 		Zones string
+		// VolumeIOPS is the provisioned IOPS for ultra-disks.
+		VolumeIOPS int
 	} `cloud:"azure"`
 	// IBM-specific arguments. These values apply only on clusters instantiated on IBM.
 	IBM struct {
 		MachineType string
-		VolumeType  string
 		VolumeIOPS  int
-		VolumeCount int
 		Zones       string
 	} `cloud:"ibm"`
 }
@@ -319,15 +317,23 @@ func awsMachineSupportsSSD(machineType string) bool {
 
 func getAWSOpts(
 	machineType string,
-	volumeSize, ebsThroughput int,
+	volumeSize, volumeCount, ebsThroughput int,
+	volumeType string,
 	ebsIOPS int,
 	localSSD bool,
+	RAID0 bool,
 	useSpotVMs bool,
 	bootDiskOnly bool,
 ) vm.ProviderOpts {
 	opts := aws.DefaultProviderOpts()
 	if volumeSize != 0 {
 		opts.DefaultEBSVolume.Disk.VolumeSize = volumeSize
+	}
+	if volumeType != "" {
+		opts.DefaultEBSVolume.Disk.VolumeType = volumeType
+	}
+	if volumeCount != 0 {
+		opts.EBSVolumeCount = volumeCount
 	}
 	if ebsIOPS != 0 {
 		opts.DefaultEBSVolume.Disk.IOPs = ebsIOPS
@@ -340,6 +346,7 @@ func getAWSOpts(
 	} else {
 		opts.MachineType = machineType
 	}
+	opts.UseMultipleDisks = !RAID0
 	opts.UseSpot = useSpotVMs
 	opts.BootDiskOnly = bootDiskOnly
 	return opts
@@ -389,13 +396,31 @@ func getGCEOpts(
 	return opts
 }
 
-func getAzureOpts(machineType string, volumeSize int, bootDiskOnly bool) vm.ProviderOpts {
+func getAzureOpts(
+	machineType string,
+	volumeSize int,
+	volumeType string,
+	volumeCount int,
+	volumeIOPS int,
+	RAID0 bool,
+	bootDiskOnly bool,
+) vm.ProviderOpts {
 	opts := azure.DefaultProviderOpts()
 	opts.MachineType = machineType
 	if volumeSize != 0 {
 		opts.NetworkDiskSize = int32(volumeSize)
 	}
 	opts.BootDiskOnly = bootDiskOnly
+	if volumeType != "" {
+		opts.NetworkDiskType = volumeType
+	}
+	if volumeCount != 0 {
+		opts.NetworkDiskCount = volumeCount
+	}
+	if volumeIOPS != 0 {
+		opts.UltraDiskIOPS = int64(volumeIOPS)
+	}
+	opts.UseMultipleDisks = !RAID0
 	return opts
 }
 
@@ -405,7 +430,7 @@ func getIBMOpts(
 	volumeSize int,
 	volumeType string,
 	volumeIOPS int,
-	extraVolumeCount int,
+	volumeCount int,
 	RAID0 bool,
 	bootDiskOnly bool,
 ) vm.ProviderOpts {
@@ -424,17 +449,10 @@ func getIBMOpts(
 	}
 
 	// We reuse the parameters of the default data volume for extra volumes.
-	opts.AttachedVolumes = make(ibm.IbmVolumeList, 0)
-	if extraVolumeCount > 0 {
-		for i := 0; i < extraVolumeCount; i++ {
-			opts.AttachedVolumes = append(opts.AttachedVolumes, &ibm.IbmVolume{
-				VolumeType: opts.DefaultVolume.VolumeType,
-				VolumeSize: opts.DefaultVolume.VolumeSize,
-				IOPS:       opts.DefaultVolume.IOPS,
-			})
-		}
-		opts.UseMultipleDisks = !RAID0
+	if volumeCount != 0 {
+		opts.AttachedVolumesCount = volumeCount
 	}
+	opts.UseMultipleDisks = !RAID0
 	opts.BootDiskOnly = bootDiskOnly
 
 	return opts
@@ -594,18 +612,25 @@ func (s *ClusterSpec) RoachprodOpts(
 		}
 	}
 
-	if s.FileSystem == Zfs {
-		if cloud != GCE && cloud != IBM {
-			return vm.CreateOpts{}, nil, nil, "", errors.Errorf(
-				"node creation with zfs file system not yet supported on %s", cloud,
-			)
+	switch s.FileSystem {
+	case Ext4:
+		// ext4 is the default, do nothing unless we randomly want to use zfs
+		if s.RandomlyUseZfs {
+			rng, _ := randutil.NewPseudoRand()
+			if rng.Float64() <= 0.2 {
+				createVMOpts.SSDOpts.FileSystem = vm.Zfs
+			}
 		}
+	case Zfs:
 		createVMOpts.SSDOpts.FileSystem = vm.Zfs
-	} else if s.RandomlyUseZfs && (cloud == GCE || cloud == IBM) {
-		rng, _ := randutil.NewPseudoRand()
-		if rng.Float64() <= 0.2 {
-			createVMOpts.SSDOpts.FileSystem = vm.Zfs
-		}
+	case Xfs:
+		createVMOpts.SSDOpts.FileSystem = vm.Xfs
+	case F2fs:
+		createVMOpts.SSDOpts.FileSystem = vm.F2fs
+	case Btrfs:
+		createVMOpts.SSDOpts.FileSystem = vm.Btrfs
+	default:
+		return vm.CreateOpts{}, nil, nil, "", errors.Errorf("unknown file system type: %v", s.FileSystem)
 	}
 
 	var workloadMachineType string
@@ -633,30 +658,34 @@ func (s *ClusterSpec) RoachprodOpts(
 	var workloadProviderOpts vm.ProviderOpts
 	switch cloud {
 	case AWS:
-		providerOpts = getAWSOpts(machineType, s.VolumeSize, s.AWS.VolumeThroughput, s.AWS.VolumeIOPS,
-			createVMOpts.SSDOpts.UseLocalSSD, s.UseSpotVMs, false)
-		workloadProviderOpts = getAWSOpts(workloadMachineType, s.VolumeSize, s.AWS.VolumeThroughput, s.AWS.VolumeIOPS,
-			createVMOpts.SSDOpts.UseLocalSSD, s.UseSpotVMs, !s.WorkloadRequiresDisk)
+		providerOpts = getAWSOpts(machineType, s.VolumeSize, s.VolumeCount, s.AWS.VolumeThroughput, s.VolumeType, s.AWS.VolumeIOPS,
+			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.UseSpotVMs, false)
+		workloadProviderOpts = getAWSOpts(workloadMachineType, s.VolumeSize, s.VolumeCount, s.AWS.VolumeThroughput, s.VolumeType, s.AWS.VolumeIOPS,
+			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.UseSpotVMs, !s.WorkloadRequiresDisk)
 	case GCE:
 		providerOpts = getGCEOpts(machineType, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType,
-			s.GCE.VolumeCount, s.UseSpotVMs, false,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.VolumeType,
+			s.VolumeCount, s.UseSpotVMs, false,
 		)
 		workloadProviderOpts = getGCEOpts(workloadMachineType, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType,
-			s.GCE.VolumeCount, s.UseSpotVMs, !s.WorkloadRequiresDisk,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.VolumeType,
+			s.VolumeCount, s.UseSpotVMs, !s.WorkloadRequiresDisk,
 		)
 	case Azure:
-		providerOpts = getAzureOpts(machineType, s.VolumeSize, false)
-		workloadProviderOpts = getAzureOpts(workloadMachineType, s.VolumeSize, true)
-	case IBM:
-		providerOpts = getIBMOpts(machineType, s.TerminateOnMigration, s.VolumeSize,
-			s.IBM.VolumeType, s.IBM.VolumeIOPS, s.IBM.VolumeCount, s.RAID0, false,
+		providerOpts = getAzureOpts(machineType,
+			s.VolumeSize, s.VolumeType, s.VolumeCount, s.Azure.VolumeIOPS, s.RAID0, false,
 		)
-		workloadProviderOpts = getIBMOpts(workloadMachineType, s.TerminateOnMigration, s.VolumeSize,
-			s.IBM.VolumeType, s.IBM.VolumeIOPS, s.IBM.VolumeCount, s.RAID0, true,
+		workloadProviderOpts = getAzureOpts(workloadMachineType,
+			s.VolumeSize, s.VolumeType, s.VolumeCount, s.Azure.VolumeIOPS, s.RAID0, true,
+		)
+	case IBM:
+		providerOpts = getIBMOpts(machineType, s.TerminateOnMigration,
+			s.VolumeSize, s.VolumeType, s.IBM.VolumeIOPS, s.VolumeCount, s.RAID0, false,
+		)
+		workloadProviderOpts = getIBMOpts(workloadMachineType, s.TerminateOnMigration,
+			s.VolumeSize, s.VolumeType, s.IBM.VolumeIOPS, s.VolumeCount, s.RAID0, true,
 		)
 	}
 

--- a/pkg/cmd/roachtest/spec/cluster_spec_test.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec_test.go
@@ -25,15 +25,22 @@ func TestClustersCompatible(t *testing.T) {
 	t.Run("spec has different GCE spec with cloud as GCE", func(t *testing.T) {
 		s1 := ClusterSpec{NodeCount: 5}
 		s2 := ClusterSpec{NodeCount: 5}
-		s1.GCE.VolumeType = "mock_volume1"
-		s2.GCE.VolumeType = "mock_volume2"
+		s1.VolumeType = "mock_volume1"
+		s2.VolumeType = "mock_volume2"
 		require.False(t, ClustersCompatible(s1, s2, GCE))
 	})
 	t.Run("spec has different GCE spec with cloud as AWS", func(t *testing.T) {
 		s1 := ClusterSpec{NodeCount: 5}
 		s2 := ClusterSpec{NodeCount: 5}
-		s1.GCE.VolumeType = "mock_volume1"
-		s2.GCE.VolumeType = "mock_volume2"
+		s1.VolumeType = "mock_volume1"
+		s2.VolumeType = "mock_volume2"
+		require.False(t, ClustersCompatible(s1, s2, AWS))
+	})
+	t.Run("spec has different spec with cloud as AWS", func(t *testing.T) {
+		s1 := ClusterSpec{NodeCount: 5}
+		s2 := ClusterSpec{NodeCount: 5}
+		s1.GCE.MinCPUPlatform = "mock_platform1"
+		s2.GCE.MinCPUPlatform = "mock_platform2"
 		require.True(t, ClustersCompatible(s1, s2, AWS))
 	})
 }

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -76,6 +76,20 @@ func VolumeSize(n int) Option {
 	}
 }
 
+// VolumeType sets the volume type.
+func VolumeType(volumeType string) Option {
+	return func(spec *ClusterSpec) {
+		spec.VolumeType = volumeType
+	}
+}
+
+// VolumeCount sets the volume count.
+func VolumeCount(volumeCount int) Option {
+	return func(spec *ClusterSpec) {
+		spec.VolumeCount = volumeCount
+	}
+}
+
 // SSD is a node option which requests nodes with the specified number of SSDs.
 func SSD(n int) Option {
 	return func(spec *ClusterSpec) {
@@ -247,20 +261,6 @@ func GCEMinCPUPlatform(platform string) Option {
 	}
 }
 
-// GCEVolumeType sets the volume type when the cluster is on GCE.
-func GCEVolumeType(volumeType string) Option {
-	return func(spec *ClusterSpec) {
-		spec.GCE.VolumeType = volumeType
-	}
-}
-
-// GCEVolumeCount sets the volume count when the cluster is on GCE.
-func GCEVolumeCount(volumeCount int) Option {
-	return func(spec *ClusterSpec) {
-		spec.GCE.VolumeCount = volumeCount
-	}
-}
-
 // GCEZones is a node option which requests Geo-distributed nodes; only applies
 // when the test runs on GCE.
 //
@@ -321,6 +321,14 @@ func AzureZones(zones string) Option {
 	}
 }
 
+// AzureVolumeIOPS sets the provisioned IOPS for ultra-disk volumes
+// when the cluster is on Azure.
+func AzureVolumeIOPS(iops int) Option {
+	return func(spec *ClusterSpec) {
+		spec.Azure.VolumeIOPS = iops
+	}
+}
+
 // IBMMachineType sets the machine (instance) type when the cluster is on IBM.
 func IBMMachineType(machineType string) Option {
 	return func(spec *ClusterSpec) {
@@ -328,24 +336,10 @@ func IBMMachineType(machineType string) Option {
 	}
 }
 
-// IBMVolumeType sets the volume type when the cluster is on IBM.
-func IBMVolumeType(volumeType string) Option {
-	return func(spec *ClusterSpec) {
-		spec.IBM.VolumeType = volumeType
-	}
-}
-
 // IBMVolumeIOPS sets the IOPS when the cluster is on IBM.
 func IBMVolumeIOPS(iops int) Option {
 	return func(spec *ClusterSpec) {
 		spec.IBM.VolumeIOPS = iops
-	}
-}
-
-// IBMVolumeCount sets the volume count when the cluster is on IBM.
-func IBMVolumeCount(count int) Option {
-	return func(spec *ClusterSpec) {
-		spec.IBM.VolumeCount = count
 	}
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2566,7 +2566,7 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 	// These params can be probabilistically set, so we pass them here to
 	// show what their actual values are in the posted issue.
 	if createOpts != nil {
-		clusterParams["fs"] = createOpts.SSDOpts.FileSystem
+		clusterParams["fs"] = string(createOpts.SSDOpts.FileSystem)
 		clusterParams["localSSD"] = fmt.Sprintf("%v", createOpts.SSDOpts.UseLocalSSD)
 	}
 

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -38,7 +38,7 @@ func registerDatabaseDrop(r registry.Registry) {
 		// node falls below 5% available capacity. 800GiB (7.2TiB) ought to be more
 		// than enough.
 		spec.VolumeSize(800),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
 	)

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -34,7 +34,7 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.WorkloadRequiresDisk(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(500),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
 	)

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_index_backfill.go
@@ -38,9 +38,9 @@ func registerMultiStoreIndexBackfill(r registry.Registry) {
 			spec.CPU(16),
 			spec.WorkloadNode(),
 			spec.WorkloadNodeCPU(16),
-			spec.GCEVolumeType("pd-ssd"),
+			spec.VolumeType("pd-ssd"),
 			spec.VolumeSize(200),
-			spec.GCEVolumeCount(4),
+			spec.VolumeCount(4),
 		),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule),

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -436,8 +436,8 @@ func registerDiskStalledWALFailoverWithProgress(r registry.Registry) {
 			spec.WorkloadNode(),
 			spec.ReuseNone(),
 			spec.DisableLocalSSD(),
-			spec.GCEVolumeCount(2),
-			spec.GCEVolumeType("pd-ssd"),
+			spec.VolumeCount(2),
+			spec.VolumeType("pd-ssd"),
 			spec.VolumeSize(100),
 			// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 			spec.Arch(spec.AllExceptFIPS),

--- a/pkg/cmd/roachtest/tests/invariant_check_detection.go
+++ b/pkg/cmd/roachtest/tests/invariant_check_detection.go
@@ -30,7 +30,7 @@ func registerInvariantCheckDetection(r registry.Registry) {
 			Name:             fmt.Sprintf("invariant-check-detection/failed=%t", failed),
 			Owner:            registry.OwnerTestEng,
 			Suites:           registry.ManualOnly,
-			Cluster:          r.MakeClusterSpec(1, spec.CPU(4), spec.ReuseNone(), spec.VolumeSize(100), spec.GCEVolumeType("pd-ssd")),
+			Cluster:          r.MakeClusterSpec(1, spec.CPU(4), spec.ReuseNone(), spec.VolumeSize(100), spec.VolumeType("pd-ssd")),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runInvariantCheckDetection(ctx, t, c, failed)
 			},

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -42,7 +42,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(800),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 	}
 	testTimeout := 19 * time.Hour

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -4,105 +4,6 @@ echo
 #!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
-function setup_disks() {
-
-
-
-
-	use_multiple_disks=''
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both EC2 NVMe Instance Storage and
-	# EBS, RAID'ing in this case can cause performance differences. So, to avoid this,
-	# EC2 NVMe Instance Storage are ignored.
-	# Scenarios:
-	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
-	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
-	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
-	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
-	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
-	# Keep track of the Local SSDs and EBS volumes for RAID'ing
-	local_disks=()
-	ebs_volumes=()
-
-
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-
-
-	# On different machine types, the drives are either called nvme... or xvdd.
-	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
-		mounted="no"
-
-		# Check if the disk is already part of a zpool or mounted; skip if so.
-		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
-			mounted="yes"
-		fi
-
-		if [ "$mounted" == "no" ]; then
-			if udevadm info --query=property --name=${d} | grep "ID_MODEL=Amazon Elastic Block Store">/dev/null; then
-				ebs_volumes+=("${d}")
-			else
-				local_disks+=("${d}")
-			fi
-			echo "Disk ${d} not mounted, need to mount..."
-		else
-			echo "Disk ${d} already mounted, skipping..."
-		fi
-	done
-
-	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
-	disks=()
-	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
-	echo "Using only EBS disks: ${ebs_volumes[@]}"
-		disks=("${ebs_volumes[@]}")
-	else
-		echo "Using only local disks: ${local_disks[@]}"
-		disks=("${local_disks[@]}")
-	fi
-
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-		chmod 777 ${mountpoint}
-	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-
-	zpool list
-
-
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -114,6 +15,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -134,9 +37,198 @@ fi
 sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
+apt-get install -yq zfsutils-linux
 
-# Initialize disks.
-setup_disks
+
+
+# Provider specific disk logic
+function detect_disks() {
+	# AWS-specific disk detection - returns list of available disks
+	# If both EC2 NVMe Instance Storage and EBS exist, prioritize EBS volumes to avoid
+	# performance differences when RAID'ing mixed disk types.
+	# Scenarios:
+	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
+	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
+	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
+	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
+	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
+	local local_disks=()
+	local ebs_volumes=()
+	local disks=()
+
+	# On different machine types, the drives are either called nvme... or xvdd.
+	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
+		mounted="no"
+
+		# Check if the disk is already part of a zpool or mounted; skip if so.
+		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			if udevadm info --query=property --name=${d} | grep "ID_MODEL=Amazon Elastic Block Store">/dev/null; then
+				ebs_volumes+=("${d}")
+			else
+				local_disks+=("${d}")
+			fi
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
+	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
+		echo "Using only EBS disks: ${ebs_volumes[@]}" >&2
+		disks=("${ebs_volumes[@]}")
+	else
+		echo "Using only local disks: ${local_disks[@]}" >&2
+		disks=("${local_disks[@]}")
+	fi
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.zfs -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.zfs -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem='zfs'
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 
 
@@ -227,6 +319,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -290,16 +384,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":9100" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9100 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9100 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":9100" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -311,18 +437,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":9435" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9435 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9435 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":9435" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -5,36 +5,6 @@ echo
 
 # Script for setting up a Azure machine for roachprod use.
 
-function setup_disks() {
-
-
-mount_opts="defaults"
-
-	devices=()
-
-
-	if (( ${#devices[@]} == 0 ));
-	then
-		# Use /mnt directly.
-		echo "No attached or NVME disks found, creating /mnt/data1"
-		mkdir -p /mnt/data1
-		chown ubuntu /mnt/data1
-		else
-		for d in "${!devices[@]}"; do
-			disk=${devices[$d]}
-			mount="/data$((d+1))"
-			sudo mkdir -p "${mount}"
-			sudo mkfs.ext4 -F "${disk}"
-			sudo mount -o "${mount_opts}" "${disk}" "${mount}"
-			echo "${disk} ${mount} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
-			ln -s "${mount}" "/mnt/$(basename $mount)"
-			tune2fs -m 0 ${disk}
-		done
-		chown ubuntu /data*
-	fi
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -46,6 +16,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -67,8 +39,187 @@ sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
 
-# Initialize disks.
-setup_disks
+
+# Provider specific disk logic
+function detect_disks() {
+	# Azure-specific disk detection - returns list of available disks
+	local local_or_network=()
+	local disks=()
+
+	# First, try to find NVMe disks (excluding boot disk nvme0n1)
+	if [ "$(ls /dev/disk/by-id/nvme-* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
+		if [ "${#local_or_network[@]}" -gt "0" ]; then
+			echo "Using NVMe disks: ${local_or_network[@]}" >&2
+		fi
+	fi
+
+	# If no NVMe disks found, try SCSI attached storage
+	if [ "${#local_or_network[@]}" -eq "0" ] && [ "$(ls /dev/disk/azure/scsi1/lun* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(ls /dev/disk/azure/scsi1/lun*))
+		echo "Using SCSI disks: ${local_or_network[@]}" >&2
+	fi
+
+	for l in ${local_or_network[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+
+		# Skip already mounted disks.
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs. -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs. -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem=''
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 # Disable Hyper-V Time Synchronization device
 # See https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-on-microsoft-azure#step-3-synchronize-clocks
@@ -166,6 +317,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -229,16 +382,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -250,18 +435,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -4,103 +4,6 @@ echo
 #!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-function setup_disks() {
-	first_setup=$1
-
-
-
-
-
-	use_multiple_disks=''
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
-	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
-	# Scenarios:
-	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
-	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
-	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
-	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
-	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	local_or_persistent=()
-	disks=()
-
-
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-
-
-	# N.B. we assume 0th disk is the boot disk.
-	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
-		local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
-		echo "Using only persistent disks: ${local_or_persistent[@]}"
-	else
-		local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
-		echo "Using only local disks: ${local_or_persistent[@]}"
-	fi
-
-	for l in ${local_or_persistent}; do
-		d=$(readlink -f $l)
-		mounted="no"
-
-		# Check if the disk is already part of a zpool or mounted; skip if so.
-		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
-			mounted="yes"
-		fi
-
-		if [ "$mounted" == "no" ]; then
-			disks+=("${d}")
-			echo "Disk ${d} not mounted, need to mount..."
-		else
-			echo "Disk ${d} already mounted, skipping..."
-		fi
-	done
-
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-		chmod 777 ${mountpoint}
-	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-
-	zpool list
-
-
-	mkdir -p /mnt/data1/cores
-	chmod a+w /mnt/data1/cores
-
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -112,6 +15,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -132,19 +37,196 @@ fi
 sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
+apt-get install -yq zfsutils-linux
+
+
 
 sudo -u ubuntu bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
 sudo -u ubuntu bash -c 'echo "dummy public key" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
 
+# Provider specific disk logic
+function detect_disks() {
+	# GCE-specific disk detection - returns list of available disks
+	# If both Local SSDs and Persistent disks exist, prioritize persistent disks to avoid
+	# performance differences when RAID'ing mixed disk types.
+	# Scenarios:
+	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
+	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
+	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
+	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
+	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
+	local local_or_persistent=()
+	local disks=()
+
+	# N.B. we assume 0th disk is the boot disk.
+	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
+		local_or_persistent=($(ls /dev/disk/by-id/google-persistent-disk-[1-9]))
+		echo "Using only persistent disks: ${local_or_persistent[@]}" >&2
+	else
+		local_or_persistent=($(ls /dev/disk/by-id/google-local-*))
+		echo "Using only local disks: ${local_or_persistent[@]}" >&2
+	fi
+
+	for l in ${local_or_persistent[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+
+		# Check if the disk is already part of a zpool or mounted; skip if so.
+		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.zfs -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.zfs -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem='zfs'
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
 if [ -e /.roachprod-initialized ]; then
   echo "OS already initialized, only initializing disks."
   # Initialize disks, but don't write fstab entries again.
-  setup_disks false
+  setup_disks_wrapper false
   exit 0
 fi
 
 # Initialize disks and write fstab entries.
-setup_disks true
+setup_disks_wrapper true
+
 
 
 
@@ -235,6 +317,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -296,16 +380,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":9100" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9100 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9100 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":9100" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -317,18 +433,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":9435" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9435 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9435 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":9435" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -25,54 +25,39 @@ import (
 const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-function setup_disks() {
-	first_setup=$1
+{{ template "head_utils" . }}
+{{ template "apt_packages" . }}
 
-{{ if .BootDiskOnly }}
-	mkdir -p /mnt/data1 && chmod 777 /mnt/data1
-	echo "VM has no disk attached other than the boot disk."
-	return 0
-{{ end }}
+sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
+sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
 
-{{ if not .Zfs }}
-	mount_opts="defaults,nofail"
-	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
-{{ end }}
-
-	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
-	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
+# Provider specific disk logic
+function detect_disks() {
+	# GCE-specific disk detection - returns list of available disks
+	# If both Local SSDs and Persistent disks exist, prioritize persistent disks to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
 	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	local_or_persistent=()
-	disks=()
-
-{{ if .Zfs }}
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-{{ end }}
+	local local_or_persistent=()
+	local disks=()
 
 	# N.B. we assume 0th disk is the boot disk.
 	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
-		local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
-		echo "Using only persistent disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-persistent-disk-[1-9]))
+		echo "Using only persistent disks: ${local_or_persistent[@]}" >&2
 	else
-		local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
-		echo "Using only local disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-local-*))
+		echo "Using only local disks: ${local_or_persistent[@]}" >&2
 	fi
 
-	for l in ${local_or_persistent}; do
+	for l in ${local_or_persistent[@]}; do
 		d=$(readlink -f $l)
 		mounted="no"
-{{ if .Zfs }}
+{{ if eq .Filesystem "zfs" }}
 		# Check if the disk is already part of a zpool or mounted; skip if so.
 		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
 			mounted="yes"
@@ -85,86 +70,20 @@ function setup_disks() {
 {{ end }}
 		if [ "$mounted" == "no" ]; then
 			disks+=("${d}")
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
 
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-{{ if .Zfs }}
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-			mkfs.ext4 -q -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			if [ "$first_setup" = "true" ]; then
-				echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			fi
-			tune2fs -m 0 ${disk}
-{{ end }}
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-{{ if .Zfs }}
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-		raiddisk="/dev/md0"
-		mdadm -q --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -q -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		if [ "$first_setup" = "true" ]; then
-			echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		fi
-		tune2fs -m 0 ${raiddisk}
-{{ end }}
-		chmod 777 ${mountpoint}
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
 	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-{{ if .Zfs }}
-	zpool list
-{{ end }}
-
-	mkdir -p /mnt/data1/cores
-	chmod a+w /mnt/data1/cores
-
-	sudo touch {{ .DisksInitializedFile }}
 }
 
-{{ template "head_utils" . }}
-{{ template "apt_packages" . }}
-
-sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
-sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
-
-if [ -e {{ .OSInitializedFile }} ]; then
-  echo "OS already initialized, only initializing disks."
-  # Initialize disks, but don't write fstab entries again.
-  setup_disks false
-  exit 0
-fi
-
-# Initialize disks and write fstab entries.
-setup_disks true
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 {{ template "ulimits" . }}
 {{ template "tcpdump" . }}
@@ -190,18 +109,18 @@ sudo touch {{ .OSInitializedFile }}
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
 	extraMountOpts string,
-	fileSystem string,
+	fileSystem vm.Filesystem,
 	useMultiple bool,
 	enableFIPS bool,
 	enableCron bool,
 	bootDiskOnly bool,
 ) (string, error) {
+
+	// We define a local type in case we need to add more provider-specific params in
+	// the future.
 	type tmplParams struct {
 		vm.StartupArgs
-		ExtraMountOpts   string
-		UseMultipleDisks bool
-		PublicKey        string
-		BootDiskOnly     bool
+		PublicKey string
 	}
 
 	publicKey, err := config.SSHPublicKey()
@@ -213,14 +132,14 @@ func writeStartupScript(
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithSharedUser(config.SharedUser),
 			vm.WithEnableCron(enableCron),
-			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithFilesystem(fileSystem),
 			vm.WithEnableFIPS(enableFIPS),
 			vm.WithChronyServers([]string{"metadata.google.internal"}),
+			vm.WithExtraMountOpts(extraMountOpts),
+			vm.WithUseMultipleDisks(useMultiple),
+			vm.WithBootDiskOnly(bootDiskOnly),
 		),
-		ExtraMountOpts:   extraMountOpts,
-		UseMultipleDisks: useMultiple,
-		PublicKey:        publicKey,
-		BootDiskOnly:     bootDiskOnly,
+		PublicKey: publicKey,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/ibm/helpers.go
+++ b/pkg/roachprod/vm/ibm/helpers.go
@@ -116,10 +116,10 @@ func (p *Provider) createInstance(
 			vm.WithVMName(opts.vmName),
 			vm.WithSharedUser(opts.providerOpts.RemoteUserName),
 			vm.WithChronyServers([]string{defaultNTPServer}),
-			vm.WithZfs(opts.vmOpts.SSDOpts.FileSystem == vm.Zfs),
+			vm.WithFilesystem(opts.vmOpts.SSDOpts.FileSystem),
+			vm.WithUseMultipleDisks(opts.providerOpts.UseMultipleDisks),
+			vm.WithBootDiskOnly(opts.providerOpts.BootDiskOnly),
 		),
-		UseMultipleDisks: opts.providerOpts.UseMultipleDisks,
-		BootDiskOnly:     opts.providerOpts.BootDiskOnly,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create startup script for instance %s", opts.vmName)
@@ -139,29 +139,35 @@ func (p *Provider) createInstance(
 	// Let's start with the default data disk.
 	attachedVolumes := volumeAttachments{}
 	if !opts.providerOpts.BootDiskOnly {
-		attachedVolumes = volumeAttachments{
-			&volumeAttachment{
-				Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, 0),
-				ResourceGroupID:        p.config.roachprodResourceGroupID,
-				Capacity:               opts.providerOpts.DefaultVolume.VolumeSize,
-				IOPS:                   opts.providerOpts.DefaultVolume.IOPS,
-				Profile:                opts.providerOpts.DefaultVolume.VolumeType,
-				UserTags:               opts.tags,
-				DeleteOnInstanceDelete: true,
-			},
+
+		// If specific attached volumes are provided, use those.
+		// Otherwise, use the default volume configuration and create the specified count.
+		if len(opts.providerOpts.AttachedVolumes) != 0 {
+			for i, attachedVolume := range opts.providerOpts.AttachedVolumes {
+				attachedVolumes = append(attachedVolumes, &volumeAttachment{
+					Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, i),
+					ResourceGroupID:        p.config.roachprodResourceGroupID,
+					Capacity:               attachedVolume.VolumeSize,
+					IOPS:                   attachedVolume.IOPS,
+					Profile:                attachedVolume.VolumeType,
+					UserTags:               opts.tags,
+					DeleteOnInstanceDelete: true,
+				})
+			}
+		} else {
+			for i := range opts.providerOpts.AttachedVolumesCount {
+				attachedVolumes = append(attachedVolumes, &volumeAttachment{
+					Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, i),
+					ResourceGroupID:        p.config.roachprodResourceGroupID,
+					Capacity:               opts.providerOpts.DefaultVolume.VolumeSize,
+					IOPS:                   opts.providerOpts.DefaultVolume.IOPS,
+					Profile:                opts.providerOpts.DefaultVolume.VolumeType,
+					UserTags:               opts.tags,
+					DeleteOnInstanceDelete: true,
+				})
+			}
 		}
-	}
-	// Then we add any additional attached volumes.
-	for i, attachedVolume := range opts.providerOpts.AttachedVolumes {
-		attachedVolumes = append(attachedVolumes, &volumeAttachment{
-			Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, i+1),
-			ResourceGroupID:        p.config.roachprodResourceGroupID,
-			Capacity:               attachedVolume.VolumeSize,
-			IOPS:                   attachedVolume.IOPS,
-			Profile:                attachedVolume.VolumeType,
-			UserTags:               opts.tags,
-			DeleteOnInstanceDelete: true,
-		})
+
 	}
 
 	// Determine what happen in case of a host failure or maintenance.

--- a/pkg/roachprod/vm/ibm/helpers_test.go
+++ b/pkg/roachprod/vm/ibm/helpers_test.go
@@ -410,7 +410,7 @@ func TestCheckCreateOpts(t *testing.T) {
 			SSDOpts: struct {
 				UseLocalSSD   bool
 				NoExt4Barrier bool
-				FileSystem    string
+				FileSystem    vm.Filesystem
 			}{
 				UseLocalSSD: true,
 			},

--- a/pkg/roachprod/vm/ibm/provider_flags.go
+++ b/pkg/roachprod/vm/ibm/provider_flags.go
@@ -27,6 +27,10 @@ type ProviderOpts struct {
 	// DefaultVolume is the default data volume to be attached.
 	DefaultVolume IbmVolume
 
+	// AttachedVolumesCount is the number of additional volumes to be attached.
+	// This is superseded by the length of AttachedVolumes if that is non-empty.
+	AttachedVolumesCount int
+
 	// AttachedVolumes is a list of additional volumes to be attached.
 	AttachedVolumes IbmVolumeList
 
@@ -92,6 +96,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		RemoteUserName:       defaultRemoteUser,
 		DefaultVolume:        IbmVolume{VolumeType: defaultVolumeType, VolumeSize: defaultVolumeSize},
 		AttachedVolumes:      IbmVolumeList{},
+		AttachedVolumesCount: 1,
 		TerminateOnMigration: false,
 	}
 }
@@ -125,6 +130,11 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		o.DefaultVolume.IOPS,
 		"Custom number of IOPS to provision for the default data volume",
 	)
+	flags.IntVar(&o.AttachedVolumesCount,
+		ProviderName+"-volume-count",
+		1,
+		"Number of additional volumes to attach, superseded by --"+ProviderName+"-attached-volume",
+	)
 
 	// Additional attached volumes
 	flags.VarP(
@@ -135,7 +145,7 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 Specified as JSON: '{ "VolumeType": "general-purpose", "VolumeSize": 1000, "IOPS": 15000 }'
 - VolumeType: 'general-purpose' (3 IOPS/GB), '5iops-tier' (5 IOPS/GB), '10iops-tier' (10 IOPS/GB), 'custom' (specify IOPS)
 - VolumeSize: Size in GB of the volume
-- IOPS: IOPS for the volume`,
+- IOPS: IOPS for the volume (if VolumeType is 'custom')`,
 	)
 
 	flags.StringSliceVar(

--- a/pkg/roachprod/vm/ibm/testdata/startup_script
+++ b/pkg/roachprod/vm/ibm/testdata/startup_script
@@ -5,80 +5,6 @@ echo
 
 # Script for setting up an IBM machine for roachprod use.
 
-function setup_disks() {
-
-
-	mount_prefix="/mnt/data"
-	use_multiple_disks=''
-
-
-	mount_opts="defaults,nofail"
-	
-
-
-	# List the attached data disks
-	disks=()
-	for d in $(find /dev/disk/by-id/ -type l -not -name *cloud-init* -not -name *part* -exec readlink -f {} \;); do
-		mounted="no"
-
-		# Check if the disk is already mounted; skip if so.
-
-		if mount | grep -q ${d}; then
-			mounted="yes"
-		fi
-
-
-		if [ "$mounted" = "no" ]; then
-			disks+=("${d}")
-			echo "Disk ${d} is not mounted, mounting it"
-		else
-			echo "Disk ${d} is already mounted, skipping"
-		fi
-	done
-
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$(( disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-
-			mkfs.ext4 -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			tune2fs -m 0 ${disk}
-
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-
-		raiddisk="/dev/md0"
-		mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		tune2fs -m 0 ${raiddisk}
-
-		chmod 777 ${mountpoint}
-	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -90,6 +16,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -111,8 +39,174 @@ sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
 
-# Initialize disks.
-setup_disks
+
+# Provider specific disk logic
+function detect_disks() {
+	# IBM-specific disk detection - returns list of available disks
+	local disks=()
+
+	# List the attached data disks
+	for d in $(find /dev/disk/by-id/ -type l -not -name *cloud-init* -not -name *part* -exec readlink -f {} \;); do
+		mounted="no"
+
+		# Check if the disk is already mounted; skip if so.
+
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+
+
+		if [ "$mounted" = "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} is not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} is already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs. -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs. -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem=''
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 
 
@@ -203,6 +297,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -266,16 +362,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -287,18 +415,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/startup_args_overrides.go
+++ b/pkg/roachprod/vm/startup_args_overrides.go
@@ -85,19 +85,64 @@ func WithDisksInitializedFile(disksInitializedFile string) WithDisksInitializedF
 	return WithDisksInitializedFileOverride{DisksInitializedFile: disksInitializedFile}
 }
 
-// WithZfsOverride is an override for the Zfs field.
-type WithZfsOverride struct {
-	Zfs bool
+// WithFilesystemOverride is an override for the Filesystem field.
+type WithFilesystemOverride struct {
+	Filesystem Filesystem
 }
 
-// apply applies the Zfs override to the StartupArgs.
-func (o WithZfsOverride) apply(args *StartupArgs) {
-	args.Zfs = o.Zfs
+// apply applies the Filesystem override to the StartupArgs.
+func (o WithFilesystemOverride) apply(args *StartupArgs) {
+	args.Filesystem = o.Filesystem
 }
 
-// WithZfs overrides the Zfs field.
-func WithZfs(zfs bool) WithZfsOverride {
-	return WithZfsOverride{Zfs: zfs}
+// WithFilesystem overrides the Filesystem field.
+func WithFilesystem(filesystem Filesystem) WithFilesystemOverride {
+	return WithFilesystemOverride{Filesystem: filesystem}
+}
+
+// WithExtraMountOptsOverride is an override for the ExtraMountOpts field.
+type WithExtraMountOptsOverride struct {
+	ExtraMountOpts string
+}
+
+// apply applies the ExtraMountOpts override to the StartupArgs.
+func (o WithExtraMountOptsOverride) apply(args *StartupArgs) {
+	args.ExtraMountOpts = o.ExtraMountOpts
+}
+
+// WithExtraMountOpts overrides the ExtraMountOpts field.
+func WithExtraMountOpts(extraMountOpts string) WithExtraMountOptsOverride {
+	return WithExtraMountOptsOverride{ExtraMountOpts: extraMountOpts}
+}
+
+// WithBootDiskOnlyOverride is an override for the BootDiskOnly field.
+type WithBootDiskOnlyOverride struct {
+	BootDiskOnly bool
+}
+
+// apply applies the BootDiskOnly override to the StartupArgs.
+func (o WithBootDiskOnlyOverride) apply(args *StartupArgs) {
+	args.BootDiskOnly = o.BootDiskOnly
+}
+
+// WithBootDiskOnly overrides the BootDiskOnly field.
+func WithBootDiskOnly(bootDiskOnly bool) WithBootDiskOnlyOverride {
+	return WithBootDiskOnlyOverride{BootDiskOnly: bootDiskOnly}
+}
+
+// WithUseMultipleDisksOverride is an override for the UseMultipleDisks field.
+type WithUseMultipleDisksOverride struct {
+	UseMultipleDisks bool
+}
+
+// apply applies the UseMultipleDisks override to the StartupArgs.
+func (o WithUseMultipleDisksOverride) apply(args *StartupArgs) {
+	args.UseMultipleDisks = o.UseMultipleDisks
+}
+
+// WithUseMultipleDisks overrides the UseMultipleDisks field.
+func WithUseMultipleDisks(useMultipleDisks bool) WithUseMultipleDisksOverride {
+	return WithUseMultipleDisksOverride{UseMultipleDisks: useMultipleDisks}
 }
 
 // WithEnableFIPSOverride is an override for the EnableFIPS field.

--- a/pkg/roachprod/vm/startup_test.go
+++ b/pkg/roachprod/vm/startup_test.go
@@ -28,13 +28,13 @@ func TestGenericStartupArgs(t *testing.T) {
 		args := DefaultStartupArgs(WithOSInitializedFile("test"))
 		require.Equal(t, args.OSInitializedFile, "test")
 	})
-	t.Run("WithDiskInitializeFile", func(t *testing.T) {
+	t.Run("WithDisksInitializedFile", func(t *testing.T) {
 		args := DefaultStartupArgs(WithDisksInitializedFile("test"))
 		require.Equal(t, args.DisksInitializedFile, "test")
 	})
 	t.Run("WithZfs", func(t *testing.T) {
-		args := DefaultStartupArgs(WithZfs(true))
-		require.Equal(t, args.Zfs, true)
+		args := DefaultStartupArgs(WithFilesystem(Ext4))
+		require.Equal(t, args.Filesystem, Ext4)
 	})
 	t.Run("WithFIPS", func(t *testing.T) {
 		args := DefaultStartupArgs(WithEnableFIPS(true))

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -279,12 +279,35 @@ func (vl List) ProviderIDs() []string {
 	return ret
 }
 
+type Filesystem string
+
 const (
 	// Zfs refers to the zfs file system.
-	Zfs = "zfs"
+	Zfs Filesystem = "zfs"
 	// Ext4 refers to the ext4 file system.
-	Ext4 = "ext4"
+	Ext4 Filesystem = "ext4"
+	// Xfs refers to the xfs file system.
+	Xfs Filesystem = "xfs"
+	// F2fs refers to the f2fs file system.
+	F2fs Filesystem = "f2fs"
+	// Btrfs refers to the btrfs file system.
+	Btrfs Filesystem = "btrfs"
 )
+
+// ParseFilesystemString parses and validates a filesystem string.
+func ParseFilesystemString(s string) (Filesystem, error) {
+	return ParseFileSystemOption(Filesystem(s))
+}
+
+// ParseFileSystemOption parses and validates a Filesystem option.
+func ParseFileSystemOption(s Filesystem) (Filesystem, error) {
+	switch s {
+	case Zfs, Ext4, Xfs, F2fs, Btrfs:
+		return s, nil
+	default:
+		return "", errors.Newf("unsupported filesystem: %s", s)
+	}
+}
 
 // CreateOpts is the set of options when creating VMs.
 type CreateOpts struct {
@@ -301,7 +324,7 @@ type CreateOpts struct {
 		// mounting the SSD. Ignored if UseLocalSSD is not set.
 		NoExt4Barrier bool
 		// The file system to be used. This is set to "ext4" by default.
-		FileSystem string
+		FileSystem Filesystem
 	}
 	OsVolumeSize int
 }


### PR DESCRIPTION
Until now, each cloud provider implementation had its own capabilities with regards to storage options. GCE was the only first class citizen with the most available options exposed in roachtest.

This patch attempts to bridge the feature parity gap between the cloud providers (up to what's exposed by each providers), bringing support for the following options in roachprod and roachtest:
- GCE:
  - local SSD
  - network disk size
  - network disk type (pd-standard, pd-ssd)
  - network disk count
  - RAID0 or multiple stores
- AWS:
  - local SSD
  - network disk size
  - network disk throughput
  - network disk IOPS
  - NEW: network disk type (gp2, gp3, io1, io2, st1, sc1, standard)
  - NEW: network disk count
  - NEW: RAID0 or multiple stores
- Azure:
  - local SSD
  - network disk size
  - NEW: network disk IOPS (ultra-disk only)
  - NEW: network disk type (standard-ssd, premium-ssd, premium-ssd-v2,
      ultra-disk)
  - NEW: network disk count
  - NEW: RAID0 or multiple stores
- IBM:
  - network disk size
  - network disk IOPS
  - network disk type (general-purpose, 5iops-tier, 10iops-tier, custom)
  - network disk count
  - RAID0 or multiple stores

This patch also splits the disk setup startup script snippets, with:
- a provider-specific way of detecting the attached disks
- a common logic to mount, format and aggregate the disks

This allows to offer the following filesystems across the board in roachprod (and roachtest):
- Ext4
- ZFS
- XFS
- F2FS (available for AWS, Azure and GCP, pending newer kernel for IBM)
- Btrfs

Epic: none
Closes: #123775
Informs: #146661, #113869
Release note: None