### PR TITLE
build: add whether build is FIPS-enabled to `cockroach version`

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -7,6 +7,7 @@ package build
 
 import (
 	"bytes"
+	"crypto/fips140"
 	_ "embed"
 	"fmt"
 	"runtime"
@@ -168,6 +169,10 @@ func (b Info) Long() string {
 	fmt.Fprintf(tw, "C Compiler:       %s\n", b.CgoCompiler)
 	fmt.Fprintf(tw, "Build Commit ID:  %s\n", b.Revision)
 	fmt.Fprintf(tw, "Build Type:       %s\n", b.Type)
+	if fips140.Enabled() {
+		fmt.Fprintf(tw, "FIPS enabled:     true\n")
+	}
+
 	fmt.Fprintf(tw, "Enabled Assertions: %t", b.EnabledAssertions) // No final newline: cobra prints one for us.
 	_ = tw.Flush()
 	return buf.String()


### PR DESCRIPTION
Part of: #155643
Epic: DEVINF-815
Release note: Display whether build is FIPS-enabled in `cockroach version`