### PR TITLE
release-25.4: workloadccl/allccl: enable test tenants

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -60,7 +60,6 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
-        "//pkg/util",
         "//pkg/util/bufalloc",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
This is a cherry-pick of https://github.com/cockroachdb/cockroach/pull/156309, which we want to stop the timeout flakes seen in https://github.com/cockroachdb/cockroach/issues/155305, specifically the logic which skips the test under duress.

Epic: None
Fixes: #155305
Release note: None
Release Justification: unit test only change
