### PR TITLE
mma: more cleanup of pending changes

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -487,7 +487,8 @@ func TestClusterState(t *testing.T) {
 							changes = append(changes, rebalanceChanges[:]...)
 						}
 					}
-					cs.createPendingChanges(changes...)
+					rangeChange := MakePendingRangeChange(rangeID, changes)
+					cs.addPendingRangeChange(rangeChange)
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 
 				case "gc-pending-changes":
@@ -503,10 +504,10 @@ func TestClusterState(t *testing.T) {
 					for _, id := range changeIDsInt {
 						if expectPanic {
 							require.Panics(t, func() {
-								cs.undoPendingChange(id, true)
+								cs.undoPendingChange(id)
 							})
 						} else {
-							cs.undoPendingChange(id, true)
+							cs.undoPendingChange(id)
 						}
 					}
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -154,7 +154,7 @@ func (m *mmaStoreRebalancer) applyChange(
 ) error {
 	repl := m.store.GetReplicaIfExists(change.RangeID)
 	if repl == nil {
-		m.as.MarkChangesAsFailed(change.ChangeIDs())
+		m.as.MarkChangeAsFailed(change)
 		return errors.Errorf("replica not found for range %d", change.RangeID)
 	}
 	changeID := m.as.MMAPreApply(ctx, repl.RangeUsageInfo(), change)

--- a/pkg/kv/kvserver/mmaintegration/allocator_op.go
+++ b/pkg/kv/kvserver/mmaintegration/allocator_op.go
@@ -15,11 +15,14 @@ import (
 // trackedAllocatorChange represents a change registered with AllocatorSync
 // (e.g. lease transfer or change replicas).
 type trackedAllocatorChange struct {
-	// changeIDs are the change IDs that are registered with mma. Nil if mma is
-	// disabled or the change cannot be registered with mma. If changeIDs is
-	// nil, PostApply does not need to inform mma. Otherwise, PostApply should
-	// inform mma by passing changeIDs to AdjustPendingChangesDisposition.
-	changeIDs []mmaprototype.ChangeID
+	// isMMARegistered is true if the change has been successfully registered
+	// with mma. When true, mmaChange is the registered change, and PostApply
+	// should inform mma by passing mmaChange to
+	// AdjustPendingChangesDisposition. It is false if mma is disabled or the
+	// change could not be registered with mma, in which case PostApply must not
+	// inform mma.
+	isMMARegistered bool
+	mmaChange       mmaprototype.PendingRangeChange
 	// Usage is range load usage.
 	usage allocator.RangeUsageInfo
 	// Exactly one of the following two fields will be set.

--- a/pkg/kv/kvserver/mmaintegration/mma_conversion.go
+++ b/pkg/kv/kvserver/mmaintegration/mma_conversion.go
@@ -21,7 +21,7 @@ func convertLeaseTransferToMMA(
 	desc *roachpb.RangeDescriptor,
 	usage allocator.RangeUsageInfo,
 	transferFrom, transferTo roachpb.ReplicationTarget,
-) []mmaprototype.ReplicaChange {
+) mmaprototype.PendingRangeChange {
 	// TODO(wenyihu6): we are passing existing replicas to
 	// mmaprototype.MakeLeaseTransferChanges just to get the add and remove
 	// replica state. See if things could be cleaned up.
@@ -47,17 +47,17 @@ func convertLeaseTransferToMMA(
 		transferTo,
 		transferFrom,
 	)
-	return replicaChanges[:]
+	return mmaprototype.MakePendingRangeChange(desc.RangeID, replicaChanges[:])
 }
 
-// convertReplicaChangeToMMA converts a replica change to mma replica changes.
-// It will be passed to mma.RegisterExternalChanges.
+// convertReplicaChangeToMMA converts a replica change to a mma range change.
+// It will be passed to mma.RegisterExternalChange.
 func convertReplicaChangeToMMA(
 	desc *roachpb.RangeDescriptor,
 	usage allocator.RangeUsageInfo,
 	changes kvpb.ReplicationChanges,
 	leaseholderStoreID roachpb.StoreID,
-) []mmaprototype.ReplicaChange {
+) mmaprototype.PendingRangeChange {
 	rLoad := mmaRangeLoad(usage)
 	replicaChanges := make([]mmaprototype.ReplicaChange, 0, len(changes))
 	replicaSet := desc.Replicas()
@@ -122,5 +122,5 @@ func convertReplicaChangeToMMA(
 			panic("unimplemented change type")
 		}
 	}
-	return replicaChanges
+	return mmaprototype.MakePendingRangeChange(desc.RangeID, replicaChanges)
 }


### PR DESCRIPTION
The existing PendingRangeChange is now used in all the exported Allocator methods. This makes it clear that the set of changes are being treated as an atomic unit in the interface. The MMA code also reduces the switching between pendingReplicaChange, ChangeID and ReplicaChange which was confusing. It now uses pendingReplicaChange in more cases.

Since we use PendingRangeChange to describe the change, and then later annotate it with the change ids, start time etc., there is some refactoring which involves producing a change using MakePendingRangeChange, and later changing its state using clusterState.addPendingRangeChange.

Minor cleanup: The Allocator interface now includes integration methods implemented by allocatorState, as originally intended.

Informs #157049

Epic: CRDB-55052

Release note: None