### PR TITLE
logictest: fix MR parallelization flake for good

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 
 # Set the closed timestamp interval to be short to shorten the amount of time
 # we need to wait for the system config to propagate.
@@ -64,7 +64,7 @@ SELECT crdb_internal.clear_table_stats_cache();
 
 # Only the scan in the main query is parallelized when we don't have stats on
 # the descendant tables.
-query I retry
+query I
 SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
 ----
 1


### PR DESCRIPTION
We saw a logic test fail because of `parallel-scan-result-threshold` value being metamorphic - force production values for this test file.

Fixes: #156973.
Release note: None