### PR TITLE
release-25.4: sql: fix COPY with some concurrent schema changes

### DIFF
--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -125,11 +125,6 @@ func (b *BatchEncoder) PrepareBatch(ctx context.Context, p row.Putter, start, en
 	}
 	for _, ind := range b.rh.TableDesc.WritableNonPrimaryIndexes() {
 		b.resetBuffers()
-		// TODO(cucaroach): COPY doesn't need ForcePut support but the encoder
-		// will need to support it eventually.
-		if ind.ForcePut() {
-			colexecerror.InternalError(errors.AssertionFailedf("vector encoder doesn't support ForcePut yet"))
-		}
 		if err := b.encodeSecondaryIndex(ctx, ind); err != nil {
 			return err
 		}
@@ -484,6 +479,13 @@ func (b *BatchEncoder) encodeSecondaryIndex(ctx context.Context, ind catalog.Ind
 	return b.checkMemory()
 }
 
+func (b *BatchEncoder) useCPutForSecondary(ind catalog.Index) bool {
+	if ind.ForcePut() {
+		return false
+	}
+	return ind.IsUnique() || b.useCPutsOnNonUniqueIndexes
+}
+
 func (b *BatchEncoder) encodeSecondaryIndexNoFamilies(ind catalog.Index, kys []roachpb.Key) error {
 	for row := 0; row < b.count; row++ {
 		// Elided partial index keys will be empty.
@@ -510,7 +512,7 @@ func (b *BatchEncoder) encodeSecondaryIndexNoFamilies(ind catalog.Index, kys []r
 	if err := b.writeColumnValues(kys, values, ind, cols); err != nil {
 		return err
 	}
-	if ind.IsUnique() || b.useCPutsOnNonUniqueIndexes {
+	if b.useCPutForSecondary(ind) {
 		b.p.CPutBytesEmpty(kys, values)
 	} else {
 		b.p.PutBytes(kys, values)
@@ -576,13 +578,13 @@ func (b *BatchEncoder) encodeSecondaryIndexWithFamilies(
 		// include encoded primary key columns. For other families,
 		// use the tuple encoding for the value.
 		if familyID == 0 {
-			if ind.IsUnique() || b.useCPutsOnNonUniqueIndexes {
+			if b.useCPutForSecondary(ind) {
 				b.p.CPutBytesEmpty(kys, values)
 			} else {
 				b.p.PutBytes(kys, values)
 			}
 		} else {
-			if ind.IsUnique() || b.useCPutsOnNonUniqueIndexes {
+			if b.useCPutForSecondary(ind) {
 				b.p.CPutTuplesEmpty(kys, values)
 			} else {
 				b.p.PutTuples(kys, values)

--- a/pkg/sql/colenc/inverted.go
+++ b/pkg/sql/colenc/inverted.go
@@ -94,7 +94,7 @@ func (b *BatchEncoder) encodeInvertedSecondaryIndexNoFamiliesOneRow(
 	}
 	var kvValue roachpb.Value
 	kvValue.SetBytes(value)
-	if ind.IsUnique() || b.useCPutsOnNonUniqueIndexes {
+	if b.useCPutForSecondary(ind) {
 		b.p.CPut(&key, &kvValue, nil /* expValue */)
 	} else {
 		b.p.Put(&key, &kvValue)


### PR DESCRIPTION
Backport 1/1 commits from #148549 on behalf of @yuzefovich.

----

Previously, if we had COPY running concurrently with some schema changes
that require usage of Puts (via ForcePut on the index), like ALTER
PRIMARY KEY, we could hit an internal error because the vectorized
encoder didn't support it. This commit adds the support for it, but it
also actually disables using the vectorized encoder for COPY when
ForcePut option is observed on at least one writable index. This is the
case since I observed many different corruption-like failures when
stressing the extended test, which aren't present if we use the
row-by-row insert.

Existing `TestLargeCopy` has been extended so that sometimes it also
performs ALTER PRIMARY KEY concurrently with the COPY as well as
randomized `copy_from_atomic_enabled` value. Note that in some cases
we're hitting "duplicate key" violation while there is a schema change,
and it seems somewhat expected to me, so I didn't look deeper and simply
made the test ignore such errors.

Fixes: #147955.

Release note (bug fix): CockroachDB could previously encounter "vector
encoder doesn't support ForcePut yet" error when performing COPY command
concurrently with some schema changes. The bug has been present since
before 23.2 and is now fixed.

----

Release justification: bug fix.