### PR TITLE
build: fix behavior of FIPS build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,12 +8,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "2a7de93b6376cea6bce4a3a20ab8b105f69a0bf7e0e970178663f3899ac63d09",
-    strip_prefix = "cockroachdb-rules_go-d853058",
+    sha256 = "3796a31d6dceca5f71975a83223e27f8aeb10b5e10d7b69e8ed2c5abd26c5234",
+    strip_prefix = "cockroachdb-rules_go-fcadc30",
     urls = [
-        # cockroachdb/rules_go as of d85305874dd3c31dfda844bb2f987e8f3628b6eb
+        # cockroachdb/rules_go as of fcadc30972ee05bb1385eb80aa42146a3809bad7
         # (upstream release-0.57 plus a few patches).
-        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.54.0-55-gd853058.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.54.0-56-gfcadc30.tar.gz",
     ],
 )
 

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -1157,7 +1157,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/bmatcuk-doublestar-v4.0.1-0-gf7a8118.tar.gz": "d11c3b3a45574f89d6a6b2f50e53feea50df60407b35f36193bf5815d32c79d1",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-protobuf-3f5d91f.tar.gz": "6d4e7fe1cbd958dee69ce9becbf8892d567f082b6782d3973a118d0aa00807a8",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_foreign_cc-8d34d77.tar.gz": "03afebfc3f173666a3820a29512265c710c3a08d0082ba77469779d3e3af5a11",
-    "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.54.0-55-gd853058.tar.gz": "2a7de93b6376cea6bce4a3a20ab8b105f69a0bf7e0e970178663f3899ac63d09",
+    "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.54.0-56-gfcadc30.tar.gz": "3796a31d6dceca5f71975a83223e27f8aeb10b5e10d7b69e8ed2c5abd26c5234",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/google-starlark-go-e043a3d.tar.gz": "a35c6468e0e0921833a63290161ff903295eaaf5915200bbce272cbc8dfd1c1c",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/googleapis-83c3605afb5a39952bf0a0809875d41cf2a558ca.zip": "ba694861340e792fd31cb77274eacaf6e4ca8bda97707898f41d8bebfd8a4984",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/metrics-f37c7837771cf0df7771d2017fd05d55eb521994.tar.gz": "05f2a1c459ed247a031ce5f026b2098687657c8ab30214222261f2fe180ae2fc",


### PR DESCRIPTION
Prior to this change, the FIPS build did not have FIPS mode enabled by default. This PR addresses this via a change to `rules_go`. We still need to fix `rules_go` so that `GOFIPS140=v1.0.0` will work, but that requires more tweaking (see [discussion](https://github.com/bazel-contrib/rules_go/pull/4449#issuecomment-3494050872)).

Release note: none
Epic: DEVINF-1477