### PR TITLE
mmaprototype: explain why localities don't care about the keys

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -1922,6 +1922,14 @@ func (lti *localityTierInterner) unintern(lt localityTiers) roachpb.Locality {
 	return locality
 }
 
+// localityTiers encodes a locality value hierarchy, represented by codes
+// from an associated stringInterner.
+//
+// Note that CockroachDB operators must use matching *keys*[1] across all nodes
+// in each deployment, so we only need to deal with a slice of locality
+// *values*.
+//
+// [1]: https://www.cockroachlabs.com/docs/stable/cockroach-start#locality
 type localityTiers struct {
 	tiers []stringCode
 	// str is useful as a map key for caching computations.


### PR DESCRIPTION
It's because operators must use matching keys across the cluster, so only the values can be different.

For example, it's not allowed to have one node with `region=foo` and another with `fruit=banana`. It must be `region=foo`,`region=banana` and that point the key no longer plays a role since it always matches.

Epic: CRDB-55052