### PR TITLE
roachtest: prefer root logger for mixed version backup test

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2145,7 +2145,10 @@ func (d *BackupRestoreTestDriver) runBackup(
 			backupErr <- err
 		}
 		return nil
-	}, task.Name(fmt.Sprintf("backup %s", collection.name)))
+	},
+		task.Logger(l),
+		task.Name(fmt.Sprintf("backup %s", collection.name)),
+	)
 
 	var numPauses int
 	for {


### PR DESCRIPTION
Previously, the task waiting for the backup job to succeed used the default task
logger which creates a log file based on the name of the task. The name of this
task exceeded the maximum file name limit, causing logger creation to fail.

This change updates the task to use the root logger instead of trying to log to a
separate file for the task. The logging output from this task is minimal and
doesn't need to log to a separate task log.

Fixes: #156635
Epic: None