### PR TITLE
sql: step txn after restoring from a savepoint for exception handling

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -3409,3 +3409,42 @@ NOTICE: i: 4 j: 2
 NOTICE: outer_counter: 4 inner_counter: 8
 
 subtest end
+
+# Regression test for a failure to step the read sequence number after catching
+# an exception and restoring a savepoint (#156412).
+subtest regression_156412
+
+statement ok
+CREATE TABLE t122278 (pk INT PRIMARY KEY);
+
+statement ok
+CREATE FUNCTION f(n INT) RETURNS INT AS $$
+  BEGIN
+    BEGIN
+      IF n = 0 THEN
+        RETURN 1 // 0;
+      END IF;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RETURN (SELECT 100 + count(*) FROM t122278);
+    END;
+    RETURN 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RETURN (SELECT 200 + count(*) FROM t122278);
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t122278 values (1);
+
+statement ok
+SELECT f(0);
+
+statement ok
+COMMIT;
+
+subtest end

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1818,6 +1818,9 @@ func (txn *Txn) CreateSavepoint(ctx context.Context) (SavepointToken, error) {
 // and can be reused later (e.g. to release or roll back again).
 //
 // This method is only valid when called on RootTxns.
+//
+// NB: after calling RollbackToSavepoint, the transaction's read sequence number
+// must be stepped by calling Step() before any further requests are performed.
 func (txn *Txn) RollbackToSavepoint(ctx context.Context, s SavepointToken) error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()


### PR DESCRIPTION
PL/pgSQL routines use a savepoint to revert any modifications that happened within a block that has an exception handler. It was previously possible to trigger an assertion failure because `RollbackToSavepoint` can leave the read sequence number within the range of ignored sequence numbers. If the user-provided exception handling code contained non-volatile reads, we wouldn't step the read sequence number.

This commit fixes the bug by stepping the txn after restoring the savepoint during exception handling.

Fixes #156412

Release note (bug fix): Fixed a bug that could cause an internal error in some cases for PL/pgSQL routines that perform database reads within an exception block.