### PR TITLE
colexecjoin: add cancel check when consuming right input in cross join

### DIFF
--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -175,6 +175,7 @@ func (c *crossJoiner) consumeRightInput(ctx context.Context) {
 	// Consume the right input if necessary.
 	if needRightTuples || needOnlyNumRightTuples {
 		for {
+			c.cancelChecker.CheckEveryCall()
 			batch := c.InputTwo.Next()
 			if needRightTuples {
 				c.rightTuples.Enqueue(ctx, batch)


### PR DESCRIPTION
We just saw a test failure where the query wasn't cancelled within 1 minute even though 0.1s statement timeout is set. In the goroutine dump we see the cross joiner building from the left input. We already check for cancellation every time Next is called on the cross joiner, at the beginning, but on the very first call there could be a long process to consume the right input. This commit adds the cancel checking before fetching the next batch from the right input (except for the first batch that might have already been fetched). I was unable to reproduce the timeout, but this shouldn't hurt.

Fixes: #156992.
Release note: None