### PR TITLE
backup, jobs: reliably emit context cancelled on drain, treat as retryable 

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -814,10 +814,10 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 					err = kvFeedErr
 				}
 			}
-			// Shut down the poller if it wasn't already.
-			ca.cancel()
 			log.Changefeed.Warningf(ca.Ctx(), "moving to draining due to error from tick: %v", err)
 			ca.MoveToDraining(err)
+			// Shut down the poller if it wasn't already.
+			ca.cancel()
 			break
 		}
 	}

--- a/pkg/jobs/joberror/errors.go
+++ b/pkg/jobs/joberror/errors.go
@@ -6,6 +6,8 @@
 package joberror
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -32,5 +34,6 @@ func IsPermanentBulkJobError(err error) bool {
 		!errors.Is(err, circuit.ErrBreakerOpen) &&
 		!sysutil.IsErrConnectionReset(err) &&
 		!sysutil.IsErrConnectionRefused(err) &&
-		!errors.Is(err, sqlinstance.NonExistentInstanceError)
+		!errors.Is(err, sqlinstance.NonExistentInstanceError) &&
+		!errors.Is(err, context.Canceled)
 }


### PR DESCRIPTION
Closes #156337.