### PR TITLE
release-25.2: base: make liveness and lease renewal fractions configurable

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -52,31 +52,6 @@ const (
 	// See https://github.com/cockroachdb/cockroach/issues/20310.
 	DefaultMetricsSampleInterval = 10 * time.Second
 
-	// defaultRangeLeaseRenewalFraction specifies what fraction the range lease
-	// renewal duration should be of the range lease active time. For example,
-	// with a value of 0.2 and a lease duration of 10 seconds, leases would be
-	// eagerly renewed 8 seconds into each lease.
-	//
-	// A range lease extension requires 1 RTT (Raft consensus), assuming the
-	// leaseholder is colocated with the Raft leader, so 3 seconds should be
-	// sufficient (see NetworkTimeout). However, on user ranges, Raft consensus
-	// uses the DefaultClass RPC class, and is thus subject to head-of-line
-	// blocking by other RPC traffic which can cause very high latencies under
-	// heavy load (several seconds).
-	defaultRangeLeaseRenewalFraction = 0.5
-
-	// livenessRenewalFraction specifies what fraction the node liveness renewal
-	// duration should be of the node liveness duration. For example, with a value
-	// of 0.2 and a liveness duration of 10 seconds, each node's liveness record
-	// would be eagerly renewed after 8 seconds.
-	//
-	// A liveness record write requires 2 RTTs (RPC and Raft consensus). Assuming
-	// a max RTT of 600ms (see NetworkTimeout), 3 seconds is enough for 2 RTTs
-	// (2*600ms) and 1 RTO (900ms), with a 900ms buffer. The write is committed
-	// 1/2 RTT before this. Liveness RPCs including Raft messages are sent via
-	// SystemClass, and thus avoid head-of-line blocking by general RPC traffic.
-	livenessRenewalFraction = 0.5
-
 	// DefaultDescriptorLeaseDuration is the default mean duration a
 	// lease will be acquired for. The actual duration is jittered using
 	// the jitter fraction. Jittering is done to prevent multiple leases
@@ -201,6 +176,33 @@ var (
 	// lease acquisition and 2.5s for Raft elections.
 	defaultRangeLeaseDuration = envutil.EnvOrDefaultDuration(
 		"COCKROACH_RANGE_LEASE_DURATION", 6*time.Second)
+
+	// defaultRangeLeaseRenewalFraction specifies what fraction the range lease
+	// renewal duration should be of the range lease active time. For example,
+	// with a value of 0.2 and a lease duration of 10 seconds, leases would be
+	// eagerly renewed 8 seconds into each lease.
+	//
+	// A range lease extension requires 1 RTT (Raft consensus), assuming the
+	// leaseholder is colocated with the Raft leader, so 3 seconds should be
+	// sufficient (see NetworkTimeout). However, on user ranges, Raft consensus
+	// uses the DefaultClass RPC class, and is thus subject to head-of-line
+	// blocking by other RPC traffic which can cause very high latencies under
+	// heavy load (several seconds).
+	defaultRangeLeaseRenewalFraction = envutil.EnvOrDefaultFloat64(
+		"COCKROACH_RANGE_LEASE_RENEWAL_FRACTION", 0.5)
+
+	// livenessRenewalFraction specifies what fraction the node liveness renewal
+	// duration should be of the node liveness duration. For example, with a value
+	// of 0.2 and a liveness duration of 10 seconds, each node's liveness record
+	// would be eagerly renewed after 8 seconds.
+	//
+	// A liveness record write requires 2 RTTs (RPC and Raft consensus). Assuming
+	// a max RTT of 600ms (see NetworkTimeout), 3 seconds is enough for 2 RTTs
+	// (2*600ms) and 1 RTO (900ms), with a 900ms buffer. The write is committed
+	// 1/2 RTT before this. Liveness RPCs including Raft messages are sent via
+	// SystemClass, and thus avoid head-of-line blocking by general RPC traffic.
+	livenessRenewalFraction = envutil.EnvOrDefaultFloat64(
+		"COCKROACH_LIVENESS_RENEWAL_FRACTION", 0.5)
 
 	// DefaultRPCHeartbeatTimeout is the default RPC heartbeat timeout. It is set
 	// very high at 3 * NetworkTimeout for several reasons: the gRPC transport may


### PR DESCRIPTION
Backport 1/1 commits from #157240 on behalf of @arulajmani.

----

Need this for the leader leases paper.

Epic: none

Release note: None

----

Release justification: