### PR TITLE
db-console: add metrics workspace to debug page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -90,6 +90,7 @@ import InsightsOverviewPage from "./views/insights/insightsOverview";
 import StatementInsightDetailsPage from "./views/insights/statementInsightDetailsPage";
 import TransactionInsightDetailsPage from "./views/insights/transactionInsightDetailsPage";
 import { JwtAuthTokenPage } from "./views/jwt/jwtAuthToken";
+import MetricsWorkspace from "./views/reports/containers/metricsWorkspace/metricsWorkspace";
 import ActiveStatementDetails from "./views/statements/activeStatementDetailsConnected";
 import ActiveTransactionDetails from "./views/transactions/activeTransactionDetailsConnected";
 
@@ -371,6 +372,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                           exact
                           path="/debug/chart"
                           component={CustomChart}
+                        />
+                        <Route
+                          exact
+                          path="/debug/metrics_workspace"
+                          component={MetricsWorkspace}
                         />
                         <Route
                           exact

--- a/pkg/ui/workspaces/db-console/src/redux/metricMetadata.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/metricMetadata.ts
@@ -8,6 +8,8 @@ import { createSelector } from "reselect";
 import { AdminUIState } from "src/redux/state";
 import { MetricMetadataResponseMessage } from "src/util/api";
 
+import { DropdownOption } from "../views/shared/components/dropdown";
+
 export type MetricsMetadata = MetricMetadataResponseMessage;
 
 // State selectors
@@ -17,4 +19,22 @@ const metricsMetadataStateSelector = (state: AdminUIState) =>
 export const metricsMetadataSelector = createSelector(
   metricsMetadataStateSelector,
   (metricsMetadata): MetricsMetadata => metricsMetadata,
+);
+
+export const metricOptionsSelector = createSelector(
+  metricsMetadataSelector,
+  (metricsMetadata): DropdownOption[] => {
+    if (metricsMetadata?.metadata == null) {
+      return [];
+    }
+
+    return Object.keys(metricsMetadata.metadata).map(k => {
+      const fullMetricName = metricsMetadata.recordedNames[k];
+      return {
+        value: fullMetricName,
+        label: k,
+        description: metricsMetadata.metadata[k]?.help,
+      };
+    });
+  },
 );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
@@ -168,6 +168,8 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
               onChange={this.changeMetric}
               placeholder="Select a metric..."
               optionComponent={MetricOption}
+              matchProp="label"
+              ignoreCase={true}
             />
           </div>
         </td>

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/metricOption.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/metricOption.tsx
@@ -9,24 +9,28 @@ import { OptionComponentProps } from "react-select";
 
 import "./metricOption.styl";
 
-export const MetricOption = (props: OptionComponentProps<string>) => {
-  const { option, className, onSelect, onFocus } = props;
-  const { label, description } = option;
-  const classes = classnames("metric-option", className);
+export const MetricOption = React.memo(
+  (props: OptionComponentProps<string>) => {
+    const { option, className, onSelect, onFocus } = props;
+    const { label, description } = option;
+    const classes = classnames("metric-option", className);
 
-  return (
-    <div
-      className={classes}
-      role="option"
-      aria-label={label}
-      title={option.title}
-      onMouseDown={event => onSelect(option, event)}
-      onMouseEnter={event => onFocus(option, event)}
-    >
-      <div className="metric-option__label">{label}</div>
-      <div className="metric-option__description" title={description}>
-        {description}
+    return (
+      <div
+        className={classes}
+        role="option"
+        aria-label={label}
+        title={option.title || description}
+        onMouseDown={event => onSelect(option, event)}
+        onMouseEnter={event => onFocus(option, event)}
+      >
+        <div className="metric-option__label">{label}</div>
+        {description && (
+          <div className="metric-option__description" title={description}>
+            {description}
+          </div>
+        )}
       </div>
-    </div>
-  );
-};
+    );
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/customMetric.tsx
@@ -1,0 +1,104 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import React from "react";
+
+import { MetricsMetadata } from "oss/src/redux/metricMetadata";
+import { NodesSummary } from "oss/src/redux/nodes";
+import { Metric } from "oss/src/views/shared/components/metricQuery";
+import { CustomMetricState } from "src/views/reports/containers/customChart/customMetric";
+
+import { getSources } from "../../customChart";
+
+type Props = {
+  key: React.Key;
+  metric: CustomMetricState;
+  tenants: string[];
+  nodesSummary: NodesSummary;
+  metricsMetadata: MetricsMetadata;
+};
+
+const CustomMetric = ({
+  key,
+  metric,
+  nodesSummary,
+  tenants,
+  metricsMetadata,
+}: Props): React.ReactElement => {
+  const sources = getSources(nodesSummary, metric, metricsMetadata);
+  if (metric.perSource && metric.perTenant) {
+    return (
+      <React.Fragment>
+        {sources.flatMap(source => {
+          return tenants.map((tenant: string, i: number) => (
+            <Metric
+              key={`${key}${i}${source}${tenant}`}
+              title={`${source}-${tenant}: ${metric.metric} (${i})`}
+              name={metric.metric}
+              aggregator={metric.aggregator}
+              downsampler={metric.downsampler}
+              derivative={metric.derivative}
+              sources={[source]}
+              tenantSource={tenant}
+            />
+          ));
+        })}
+      </React.Fragment>
+    );
+  }
+
+  if (metric.perSource) {
+    return (
+      <React.Fragment>
+        {sources.map((source: string, i: number) => (
+          <Metric
+            key={`${key}${i}${source}`}
+            title={`${source}: ${metric.metric} (${i})`}
+            name={metric.metric}
+            aggregator={metric.aggregator}
+            downsampler={metric.downsampler}
+            derivative={metric.derivative}
+            sources={[source]}
+            tenantSource={metric.tenantSource}
+          />
+        ))}
+      </React.Fragment>
+    );
+  }
+
+  if (metric.perTenant) {
+    return (
+      <React.Fragment>
+        {tenants.map((tenant: string, i: number) => (
+          <Metric
+            key={`${key}${i}${tenant}`}
+            title={`${tenant}: ${metric.metric} (${i})`}
+            name={metric.metric}
+            aggregator={metric.aggregator}
+            downsampler={metric.downsampler}
+            derivative={metric.derivative}
+            sources={sources}
+            tenantSource={tenant}
+          />
+        ))}
+      </React.Fragment>
+    );
+  }
+
+  return (
+    <Metric
+      key={key}
+      title={`${metric.metric}`}
+      name={metric.metric}
+      aggregator={metric.aggregator}
+      downsampler={metric.downsampler}
+      derivative={metric.derivative}
+      sources={sources}
+      tenantSource={metric.tenantSource}
+    />
+  );
+};
+
+export default CustomMetric;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/dashboardTab.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/dashboardTab.tsx
@@ -1,0 +1,137 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { AxisUnits } from "@cockroachlabs/cluster-ui";
+import React from "react";
+
+import { Button } from "src/components/button";
+
+import { CustomMetricState } from "../../customChart/customMetric";
+import { DashboardConfig, GraphConfig } from "../dashboardConfig";
+
+import EditableTitle from "./editableTitle";
+import GraphContainer from "./graphContainer";
+
+interface DashboardTabProps {
+  config: DashboardConfig;
+  onDashboardChange: (
+    updater: (dashboard: DashboardConfig) => DashboardConfig,
+  ) => void;
+}
+
+const DashboardTab: React.FC<DashboardTabProps> = ({
+  config,
+  onDashboardChange,
+}: DashboardTabProps) => {
+  const handleNameChange = (newName: string) => {
+    onDashboardChange(dashboard => ({
+      ...dashboard,
+      name: newName,
+    }));
+  };
+
+  const handleCreateNewGraph = () => {
+    const newMetrics = [new CustomMetricState()];
+    onDashboardChange(dashboard => ({
+      ...dashboard,
+      graphs: [
+        ...dashboard.graphs,
+        {
+          title: "",
+          axis: {
+            units: AxisUnits.Count,
+            label: "",
+          },
+          metrics: newMetrics,
+        },
+      ],
+    }));
+  };
+
+  const handleGraphConfigChange = (
+    graphIndex: number,
+    newGraphConfig: GraphConfig,
+  ) => {
+    onDashboardChange(dashboard => ({
+      ...dashboard,
+      graphs: dashboard.graphs.map((graph, idx) =>
+        idx === graphIndex ? newGraphConfig : graph,
+      ),
+    }));
+  };
+
+  const handleGraphDelete = (graphIndex: number) => {
+    onDashboardChange(dashboard => ({
+      ...dashboard,
+      graphs: dashboard.graphs.filter((_, idx) => idx !== graphIndex),
+    }));
+  };
+
+  const handleExport = () => {
+    // Create export config without the internal 'key' field
+    const exportConfig = {
+      name: config.name,
+      graphs: config.graphs,
+    };
+
+    const jsonString = JSON.stringify(exportConfig, null, 2);
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${config.name || "dashboard"}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="metrics-workspace__dashboard-content">
+      <div
+        style={{
+          marginBottom: "24px",
+          paddingBottom: "16px",
+          borderBottom: "1px solid #e8e8e8",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <EditableTitle
+          value={config.name}
+          onChange={handleNameChange}
+          placeholder="Dashboard Name"
+          size="large"
+        />
+        <Button type="secondary" onClick={handleExport}>
+          Export Dashboard
+        </Button>
+      </div>
+      {config.graphs.length > 0 &&
+        config.graphs.map((graph, index) => (
+          <GraphContainer
+            key={index}
+            index={index}
+            graphConfig={graph}
+            onConfigChange={handleGraphConfigChange}
+            onDelete={handleGraphDelete}
+          />
+        ))}
+      <div style={{ marginTop: "24px" }}>
+        <Button type="primary" onClick={handleCreateNewGraph}>
+          Add Graph
+        </Button>
+      </div>
+      {!config.graphs?.length && (
+        <div className="metrics-workspace__empty-state">
+          No graphs configured. Add graphs to this dashboard.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DashboardTab;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/editableTitle.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/editableTitle.tsx
@@ -1,0 +1,158 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Input } from "antd";
+import React, { useState, useRef, useEffect } from "react";
+
+interface EditableTitleProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  size?: "small" | "medium" | "large";
+}
+
+const EditableTitle: React.FC<EditableTitleProps> = ({
+  value,
+  onChange,
+  placeholder = "Enter title...",
+  className = "",
+  size = "medium",
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+  const [isHovered, setIsHovered] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    setEditValue(value);
+  }, [value]);
+
+  const handleClick = () => {
+    setIsEditing(true);
+    setEditValue(value);
+  };
+
+  const handleBlur = () => {
+    if (editValue.trim() !== value) {
+      onChange(editValue.trim() || placeholder);
+    }
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (editValue.trim() !== value) {
+        onChange(editValue.trim() || placeholder);
+      }
+      setIsEditing(false);
+    } else if (e.key === "Escape") {
+      setEditValue(value);
+      setIsEditing(false);
+    }
+  };
+
+  const sizeStyles = {
+    small: { fontSize: "14px", padding: "2px 6px" },
+    medium: { fontSize: "16px", padding: "4px 8px" },
+    large: { fontSize: "20px", padding: "6px 10px", fontWeight: 500 },
+  };
+
+  const baseStyle: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "8px",
+    cursor: "pointer",
+    borderRadius: "4px",
+    transition: "all 0.2s ease",
+    userSelect: "none",
+    maxWidth: "100%",
+  };
+
+  const hoverStyle: React.CSSProperties = {
+    backgroundColor: "rgba(0, 0, 0, 0.02)",
+  };
+
+  if (isEditing) {
+    return (
+      <Input
+        ref={inputRef}
+        value={editValue}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setEditValue(e.target.value)
+        }
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        style={{
+          ...sizeStyles[size],
+          border: "1px solid #d9d9d9",
+          borderRadius: "4px",
+        }}
+        className={className}
+        bordered={false}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      style={{
+        ...baseStyle,
+        ...sizeStyles[size],
+        ...(isHovered ? hoverStyle : {}),
+      }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <span
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {value || (
+          <span style={{ color: "#bfbfbf", fontStyle: "italic" }}>
+            {placeholder}
+          </span>
+        )}
+      </span>
+      <span
+        style={{
+          opacity: isHovered ? 0.6 : 0,
+          transition: "opacity 0.2s ease",
+          color: "#8c8c8c",
+          fontSize: "0.9em",
+          flexShrink: 0,
+        }}
+      >
+        ✎
+      </span>
+    </div>
+  );
+};
+
+export default EditableTitle;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/graphContainer.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/components/graphContainer.tsx
@@ -1,0 +1,237 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { UpOutlined, DownOutlined } from "@ant-design/icons";
+import { TimeScale } from "@cockroachlabs/cluster-ui/dist/types/timeScaleDropdown";
+import { PayloadAction } from "@reduxjs/toolkit";
+import React, { useState } from "react";
+import { connect } from "react-redux";
+import { withRouter, RouteComponentProps } from "react-router-dom";
+
+import {
+  setMetricsFixedWindow,
+  setTimeScale,
+  TimeWindow,
+} from "oss/src/redux/timeScale";
+import { MetricsDataProvider } from "oss/src/views/shared/containers/metricDataProvider";
+import { getCookieValue } from "src/redux/cookies";
+import {
+  metricOptionsSelector,
+  MetricsMetadata,
+  metricsMetadataSelector,
+} from "src/redux/metricMetadata";
+import {
+  NodesSummary,
+  nodeOptionsSelector,
+  nodesSummarySelector,
+} from "src/redux/nodes";
+import { AdminUIState } from "src/redux/state";
+import { tenantDropdownOptions } from "src/redux/tenants";
+import LineGraph from "src/views/cluster/components/linegraph";
+import { DropdownOption } from "src/views/shared/components/dropdown";
+import { Axis } from "src/views/shared/components/metricQuery";
+
+import {
+  CustomChartState,
+  CustomChartTable,
+} from "../../customChart/customMetric";
+import { generateGraphTitleFromMetrics, GraphConfig } from "../dashboardConfig";
+
+import CustomMetric from "./customMetric";
+import EditableTitle from "./editableTitle";
+
+export type GraphContainerOwnProps = {
+  graphConfig: GraphConfig;
+  onConfigChange: (index: number, newGraphConfig: GraphConfig) => void;
+  index: number;
+  onDelete: (index: number) => void;
+} & RouteComponentProps;
+
+export type GraphContainerProps = GraphContainerOwnProps & {
+  nodesSummary: NodesSummary;
+  tenantOptions: DropdownOption[];
+  metricOptions: DropdownOption[];
+  nodeOptions: DropdownOption[];
+  currentTenant: string | null;
+  metricsMetadata: MetricsMetadata;
+  setMetricsFixedWindow: (tw: TimeWindow) => PayloadAction<TimeWindow>;
+  setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale>;
+};
+
+const GraphContainer: React.FC<GraphContainerProps> = ({
+  graphConfig,
+  index,
+  nodesSummary,
+  tenantOptions,
+  metricOptions,
+  nodeOptions,
+  currentTenant,
+  history,
+  metricsMetadata,
+  onConfigChange,
+  onDelete,
+  setMetricsFixedWindow,
+  setTimeScale,
+}) => {
+  const tenants = tenantOptions.slice(1).map(tenant => tenant.value);
+  const [isTableCollapsed, setIsTableCollapsed] = useState(false);
+
+  const onChange = (_index: number, newState: CustomChartState) => {
+    onConfigChange(index, {
+      ...graphConfig,
+      metrics: newState.metrics,
+      axis: {
+        ...graphConfig.axis,
+        units: newState.axisUnits,
+      },
+    });
+  };
+
+  const handleTitleChange = (newTitle: string) => {
+    onConfigChange(index, {
+      ...graphConfig,
+      title: newTitle,
+    });
+  };
+
+  // We require nodes information to determine sources (storeIDs/nodeIDs) down below.
+  if (!(nodesSummary?.nodeStatuses?.length > 0)) {
+    return;
+  }
+
+  return (
+    <div
+      className="metrics-workspace__graph-container"
+      style={{ marginBottom: "32px" }}
+    >
+      <div
+        style={{
+          marginBottom: "12px",
+          paddingLeft: "4px",
+        }}
+      >
+        <EditableTitle
+          value={graphConfig.title}
+          onChange={handleTitleChange}
+          placeholder={generateGraphTitleFromMetrics(graphConfig.metrics)}
+          size="medium"
+        />
+      </div>
+      {graphConfig.metrics.length > 0 && (
+        <MetricsDataProvider
+          id={`custom-dashboard-graph-${index}`}
+          key={`custom-dashboard-graph-${index}-${graphConfig.axis.units}`}
+          setMetricsFixedWindow={setMetricsFixedWindow}
+          setTimeScale={setTimeScale}
+          history={history}
+        >
+          <LineGraph title="">
+            <Axis
+              units={graphConfig.axis.units}
+              label={graphConfig.axis.label}
+            />
+            {/* We have to call CustomMetric as a function instead of mounting it as a component
+          LinGraph won't render its children. To query metrics, it does a DFS to find <Mteric> 
+          componenets in props.children.
+           */}
+            {graphConfig.metrics.map((metric, index) =>
+              CustomMetric({
+                key: index,
+                metric: metric,
+                tenants: tenants,
+                nodesSummary: nodesSummary,
+                metricsMetadata: metricsMetadata,
+              }),
+            )}
+          </LineGraph>
+        </MetricsDataProvider>
+      )}
+      <div style={{ marginTop: "12px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            marginBottom: "8px",
+          }}
+        >
+          <span
+            onClick={() => setIsTableCollapsed(!isTableCollapsed)}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+              fontSize: "12px",
+              color: "#8c8c8c",
+              cursor: "pointer",
+              padding: "4px 8px",
+              borderRadius: "4px",
+              transition: "background-color 0.2s",
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.backgroundColor = "rgba(0, 0, 0, 0.02)";
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.backgroundColor = "transparent";
+            }}
+          >
+            {isTableCollapsed ? (
+              <>
+                <DownOutlined style={{ fontSize: "10px" }} />
+                <span>Show metrics</span>
+              </>
+            ) : (
+              <>
+                <UpOutlined style={{ fontSize: "10px" }} />
+                <span>Hide metrics</span>
+              </>
+            )}
+          </span>
+        </div>
+        {!isTableCollapsed && (
+          <div>
+            <CustomChartTable
+              metricOptions={metricOptions}
+              nodeOptions={nodeOptions}
+              tenantOptions={tenantOptions}
+              currentTenant={currentTenant}
+              index={index}
+              chartState={{
+                metrics: graphConfig.metrics,
+                axisUnits: graphConfig.axis.units,
+              }}
+              onChange={onChange}
+              onDelete={onDelete}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const mapStateToProps = (state: AdminUIState) => ({
+  nodesSummary: nodesSummarySelector(state),
+  tenantOptions: tenantDropdownOptions(state),
+  metricOptions: metricOptionsSelector(state),
+  nodeOptions: nodeOptionsSelector(state),
+  metricsMetadata: metricsMetadataSelector(state),
+  currentTenant: getCookieValue("tenant"),
+});
+
+const mapDispatchToProps = {
+  setMetricsFixedWindow: setMetricsFixedWindow,
+  setTimeScale: setTimeScale,
+};
+
+export default withRouter<
+  GraphContainerOwnProps,
+  React.ComponentType<GraphContainerOwnProps>
+>(
+  connect<{}, {}, GraphContainerOwnProps, AdminUIState>(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(GraphContainer),
+);

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/dashboardConfig.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/dashboardConfig.ts
@@ -1,0 +1,45 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import React from "react";
+
+import { AxisProps } from "src/views/shared/components/metricQuery";
+
+import { CustomMetricState } from "../customChart/customMetric";
+
+/**
+ * DashboardConfig is the configuration for a dashboard.
+ */
+export interface DashboardConfig {
+  key: React.Key;
+  name: string; // File name.
+  graphs: GraphConfig[];
+}
+
+export interface GraphConfig {
+  title: string;
+  axis: AxisProps;
+  metrics: CustomMetricState[];
+}
+
+/**
+ * Generates a default title from metric names, capped at 3 metrics.
+ * Uses the full metric name.
+ */
+export function generateGraphTitleFromMetrics(
+  metrics: CustomMetricState[],
+): string {
+  const validMetrics = metrics.filter(m => m.metric && m.metric.trim() !== "");
+  if (validMetrics.length === 0) {
+    return "";
+  }
+
+  const metricNames = validMetrics.slice(0, 3).map(m => m.metric);
+
+  if (validMetrics.length > 3) {
+    return `${metricNames.join(", ")} (+${validMetrics.length - 3} more)`;
+  }
+  return metricNames.join(", ");
+}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/metricsWorkspace.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/metricsWorkspace.styl
@@ -1,0 +1,48 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+@require "~styl/base/palette.styl"
+@require "~src/components/core/index.styl"
+
+.metrics-workspace
+  padding 24px
+
+  &__header
+    display flex
+    justify-content space-between
+    align-items center
+    margin-bottom 24px
+
+  &__title
+    margin 0
+    font-size 24px
+    font-weight 600
+
+  &__header-actions
+    display flex
+    gap 12px
+
+  &__time-selector
+    margin-bottom 24px
+
+  &__empty-state
+    text-align center
+    padding 48px
+    color $colors--neutral-6
+
+  &__dashboard-content
+    padding 16px
+
+  &__graph-container
+    margin-bottom 24px
+
+  &__graph-header
+    display flex
+    justify-content space-between
+    align-items center
+    margin-bottom 16px
+
+  &__graph-title
+    margin 0

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/metricsWorkspace.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/metricsWorkspace/metricsWorkspace.tsx
@@ -1,0 +1,229 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { TimeScale } from "@cockroachlabs/cluster-ui";
+import { Tabs, Upload } from "antd";
+import { RcFile } from "antd/es/upload";
+import React, { useState, useEffect, useRef } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+
+import { getCookieValue } from "oss/src/redux/cookies";
+import { AdminUIState } from "oss/src/redux/state";
+import TimeScaleDropdown from "oss/src/views/cluster/containers/timeScaleDropdownWithSearchParams";
+import { Button } from "src/components/button";
+import {
+  refreshMetricMetadata,
+  refreshNodes,
+  refreshTenantsList,
+} from "src/redux/apiReducers";
+import {
+  setMetricsFixedWindow,
+  selectTimeScale,
+  setTimeScale,
+} from "src/redux/timeScale";
+
+import DashboardTab from "./components/dashboardTab";
+import { DashboardConfig } from "./dashboardConfig";
+
+import type { TabsProps } from "antd";
+
+import "./metricsWorkspace.styl";
+
+type Props = {
+  timeScale: TimeScale;
+  setTimeScale: (timeScale: TimeScale) => void;
+  refreshNodes: typeof refreshNodes;
+  refreshMetricMetadata: typeof refreshMetricMetadata;
+  refreshTenantsList: typeof refreshTenantsList;
+};
+const MetricsWorkspace = ({
+  timeScale,
+  setTimeScale,
+  refreshNodes,
+  refreshMetricMetadata,
+  refreshTenantsList,
+}: Props) => {
+  const dashboardCount = useRef(1);
+  const [dashboardTabs, setDashboardTabs] = useState<DashboardConfig[]>([]);
+  const [activeTabKey, setActiveTabKey] = useState<string>();
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    refreshNodes();
+    refreshMetricMetadata();
+    refreshTenantsList();
+  }, [refreshNodes, refreshMetricMetadata, refreshTenantsList]);
+
+  const handleCreateNewDashboard = () => {
+    const name = `Dashboard ${dashboardCount.current}`;
+    dashboardCount.current++;
+    const newTab: DashboardConfig = {
+      key: name,
+      name,
+      graphs: [],
+    };
+    setDashboardTabs(prev => [...prev, newTab]);
+    setActiveTabKey(newTab.key as string);
+  };
+
+  const handleLoadDashboard = (file: RcFile) => {
+    setLoadError(null);
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const config: DashboardConfig = JSON.parse(e.target?.result as string);
+        const fileName = (file as any).name || "dashboard";
+        // Use timestamp and index to create a unique key, avoiding file names
+        const uniqueKey = `dashboard-${Date.now()}`;
+        const newTab: DashboardConfig = {
+          key: uniqueKey,
+          name: config.name || fileName.replace(".json", ""),
+          graphs: config.graphs || [],
+        };
+        setDashboardTabs(prev => [...prev, newTab]);
+        setActiveTabKey(newTab.key as string);
+        setLoadError(null);
+      } catch (error) {
+        setLoadError(
+          "Failed to parse dashboard file. Please ensure it's valid JSON.",
+        );
+      }
+    };
+    reader.onerror = () => {
+      setLoadError("Failed to read file. Please try again.");
+    };
+    reader.readAsText(file as any);
+    // Return false to prevent default upload behavior
+    return false;
+  };
+
+  const handleTabEdit = (
+    targetKey:
+      | string
+      | React.MouseEvent<Element, MouseEvent>
+      | React.KeyboardEvent<Element>,
+    action: "add" | "remove",
+  ) => {
+    switch (action) {
+      case "add":
+        handleCreateNewDashboard();
+        break;
+      case "remove":
+        setDashboardTabs(prev => prev.filter(tab => tab.key !== targetKey));
+        if (activeTabKey === targetKey) {
+          const remainingTabs = dashboardTabs.filter(
+            tab => tab.key !== targetKey,
+          );
+          setActiveTabKey(
+            remainingTabs.length > 0
+              ? (remainingTabs[0].key as string)
+              : undefined,
+          );
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleDashboardChange = (
+    dashboardKey: string,
+    updater: (dashboard: DashboardConfig) => DashboardConfig,
+  ) => {
+    setDashboardTabs(prev =>
+      prev.map(tab => (tab.key === dashboardKey ? updater(tab) : tab)),
+    );
+  };
+
+  const tabItems: TabsProps["items"] = dashboardTabs.map(tab => ({
+    key: tab.key,
+    label: tab.name,
+    children: (
+      <DashboardTab
+        config={tab}
+        onDashboardChange={(
+          updater: (dashboard: DashboardConfig) => DashboardConfig,
+        ) => handleDashboardChange(tab.key as string, updater)}
+      />
+    ),
+  }));
+
+  return (
+    <div className="metrics-workspace">
+      <div className="metrics-workspace__header">
+        <h1 className="metrics-workspace__title">Metrics Workspace</h1>
+        <div className="metrics-workspace__header-actions">
+          <Button type="primary" onClick={handleCreateNewDashboard}>
+            Create New Dashboard
+          </Button>
+          <div>
+            <Upload
+              accept=".json"
+              beforeUpload={handleLoadDashboard}
+              capture="file"
+              showUploadList={false}
+            >
+              <Button type="secondary">Load Dashboard</Button>
+            </Upload>
+            {loadError && (
+              <div
+                style={{
+                  color: "#ff4d4f",
+                  fontSize: "12px",
+                  marginTop: "8px",
+                }}
+              >
+                {loadError}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="metrics-workspace__time-selector">
+        <TimeScaleDropdown
+          currentScale={timeScale}
+          setTimeScale={setTimeScale}
+        />
+      </div>
+
+      {dashboardTabs.length > 0 ? (
+        <Tabs
+          type="editable-card"
+          activeKey={activeTabKey}
+          onChange={setActiveTabKey}
+          onEdit={handleTabEdit}
+          items={tabItems}
+          destroyInactiveTabPane={true}
+        />
+      ) : (
+        <div className="metrics-workspace__empty-state">
+          <p>No dashboards loaded.</p>
+          <p>
+            Create a new dashboard or load one from a JSON file to get started.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const mapStateToProps = (state: AdminUIState) => ({
+  timeScale: selectTimeScale(state),
+  currentTenant: getCookieValue("tenant"),
+});
+
+const mapDispatchToProps = {
+  setMetricsFixedWindow: setMetricsFixedWindow,
+  setTimeScale: setTimeScale,
+  refreshNodes,
+  refreshMetricMetadata,
+  refreshTenantsList,
+};
+
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(MetricsWorkspace),
+);


### PR DESCRIPTION
This debug page is similar to `Custom Time Series` but allows for exporting and loading of custom time series dashboards.

Epic: none

Release note: None