### PR TITLE
release-25.2: roachtest: deflake splits/load/ycsb/e

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -410,7 +410,7 @@ func registerLoadSplits(r registry.Registry) {
 				// YCSB/E has a zipfian distribution with 95% scans (limit 1k) and 5%
 				// inserts.
 				minimumRanges:     5,
-				maximumRanges:     30,
+				maximumRanges:     33,
 				initialRangeCount: 2,
 				load: ycsbSplitLoad{
 					workload:     "e",


### PR DESCRIPTION
Backport 1/1 commits from #157147.

/cc @cockroachdb/release

---

Resolves #156923

Release justification: test deflake