### PR TITLE
sql/schemachanger: rename sequence option mutation

### DIFF
--- a/pkg/sql/schemachanger/scexec/scmutationexec/sequence.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/sequence.go
@@ -48,9 +48,7 @@ func (i *immediateVisitor) CreateSequenceDescriptor(
 	return nil
 }
 
-func (i *immediateVisitor) SetSequenceOptions(
-	ctx context.Context, op scop.SetSequenceOptions,
-) error {
+func (i *immediateVisitor) SetSequenceOption(ctx context.Context, op scop.SetSequenceOption) error {
 	sc, err := i.checkOutTable(ctx, op.SequenceID)
 	if err != nil {
 		return err

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1099,7 +1099,7 @@ type CreateSequenceDescriptor struct {
 	Temporary  bool
 }
 
-type SetSequenceOptions struct {
+type SetSequenceOption struct {
 	immediateMutationOp
 	SequenceID descpb.ID
 	Key        string

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -158,7 +158,7 @@ type ImmediateMutationVisitor interface {
 	UpdateOwner(context.Context, UpdateOwner) error
 	CreateSchemaDescriptor(context.Context, CreateSchemaDescriptor) error
 	CreateSequenceDescriptor(context.Context, CreateSequenceDescriptor) error
-	SetSequenceOptions(context.Context, SetSequenceOptions) error
+	SetSequenceOption(context.Context, SetSequenceOption) error
 	InitSequence(context.Context, InitSequence) error
 	CreateDatabaseDescriptor(context.Context, CreateDatabaseDescriptor) error
 	AddNamedRangeZoneConfig(context.Context, AddNamedRangeZoneConfig) error
@@ -884,8 +884,8 @@ func (op CreateSequenceDescriptor) Visit(ctx context.Context, v ImmediateMutatio
 }
 
 // Visit is part of the ImmediateMutationOp interface.
-func (op SetSequenceOptions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
-	return v.SetSequenceOptions(ctx, op)
+func (op SetSequenceOption) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.SetSequenceOption(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence_option.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence_option.go
@@ -15,8 +15,8 @@ func init() {
 		toPublic(
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.SequenceOption) *scop.SetSequenceOptions {
-					return &scop.SetSequenceOptions{
+				emit(func(this *scpb.SequenceOption) *scop.SetSequenceOption {
+					return &scop.SetSequenceOption{
 						SequenceID: this.SequenceID,
 						Key:        this.Key,
 						Value:      this.Value,

--- a/pkg/sql/schemachanger/scplan/testdata/create_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/create_sequence
@@ -34,7 +34,7 @@ StatementPhase stage 1 of 1 with 24 MutationType ops
       ObjParent:
         ChildObjectID: 104
         SchemaID: 101
-    *scop.SetSequenceOptions
+    *scop.SetSequenceOption
       Key: START
       SequenceID: 104
       Value: "32"
@@ -172,7 +172,7 @@ PreCommitPhase stage 2 of 2 with 25 MutationType ops
       ObjParent:
         ChildObjectID: 104
         SchemaID: 101
-    *scop.SetSequenceOptions
+    *scop.SetSequenceOption
       Key: START
       SequenceID: 104
       Value: "32"

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated.explain
@@ -48,9 +48,9 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── SetNameInDescriptor {"DescriptorID":107,"Name":"tbl_serial_id_se..."}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"INCREMENT","SequenceID":107,"Value":"32"}
- │              ├── SetSequenceOptions {"Key":"MINVALUE","SequenceID":107,"Value":"0"}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":107,"Value":"0"}
+ │              ├── SetSequenceOption {"Key":"INCREMENT","SequenceID":107,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"MINVALUE","SequenceID":107,"Value":"0"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":107,"Value":"0"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}
@@ -164,9 +164,9 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── UpdateTTLScheduleMetadata {"NewName":"tbl_serial_id_se...","TableID":107}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"INCREMENT","SequenceID":107,"Value":"32"}
- │              ├── SetSequenceOptions {"Key":"MINVALUE","SequenceID":107,"Value":"0"}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":107,"Value":"0"}
+ │              ├── SetSequenceOption {"Key":"INCREMENT","SequenceID":107,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"MINVALUE","SequenceID":107,"Value":"0"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":107,"Value":"0"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached.explain
@@ -46,7 +46,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── SetNameInDescriptor {"DescriptorID":107,"Name":"tbl_serial_id_se..."}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"PER SESSION CACH...","SequenceID":107,"Value":"256"}
+ │              ├── SetSequenceOption {"Key":"PER SESSION CACH...","SequenceID":107,"Value":"256"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}
@@ -153,7 +153,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── UpdateTTLScheduleMetadata {"NewName":"tbl_serial_id_se...","TableID":107}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"PER SESSION CACH...","SequenceID":107,"Value":"256"}
+ │              ├── SetSequenceOption {"Key":"PER SESSION CACH...","SequenceID":107,"Value":"256"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node.explain
@@ -46,7 +46,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── SetNameInDescriptor {"DescriptorID":107,"Name":"tbl_serial_id_se..."}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"PER NODE CACHE","SequenceID":107,"Value":"256"}
+ │              ├── SetSequenceOption {"Key":"PER NODE CACHE","SequenceID":107,"Value":"256"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}
@@ -153,7 +153,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── UpdateTTLScheduleMetadata {"NewName":"tbl_serial_id_se...","TableID":107}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"PER NODE CACHE","SequenceID":107,"Value":"256"}
+ │              ├── SetSequenceOption {"Key":"PER NODE CACHE","SequenceID":107,"Value":"256"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual.explain
@@ -46,7 +46,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── SetNameInDescriptor {"DescriptorID":107,"Name":"tbl_serial_id_se..."}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"VIRTUAL","SequenceID":107,"Value":"true"}
+ │              ├── SetSequenceOption {"Key":"VIRTUAL","SequenceID":107,"Value":"true"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}
@@ -153,7 +153,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"tbl_serial_id_se...","SchemaID":105}}
  │              ├── UpdateTTLScheduleMetadata {"NewName":"tbl_serial_id_se...","TableID":107}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":107,"SchemaID":105}}
- │              ├── SetSequenceOptions {"Key":"VIRTUAL","SequenceID":107,"Value":"true"}
+ │              ├── SetSequenceOption {"Key":"VIRTUAL","SequenceID":107,"Value":"true"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":107}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":107}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":107}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_4_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_4_of_4.explain
@@ -34,7 +34,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
  │              ├── SetNameInDescriptor {"DescriptorID":108,"Name":"sq1"}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"sq1","SchemaID":106}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":108,"SchemaID":106}}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":108,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":108,"Value":"32"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":108}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":108}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":108}
@@ -161,7 +161,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
                 ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"sq1","SchemaID":106}}
                 ├── UpdateTTLScheduleMetadata {"NewName":"sq1","TableID":108}
                 ├── SetObjectParentID {"ObjParent":{"ChildObjectID":108,"SchemaID":106}}
-                ├── SetSequenceOptions {"Key":"START","SequenceID":108,"Value":"32"}
+                ├── SetSequenceOption {"Key":"START","SequenceID":108,"Value":"32"}
                 ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":108}}
                 ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":108}}
                 ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":108}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.explain
@@ -27,7 +27,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"sq1"}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sq1","SchemaID":101}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":101}}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":104,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":104,"Value":"32"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":104}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":104}
@@ -90,7 +90,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
                 ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sq1","SchemaID":101}}
                 ├── UpdateTTLScheduleMetadata {"NewName":"sq1","TableID":104}
                 ├── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":101}}
-                ├── SetSequenceOptions {"Key":"START","SequenceID":104,"Value":"32"}
+                ├── SetSequenceOption {"Key":"START","SequenceID":104,"Value":"32"}
                 ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":104}}
                 ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":104}}
                 ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_1_of_2.explain
@@ -28,7 +28,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"sq1"}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"sq1","SchemaID":101}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":101}}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":105,"Value":"32"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":105}
@@ -91,7 +91,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
                 ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"sq1","SchemaID":101}}
                 ├── UpdateTTLScheduleMetadata {"NewName":"sq1","TableID":105}
                 ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":101}}
-                ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+                ├── SetSequenceOption {"Key":"START","SequenceID":105,"Value":"32"}
                 ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
                 ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}
                 ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
@@ -103,7 +103,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │         │    └── PUBLIC → ABSENT        TableSchemaLocked:{DescID: 104 (t)}
  │         └── 42 Mutation operations
  │              ├── CreateSequenceDescriptor {"SequenceID":105}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":105,"Value":"32"}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":101}}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_1_of_2.explain
@@ -27,7 +27,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"sq1"}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sq1","SchemaID":101}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":101}}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":104,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":104,"Value":"32"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":104}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":104}
@@ -90,7 +90,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
                 ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sq1","SchemaID":101}}
                 ├── UpdateTTLScheduleMetadata {"NewName":"sq1","TableID":104}
                 ├── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":101}}
-                ├── SetSequenceOptions {"Key":"START","SequenceID":104,"Value":"32"}
+                ├── SetSequenceOption {"Key":"START","SequenceID":104,"Value":"32"}
                 ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":104}}
                 ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":104}}
                 ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
@@ -33,7 +33,7 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
  │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"sq1"}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"sq1","SchemaID":104}}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":104}}
- │              ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+ │              ├── SetSequenceOption {"Key":"START","SequenceID":105,"Value":"32"}
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}
  │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":105}
@@ -105,7 +105,7 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
                 ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"sq1","SchemaID":104}}
                 ├── UpdateTTLScheduleMetadata {"NewName":"sq1","TableID":105}
                 ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":104}}
-                ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+                ├── SetSequenceOption {"Key":"START","SequenceID":105,"Value":"32"}
                 ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
                 ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}
                 ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":105}


### PR DESCRIPTION
This operation covers a single option not multiple.

Part of: #142914
Epic: CRDB-31283

Release note: None
