### PR TITLE
roachtest: update MinimumBootstrapVersion to v25.3.0 [for review]

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -56,9 +56,9 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 				),
 				mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 				mixedversion.AlwaysUseLatestPredecessors,
-				// Don't go back too far. We are mostly interested in upgrading to v24.3
-				// where RACv2 was introduced.
-				mixedversion.MinimumBootstrapVersion("v24.1.0"),
+				// The test requires the cluster to start at or above MinSupported.
+				// Updated to v25.3.0 after bumping MinSupported from v25.2 to v25.3.
+				mixedversion.MinimumBootstrapVersion("v25.3.0"),
 			)
 
 			// Limit the disk throughput to 128 MiB/s, to more easily stress the

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -196,8 +196,9 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	ctx context.Context, t test.Test, c cluster.Cluster,
 ) {
 	validateSystemSchemaAfterUpgradeTest(ctx, t, c,
-		// The test is not expected to work on versions older than 22.2.
-		mixedversion.MinimumBootstrapVersion("v22.2.0"),
+		// The test requires the cluster to start at or above MinSupported.
+		// Updated to v25.3.0 after bumping MinSupported from v25.2 to v25.3.
+		mixedversion.MinimumBootstrapVersion("v25.3.0"),
 		// Fixtures are generated on a version that's too old for this test.
 		mixedversion.NeverUseFixtures,
 		// Separate-process deployments can't run in 1-node clusters since
@@ -217,8 +218,9 @@ func runValidateSystemSchemaAfterVersionUpgradeSeparateProcess(
 	ctx context.Context, t test.Test, c cluster.Cluster,
 ) {
 	validateSystemSchemaAfterUpgradeTest(ctx, t, c,
-		// The test is not expected to work on versions older than 22.2.
-		mixedversion.MinimumBootstrapVersion("v22.2.0"),
+		// The test requires the cluster to start at or above MinSupported.
+		// Updated to v25.3.0 after bumping MinSupported from v25.2 to v25.3.
+		mixedversion.MinimumBootstrapVersion("v25.3.0"),
 		// Fixtures are generated on a version that's too old for this test.
 		mixedversion.NeverUseFixtures,
 		mixedversion.EnabledDeploymentModes(mixedversion.SeparateProcessDeployment),

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -320,12 +320,9 @@ func runHTTPRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c,
 		c.CRDBNodes(),
 		mixedversion.AlwaysUseLatestPredecessors,
-		// We set the min bootstrap version to v24.2, as the fix for the
-		// race condition was only backported to v24.2+ but exists as early
-		// as v23.2. We use this over setting min supported version as this
-		// test is concerned about testing cluster startup. We don't want the
-		// framework to bootstrap the cluster before we can start running hooks.
-		mixedversion.MinimumBootstrapVersion("v24.2.0"),
+		// The test requires the cluster to start at or above MinSupported.
+		// Updated to v25.3.0 after bumping MinSupported from v25.2 to v25.3.
+		mixedversion.MinimumBootstrapVersion("v25.3.0"),
 	)
 
 	// Any http request requiring auth will do.


### PR DESCRIPTION
This PR updates MinimumBootstrapVersion in 3 roachtests from old values to v25.3.0.

## Context

These changes were originally part of the M.4 "Bump MinSupported from v25.2 to v25.3" PR (#157767), but are being submitted separately for review by test owners.

## Changes

- **validate_system_schema_after_version_upgrade** (2 occurrences):  → 
- **admission_control_elastic_mixed_version**:  →   
- **versionupgrade (runHTTPRestart)**:  → 

## Issue

After bumping MinSupported from v25.2 to v25.3 in the main codebase, these roachtests fail because they allow starting clusters below v25.3.0, but the current binary requires MinSupported v25.3.

## Request for Review

The original version constraints (v22.2.0, v24.1.0, v24.2.0) may have been chosen for specific test-related reasons. Please review whether:

1. Updating to v25.3.0 is appropriate for these tests
2. There are alternative fixes that better preserve the original test intent
3. Any test behavior needs adjustment alongside the version bump

Epic: None
Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>