### PR TITLE
jobs: log message on job pause and cancel state change

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -501,6 +501,11 @@ func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqllivenes
 			job := &Job{id: id, registry: r}
 			stateString := *row[1].(*tree.DString)
 			jobTypeString := *row[2].(*tree.DString)
+
+			if err := job.Messages().Record(ctx, txn, "state", string(stateString)); err != nil {
+				return err
+			}
+
 			switch State(stateString) {
 			case StatePaused:
 				if !r.cancelRegisteredJobContext(id) {


### PR DESCRIPTION
The message logger is supposed to log all job state changes.

Epic: none

Release note: none