### PR TITLE
kvcoord: default KeepRefreshSpansOnSavepointRollback to true

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -50,12 +50,11 @@ var MaxTxnRefreshSpansBytes = settings.RegisterIntSetting(
 // to impact customers because they should already be able to handle
 // serialization errors; in case any unforeseen customer issues arise, the
 // setting here allows us to revert to the old behavior.
-// TODO(mira): set the default to true after #113765.
 var KeepRefreshSpansOnSavepointRollback = settings.RegisterBoolSetting(
 	settings.SystemVisible,
 	"kv.transaction.keep_refresh_spans_on_savepoint_rollback.enabled",
 	"if enabled, all refresh spans accumulated since a savepoint was created are kept after the savepoint is rolled back",
-	false)
+	true)
 
 // txnSpanRefresher is a txnInterceptor that collects the read spans of a
 // serializable transaction in the event it gets a serializable retry error. It

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -175,8 +175,6 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	// TODO(mira): Remove this cluster setting once the default is set to true.
-	kvcoord.KeepRefreshSpansOnSavepointRollback.Override(ctx, &st.SV, true)
 	kvcoord.NonTransactionalWritesNotIdempotent.Override(ctx, &st.SV, true)
 	if cfg.leaseTypeOverride != 0 {
 		kvserver.OverrideDefaultLeaseType(ctx, &st.SV, cfg.leaseTypeOverride)


### PR DESCRIPTION
Now that #113765 is resolved, we can flip the default of the `KeepRefreshSpansOnSavepointRollback` cluster setting, which will enable transactions to keep refresh spans across savepoint rollbacks.

See #111228 to more details.

Part of: #111228

Release note: None