### PR TITLE
sql: don't store plan gist as FastValue in context

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -567,7 +567,6 @@ go_library(
         "//pkg/util/collatedstring",
         "//pkg/util/ctxgroup",
         "//pkg/util/ctxlog",
-        "//pkg/util/ctxutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/encoding/csv",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -76,7 +76,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxlog"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -4937,29 +4936,4 @@ func (ex *connExecutor) WithAnonymizedStatementAndGist(err error) error {
 		err = errors.WithSafeDetails(err, "plan gist: %s", ex.curStmtPlanGist)
 	}
 	return err
-}
-
-var contextPlanGistKey = ctxutil.RegisterFastValueKey()
-
-func withPlanGist(ctx context.Context, gist string) context.Context {
-	if gist == "" {
-		return ctx
-	}
-	return ctxutil.WithFastValue(ctx, contextPlanGistKey, gist)
-}
-
-func planGistFromCtx(ctx context.Context) string {
-	val := ctxutil.FastValue(ctx, contextPlanGistKey)
-	if val != nil {
-		return val.(string)
-	}
-	return ""
-}
-
-func init() {
-	// Register a function to include the plan gist in crash reports.
-	logcrash.RegisterTagFn("gist", func(ctx context.Context) string {
-		return planGistFromCtx(ctx)
-	})
-	tree.PlanGistFromCtx = planGistFromCtx
 }

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3278,7 +3278,6 @@ func (ex *connExecutor) makeExecPlan(
 	// Include gist in error reports.
 	ih := &planner.instrumentation
 	ex.curStmtPlanGist = redact.SafeString(ih.planGist.String())
-	ctx = withPlanGist(ctx, ih.planGist.String())
 	if buildutil.CrdbTestBuild && ih.planGist.String() != "" {
 		// Ensure that the gist can be decoded in test builds.
 		//

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5293,10 +5293,6 @@ func (d *DEnum) ResolvedType() *types.T {
 	return d.EnumTyp
 }
 
-// PlanGistFromCtx returns the plan gist if it is stored in the context. It is
-// injected from the sql package to avoid import cycle.
-var PlanGistFromCtx func(context.Context) string
-
 // Compare implements the Datum interface.
 func (d *DEnum) Compare(ctx context.Context, cmpCtx CompareContext, other Datum) (int, error) {
 	if other == DNull {
@@ -5314,16 +5310,10 @@ func (d *DEnum) Compare(ctx context.Context, cmpCtx CompareContext, other Datum)
 
 	// We should never be comparing two different versions of the same enum.
 	if v.EnumTyp.TypeMeta.Version != d.EnumTyp.TypeMeta.Version {
-		var gist redact.SafeString
-		if PlanGistFromCtx != nil {
-			// Plan gist, by construction, doesn't contain any PII, so it's a
-			// safe string.
-			gist = redact.SafeString(PlanGistFromCtx(ctx))
-		}
 		return 0, errors.AssertionFailedf(
-			"comparison of two different versions of enum %s oid %d: versions %d and %d, gist %q",
-			d.EnumTyp.SQLStringForError(), errors.Safe(d.EnumTyp.Oid()), d.EnumTyp.TypeMeta.Version,
-			v.EnumTyp.TypeMeta.Version, gist,
+			"comparison of two different versions of enum %s oid %d: versions %d and %d",
+			d.EnumTyp.SQLStringForError(), errors.Safe(d.EnumTyp.Oid()),
+			d.EnumTyp.TypeMeta.Version, v.EnumTyp.TypeMeta.Version,
 		)
 	}
 


### PR DESCRIPTION
Given that in 67e45fdb2dcebdccfcb8106835038d1559070062 we introduced a different way to include plan gists into sentry reports, I don't think we need to include the plan gists into the context anymore, so we can free up the FastValue context slot for a better use.

Epic: None
Release note: None