### PR TITLE
rpc: fix DialRPC when NoLoopbackDialer is true

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -55,7 +55,7 @@ func DialDRPC(
 			_ struct{}) (drpcpool.Conn, error) {
 
 			netConn, err := func(ctx context.Context) (net.Conn, error) {
-				if rpcCtx.ContextOptions.AdvertiseAddr == target && !rpcCtx.ClientOnly {
+				if rpcCtx.ContextOptions.AdvertiseAddr == target && rpcCtx.canLoopbackDial() {
 					return rpcCtx.loopbackDRPCDialFn(ctx)
 				}
 				return drpcmigrate.DialWithHeader(ctx, "tcp", target, drpcmigrate.DRPCHeader)


### PR DESCRIPTION
If NoLoopbackDialer is true, then loopbackDRPCDialFn would return the error "loopback dialer called but NoLoopbackDialer was set". This was causing problem with sysbench benchmarks.

Fixes: none
Epic: none
Release note: none