### PR TITLE
rttanalysis: deflake BenchmarkJobs

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/sql/catalog/descpb",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/bench/rttanalysis/jobs_test.go
+++ b/pkg/bench/rttanalysis/jobs_test.go
@@ -14,13 +14,27 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 func BenchmarkJobs(b *testing.B) { reg.Run(b) }
 func init() {
+	// Create a minimal table descriptor for the import job.
+	tableDesc := &descpb.TableDescriptor{
+		ID:            100,
+		ParentID:      1,
+		Name:          "benchmark_table",
+		FormatVersion: descpb.InterleavedFormatVersion,
+		Version:       1,
+	}
+
 	payloadBytes, err := protoutil.Marshal(&jobspb.Payload{
-		Details:       jobspb.WrapPayloadDetails(jobspb.ImportDetails{}),
+		Details: jobspb.WrapPayloadDetails(jobspb.ImportDetails{
+			Table: jobspb.ImportDetails_Table{
+				Desc: tableDesc,
+			},
+		}),
 		UsernameProto: username.RootUserName().EncodeProto(),
 	})
 	if err != nil {


### PR DESCRIPTION
The benchmark started failing since the code doesn't handle a nil table descriptor. The fix is to create a dummy descriptor in the job payload details.

fixes https://github.com/cockroachdb/cockroach/issues/151302
Release note: None