### PR TITLE
ui: add store disk write bytes to storage dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -466,5 +466,30 @@ export default function (props: GraphDashboardProps) {
         )}
       </Axis>
     </LineGraph>,
+
+    <LineGraph
+      title="Store Disk Write Bytes/s"
+      sources={storeSources}
+      isKvGraph={true}
+      tenantSource={tenantSource}
+      tooltip={
+        <div>
+          The number of bytes written to the store's disk per second{" "}
+          {tooltipSelection} (as reported by the OS).
+        </div>
+      }
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        {storeMetrics(
+          {
+            name: "cr.store.storage.disk.write.bytes",
+            nonNegativeRate: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
+      </Axis>
+    </LineGraph>,
   ];
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -491,5 +491,30 @@ export default function (props: GraphDashboardProps) {
         )}
       </Axis>
     </LineGraph>,
+
+    <LineGraph
+      title="Store Disk Read Bytes/s"
+      sources={storeSources}
+      isKvGraph={true}
+      tenantSource={tenantSource}
+      tooltip={
+        <div>
+          The number of bytes read from the store's disk per second{" "}
+          {tooltipSelection} (as reported by the OS).
+        </div>
+      }
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        {storeMetrics(
+          {
+            name: "cr.store.storage.disk.read.bytes",
+            nonNegativeRate: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
+      </Axis>
+    </LineGraph>,
   ];
 }


### PR DESCRIPTION
This patch adds a metric for store disk write bytes in the Storage dashboard.

Epic: none
Informs: https://github.com/cockroachlabs/support/issues/3470

Release note: None

<img width="720" height="308" alt="image" src="https://github.com/user-attachments/assets/94629b53-2dc7-4a42-8b68-85ddbd93d006" />
<img width="968" height="411" alt="image" src="https://github.com/user-attachments/assets/e7136191-8df7-4dcf-8150-815661395af1" />

<img width="968" height="407" alt="image" src="https://github.com/user-attachments/assets/3add06df-0f76-48c5-b467-aca2f9742869" />
<img width="975" height="414" alt="image" src="https://github.com/user-attachments/assets/0b6b5812-be09-4def-83e4-96ce57dd36de" />
