### PR TITLE
kvserver: disable DRPC for TestReplicateQueueRebalanceMultiStore test

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -230,7 +230,10 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 			}
 			// Set up a test cluster with multiple stores per node if needed.
 			args := base.TestClusterArgs{
-				ReplicationMode:   base.ReplicationAuto,
+				ReplicationMode: base.ReplicationAuto,
+				ServerArgs: base.TestServerArgs{
+					DefaultDRPCOption: base.TestDRPCDisabled,
+				},
 				ServerArgsPerNode: map[int]base.TestServerArgs{},
 			}
 			for i := 0; i < testCase.nodes; i++ {


### PR DESCRIPTION
TestReplicateQueueRebalanceMultiStore test is currently flaky. Failures have been observed with both DRPC enabled and disabled. To reduce noise, DRPC is temporarily disabled for this test.

Informs: #156293
Epic: None
Release note: None