### PR TITLE
release-25.4: sql: fix a couple of spots where we missed JSONPATH and LTREE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -216,6 +216,17 @@ SELECT to_json((1, 2, 'hello', NULL, NULL))
 {"f1": 1, "f2": 2, "f3": "hello", "f4": null, "f5": null}
 
 query T
+SELECT to_json(('$'::JSONPATH, '$.foo'::JSONPATH))
+----
+{"f1": "$", "f2": "$.\"foo\""}
+
+skipif config local-mixed-25.2 local-mixed-25.3
+query T
+SELECT to_json(('foo'::LTREE, 'bar'::LTREE))
+----
+{"f1": "foo", "f2": "bar"}
+
+query T
 SELECT to_jsonb(123::INT)
 ----
 123
@@ -612,6 +623,17 @@ query T
 SELECT json_build_object('a'::tsvector, 1, 'b'::tsquery, 2)
 ----
 {"'a'": 1, "'b'": 2}
+
+query T
+SELECT json_build_object('$'::JSONPATH, 1)
+----
+{"$": 1}
+
+skipif config local-mixed-25.2 local-mixed-25.3
+query T
+SELECT json_build_object('foo'::LTREE, 2)
+----
+{"foo": 2}
 
 query T
 SELECT json_extract_path('{"a": 1}', 'a')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -12125,8 +12125,9 @@ func asJSONBuildObjectKey(
 		), nil
 	case *tree.DBitArray, *tree.DBool, *tree.DBox2D, *tree.DBytes, *tree.DDate,
 		*tree.DDecimal, *tree.DEnum, *tree.DFloat, *tree.DGeography,
-		*tree.DGeometry, *tree.DIPAddr, *tree.DInt, *tree.DInterval, *tree.DOid,
-		*tree.DOidWrapper, *tree.DPGLSN, *tree.DPGVector, *tree.DTime, *tree.DTimeTZ,
+		*tree.DGeometry, *tree.DIPAddr, *tree.DInt, *tree.DInterval,
+		*tree.DJsonpath, *tree.DLTree, *tree.DOid, *tree.DOidWrapper,
+		*tree.DPGLSN, *tree.DPGVector, *tree.DTime, *tree.DTimeTZ,
 		*tree.DTimestamp, *tree.DTSQuery, *tree.DTSVector, *tree.DUuid, *tree.DVoid:
 		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
 	default:

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3877,7 +3877,7 @@ func AsJSON(
 		// This is RFC3339Nano, but without the TZ fields.
 		return json.FromString(formatTime(t.UTC(), "2006-01-02T15:04:05.999999999")), nil
 	case *DDate, *DUuid, *DOid, *DInterval, *DBytes, *DIPAddr, *DTime, *DTimeTZ, *DBitArray, *DBox2D,
-		*DTSVector, *DTSQuery, *DPGLSN, *DPGVector, *DLTree:
+		*DTSVector, *DTSQuery, *DPGLSN, *DPGVector, *DJsonpath, *DLTree:
 		return json.FromString(
 			AsStringWithFlags(t, FmtBareStrings, FmtDataConversionConfig(dcc), FmtLocation(loc)),
 		), nil


### PR DESCRIPTION
Backport 1/1 commits from #156691 on behalf of @yuzefovich.

----

We forgot to include `DJsonpath` and `DLTree` into some of the type switches when converting datums into string format for miscellaneous builtins. This is now fixed. I decided to omit a release note given these seem like edge cases.

Fixes: #156511.
Fixes: #156611.
Release note: None

----

Release justification: bug fix.