### PR TITLE
tree: speed up two tests

### DIFF
--- a/pkg/sql/sem/tree/inject_hints_test.go
+++ b/pkg/sql/sem/tree/inject_hints_test.go
@@ -241,7 +241,7 @@ func TestRandomInjectHints(t *testing.T) {
 	skip.UnderDeadlock(t, "the test is too slow")
 	skip.UnderRace(t, "the test is too slow")
 
-	const numStatements = 500
+	const numStatements = 100
 
 	ctx := context.Background()
 	rng, seed := randutil.NewTestRand()

--- a/pkg/sql/sem/tree/parse_array_test.go
+++ b/pkg/sql/sem/tree/parse_array_test.go
@@ -8,12 +8,12 @@ package tree
 import (
 	"bytes"
 	"context"
-	"math/rand"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 var tupleOfTwoInts = types.MakeTuple([]*types.T{types.Int, types.Int})
@@ -144,21 +144,22 @@ type noopUnwrapCompareContext struct {
 
 func (noopUnwrapCompareContext) UnwrapDatum(ctx context.Context, d Datum) Datum { return d }
 
-const randomArrayIterations = 1000
+const randomArrayIterations = 100
 const randomArrayMaxLength = 10
 const randomStringMaxLength = 1000
 
 func TestParseArrayRandomParseArray(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	rng, _ := randutil.NewTestRand()
 	for i := 0; i < randomArrayIterations; i++ {
-		numElems := rand.Intn(randomArrayMaxLength)
+		numElems := rng.Intn(randomArrayMaxLength)
 		ary := make([][]byte, numElems)
 		for aryIdx := range ary {
-			len := rand.Intn(randomStringMaxLength)
+			len := rng.Intn(randomStringMaxLength)
 			str := make([]byte, len)
 			for strIdx := 0; strIdx < len; strIdx++ {
-				str[strIdx] = byte(rand.Intn(256))
+				str[strIdx] = byte(rng.Intn(256))
 			}
 			ary[aryIdx] = str
 		}
@@ -175,7 +176,7 @@ func TestParseArrayRandomParseArray(t *testing.T) {
 			// means that there's no printable way to encode non-printing characters,
 			// users must use `e` prefixed strings).
 			for _, c := range b {
-				if c == '"' || c == '\\' || rand.Intn(10) == 0 {
+				if c == '"' || c == '\\' || rng.Intn(10) == 0 {
 					buf.WriteByte('\\')
 				}
 				buf.WriteByte(c)


### PR DESCRIPTION
We just saw a package-level test timeout of 1 minute being hit because `TestRandomInjectHints` took 29s and `TestParseArrayRandomParseArray` took 16s before interruption. This commit reduces the number of iterations by 5x and 10x, respectively.

Fixes: #157256.
Release note: None