### PR TITLE
backup: run tests with DRPC randomly enabled

### DIFF
--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -38,7 +38,11 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tc, _, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(t, backuptestutils.MultiNode)
+	var params base.TestClusterArgs
+	params.ServerArgs.DefaultDRPCOption = base.TestDRPCDisabled
+
+	tc, _, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(t,
+		backuptestutils.MultiNode, backuptestutils.WithParams(params))
 	defer cleanupFn()
 
 	ctx := context.Background()

--- a/pkg/backup/backupdest/main_test.go
+++ b/pkg/backup/backupdest/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -24,6 +25,9 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 	os.Exit(m.Run())
 }
 

--- a/pkg/backup/backupinfo/main_test.go
+++ b/pkg/backup/backupinfo/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -24,6 +25,9 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 	os.Exit(m.Run())
 }
 

--- a/pkg/backup/backuprand/main_test.go
+++ b/pkg/backup/backuprand/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
@@ -25,6 +26,9 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 	os.Exit(m.Run())
 }
 

--- a/pkg/backup/backupresolver/BUILD.bazel
+++ b/pkg/backup/backupresolver/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     ],
     embed = [":backupresolver"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl/storageccl",
         "//pkg/keys",
         "//pkg/security/securityassets",

--- a/pkg/backup/backupresolver/main_test.go
+++ b/pkg/backup/backupresolver/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -23,6 +24,9 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	defer serverutils.TestingGlobalDRPCOption(
+		base.TestDRPCEnabledRandomly,
+	)()
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This change introduces a package-level setting that randomly enables DRPC in pkg/backup.

Epic: [CRDB-48935](https://cockroachlabs.atlassian.net/browse/CRDB-48935)
Fixes: https://github.com/cockroachdb/cockroach/issues/155569
Release note: None

**Notes:**
- Manual verification: Since the setting turns on/off randomly during test runs, the following command was used to manually verify that all combinations of the newly added setting and the existing  tenant setting (that is also enabled randomly) pass.
 `./dev test pkg/backup/<subdir> -v -- --test_env=COCKROACH_TEST_TENANT=<true/false/shared/external> --test_env=COCKROACH_TEST_DRPC=<true/false> 
`
- The following tests are disabled in this PR because they currently fail with the following error:
`"grpc: could not fetch metadata or no filename in metadata"`
This is a known issue that has been root-caused to differences in how metadata is handled between grpc and drpc and work to fix this issue is in progress as per @shubhamdhama. Relevant slack thread - https://cockroachlabs.slack.com/archives/C06V95X6CVA/p1761751554364579
The tests can be enabled after the issue is fixed.
Disabled tests:
TestBackupRestoreResolveDestination
All tests directly under pkg/backup





