### PR TITLE
release-24.3: workflows: run `lint` on `huge` machines

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: ./cockroach/build/github/cleanup-engflow-keys.sh
         if: always()
   lint:
-    runs-on: [self-hosted, ubuntu_big_2004]
+    runs-on: [self-hosted, ubuntu_huge_2004]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Backport 1/1 commits from #157781 on behalf of @rickystewart.

----

This job is the bottleneck, so this should hopefully speed it up some.

Part of: DEVINF-1625
Release note: none
Epic: DEVINF-1604

----

Release justification: Non-production code changes