### PR TITLE
spanset: fix and simplify mergeSpans

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -1037,7 +1037,7 @@ func spansForAllTableIndexes(
 	// Attempt to merge any contiguous spans generated from the tables and revs.
 	// No need to check if the spans are distinct, since some of the merged
 	// indexes may overlap between different revisions of the same descriptor.
-	mergedSpans, _ := roachpb.MergeSpans(&spans)
+	mergedSpans, _ := roachpb.MergeSpans(spans)
 
 	knobs := execCfg.BackupRestoreTestingKnobs
 	if knobs != nil && knobs.CaptureResolvedTableDescSpans != nil {

--- a/pkg/backup/restore_span_covering_test.go
+++ b/pkg/backup/restore_span_covering_test.go
@@ -797,7 +797,7 @@ func runTestRestoreEntryCoverForSpanAndFileCounts(
 			completedSpans = append(completedSpans, sp)
 		}
 
-		merged, _ := roachpb.MergeSpans(&completedSpans)
+		merged, _ := roachpb.MergeSpans(completedSpans)
 		return merged
 	}
 

--- a/pkg/backup/utils_test.go
+++ b/pkg/backup/utils_test.go
@@ -239,7 +239,7 @@ func getSpansFromManifest(ctx context.Context, t *testing.T, backupPath string) 
 	for _, file := range backupManifest.Files {
 		spans = append(spans, file.Span)
 	}
-	mergedSpans, _ := roachpb.MergeSpans(&spans)
+	mergedSpans, _ := roachpb.MergeSpans(spans)
 	return mergedSpans
 }
 

--- a/pkg/kv/kvclient/kvcoord/condensable_span_set.go
+++ b/pkg/kv/kvclient/kvcoord/condensable_span_set.go
@@ -63,7 +63,7 @@ func (s *condensableSpanSet) insert(spans ...roachpb.Span) {
 // The method has the side effect of sorting the set.
 func (s *condensableSpanSet) mergeAndSort() {
 	oldLen := len(s.s)
-	s.s, _ = roachpb.MergeSpans(&s.s)
+	s.s, _ = roachpb.MergeSpans(s.s)
 	// Recompute the size if anything has changed.
 	if oldLen != len(s.s) {
 		s.bytes = 0
@@ -222,7 +222,7 @@ func (s *condensableSpanSet) estimateSize(spans []roachpb.Span, mergeThresholdBy
 	// Try harder - merge (a copy of) the existing spans with the new spans.
 	spans = append(spans, s.s...)
 	lenBeforeMerge := len(spans)
-	spans, _ = roachpb.MergeSpans(&spans)
+	spans, _ = roachpb.MergeSpans(spans)
 	if len(spans) == lenBeforeMerge {
 		// Nothing changed -i.e. we failed to merge any spans.
 		return estimate

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -404,7 +404,7 @@ func mergeIntoSpans(s []roachpb.Span, ws []roachpb.SequencedWrite) ([]roachpb.Sp
 	for i, w := range ws {
 		m[len(s)+i] = roachpb.Span{Key: w.Key}
 	}
-	return roachpb.MergeSpans(&m)
+	return roachpb.MergeSpans(m)
 }
 
 // isTxnCommitImplicit determines whether the transaction has satisfied the

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -485,7 +485,7 @@ func (tp *txnPipeliner) attachLocksToEndTxn(
 	}
 
 	// Sort both sets and condense the lock spans.
-	et.LockSpans, _ = roachpb.MergeSpans(&et.LockSpans)
+	et.LockSpans, _ = roachpb.MergeSpans(et.LockSpans)
 	sort.Sort(roachpb.SequencedWriteBySeq(et.InFlightWrites))
 
 	if log.V(3) {

--- a/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recover_txn.go
@@ -204,7 +204,7 @@ func RecoverTxn(
 		sp := roachpb.Span{Key: w.Key}
 		reply.RecoveredTxn.LockSpans = append(reply.RecoveredTxn.LockSpans, sp)
 	}
-	reply.RecoveredTxn.LockSpans, _ = roachpb.MergeSpans(&reply.RecoveredTxn.LockSpans)
+	reply.RecoveredTxn.LockSpans, _ = roachpb.MergeSpans(reply.RecoveredTxn.LockSpans)
 	reply.RecoveredTxn.InFlightWrites = nil
 
 	// Recover the transaction based on whether or not all of its writes

--- a/pkg/kv/kvserver/lockspanset/lockspanset.go
+++ b/pkg/kv/kvserver/lockspanset/lockspanset.go
@@ -42,7 +42,7 @@ func (l *LockSpanSet) Add(str lock.Strength, span roachpb.Span) {
 // SortAndDeDup sorts the spans in the LockSpanSet and removes any duplicates.
 func (l *LockSpanSet) SortAndDeDup() {
 	for st := range l.spans {
-		l.spans[st], _ /* distinct */ = roachpb.MergeSpans(&l.spans[st])
+		l.spans[st], _ /* distinct */ = roachpb.MergeSpans(l.spans[st])
 	}
 }
 

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -92,7 +92,7 @@ func maybeStripInFlightWrites(ba *kvpb.BatchRequest) (*kvpb.BatchRequest, error)
 				et.LockSpans[len(origET.LockSpans)+i] = roachpb.Span{Key: w.Key}
 			}
 			// See below for why we set Header.DistinctSpans here.
-			et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(&et.LockSpans)
+			et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(et.LockSpans)
 			return ba, nil
 		}
 	}
@@ -164,7 +164,7 @@ func maybeStripInFlightWrites(ba *kvpb.BatchRequest) (*kvpb.BatchRequest, error)
 		// batch overlap with each other. This will have (rare) false negatives
 		// when the in-flight writes overlap with existing lock spans, but never
 		// false positives.
-		et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(&et.LockSpans)
+		et.LockSpans, ba.Header.DistinctSpans = roachpb.MergeSpans(et.LockSpans)
 	}
 	return ba, nil
 }

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     size = "small",
     srcs = [
         "batch_test.go",
+        "merge_test.go",
         "spanset_test.go",
     ],
     embed = [":spanset"],

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -13,14 +13,14 @@ import "slices"
 //
 // Returns true iff all of the spans are distinct.
 // The input spans are not safe for re-use.
-func mergeSpans(latches *[]Span) ([]Span, bool) {
-	if len(*latches) == 0 {
-		return *latches, true
+func mergeSpans(latches []Span) ([]Span, bool) {
+	if len(latches) == 0 {
+		return latches, true
 	}
 
 	// Sort first on the start key and second on the end key. Note that we're
 	// relying on empty EndKey sorting before other EndKeys.
-	slices.SortFunc(*latches, func(s1, s2 Span) int {
+	slices.SortFunc(latches, func(s1, s2 Span) int {
 		if c := s1.Key.Compare(s2.Key); c != 0 {
 			return c
 		}
@@ -30,10 +30,10 @@ func mergeSpans(latches *[]Span) ([]Span, bool) {
 	// We build up the resulting slice of merged spans in place. This is safe
 	// because "r" grows by at most 1 element on each iteration, staying abreast
 	// or behind the iteration over "latches".
-	r := (*latches)[:1]
+	r := latches[:1]
 	distinct := true
 
-	for _, cur := range (*latches)[1:] {
+	for _, cur := range latches[1:] {
 		prev := &r[len(r)-1]
 		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
 			if cur.Key.Compare(prev.Key) != 0 {

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -78,8 +78,9 @@ func mergeSpans(latches []Span) []Span {
 				// [a, b] merge [b, nil]
 				if cur.Timestamp != prev.Timestamp {
 					r = append(r, cur)
+				} else {
+					prev.EndKey = cur.Key.Next()
 				}
-				prev.EndKey = cur.Key.Next()
 			} else {
 				// [a, c] merge [b, nil]
 				if cur.Timestamp != prev.Timestamp {

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -32,26 +32,22 @@ func mergeSpans(latches []Span) []Span {
 
 	for _, cur := range latches[1:] {
 		prev := &r[len(r)-1]
+		// Can only merge spans at the same timestamp.
+		if cur.Timestamp != prev.Timestamp {
+			r = append(r, cur)
+			continue
+		}
 		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
 			if cur.Key.Compare(prev.Key) != 0 {
 				// [a, nil] merge [b, nil]
 				r = append(r, cur)
-			} else {
-				// [a, nil] merge [a, nil]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				}
 			}
 			continue
 		}
 		if len(prev.EndKey) == 0 {
 			if cur.Key.Compare(prev.Key) == 0 {
 				// [a, nil] merge [a, b]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				} else {
-					prev.EndKey = cur.EndKey
-				}
+				prev.EndKey = cur.EndKey
 			} else {
 				// [a, nil] merge [b, c]
 				r = append(r, cur)
@@ -63,29 +59,11 @@ func mergeSpans(latches []Span) []Span {
 			if cur.EndKey != nil {
 				if prev.EndKey.Compare(cur.EndKey) < 0 {
 					// [a, c] merge [b, d]
-					if cur.Timestamp != prev.Timestamp {
-						r = append(r, cur)
-					} else {
-						prev.EndKey = cur.EndKey
-					}
-				} else {
-					// [a, c] merge [b, c]
-					if cur.Timestamp != prev.Timestamp {
-						r = append(r, cur)
-					}
+					prev.EndKey = cur.EndKey
 				}
 			} else if c == 0 {
 				// [a, b] merge [b, nil]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				} else {
-					prev.EndKey = cur.Key.Next()
-				}
-			} else {
-				// [a, c] merge [b, nil]
-				if cur.Timestamp != prev.Timestamp {
-					r = append(r, cur)
-				}
+				prev.EndKey = cur.Key.Next()
 			}
 			continue
 		}

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -7,15 +7,13 @@ package spanset
 
 import "slices"
 
-// mergeSpans sorts the given spans and merges ones with overlapping
-// spans and equal access timestamps. The implementation is a copy of
-// roachpb.MergeSpans.
+// mergeSpans sorts the given spans and merges ones with overlapping spans and
+// equal access timestamps. The implementation is a modified roachpb.MergeSpans.
 //
-// Returns true iff all of the spans are distinct.
 // The input spans are not safe for re-use.
-func mergeSpans(latches []Span) ([]Span, bool) {
+func mergeSpans(latches []Span) []Span {
 	if len(latches) == 0 {
-		return latches, true
+		return latches
 	}
 
 	// Sort first on the start key and second on the end key. Note that we're
@@ -31,7 +29,6 @@ func mergeSpans(latches []Span) ([]Span, bool) {
 	// because "r" grows by at most 1 element on each iteration, staying abreast
 	// or behind the iteration over "latches".
 	r := latches[:1]
-	distinct := true
 
 	for _, cur := range latches[1:] {
 		prev := &r[len(r)-1]
@@ -44,7 +41,6 @@ func mergeSpans(latches []Span) ([]Span, bool) {
 				if cur.Timestamp != prev.Timestamp {
 					r = append(r, cur)
 				}
-				distinct = false
 			}
 			continue
 		}
@@ -56,7 +52,6 @@ func mergeSpans(latches []Span) ([]Span, bool) {
 				} else {
 					prev.EndKey = cur.EndKey
 				}
-				distinct = false
 			} else {
 				// [a, nil] merge [b, c]
 				r = append(r, cur)
@@ -73,15 +68,11 @@ func mergeSpans(latches []Span) ([]Span, bool) {
 					} else {
 						prev.EndKey = cur.EndKey
 					}
-					if c > 0 {
-						distinct = false
-					}
 				} else {
 					// [a, c] merge [b, c]
 					if cur.Timestamp != prev.Timestamp {
 						r = append(r, cur)
 					}
-					distinct = false
 				}
 			} else if c == 0 {
 				// [a, b] merge [b, nil]
@@ -94,11 +85,10 @@ func mergeSpans(latches []Span) ([]Span, bool) {
 				if cur.Timestamp != prev.Timestamp {
 					r = append(r, cur)
 				}
-				distinct = false
 			}
 			continue
 		}
 		r = append(r, cur)
 	}
-	return r, distinct
+	return r
 }

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -5,28 +5,7 @@
 
 package spanset
 
-import "sort"
-
-type sortedSpans []Span
-
-func (s *sortedSpans) Less(i, j int) bool {
-	// Sort first on the start key and second on the end key. Note that we're
-	// relying on EndKey = nil (and len(EndKey) == 0) sorting before other
-	// EndKeys.
-	c := (*s)[i].Key.Compare((*s)[j].Key)
-	if c != 0 {
-		return c < 0
-	}
-	return (*s)[i].EndKey.Compare((*s)[j].EndKey) < 0
-}
-
-func (s *sortedSpans) Swap(i, j int) {
-	(*s)[i], (*s)[j] = (*s)[j], (*s)[i]
-}
-
-func (s *sortedSpans) Len() int {
-	return len(*s)
-}
+import "slices"
 
 // mergeSpans sorts the given spans and merges ones with overlapping
 // spans and equal access timestamps. The implementation is a copy of
@@ -39,7 +18,14 @@ func mergeSpans(latches *[]Span) ([]Span, bool) {
 		return *latches, true
 	}
 
-	sort.Sort((*sortedSpans)(latches))
+	// Sort first on the start key and second on the end key. Note that we're
+	// relying on empty EndKey sorting before other EndKeys.
+	slices.SortFunc(*latches, func(s1, s2 Span) int {
+		if c := s1.Key.Compare(s2.Key); c != 0 {
+			return c
+		}
+		return s1.EndKey.Compare(s2.EndKey)
+	})
 
 	// We build up the resulting slice of merged spans in place. This is safe
 	// because "r" grows by at most 1 element on each iteration, staying abreast

--- a/pkg/kv/kvserver/spanset/merge.go
+++ b/pkg/kv/kvserver/spanset/merge.go
@@ -10,6 +10,27 @@ import "slices"
 // mergeSpans sorts the given spans and merges ones with overlapping spans and
 // equal access timestamps. The implementation is a modified roachpb.MergeSpans.
 //
+// The input and output spans represent the same subset of {keys}x{timestamps}
+// space. The resulting spans are ordered by key. It is minimal (impossible to
+// "merge" further without losing precision) only if there are no keys present
+// under multiple timestamps.
+//
+// When there are keys present under multiple timestamps, the resulting merged
+// set is not guaranteed to be minimal. For example, [{a-b}@10, b@20, {b-c}@10]
+// is returned as is, even though we could merge it as [{a-c}@10, b@20]. This is
+// due to an arbitrary choice of sorting it by key.
+//
+// TODO(pav-kv): we could sort by (timestamp, key), which makes it possible to
+// merge spans with the same timestamp and guarantee minimality. After which, we
+// can optionally sort by key again. This is still more expensive than one sort,
+// so consider if the users are fine with the set sorted by (timestamp, key).
+//
+// The priority for this function is to be simple and free from assumptions
+// about how to "resolve" the situation of having the same key under multiple
+// timestamps. E.g. it does not assume that higher/lower timestamp "wins", or
+// what the semantics of an empty timestamp are. Considerations like that are
+// left to the consumer of this span set, e.g. the latch manager.
+//
 // The input spans are not safe for re-use.
 func mergeSpans(latches []Span) []Span {
 	if len(latches) == 0 {

--- a/pkg/kv/kvserver/spanset/merge_test.go
+++ b/pkg/kv/kvserver/spanset/merge_test.go
@@ -47,7 +47,7 @@ func TestMergeSpans(t *testing.T) {
 		{"a@10,a-b@10", "a-b@10"},
 		{"a@10,a-b@20", "a@10,a-b@20"},
 		{"a-b@20,b@20", "a-b\x00@20"},
-		{"a-b@20,b@30", "a-b\x00@20,b@30"}, // FIXME: this is a bug
+		{"a-b@20,b@30", "a-b@20,b@30"},
 		{"a-c@20,m-n@10,c-o@10,o-z@20", "a-c@20,c-o@10,o-z@20"},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/pkg/kv/kvserver/spanset/merge_test.go
+++ b/pkg/kv/kvserver/spanset/merge_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package spanset
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeSpans(t *testing.T) {
+	for _, tc := range []struct {
+		spans    string
+		expected string
+	}{
+		{"", ""},
+		{"a", "a"},
+		{"a,b", "a,b"},
+		{"b,a", "a,b"},
+		{"a,a", "a"},
+		{"a-b", "a-b"},
+		{"a-b,b-c", "a-c"},
+		{"a-c,a-b", "a-c"},
+		{"a,b-c", "a,b-c"},
+		{"a,a-c", "a-c"},
+		{"a-c,b", "a-c"},
+		{"a-c,c", "a-c\x00"},
+		{"a-c,b-bb", "a-c"},
+		{"a-c,b-c", "a-c"},
+		{"a-c,b-d", "a-d"},
+
+		{"a-b,b-b\x00", "a-b\x00"},
+		{"b,b\x00", "b,b\x00"},     // TODO(pav-kv): should merge here too
+		{"b,b\x00-c", "b,b\x00-c"}, // TODO(pav-kv): should merge here too
+
+		{"a@10", "a@10"},
+		{"a@10,b@10", "a@10,b@10"},
+		{"a@10,b@20", "a@10,b@20"},
+		{"b@20,a@10", "a@10,b@20"},
+		{"a@10,a-b@10", "a-b@10"},
+		{"a@10,a-b@20", "a@10,a-b@20"},
+		{"a-b@20,b@20", "a-b\x00@20"},
+		{"a-b@20,b@30", "a-b\x00@20,b@30"}, // FIXME: this is a bug
+		{"a-c@20,m-n@10,c-o@10,o-z@20", "a-c@20,c-o@10,o-z@20"},
+	} {
+		t.Run("", func(t *testing.T) {
+			spans := mergeSpans(makeSpans(t, tc.spans))
+			expected := makeSpans(t, tc.expected)
+			require.Equal(t, expected, spans, tc.spans)
+		})
+	}
+}
+
+func makeSpan(t *testing.T, s string) Span {
+	var ts hlc.Timestamp
+	if idx := strings.IndexByte(s, '@'); idx != -1 {
+		i, err := strconv.ParseInt(s[idx+1:], 10, 63)
+		require.NoError(t, err)
+		ts = hlc.Timestamp{WallTime: i}
+		s = s[:idx]
+	}
+	parts := strings.Split(s, "-")
+	if len(parts) != 2 {
+		return Span{Span: roachpb.Span{Key: roachpb.Key(s)}, Timestamp: ts}
+	}
+	return Span{
+		Span: roachpb.Span{
+			Key:    roachpb.Key(parts[0]),
+			EndKey: roachpb.Key(parts[1]),
+		},
+		Timestamp: ts,
+	}
+}
+
+func makeSpans(t *testing.T, s string) []Span {
+	var spans []Span
+	for _, p := range strings.Split(s, ",") {
+		spans = append(spans, makeSpan(t, p))
+	}
+	return spans
+}

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -216,7 +216,7 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 func (s *SpanSet) SortAndDedup() {
 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			s.spans[sa][ss], _ /* distinct */ = mergeSpans(&s.spans[sa][ss])
+			s.spans[sa][ss], _ /* distinct */ = mergeSpans(s.spans[sa][ss])
 		}
 	}
 }

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -226,21 +226,6 @@ func (s *SpanSet) GetSpans(access SpanAccess, scope SpanScope) []Span {
 	return s.spans[access][scope]
 }
 
-// BoundarySpan returns a span containing all the spans with the given params.
-func (s *SpanSet) BoundarySpan(scope SpanScope) roachpb.Span {
-	var boundary roachpb.Span
-	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
-		for _, cur := range s.GetSpans(sa, scope) {
-			if !boundary.Valid() {
-				boundary = cur.Span
-				continue
-			}
-			boundary = boundary.Combine(cur.Span)
-		}
-	}
-	return boundary
-}
-
 // Intersects returns true iff the span set denoted by `other` has any
 // overlapping spans with `s`, and that those spans overlap in access type. Note
 // that timestamps associated with the spans in the spanset are not considered,

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -216,7 +216,7 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 func (s *SpanSet) SortAndDedup() {
 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {
-			s.spans[sa][ss], _ /* distinct */ = mergeSpans(s.spans[sa][ss])
+			s.spans[sa][ss] = mergeSpans(s.spans[sa][ss])
 		}
 	}
 }

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -212,7 +212,13 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 	s.SortAndDedup()
 }
 
-// SortAndDedup sorts the spans in the SpanSet and removes any duplicates.
+// SortAndDedup sorts the spans in the SpanSet by key and removes duplicate or
+// overlapping / redundant spans. The SpanSet represents the same subset of the
+// {keys}x{timestamps} space before and after this call, but is not guaranteed
+// to have a minimal number of spans in a general case (see mergeSpans comment).
+//
+// TODO(pav-kv): does this make CheckAllowed falsely fail in some cases? Maybe
+// it's fine: importantly, it should not falsely succeed.
 func (s *SpanSet) SortAndDedup() {
 	for sa := SpanAccess(0); sa < NumSpanAccess; sa++ {
 		for ss := SpanScope(0); ss < NumSpanScope; ss++ {

--- a/pkg/roachpb/merge_spans.go
+++ b/pkg/roachpb/merge_spans.go
@@ -16,14 +16,14 @@ import (
 // but the two are still merged.
 //
 // The input spans are not safe for re-use.
-func MergeSpans(spans *[]Span) ([]Span, bool) {
-	if len(*spans) == 0 {
-		return *spans, true
+func MergeSpans(spans []Span) ([]Span, bool) {
+	if len(spans) == 0 {
+		return spans, true
 	}
 
 	// Sort first on the start key and second on the end key. Note that we're
 	// relying on empty EndKey sorting before other EndKeys.
-	slices.SortFunc(*spans, func(s1, s2 Span) int {
+	slices.SortFunc(spans, func(s1, s2 Span) int {
 		if c := s1.Key.Compare(s2.Key); c != 0 {
 			return c
 		}
@@ -33,10 +33,10 @@ func MergeSpans(spans *[]Span) ([]Span, bool) {
 	// We build up the resulting slice of merged spans in place. This is safe
 	// because "r" grows by at most 1 element on each iteration, staying abreast
 	// or behind the iteration over "spans".
-	r := (*spans)[:1]
+	r := spans[:1]
 	distinct := true
 
-	for _, cur := range (*spans)[1:] {
+	for _, cur := range spans[1:] {
 		prev := &r[len(r)-1]
 		if len(cur.EndKey) == 0 && len(prev.EndKey) == 0 {
 			if cur.Key.Compare(prev.Key) != 0 {

--- a/pkg/roachpb/merge_spans_test.go
+++ b/pkg/roachpb/merge_spans_test.go
@@ -56,7 +56,7 @@ func TestMergeSpans(t *testing.T) {
 	}
 	for _, c := range testCases {
 		spans := makeSpans(c.spans)
-		spans, distinct := MergeSpans((*[]Span)(&spans))
+		spans, distinct := MergeSpans(spans)
 		expected := makeSpans(c.expected)
 		require.Equal(t, expected, spans)
 		require.Equal(t, c.distinct, distinct)

--- a/pkg/roachpb/merge_spans_test.go
+++ b/pkg/roachpb/merge_spans_test.go
@@ -34,7 +34,7 @@ func makeSpans(s string) Spans {
 }
 
 func TestMergeSpans(t *testing.T) {
-	testCases := []struct {
+	for _, tc := range []struct {
 		spans    string
 		expected string
 		distinct bool
@@ -53,13 +53,15 @@ func TestMergeSpans(t *testing.T) {
 		{"a-c,c", "a-c\x00", true},
 		{"a-c,b-bb", "a-c", false},
 		{"a-c,b-c", "a-c", false},
-	}
-	for _, c := range testCases {
-		spans := makeSpans(c.spans)
-		spans, distinct := MergeSpans(spans)
-		expected := makeSpans(c.expected)
-		require.Equal(t, expected, spans)
-		require.Equal(t, c.distinct, distinct)
+		{"a-c,b-d", "a-d", false},
+	} {
+		t.Run("", func(t *testing.T) {
+			spans := makeSpans(tc.spans)
+			spans, distinct := MergeSpans(spans)
+			expected := makeSpans(tc.expected)
+			require.Equal(t, expected, spans)
+			require.Equal(t, tc.distinct, distinct)
+		})
 	}
 }
 

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -160,7 +160,7 @@ func addKeyToLockSpans(txn *roachpb.Transaction, key roachpb.Key) {
 	newLockSpans = append(newLockSpans, roachpb.Span{
 		Key: key,
 	})
-	txn.LockSpans, _ = roachpb.MergeSpans(&newLockSpans)
+	txn.LockSpans, _ = roachpb.MergeSpans(newLockSpans)
 }
 
 type mvccGetOp struct {


### PR DESCRIPTION
The `mergeSpans` function used for `SortAndDedup` calls on `SpanSet` is not tested and not clear about the semantics when the input slice of `Span@Timestamp` has keys that are present at multiple timestamps. In the latter case, `mergeSpans` does not output a minimal / "canonical" set of spans.

This does not look good because the result of this call is fed to the latch manager, i.e. this function is on the critical path for CRDB correctness / performance. Adding a test revealed a bug in this function that could result in placing a wider latch than was requested. This PR fixes this bug, adds tests, clarifies the semantics of and refactors `mergeSpans` (and the `roachpb.MergeSpans` that it is mostly a copy of) into a readable state.

Epic: none
Release note (bug fix): a bug in key span merging could result in placing wider latches than needed for a request, which could impose unnecessary contention. The effect of this bug hasn't been observed in the wild, and possibly never happened.