### PR TITLE
release: do not install openssl in FIPS mode

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,30 +1,20 @@
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 FROM us-east1-docker.pkg.dev/crl-docker-sync/registry-access-redhat-com/ubi10/ubi-minimal
-ARG fips_enabled
 
-# For deployment, we need the following additionally installed:
-# tzdata - for time zone functions
+# For deployment, we need the following additional packages:
+# ca-certificates - to validate TLS certs
 # hostname - used in cockroach k8s manifests
-# tar - used by kubectl cp
-RUN microdnf update -y \
-    && microdnf install tzdata hostname tar gzip xz -y \
+# tar, gzip, xz - used by kubectl cp
+# tzdata - for time zone functions
+RUN microdnf update -y && microdnf install -y \
+      ca-certificates \
+      tzdata \
+      hostname \
+      tar \
+      gzip \
+      xz \
     && rm -rf /var/cache/yum
-# FIPS mode requires the `openssl` package installed. Also we need to temporarily
-# install the `crypto-policies-scripts` packege to tweak some configs. Because
-# `microdnf` doesn't support `autoremove`, we need to record the list of
-# packages before and after, and remove the installed ones afterward.
-RUN if [ "$fips_enabled" == "1" ]; then \
-    microdnf install -y openssl && \
-    rpm -qa | sort > /before.txt && \
-    microdnf install -y crypto-policies-scripts && \
-    update-crypto-policies --set FIPS && \
-    rpm -qa | sort > /after.txt && \
-    microdnf remove -y $(comm -13 /before.txt /after.txt) && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum /before.txt /after.txt; \
-    fi
-
 
 RUN mkdir /usr/local/lib/cockroach /cockroach /licenses /docker-entrypoint-initdb.d
 COPY cockroach.sh cockroach /cockroach/

--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -106,10 +106,8 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
   build_docker_tag="${gcr_staged_repository}:${arch}-${version}"
   if [[ $platform == "linux-amd64-fips" ]]; then
     build_docker_tag="${gcr_staged_repository}:${version}-fips"
-    docker build --label version="$version_label" --no-cache --pull --platform="linux/${arch}" --tag="${build_docker_tag}" --build-arg fips_enabled=1 "build/deploy-${platform}"
-  else
-    docker build --label version="$version_label" --no-cache --pull --platform="linux/${arch}" --tag="${build_docker_tag}" "build/deploy-${platform}"
   fi
+  docker build --label version="$version_label" --no-cache --pull --platform="linux/${arch}" --tag="${build_docker_tag}" "build/deploy-${platform}"
   docker push "$build_docker_tag"
   tc_end_block "Make and push docker image"
 fi

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -133,10 +133,8 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
   build_docker_tag="${gcr_repository}:${arch}-${build_name}"
   if [[ $platform == "linux-amd64-fips" ]]; then
     build_docker_tag="${gcr_repository}:${build_name}-fips"
-    docker build --no-cache --pull --platform "linux/${arch}" --tag="${build_docker_tag}" --build-arg fips_enabled=1 "build/deploy-${platform}"
-  else
-    docker build --no-cache --pull --platform "linux/${arch}" --tag="${build_docker_tag}" "build/deploy-${platform}"
   fi
+  docker build --no-cache --pull --platform "linux/${arch}" --tag="${build_docker_tag}" "build/deploy-${platform}"
   docker push "$build_docker_tag"
 
   tc_end_block "Make and push docker images"


### PR DESCRIPTION
Previously, our Dockerfile for deployment would install the `openssl` package when FIPS mode was enabled. However, this is unnecessary because the current implementation of FIPS mode does not rely on the system's OpenSSL library. This allows us to unify the Dockerfile for both variants.

Additionally, install `ca-certificates` to ensure that TLS certificates can be properly validated, without implicitly using `x509.SetFallbackRoots`.

Epic: none
Release note: none