### PR TITLE
security: handle transient files in certificate directory loading

### DIFF
--- a/pkg/security/securityassets/security_assets.go
+++ b/pkg/security/securityassets/security_assets.go
@@ -69,6 +69,12 @@ func readDir(dirname string) ([]os.FileInfo, error) {
 	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {
+			// Skip files that disappeared between ReadDir and Info().
+			// This can happen when the directory contains transient files
+			// like Unix socket lock files that are created/deleted rapidly.
+			if oserror.IsNotExist(err) {
+				continue
+			}
 			return nil, err
 		}
 		infos = append(infos, info)


### PR DESCRIPTION
The 'TestDemoLocality' was failing with "no certificates found; does certs dir exist?" errors. This resulted in connection failures when nodes attempted to establish RPC connections.

Root cause: The demo cluster stores both TLS certificates and Unix socket files (e.g., `.s.PGSQL.26267`) in the same directory. When loading certificates, `readDir()` lists all directory entries and then calls `entry.Info()` to stat each file. Between these operations, transient socket lock files (e.g., `.s.PGSQL.26267.lock.887590299`) can be deleted, causing `lstat()` to fail with ENOENT. This caused the entire certificate loading to fail, even though the actual certificate files existed and were valid.

Fix: this change modified the `readDir()` to skip files that disappear between directory listing and stat operations (a standard pattern for handling concurrent file-system modifications).

Fixes #155255
Epic: none
Release note: None