### PR TITLE
build: update PGO profile to 20251111144418-db78725d235f569f49de913359e23c68a828d37e.pb.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -647,6 +647,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
+    sha256 = "c84ca8396848c77fd3fbc5882201765b3a9b73246fc89a57d2e5286bdc1034b6",
+    url = "https://storage.googleapis.com/cockroach-profiles/20251111144418-db78725d235f569f49de913359e23c68a828d37e.pb.gz",
 )

--- a/build/teamcity/internal/release/pgo_profile_update.sh
+++ b/build/teamcity/internal/release/pgo_profile_update.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+cleanup() {
+    rm -f ~/.config/gcloud/application_default_credentials.json
+}
+trap cleanup EXIT
+
+
+# Install `gh` CLI tool if not already available
+if ! command -v gh &> /dev/null; then
+    echo "Installing gh CLI tool..."
+    wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz
+    echo "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401  /tmp/gh.tar.gz" | sha256sum -c -
+    tar --strip-components 1 -xf /tmp/gh.tar.gz -C /tmp
+    export PATH=/tmp/bin:$PATH
+    echo "gh CLI installed successfully"
+fi
+
+# Configuration
+export TESTS="${TESTS:-tpcc-nowait/literal/w=1000/nodes=5/cpu=16}"
+export COUNT="${COUNT:-20}"
+export CLOUD="${CLOUD:-gce}"
+# Do not use spot instances for PGO profile generation to ensure consistent
+# performance and random VM preemptions.
+export USE_SPOT="${USE_SPOT:-never}"
+
+docker_env_args=(
+  SELECT_PROBABILITY=1.0
+  ARM_PROBABILITY=0.0
+  COCKROACH_EA_PROBABILITY=0.0
+  FIPS_PROBABILITY=0.0
+  LITERAL_ARTIFACTS_DIR=$root/artifacts
+  BUILD_VCS_NUMBER
+  CLOUD
+  COCKROACH_DEV_LICENSE
+  COCKROACH_RANDOM_SEED
+  COUNT
+  EXPORT_OPENMETRICS
+  GITHUB_API_TOKEN
+  GITHUB_ORG
+  GITHUB_REPO
+  GOOGLE_CREDENTIALS_ASSUME_ROLE
+  GOOGLE_EPHEMERAL_CREDENTIALS
+  GOOGLE_KMS_KEY_A
+  GOOGLE_KMS_KEY_B
+  GOOGLE_SERVICE_ACCOUNT
+  GRAFANA_SERVICE_ACCOUNT_AUDIENCE
+  GRAFANA_SERVICE_ACCOUNT_JSON
+  ROACHPERF_OPENMETRICS_CREDENTIALS
+  ROACHTEST_ASSERTIONS_ENABLED_SEED
+  ROACHTEST_FORCE_RUN_INVALID_RELEASE_BRANCH
+  SELECTIVE_TESTS
+  SLACK_TOKEN
+  SNOWFLAKE_PVT_KEY
+  SNOWFLAKE_USER
+  TC_BUILDTYPE_ID
+  TC_BUILD_BRANCH
+  TC_BUILD_ID
+  TC_SERVER_URL
+  TESTS
+  USE_SPOT
+)
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$(printf -- "-e %s " "${docker_env_args[@]}")"
+
+benchstat_before="artifacts/benchstat_before.txt"
+benchstat_after="artifacts/benchstat_after.txt"
+
+# Step 1: Run initial benchmark tests to establish baseline
+echo "=== Step 1: Running baseline tpcc-nowait tests ==="
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+
+# Benchmark results are zipped in artifacts; extract them for analysis in a temp dir.
+tmp_artifacts_before="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_before"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe ./scripts/tpcc_results.sh "$tmp_artifacts_before" > "$benchstat_before"
+rm -rf "$tmp_artifacts_before"
+
+echo "=== Baseline benchstat saved to $benchstat_before ==="
+
+# Step 2: Generate new PGO profile
+echo "=== Step 2: Generating new PGO profile ==="
+filename="$(date +"%Y%m%d%H%M%S")-$(git rev-parse HEAD).pb.gz"
+bazel build //pkg/cmd/run-pgo-build
+"$(bazel info bazel-bin)"/pkg/cmd/run-pgo-build/run-pgo-build_/run-pgo-build -out "artifacts/$filename"
+sha256_hash=$(shasum -a 256 "artifacts/$filename" | awk '{print $1}')
+
+# Upload to GCS
+google_credentials="$GCS_GOOGLE_CREDENTIALS" log_into_gcloud
+gcs_url="gs://cockroach-profiles/$filename"
+gsutil cp "artifacts/$filename" "$gcs_url"
+
+# Convert GCS URL to HTTPS URL for WORKSPACE
+https_url="https://storage.googleapis.com/cockroach-profiles/$filename"
+
+echo "=== PGO profile uploaded to $gcs_url ==="
+echo "=== SHA256: $sha256_hash ==="
+
+# Step 3: Update WORKSPACE file with new PGO profile
+echo "=== Step 3: Updating WORKSPACE file ==="
+
+# Use sed to update the sha256 and url in the pgo_profile block
+# This is more robust than string replacement
+sed -i.bak -e '/pgo_profile(/,/)/ {
+    s|sha256 = ".*"|sha256 = "'"$sha256_hash"'"|
+    s|url = ".*"|url = "'"$https_url"'"|
+}' WORKSPACE
+
+# Remove backup file
+rm -f WORKSPACE.bak
+
+echo "=== WORKSPACE file updated ==="
+
+# Step 4: Rebuild with new PGO profile and run tests again
+echo "=== Step 4: Running tests with new PGO profile ==="
+
+# Clear build cache to ensure new profile is used
+bazel clean
+rm -rf "artifacts/tpcc-nowait"
+
+# Run the same tests again with the new PGO profile
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+
+# Benchmark results are zipped in artifacts; extract them for analysis in a temp dir.
+tmp_artifacts_after="$(mktemp -d)"
+find "${root}/artifacts" -type f -name "artifacts.zip" -exec sh -c '
+  src="$1"
+  dest="'"$tmp_artifacts_after"'"
+  base="'"${root}/artifacts"'"
+  rel="${src#$base/}"
+  rel_dir="$(dirname "$rel")"
+  outdir="$dest/$rel_dir"
+  mkdir -p "$outdir"
+  unzip -o "$src" -d "$outdir"
+' _ {} \;
+
+bash -xe ./scripts/tpcc_results.sh "$tmp_artifacts_after" > "$benchstat_after"
+rm -rf "$tmp_artifacts_after"
+
+echo "=== Post-PGO benchstat saved to $benchstat_after ==="
+
+# Step 5: Compare benchstats
+echo "=== Step 5: Comparing benchmark results ==="
+
+# Run benchstat comparison using bazel and save to file
+benchstat_comparison="artifacts/benchstat_comparison.txt"
+
+bazel build @org_golang_x_perf//cmd/benchstat
+"$(bazel info bazel-bin)"/external/org_golang_x_perf/cmd/benchstat/benchstat_/benchstat \
+    "$benchstat_before" "$benchstat_after" | tee "$benchstat_comparison"
+
+echo "=== Benchstat comparison saved to $benchstat_comparison ==="
+
+# Step 6: Create PR with changes
+echo "=== Step 6: Creating pull request ==="
+export GIT_AUTHOR_NAME="Justin Beaver"
+export GIT_COMMITTER_NAME="Justin Beaver"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+gh_username="cockroach-teamcity"
+
+# Create a new branch for the PR
+branch_name="pgo-profile-update-$(date +"%Y%m%d%H%M%S")"
+git checkout -b "$branch_name"
+
+# Stage the WORKSPACE file changes
+git add WORKSPACE
+
+# Create commit with descriptive message
+# Note: Full benchstat comparison is in the PR description, not in commit message
+commit_message="build: update PGO profile to $filename
+
+This commit updates the PGO profile used for building CockroachDB.
+
+The new profile was generated from tpcc-nowait benchmarks.
+See PR description for full benchmark comparison results.
+
+Epic: none
+Release note: none"
+
+git commit -m "$commit_message"
+set +x
+git push "https://$gh_username:$GH_TOKEN@github.com/$gh_username/cockroach.git" "$branch_name"
+set -x
+
+# Create PR using gh CLI
+pr_body="This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.
+
+The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):
+
+\`\`\`
+$(cat "$benchstat_comparison")
+\`\`\`
+
+Epic: none
+Release note: none"
+
+gh pr create \
+    --head "$gh_username:$branch_name" \
+    --title "build: update PGO profile to $filename" \
+    --body "$pr_body" \
+    --reviewer "cockroachdb/release-eng-prs" \
+    --base master


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │            ops/sec             │   ops/sec    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          134.9 ± 2%    134.4 ± 2%       ~ (p=0.588 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         1.350k ± 2%   1.344k ± 2%       ~ (p=0.583 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       134.9 ± 2%    134.4 ± 2%       ~ (p=0.569 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          1.350k ± 2%   1.344k ± 2%       ~ (p=0.583 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        134.9 ± 2%    134.4 ± 2%       ~ (p=0.542 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            3.104k ± 2%   3.092k ± 2%       ~ (p=0.583 n=20)
geomean                                                                          490.3         488.4       -0.38%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/avg             │   ms/avg    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          66.55 ± 5%   67.50 ± 9%       ~ (p=0.090 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          108.0 ± 2%   108.8 ± 2%       ~ (p=0.465 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       14.50 ± 2%   14.50 ± 3%       ~ (p=0.672 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           30.30 ± 3%   30.10 ± 3%       ~ (p=0.723 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        20.15 ± 2%   19.90 ± 2%       ~ (p=0.559 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             64.45 ± 2%   64.70 ± 2%       ~ (p=0.616 n=20)
geomean                                                                          40.01        40.05       +0.11%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/p50             │   ms/p50     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          62.90 ± 7%   65.00 ± 10%       ~ (p=0.099 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          104.9 ± 4%   104.9 ±  4%       ~ (p=0.628 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       9.400 ± 0%   9.400 ±  6%       ~ (p=0.790 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           26.20 ± 4%   26.20 ±  4%       ~ (p=0.698 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        15.70 ± 4%   15.70 ±  0%       ~ (p=0.270 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             50.30 ± 4%   50.30 ±  4%       ~ (p=0.277 n=20)
geomean                                                                          32.97        33.15        +0.55%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p95             │   ms/p95    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          113.2 ± 4%   115.3 ± 2%       ~ (p=0.123 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          192.9 ± 4%   192.9 ± 4%       ~ (p=0.705 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       44.00 ± 5%   44.00 ± 5%       ~ (p=0.242 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           60.80 ± 3%   62.90 ± 3%       ~ (p=0.497 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        48.20 ± 4%   48.20 ± 4%       ~ (p=0.415 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             163.6 ± 3%   167.8 ± 5%       ~ (p=0.281 n=20)
geomean                                                                          87.88        89.03       +1.30%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p99             │   ms/p99    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          142.6 ± 6%   151.0 ± 6%       ~ (p=0.219 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          234.9 ± 4%   239.1 ± 2%       ~ (p=0.202 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       66.05 ± 5%   67.10 ± 3%       ~ (p=0.423 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           88.10 ± 5%   88.10 ± 0%       ~ (p=0.595 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        71.30 ± 6%   71.30 ± 6%       ~ (p=0.776 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             209.7 ± 4%   218.1 ± 4%       ~ (p=0.133 n=20)
geomean                                                                          119.5        122.1       +2.19%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/max             │   ms/max    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                         251.7 ±  7%   260.0 ± 6%       ~ (p=0.557 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         402.7 ±  8%   419.4 ± 8%       ~ (p=0.710 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      167.8 ± 15%   184.5 ± 4%       ~ (p=0.425 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          230.7 ±  5%   222.3 ± 6%       ~ (p=0.314 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                       184.5 ± 18%   184.5 ± 5%       ~ (p=0.174 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            402.7 ±  8%   419.4 ± 8%       ~ (p=0.710 n=20)
geomean                                                                         257.5         265.0       +2.90%
```

Epic: none
Release note: none