### PR TITLE
release-25.4: sql: skip flaky npgsql test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -662,6 +662,7 @@ var npgsqlBlocklist = blocklist{
 
 var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.ConnectionTests(Multiplexing).Fail_connect_then_succeed(True)`:                     "flaky",
+	`Npgsql.Tests.CopyTests(Multiplexing).Import_numeric`:                                            "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Import_string_array`:                                       "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Prepended_messages`:                                        "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).Failed_transaction_on_close_with_custom_timeout`: "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #156469 on behalf of @bghal.

----

The test was flaking.

Epic: none
Fixes: #156219

Release note: None


----

Release justification: