### PR TITLE
logictest: add retry directive to one query that relies on stats

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
@@ -64,7 +64,7 @@ SELECT crdb_internal.clear_table_stats_cache();
 
 # Only the scan in the main query is parallelized when we don't have stats on
 # the descendant tables.
-query I
+query I retry
 SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
 ----
 1


### PR DESCRIPTION
We've seen a couple of failures where we didn't parallelize lookup joins when we expected to. This flake should've been fixed in 41d129af4db8d20391858219e466b8106cfa2b7f yet it still failed twice after that. I don't have any explanation for the flake, so let's just add a retry directive in one spot.

Fixes: #155750.
Release note: None