### PR TITLE
rowenc: fix decoding for Canonical types

### DIFF
--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -117,6 +117,9 @@ func RandTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 	case types.BitFamily:
 		return types.MakeBit(int32(rng.Intn(50)))
 	case types.CollatedStringFamily:
+		if typ.Oid() == oidext.T_citext {
+			return types.CIText
+		}
 		return types.MakeCollatedString(types.String, *RandCollationLocale(rng))
 	case types.ArrayFamily:
 		if typ.ArrayContents().Family() == types.AnyFamily {

--- a/pkg/sql/rowenc/keyside/BUILD.bazel
+++ b/pkg/sql/rowenc/keyside/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/geo",
         "//pkg/geo/geopb",
+        "//pkg/sql/oidext",
         "//pkg/sql/pgrepl/lsn",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgrepl/lsn"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -130,6 +131,10 @@ func Decode(
 		}
 		if err != nil {
 			return nil, nil, err
+		}
+		if valType.Oid() == oidext.T_citext {
+			d, err := a.NewDCIText(r)
+			return d, rkey, err
 		}
 		d, err := a.NewDCollatedString(r, valType.Locale())
 		return d, rkey, err

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -65,6 +65,9 @@ func DecodeUntaggedDatum(
 		if err != nil {
 			return nil, b, err
 		}
+		if t.Oid() == oid.T_name {
+			return a.NewDName(tree.DString(data)), b, nil
+		}
 		return a.NewDString(tree.DString(data)), b, nil
 	case types.CollatedStringFamily:
 		b, data, err := encoding.DecodeUntaggedBytesValue(buf)


### PR DESCRIPTION
The definition of a Canonical type is the Canonical type is the type of the datum that a column decodes into. This was only partially true for the two canonical types that use the oid wrapper. The citext type was decoded by the value side decoder, but not the keyside decoder. The name type was decoded by the key side decoder, but not the value side decoder.

Release note: none
Epic: CRDB-48647