### PR TITLE
roachtest: task logger creation error handling

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/task/manager.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/manager.go
@@ -205,7 +205,8 @@ func (t *group) GoWithCancel(fn Func, opts ...Option) context.CancelFunc {
 	t.ctxGroup.Go(func() error {
 		l, err := opt.L(opt.Name)
 		if err != nil {
-			return err
+			t.manager.logger.Errorf("WARN: defaulting to root logger after failing to create logger for task %q: %v", opt.Name, err)
+			l = t.manager.logger
 		}
 		err = internalFunc(l)
 		event := Event{


### PR DESCRIPTION
Previously, if a task failed to create a logger internally during the call to create a goroutine, the error would only be returned if the task (or task group) was waited on with `WaitE`. This could lead to a race condition in tests, since it's expected that the function passed to the `task.Go` call is executed. And if something within the test is waiting on results from that goroutine, it could end up waiting indefinitely.

This change ensures the function passed to a `task.Go` call is always executed. The only way this could not happen currently was if an error occurred while trying to create a logger for the task. This has been updated to rather fall back to the root logger; and print an error to the root logger.

Informs: #156635
Epic: None