### PR TITLE
logical: allow source sequences on unidirectional CREATE LOGICALLY REPLICATED

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2772,15 +2772,6 @@ func TestLogicalReplicationCreationChecks(t *testing.T) {
 	expectErr(t, "tab", "cannot create logical replication stream: table tab references functions with IDs [[0-9]+]")
 	replicationtestutils.WaitForAllProducerJobsToFail(t, dbB)
 
-	// Check if the table references a sequence.
-	dbA.Exec(t, "ALTER TABLE tab DROP COLUMN udf_col")
-	dbB.Exec(t, "ALTER TABLE tab DROP COLUMN udf_col")
-	dbA.Exec(t, "CREATE SEQUENCE my_seq")
-	dbA.Exec(t, "ALTER TABLE tab ADD COLUMN seq_col INT NOT NULL DEFAULT nextval('my_seq')")
-	dbB.Exec(t, "ALTER TABLE tab ADD COLUMN seq_col INT NOT NULL DEFAULT 1")
-	expectErr(t, "tab", "cannot create logical replication stream: table tab references sequences with IDs [[0-9]+]")
-	replicationtestutils.WaitForAllProducerJobsToFail(t, dbB)
-
 	// Check if table has a trigger.
 	dbA.Exec(t, "ALTER TABLE tab DROP COLUMN seq_col")
 	dbB.Exec(t, "ALTER TABLE tab DROP COLUMN seq_col")
@@ -3011,4 +3002,49 @@ func TestLogicalReplicationCapitalTableName(t *testing.T) {
 
 	reverseJobID := GetReverseJobID(ctx, t, dbA, jobID)
 	WaitUntilReplicatedTime(t, s.Clock().Now(), dbA, reverseJobID)
+}
+
+func TestCreateLogicallyReplicatedWithSourceSequences(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
+	defer server.Stopper().Stop(ctx)
+
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
+
+	dbA.Exec(t, "CREATE SEQUENCE test_seq")
+	dbA.Exec(t, "CREATE TABLE foo (x INT DEFAULT nextval('test_seq'))")
+	dbA.Exec(t, "INSERT INTO foo VALUES (DEFAULT), (DEFAULT), (DEFAULT)")
+
+	t.Run("unidirectional replication succeeds", func(t *testing.T) {
+		var jobID jobspb.JobID
+		dbB.QueryRow(
+			t,
+			"CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON $1 WITH UNIDIRECTIONAL",
+			dbAURL.String(),
+		).Scan(&jobID)
+		WaitUntilReplicatedTime(t, s.Clock().Now(), dbB, jobID)
+		dbB.CheckQueryResults(t, "SELECT * FROM foo", [][]string{
+			{"1"}, {"2"}, {"3"},
+		})
+		dbA.Exec(t, "INSERT INTO foo VALUES (DEFAULT), (DEFAULT), (DEFAULT)")
+		WaitUntilReplicatedTime(t, s.Clock().Now(), dbB, jobID)
+		dbB.CheckQueryResults(t, "SELECT * FROM foo", [][]string{
+			{"1"}, {"2"}, {"3"}, {"4"}, {"5"}, {"6"},
+		})
+	})
+
+	t.Run("bidirectional replication fails", func(t *testing.T) {
+		dbB.ExpectErr(
+			t,
+			"sequence references are not supported",
+			"CREATE LOGICALLY REPLICATED TABLE bar FROM TABLE foo ON $1 WITH BIDIRECTIONAL ON $2",
+			dbAURL.String(),
+			dbBURL.String(),
+		)
+	})
 }

--- a/pkg/sql/catalog/externalcatalog/external_catalog.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog.go
@@ -124,6 +124,7 @@ func IngestExternalCatalog(
 	schemaID descpb.ID,
 	setOffline bool,
 	ingestingUnqualifiedTableNames []string,
+	transform func(parent descpb.TableDescriptor, ingested *tabledesc.Mutable),
 ) (externalpb.ExternalCatalog, error) {
 
 	ingestedCatalog := externalpb.ExternalCatalog{}
@@ -157,6 +158,9 @@ func IngestExternalCatalog(
 		mutTable.ParentID = dbDesc.GetID()
 		mutTable.Version = 1
 		mutTable.ID = newID
+		if transform != nil {
+			transform(table, mutTable)
+		}
 		tablesToWrite = append(tablesToWrite, mutTable)
 		ingestedCatalog.Tables = append(ingestedCatalog.Tables, mutTable.TableDescriptor)
 	}

--- a/pkg/sql/catalog/externalcatalog/external_catalog_test.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog_test.go
@@ -110,7 +110,7 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 
 		var written externalpb.ExternalCatalog
 		require.NoError(t, sqltestutils.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-			written, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, ingestableCatalog, txn, col, defaultdbID, defaultdbpublicID, false, ingestedTableNames)
+			written, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, ingestableCatalog, txn, col, defaultdbID, defaultdbpublicID, false, ingestedTableNames, nil)
 			return err
 		}))
 		require.Equal(t, 2, len(written.Tables))
@@ -148,7 +148,7 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 		// an error.
 		require.ErrorContains(t,
 			sqltestutils.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				_, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, udtCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"data"})
+				_, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, udtCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"data"}, nil)
 				return err
 			}),
 			"cross database type references are not supported",
@@ -163,14 +163,14 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 		sadCatalog, err := extractCatalog("db1.sc1.tab3")
 		require.NoError(t, err)
 		require.ErrorContains(t, sqltestutils.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, sadCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"tab3"})
+			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, sadCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"tab3"}, nil)
 			return err
 		}), "invalid outbound foreign key")
 
 		anotherSadCatalog, err := extractCatalog("db1.sc1.tab2")
 		require.NoError(t, err)
 		require.ErrorContains(t, sqltestutils.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, anotherSadCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"tab2"})
+			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, anotherSadCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"tab2"}, nil)
 			return err
 		}), "invalid inbound foreign key")
 	})


### PR DESCRIPTION
This commit teaches LDR to support sequences on the source in a unidirectional LDR stream. While this is already supported for `CREATE LOGICAL REPLICATION` as the user can create a destination table that is not dependent on a sequence, it is not supported via `CREATAE LOGICALLY REPLICATED` as it attempts to duplicate the source-side descriptor. This patch updates LDR to remove sequence dependencies when ingesting the external catalog.

Fixes: #155521

Epic: `CREATE LOGICALLY REPLICATED` now supports source-side sequences in a unidirectional stream.