### PR TITLE
sql: avoid buffering notice for upgrading to SERIALIZABLE

### DIFF
--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -82,7 +82,13 @@ func (ex *connExecutor) maybeAdjustTxnForDDL(ctx context.Context, stmt Statement
 					return err
 				}
 				ex.extraTxnState.upgradedToSerializable = true
-				p.BufferClientNotice(ctx, pgnotice.Newf("setting transaction isolation level to SERIALIZABLE due to schema change"))
+				if err := p.SendClientNotice(
+					ctx,
+					pgnotice.Newf("setting transaction isolation level to SERIALIZABLE due to schema change"),
+					false, /* immediateFlush */
+				); err != nil {
+					return err
+				}
 			} else {
 				return txnSchemaChangeErr
 			}


### PR DESCRIPTION
This avoids flakiness in a test which expects the notice, but would sometimes not see it.

informs https://github.com/cockroachdb/cockroach/issues/157069
informs https://github.com/cockroachdb/cockroach/issues/157068
informs https://github.com/cockroachdb/cockroach/issues/153543
informs https://github.com/cockroachdb/cockroach/issues/156686
informs https://github.com/cockroachdb/cockroach/issues/156638
informs https://github.com/cockroachdb/cockroach/issues/156513
informs https://github.com/cockroachdb/cockroach/issues/156911

Release note: None