### PR TITLE
build: update PGO profile to 20251111094804-f9e10fda08c46b98ca7131d0b30cbee9189e97b8.pb.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -647,6 +647,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
+    sha256 = "8a2d099295327ddd61f454340195c0ce58334b980c5a094f16895775a87ece6f",
+    url = "https://storage.googleapis.com/cockroach-profiles/20251111094804-f9e10fda08c46b98ca7131d0b30cbee9189e97b8.pb.gz",
 )

--- a/build/teamcity/internal/release/pgo_profile_update.sh
+++ b/build/teamcity/internal/release/pgo_profile_update.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+cleanup() {
+    rm -f ~/.config/gcloud/application_default_credentials.json
+}
+trap cleanup EXIT
+
+
+# Install `gh` CLI tool if not already available
+if ! command -v gh &> /dev/null; then
+    echo "Installing gh CLI tool..."
+    wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz
+    echo "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401  /tmp/gh.tar.gz" | sha256sum -c -
+    tar --strip-components 1 -xf /tmp/gh.tar.gz -C /tmp
+    export PATH=/tmp/bin:$PATH
+    echo "gh CLI installed successfully"
+fi
+
+# Configuration
+export TESTS="${TESTS:-tpcc-nowait/literal/w=1000/nodes=5/cpu=16}"
+export COUNT="${COUNT:-20}"
+export CLOUD="${CLOUD:-gce}"
+# Do not use spot instances for PGO profile generation to ensure consistent
+# performance and random VM preemptions.
+export USE_SPOT="${USE_SPOT:-never}"
+
+docker_env_args=(
+  SELECT_PROBABILITY=1.0
+  ARM_PROBABILITY=0.0
+  COCKROACH_EA_PROBABILITY=0.0
+  FIPS_PROBABILITY=0.0
+  LITERAL_ARTIFACTS_DIR=$root/artifacts
+  BUILD_VCS_NUMBER
+  CLOUD
+  COCKROACH_DEV_LICENSE
+  COCKROACH_RANDOM_SEED
+  COUNT
+  EXPORT_OPENMETRICS
+  GITHUB_API_TOKEN
+  GITHUB_ORG
+  GITHUB_REPO
+  GOOGLE_CREDENTIALS_ASSUME_ROLE
+  GOOGLE_EPHEMERAL_CREDENTIALS
+  GOOGLE_KMS_KEY_A
+  GOOGLE_KMS_KEY_B
+  GOOGLE_SERVICE_ACCOUNT
+  GRAFANA_SERVICE_ACCOUNT_AUDIENCE
+  GRAFANA_SERVICE_ACCOUNT_JSON
+  ROACHPERF_OPENMETRICS_CREDENTIALS
+  ROACHTEST_ASSERTIONS_ENABLED_SEED
+  ROACHTEST_FORCE_RUN_INVALID_RELEASE_BRANCH
+  SELECTIVE_TESTS
+  SLACK_TOKEN
+  SNOWFLAKE_PVT_KEY
+  SNOWFLAKE_USER
+  TC_BUILDTYPE_ID
+  TC_BUILD_BRANCH
+  TC_BUILD_ID
+  TC_SERVER_URL
+  TESTS
+  USE_SPOT
+)
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$(printf -- "-e %s " "${docker_env_args[@]}")"
+
+benchstat_before="artifacts/benchstat_before.txt"
+benchstat_after="artifacts/benchstat_after.txt"
+
+# Step 1: Run initial benchmark tests to establish baseline
+echo "=== Step 1: Running baseline tpcc-nowait tests ==="
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+
+# Benchmark results are zipped in artifacts; extract them for analysis in a temp dir.
+tmp_artifacts_before="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_before"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe ./scripts/tpcc_results.sh "$tmp_artifacts_before" > "$benchstat_before"
+rm -rf "$tmp_artifacts_before"
+
+echo "=== Baseline benchstat saved to $benchstat_before ==="
+
+# Step 2: Generate new PGO profile
+echo "=== Step 2: Generating new PGO profile ==="
+filename="$(date +"%Y%m%d%H%M%S")-$(git rev-parse HEAD).pb.gz"
+bazel build //pkg/cmd/run-pgo-build
+_bazel/bin/pkg/cmd/run-pgo-build/run-pgo-build_/run-pgo-build -out "artifacts/$filename"
+sha256_hash=$(shasum -a 256 "artifacts/$filename" | awk '{print $1}')
+
+# Upload to GCS
+google_credentials="$GCS_GOOGLE_CREDENTIALS" log_into_gcloud
+gcs_url="gs://cockroach-profiles/$filename"
+gsutil cp "artifacts/$filename" "$gcs_url"
+
+# Convert GCS URL to HTTPS URL for WORKSPACE
+https_url="https://storage.googleapis.com/cockroach-profiles/$filename"
+
+echo "=== PGO profile uploaded to $gcs_url ==="
+echo "=== SHA256: $sha256_hash ==="
+
+# Step 3: Update WORKSPACE file with new PGO profile
+echo "=== Step 3: Updating WORKSPACE file ==="
+
+# Use sed to update the sha256 and url in the pgo_profile block
+# This is more robust than string replacement
+sed -i.bak -e '/pgo_profile(/,/)/ {
+    s|sha256 = ".*"|sha256 = "'"$sha256_hash"'"|
+    s|url = ".*"|url = "'"$https_url"'"|
+}' WORKSPACE
+
+# Remove backup file
+rm -f WORKSPACE.bak
+
+echo "=== WORKSPACE file updated ==="
+
+# Step 4: Rebuild with new PGO profile and run tests again
+echo "=== Step 4: Running tests with new PGO profile ==="
+
+# Clear build cache to ensure new profile is used
+bazel clean
+rm -rf "artifacts/tpcc-nowait"
+
+# Run the same tests again with the new PGO profile
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+
+# Benchmark results are zipped in artifacts; extract them for analysis in a temp dir.
+tmp_artifacts_after="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_after"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe ./scripts/tpcc_results.sh "$tmp_artifacts_after" > "$benchstat_after"
+rm -rf "$tmp_artifacts_after"
+rm -rf "artifacts/tpcc-nowait"
+
+echo "=== Post-PGO benchstat saved to $benchstat_after ==="
+
+# Step 5: Compare benchstats
+echo "=== Step 5: Comparing benchmark results ==="
+
+# Run benchstat comparison using bazel and save to file
+benchstat_comparison="artifacts/benchstat_comparison.txt"
+
+bazel build @org_golang_x_perf//cmd/benchstat
+_bazel/bin/external/org_golang_x_perf/cmd/benchstat/benchstat_/benchstat \
+    "$benchstat_before" "$benchstat_after" | tee "$benchstat_comparison"
+
+echo "=== Benchstat comparison saved to $benchstat_comparison ==="
+
+# Step 6: Create PR with changes
+echo "=== Step 6: Creating pull request ==="
+export GIT_AUTHOR_NAME="Justin Beaver"
+export GIT_COMMITTER_NAME="Justin Beaver"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+gh_username="cockroach-teamcity"
+
+# Create a new branch for the PR
+branch_name="pgo-profile-update-$(date +"%Y%m%d%H%M%S")"
+git checkout -b "$branch_name"
+
+# Stage the WORKSPACE file changes
+git add WORKSPACE
+
+# Create commit with descriptive message
+# Note: Full benchstat comparison is in the PR description, not in commit message
+commit_message="build: update PGO profile to $filename
+
+This commit updates the PGO profile used for building CockroachDB.
+
+The new profile was generated from tpcc-nowait benchmarks.
+See PR description for full benchmark comparison results.
+
+Epic: none
+Release note: none"
+
+git commit -m "$commit_message"
+set +x
+git push "https://$gh_username:$GH_TOKEN@github.com/$gh_username/cockroach.git" "$branch_name"
+set -x
+
+# Create PR using gh CLI
+pr_body="This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.
+
+The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):
+
+\`\`\`
+$(cat "$benchstat_comparison")
+\`\`\`
+
+Epic: none
+Release note: none"
+
+gh pr create \
+    --head "$gh_username:$branch_name" \
+    --title "build: update PGO profile to $filename" \
+    --body "$pr_body" \
+    --reviewer "cockroachdb/release-eng-prs" \
+    --base master


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │            ops/sec             │   ops/sec    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          134.2 ± 2%    133.6 ± 3%       ~ (p=0.417 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         1.341k ± 2%   1.336k ± 3%       ~ (p=0.414 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       134.2 ± 2%    133.6 ± 3%       ~ (p=0.402 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          1.341k ± 2%   1.336k ± 3%       ~ (p=0.414 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        134.2 ± 2%    133.6 ± 3%       ~ (p=0.402 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            3.085k ± 2%   3.072k ± 3%       ~ (p=0.402 n=20)
geomean                                                                          487.4         485.2       -0.44%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/avg             │   ms/avg    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          68.00 ± 2%   66.70 ± 6%       ~ (p=0.703 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          107.8 ± 2%   109.0 ± 5%       ~ (p=0.213 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       14.60 ± 2%   14.75 ± 4%       ~ (p=0.416 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           30.50 ± 6%   30.50 ± 6%       ~ (p=0.867 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        20.00 ± 2%   19.90 ± 3%       ~ (p=0.995 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             64.85 ± 2%   65.15 ± 3%       ~ (p=0.380 n=20)
geomean                                                                          40.22        40.23       +0.01%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p50             │   ms/p50    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          62.90 ± 3%   62.90 ± 7%       ~ (p=0.844 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          102.8 ± 2%   104.9 ± 4%       ~ (p=0.115 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       9.400 ± 6%   9.700 ± 3%       ~ (p=0.706 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           26.20 ± 8%   26.75 ± 6%       ~ (p=0.994 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        15.70 ± 4%   15.70 ± 4%       ~ (p=0.269 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             51.35 ± 2%   50.30 ± 4%       ~ (p=0.524 n=20)
geomean                                                                          32.97        33.25       +0.87%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p95             │   ms/p95    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          113.2 ± 4%   113.2 ± 7%       ~ (p=0.811 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          192.9 ± 4%   192.9 ± 4%       ~ (p=0.127 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       41.90 ± 5%   44.00 ± 5%       ~ (p=0.132 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           61.85 ± 2%   62.90 ± 3%       ~ (p=0.595 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        48.20 ± 4%   48.20 ± 4%   0.00% (p=0.047 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             163.6 ± 3%   167.8 ± 5%  +2.57% (p=0.039 n=20)
geomean                                                                          87.42        88.75       +1.53%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/p99             │   ms/p99     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          146.8 ± 3%   142.6 ± 12%       ~ (p=0.832 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          234.9 ± 4%   239.1 ±  5%       ~ (p=0.294 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       65.00 ± 3%   65.00 ± 10%       ~ (p=0.330 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           88.10 ± 5%   88.10 ±  5%       ~ (p=0.370 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        71.30 ± 6%   75.50 ±  6%       ~ (p=0.243 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             218.1 ± 4%   218.1 ±  4%       ~ (p=0.370 n=20)
geomean                                                                          120.6        121.5        +0.77%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/max             │   ms/max     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          260.0 ± 3%   276.8 ±  9%       ~ (p=0.369 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          419.4 ± 4%   436.2 ±  8%       ~ (p=0.544 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       184.5 ± 9%   197.1 ± 11%       ~ (p=0.113 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           218.1 ± 8%   234.9 ±  7%       ~ (p=0.146 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        201.3 ± 8%   197.1 ±  6%       ~ (p=1.000 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             419.4 ± 4%   436.2 ±  8%       ~ (p=0.544 n=20)
geomean                                                                          268.0        279.9        +4.43%
```

Epic: none
Release note: none