### PR TITLE
allocator: change rebalanceStores receiver to *clusterState

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -705,7 +705,7 @@ type storeState struct {
 	localityTiers
 
 	// Time when this store started to be observed as overloaded. Set by
-	// allocatorState.rebalanceStores.
+	// clusterState.rebalanceStores.
 	overloadStartTime time.Time
 	// When overloaded this is equal to time.Time{}.
 	overloadEndTime time.Time

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -8,6 +8,7 @@ package mmaprototype
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"slices"
 	"sort"
 	"strconv"
@@ -511,6 +512,13 @@ func TestClusterState(t *testing.T) {
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 
 				case "get-pending-changes":
+					return printPendingChangesTest(testingGetPendingChanges(t, cs))
+
+				case "rebalance-stores":
+					storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")
+					rng := rand.New(rand.NewSource(0))
+					dsm := newDiversityScoringMemo()
+					cs.rebalanceStores(context.Background(), storeID, rng, dsm)
 					return printPendingChangesTest(testingGetPendingChanges(t, cs))
 
 				case "tick":

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -92,7 +92,7 @@ const (
 // are considered here. Lease rebalancing will see if there is scope to move
 // some leases between stores that do not have any pending changes and are not
 // overloaded (and will not get overloaded by the movement). This will happen
-// in a separate pass (i.e., not in allocatorState.rebalanceStores) -- the
+// in a separate pass (i.e., not in clusterState.rebalanceStores) -- the
 // current plan is to continue using the leaseQueue and call from it into MMA.
 //
 // Note that lease rebalancing will only move leases and not replicas. Also,

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_basic
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_basic
@@ -1,0 +1,68 @@
+# Basic test that rebalanceStores issues a lease transfer when seeing a single replica
+# contributing to overload on the first out of three single-store nodes.
+
+set-store
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+  store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+  store-id=3 node-id=3 attrs=green locality-tiers=region=us-central-1,zone=us-central-1a
+----
+node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 attrs=purple locality-code=1:2:3:
+node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
+  store-id=2 attrs=yellow locality-code=4:5:6:
+node-id=3 locality-tiers=region=us-central-1,zone=us-central-1a,node=3
+  store-id=3 attrs=green locality-code=7:8:9:
+
+store-load-msg
+  store-id=1 node-id=1 load=[80,0,0] capacity=[100,100,100] secondary-load=0 load-time=0s
+----
+
+store-load-msg
+  store-id=2 node-id=2 load=[10,0,0] capacity=[100,100,100] secondary-load=0 load-time=0s
+----
+
+store-load-msg
+  store-id=3 node-id=3 load=[10,0,0] capacity=[100,100,100] secondary-load=0 load-time=0s
+----
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:0, byte-size:0] adjusted=[cpu:80, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:10, write-bandwidth:0, byte-size:0] adjusted=[cpu:10, write-bandwidth:0, byte-size:0] node-reported-cpu=10 node-adjusted-cpu=10 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:10, write-bandwidth:0, byte-size:0] adjusted=[cpu:10, write-bandwidth:0, byte-size:0] node-reported-cpu=10 node-adjusted-cpu=10 seq=1
+
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[60,0,0] raft-cpu=20 config=(num_replicas=3 constraints={} voter_constraints={})
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+----
+
+ranges
+----
+range-id=1 local-store=1 load=[cpu:60, write-bandwidth:0, byte-size:0] raft-cpu=20
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+  store-id=2 replica-id=2 type=VOTER_FULL
+  store-id=3 replica-id=3 type=VOTER_FULL
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:0, byte-size:0] adjusted=[cpu:80, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:10, write-bandwidth:0, byte-size:0] adjusted=[cpu:10, write-bandwidth:0, byte-size:0] node-reported-cpu=10 node-adjusted-cpu=10 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:10, write-bandwidth:0, byte-size:0] adjusted=[cpu:10, write-bandwidth:0, byte-size:0] node-reported-cpu=10 node-adjusted-cpu=10 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+
+# TODO(tbg): maybe it'll be good to at least optionally be able to have the
+# trace printed in the output here.
+rebalance-stores store-id=1
+----
+pending(2)
+change-id=1 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-40, write-bandwidth:0, byte-size:0] start=0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=1 type=VOTER_FULL)
+change-id=2 store-id=2 node-id=2 range-id=1 load-delta=[cpu:44, write-bandwidth:0, byte-size:0] start=0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=2 type=VOTER_FULL leaseholder=true)


### PR DESCRIPTION
Change rebalanceStores from *allocatorState to *clusterState receiver and
add rng and dsm as parameters. This enables direct testing of rebalanceStores
from cluster_state_test.go without instantiating allocatorState.

Also update ensureAnalyzedConstraints and computeCandidatesForRange to
use *clusterState receiver.

I intentionally didn't move methods around to avoid large diffs and merge conflicts.
At some point, I'll do a "mostly moving things around" PR when we don't have as
much inflight.

The upshot of the refactor is that we can now use `TestClusterState` to exercise `rebalanceStores`.

I added a TODO to also print the trace output. This is turning into a bigger yak shave
than I anticipated (we need to pare down the default trace output to make sure it's
deterministic and not noisy), so I'll send that separately.

Once I have that, I'll start adding store health logic to the allocator while adding
suitable tests.

Informs #156776.

Epic: CRDB-55052