### PR TITLE
release-25.4: logictest: skip 3 tests for SERIALIZABLE notice

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -227,20 +227,27 @@ DROP TABLE supermarket
 ----
 NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
-query T noticetrace
-DROP USER testuser
-----
-NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+# Skip test cases for user/role creation, removal, and inheritance, as they are
+# flaky. https://github.com/cockroachdb/cockroach/pull/157072 should help, but
+# we are not backporting that to the 25.4 branch.
 
-query T noticetrace
-CREATE USER testuser
-----
-NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+# query T noticetrace
+# DROP USER testuser
+# ----
+# NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
-query T noticetrace
+# query T noticetrace
+# CREATE USER testuser
+# ----
+# NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+# query T noticetrace
+# GRANT admin TO testuser
+# ----
+# NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+statement ok
 GRANT admin TO testuser
-----
-NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT SELECT ON foo TO testuser


### PR DESCRIPTION
These test cases are flaky, and it appears to do with how the notice gets buffered before sending to the client. This is being fixed on master, but since it's a non-test code change and the bug is very minor, we won't backport the fix to 25.4.

fixes https://github.com/cockroachdb/cockroach/issues/156686
fixes https://github.com/cockroachdb/cockroach/issues/156638
fixes https://github.com/cockroachdb/cockroach/issues/157071

Release justification: test only change
Release note: None