### PR TITLE
sql: speed up recently added TestTruncateLarge

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1557,42 +1557,52 @@ func TestDropLargeDatabaseWithDeclarativeSchemaChanger(t *testing.T) {
 func TestTruncateLarge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	testTruncateLarge(t, true /* batchLimitSet */)
+}
+
+// TestTruncateLargeErr verifies that an error is returned if the batch limit is
+// effectively not set.
+func TestTruncateLargeErr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testTruncateLarge(t, false /* batchLimitSet */)
+}
+
+func testTruncateLarge(t *testing.T, batchLimitSet bool) {
 	skip.UnderDuress(t, "truncating a large number of tables")
 
-	testutils.RunTrueAndFalse(t, "batch limit set", func(t *testing.T, batchLimitSet bool) {
-		ctx := context.Background()
-		srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
-		defer srv.Stopper().Stop(ctx)
-		sqlDB := sqlutils.MakeSQLRunner(conn)
-		createCommand := strings.Builder{}
-		truncateCommand := strings.Builder{}
-		systemDB := sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t))
-		systemDB.Exec(t, "SET CLUSTER SETTING kv.raft.command.max_size='5m'")
-		if batchLimitSet {
-			sqlDB.Exec(t, "SET CLUSTER SETTING sql.schema_changer.batch_flush_threshold_size='2m'")
-		}
-		// Generate the truncate and create table commands.
-		const numTables = 500
-		truncateCommand.WriteString("TRUNCATE TABLE ")
-		for i := range numTables {
-			createCommand.WriteString(fmt.Sprintf("CREATE TABLE t%d (a INT PRIMARY KEY, j INT, k INT, INDEX (j), INDEX (k), UNIQUE (j, k));\n", i))
-			truncateCommand.WriteString(fmt.Sprintf("t%d", i))
-			if i != numTables-1 {
-				truncateCommand.WriteString(", ")
-			}
-		}
-		// Execute the create commands first.
-		sqlDB.Exec(t, createCommand.String())
-
-		// The default limit is larger than our reduced raft command size, so if the
-		// limit is not modified, the truncate command will fail.
-		if batchLimitSet {
-			sqlDB.Exec(t, truncateCommand.String())
-		} else {
-			sqlDB.ExpectErr(t, "command is too large", truncateCommand.String())
-		}
+	srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		SQLMemoryPoolSize: 1 << 30, /* 1 GiB */
 	})
+	defer srv.Stopper().Stop(context.Background())
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+	createCommand := strings.Builder{}
+	truncateCommand := strings.Builder{}
+	systemDB := sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t))
+	systemDB.Exec(t, "SET CLUSTER SETTING kv.raft.command.max_size='4.1MiB'")
+	if batchLimitSet {
+		sqlDB.Exec(t, "SET CLUSTER SETTING sql.schema_changer.batch_flush_threshold_size='1.8MiB'")
+	}
+	// Generate the truncate and create table commands.
+	const numTables = 340
+	truncateCommand.WriteString("TRUNCATE TABLE ")
+	for i := range numTables {
+		createCommand.WriteString(fmt.Sprintf("CREATE TABLE t%d (a INT PRIMARY KEY, j INT, k INT, INDEX (j), INDEX (k), UNIQUE (j, k));\n", i))
+		truncateCommand.WriteString(fmt.Sprintf("t%d", i))
+		if i != numTables-1 {
+			truncateCommand.WriteString(", ")
+		}
+	}
+	// Execute the create commands first.
+	sqlDB.Exec(t, createCommand.String())
 
+	// The default limit is larger than our reduced raft command size, so if the
+	// limit is not modified, the truncate command will fail.
+	if batchLimitSet {
+		sqlDB.Exec(t, truncateCommand.String())
+	} else {
+		sqlDB.ExpectErr(t, "command is too large", truncateCommand.String())
+	}
 }
 
 func BenchmarkDropLargeDatabaseWithGenerateTestObjects(b *testing.B) {


### PR DESCRIPTION
We just saw a timeout in tests where 15m limit was exceeded because more than 11m were consumed by TestTruncateLarge. In order to speed up the test, this commit reduces the number of tables affected as well as splits up two sub-tests into separate tests (hoping that they will end up in different shards).

Fixes: #156998.
Release note: None