### PR TITLE
kvserver: run bench without extra arguments

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -616,9 +616,11 @@ go_proto_library(
     proto = ":kvserver_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvpb",  # keep
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
+        "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )


### PR DESCRIPTION
Without these additions, users of `./dev bench` need to manually specify an explicit bazel target for the kvserver_test package. This always causes a few seconds (or minutes) of confusion because (1) most of us are used to not having to specify the test package and (2) its reasonable to first suspect your recent change when you hit some bazel error.

Informs #147833
Epic: None
Release note: none