### PR TITLE
backfill: skip external tenant under deadlock in vector backfill test

### DIFF
--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -346,6 +346,13 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 	blockBackfill := make(chan struct{})
 	backfillBlocked := make(chan struct{})
 
+	var testTenant base.DefaultTestTenantOptions
+	if syncutil.DeadlockEnabled {
+		// The cluster can get overloaded under deadlock with external process
+		// mode.
+		testTenant = base.TestSkipForExternalProcessMode()
+	}
+
 	ctx := context.Background()
 	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
@@ -357,6 +364,7 @@ func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
 				},
 			},
 		},
+		DefaultTestTenant: testTenant,
 	})
 	defer srv.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)


### PR DESCRIPTION
`TestVectorIndexMergingDuringBackfillWithPrefix` is rather intensive, and we've seen a couple of failures due to general overload in the external-process mode under deadlock, so we'll just disable that mode under deadlock. Alternative idea I had was to exempt the tenant from rate limiting, but I wasn't able to reproduce the failure on gceworker, so I couldn't verify that it worked and decided to not go with it.

Fixes: #156995.
Release note: None