### PR TITLE
sql: remove now-stale growstack for internal executor

### DIFF
--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -407,10 +407,6 @@ var (
 		// Use generic query plans since our queries are extremely simple and
 		// won't benefit from custom plans.
 		PlanCacheMode: &forceGenericPlan,
-		// We've observed in the CPU profiles that the default goroutine stack
-		// of the connExecutor goroutine is insufficient for evaluation of the
-		// ingestion queries, so we grow the stack right away to 32KiB.
-		GrowStackSize: true,
 		// We don't get any benefits from generating plan gists for internal
 		// queries, so we disable them.
 		DisablePlanGists:      true,

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -575,7 +575,6 @@ go_library(
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/fsm",
-        "//pkg/util/growstack",
         "//pkg/util/grpcutil",
         "//pkg/util/grunning",
         "//pkg/util/hlc",

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -79,9 +79,6 @@ type InternalExecutorOverride struct {
 	OriginTimestampForLogicalDataReplication hlc.Timestamp
 	// PlanCacheMode, if set, overrides the plan_cache_mode session variable.
 	PlanCacheMode *sessiondatapb.PlanCacheMode
-	// GrowStackSize, if true, indicates that the connExecutor goroutine stack
-	// should be grown to 32KiB right away.
-	GrowStackSize bool
 	// DisablePlanGists, if true, overrides the disable_plan_gists session var.
 	DisablePlanGists bool
 	// BufferedWritesEnabled, if set, controls whether the buffered writes KV transaction


### PR DESCRIPTION
As of 4a5c503e960d5a9fefb49e4373ef43e37245827c, we now grow stack unconditionally for all async tasks. Some time ago we added an ability to growstack in the async task of the internal executor when used in the LDR, and now that has become redundant, so we remove this special case.

Epic: None
Release note: None