### PR TITLE
release-25.2: publish-artifacts: change GCS latest key prefix for Workload binary

### DIFF
--- a/pkg/cmd/publish-artifacts/main_test.go
+++ b/pkg/cmd/publish-artifacts/main_test.go
@@ -204,7 +204,7 @@ func TestPublish(t *testing.T) {
 					"-c opt --config=force_build_cdeps --config=pgo --config=crosslinuxbase --norun_validations",
 				"gs://edge-binaries-bucket/cockroach/lib/libgeos_c.linux-gnu-amd64.so.LATEST/no-cache REDIRECT /cockroach/lib/libgeos_c.linux-gnu-amd64.1234567890abcdef.so",
 				"gs://edge-binaries-bucket/cockroach/workload.1234567890abcdef CONTENTS env=[] args=bazel build //pkg/cmd/workload -c opt --config=crosslinuxbase --norun_validations",
-				"gs://edge-binaries-bucket/cockroach/workload.LATEST/no-cache REDIRECT /cockroach/workload.1234567890abcdef",
+				"gs://edge-binaries-bucket/workload/workload.LATEST/no-cache REDIRECT /cockroach/workload.1234567890abcdef",
 				"gs://edge-binaries-bucket/cockroach/cockroach.linux-gnu-amd64-fips.1234567890abcdef CONTENTS env=[] args=bazel build " +
 					"//pkg/cmd/cockroach //pkg/cmd/cockroach-sql //c-deps:libgeos " +
 					"'--workspace_status_command=./build/bazelutil/stamp.sh -t x86_64-pc-linux-gnu -c official-fips-binary' " +
@@ -246,7 +246,7 @@ func TestPublish(t *testing.T) {
 					"-c opt --config=force_build_cdeps --config=pgo --config=crosslinuxarmbase --norun_validations",
 				"gs://edge-binaries-bucket/cockroach/lib/libgeos_c.linux-gnu-arm64.so.LATEST/no-cache REDIRECT /cockroach/lib/libgeos_c.linux-gnu-arm64.1234567890abcdef.so",
 				"gs://edge-binaries-bucket/cockroach/workload.linux-gnu-arm64.1234567890abcdef CONTENTS env=[] args=bazel build //pkg/cmd/workload -c opt --config=crosslinuxarmbase --norun_validations",
-				"gs://edge-binaries-bucket/cockroach/workload.linux-gnu-arm64.LATEST/no-cache REDIRECT /cockroach/workload.linux-gnu-arm64.1234567890abcdef",
+				"gs://edge-binaries-bucket/workload/workload.linux-gnu-arm64.LATEST/no-cache REDIRECT /cockroach/workload.linux-gnu-arm64.1234567890abcdef",
 				"gs://edge-binaries-bucket/cockroach/cockroach.darwin-amd64.1234567890abcdef CONTENTS env=[] args=bazel build " +
 					"//pkg/cmd/cockroach //pkg/cmd/cockroach-sql //c-deps:libgeos " +
 					"'--workspace_status_command=./build/bazelutil/stamp.sh -t x86_64-apple-darwin19 -c official-binary' " +
@@ -322,7 +322,7 @@ func TestPublish(t *testing.T) {
 					"-c opt --config=force_build_cdeps --config=pgo --config=crosslinuxbase --norun_validations",
 				"gs://edge-binaries-bucket/cockroach/lib/libgeos_c.linux-gnu-amd64.so.LATEST/no-cache REDIRECT /cockroach/lib/libgeos_c.linux-gnu-amd64.1234567890abcdef.so",
 				"gs://edge-binaries-bucket/cockroach/workload.1234567890abcdef CONTENTS env=[] args=bazel build //pkg/cmd/workload -c opt --config=crosslinuxbase --norun_validations",
-				"gs://edge-binaries-bucket/cockroach/workload.LATEST/no-cache REDIRECT /cockroach/workload.1234567890abcdef",
+				"gs://edge-binaries-bucket/workload/workload.LATEST/no-cache REDIRECT /cockroach/workload.1234567890abcdef",
 			},
 			platforms: release.Platforms{release.PlatformLinux},
 		},
@@ -373,7 +373,7 @@ func TestPublish(t *testing.T) {
 					"-c opt --config=force_build_cdeps --config=pgo --config=crosslinuxbase --norun_validations",
 				"gs://edge-binaries-bucket/cockroach/lib/libgeos_c.linux-gnu-amd64.so.LATEST/no-cache REDIRECT /cockroach/lib/libgeos_c.linux-gnu-amd64.1234567890abcdef.so",
 				"gs://edge-binaries-bucket/cockroach/workload.1234567890abcdef CONTENTS env=[] args=bazel build //pkg/cmd/workload -c opt --config=crosslinuxbase --norun_validations",
-				"gs://edge-binaries-bucket/cockroach/workload.LATEST/no-cache REDIRECT /cockroach/workload.1234567890abcdef",
+				"gs://edge-binaries-bucket/workload/workload.LATEST/no-cache REDIRECT /cockroach/workload.1234567890abcdef",
 				"gs://edge-binaries-bucket/cockroach/cockroach.linux-gnu-amd64-fips.1234567890abcdef CONTENTS env=[] args=bazel build " +
 					"//pkg/cmd/cockroach //pkg/cmd/cockroach-sql //c-deps:libgeos " +
 					"'--workspace_status_command=./build/bazelutil/stamp.sh -t x86_64-pc-linux-gnu -c official-fips-binary' " +
@@ -415,7 +415,7 @@ func TestPublish(t *testing.T) {
 					"-c opt --config=force_build_cdeps --config=pgo --config=crosslinuxarmbase --norun_validations",
 				"gs://edge-binaries-bucket/cockroach/lib/libgeos_c.linux-gnu-arm64.so.LATEST/no-cache REDIRECT /cockroach/lib/libgeos_c.linux-gnu-arm64.1234567890abcdef.so",
 				"gs://edge-binaries-bucket/cockroach/workload.linux-gnu-arm64.1234567890abcdef CONTENTS env=[] args=bazel build //pkg/cmd/workload -c opt --config=crosslinuxarmbase --norun_validations",
-				"gs://edge-binaries-bucket/cockroach/workload.linux-gnu-arm64.LATEST/no-cache REDIRECT /cockroach/workload.linux-gnu-arm64.1234567890abcdef",
+				"gs://edge-binaries-bucket/workload/workload.linux-gnu-arm64.LATEST/no-cache REDIRECT /cockroach/workload.linux-gnu-arm64.1234567890abcdef",
 			},
 			platforms: release.Platforms{release.PlatformLinux, release.PlatformLinuxFIPS, release.PlatformLinuxArm},
 		},

--- a/pkg/release/upload.go
+++ b/pkg/release/upload.go
@@ -187,8 +187,10 @@ func readFile(path string, dst io.Writer) error {
 // Files are uploaded to /cockroach/<FilePath> for each non release file.
 // A `latest` key is then put at cockroach/<RedirectPrefix>.<BranchName> that redirects
 // to the above file.
+// The `latest` key for workload binaries will be prefixed with /workload instead
 func PutNonRelease(svc ObjectPutGetter, o PutNonReleaseOptions) {
 	const nonReleasePrefix = "cockroach"
+	const workloadPrefix = "workload"
 	for _, f := range o.Files {
 		disposition := mime.FormatMediaType("attachment", map[string]string{
 			"filename": f.FileName,
@@ -214,7 +216,13 @@ func PutNonRelease(svc ObjectPutGetter, o PutNonReleaseOptions) {
 		if latestSuffix == "master" {
 			latestSuffix = "LATEST"
 		}
-		latestKey := fmt.Sprintf("%s/%s.%s", nonReleasePrefix, f.RedirectPathPrefix, latestSuffix)
+		var latestPrefix string
+		if strings.HasPrefix(f.RedirectPathPrefix, "workload") {
+			latestPrefix = workloadPrefix
+		} else {
+			latestPrefix = nonReleasePrefix
+		}
+		latestKey := fmt.Sprintf("%s/%s.%s", latestPrefix, f.RedirectPathPrefix, latestSuffix)
 		// NB: The leading slash is required to make redirects work
 		// correctly since we reuse this key as the redirect location.
 		target := "/" + versionKey


### PR DESCRIPTION
Backport 1/2 commits from #156092.

/cc @cockroachdb/release

---

Original PR that was reverted: https://github.com/cockroachdb/cockroach/pull/155789 

Changes split into 2 separate commits to allow for backporting only the required changes for easier merge conflict resolution 

Informs https://github.com/cockroachdb/cockroach/issues/154274 

In gcs `gs://cockroach-edge-artifacts-prod`, change `latest` Workload binary key prefix from `cockroach` to `workload`
i.e.
```
gs://cockroach-edge-artifacts-prod/cockroach/workload.release-24.1
to
gs://cockroach-edge-artifacts-prod/workload/workload.release-24.1
```
This will allow `latest` workload binary to not be deleted after 30 days so tests can download and use workload binaries from unsupported versions (that no longer have nightlies running against them)

Notes:
* Will need to backfill currently unsupported versions 
* ".../workload/workload...." while descriptive also sounds redundant, open to suggestions if folks don't like that prefix
* The non latest copy of the obj i.e. `gs://cockroach-edge-artifacts-prod/cockroach/workload.ee80eab77ca6434f4be7c33c0f6d29dd0b9d07b1` is still prefixed with `cockroach` so these objects will get deleted after 30 days with the current lifecycle policy

Edited `PutNonRelease`'s docstring to remove "redirect" terminology, looks to be from a previous s3 implementation which is not a feature of GCS.
* Note: I don't feel that strongly about the docstring, it just confused me a bit when reading the code and just wanted it to match what the function is actually doing 

Also noticed there's no unit test coverage for non master branches, added 1 release branch test with simple coverage

Also noticed there's a slight difference between mockGCSProvider.PutObject & release.PutObject
```
# obj latest key names on gs://cockroach-edge-artifacts-prod
gs://cockroach-edge-artifacts-prod/cockroach/workload.release-23.2

# obj latest key names in unit tests
gs://edge-binaries-bucket/workload/workload.release-25.4/no-cache
```
Actual `release.PutObject` does not modify the key name based on the `PutObjectInput.CacheControl` field, but in `mockGCSProvider.PutObject` the `"/no-cache"` gets appended
I changed the behavior in the mock to match the actual function, and modified the unit tests
FWIW `PutObjectInput.CacheControl` is only set to `False` currently
* It looks like this might be a hold over from the S3 implementation? I didn't read that diff but let me know if I should revert this change

This PR is a dependency for these roachtest changes: https://github.com/cockroachdb/cockroach/pull/155397
Also discussed other options like using a new bucket or using the release bucket here: https://cockroachlabs.slack.com/archives/C03SG8QKYRJ/p1760977289072049?thread_ts=1760976858.868889&cid=C03SG8QKYRJ 
Decided on this approach for simplicity 

For verification, I'm relying on the unit tests. Just assumed this wouldn't work on my local, but if there's a simple way to verify this E2E let me know and i'll do it 

Will squash and write a proper commit msg after review, leaving commit separate incase i need to revert anything

Release justification: ci test artifact only changes
