### PR TITLE
roachtest: lower max-rate in kv-rangefeed tests

### DIFF
--- a/pkg/cmd/roachtest/tests/kv_rangefeed.go
+++ b/pkg/cmd/roachtest/tests/kv_rangefeed.go
@@ -410,7 +410,7 @@ func registerKVRangefeed(r registry.Registry) {
 	testConfigs := []kvRangefeedTest{
 		// Adequately provisioned sink
 		{
-			writeMaxRate:              20000,
+			writeMaxRate:              10000,
 			duration:                  30 * time.Minute,
 			sinkProvisioning:          1.2,
 			splits:                    splits,
@@ -420,7 +420,7 @@ func registerKVRangefeed(r registry.Registry) {
 		},
 		// Underprovisioned sink
 		{
-			writeMaxRate:              20000,
+			writeMaxRate:              10000,
 			duration:                  30 * time.Minute,
 			sinkProvisioning:          0.8,
 			splits:                    splits,


### PR DESCRIPTION
During local testing this configuration looked stable, but 20k wps pushes the cluster CPU to 85+% and the cluster is not able to keep up even when a rangefeed isn't running. The changefeed then drives us right over the cliff in terms of CPU.

Here, we lower the write rate to keep the test more stable.

Fixes #156916
Fixes #156927

Release note: None