### PR TITLE
release-25.4: gossip: fix gossip.callbacks.pending_duration time metric

### DIFF
--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -272,7 +272,7 @@ func (is *infoStore) launchCallbackWorker(ambient log.AmbientContext, cw *callba
 				// metrics accordingly.
 				afterQueue := crtime.NowMono()
 				for _, work := range wq {
-					queueDur := work.schedulingTime.Sub(afterQueue)
+					queueDur := afterQueue.Sub(work.schedulingTime)
 					is.metrics.CallbacksPending.Dec(1)
 					if queueDur >= minCallbackDurationToRecord {
 						is.metrics.CallbacksPendingDuration.RecordValue(queueDur.Nanoseconds())


### PR DESCRIPTION
Backport 1/1 commits from #156939 on behalf of @stevendanna.

----

In 32723e5c I reversed this subtraction somehow.

Release note (bug fix): Fix bug that could result in incorrect gossip.callbacks.pending_duration metric value being recorded.

----

Release justification: Low risk observability bug fix