### PR TITLE
build: update PGO profile to 20251111011436-a802e708a8052c5b7b1309801c7d15da17950bec.pb.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -647,6 +647,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
+    sha256 = "23d69c7dcf70c93904c515fe42ea341f6568dba15e53884aca58c3f755e6dd76",
+    url = "https://storage.googleapis.com/cockroach-profiles/20251111011436-a802e708a8052c5b7b1309801c7d15da17950bec.pb.gz",
 )

--- a/build/teamcity/internal/release/pgo_profile_update.sh
+++ b/build/teamcity/internal/release/pgo_profile_update.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+cleanup() {
+    rm -f ~/.config/gcloud/application_default_credentials.json
+}
+trap cleanup EXIT
+
+
+# Install `gh` CLI tool if not already available
+if ! command -v gh &> /dev/null; then
+    echo "Installing gh CLI tool..."
+    wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz
+    echo "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401  /tmp/gh.tar.gz" | sha256sum -c -
+    tar --strip-components 1 -xf /tmp/gh.tar.gz -C /tmp
+    export PATH=/tmp/bin:$PATH
+    echo "gh CLI installed successfully"
+fi
+
+# Configuration
+export TESTS="${TESTS:-tpcc-nowait/literal/w=1000/nodes=5/cpu=16}"
+export COUNT="${COUNT:-20}"
+export CLOUD="${CLOUD:-gce}"
+export USE_SPOT="${USE_SPOT:-never}"
+
+docker_args=(
+  ARM_PROBABILITY=0.0
+  SELECT_PROBABILITY=1.0
+  COCKROACH_EA_PROBABILITY=0.0
+  FIPS_PROBABILITY=0.0
+  LITERAL_ARTIFACTS_DIR=$root/artifacts
+  BUILD_VCS_NUMBER
+  CLOUD
+  COCKROACH_DEV_LICENSE
+  COCKROACH_RANDOM_SEED
+  COUNT
+  EXPORT_OPENMETRICS
+  GITHUB_API_TOKEN
+  GITHUB_ORG
+  GITHUB_REPO
+  GOOGLE_CREDENTIALS_ASSUME_ROLE
+  GOOGLE_EPHEMERAL_CREDENTIALS
+  GOOGLE_KMS_KEY_A
+  GOOGLE_KMS_KEY_B
+  GOOGLE_SERVICE_ACCOUNT
+  GRAFANA_SERVICE_ACCOUNT_AUDIENCE
+  GRAFANA_SERVICE_ACCOUNT_JSON
+  ROACHPERF_OPENMETRICS_CREDENTIALS
+  ROACHTEST_ASSERTIONS_ENABLED_SEED
+  ROACHTEST_FORCE_RUN_INVALID_RELEASE_BRANCH
+  SELECTIVE_TESTS
+  SLACK_TOKEN
+  SNOWFLAKE_PVT_KEY
+  SNOWFLAKE_USER
+  TC_BUILDTYPE_ID
+  TC_BUILD_BRANCH
+  TC_BUILD_ID
+  TC_SERVER_URL
+  TESTS
+  USE_SPOT
+)
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$(printf -- "-e %s " "${docker_args[@]}")"
+
+benchstat_before="$root/artifacts/benchstat_before.txt"
+benchstat_after="$root/artifacts/benchstat_after.txt"
+
+# Step 1: Run initial benchmark tests to establish baseline
+echo "=== Step 1: Running baseline tpcc-nowait tests ==="
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+
+tmp_artifacts_before="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_before"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe "$root/scripts/tpcc_results.sh" "$tmp_artifacts_before" > "$benchstat_before"
+rm -rf "$tmp_artifacts_before"
+
+echo "=== Baseline benchstat saved to $benchstat_before ==="
+
+# Step 2: Generate new PGO profile
+echo "=== Step 2: Generating new PGO profile ==="
+filename="$(date +"%Y%m%d%H%M%S")-$(git rev-parse HEAD).pb.gz"
+bazel build //pkg/cmd/run-pgo-build
+_bazel/bin/pkg/cmd/run-pgo-build/run-pgo-build_/run-pgo-build -out "artifacts/$filename"
+sha256_hash=$(shasum -a 256 "artifacts/$filename" | awk '{print $1}')
+echo "$sha256_hash" | tee "artifacts/location.txt"
+
+# Upload to GCS
+google_credentials="$GCS_GOOGLE_CREDENTIALS" log_into_gcloud
+gcs_url="gs://cockroach-profiles/$filename"
+gsutil cp "artifacts/$filename" "$gcs_url"
+echo "$gcs_url" >> "artifacts/location.txt"
+
+# Convert GCS URL to HTTPS URL for WORKSPACE
+https_url="https://storage.googleapis.com/cockroach-profiles/$filename"
+
+echo "=== PGO profile uploaded to $gcs_url ==="
+echo "=== SHA256: $sha256_hash ==="
+
+# Step 3: Update WORKSPACE file with new PGO profile
+echo "=== Step 3: Updating WORKSPACE file ==="
+
+# Update the pgo_profile stanza in WORKSPACE
+workspace_file="$root/WORKSPACE"
+
+# Use sed to update the sha256 and url in the pgo_profile block
+# This is more robust than string replacement
+sed -i.bak -e '/pgo_profile(/,/)/ {
+    s|sha256 = ".*"|sha256 = "'"$sha256_hash"'"|
+    s|url = ".*"|url = "'"$https_url"'"|
+}' "$workspace_file"
+
+# Remove backup file
+rm -f "${workspace_file}.bak"
+
+echo "=== WORKSPACE file updated ==="
+
+# Step 4: Rebuild with new PGO profile and run tests again
+echo "=== Step 4: Running tests with new PGO profile ==="
+
+# Clear build cache to ensure new profile is used
+bazel clean
+rm -rf "$root/artifacts/tpcc-nowait"
+
+# Run the same tests again with the new PGO profile
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+#
+tmp_artifacts_after="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_after"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe "$root/scripts/tpcc_results.sh" "$tmp_artifacts_after" > "$benchstat_after"
+rm -rf "$tmp_artifacts_after"
+rm -rf "$root/artifacts/tpcc-nowait"
+
+echo "=== Post-PGO benchstat saved to $benchstat_after ==="
+
+# Step 5: Compare benchstats
+echo "=== Step 5: Comparing benchmark results ==="
+
+# Run benchstat comparison using bazel and save to file
+benchstat_comparison="${root}/artifacts/benchstat_comparison.txt"
+bazel run @org_golang_x_perf//cmd/benchstat -- "$benchstat_before" "$benchstat_after" | tee "$benchstat_comparison"
+
+echo "=== Benchstat comparison saved to $benchstat_comparison ==="
+
+# Step 6: Create PR with changes
+echo "=== Step 6: Creating pull request ==="
+export GIT_AUTHOR_NAME="Justin Beaver"
+export GIT_COMMITTER_NAME="Justin Beaver"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+gh_username="cockroach-teamcity"
+
+# Create a new branch for the PR
+branch_name="pgo-profile-update-$(date +"%Y%m%d%H%M%S")"
+git checkout -b "$branch_name"
+
+# Stage the WORKSPACE file changes
+git add WORKSPACE
+
+# Create commit with descriptive message
+# Note: Full benchstat comparison is in the PR description, not in commit message
+commit_message="build: update PGO profile to $filename
+
+This commit updates the PGO profile used for building CockroachDB.
+
+The new profile was generated from tpcc-nowait benchmarks.
+See PR description for full benchmark comparison results.
+
+Epic: none
+Release note: none"
+
+git commit -m "$commit_message"
+set +x
+git push "https://$gh_username:$GH_TOKEN@github.com/$gh_username/cockroach.git" "$branch_name"
+set -x
+
+# Create PR using gh CLI
+pr_body="This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.
+
+The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):
+
+\`\`\`
+$(cat "$benchstat_comparison")
+\`\`\`
+
+Epic: none
+Release note: none"
+
+gh pr create \
+    --head "$gh_username:$branch_name" \
+    --title "build: update PGO profile to $filename" \
+    --body "$pr_body" \
+    --reviewer "cockroachdb/release-eng-prs" \
+    --base master


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                         ops/sec                                          │                              ops/sec                               vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   136.2 ± ∞ ¹                                                         132.9 ± ∞ ¹       ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                  1.362k ± ∞ ¹                                                        1.329k ± ∞ ¹       ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                136.2 ± ∞ ¹                                                         132.9 ± ∞ ¹       ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                   1.362k ± ∞ ¹                                                        1.329k ± ∞ ¹       ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 136.2 ± ∞ ¹                                                         132.9 ± ∞ ¹       ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                     3.132k ± ∞ ¹                                                        3.057k ± ∞ ¹       ~ (p=0.686 n=4)
geomean                                                                                                                                   494.8                                                               482.8        -2.42%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/avg                                          │                              ms/avg                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   69.50 ± ∞ ¹                                                         68.60 ± ∞ ¹       ~ (p=0.943 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   106.4 ± ∞ ¹                                                         111.0 ± ∞ ¹       ~ (p=0.543 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                14.70 ± ∞ ¹                                                         14.45 ± ∞ ¹       ~ (p=0.943 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    28.80 ± ∞ ¹                                                         30.55 ± ∞ ¹       ~ (p=0.343 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 20.00 ± ∞ ¹                                                         19.90 ± ∞ ¹       ~ (p=0.886 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      63.90 ± ∞ ¹                                                         65.45 ± ∞ ¹       ~ (p=0.686 n=4)
geomean                                                                                                                                   39.84                                                               40.45        +1.52%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/p50                                          │                              ms/p50                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   68.15 ± ∞ ¹                                                         66.05 ± ∞ ¹       ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   100.7 ± ∞ ¹                                                         107.0 ± ∞ ¹       ~ (p=0.629 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                9.700 ± ∞ ¹                                                         9.400 ± ∞ ¹       ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    24.65 ± ∞ ¹                                                         26.75 ± ∞ ¹       ~ (p=0.571 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 15.70 ± ∞ ¹                                                         15.75 ± ∞ ¹       ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      50.30 ± ∞ ¹                                                         51.35 ± ∞ ¹       ~ (p=0.714 n=4)
geomean                                                                                                                                   33.02                                                               33.59        +1.74%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/p95                                          │                              ms/p95                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   115.3 ± ∞ ¹                                                         115.3 ± ∞ ¹       ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   188.7 ± ∞ ¹                                                         197.1 ± ∞ ¹       ~ (p=0.571 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                41.90 ± ∞ ¹                                                         44.00 ± ∞ ¹       ~ (p=0.543 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    60.80 ± ∞ ¹                                                         62.90 ± ∞ ¹       ~ (p=0.343 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 48.20 ± ∞ ¹                                                         49.25 ± ∞ ¹       ~ (p=0.771 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      163.6 ± ∞ ¹                                                         167.8 ± ∞ ¹       ~ (p=0.657 n=4)
geomean                                                                                                                                   87.11                                                               89.67        +2.94%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/p99                                          │                              ms/p99                                vs base              │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   151.0 ± ∞ ¹                                                         151.0 ± ∞ ¹       ~ (p=1.000 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   239.1 ± ∞ ¹                                                         239.1 ± ∞ ¹       ~ (p=0.714 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                65.00 ± ∞ ¹                                                         68.15 ± ∞ ¹       ~ (p=0.886 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    86.00 ± ∞ ¹                                                         90.20 ± ∞ ¹       ~ (p=0.171 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 71.30 ± ∞ ¹                                                         73.40 ± ∞ ¹       ~ (p=0.886 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      213.9 ± ∞ ¹                                                         222.3 ± ∞ ¹       ~ (p=0.400 n=4)
geomean                                                                                                                                   120.6                                                               123.9        +2.75%
¹ need >= 6 samples for confidence interval at level 0.95

                                                           │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_before.txt │ /home/agent/work/.go/src/github.com/cockroachdb/cockroach/artifacts/benchstat_after.txt │
                                                           │                                          ms/max                                          │                              ms/max                               vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                                                                                   243.3 ± ∞ ¹                                                        302.0 ± ∞ ¹  +24.13% (p=0.029 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                                                                                   402.6 ± ∞ ¹                                                        411.0 ± ∞ ¹        ~ (p=0.514 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                                                                                184.5 ± ∞ ¹                                                        176.2 ± ∞ ¹        ~ (p=0.657 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                                                                                    213.9 ± ∞ ¹                                                        226.5 ± ∞ ¹        ~ (p=0.686 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                                                                                 176.2 ± ∞ ¹                                                        188.8 ± ∞ ¹        ~ (p=0.771 n=4)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                                                                                      402.6 ± ∞ ¹                                                        411.0 ± ∞ ¹        ~ (p=0.514 n=4)
geomean                                                                                                                                   254.9                                                              269.6         +5.78%
¹ need >= 6 samples for confidence interval at level 0.95
```

Epic: none
Release note: none