### PR TITLE
opt: avoid more types of bad generic query plans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -474,8 +474,9 @@ plan type: custom
 statement ok
 DEALLOCATE p
 
-# Regression test for #155159. Do not choose a generic query plan with unbounded
-# cardinality when the custom plans have bounded cardinality.
+# Regression test for #155159 and #156690. Do not choose a generic query plan
+# with reads that have unbounded cardinality when the reads in the custom plan
+# have bounded cardinality.
 statement ok
 CREATE TABLE t155159 (
   id INT PRIMARY KEY,
@@ -537,6 +538,87 @@ quality of service: regular
   table: t155159@t155159_a_b_idx
   spans: [/33/44 - /33]
   limit: 250
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS
+SELECT * FROM (
+  SELECT id FROM t155159 WHERE a = $1 AND b >= $2
+  ORDER BY b, id
+  LIMIT 250
+)
+UNION
+SELECT * FROM (
+  SELECT id FROM t155159 WHERE a = $3 AND b >= $4
+)
+
+statement ok
+EXECUTE p (33, 44, 55, 66)
+
+statement ok
+EXECUTE p (33, 44, 55, 66)
+
+statement ok
+EXECUTE p (33, 44, 55, 66)
+
+statement ok
+EXECUTE p (33, 44, 55, 66)
+
+statement ok
+EXECUTE p (33, 44, 55, 66)
+
+query T
+EXPLAIN ANALYZE EXECUTE p (33, 44, 55, 66);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• union
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ execution time: 0µs
+│ estimated max memory allocated: 0 B
+│
+├── • scan
+│     sql nodes: <hidden>
+│     kv nodes: <hidden>
+│     regions: <hidden>
+│     actual row count: 0
+│     KV time: 0µs
+│     KV rows decoded: 0
+│     KV bytes read: 0 B
+│     KV gRPC calls: 0
+│     estimated max memory allocated: 0 B
+│     missing stats
+│     table: t155159@t155159_a_b_idx
+│     spans: [/33/44 - /33]
+│     limit: 250
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t155159@t155159_a_b_idx
+      spans: [/55/66 - /55]
 
 statement ok
 DEALLOCATE p

--- a/pkg/sql/prep/statement.go
+++ b/pkg/sql/prep/statement.go
@@ -187,14 +187,14 @@ func (p *planCosts) NumCustom() int {
 // average cost of the custom plans.
 func (p *planCosts) IsGenericOptimal() bool {
 	// Check cost flags and full scan counts.
-	if gc := p.generic.FullScanCount(); gc > 0 ||
-		p.generic.HasUnboundedCardinality() ||
-		p.generic.Penalties != memo.NoPenalties {
+	genFullScans := p.generic.FullScanCount()
+	genUnboundedReads := p.generic.UnboundedReadCount()
+	if genFullScans > 0 || genUnboundedReads > 0 || p.generic.Penalties != memo.NoPenalties {
 		for i := 0; i < p.custom.length; i++ {
 			custom := &p.custom.costs[i]
 			if custom.Penalties < p.generic.Penalties ||
-				(p.generic.HasUnboundedCardinality() && !custom.HasUnboundedCardinality()) ||
-				gc > custom.FullScanCount() {
+				genFullScans > custom.FullScanCount() ||
+				genUnboundedReads > custom.UnboundedReadCount() {
 				return false
 			}
 		}
@@ -229,7 +229,7 @@ func (p *planCosts) avgCustom() memo.Cost {
 //
 // A full example:
 //
-//	custom costs: 1.5 [3]{1.25:U:0u 1.75:U:0u 1.50:U:0u}, generic cost: 4.56:U:0u
+//	custom costs: 1.5 [3]{1.25:U:0f0u 1.75:U:0f0u 1.50:U:0f0u}, generic cost: 4.56:U:0f0u
 func (p *planCosts) Summary() string {
 	var sb strings.Builder
 	sb.WriteString("custom costs: ")


### PR DESCRIPTION
This commit extends #155163. Instead of tracking an auxiliary boolean
value to indicate that a plan has one or more expressions with unbounded
cardinality, the `memo.Cost` struct now tracks the number of read
expressions (i.e., expressions that perform KV reads) that have
unbounded cardinality. This helps to avoid picking generic query plans
that will perform significantly worse than their related custom query
plans.

Fixes #156690

Release note: None
