### PR TITLE
roachtest: deflake cdc/ledger

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2574,7 +2574,7 @@ CONFIGURE ZONE USING
 			})
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
 				initialScanLatency: 10 * time.Minute,
-				steadyLatency:      time.Minute,
+				steadyLatency:      3 * time.Minute,
 			})
 			ct.waitForWorkload()
 		},

--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -116,7 +116,7 @@ func (lv *latencyVerifier) noteHighwater(highwaterTime time.Time) {
 		return
 	}
 
-	if lv.targetSteadyLatency == 0 || latency < lv.targetSteadyLatency/2 {
+	if lv.targetSteadyLatency == 0 || latency < lv.targetSteadyLatency {
 		lv.latencyBecameSteady = true
 	}
 	if !lv.latencyBecameSteady {


### PR DESCRIPTION
This patch deflakes `cdc/ledger` by increasing the target steady latency
from 1 minute to 3 minutes. It also eliminates a weird quirk where the
latency verifier expects the latency to be less than half of the target
latency before it'll be considered steady, which led to weird logs and
added unnecessary complexity.

Fixes #151381

Release note: None