### PR TITLE
admission: compute cpu time token refill rates

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -6,11 +6,58 @@
 package admission
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
+
+// Below two are the non-burstable utilization goals. See resetInterval for
+// more.
+var KVCPUTimeAppUtilGoal = settings.RegisterFloatSetting(
+	settings.SystemOnly,
+	"admission.cpu_time_tokens.target_util.app_tenant",
+	"the target CPU utilization for app tenant work if using the KV CPU time "+
+		"token system, value is in the interval [0,1] where 1 means all cores",
+	0.8,
+	settings.FloatWithMinimum(0.2))
+
+var KVCPUTimeSystemUtilGoal = settings.RegisterFloatSetting(
+	settings.SystemOnly,
+	"admission.cpu_time_tokens.target_util.system_tenant",
+	"the target CPU utilization for system tenant work if using the KV CPU "+
+		"time token system, value is in the interval [0,1] where 1 means all cores",
+	0.95,
+	settings.FloatWithMinimum(0.2))
+
+// Burstable work is given this much CPU headroom above non-burstable. See
+// resetInterval for more.
+var KVCPUTimeUtilBurstDelta = settings.RegisterFloatSetting(
+	settings.SystemOnly,
+	"admission.cpu_time_tokens.target_util.burst_delta",
+	"the delta between non-burstable & burstable CPU utilization target if "+
+		"using the KV CPU time token system, this delta is the same for both system "+
+		"& app tenant work, and is expressed in the same units as "+
+		"admission.cpu_time_tokens.target_util.app_tenant & "+
+		"admission.cpu_time_tokens.target_util.system_tenant (value is in the "+
+		"interval [0,1] where 1 means all cores)",
+	// Why is the default value 0.05 (5%)? It tends to work out because in the
+	// worst case there is  5% remaining burst budget and then over time the 85%
+	// bucket fills itself to full. For example, say the rates were 80 tokens/s
+	// and 85 tokens/s respectively and the usage due to well-behaved tenants was
+	// 30 tokens/s. Both buckets would be full, containing 80 and 85 tokens
+	// respectively. If the noisy neighbor came and consumed all 80 tokens, the
+	// burst bucket still has 5 tokens. From now on, if the noisy neighbor continues
+	// to be present, it will fair share with the others and the actual steady
+	// state consumption will continue to be 80 tokens/s (across all tenants, since
+	// the others are still consuming 30 tokens/s and the noisy neighbor can only
+	// consume the remaining 50 tokens/s). Which will keep the smaller bucket at 0
+	// tokens, and the other bucket will slowly use the excess tokens to fill up
+	// to its full size of 85 tokens.
+	0.05)
 
 // timePerTick is how frequently cpuTimeTokenFiller ticks its time.Ticker & adds
 // tokens to the buckets. Must be < 1s. Must divide 1s evenly.
@@ -19,7 +66,7 @@ const timePerTick = 1 * time.Millisecond
 // cpuTimeTokenFiller starts a goroutine which periodically calls
 // cpuTimeTokenAllocator to add tokens to a cpuTimeTokenGranter. For example, on
 // an 8 vCPU machine, we may want to allow burstable tier-0 work to use 6 seconds
-// of CPU time per second. Then cpuTimeTokenAllocator.rates[tier0][canBurst] would
+// of CPU time per second. Then the refill rates for tier0 burstable work would
 // equal 6 seconds per second, and cpuTimeTokenFiller would add 6 seconds of token
 // every second, but smoothly -- 1ms at a time. See cpuTimeTokenGranter for details
 // on the multi-dimensional token buckets owned by cpuTimeTokenGranter; the TLDR is
@@ -48,20 +95,18 @@ const timePerTick = 1 * time.Millisecond
 //   - once interval is complete, all remaining tokens needed for that interval
 //     are added (e.g. see t.allocateTokens(1) below), then a new interval starts
 type cpuTimeTokenFiller struct {
-	allocator  tokenAllocator
+	allocator  cpuTimeTokenAllocatorI
 	timeSource timeutil.TimeSource
 	closeCh    chan struct{}
 	// Used only in unit tests.
 	tickCh *chan struct{}
 }
 
-// tokenAllocator abstracts cpuTimeTokenAllocator for testing.
-type tokenAllocator interface {
-	allocateTokens(remainingTicksInInInterval int64)
-	resetInterval()
-}
-
 func (f *cpuTimeTokenFiller) start() {
+	// The token buckets should start full. The first call to resetInterval will
+	// fill the buckets.
+	f.allocator.resetInterval()
+
 	ticker := f.timeSource.NewTicker(timePerTick)
 	intervalStart := f.timeSource.Now()
 	// Every 1s a new interval starts. every timePerTick time token allocation
@@ -69,18 +114,32 @@ func (f *cpuTimeTokenFiller) start() {
 	// the allocator. The expected number of ticks left can jump around, if
 	// time.Timer ticks are delayed or dropped.
 	go func() {
-		lastRemainingTicks := int64(0)
+		// We start with the assumption that a full interval worth of ticks are
+		// remaining. Thus, in the unlikely case where a full 1s passes before
+		// the first tick, the below allocateTokens(1) invariant is still
+		// respected.
+		lastRemainingTicks := int64(time.Second / timePerTick)
 		for {
 			select {
 			case t := <-ticker.Ch():
 				var remainingTicks int64
 				elapsedSinceIntervalStart := t.Sub(intervalStart)
 				if elapsedSinceIntervalStart >= time.Second {
-					// INVARIANT: During each interval, allocateTokens(1) must be called, before
-					// resetInterval() can be called.
+					// INVARIANT: During each interval, allocateTokens(1) must be
+					// called, before resetInterval() can be called. Without this
+					// invariant, cpuTimeTokenAllocator.refillRates tokens would not
+					// be allocated every 1s.
 					//
-					// Without this invariant, cpuTimeTokenAllocator.rates tokens would not be
-					// allocated every 1s.
+					// The below conditional ensures the rate provisioned since the
+					// last tick was fully emitted, which may not be the case if ticks
+					// arrived late. Ideally, this already happened in the else branch
+					// during the previous tick which typically would have occurred at
+					// millisecond 999 and then would compute remainingTicks <= 1 and
+					// would have called allocateTokens(1) (i.e. "emit everything that's
+					// left for this second"). But if the previous tick was not the
+					// designated "last" tick yet (say it occurred at 900ms), and a delay
+					// had occurred before our tick arrived, we need to call
+					// allocateTokens(1) here to release the quota held back by the delay.
 					if lastRemainingTicks > 1 {
 						f.allocator.allocateTokens(1)
 					}
@@ -89,12 +148,12 @@ func (f *cpuTimeTokenFiller) start() {
 					remainingTicks = int64(time.Second / timePerTick)
 				} else {
 					remainingSinceIntervalStart := time.Second - elapsedSinceIntervalStart
-					if remainingSinceIntervalStart < 0 {
-						panic(errors.AssertionFailedf("remainingSinceIntervalStart is negative %d", remainingSinceIntervalStart))
+					if remainingSinceIntervalStart <= 0 {
+						panic(errors.AssertionFailedf("remainingSinceIntervalStart %d is <= 0", remainingSinceIntervalStart))
 					}
 					// ceil(a / b) == (a + b - 1) / b, when using integer division.
-					// Round up so that we don't accumulate tokens to give in a burst on the
-					// last tick.
+					// Round up so that we don't accumulate tokens to give in a burst on
+					// the last tick.
 					remainingTicks =
 						int64((remainingSinceIntervalStart + timePerTick - 1) / timePerTick)
 				}
@@ -111,33 +170,55 @@ func (f *cpuTimeTokenFiller) start() {
 	}()
 }
 
-// cpuTimeTokenAllocator allocates tokens to a cpuTimeTokenGranter. See the comment
-// above cpuTimeTokenFiller for a high level picture. The responsibility of
-// cpuTimeTokenAllocator is to gradually allocate rates tokens every interval,
-// while respecting bucketCapacity. We have split up the ticking & token allocation
-// logic, in order to improve clarity & testability.
-type cpuTimeTokenAllocator struct {
-	granter *cpuTimeTokenGranter
-
-	// Mutable fields. No mutex, since only a single goroutine will call the
-	// cpuTimeTokenAllocator.
-
-	// rates stores the number of token added to each bucket every interval.
-	rates [numResourceTiers][numBurstQualifications]int64
-	// bucketCapacity stores the maximum number of tokens that can be in each bucket.
-	// That is, if a bucket is already at capacity, no more tokens will be added.
-	bucketCapacity [numResourceTiers][numBurstQualifications]int64
-	// allocated stores the number of tokens added to each bucket in the current
-	// interval.
-	allocated [numResourceTiers][numBurstQualifications]int64
+// cpuTimeTokenAllocatorI abstracts cpuTimeTokenAllocator for testing.
+type cpuTimeTokenAllocatorI interface {
+	allocateTokens(expectedRemainingTicksInInterval int64)
+	resetInterval()
 }
 
-var _ tokenAllocator = &cpuTimeTokenAllocator{}
+var _ cpuTimeTokenAllocatorI = &cpuTimeTokenAllocator{}
+
+// cpuTimeTokenAllocator allocates tokens to a cpuTimeTokenGranter. See the
+// comment above cpuTimeTokenFiller for a high level picture. The
+// responsibility of cpuTimeTokenAllocator is to gradually allocate tokens
+// every interval, while respecting the bucket capacities. The computation
+// of the rate of tokens to add every interval is left to cpuTimeModel.
+type cpuTimeTokenAllocator struct {
+	granter  *cpuTimeTokenGranter
+	settings *cluster.Settings
+	model    cpuTimeModel
+
+	// refillRates stores the number of CPU time tokens to add to each bucket
+	// per interval (1s).
+	refillRates rates
+	// allocated stores the number of tokens added to each bucket in the current
+	// cpuTimeTokenAllocator. No mutex, since only a single goroutine will call
+	// the allocator.
+	allocated tokenCounts
+}
+
+// rates stores a token count per second, for example, the refill
+// rates at which we add tokens per second, one per bucket in
+// cpuTimeTokenGranter.
+type rates [numResourceTiers][numBurstQualifications]int64
+
+// capacities stores the maximum number of tokens that can be in the
+// buckets, one per bucket in cpuTimeTokenGranter.
+type capacities [numResourceTiers][numBurstQualifications]int64
+
+// tokenCounts stores unit-less token counts, one per bucket in
+// cpuTimeTokenGranter.
+type tokenCounts [numResourceTiers][numBurstQualifications]int64
+
+// targetUtilizations stores a target CPU utilization, as a float64 (so
+// 0.8 for 80% CPU utilization), one per bucket in CPUTimeTokenGranter. This
+// is aggregate CPU usage, so 0.8 means 80% of CPU time across all cores.
+type targetUtilizations [numResourceTiers][numBurstQualifications]float64
 
 // allocateTokens allocates tokens to a cpuTimeTokenGranter. allocateTokens
-// adds rates tokens every interval, while respecting bucketCapacity.
-// allocateTokens adds tokens evenly among the expected remaining ticks in
-// the interval.
+// adds the desired number of tokens every interval, while respecting the bucket
+// capacities. allocateTokens adds tokens evenly among the expected remaining
+// ticks in the interval.
 // INVARIANT: remainingTicks >= 1.
 // TODO(josh): Expand to cover tenant-specific token buckets too.
 func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval int64) {
@@ -156,24 +237,343 @@ func (a *cpuTimeTokenAllocator) allocateTokens(expectedRemainingTicksInInterval 
 		return toAllocate
 	}
 
-	var delta [numResourceTiers][numBurstQualifications]int64
-	for wc := range a.rates {
-		for kind := range a.rates[wc] {
-			toAllocateTokens := allocateFunc(
-				a.rates[wc][kind], a.allocated[wc][kind], expectedRemainingTicksInInterval)
-			a.allocated[wc][kind] += toAllocateTokens
-			delta[wc][kind] = toAllocateTokens
+	// a.refillRates must be added every 1s, but allocateTokens is called more than once
+	// every 1s (typically). The amount we need to allocate this call to allocateTokens
+	// is stored in allocations.
+	var allocations tokenCounts
+	for wc := range a.refillRates {
+		for kind := range a.refillRates[wc] {
+			toAllocate := allocateFunc(
+				a.refillRates[wc][kind], a.allocated[wc][kind], expectedRemainingTicksInInterval)
+			a.allocated[wc][kind] += toAllocate
+			allocations[wc][kind] = toAllocate
 		}
 	}
-	a.granter.refill(delta, a.bucketCapacity)
+	// Each bucket has a max capacity. The max capacity for each bucket is
+	// one second worth of tokens at the current refill rate. This is a fairly
+	// arbitrary decision.
+	bucketCapacities := capacities(a.refillRates)
+	a.granter.refill(allocations, bucketCapacities)
 }
 
-// resetInterval is called to signal the beginning of a new interval. allocateTokens
-// adds rates tokens every interval.
+// resetInterval is called to signal the beginning of a new interval.
+// allocateTokens adds the desired number of tokens every interval.
 func (a *cpuTimeTokenAllocator) resetInterval() {
+	// Compute target utilizations from cluster settings. The noBurst targets are
+	// configurable by cluster settings. A canBurst target adds a delta to the
+	// corresponding noBurst target, and the delta is also configurable by a
+	// cluster setting. The code here is not general with respect to
+	// numResourceTiers & numBurstQualifications. This isn't necessary for the
+	// Serverless use case on which we will first introduce CPU time token AC.
+	var targets targetUtilizations
+	if numResourceTiers != 2 || numBurstQualifications != 2 {
+		panic(fmt.Sprintf(
+			"resetInterval requires that numResourceTiers = 2 and numBurstQualifications = 2 but got %d, %d", numResourceTiers, numBurstQualifications))
+	}
+	burstDelta := KVCPUTimeUtilBurstDelta.Get(&a.settings.SV)
+	appTarget := KVCPUTimeAppUtilGoal.Get(&a.settings.SV)
+	targets[appTenant][noBurst] = appTarget
+	targets[appTenant][canBurst] = appTarget + burstDelta
+	systemTarget := KVCPUTimeSystemUtilGoal.Get(&a.settings.SV)
+	targets[systemTenant][noBurst] = systemTarget
+	targets[systemTenant][canBurst] = systemTarget + burstDelta
+
+	newRefillRates := a.model.fit(targets)
+
+	// deltaRefillRates is the difference in tokens to add per interval (1s)
+	// from the previous call to fit to this one. We add it immediately to the
+	// bucket, which could mean adding tokens, or removing them, depending on
+	// what change has been made to refillRates. The idea here is this: The model
+	// itself handles smoothing; once a decision has been made by the model, the
+	// allocator should immediately execute on the decision.
+	// TODO(josh): This is missing logic to prevent token counts from becoming
+	// negative. Also, the above comment needs to be beefed up.
+	// https://github.com/cockroachdb/cockroach/issues/158539
+	var deltaRefillRates tokenCounts
+	for tier := range newRefillRates {
+		for qual := range newRefillRates[tier] {
+			deltaRefillRates[tier][qual] = newRefillRates[tier][qual] - a.refillRates[tier][qual]
+		}
+	}
+	// See comment above the call to refill in allocateTokens for a discussion of
+	// bucketCapacities.
+	bucketCapacities := capacities(newRefillRates)
+	a.granter.refill(deltaRefillRates, bucketCapacities)
+	a.refillRates = newRefillRates
+
+	// Reset allocated.
 	for wc := range a.allocated {
 		for kind := range a.allocated[wc] {
 			a.allocated[wc][kind] = 0
 		}
 	}
+}
+
+// cpuTimeModel abstracts cpuTimeLinearModel for testing.
+type cpuTimeModel interface {
+	fit(targetUtilizations) rates
+}
+
+var _ cpuTimeModel = &cpuTimeTokenLinearModel{}
+
+// cpuTimeTokenLinearModel computes the number of CPU time tokens to add
+// to each bucket in the cpuTimeTokenGranter, per interval (per 1s).
+//
+// The refill rate is chosen such that the rate at which tokens are added
+// results in an (actual measured) CPU utilization matching the target
+// utilization. Tokens represent CPU work carried out by requests which acquired
+// from the bucket, and the actual CPU time used by the requests is consumed
+// from the bucket. However, requests can use additional CPU time that isn't
+// reflected in what's consumed - for example, the CPU work incurred by heap
+// allocations, which need to be garbage collected by the runtime at a
+// near-future point in time, or more generally any other asynchronous work
+// triggered by the request which may outlive it. Additionally, not all work
+// in the system is visible to the bucket: work by the Go runtime is a basic
+// example, but even "userspace work" is likely not tracked in its entirety.
+//
+// We address both of these issues by assuming an approximately constant ratio
+// between the rate of total and tracked CPU time (at least over short periods
+// of time) and then "punishing" tracked work by that factor, in effect assuming
+// that any "untracked" CPU work is incurred by the tracked work. This motivates
+// the tokenToCPUTimeMultiplier below, which is computed via
+//
+//	tokenToCPUTimeMultiplier = totalCPUTime / trackedCPUTime (over a short interval)
+//
+// Observing, for example, 20s of CPU time consumed in the process but only 10s
+// in tracked requests, we would set tokenToCPUTimeMultiplier to 2 (dimensionless),
+// and the refill rate would be halved (which corresponds to saying that a request
+// that consumes, say, 100ms of CPU time should really be billed for twice that
+// amount).
+//
+// Since 1 token represents 1 nanosecond of CPU time, we express CPU capacity in
+// tokens/s (i.e., CPU-nanoseconds per wall-clock second). For example, an 8 vCPU
+// machine has a capacity of 8E9 tokens/s. The refill rate is then simply:
+//
+//	refillRate [tokens/s] = targetUtilization * capacity [tokens/s] / tokenToCPUTimeMultiplier
+//
+// For an 8 vCPU machine (capacity = 8E9 tokens/s), with a target utilization of
+// 80% and a tokenToCPUTimeMultiplier of 1:
+//
+//	refillRate = 0.8 * 8E9 tokens/s / 1 = 6.4E9 tokens/s
+//
+// which corresponds to 6.4 CPU-seconds of work admitted per wall-clock second.
+//
+// We clamp tokenToCPUTimeMultiplier to be in the interval [1, 20]. The lower
+// bound 1 reflects our knowledge that whatever is measured by tracked requests
+// was actually consumed (i.e. consumed tokens represent at least the
+// corresponding amount of CPU time). As the multiplier increases, it is less and
+// less likely that the tracked requests are actually to blame for the high
+// utilization, but we continue to pretend that we are, to shift queuing into
+// admission control rather than the Go scheduler (where we have little
+// control). In highly degraded situations (multiplier >= 20), we cap the
+// multiplier at 20 to avoid penalizing tracked requests further. See fit() for
+// more details.
+//
+// As is discussed in the cpuTimeTokenGranter docs, the buckets are arranged in
+// a priority hierarchy. Higher priority buckets have higher target utilizations
+// than lower priority buckets, and incoming requests generally require that the
+// bucket for their priority has enough tokens to accommodate the request, but then
+// withdraw from all buckets (which may put lower-priority buckets in a deficit).
+// Due to this, higher priority buckets have more tokens added per second than
+// lower priority buckets.
+type cpuTimeTokenLinearModel struct {
+	granter           tokenUsageTracker
+	cpuMetricProvider CPUMetricProvider
+	timeSource        timeutil.TimeSource
+
+	// True after first call to fit.
+	init bool
+	// The time that fit was called last.
+	lastFitTime time.Time
+	// The cumulative user/sys CPU time used since process start in
+	// milliseconds.
+	totalCPUTimeMillis int64
+	// The linear correction term, see the docs above cpuTimeTokenLinearModel.
+	tokenToCPUTimeMultiplier float64
+}
+
+// tokenUsageTracker is implemented by cpuTimeTokenGranter. It provides
+// information regarding the net token deduction since the last call to
+// resetTokensUsedInInterval. This information is needed to model the
+// relationship between token usage and actual CPU usage.
+type tokenUsageTracker interface {
+	// resetTokensUsedInInterval resets the tracked used tokens to zero.
+	// The previous value is returned.
+	resetTokensUsedInInterval() int64
+}
+
+var _ tokenUsageTracker = &cpuTimeTokenGranter{}
+
+type CPUMetricProvider interface {
+	// GetCPUInfo returns the cumulative user/sys CPU time used since process
+	// start in milliseconds, and the cpuCapacity measured in vCPUs.
+	GetCPUInfo() (totalCPUTimeMillis int64, cpuCapacity float64)
+}
+
+// fit adjusts tokenToCPUTimeMultiplier based on CPU usage & token usage.
+// fit computes refill rates from tokenToCPUTimeMultiplier and the targets
+// parameter. targets tracks a target CPU utilization for all buckets in
+// the multi-dimensional token buckets owned by cpuTimeTokenGranter. fit
+// returns the refill rates.
+func (m *cpuTimeTokenLinearModel) fit(targets targetUtilizations) rates {
+	if !m.init {
+		m.init = true
+		m.lastFitTime = m.timeSource.Now()
+		totalCPUTimeMillis, cpuCapacity := m.cpuMetricProvider.GetCPUInfo()
+		m.totalCPUTimeMillis = totalCPUTimeMillis
+		m.tokenToCPUTimeMultiplier = 1
+		return m.computeRefillRates(targets, m.tokenToCPUTimeMultiplier, cpuCapacity)
+	}
+
+	now := m.timeSource.Now()
+	elapsedSinceLastFit := now.Sub(m.lastFitTime)
+	m.lastFitTime = now
+
+	// Get used CPU tokens.
+	// TODO(josh): Get tokens used by the elastic CPU AC in addition to
+	// the normal CPU AC.
+	tokensUsed := m.granter.resetTokensUsedInInterval()
+	// At admission time, an estimate of CPU time is deducted. After
+	// the request is done processing, a correction based on a measurement
+	// from grunning is deducted. Thus it is theoretically possible for net
+	// tokens used to be <=0. In this case, we set tokensUsed to 1, so that
+	// the computation of tokenToCPUTimeMultiplier is well-behaved.
+	if tokensUsed <= 0 {
+		tokensUsed = 1
+	}
+
+	// Get used CPU time.
+	totalCPUTimeMillis, cpuCapacity := m.cpuMetricProvider.GetCPUInfo()
+	intCPUTimeMillis := totalCPUTimeMillis - m.totalCPUTimeMillis
+	// totalCPUTimeMillis is not necessarily monotonic in all environments,
+	// e.g. in case of VM live migration on a public cloud provider. In this
+	// case, we set intCPUTimeMillis to 0, so that the computation of
+	// tokenToCPUTimeMultiplier is well-behaved.
+	if intCPUTimeMillis < 0 {
+		intCPUTimeMillis = 0
+	}
+	m.totalCPUTimeMillis = totalCPUTimeMillis
+	intCPUTimeNanos := intCPUTimeMillis * 1e6
+
+	// Update multiplier.
+	const lowCPUUtilFrac = 0.25
+	isLowCPUUtil := intCPUTimeNanos < int64(float64(elapsedSinceLastFit.Nanoseconds())*cpuCapacity*lowCPUUtilFrac)
+	if isLowCPUUtil {
+		// With good integration with admission control, most foreground
+		// work will be tracked by AC and reflected in the model, and the
+		// unaccounted CPU utilization in the system is likely to a large degree
+		// directly induced by foreground work (heap GC, etc).
+		//
+		// As a result, in that situation, we expect a tokenToCPUTimeMultiplier
+		// < 2 (in experiments, we have seen values as high as 3).
+		//
+		// Re-fitting the model at low utilization is generally problematic
+		// because smaller sample sizes and inaccuracies can dominate and
+		// result in noisy measurements. So we want to leave the multiplier
+		// (which was computed at a higher utilization, and is hopefully
+		// still meaningful) unchanged until CPU utilization picks up again.
+		//
+		// The exception to this is when the multiplier is actually the cause
+		// of the low utilization. Consider the following scenario:
+		//
+		// - t=0: we re-fit and compute a multiplier of 10. Unbeknownst to the
+		//   model, there was a one-off untracked request that consumed a large
+		//   amount of CPU time during this interval; regular workload is unchanged
+		//   in this example and would have resulted in a true multiplier of 1.
+		// - t=[0,1s]: the large multiplier throttles tracked work (which is all
+		//   work in this example) and CPU utilization drops to 10%.
+		// - t=1s: the model re-fits and enters this branch. If it skips adjusting
+		//   the multiplier (for the reasons outlined above), the workload remains
+		//   throttled indefinitely.
+		//
+		// We address this scenario as follows:
+		// - for simplicity, assume a 1 vCPU machine, so targetUtil represents the
+		//   fraction of 1 second of CPU time we're willing to spend per wall-second.
+		// - assume our high multiplier is M (10 for example)
+		// - assume there is a "true" multiplier T (2 for example), i.e. a reported
+		//   token causes T nanoseconds of CPU time to be consumed.
+		// - M emits tokens at rate R := targetUtil/M tokens/second.
+		// - if this rate were consumed by the workload in entirety, this would
+		//   result in a CPU utilization of T*R = T*targetUtil/M.
+		// - solving for T*R < lowCPUUtilFrac, we get
+		//     M >  T*targetUtil/lowCPUUtilFrac
+		//       >= targetUtil/lowCPUUtilFrac       (because T>=1)
+		// - so whenever M > targetUtil/lowCPUUtilFrac, it could possibly be true
+		//   that the multiplier is the cause of the low utilization. So we adjust
+		//   the multiplier down by 50%, so that, possibly over multiple fitting
+		//   intervals, it will drop below the threshold at which it could be
+		//   responsible for the low utilization. (We smear this process over
+		//   multiple intervals because the multiplier may also have been correct
+		//   and load might pick up again soon.)
+		//
+		// TODO(josh): Stop hard-coding target utilization to 0.9 here.
+		// https://github.com/cockroachdb/cockroach/issues/158600
+		const upperBound = 0.9 / lowCPUUtilFrac // example: 3.6 for 25% threshold
+		if mult := m.tokenToCPUTimeMultiplier; mult > upperBound {
+			m.tokenToCPUTimeMultiplier = max(mult/1.5, upperBound)
+		}
+	} else {
+		tokenToCPUTimeMultiplier :=
+			float64(intCPUTimeNanos) / float64(tokensUsed)
+		// We clamp tokenToCPUTimeMultiplier to be in the interval [1, 20]. The
+		// lower bound 1 reflects our knowledge that whatever is measured by
+		// tracked requests was actually consumed (i.e. consumed tokens represent
+		// at least the corresponding amount of CPU time). As the multiplier
+		// increases, it is less and less likely that the tracked requests are
+		// actually to blame for the high utilization, but we continue to pretend
+		// that we are, to shift queuing into admission control rather than the Go
+		// scheduler (where we have little control). In highly degraded situations
+		// (multiplier >= 20), we cap the multiplier at 20 to avoid penalizing
+		// tracked requests further. See fit() for more details.
+		if tokenToCPUTimeMultiplier > 20 {
+			tokenToCPUTimeMultiplier = 20
+		} else if tokenToCPUTimeMultiplier < 1 {
+			tokenToCPUTimeMultiplier = 1
+		}
+		// The model responds quicker to downward changes in tokenToCPUTimeMultiplier
+		// than upward changes to tokenToCPUTimeMultiplier, since alpha is large
+		// in the case of the former. Downward changes to tokenToCPUTimeMultiplier
+		// imply increasing the number of tokens that are given out per second.
+		// Upward changes to tokenToCPUTimeMultiplier imply decreasing the number
+		// of tokens. This implies the model responds faster to under-admission
+		// than over-admission, which should, slightly, decrease the risk of
+		// under-admission and increase the risk of over-admission. This is
+		// sensible, since in case of over-admission, there is a limit to how
+		// performant CRDB can be (in a latency sense); CPU is constrained after
+		// all. OTOH, we do not want under-admission to happen in case of
+		// temporary model error, as that is avoidable.
+		//
+		// We can make this more concrete with an example. Say for some reason the
+		// model estimates the multiplier to be 20 and it should have been 2. With
+		// a 0.5 alpha, the model would get 11, then 6.5, 4.25, 3.125, so we have
+		// multiple seconds of under-admission. With 0.8 alpha, it's 5.6, 2.72,
+		// 2.144. So much faster. Note that the specific alphas we have here were
+		// chosen somewhat arbitrarily.
+		alpha := 0.5
+		if tokenToCPUTimeMultiplier < m.tokenToCPUTimeMultiplier {
+			alpha = 0.8
+		}
+
+		// Exponentially smooth changes to the multiplier. 1s of data is noisy,
+		// so smoothing is necessary.
+		m.tokenToCPUTimeMultiplier =
+			alpha*tokenToCPUTimeMultiplier + (1-alpha)*m.tokenToCPUTimeMultiplier
+	}
+
+	return m.computeRefillRates(targets, m.tokenToCPUTimeMultiplier, cpuCapacity)
+}
+
+// computeRefillRates is a pure helper function that computes refill rates.
+// The CPU capacity is measured in vCPUs. This takes into account the cgroup, so
+// can be fractional.
+func (*cpuTimeTokenLinearModel) computeRefillRates(
+	targets targetUtilizations, tokenToCPUTimeMultiplier float64, cpuCapacity float64,
+) rates {
+	var refillRates rates
+	for tier := range targets {
+		for qual := range targets[tier] {
+			refillRates[tier][qual] = int64(cpuCapacity * float64(time.Second) * targets[tier][qual] / tokenToCPUTimeMultiplier)
+		}
+	}
+	return refillRates
 }

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -6,16 +6,20 @@
 package admission
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCPUTimeTokenFiller(t *testing.T) {
@@ -68,12 +72,39 @@ type testTokenAllocator struct {
 	buf *strings.Builder
 }
 
+func (m *testTokenAllocator) init() {}
+
 func (a *testTokenAllocator) resetInterval() {
 	fmt.Fprintf(a.buf, "resetInterval()\n")
 }
 
 func (a *testTokenAllocator) allocateTokens(remainingTicks int64) {
 	fmt.Fprintf(a.buf, "allocateTokens(%d)\n", remainingTicks)
+}
+
+type testModel struct {
+	buf   *strings.Builder
+	rates rates
+}
+
+func (m *testModel) init() {}
+
+func (m *testModel) fit(targets targetUtilizations) rates {
+	// targets uses float64, which when written to golden file can lead to
+	// test reproducibility issues. Here, we multiply by 100 & then round to
+	// the nearest integer.
+	round := func(x float64) int {
+		scaled := x * 100
+		return int(math.Round(scaled))
+	}
+	fmt.Fprint(m.buf, "fit(\n")
+	for tier := int(numResourceTiers - 1); tier >= 0; tier-- {
+		for qual := int(numBurstQualifications - 1); qual >= 0; qual-- {
+			fmt.Fprintf(m.buf, "\ttier%d %s -> %v%%\n", tier, burstQualification(qual).String(), round(targets[tier][qual]))
+		}
+	}
+	fmt.Fprint(m.buf, ")\n")
+	return m.rates
 }
 
 func TestCPUTimeTokenAllocator(t *testing.T) {
@@ -101,43 +132,284 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 	granter.requester[testTier0] = requesters[testTier0]
 	granter.requester[testTier1] = requesters[testTier1]
 
-	allocator := cpuTimeTokenAllocator{
-		granter: granter,
-	}
-	allocator.rates[testTier0][canBurst] = 5
-	allocator.rates[testTier0][noBurst] = 4
-	allocator.rates[testTier1][canBurst] = 3
-	allocator.rates[testTier1][noBurst] = 2
-	allocator.bucketCapacity = allocator.rates
-
 	var buf strings.Builder
-	flushAndReset := func(printGranter bool) string {
-		if printGranter {
-			fmt.Fprint(&buf, granter.String())
-		}
+	flushAndReset := func() string {
+		fmt.Fprint(&buf, granter.String())
 		str := buf.String()
 		buf.Reset()
 		return str
 	}
 
+	model := &testModel{buf: &buf}
+	model.rates[testTier0][canBurst] = 5
+	model.rates[testTier0][noBurst] = 4
+	model.rates[testTier1][canBurst] = 3
+	model.rates[testTier1][noBurst] = 2
+	allocator := cpuTimeTokenAllocator{
+		granter:  granter,
+		settings: cluster.MakeClusterSettings(),
+		model:    model,
+	}
+
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "cpu_time_token_allocator"), func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "resetInterval":
+			var increaseRatesBy int64
+			d.MaybeScanArgs(t, "increase_rates_by", &increaseRatesBy)
+			if increaseRatesBy != 0 {
+				model.rates[testTier0][canBurst] += increaseRatesBy
+				model.rates[testTier0][noBurst] += increaseRatesBy
+				model.rates[testTier1][canBurst] += increaseRatesBy
+				model.rates[testTier1][noBurst] += increaseRatesBy
+			}
 			allocator.resetInterval()
-			return flushAndReset(false /* printGranter */)
+			return flushAndReset()
 		case "allocate":
 			var remainingTicks int64
 			d.ScanArgs(t, "remaining", &remainingTicks)
 			allocator.allocateTokens(remainingTicks)
-			return flushAndReset(true /* printGranter */)
+			return flushAndReset()
 		case "clear":
 			granter.mu.buckets[testTier0][canBurst].tokens = 0
 			granter.mu.buckets[testTier0][noBurst].tokens = 0
 			granter.mu.buckets[testTier1][canBurst].tokens = 0
 			granter.mu.buckets[testTier1][noBurst].tokens = 0
-			return flushAndReset(true /* printGranter */)
+			return flushAndReset()
+		case "setClusterSettings":
+			ctx := context.Background()
+			var override float64
+			if d.MaybeScanArgs(t, "app", &override) {
+				fmt.Fprintf(&buf, "SET CLUSTER SETTING admission.cpu_time_tokens.target_util.app_tenant = %v\n", override)
+				KVCPUTimeAppUtilGoal.Override(ctx, &allocator.settings.SV, override)
+			}
+			if d.MaybeScanArgs(t, "system", &override) {
+				fmt.Fprintf(&buf, "SET CLUSTER SETTING admission.cpu_time_tokens.target_util.system_tenant = %v\n", override)
+				KVCPUTimeSystemUtilGoal.Override(ctx, &allocator.settings.SV, override)
+			}
+			if d.MaybeScanArgs(t, "burst", &override) {
+				fmt.Fprintf(&buf, "SET CLUSTER SETTING admission.cpu_time_tokens.target_util.burst_delta = %v\n", override)
+				KVCPUTimeUtilBurstDelta.Override(ctx, &allocator.settings.SV, override)
+			}
+			return flushAndReset()
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}
 	})
+}
+
+func TestCPUTimeTokenLinearModel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	unixNanos := int64(1758938600000000000) // 2025-09-24T14:30:00Z
+	testTime := timeutil.NewManualTime(time.Unix(0, unixNanos).UTC())
+	model := cpuTimeTokenLinearModel{
+		timeSource:               testTime,
+		lastFitTime:              testTime.Now(),
+		totalCPUTimeMillis:       0,
+		tokenToCPUTimeMultiplier: 1,
+	}
+	tokenCPUTime := &testTokenUsageTracker{}
+	model.granter = tokenCPUTime
+	actualCPUTime := &testCPUMetricProvider{
+		capacity: 10,
+	}
+	model.cpuMetricProvider = actualCPUTime
+
+	dur := 5 * time.Second
+	actualCPUTime.append(dur.Nanoseconds(), 1) // appended value ignored by init
+
+	var targets targetUtilizations
+	targets[testTier1][noBurst] = 0.8
+	targets[testTier1][canBurst] = 0.85
+	targets[testTier0][noBurst] = 0.9
+	targets[testTier0][canBurst] = 0.95
+
+	// The first call to fit inits the model, by setting tokenToCPUTimeMultiplier
+	// to one, since in prod on the first call to fit, there will be no CPU
+	// usage data to use to determine tokenToCPUTimeMultiplier.
+	refillRates := model.fit(targets)
+	require.Equal(t, float64(1), model.tokenToCPUTimeMultiplier)
+	// Given that tokenToCPUTimeMultiplier equals one, refillRates is equal
+	// to target utilization for the bucket * the vCPU count (10 vCPUs in this
+	// test). The unit of refillRates is nanoseconds.
+	//
+	// 80% util -> 10 vCPUs * .8 * 1s = 8s
+	require.Equal(t, int64(8000000000), refillRates[testTier1][noBurst])
+	// 85% util -> 10 vCPUs * .85 * 1s = 8.5s
+	require.Equal(t, int64(8500000000), refillRates[testTier1][canBurst])
+	// 90% util -> 10 vCPUs * .9 * 1s = 9s
+	require.Equal(t, int64(9000000000), refillRates[testTier0][noBurst])
+	// 95% util -> 10 vCPUs * .95 * 1s = 9.5s
+	require.Equal(t, int64(9500000000), refillRates[testTier0][canBurst])
+
+	// Below tests are of the computation of tokenToCPUTimeMultiplier only. The
+	// computation of tokenToCPUTimeMultiplier involves state stored on the model,
+	// since the model does exponential smoothing. The computation of refillRates
+	// (given a fixed tokenToCPUTimeMultiplier) is simpler: It is a pure function,
+	// described up above in the test case of the first call to fit. So here we
+	// focus on tokenToCPUTimeMultiplier.
+	//
+	// 2x
+	// Token time is half of actual time, so tokenToCPUTimeMultiplier is two.
+	// 100 data points are appended, to give the filter time to converge on two.
+	tokenCPUTime.append(dur.Nanoseconds()/2, 100)
+	actualCPUTime.append(dur.Milliseconds(), 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	tolerance := 0.01
+	require.InDelta(t, 2, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// 4x
+	// Token time is one fourth of actual time, so tokenToCPUTimeMultiplier is
+	// four.
+	tokenCPUTime.append(dur.Nanoseconds()/2, 100)
+	actualCPUTime.append(dur.Milliseconds()*2, 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 4, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// 1x
+	// Token time is one equal to actual time, so tokenToCPUTimeMultiplier is one.
+	tokenCPUTime.append(dur.Nanoseconds()*2, 100)
+	actualCPUTime.append(dur.Milliseconds()*2, 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 1, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// 20x
+	// tokenToCPUTimeMultiplier should be 40, based on the data, but the model caps
+	// tokenToCPUTimeMultiplier at 20.
+	tokenCPUTime.append(dur.Nanoseconds(), 100)
+	actualCPUTime.append(dur.Milliseconds()*40, 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 20, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// 1x
+	// tokenToCPUTimeMultiplier should be 0.5, based on the data, but the model caps
+	// tokenToCPUTimeMultiplier at 1.
+	tokenCPUTime.append(dur.Nanoseconds()*2, 100)
+	actualCPUTime.append(dur.Milliseconds(), 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 1, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// 2x
+	// Token time is half of actual time, so tokenToCPUTimeMultiplier is two.
+	tokenCPUTime.append(dur.Nanoseconds(), 100)
+	actualCPUTime.append(dur.Milliseconds()*2, 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 2, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// Below tests are of the low CPU logic. See the comments in fit for a full
+	// explanation of the logic & especially the rationale for the logic. TLDR:
+	// if CPU is less than 25%, and if tokenToCPUTimeMultiplier is less 3.6,
+	// tokenToCPUTimeMultiplier is left alone. If tokenToCPUTimeMultiplier is
+	// greater than 3.6, tokenToCPUTimeMultiplier is divided by 1.5 until it is
+	// <= 3.6.
+	//
+	// vCPU count is 10. dur /.5 = 1s. 1s / 10s = 0.1 < 0.25. So low CPU mode
+	// should be activated.
+	//
+	// Leave existing tokenToCPUTimeMultiplier multiplier as is, since 2 <= 3.6.
+	tokenCPUTime.append(dur.Nanoseconds()/5, 100)
+	actualCPUTime.append(dur.Milliseconds()/5, 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 2, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// Leave low vCPU mode, in order to set tokenToCPUTimeMultiplier equal to 20,
+	// which is set up for the next test case.
+	tokenCPUTime.append(dur.Nanoseconds(), 100)
+	actualCPUTime.append(dur.Milliseconds()*100, 100)
+	for i := 0; i < 100; i++ {
+		testTime.Advance(time.Second)
+		_ = model.fit(targets)
+	}
+	require.InDelta(t, 20, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// Iteratively reduce to 3.6x, since low CPU mode, and
+	// tokenToCPUTimeMultiplier = 20 > 3.6.
+	tokenCPUTime.append(dur.Nanoseconds()/5, 100)
+	actualCPUTime.append(dur.Milliseconds()/5, 100)
+	{
+		lastMult := model.tokenToCPUTimeMultiplier
+		for i := 0; ; i++ {
+			require.Less(t, i, 100)
+			testTime.Advance(time.Second)
+			refillRates = model.fit(targets)
+			mult := model.tokenToCPUTimeMultiplier
+			if mult == lastMult {
+				break
+			}
+			require.Less(t, mult, lastMult)
+			lastMult = mult
+		}
+	}
+	require.InDelta(t, 3.6, model.tokenToCPUTimeMultiplier, tolerance)
+
+	// Check refillRates again, this time with tokenToCPUTimeMultiplier
+	// equal to 3.6 instead of one.
+
+	// 80% -> 10 vCPUs * .8 * 1s = 8s -> 8s / 3.6 ~= 2.22222222s
+	require.Equal(t, int64(2222222222), refillRates[testTier1][noBurst])
+	// 85% -> 10 vCPUs * .85 * 1s = 8.5s -> 8.5s / 3.6 ~= 2.36111111s
+	require.Equal(t, int64(2361111111), refillRates[testTier1][canBurst])
+	// 90% -> 10 vCPUs * .9 * 1s = 9s -> 9s / 3.6 ~= 2.5s
+	require.Equal(t, int64(2500000000), refillRates[testTier0][noBurst])
+	// 95% -> 10 vCPUs * .95 * 1s = 9.5s -> 9.5s / 3.6 ~= 2.63888889
+	require.Equal(t, int64(2638888888), refillRates[testTier0][canBurst])
+}
+
+type testTokenUsageTracker struct {
+	i          int
+	tokensUsed []int64
+}
+
+func (t *testTokenUsageTracker) append(tokens int64, count int) {
+	for i := 0; i < count; i++ {
+		t.tokensUsed = append(t.tokensUsed, tokens)
+	}
+}
+
+func (t *testTokenUsageTracker) resetTokensUsedInInterval() int64 {
+	ret := t.tokensUsed[t.i]
+	t.i++
+	return ret
+}
+
+type testCPUMetricProvider struct {
+	i        int
+	cum      int64
+	millis   []int64
+	capacity float64
+}
+
+func (m *testCPUMetricProvider) GetCPUInfo() (int64, float64) {
+	cycle := m.millis[m.i]
+	m.i++
+	m.cum += cycle
+	return m.cum, m.capacity
+}
+
+func (t *testCPUMetricProvider) append(millis int64, count int) {
+	for i := 0; i < count; i++ {
+		t.millis = append(t.millis, millis)
+	}
 }

--- a/pkg/util/admission/cpu_time_token_granter_test.go
+++ b/pkg/util/admission/cpu_time_token_granter_test.go
@@ -167,6 +167,11 @@ func TestCPUTimeTokenGranter(t *testing.T) {
 			fmt.Fprintf(&buf, "refill(%v %v)\n", delta, bucketCapacity)
 			return flushAndReset(false /* init */)
 
+		case "reset-tokens-used":
+			used := granter.resetTokensUsedInInterval()
+			fmt.Fprintf(&buf, "reset-tokens-used-in-interval() returned %d\n", used)
+			return flushAndReset(false /* init */)
+
 		// For cpuTimeTokenChildGranter, this is a NOP. Still, it will be
 		// called in production. So best to test it doesn't panic, or similar.
 		case "continue-grant-chain":

--- a/pkg/util/admission/testdata/cpu_time_token_allocator
+++ b/pkg/util/admission/testdata/cpu_time_token_allocator
@@ -1,3 +1,27 @@
+# First call to resetInterval should add refillRates to all buckets.
+# We want the buckets to start full, and cpuTimeTokenFiller calls
+# resetInterval on startup. The target CPU utilizations are passed as
+# an argument to fit, and they are a function of cluster settings, plus
+# some simple logic in resetInterval. Here, the  default values for the
+# target CPU utilizations are shown.
+resetInterval
+----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
 allocate remaining=5
 ----
 cpuTTG canBurst noBurst
@@ -30,8 +54,17 @@ tier1  3        2
 
 resetInterval
 ----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2
 
-# No more tokens added due to burst budget.
+# No more tokens added due to bucket capacities being hit.
 allocate remaining=5
 ----
 cpuTTG canBurst noBurst
@@ -55,6 +88,15 @@ tier1  2        1
 
 resetInterval
 ----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  4        3
+tier1  2        1
 
 clear
 ----
@@ -72,6 +114,15 @@ tier1  3        2
 
 resetInterval
 ----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  5        4
+tier1  3        2
 
 clear
 ----
@@ -90,3 +141,96 @@ allocate remaining=1
 cpuTTG canBurst noBurst
 tier0  5        4
 tier1  3        2
+
+# These final cases test how cpuTimeTokenAllocator handles changes to
+# refillRates. See the comment above deltaRefillRates for a full explanation
+# of the approach. TLDR is the allocator will compute the amount of change in
+# refillRates & add it immediately to the buckets, before any calls to allocate
+# are made. Thus, if we increase refillRates by one (on all buckets), we expect
+# one token is added to all buckets, as below.
+resetInterval increase_rates_by=1
+----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  6        5
+tier1  4        3
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# The updated refillRate is added to the buckets (in one tick for simplicity,
+# since remaining=1).
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  6        5
+tier1  4        3
+
+# Another test of a change to refillRates. If we decrease refillRates by two
+# (on all buckets), we expect two tokens to be removed from all buckets, as
+# below.
+resetInterval increase_rates_by=-2
+----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  4        3
+tier1  2        1
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# The updated refillRate is added to the buckets (in one tick for simplicity,
+# since remaining=1).
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  4        3
+tier1  2        1
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# Test of computation of target CPU utilizations from overridden cluster
+# settings. The noBurst targets are configurable by cluster settings, which
+# are overridden in this test case. A canBurst target adds
+# admission.cpu_time_tokens.target_util.burst_delta, which is also overridden
+# here, to the corresponding noBurst target. See resetInterval for more.
+setClusterSettings app=0.5 system=0.75 burst=0.1
+----
+SET CLUSTER SETTING admission.cpu_time_tokens.target_util.app_tenant = 0.5
+SET CLUSTER SETTING admission.cpu_time_tokens.target_util.system_tenant = 0.75
+SET CLUSTER SETTING admission.cpu_time_tokens.target_util.burst_delta = 0.1
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+resetInterval
+----
+fit(
+	tier1 noBurst -> 50%
+	tier1 canBurst -> 60%
+	tier0 noBurst -> 75%
+	tier0 canBurst -> 85%
+)
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0

--- a/pkg/util/admission/testdata/cpu_time_token_filler
+++ b/pkg/util/admission/testdata/cpu_time_token_filler
@@ -1,5 +1,6 @@
 init
 ----
+resetInterval()
 elapsed: 0s
 
 # Let 2s pass, 200ms at a time. Expect a call to allocateTokens

--- a/pkg/util/admission/testdata/cpu_time_token_granter
+++ b/pkg/util/admission/testdata/cpu_time_token_granter
@@ -22,6 +22,17 @@ try-get tier=tier0 v=1
 ----
 kvtier0: tryGet(1) returned false
 
+# Returns tokens used since last call to reset-tokens-used.
+# Since only one try-get v=1 succeeded, only one token used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 1
+
+# Since reset-tokens-used just called, should return zero.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 0
+
 # More simple tryGet calls. This time, tier1 work is admitted.
 init tier0=2 tier1=1
 ----
@@ -59,6 +70,11 @@ try-get tier=tier0 v=1
 ----
 kvtier0: tryGet(1) returned false
 
+# Since two try-gets v=1 succeeded, should return two.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 2
+
 # returnGrant adds tokens to the buckets, when a positive count is used.
 init tier0=1 tier1=1
 ----
@@ -89,6 +105,12 @@ cpuTTG canBurst noBurst
 tier0  -1       0
 tier1  -1       0
 
+# The net of one return-grant v=1 with two try-gets v=1 is one
+# token used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 1
+
 # Simple tookWithoutPermission test.
 init tier0=3 tier1=3
 ----
@@ -113,6 +135,11 @@ try-get tier=tier1 v=1
 ----
 kvtier1: tryGet(1) returned false
 
+# took-without-permission v=3 is the only successful call, so three tokens used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 3
+
 # Test granting. A single tier0 request will be admitted.
 init tier0waiter=2 tier1waiter=1
 ----
@@ -127,6 +154,12 @@ return-grant tier=tier0 v=2
 kvtier0: returnGrant(2)
 kvtier0: granted in chain 0, and returning 2
 
+# The net of one return-grant v=2 with that grant leading to admission of request
+# with token count equal to two is zero tokens used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 0
+
 # Test granting. Two tier1 requests will be admitted.
 init tier0=-1 tier0burst=-1 tier1=-1 tier1burst=-1 tier1waiter=1
 ----
@@ -138,7 +171,7 @@ tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurs
 
 # With three returned, tier1 burst will have two tokens. Thus two tier1
 # requests can be granted admission. Note that the test requester is not
-# stateful. In init, tier1water=1 means the tier1 requester always has a waiting
+# stateful. In init, tier1waiter=1 means the tier1 requester always has a waiting
 # request, and the ret value from granted is always 1. Thus, after two tier1 requests
 # are granted admission, the bucket is empty again.
 return-grant tier=tier0 v=3
@@ -149,6 +182,12 @@ kvtier1: granted in chain 0, and returning 1
 cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
+
+# The net of one return-grant v=3 with that grant leading to admission of two requests
+# with token count equal to one is -1 tokens used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned -1
 
 # Simple tryGet calls, with burst this time.
 init tier0burst=1
@@ -174,6 +213,11 @@ try-get tier=tier0 burst v=1
 ----
 kvtier0: tryGet(1) returned false
 
+# Since two try-gets v=1 succeeded, should return one.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 1
+
 # Test granting, with burst. After the call to return-grant, only tier1 burst will
 # have enough tokens to grant. So grant a tier1 request.
 init tier0burst=-1 tier0=-1 tier1burst=0 tier1=-1 tier1waiter=1 tier1burstwaiter
@@ -188,6 +232,12 @@ return-grant tier=tier0 v=1
 ----
 kvtier0: returnGrant(1)
 kvtier1: granted in chain 0, and returning 1
+
+# The net of one return-grant v=1 with that grant leading to admission of one request
+# with token count equal to one is zero tokens used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 0
 
 # Test granting, with burst. After the call to return-grant, only tier1 no-burst will
 # have enough tokens to grant. So no grant, since the tier1 waiting request is a burst request.
@@ -206,9 +256,15 @@ cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        1
 
+# The net of one return-grant v=1 with that grant not leading to any admission is
+# -1 tokens used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned -1
+
 # Test refill, which is the interface cpuTimeTokenFiller uses to add tokens to
 # the buckets. The final allocation of tokens in the buckets is a result of
-# the delta argument to refill, the bucket capacities in certain cases capping how
+# the toAdd argument to refill, the bucket capacities in certain cases capping how
 # tokens should be added, and one queued request being granted admission.
 init tier1waiter=1
 ----
@@ -225,3 +281,10 @@ refill([[5 4] [3 1]] [[4 3] [10 1]])
 cpuTTG canBurst noBurst
 tier0  3        2
 tier1  2        0
+
+# Refilling the buckets does not count as token usage. The only usage that happens
+# here is that one request with token count equal to one is granted admission, due to
+# the refill (see "granted in..." message above). So one token used.
+reset-tokens-used
+----
+reset-tokens-used-in-interval() returned 1


### PR DESCRIPTION
**admission: compute cpu time token refill rates**
    
This commit introduces a linear model that computes cpu
time token refill rates. cpuTimeTokenFiller uses this
model to determine how many tokens to add per second to
the buckets in cpuTimeTokenGranter.
    
Fixes: #154471
    
Release note: None.