### PR TITLE
sql: fix TestSessionMigration

### DIFF
--- a/pkg/sql/session_migration_test.go
+++ b/pkg/sql/session_migration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -206,6 +208,21 @@ WHERE dump.variable IS NULL OR dump2.variable IS NULL OR dump.variable != dump2.
 				if err != nil {
 					return err.Error()
 				}
+				// Block until the application layer observes the change.
+				testutils.SucceedsSoon(t, func() error {
+					row := dbConn.QueryRow(ctx, `SHOW CLUSTER SETTING sql.session_transfer.max_session_size;`)
+					var sessionSize string
+					err := row.Scan(&sessionSize)
+					if err != nil {
+						return err
+					}
+					// Remove spaces to match format from the test file.
+					sessionSize = strings.ReplaceAll(sessionSize, " ", "")
+					if sessionSize != d.CmdArgs[0].Key {
+						return errors.Newf("expected session size to be %s, got %s", d.CmdArgs[0].Key, sessionSize)
+					}
+					return nil
+				})
 				return ""
 
 			case "error":

--- a/pkg/sql/testdata/session_migration/max_size
+++ b/pkg/sql/testdata/session_migration/max_size
@@ -1,4 +1,4 @@
-change_session_size 2KB
+change_session_size 2.0KiB
 ----
 
 let $large_string


### PR DESCRIPTION
In `TestSessionMigration/max_size` we're changing SystemVisible cluster setting via the system layer, so if we're running in a secondary tenant, we must block until that change is picked up by the settings-watcher rangefeed.

Fixes: #157042.
Release note: None