### PR TITLE
apply: improve Asserter logging and error handling

### DIFF
--- a/pkg/kv/kvserver/apply/BUILD.bazel
+++ b/pkg/kv/kvserver/apply/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/util/hlc",
+        "//pkg/util/log",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
Previously, the `Asserter` would panic if it found any discrepancy. This usually works as expected and the panic message in the test failure (e.g. kvnemesis). However, it's possible that the goroutine that invoked the `Asserter` is in a part of the code that doesn't check/recover from panics (e.g. the `defer` logic in `processRaftSnapshotRequest`).

This commit changes the panics to `log.Fatalf`s to have a better chance of logging these. It also improves one of the log messages in the `Asserter` to print out the log state in case of a discrepancy.

Closes: #157253

Release note: None