### PR TITLE
release-24.1: build/github: enable more logging for EngFlow invocations in CI

### DIFF
--- a/build/github/engflow-args.sh
+++ b/build/github/engflow-args.sh
@@ -8,7 +8,9 @@
 # remote execution arguments to the invocation. You must call get-engflow-keys.sh
 # before this.
 
-ARGS='--config engflowpublic --tls_client_certificate=/home/agent/engflow.crt --tls_client_key=/home/agent/engflow.key --experimental_build_event_upload_retry_minimum_delay 3s --experimental_build_event_upload_max_retries 8'
+tmpfile=$(mktemp)
+
+ARGS="--config engflowpublic --tls_client_certificate=/home/agent/engflow.crt --tls_client_key=/home/agent/engflow.key --experimental_build_event_upload_retry_minimum_delay 3s --experimental_build_event_upload_max_retries 8 --execution_log_compact_file=$tmpfile --experimental_build_event_upload_strategy=remote"
 
 if [[ "$GITHUB_ACTIONS_BRANCH" == staging-* ]]
 then


### PR DESCRIPTION
Backport 1/1 commits from #157769 on behalf of @rickystewart.

----

See [the EngFlow blog post](https://blog.engflow.com/2025/11/10/enhanced-invocation-level-insights-for-bazel-builds/).

Release note: none
Epic: none

----

Release justification: Non-production code changes