### PR TITLE
release-25.4: roachtest/npgsql: skip on s390x

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -173,7 +173,7 @@ echo '%s' | git apply --ignore-whitespace -`, fmt.Sprintf(npgsqlPatch, result.St
 		// .NET only supports AMD64 arch for 7.0.
 		Cluster:          r.MakeClusterSpec(1, spec.Arch(spec.OnlyAMD64)),
 		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.AllExceptAWS.NoIBM(),
 		Suites:           registry.Suites(registry.Nightly, registry.Driver),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNpgsql(ctx, t, c)


### PR DESCRIPTION
Backport 1/1 commits from #156954 on behalf of @fqazi.

----

Previously, the npgsql test was running on S390X, which doesn't have the required binaries. To address this, this patch excludes the IBM cloud.

Fixes: #156622

Release note: None

----

Release justification: test only change