### PR TITLE
kvserver: update compacted bytes timeseries to include BlobRewrite bytes

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1368,6 +1368,8 @@ func (m *Metrics) CompactedBytes() (read, written uint64) {
 		read += lm.TableBytesRead + lm.BlobBytesRead
 		written += lm.TablesCompacted.Bytes + lm.BlobBytesCompacted
 	}
+	read += uint64(m.Metrics.Compact.BlobFileRewrite.BytesRead)
+	written += uint64(m.Metrics.Compact.BlobFileRewrite.BytesWritten)
 	return read, written
 }
 


### PR DESCRIPTION
This patch updates `CompactedBytes()` to include bytes written/read during a blob file rewrite. This function is used to determine our compaction bytes written/read timeseries.

Epic: none
Fixes: #157024

Release note: None