### PR TITLE
testutils: remove ForceTableGC from ApplicationLayerInterface

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -10502,6 +10502,7 @@ func TestBackupDBWithViewOnAdjacentDBRange(t *testing.T) {
 			},
 		})
 	defer cleanupFn()
+	srv0 := tc.StorageLayer(0)
 	s0 := tc.ApplicationLayer(0)
 
 	// Speeds up the test.
@@ -10532,7 +10533,7 @@ func TestBackupDBWithViewOnAdjacentDBRange(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// Force GC on da.t2 to advance its GC threshold.
-	err := s0.ForceTableGC(context.Background(), "da", "t2", s0.Clock().Now().Add(-int64(1*time.Second), 0))
+	err := srv0.ForceTableGC(context.Background(), "da", "t2", s0.Clock().Now().Add(-int64(1*time.Second), 0))
 	require.NoError(t, err)
 
 	// This statement should succeed as we are not backing up the span for dbview,

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -36,10 +36,8 @@ func TestUserLoginAfterGC(t *testing.T) {
 	ctx := context.Background()
 
 	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		// In external-process mode the tenant doesn't have kvpb.GCRequest
-		// capability (and this capability can't be granted at the time of
-		// writing either), so we skip the external mode only.
-		DefaultTestTenant: base.TestSkipForExternalProcessMode(),
+		// ForceTableGC is only available for the system tenant.
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
@@ -55,7 +53,7 @@ func TestUserLoginAfterGC(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Force a table GC with a threshold of 500ms in the past.
-	err = s.ForceTableGC(ctx, "system", "role_members", s.Clock().Now().Add(-int64(500*time.Millisecond), 0))
+	err = srv.ForceTableGC(ctx, "system", "role_members", s.Clock().Now().Add(-int64(500*time.Millisecond), 0))
 	require.NoError(t, err)
 
 	// Verify that newuser can still log in.

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -463,11 +463,6 @@ type ApplicationLayerInterface interface {
 		ctx context.Context, span roachpb.Span,
 	) (*serverpb.TableStatsResponse, error)
 
-	// ForceTableGC forces a KV GC round on the key range for the given table.
-	ForceTableGC(
-		ctx context.Context, database, table string, timestamp hlc.Timestamp,
-	) error
-
 	// DefaultZoneConfig is a convenience function that accesses
 	// .SystemConfigProvider().GetSystemConfig().DefaultZoneConfig.
 	DefaultZoneConfig() zonepb.ZoneConfig
@@ -732,6 +727,17 @@ type StorageLayerInterface interface {
 
 	// RaftConfig retrieves a copy of the raft configuration.
 	RaftConfig() base.RaftConfig
+
+	// ForceTableGC forces a KV GC round on the key range for the given table.
+	//
+	// Note that we don't provide this functionality as part of the
+	// ApplicationLayerInterface because on secondary tenants we don't put
+	// split points between all tables, so the KV GC request could affect other
+	// system tables (since they could share the underlying range with the user
+	// table).
+	ForceTableGC(
+		ctx context.Context, database, table string, timestamp hlc.Timestamp,
+	) error
 }
 
 // TestServerFactory encompasses the actual implementation of the shim


### PR DESCRIPTION
In 9d0d231bd1a9c9bacc7590d4984205f6775750ce we made `ForceTableGC` helper method of the test server work with secondary tenants and moved it into the ApplicationLayer interface. The method works by issuing the KV GCRequest command on the range containing the user table. However, with secondary tenants (both in shared-process and external-process modes) IIUC we don't add split points between all tables, so it's possible that when trying to GC the "user" table we also GC the "system" table. This showed up as a failure in TestStatsWithLowTTL where an update to a cluster setting was never observed by the tenant because the settings-watcher rangefeed failed since it ran into the GC threshold and exited.

I think if we're mucking with KV GC requests it makes sense that such tests would be specific to the system tenant, so this commit removes ForceTableGC method from the ApplicationLayer interface and adjusts a couple of tests to only work with system tenants.

Fixes: #157126.
Release note: None