### PR TITLE
schemachanger/rel: fix notJoin subquery depth calculation for non-entity variables

### DIFF
--- a/pkg/sql/schemachanger/rel/query_eval.go
+++ b/pkg/sql/schemachanger/rel/query_eval.go
@@ -450,6 +450,7 @@ func (ec *evalContext) maybeVisitSubqueries() (nextSubQuery int, done bool, erro
 func (ec *evalContext) visitSubquery(query int) (done bool, _ error) {
 	sub := ec.q.notJoins[query]
 	sec := sub.query.getEvalContext()
+
 	defer sub.query.putEvalContext(sec)
 	defer func() { // reset the slots populated to run the subquery
 		sub.inputSlotMappings.ForEach(func(_, subSlot int) {


### PR DESCRIPTION
Previously, the subquery depth calculation in setSubqueryDepth only considered
direct entity dependencies when determining when a notJoin subquery should
execute. It tracked the maximum entity slot among the subquery's inputs but
ignored when non-entity variables (like table-id, index-id) were actually bound.
This caused notJoin subqueries to execute too early, before all their required
variables were available, leading to "unbound variable" errors.

This commit fixes the depth calculation by tracking which entity provides each
variable through the facts. When a subquery needs a non-entity variable, we now
find which entity binds that variable and use that entity's slot to determine
the correct execution depth. This ensures notJoin subqueries only execute after
all their input variables have been bound by the appropriate entities in the
join order.

The fix is needed for rules that pass non-entity variables to notJoin
predicates, particularly in constraint rename scenarios where variables may
be bound at different join depths. (At the time of this writing, we
don't yet have rules like this, but we soon will add one.)

informs https://github.com/cockroachdb/cockroach/issues/148341
Release note: None