### PR TITLE
kv, sql: Accumulate CPU time from KV BatchResponses

### DIFF
--- a/pkg/cli/debug_send_kv_batch_test.go
+++ b/pkg/cli/debug_send_kv_batch_test.go
@@ -78,7 +78,8 @@ func TestSendKVBatch(t *testing.T) {
 		{
 			"header": {
 				"Timestamp": {},
-				"now": {}
+				"now": {},
+				"cpuTime": {}
 			},
 			"responses": [
 				{"put": {
@@ -112,9 +113,11 @@ func TestSendKVBatch(t *testing.T) {
 		require.NoError(t, err)
 
 		// Clean and check the BatchResponse output, by removing first line
-		// (contains input command) and emptying out all HLC timestamp objects.
+		// (contains input command), emptying out all HLC timestamp objects,
+		// and zeroing out the cpuTime value.
 		output = strings.SplitN(output, "\n", 2)[1]
 		output = regexp.MustCompile(`(?s)\{\s*"wallTime":.*?\}`).ReplaceAllString(output, "{}")
+		output = regexp.MustCompile(`"cpuTime"\s*:\s*("[^"]*"|\d+)`).ReplaceAllString(output, `"cpuTime": {}`)
 		require.JSONEq(t, jsonResponse, output)
 
 		// Check that a structured log event was emitted.

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -100,6 +100,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 			math.MaxInt64,
 			&acc,
 			nil, /* kvPairsRead */
+			nil, /* kvCPUTime */
 			lock.None,
 			lock.Unreplicated,
 			reverse,

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -70,6 +70,7 @@ func getStreamer(
 		limitBytes,
 		acc,
 		nil, /* kvPairsRead */
+		nil, /* kvCPUTime */
 		lock.None,
 		lock.Unreplicated,
 		reverse,
@@ -131,6 +132,7 @@ func TestStreamerLimitations(t *testing.T) {
 				math.MaxInt64, /* limitBytes */
 				nil,           /* acc */
 				nil,           /* kvPairsRead */
+				nil,           /* kvCpuTime */
 				lock.None,
 				lock.Unreplicated,
 				false, /* reverse */

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -754,6 +754,7 @@ func (h *BatchResponse_Header) combine(o BatchResponse_Header) error {
 	h.Now.Forward(o.Now)
 	h.RangeInfos = append(h.RangeInfos, o.RangeInfos...)
 	h.CollectedSpans = append(h.CollectedSpans, o.CollectedSpans...)
+	h.CPUTime += o.CPUTime
 	return nil
 }
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3207,6 +3207,10 @@ message BatchResponse {
     // The field is cleared by the DistSender because it refers routing
     // information not exposed by the KV API.
     repeated RangeInfo range_infos = 7 [(gogoproto.nullable) = false];
+    // CPUTime is tracked in Replica.Send, meaning it only tracks the CPU time
+    // for the request evaluation goroutine, and not the other replication related
+    // work. The value is either zero (unset) or positive.
+    int64 cpu_time = 8 [(gogoproto.customname) = "CPUTime"];
     // NB: if you add a field here, don't forget to update combine().
   }
   Header header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -705,7 +705,8 @@ func TestBatchResponseCombine(t *testing.T) {
 		)
 		brTxn := &BatchResponse{
 			BatchResponse_Header: BatchResponse_Header{
-				Txn: &txn,
+				Txn:     &txn,
+				CPUTime: 123,
 			},
 		}
 		if err := br.Combine(context.Background(), brTxn, nil, &BatchRequest{}); err != nil {
@@ -713,6 +714,9 @@ func TestBatchResponseCombine(t *testing.T) {
 		}
 		if br.Txn.Name != "test" {
 			t.Fatal("Combine() did not update the header")
+		}
+		if br.CPUTime != 123 {
+			t.Fatalf("Combine() did not accumulate CPUTime: expected 123, got %d", br.CPUTime)
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -206,6 +206,10 @@ func (r *Replica) SendWithWriteBytes(
 		}
 	}
 
+	cpuTime := grunning.Difference(startCPU, grunning.Time())
+	if br != nil {
+		br.CPUTime = int64(cpuTime)
+	}
 	if pErr == nil {
 		// Return range information if it was requested. Note that we don't return it
 		// on errors because the code doesn't currently support returning both a br
@@ -213,7 +217,7 @@ func (r *Replica) SendWithWriteBytes(
 		// ways of returning range info.
 		r.maybeAddRangeInfoToResponse(ctx, ba, br)
 		// Handle load-based splitting, if necessary.
-		r.recordBatchForLoadBasedSplitting(ctx, ba, br, int(grunning.Difference(startCPU, grunning.Time())))
+		r.recordBatchForLoadBasedSplitting(ctx, ba, br, int(cpuTime))
 	}
 
 	// Record summary throughput information about the batch request for

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -92,6 +92,9 @@ type KVReader interface {
 	// KV requests. It must be safe for concurrent use. It is used to calculate
 	// the SQL CPU time.
 	GetKVCPUTime() time.Duration
+	// GetKVResponseCPUTime returns the CPU time as reported by KV BatchResponses
+	// processed by the KVReader throughout its lifetime so far.
+	GetKVResponseCPUTime() int64
 	// UsedStreamer returns whether the Streamer API was used by the KVReader.
 	UsedStreamer() bool
 }

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -271,16 +271,17 @@ type cFetcher struct {
 	// stableKVs indicates whether the KVs returned by nextKVer are stable (i.e.
 	// are not invalidated) across NextKV() calls.
 	stableKVs bool
-	// bytesRead, kvPairsRead, and batchRequestsIssued store the total number of
-	// bytes read, key-values pairs read, and of BatchRequests issued,
-	// respectively, by this cFetcher throughout its lifetime in case when the
-	// underlying row.KVFetcher has already been closed and nil-ed out.
+	// bytesRead, kvPairsRead, kvCPUTime, and batchRequestsIssued store the total number of
+	// bytes read, key-values pairs read, CPU time reported by KV BatchResponses, and of
+	// BatchRequests issued, respectively, by this cFetcher throughout its lifetime in
+	// case when the underlying row.KVFetcher has already been closed and nil-ed out.
 	//
 	// The fields should not be accessed directly by the users of the cFetcher -
-	// getBytesRead(), getKVPairsRead(), and getBatchRequestsIssued() should be
+	// getBytesRead(), getKVPairsRead(), getKVCpuTime(), and getBatchRequestsIssued() should be
 	// used instead.
 	bytesRead           int64
 	kvPairsRead         int64
+	kvCPUTime           int64
 	batchRequestsIssued int64
 	// cpuStopWatch tracks the CPU time spent by this cFetcher while fulfilling KV
 	// requests *in the current goroutine*.
@@ -1484,6 +1485,15 @@ func (cf *cFetcher) getKVPairsRead() int64 {
 	return cf.kvPairsRead
 }
 
+// getKVCPUTime returns the CPU time as reported by KV BatchResponses processed
+// by the cFetcher throughout its lifetime so far.
+func (cf *cFetcher) getKVCPUTime() int64 {
+	if cf.fetcher != nil {
+		return cf.fetcher.GetKVCPUTime()
+	}
+	return cf.kvCPUTime
+}
+
 // getBatchRequestsIssued returns the number of BatchRequests issued by the
 // cFetcher throughout its lifetime so far.
 func (cf *cFetcher) getBatchRequestsIssued() int64 {
@@ -1522,6 +1532,7 @@ func (cf *cFetcher) Close(ctx context.Context) {
 		if cf.fetcher != nil {
 			cf.bytesRead = cf.fetcher.GetBytesRead()
 			cf.kvPairsRead = cf.fetcher.GetKVPairsRead()
+			cf.kvCPUTime = cf.fetcher.GetKVCPUTime()
 			cf.batchRequestsIssued = cf.fetcher.GetBatchRequestsIssued()
 			cf.fetcher.Close(ctx)
 			cf.fetcher = nil

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -127,6 +127,7 @@ func (s *ColBatchDirectScan) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.GetRowsRead()
+	meta.Metrics.KVCPUTime = s.GetKVResponseCPUTime()
 	meta.Metrics.StageID = s.stageID
 	trailingMeta = append(trailingMeta, *meta)
 	return trailingMeta
@@ -140,6 +141,11 @@ func (s *ColBatchDirectScan) GetBytesRead() int64 {
 // GetKVPairsRead is part of the colexecop.KVReader interface.
 func (s *ColBatchDirectScan) GetKVPairsRead() int64 {
 	return s.fetcher.GetKVPairsRead()
+}
+
+// GetKVResponseCPUTime is part of the colexecop.KVReader interface.
+func (s *ColBatchDirectScan) GetKVResponseCPUTime() int64 {
+	return s.fetcher.GetKVCPUTime()
 }
 
 // GetBatchRequestsIssued is part of the colexecop.KVReader interface.

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -257,6 +257,7 @@ func (s *ColBatchScan) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.GetRowsRead()
+	meta.Metrics.KVCPUTime = s.GetKVResponseCPUTime()
 	meta.Metrics.StageID = s.stageID
 	trailingMeta = append(trailingMeta, *meta)
 	return trailingMeta
@@ -274,6 +275,13 @@ func (s *ColBatchScan) GetKVPairsRead() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.cf.getKVPairsRead()
+}
+
+// GetKVResponseCPUTime is part of the colexecop.KVReader interface.
+func (s *ColBatchScan) GetKVResponseCPUTime() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cf.getKVCPUTime()
 }
 
 // GetBatchRequestsIssued is part of the colexecop.KVReader interface.

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -416,6 +416,7 @@ func (s *ColIndexJoin) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.GetRowsRead()
+	meta.Metrics.KVCPUTime = s.GetKVResponseCPUTime()
 	trailingMeta = append(trailingMeta, *meta)
 	if !s.flowCtx.Gateway {
 		if trace := tracing.SpanFromContext(s.Ctx).GetConfiguredRecording(); trace != nil {
@@ -437,6 +438,13 @@ func (s *ColIndexJoin) GetKVPairsRead() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.cf.getKVPairsRead()
+}
+
+// GetKVResponseCPUTime is part of the colexecop.KVReader interface.
+func (s *ColIndexJoin) GetKVResponseCPUTime() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cf.getKVCPUTime()
 }
 
 // GetRowsRead is part of the colexecop.KVReader interface.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3327,6 +3327,8 @@ type topLevelQueryStats struct {
 	// client receiving the PGWire protocol messages (as well as construcing
 	// those messages).
 	clientTime time.Duration
+	// kvCPUTime is the CPU time consumed by KV operations during query execution.
+	kvCPUTime time.Duration
 	// NB: when adding another field here, consider whether
 	// forwardInnerQueryStats method needs an adjustment.
 }
@@ -3339,6 +3341,7 @@ func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
 	s.indexRowsWritten += other.indexRowsWritten
 	s.networkEgressEstimate += other.networkEgressEstimate
 	s.clientTime += other.clientTime
+	s.kvCPUTime += other.kvCPUTime
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -264,6 +264,10 @@ func (d *deleteNode) returnsRowsAffected() bool {
 	return !d.run.rowsNeeded
 }
 
+func (d *deleteNode) kvCPUTime() int64 {
+	return d.run.td.kvCPUTime
+}
+
 func (d *deleteNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/delete_swap.go
+++ b/pkg/sql/delete_swap.go
@@ -143,6 +143,10 @@ func (d *deleteSwapNode) returnsRowsAffected() bool {
 	return !d.run.rowsNeeded
 }
 
+func (d *deleteSwapNode) kvCPUTime() int64 {
+	return d.run.td.kvCPUTime
+}
+
 func (d *deleteSwapNode) enableAutoCommit() {
 	d.run.td.enableAutoCommit()
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1625,6 +1625,7 @@ func forwardInnerQueryStats(f metadataForwarder, stats topLevelQueryStats) {
 	meta.Metrics.RowsWritten = stats.rowsWritten
 	meta.Metrics.IndexRowsWritten = stats.indexRowsWritten
 	meta.Metrics.IndexBytesWritten = stats.indexBytesWritten
+	meta.Metrics.KVCPUTime = int64(stats.kvCPUTime)
 	// stats.networkEgressEstimate and stats.clientTime are ignored since they
 	// only matter at the "true" top-level query (and actually should be zero
 	// here anyway).
@@ -1675,6 +1676,7 @@ func (r *DistSQLReceiver) pushMeta(meta *execinfrapb.ProducerMetadata) execinfra
 		r.stats.rowsWritten += meta.Metrics.RowsWritten
 		r.stats.indexRowsWritten += meta.Metrics.IndexRowsWritten
 		r.stats.indexBytesWritten += meta.Metrics.IndexBytesWritten
+		r.stats.kvCPUTime += time.Duration(meta.Metrics.KVCPUTime)
 
 		if sm, ok := r.scanStageEstimateMap[meta.Metrics.StageID]; ok {
 			sm.rowsRead += uint64(meta.Metrics.RowsRead)

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -1251,9 +1251,7 @@ func TestTopLevelQueryStats(t *testing.T) {
 	ctx := context.Background()
 	// testQuery will be updated throughout the test to the current target.
 	var testQuery atomic.Value
-	// The callback will send number of rows read and rows written (for each
-	// ProducerMetadata.Metrics object) on these channels, respectively.
-	rowsReadCh, rowsWrittenCh, indexRowsWrittenCh := make(chan int64), make(chan int64), make(chan int64)
+	rowsReadCh, rowsWrittenCh, indexRowsWrittenCh, kvCPUTimeCh := make(chan int64), make(chan int64), make(chan int64), make(chan int64)
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			SQLExecutor: &ExecutorTestingKnobs{
@@ -1266,6 +1264,7 @@ func TestTopLevelQueryStats(t *testing.T) {
 							rowsReadCh <- meta.Metrics.RowsRead
 							rowsWrittenCh <- meta.Metrics.RowsWritten
 							indexRowsWrittenCh <- meta.Metrics.IndexRowsWritten
+							kvCPUTimeCh <- meta.Metrics.KVCPUTime
 						}
 						return row, batch, meta
 					}
@@ -1381,7 +1380,7 @@ CREATE FUNCTION write(x INT) RETURNS INT AS 'INSERT INTO t VALUES (x, x); SELECT
 			}()
 			// In the main goroutine, loop until the query is completed while
 			// accumulating the top-level query stats.
-			var rowsRead, rowsWritten, indexRowsWritten int64
+			var rowsRead, rowsWritten, indexRowsWritten, kvCPUTime int64
 		LOOP:
 			for {
 				select {
@@ -1391,6 +1390,8 @@ CREATE FUNCTION write(x INT) RETURNS INT AS 'INSERT INTO t VALUES (x, x); SELECT
 					rowsWritten += written
 				case written := <-indexRowsWrittenCh:
 					indexRowsWritten += written
+				case cpuTime := <-kvCPUTimeCh:
+					kvCPUTime += cpuTime
 				case err := <-errCh:
 					require.NoError(t, err)
 					break LOOP
@@ -1399,6 +1400,9 @@ CREATE FUNCTION write(x INT) RETURNS INT AS 'INSERT INTO t VALUES (x, x); SELECT
 			require.Equal(t, tc.expRowsRead, rowsRead)
 			require.Equal(t, tc.expRowsWritten, rowsWritten)
 			require.Equal(t, tc.expIndexRowsWritten, indexRowsWritten)
+			if rowsWritten > 0 || rowsRead > 0 {
+				require.Positive(t, kvCPUTime, "KVCPUTime should be positive")
+			}
 		})
 	}
 }

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -355,7 +355,11 @@ message RemoteProducerMetadata {
     // we enumerate physical plan stages starting at 1, so the default value of
     // 0 isn't conflated with any actual plan stage.
     optional int32 stage_id = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "StageID"];
-    // NEXT ID: 7
+    // KVCPUTime is the total cpu time reported by KV BatchResponses. This is
+    // representative of the "synchronous" portion of work performed by KV.
+    // See the CPUTime field in the kvpb.BatchResponse_Header.
+    optional int64 kv_cpu_time = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVCPUTime"];
+    // NEXT ID: 8
   }
   oneof value {
     RangeInfos range_info = 1;

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -390,3 +390,7 @@ func (n *insertNode) indexBytesWritten() int64 {
 func (n *insertNode) returnsRowsAffected() bool {
 	return !n.run.rowsNeeded
 }
+
+func (n *insertNode) kvCPUTime() int64 {
+	return n.run.ti.kvCPUTime
+}

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -82,6 +82,11 @@ type insertFastPathRun struct {
 	// fkSpanMap is used to de-duplicate FK existence checks. Only used if there
 	// is more than one input row.
 	fkSpanMap map[string]struct{}
+
+	// kvCPUTime tracks the cumulative CPU time (in nanoseconds) that KV reported
+	// in BatchResponse headers for FK and uniqueness check batches. The KVCPUTime
+	// performed by the INSERT is tracked by the table inserter (insertRun.ti.kvCPUTime).
+	kvCPUTime int64
 }
 
 // insertFastPathFKUniqSpanInfo records information about each Request in the
@@ -314,6 +319,11 @@ func (n *insertFastPathNode) runUniqChecks(params runParams) error {
 		return err.GoError()
 	}
 
+	// Accumulate CPU time from the BatchResponse.
+	if br.CPUTime > 0 {
+		n.run.kvCPUTime += br.CPUTime
+	}
+
 	for i := range br.Responses {
 		resp := br.Responses[i].GetInner().(*kvpb.ScanResponse)
 		if len(resp.Rows) > 0 {
@@ -340,6 +350,11 @@ func (n *insertFastPathNode) runFKChecks(params runParams) error {
 	br, err := params.p.txn.Send(params.ctx, ba)
 	if err != nil {
 		return err.GoError()
+	}
+
+	// Accumulate CPU time from the BatchResponse.
+	if br.CPUTime > 0 {
+		n.run.kvCPUTime += br.CPUTime
 	}
 
 	for i := range br.Responses {
@@ -372,6 +387,11 @@ func (n *insertFastPathNode) runFKUniqChecks(params runParams) error {
 	br, err := params.p.txn.Send(params.ctx, ba)
 	if err != nil {
 		return err.GoError()
+	}
+
+	// Accumulate CPU time from the BatchResponse.
+	if br.CPUTime > 0 {
+		n.run.kvCPUTime += br.CPUTime
 	}
 
 	for i := range br.Responses {
@@ -550,6 +570,10 @@ func (n *insertFastPathNode) indexBytesWritten() int64 {
 
 func (n *insertFastPathNode) returnsRowsAffected() bool {
 	return !n.run.rowsNeeded
+}
+
+func (n *insertFastPathNode) kvCPUTime() int64 {
+	return n.run.ti.kvCPUTime + n.run.kvCPUTime
 }
 
 // See planner.autoCommit.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -164,6 +164,11 @@ type mutationPlanNode interface {
 	// returnsRowsAffected indicates that the planNode returns the number of
 	// rows affected by the mutation, rather than the rows themselves.
 	returnsRowsAffected() bool
+
+	// kvCPUTime returns the cumulative CPU time (in nanoseconds) that KV reported
+	// in BatchResponse headers during the execution of this mutation. It should
+	// only be called once Next returns false.
+	kvCPUTime() int64
 }
 
 // planNodeReadingOwnWrites can be implemented by planNodes which do

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -262,6 +262,7 @@ func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetad
 			metrics.RowsWritten = m.rowsWritten()
 			metrics.IndexRowsWritten = m.indexRowsWritten()
 			metrics.IndexBytesWritten = m.indexBytesWritten()
+			metrics.KVCPUTime = m.kvCPUTime()
 			meta = []execinfrapb.ProducerMetadata{{Metrics: metrics}}
 		}
 	}

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -60,6 +60,7 @@ func newTxnKVStreamer(
 	acc *mon.BoundAccount,
 	kvPairsRead *int64,
 	batchRequestsIssued *int64,
+	kvCPUTime *int64,
 	rawMVCCValues bool,
 	reverse bool,
 ) KVBatchFetcher {
@@ -71,7 +72,7 @@ func newTxnKVStreamer(
 		acc:            acc,
 		rawMVCCValues:  rawMVCCValues,
 	}
-	f.kvBatchMetrics.init(kvPairsRead, batchRequestsIssued)
+	f.kvBatchMetrics.init(kvPairsRead, batchRequestsIssued, kvCPUTime)
 	return f
 }
 

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -65,10 +65,11 @@ func newTxnKVFetcher(
 	alloc := new(struct {
 		batchRequestsIssued int64
 		kvPairsRead         int64
+		kvCPUTime           int64
 	})
 	var sendFn sendFunc
 	if bsHeader == nil {
-		sendFn = makeSendFunc(txn, ext, &alloc.batchRequestsIssued)
+		sendFn = makeSendFunc(txn, ext, &alloc.batchRequestsIssued, &alloc.kvCPUTime)
 	} else {
 		negotiated := false
 		sendFn = func(ctx context.Context, ba *kvpb.BatchRequest) (br *kvpb.BatchResponse, _ error) {
@@ -95,6 +96,9 @@ func newTxnKVFetcher(
 				return nil, pErr.GoError()
 			}
 			alloc.batchRequestsIssued++
+			if br.CPUTime > 0 {
+				alloc.kvCPUTime += br.CPUTime
+			}
 			return br, nil
 		}
 	}
@@ -112,6 +116,7 @@ func newTxnKVFetcher(
 		forceProductionKVBatchSize: forceProductionKVBatchSize,
 		kvPairsRead:                &alloc.kvPairsRead,
 		batchRequestsIssued:        &alloc.batchRequestsIssued,
+		kvCPUTime:                  &alloc.kvCPUTime,
 	}
 	fetcherArgs.admission.requestHeader = txn.AdmissionHeader()
 	fetcherArgs.admission.responseQ = txn.DB().SQLKVResponseAdmissionQ
@@ -206,7 +211,8 @@ func NewStreamingKVFetcher(
 ) *KVFetcher {
 	var kvPairsRead int64
 	var batchRequestsIssued int64
-	sendFn := makeSendFunc(txn, ext, &batchRequestsIssued)
+	var kvCPUTime int64
+	sendFn := makeSendFunc(txn, ext, &batchRequestsIssued, &kvCPUTime)
 	streamer := kvstreamer.NewStreamer(
 		distSender,
 		metrics,
@@ -219,6 +225,7 @@ func NewStreamingKVFetcher(
 		streamerBudgetLimit,
 		streamerBudgetAcc,
 		&kvPairsRead,
+		&kvCPUTime,
 		GetKeyLockingStrength(lockStrength),
 		GetKeyLockingDurability(lockDurability),
 		reverse,
@@ -238,7 +245,7 @@ func NewStreamingKVFetcher(
 	)
 	return newKVFetcher(newTxnKVStreamer(
 		streamer, lockStrength, lockDurability, kvFetcherMemAcc,
-		&kvPairsRead, &batchRequestsIssued, rawMVCCValues, reverse,
+		&kvPairsRead, &batchRequestsIssued, &kvCPUTime, rawMVCCValues, reverse,
 	))
 }
 
@@ -418,6 +425,11 @@ func (f *KVProvider) GetKVPairsRead() int64 {
 
 // GetBatchRequestsIssued implements the KVBatchFetcher interface.
 func (f *KVProvider) GetBatchRequestsIssued() int64 {
+	return 0
+}
+
+// GetKVCPUTime implements the KVBatchFetcher interface.
+func (f *KVProvider) GetKVCPUTime() int64 {
 	return 0
 }
 

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -810,6 +810,7 @@ func (ij *invertedJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = ij.fetcher.GetBytesRead()
 	meta.Metrics.RowsRead = ij.rowsRead
+	meta.Metrics.KVCPUTime = ij.fetcher.GetKVCPUTime()
 	if tfs := execinfra.GetLeafTxnFinalState(ij.Ctx(), ij.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1350,6 +1350,7 @@ func (jr *joinReader) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.RowsRead = jr.rowsRead
 	meta.Metrics.BytesRead = jr.fetcher.GetBytesRead()
+	meta.Metrics.KVCPUTime = jr.fetcher.GetKVCPUTime()
 	if tfs := execinfra.GetLeafTxnFinalState(jr.Ctx(), jr.txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -42,6 +42,7 @@ type rowFetcher interface {
 	) (ok bool, err error)
 
 	Reset()
+	GetKVCPUTime() int64
 	GetBytesRead() int64
 	GetKVPairsRead() int64
 	GetBatchRequestsIssued() int64

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -347,6 +347,7 @@ func (tr *tableReader) generateMeta() []execinfrapb.ProducerMetadata {
 	meta := execinfrapb.GetProducerMeta()
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = tr.fetcher.GetBytesRead()
+	meta.Metrics.KVCPUTime = tr.fetcher.GetKVCPUTime()
 	meta.Metrics.RowsRead = tr.rowsRead
 	meta.Metrics.StageID = tr.stageID
 	return append(trailingMeta, *meta)

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -892,6 +892,14 @@ func (z *zigzagJoiner) getKVPairsRead() int64 {
 	return kvPairsRead
 }
 
+func (z *zigzagJoiner) getKVCPUTime() int64 {
+	var kvCPUTime int64
+	for i := range z.infos {
+		kvCPUTime += z.infos[i].fetcher.GetKVCPUTime()
+	}
+	return kvCPUTime
+}
+
 func (z *zigzagJoiner) getRowsRead() int64 {
 	var rowsRead int64
 	for i := range z.infos {
@@ -914,6 +922,7 @@ func (z *zigzagJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = z.getBytesRead()
 	meta.Metrics.RowsRead = z.getRowsRead()
+	meta.Metrics.KVCPUTime = z.getKVCPUTime()
 	if tfs := execinfra.GetLeafTxnFinalState(z.Ctx(), z.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -309,6 +309,10 @@ func (u *updateNode) returnsRowsAffected() bool {
 	return !u.run.rowsNeeded
 }
 
+func (u *updateNode) kvCPUTime() int64 {
+	return u.run.tu.kvCPUTime
+}
+
 func (u *updateNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/update_swap.go
+++ b/pkg/sql/update_swap.go
@@ -142,6 +142,10 @@ func (u *updateSwapNode) returnsRowsAffected() bool {
 	return !u.run.rowsNeeded
 }
 
+func (u *updateSwapNode) kvCPUTime() int64 {
+	return u.run.tu.kvCPUTime
+}
+
 func (u *updateSwapNode) enableAutoCommit() {
 	u.run.tu.enableAutoCommit()
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -233,6 +233,10 @@ func (n *upsertNode) returnsRowsAffected() bool {
 	return !n.run.tw.rowsNeeded
 }
 
+func (n *upsertNode) kvCPUTime() int64 {
+	return n.run.tw.kvCPUTime
+}
+
 func (n *upsertNode) enableAutoCommit() {
 	n.run.tw.enableAutoCommit()
 }


### PR DESCRIPTION
This commit implements a solution to recording kv cpu time on
every query execution - similar to other fields recorded in topLevelQueryStats.

This is done by including a new cpuTime field in the BatchResponse Header
from KV. The cpuTime field tracks the time reported in Replica.Send which
is representative of the "synchronous" work done by KV for the request, i.e.
it does not include other async replication related work.

GetKVCpuTime is added to the KVBatchFetcher interface.
GetKVResponseCpuTime is added to the KVReader interface.
kvCpuTime is added to the mutationPlanNode interface.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-55080
Part of: https://cockroachlabs.atlassian.net/browse/CRDB-55922
Release note: None