### PR TITLE
sql/bulksst: coordinate distributed SST metadata merge with CombineFileInfo

### DIFF
--- a/pkg/sql/bulksst/BUILD.bazel
+++ b/pkg/sql/bulksst/BUILD.bazel
@@ -22,6 +22,7 @@ go_proto_library(
 go_library(
     name = "bulksst",
     srcs = [
+        "combine_file_info.go",
         "sst_file_allocator.go",
         "sst_writer.go",
     ],
@@ -35,11 +36,13 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/execinfrapb",
         "//pkg/storage",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//objstorage",
         "@com_github_cockroachdb_pebble//objstorage/objstorageprovider",
     ],
@@ -48,6 +51,7 @@ go_library(
 go_test(
     name = "bulksst_test",
     srcs = [
+        "combine_file_info_test.go",
         "main_test.go",
         "sst_file_allocator_test.go",
         "sst_writer_test.go",
@@ -64,6 +68,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/sql/execinfrapb",
         "//pkg/storage",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/bulksst/combine_file_info.go
+++ b/pkg/sql/bulksst/combine_file_info.go
@@ -1,0 +1,171 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulksst
+
+import (
+	"bytes"
+	"slices"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/errors"
+)
+
+// CombineFileInfo combines SST file metadata from multiple workers and
+// determines how to split merge work across processors.
+//
+// The function takes SST files and row samples collected earlier, and produces:
+//  1. A list of all SST files to be merged (consolidating metadata from all workers)
+//  2. Merge task spans that partition the work across merge processors
+//
+// The row samples represent keys seen during import/backfill and are used to
+// split schema spans into smaller merge tasks. Each merge processor will be
+// assigned one or more spans and will merge only the SST data within those
+// spans.
+//
+// For example, if schema spans are [a,z) and samples are [c, m, r], the merge
+// spans will be [a,c), [c,m), [m,r), [r,z), allowing four processors to work in
+// parallel on roughly equal amounts of data.
+func CombineFileInfo(
+	files []SSTFiles, schemaSpans []roachpb.Span,
+) ([]execinfrapb.BulkMergeSpec_SST, []roachpb.Span, error) {
+	// Validate that schema spans are properly ordered. This is a critical
+	// precondition for the algorithm to work correctly.
+	if err := validateSchemaSpansOrdered(schemaSpans); err != nil {
+		return nil, nil, err
+	}
+
+	result := make([]execinfrapb.BulkMergeSpec_SST, 0)
+	samples := make([]roachpb.Key, 0)
+	for _, file := range files {
+		for _, sst := range file.SST {
+			result = append(result, execinfrapb.BulkMergeSpec_SST{
+				StartKey: string(sst.StartKey),
+				EndKey:   string(sst.EndKey),
+				URI:      sst.URI,
+			})
+		}
+		for _, sample := range file.RowSamples {
+			samples = append(samples, roachpb.Key(sample))
+		}
+	}
+	// Sort samples to ensure merge spans are non-overlapping and contiguous.
+	// Samples are collected from multiple workers and arrive in arbitrary order.
+	// getMergeSpans uses these samples as split points to create merge task spans.
+	// If samples are unsorted (e.g., ["k", "d", "a"]), getMergeSpans would create
+	// overlapping spans that cause the same keys to be processed multiple times,
+	// resulting in duplicate data in the output SSTs.
+	slices.SortFunc(samples, func(i, j roachpb.Key) int {
+		return bytes.Compare(i, j)
+	})
+
+	mergeSpans, err := getMergeSpans(schemaSpans, samples)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result, mergeSpans, nil
+}
+
+// getMergeSpans determines which spans should be used as merge tasks. The
+// output spans must fully cover the input spans. The samples are used to
+// determine where schema spans should be split.
+//
+// Precondition: schemaSpans must be sorted by start key and non-overlapping.
+// This precondition is validated in validateSchemaSpansOrdered.
+func getMergeSpans(schemaSpans []roachpb.Span, sortedSample []roachpb.Key) ([]roachpb.Span, error) {
+	result := make([]roachpb.Span, 0, len(schemaSpans)+len(sortedSample))
+
+	for _, span := range schemaSpans {
+		samples, consumed := getCoveredSamples(span, sortedSample)
+
+		// Validate: if we consumed more samples than we returned, it means some
+		// samples were outside this span (either before it or in a gap). Since
+		// schema spans are processed in order, any sample before this span indicates
+		// a sample not covered by the schema spans.
+		if consumed > len(samples) {
+			// Find the first skipped sample for a clear error message
+			for i := 0; i < consumed; i++ {
+				if i >= len(samples) || !sortedSample[i].Equal(samples[i]) {
+					return nil, errors.AssertionFailedf(
+						"sample %q is before schema span [%q, %q); this indicates samples were collected for keys outside schema spans",
+						sortedSample[i], span.Key, span.EndKey)
+				}
+			}
+		}
+
+		sortedSample = sortedSample[consumed:]
+
+		startKey := span.Key
+		for _, sample := range samples {
+			// Skip samples that would create invalid (zero-length) spans.
+			// This handles duplicates and samples at span boundaries.
+			if bytes.Compare(sample, startKey) <= 0 {
+				continue
+			}
+			result = append(result, roachpb.Span{
+				Key:    startKey,
+				EndKey: sample,
+			})
+			startKey = sample
+		}
+		result = append(result, roachpb.Span{
+			Key:    startKey,
+			EndKey: span.EndKey,
+		})
+	}
+
+	// Validate that all samples were contained within schema spans. Any remaining
+	// samples indicate they were collected after the last span.
+	if len(sortedSample) > 0 {
+		return nil, errors.AssertionFailedf(
+			"samples outside schema spans: %d samples remain after processing all spans, first uncovered sample: %q",
+			len(sortedSample), sortedSample[0])
+	}
+
+	return result, nil
+}
+
+// getCoveredSamples returns the samples within the given span and the total
+// number of samples consumed (including any that were before the span start).
+func getCoveredSamples(schemaSpan roachpb.Span, sortedSamples []roachpb.Key) ([]roachpb.Key, int) {
+	// Count how many samples are before the span start.
+	// Since sortedSamples are sorted and schema spans are processed in order,
+	// samples before this span's start either:
+	// 1. Should have been covered by a previous span, or
+	// 2. Fall in a gap between spans.
+	startIdx := 0
+	for startIdx < len(sortedSamples) && bytes.Compare(sortedSamples[startIdx], schemaSpan.Key) < 0 {
+		startIdx++
+	}
+
+	// Find samples within this span: [schemaSpan.Key, schemaSpan.EndKey)
+	endIdx := startIdx
+	for endIdx < len(sortedSamples) && bytes.Compare(sortedSamples[endIdx], schemaSpan.EndKey) < 0 {
+		endIdx++
+	}
+
+	return sortedSamples[startIdx:endIdx], endIdx
+}
+
+// validateSchemaSpansOrdered checks that schema spans are sorted by start key
+// and non-overlapping. This is a precondition for getMergeSpans to work correctly.
+func validateSchemaSpansOrdered(schemaSpans []roachpb.Span) error {
+	for i := 1; i < len(schemaSpans); i++ {
+		if bytes.Compare(schemaSpans[i-1].Key, schemaSpans[i].Key) >= 0 {
+			return errors.AssertionFailedf(
+				"schema spans not ordered: span %d [%q, %q) >= span %d [%q, %q)",
+				i-1, schemaSpans[i-1].Key, schemaSpans[i-1].EndKey,
+				i, schemaSpans[i].Key, schemaSpans[i].EndKey)
+		}
+		if bytes.Compare(schemaSpans[i-1].EndKey, schemaSpans[i].Key) > 0 {
+			return errors.AssertionFailedf(
+				"schema spans overlapping: span %d ends at %q but span %d starts at %q",
+				i-1, schemaSpans[i-1].EndKey, i, schemaSpans[i].Key)
+		}
+	}
+	return nil
+}

--- a/pkg/sql/bulksst/combine_file_info_test.go
+++ b/pkg/sql/bulksst/combine_file_info_test.go
@@ -1,0 +1,366 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulksst
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCombineFileInfo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	span := func(key, end string) roachpb.Span {
+		return roachpb.Span{
+			Key:    []byte(key),
+			EndKey: []byte(end),
+		}
+	}
+
+	sst := func(uri, start, end string) *SSTFileInfo {
+		return &SSTFileInfo{
+			URI:      uri,
+			StartKey: roachpb.Key(start),
+			EndKey:   roachpb.Key(end),
+			FileSize: 1024,
+		}
+	}
+
+	tests := []struct {
+		name              string
+		files             []SSTFiles
+		schemaSpans       []roachpb.Span
+		expectedSSTs      []execinfrapb.BulkMergeSpec_SST
+		expectedMergeSpan []roachpb.Span
+	}{
+		{
+			name: "empty samples",
+			files: []SSTFiles{
+				{
+					SST:        []*SSTFileInfo{sst("file1.sst", "b", "d")},
+					RowSamples: []string{},
+					TotalSize:  1024,
+				},
+			},
+			schemaSpans: []roachpb.Span{span("a", "z")},
+			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
+				{URI: "file1.sst", StartKey: "b", EndKey: "d"},
+			},
+			expectedMergeSpan: []roachpb.Span{span("a", "z")},
+		},
+		{
+			name: "single schema span with samples",
+			files: []SSTFiles{
+				{
+					SST:        []*SSTFileInfo{sst("file1.sst", "a", "e")},
+					RowSamples: []string{"c", "f"},
+					TotalSize:  1024,
+				},
+				{
+					SST:        []*SSTFileInfo{sst("file2.sst", "e", "z")},
+					RowSamples: []string{"h"},
+					TotalSize:  1024,
+				},
+			},
+			schemaSpans: []roachpb.Span{span("a", "z")},
+			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
+				{URI: "file1.sst", StartKey: "a", EndKey: "e"},
+				{URI: "file2.sst", StartKey: "e", EndKey: "z"},
+			},
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "c"),
+				span("c", "f"),
+				span("f", "h"),
+				span("h", "z"),
+			},
+		},
+		{
+			name: "multiple schema spans",
+			files: []SSTFiles{
+				{
+					SST:        []*SSTFileInfo{sst("file1.sst", "a", "m")},
+					RowSamples: []string{"c", "f"},
+					TotalSize:  1024,
+				},
+				{
+					SST:        []*SSTFileInfo{sst("file2.sst", "m", "z")},
+					RowSamples: []string{"n", "r"},
+					TotalSize:  1024,
+				},
+			},
+			schemaSpans: []roachpb.Span{
+				span("a", "m"),
+				span("m", "z"),
+			},
+			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
+				{URI: "file1.sst", StartKey: "a", EndKey: "m"},
+				{URI: "file2.sst", StartKey: "m", EndKey: "z"},
+			},
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "c"),
+				span("c", "f"),
+				span("f", "m"),
+				span("m", "n"),
+				span("n", "r"),
+				span("r", "z"),
+			},
+		},
+		{
+			name: "unsorted samples across files",
+			files: []SSTFiles{
+				{
+					SST:        []*SSTFileInfo{sst("file1.sst", "a", "m")},
+					RowSamples: []string{"f", "c"}, // Unsorted
+					TotalSize:  1024,
+				},
+				{
+					SST:        []*SSTFileInfo{sst("file2.sst", "m", "z")},
+					RowSamples: []string{"r", "n"}, // Unsorted
+					TotalSize:  1024,
+				},
+			},
+			schemaSpans: []roachpb.Span{
+				span("a", "m"),
+				span("m", "z"),
+			},
+			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
+				{URI: "file1.sst", StartKey: "a", EndKey: "m"},
+				{URI: "file2.sst", StartKey: "m", EndKey: "z"},
+			},
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "c"),
+				span("c", "f"),
+				span("f", "m"),
+				span("m", "n"),
+				span("n", "r"),
+				span("r", "z"),
+			},
+		},
+		{
+			name: "multiple SSTs per file",
+			files: []SSTFiles{
+				{
+					SST: []*SSTFileInfo{
+						sst("file1a.sst", "a", "e"),
+						sst("file1b.sst", "e", "m"),
+					},
+					RowSamples: []string{"c", "g"},
+					TotalSize:  2048,
+				},
+			},
+			schemaSpans: []roachpb.Span{span("a", "z")},
+			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
+				{URI: "file1a.sst", StartKey: "a", EndKey: "e"},
+				{URI: "file1b.sst", StartKey: "e", EndKey: "m"},
+			},
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "c"),
+				span("c", "g"),
+				span("g", "z"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ssts, mergeSpans, err := CombineFileInfo(tc.files, tc.schemaSpans)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedSSTs, ssts)
+			// Validate all returned spans are valid (Key < EndKey)
+			for i, s := range mergeSpans {
+				require.True(t, s.Valid(), "span %d [%q, %q) is invalid: Key >= EndKey", i, s.Key, s.EndKey)
+			}
+			require.Equal(t, tc.expectedMergeSpan, mergeSpans)
+		})
+	}
+}
+
+// TestCombineFileInfo_Validation tests that samples outside schema spans are detected.
+func TestCombineFileInfo_Validation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	span := func(key, end string) roachpb.Span {
+		return roachpb.Span{
+			Key:    []byte(key),
+			EndKey: []byte(end),
+		}
+	}
+
+	files := func(samples ...string) []SSTFiles {
+		return []SSTFiles{
+			{
+				SST:        []*SSTFileInfo{},
+				RowSamples: samples,
+				TotalSize:  0,
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		files             []SSTFiles
+		schemaSpans       []roachpb.Span
+		expectError       bool
+		errorContains     []string
+		validateNonNilRes bool
+		expectedMergeSpan []roachpb.Span
+	}{
+		{
+			name:        "sample before first span",
+			files:       files("a", "c"),
+			schemaSpans: []roachpb.Span{span("b", "z")},
+			expectError: true,
+			errorContains: []string{
+				"is before schema span",
+				"\"a\"",
+			},
+		},
+		{
+			name:        "sample after last span",
+			files:       files("c", "z"),
+			schemaSpans: []roachpb.Span{span("a", "m")},
+			expectError: true,
+			errorContains: []string{
+				"samples outside schema spans",
+				"\"z\"",
+			},
+		},
+		{
+			name:  "sample in gap between spans",
+			files: files("c", "m", "r"),
+			schemaSpans: []roachpb.Span{
+				span("a", "f"),
+				span("p", "z"),
+			},
+			expectError: true,
+			errorContains: []string{
+				"is before schema span",
+				"\"m\"",
+			},
+		},
+		{
+			name:  "all samples within spans",
+			files: files("c", "m", "r"),
+			schemaSpans: []roachpb.Span{
+				span("a", "f"),
+				span("f", "z"),
+			},
+			expectError:       false,
+			validateNonNilRes: true,
+		},
+		{
+			name:  "samples at span boundaries",
+			files: files("m"),
+			schemaSpans: []roachpb.Span{
+				span("a", "m"),
+				span("m", "z"),
+			},
+			expectError:       false,
+			validateNonNilRes: true,
+		},
+		{
+			name:  "unordered spans",
+			files: files("c", "p"),
+			schemaSpans: []roachpb.Span{
+				span("m", "z"),
+				span("a", "m"), // Out of order!
+			},
+			expectError: true,
+			errorContains: []string{
+				"schema spans not ordered",
+			},
+		},
+		{
+			name:  "overlapping spans",
+			files: files("c", "p"),
+			schemaSpans: []roachpb.Span{
+				span("a", "m"),
+				span("k", "z"), // Overlaps with previous span
+			},
+			expectError: true,
+			errorContains: []string{
+				"schema spans overlapping",
+			},
+		},
+		{
+			name:        "duplicate samples",
+			files:       files("c", "c", "f"),
+			schemaSpans: []roachpb.Span{span("a", "z")},
+			expectError: false,
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "c"),
+				span("c", "f"),
+				span("f", "z"),
+			},
+		},
+		{
+			name:        "sample at schema span start",
+			files:       files("a", "f"),
+			schemaSpans: []roachpb.Span{span("a", "z")},
+			expectError: false,
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "f"),
+				span("f", "z"),
+			},
+		},
+		{
+			name:        "multiple consecutive identical samples",
+			files:       files("c", "c", "c", "f", "f"),
+			schemaSpans: []roachpb.Span{span("a", "z")},
+			expectError: false,
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "c"),
+				span("c", "f"),
+				span("f", "z"),
+			},
+		},
+		{
+			name:  "sample at boundary between spans",
+			files: files("m", "m", "p"),
+			schemaSpans: []roachpb.Span{
+				span("a", "m"),
+				span("m", "z"),
+			},
+			expectError: false,
+			expectedMergeSpan: []roachpb.Span{
+				span("a", "m"),
+				span("m", "p"),
+				span("p", "z"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, result, err := CombineFileInfo(tc.files, tc.schemaSpans)
+			if tc.expectError {
+				require.Error(t, err)
+				for _, contains := range tc.errorContains {
+					require.Contains(t, err.Error(), contains)
+				}
+			} else {
+				require.NoError(t, err)
+				if tc.validateNonNilRes {
+					require.NotNil(t, result)
+				}
+				// Validate all returned spans are valid (Key < EndKey)
+				for i, s := range result {
+					require.True(t, s.Valid(), "span %d [%q, %q) is invalid: Key >= EndKey", i, s.Key, s.EndKey)
+				}
+				if tc.expectedMergeSpan != nil {
+					require.Equal(t, tc.expectedMergeSpan, result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -583,3 +583,27 @@ message CompactBackupsSpec {
 	optional int64 max_files = 12 [(gogoproto.nullable) = false];
 	// NEXT ID: 13.
 }
+
+message BulkMergeSpec {
+	// SST represents metadata about a single SST file to be merged.
+	message SST {
+		optional string uri = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "URI"];
+		// start_key is the first key in the SST.
+		optional string start_key = 2 [(gogoproto.nullable) = false];
+		// end_key is the last key in the SST.
+		optional string end_key = 3 [(gogoproto.nullable) = false];
+	}
+
+	// ssts is the list of input SSTs to merge.
+	repeated SST ssts = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "SSTs"];
+
+	// spans are the key ranges that should be merged. Each merge processor
+	// will be assigned one or more spans to merge.
+	repeated roachpb.Span spans = 2 [(gogoproto.nullable) = false];
+
+	// output_uri is a URI prefix like 'nodelocal://1/<job_id>/merger'. The processor
+	// should use this as the base for all output files.
+	optional string output_uri = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "OutputURI"];
+
+	// NEXT ID: 4.
+}


### PR DESCRIPTION
Implements CombineFileInfo(), a coordinator utility that aggregates SST metadata from distributed workers and determines merge task spans based on sampled keys.

The function combines SST file metadata from multiple workers and uses their row samples to split schema spans into merge task spans. This will be used by the new distributed merge pipeline.

Resolves: #156662
Epic: CRDB-48845

Release note: none

Co-authored by: @jeffswenson