### PR TITLE
mmaprototype: introduce store status

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "rebalance_advisor.go",
         "store_load_summary.go",
         "store_set.go",
+        "store_status.go",
         "top_k_replicas.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype",

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -600,6 +600,7 @@ type pendingReplicaChange struct {
 // storeState maintains the complete state about a store as known to the
 // allocator.
 type storeState struct {
+	status Status
 	storeLoad
 	StoreAttributesAndLocality
 	adjusted struct {
@@ -1822,6 +1823,11 @@ func (cs *clusterState) setStore(sal StoreAttributesAndLocality) {
 	if !ok {
 		// This is the first time seeing this store.
 		ss := newStoreState()
+		// At this point, the store's health is unknown. It will need to be marked
+		// as healthy separately. Until we know more, we won't place leases or
+		// replicas on it (nor will we try to shed any that are already reported to
+		// have replicas on it).
+		ss.status = MakeStatus(HealthUnknown, LeaseDispositionRefusing, ReplicaDispositionRefusing)
 		ss.localityTiers = cs.localityTierInterner.intern(sal.locality())
 		ss.overloadStartTime = cs.ts.Now()
 		ss.overloadEndTime = cs.ts.Now()

--- a/pkg/kv/kvserver/allocator/mmaprototype/store_status.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/store_status.go
@@ -1,0 +1,256 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaprototype
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+type (
+	// Health represents whether the store "is around", i.e. able to participate
+	// in replication. What this means exactly is left to the outside world. MMA
+	// relies on the Disposition as much as possible without consulting the health
+	// status, aided by the invariant described on Status (only healthy nodes can
+	// have "green" dispositions). Its only (envisioned) use for explicit health
+	// tracking are sanity checks and preferring unhealthy candidates when picking
+	// sources (for example, when rebalancing, it may make sense to rebalance off
+	// an unhealthy or dead node over a healthy one as this actually improves
+	// availability).
+	Health             byte
+	LeaseDisposition   byte
+	ReplicaDisposition byte
+)
+
+const (
+	// HealthUnknown is the initial state for health. It's treated as an unhealthy
+	// state, distinguished from HealthUnhealthy to tailor logging and metrics.
+	HealthUnknown Health = iota
+	// HealthOK describes a store that has been determined to be alive and well.
+	HealthOK
+	// HealthUnhealthy describes a store that has recently become unhealthy, but
+	// which has not been unhealthy for "extended periods of time" and is expected
+	// to return (as determined by a higher layer)
+	HealthUnhealthy
+	// HealthDead describes a store that is unhealthy and has been in that state
+	// for what is considered a "long time" or which may not return.
+	HealthDead
+	healthCount // sentinel
+)
+
+const (
+	// LeaseDispositionOK denotes that the store is in principle willing to
+	// receive leases.
+	LeaseDispositionOK LeaseDisposition = iota
+	// LeaseDispositionRefusing denotes that the store should not be considered
+	// as a target for leases.
+	LeaseDispositionRefusing
+	// LeaseDispositionShedding denotes that the store should actively be
+	// considered for removal of leases.
+	LeaseDispositionShedding
+	leaseDispositionCount // sentinel
+)
+
+const (
+	// ReplicaDispositionRefusing denotes that the store can receive replicas.
+	ReplicaDispositionOK ReplicaDisposition = iota
+	// ReplicaDispositionRefusing denotes that the store should not be considered as
+	// a target for replica placement.
+	ReplicaDispositionRefusing
+	// ReplicaDispositionShedding denotes that the store should actively be
+	// considered for removal of replicas.
+	ReplicaDispositionShedding
+	replicaDispositionCount // sentinel
+)
+
+// Disposition represents the interest a store has in accepting or
+// shedding leases or replicas.
+type Disposition struct {
+	Lease   LeaseDisposition
+	Replica ReplicaDisposition
+}
+
+// Status represents the health and disposition of a store. It serves as a
+// translation layer between the "messy" outside world in which we may have
+// multiple possibly conflicting health signals, and various lifecycle states.
+// The Status is never derived internally in mma, but is always passed in and
+// kept up to date through the Allocator interface.
+//
+// The contained Health primarily plays a role when looking for (lease or
+// replicas) sources: all other things being equal, we want to be able to
+// identify suspect or dead stores as more beneficial sources for, say, a
+// replica removal. We also want to be able to tell when a range has lost quorum
+// so that we don't even try to make changes in that case. On the flip side, due
+// to the INVARIANT below, when looking for targets, health does not typically
+// need to be considered as we prohibit "non-healthy" stores from claiming to
+// accept replicas or leases.
+//
+// The wrapped Disposition is important when looking for both targets and
+// sources. In principle, stores can reject leases but accept replicas and vice
+// versa, though not all combinations may be used in practice (because they do
+// not all make sense).
+//
+// The multi-metric allocator is not currently responsible for establishing
+// constraint conformance or for shedding, so not all aspects discussed above
+// are necessarily used by it yet.
+//
+// INVARIANT: if Health != HealthOK, Disposition.{Lease,Replica} = Shedding.
+type Status struct {
+	Health      Health
+	Disposition Disposition
+}
+
+func MakeStatus(h Health, l LeaseDisposition, r ReplicaDisposition) Status {
+	s := Status{
+		Health:      h,
+		Disposition: Disposition{Lease: l, Replica: r},
+	}
+	s.assertOrPanic()
+	return s
+}
+
+func (ss *Status) assert() error {
+	// NB: byte values can't be negative, so we don't have to check.
+
+	if ss.Health >= healthCount {
+		return errors.AssertionFailedf("invalid health status %d", ss.Health)
+	}
+	d := ss.Disposition
+	if d.Lease >= leaseDispositionCount {
+		return errors.AssertionFailedf("invalid lease disposition %d", d.Lease)
+	}
+	if d.Replica >= replicaDispositionCount {
+		return errors.AssertionFailedf("invalid replica disposition %d", d.Replica)
+	}
+	if ss.Health != HealthOK && (ss.Disposition.Replica == ReplicaDispositionOK || ss.Disposition.Lease == LeaseDispositionOK) {
+		return errors.AssertionFailedf("non-healthy status must not accept leases or replicas: %+v", ss)
+	}
+	return nil
+}
+
+func (ss *Status) assertOrPanic() {
+	if err := ss.assert(); err != nil {
+		panic(err)
+	}
+}
+
+func (h Health) String() string {
+	return redact.StringWithoutMarkers(h)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (h Health) SafeFormat(w redact.SafePrinter, _ rune) {
+	switch h {
+	case HealthUnknown:
+		w.Print("unknown")
+	case HealthOK:
+		w.Print("ok")
+	case HealthUnhealthy:
+		w.Print("unhealthy")
+	case HealthDead:
+		w.Print("dead")
+	default:
+		w.Print("unknown")
+	}
+}
+
+func (l LeaseDisposition) String() string {
+	return redact.StringWithoutMarkers(l)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (l LeaseDisposition) SafeFormat(w redact.SafePrinter, _ rune) {
+	switch l {
+	case LeaseDispositionOK:
+		w.Print("ok")
+	case LeaseDispositionRefusing:
+		w.Print("refusing")
+	case LeaseDispositionShedding:
+		w.Print("shedding")
+	default:
+		w.Print("unknown")
+	}
+}
+
+func (r ReplicaDisposition) String() string {
+	return redact.StringWithoutMarkers(r)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (r ReplicaDisposition) SafeFormat(w redact.SafePrinter, _ rune) {
+	switch r {
+	case ReplicaDispositionOK:
+		w.Print("ok")
+	case ReplicaDispositionRefusing:
+		w.Print("refusing")
+	case ReplicaDispositionShedding:
+		w.Print("shedding")
+	default:
+		w.Print("unknown")
+	}
+}
+
+func (d Disposition) String() string {
+	return redact.StringWithoutMarkers(d)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (d Disposition) SafeFormat(w redact.SafePrinter, _ rune) {
+	if d.Lease == LeaseDispositionOK && d.Replica == ReplicaDispositionOK {
+		w.Print("accepting all")
+		return
+	}
+
+	var refusing []redact.SafeString
+	var shedding []redact.SafeString
+
+	if d.Lease == LeaseDispositionRefusing {
+		refusing = append(refusing, redact.SafeString("leases"))
+	} else if d.Lease == LeaseDispositionShedding {
+		shedding = append(shedding, redact.SafeString("leases"))
+	}
+
+	if d.Replica == ReplicaDispositionRefusing {
+		refusing = append(refusing, redact.SafeString("replicas"))
+	} else if d.Replica == ReplicaDispositionShedding {
+		shedding = append(shedding, redact.SafeString("replicas"))
+	}
+
+	first := true
+	if len(refusing) > 0 {
+		w.Print("refusing=")
+		for i, s := range refusing {
+			if i > 0 {
+				w.Print(",")
+			}
+			w.Print(s)
+		}
+		first = false
+	}
+	if len(shedding) > 0 {
+		if !first {
+			w.Print(" ")
+		}
+		w.Print("shedding=")
+		for i, s := range shedding {
+			if i > 0 {
+				w.Print(",")
+			}
+			w.Print(s)
+		}
+	}
+}
+
+func (ss Status) String() string {
+	return redact.StringWithoutMarkers(ss)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (ss Status) SafeFormat(w redact.SafePrinter, _ rune) {
+	ss.Health.SafeFormat(w, 's')
+	w.Print(" ")
+	ss.Disposition.SafeFormat(w, 's')
+}

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
@@ -36,9 +36,9 @@ store-id=1
 # The top-k uses CPURate.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3
-store-id=2 node-id=2 reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2
 
 
@@ -67,9 +67,9 @@ store-id=1
 # The top-2 ranges for store 2 are based on ByteSize.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3
-store-id=2 node-id=2 reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r1 r2
 
 # StoreLeaseholderMsg not containing r1 and r4 since no longer the leaseholder.
@@ -86,7 +86,7 @@ store-id=1
 # r1 and r4 no longer mentioned in the top-k.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2
-store-id=2 node-id=2 reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r2 r3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges
@@ -36,9 +36,9 @@ store-id=1
 # The top-k uses CPURate.
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2
 
 
@@ -67,9 +67,9 @@ store-id=1
 # The top-2 ranges for store 2 are based on ByteSize.
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r1 r2
 
 # StoreLeaseholderMsg not containing r1 and r4 since no longer the leaseholder.
@@ -86,7 +86,7 @@ store-id=1
 # r1 and r4 no longer mentioned in the top-k.
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r2 r3

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
@@ -13,10 +13,10 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
-store-leaseholder-msg 
+store-leaseholder-msg
 store-id=1
   range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
@@ -30,9 +30,9 @@ range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
@@ -52,9 +52,9 @@ range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # TODO: this test is confusing since it is sending StoreLeaseholderMsgs from
 # s1 and s2 to the same clusterState, but s1 and s2 are not on the same node.
@@ -66,9 +66,9 @@ store-id=2
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 get-pending-changes
@@ -94,9 +94,9 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 
@@ -110,7 +110,7 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
   top-k-ranges (local-store-id=2) dim=ByteSize: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica
@@ -13,8 +13,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 store-leaseholder-msg 
 store-id=1
@@ -30,9 +30,9 @@ range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
@@ -52,9 +52,9 @@ range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # TODO: this test is confusing since it is sending StoreLeaseholderMsgs from
 # s1 and s2 to the same clusterState, but s1 and s2 are not on the same node.
@@ -66,9 +66,9 @@ store-id=2
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 get-pending-changes
@@ -94,9 +94,9 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 
@@ -110,7 +110,7 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=2
   top-k-ranges (local-store-id=2) dim=ByteSize: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica
@@ -13,8 +13,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
 
 store-leaseholder-msg 
 store-id=1
@@ -25,9 +25,9 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 
 ranges
@@ -55,9 +55,9 @@ range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
 # applied.
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 
 store-leaseholder-msg
@@ -68,9 +68,9 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
 
 get-pending-changes
 ----
@@ -85,9 +85,9 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
 
 get-pending-changes
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica
@@ -13,8 +13,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
 
 store-leaseholder-msg 
 store-id=1
@@ -25,9 +25,9 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 
 ranges
@@ -55,9 +55,9 @@ range-id=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
 # applied.
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 
 store-leaseholder-msg
@@ -68,9 +68,9 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
 
 get-pending-changes
 ----
@@ -85,9 +85,9 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
 
 get-pending-changes
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status
@@ -1,0 +1,21 @@
+set-store
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=foo
+----
+node-id=1 locality-tiers=region=foo,node=1
+  store-id=1 attrs=purple locality-code=1:2:
+
+set-store-status store-id=1 health=unhealthy replicas=refusing leases=shedding
+----
+unhealthy refusing=replicas shedding=leases
+
+set-store-status store-id=1 health=unhealthy replicas=shedding leases=shedding
+----
+unhealthy shedding=leases,replicas
+
+get-load-info
+----
+store-id=1 node-id=1 status=unhealthy shedding=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+
+set-store-status store-id=1 health=ok
+----
+ok accepting all

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease
@@ -17,8 +17,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
 
 store-leaseholder-msg 
 store-id=1
@@ -29,9 +29,9 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
@@ -53,9 +53,9 @@ change-id=2 store-id=2 node-id=2 range-id=1 load-delta=[cpu:66, write-bandwidth:
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=20 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=20 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:86, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=86 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:86, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=86 seq=2
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
@@ -70,9 +70,9 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=3
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=3
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=3
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease
@@ -17,8 +17,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
 
 store-leaseholder-msg 
 store-id=1
@@ -29,9 +29,9 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
@@ -53,9 +53,9 @@ change-id=2 store-id=2 node-id=2 range-id=1 load-delta=[cpu:66, write-bandwidth:
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=20 seq=2
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=20 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:86, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=86 seq=2
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:86, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=86 seq=2
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
@@ -70,9 +70,9 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=3
+store-id=1 node-id=1 status=unknown, refusing=leases,replicas reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=3
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=3
+store-id=2 node-id=2 status=unknown, refusing=leases,replicas reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=3
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges


### PR DESCRIPTION
This introduces the `Status` struct and hooks it up to the `TestClusterState` test.
It doesn't yet attach any actual semantics to the new member of `storeStatus`
that is being added as part of doing so. This will happen in follow-up commits,
loosely replacing the integration points removed in #156933.

Touches #156776.

Epic: CRDB-55052