### PR TITLE
kvserver: avoid starting async raft worker on error

### DIFF
--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -324,6 +324,7 @@ func (s *raftScheduler) Start(stopper *stop.Stopper) {
 				})
 			if err != nil {
 				s.done.Done()
+				continue
 			}
 			go f(ctx, hdl)
 		}


### PR DESCRIPTION
Before this change, when GetHandle returns an error, we mark the task as done but continue to start raft worker asynchronously.

Epic: None
Fixes: None
Release note: None