### PR TITLE
build: update PGO profile to 20251111010633-849f2e252f1777a48cea3ae3655a597f582739f1.pb.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -647,6 +647,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
+    sha256 = "26ce3254cb571d59cff9d491aa5731c7c1151c6f405e432417e51b3eef2427b0",
+    url = "https://storage.googleapis.com/cockroach-profiles/20251111010633-849f2e252f1777a48cea3ae3655a597f582739f1.pb.gz",
 )

--- a/build/teamcity/internal/release/pgo_profile_update.sh
+++ b/build/teamcity/internal/release/pgo_profile_update.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+cleanup() {
+    rm -f ~/.config/gcloud/application_default_credentials.json
+}
+trap cleanup EXIT
+
+
+# Install `gh` CLI tool if not already available
+if ! command -v gh &> /dev/null; then
+    echo "Installing gh CLI tool..."
+    wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz
+    echo "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401  /tmp/gh.tar.gz" | sha256sum -c -
+    tar --strip-components 1 -xf /tmp/gh.tar.gz -C /tmp
+    export PATH=/tmp/bin:$PATH
+    echo "gh CLI installed successfully"
+fi
+
+# Configuration
+export TESTS="${TESTS:-tpcc-nowait/literal/w=1000/nodes=5/cpu=16}"
+export COUNT="${COUNT:-20}"
+export CLOUD="${CLOUD:-gce}"
+
+docker_args=(
+  ARM_PROBABILITY=0.0
+  SELECT_PROBABILITY=1.0
+  COCKROACH_EA_PROBABILITY=0.0
+  FIPS_PROBABILITY=0.0
+  LITERAL_ARTIFACTS_DIR=$root/artifacts
+  BUILD_VCS_NUMBER
+  CLOUD
+  COCKROACH_DEV_LICENSE
+  COCKROACH_RANDOM_SEED
+  COUNT
+  EXPORT_OPENMETRICS
+  GITHUB_API_TOKEN
+  GITHUB_ORG
+  GITHUB_REPO
+  GOOGLE_CREDENTIALS_ASSUME_ROLE
+  GOOGLE_EPHEMERAL_CREDENTIALS
+  GOOGLE_KMS_KEY_A
+  GOOGLE_KMS_KEY_B
+  GOOGLE_SERVICE_ACCOUNT
+  GRAFANA_SERVICE_ACCOUNT_AUDIENCE
+  GRAFANA_SERVICE_ACCOUNT_JSON
+  ROACHPERF_OPENMETRICS_CREDENTIALS
+  ROACHTEST_ASSERTIONS_ENABLED_SEED
+  ROACHTEST_FORCE_RUN_INVALID_RELEASE_BRANCH
+  SELECTIVE_TESTS
+  SLACK_TOKEN
+  SNOWFLAKE_PVT_KEY
+  SNOWFLAKE_USER
+  TC_BUILDTYPE_ID
+  TC_BUILD_BRANCH
+  TC_BUILD_ID
+  TC_SERVER_URL
+  TESTS
+  USE_SPOT
+)
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$(printf -- "-e %s " "${docker_args[@]}")"
+
+benchstat_before="$root/artifacts/benchstat_before.txt"
+benchstat_after="$root/artifacts/benchstat_after.txt"
+
+# Step 1: Run initial benchmark tests to establish baseline
+echo "=== Step 1: Running baseline tpcc-nowait tests ==="
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+
+tmp_artifacts_before="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_before"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe "$root/scripts/tpcc_results.sh" "$tmp_artifacts_before" > "$benchstat_before"
+rm -rf "$tmp_artifacts_before"
+
+echo "=== Baseline benchstat saved to $benchstat_before ==="
+
+# Step 2: Generate new PGO profile
+echo "=== Step 2: Generating new PGO profile ==="
+filename="$(date +"%Y%m%d%H%M%S")-$(git rev-parse HEAD).pb.gz"
+bazel build //pkg/cmd/run-pgo-build
+_bazel/bin/pkg/cmd/run-pgo-build/run-pgo-build_/run-pgo-build -out "artifacts/$filename"
+sha256_hash=$(shasum -a 256 "artifacts/$filename" | awk '{print $1}')
+echo "$sha256_hash" | tee "artifacts/location.txt"
+
+# Upload to GCS
+google_credentials="$GCS_GOOGLE_CREDENTIALS" log_into_gcloud
+gcs_url="gs://cockroach-profiles/$filename"
+gsutil cp "artifacts/$filename" "$gcs_url"
+echo "$gcs_url" >> "artifacts/location.txt"
+
+# Convert GCS URL to HTTPS URL for WORKSPACE
+https_url="https://storage.googleapis.com/cockroach-profiles/$filename"
+
+echo "=== PGO profile uploaded to $gcs_url ==="
+echo "=== SHA256: $sha256_hash ==="
+
+# Step 3: Update WORKSPACE file with new PGO profile
+echo "=== Step 3: Updating WORKSPACE file ==="
+
+# Update the pgo_profile stanza in WORKSPACE
+workspace_file="$root/WORKSPACE"
+
+# Use sed to update the sha256 and url in the pgo_profile block
+# This is more robust than string replacement
+sed -i.bak -e '/pgo_profile(/,/)/ {
+    s|sha256 = ".*"|sha256 = "'"$sha256_hash"'"|
+    s|url = ".*"|url = "'"$https_url"'"|
+}' "$workspace_file"
+
+# Remove backup file
+rm -f "${workspace_file}.bak"
+
+echo "=== WORKSPACE file updated ==="
+
+# Step 4: Rebuild with new PGO profile and run tests again
+echo "=== Step 4: Running tests with new PGO profile ==="
+
+# Clear build cache to ensure new profile is used
+bazel clean
+rm -rf "$root/artifacts/tpcc-nowait"
+
+# Run the same tests again with the new PGO profile
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+#
+tmp_artifacts_after="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_after"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe "$root/scripts/tpcc_results.sh" "$tmp_artifacts_after" > "$benchstat_after"
+rm -rf "$tmp_artifacts_after"
+rm -rf "$root/artifacts/tpcc-nowait"
+
+echo "=== Post-PGO benchstat saved to $benchstat_after ==="
+
+# Step 5: Compare benchstats
+echo "=== Step 5: Comparing benchmark results ==="
+
+# Run benchstat comparison using bazel and save to file
+benchstat_comparison="${root}/artifacts/benchstat_comparison.txt"
+bazel run @org_golang_x_perf//cmd/benchstat -- "$benchstat_before" "$benchstat_after" | tee "$benchstat_comparison"
+
+echo "=== Benchstat comparison saved to $benchstat_comparison ==="
+
+# Step 6: Create PR with changes
+echo "=== Step 6: Creating pull request ==="
+export GIT_AUTHOR_NAME="Justin Beaver"
+export GIT_COMMITTER_NAME="Justin Beaver"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+gh_username="cockroach-teamcity"
+
+# Create a new branch for the PR
+branch_name="pgo-profile-update-$(date +"%Y%m%d%H%M%S")"
+git checkout -b "$branch_name"
+
+# Stage the WORKSPACE file changes
+git add WORKSPACE
+
+# Create commit with descriptive message
+# Note: Full benchstat comparison is in the PR description, not in commit message
+commit_message="build: update PGO profile to $filename
+
+This commit updates the PGO profile used for building CockroachDB.
+
+The new profile was generated from tpcc-nowait benchmarks.
+See PR description for full benchmark comparison results.
+
+Epic: none
+Release note: none"
+
+git commit -m "$commit_message"
+set +x
+git push "https://$gh_username:$GH_TOKEN@github.com/$gh_username/cockroach.git" "$branch_name"
+set -x
+
+# Create PR using gh CLI
+pr_body="This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.
+
+The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):
+
+\`\`\`
+$(cat "$benchstat_comparison")
+\`\`\`
+
+Epic: none
+Release note: none"
+
+gh pr create \
+    --head "$gh_username:$branch_name" \
+    --title "build: update PGO profile to $filename" \
+    --body "$pr_body" \
+    --reviewer "cockroachdb/release-eng-prs" \
+    --base master


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                         ops/sec                                          │                              ops/sec                               vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   129.2 ± ∞ ¹                                                         133.8 ± ∞ ¹       ~ (p=0.200 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                  1.292k ± ∞ ¹                                                        1.338k ± ∞ ¹       ~ (p=0.200 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                129.2 ± ∞ ¹                                                         133.8 ± ∞ ¹       ~ (p=0.200 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                   1.292k ± ∞ ¹                                                        1.338k ± ∞ ¹       ~ (p=0.200 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 129.2 ± ∞ ¹                                                         133.8 ± ∞ ¹       ~ (p=0.200 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                     2.972k ± ∞ ¹                                                        3.076k ± ∞ ¹       ~ (p=0.200 n=4)
geomean                                                                                                                                   469.5                                                               486.0        +3.50%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/avg                                          │                              ms/avg                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   68.60 ± ∞ ¹                                                         70.45 ± ∞ ¹       ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   113.0 ± ∞ ¹                                                         109.8 ± ∞ ¹       ~ (p=0.486 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                15.15 ± ∞ ¹                                                         14.80 ± ∞ ¹       ~ (p=0.171 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    32.15 ± ∞ ¹                                                         30.90 ± ∞ ¹       ~ (p=0.486 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 20.60 ± ∞ ¹                                                         20.00 ± ∞ ¹       ~ (p=0.429 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      67.30 ± ∞ ¹                                                         65.00 ± ∞ ¹       ~ (p=0.171 n=4)
geomean                                                                                                                                   41.67                                                               40.78        -2.14%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/p50                                          │                              ms/p50                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   63.95 ± ∞ ¹                                                         68.15 ± ∞ ¹       ~ (p=0.743 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   107.0 ± ∞ ¹                                                         104.9 ± ∞ ¹       ~ (p=0.657 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                               10.000 ± ∞ ¹                                                         9.700 ± ∞ ¹       ~ (p=0.657 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    28.30 ± ∞ ¹                                                         27.25 ± ∞ ¹       ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 16.30 ± ∞ ¹                                                         15.75 ± ∞ ¹       ~ (p=0.571 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      52.40 ± ∞ ¹                                                         50.30 ± ∞ ¹       ~ (p=0.143 n=4)
geomean                                                                                                                                   34.39                                                               33.82        -1.65%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/p95                                          │                              ms/p95                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   117.4 ± ∞ ¹                                                         115.3 ± ∞ ¹       ~ (p=0.743 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   201.3 ± ∞ ¹                                                         192.9 ± ∞ ¹       ~ (p=0.429 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                44.00 ± ∞ ¹                                                         44.00 ± ∞ ¹       ~ (p=0.571 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    65.00 ± ∞ ¹                                                         61.85 ± ∞ ¹       ~ (p=0.229 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 50.30 ± ∞ ¹                                                         48.20 ± ∞ ¹       ~ (p=0.371 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      176.2 ± ∞ ¹                                                         167.8 ± ∞ ¹       ~ (p=0.371 n=4)
geomean                                                                                                                                   91.81                                                               88.78        -3.31%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/p99                                          │                              ms/p99                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   155.2 ± ∞ ¹                                                         146.8 ± ∞ ¹       ~ (p=0.400 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   251.7 ± ∞ ¹                                                         239.1 ± ∞ ¹       ~ (p=0.400 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                71.30 ± ∞ ¹                                                         67.10 ± ∞ ¹       ~ (p=0.371 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    92.30 ± ∞ ¹                                                         86.00 ± ∞ ¹       ~ (p=0.229 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 77.60 ± ∞ ¹                                                         75.50 ± ∞ ¹       ~ (p=0.286 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      226.5 ± ∞ ¹                                                         218.1 ± ∞ ¹       ~ (p=0.429 n=4)
geomean                                                                                                                                   128.6                                                               122.2        -4.93%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/max                                          │                              ms/max                               vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   302.0 ± ∞ ¹                                                        302.0 ± ∞ ¹        ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   469.8 ± ∞ ¹                                                        411.0 ± ∞ ¹        ~ (p=0.143 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                209.7 ± ∞ ¹                                                        176.2 ± ∞ ¹        ~ (p=0.057 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    255.8 ± ∞ ¹                                                        239.1 ± ∞ ¹        ~ (p=0.571 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 226.5 ± ∞ ¹                                                        188.7 ± ∞ ¹        ~ (p=0.086 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      469.8 ± ∞ ¹                                                        411.0 ± ∞ ¹        ~ (p=0.143 n=4)
geomean                                                                                                                                   305.3                                                              272.1        -10.89%
¹ need >= 6 samples for confidence interval at level 0.95
```

Epic: none
Release note: none