### PR TITLE
mmaprototype: introduce and adopt mmaload package

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1495,6 +1495,7 @@ GO_TARGETS = [
     "//pkg/kv/kvserver/allocator/allocatorimpl:allocatorimpl_test",
     "//pkg/kv/kvserver/allocator/load:load",
     "//pkg/kv/kvserver/allocator/load:load_test",
+    "//pkg/kv/kvserver/allocator/mmaprototype/mmaload:mmaload",
     "//pkg/kv/kvserver/allocator/mmaprototype:mmaprototype",
     "//pkg/kv/kvserver/allocator/mmaprototype:mmaprototype_test",
     "//pkg/kv/kvserver/allocator/plan:plan",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -132,6 +132,7 @@ go_library(
         "//pkg/kv/kvserver/allocator/allocatorimpl",
         "//pkg/kv/kvserver/allocator/load",
         "//pkg/kv/kvserver/allocator/mmaprototype",
+        "//pkg/kv/kvserver/allocator/mmaprototype/mmaload",
         "//pkg/kv/kvserver/allocator/plan",
         "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/apply",

--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/allocator/mmaprototype/mmaload",
         "//pkg/roachpb",
         "//pkg/util/log",
         "//pkg/util/metric",
@@ -48,6 +49,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":mmaprototype"],
     deps = [
+        "//pkg/kv/kvserver/allocator/mmaprototype/mmaload",
         "//pkg/roachpb",
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/testutils/datapathutils",

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -492,7 +493,7 @@ func sortTargetCandidateSetAndPick(
 	cands candidateSet,
 	loadThreshold loadSummary,
 	ignoreLevel ignoreLevel,
-	overloadedDim LoadDimension,
+	overloadedDim mmaload.LoadDimension,
 	rng *rand.Rand,
 ) roachpb.StoreID {
 	var b strings.Builder
@@ -570,7 +571,7 @@ func sortTargetCandidateSetAndPick(
 			if j == 0 {
 				// This is the lowestLoad set being considered now.
 				lowestLoadSet = cand.sls
-			} else if ignoreLevel < ignoreHigherThanLoadThreshold || overloadedDim == NumLoadDimensions {
+			} else if ignoreLevel < ignoreHigherThanLoadThreshold || overloadedDim == mmaload.NumLoadDimensions {
 				// Past the lowestLoad set. We don't care about these.
 				break
 			}
@@ -583,7 +584,7 @@ func sortTargetCandidateSetAndPick(
 		}
 		candDiscardedByNLS := cand.nls > loadThreshold ||
 			(cand.nls == loadThreshold && ignoreLevel < ignoreHigherThanLoadThreshold)
-		candDiscardedByOverloadDim := overloadedDim != NumLoadDimensions &&
+		candDiscardedByOverloadDim := overloadedDim != mmaload.NumLoadDimensions &&
 			cand.dimSummary[overloadedDim] >= loadNoChange
 		if candDiscardedByNLS || candDiscardedByOverloadDim ||
 			cand.maxFractionPendingIncrease >= maxFractionPendingThreshold {
@@ -664,7 +665,7 @@ func sortTargetCandidateSetAndPick(
 		return 0
 	}
 	cands.candidates = cands.candidates[:j]
-	if lowestLoadSet != highestLoadSet || (lowestLoadSet >= loadNoChange && overloadedDim != NumLoadDimensions) {
+	if lowestLoadSet != highestLoadSet || (lowestLoadSet >= loadNoChange && overloadedDim != mmaload.NumLoadDimensions) {
 		// Sort candidates from lowest to highest along overloaded dimension. We
 		// limit when we do this, since this will further restrict the pool of
 		// candidates and in general we don't want to restrict the pool.

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -776,7 +776,8 @@ type storeState struct {
 		// NB: these load values can become negative due to applying pending
 		// changes. We need to let them be negative to retain the ability to undo
 		// pending changes.
-		load          mmaload.SignedLoadVector
+		load mmaload.SignedLoadVector
+		// TODO: make this a signed vector, like adjusted load.
 		secondaryLoad mmaload.SecondaryLoadVector
 		// Pending changes for computing loadReplicas and load.
 		// Added to at the same time as clusterState.pendingChanges.

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -58,10 +58,10 @@ func parseLoadVector(t *testing.T, in string) mmaload.LoadVector {
 	return vec
 }
 
-func parseSecondaryLoadVector(t *testing.T, in string) SecondaryLoadVector {
-	var vec SecondaryLoadVector
+func parseSecondaryLoadVector(t *testing.T, in string) mmaload.SecondaryLoadVector {
+	var vec mmaload.SecondaryLoadVector
 	parts := strings.Split(stripBrackets(t, in), ",")
-	require.LessOrEqual(t, len(parts), int(NumSecondaryLoadDimensions))
+	require.LessOrEqual(t, len(parts), int(mmaload.NumSecondaryLoadDimensions))
 	for dim := range parts {
 		vec[dim] = mmaload.LoadValue(parseInt(t, parts[dim]))
 	}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -47,12 +48,12 @@ func stripBrackets(t *testing.T, in string) string {
 	return lrTrim
 }
 
-func parseLoadVector(t *testing.T, in string) LoadVector {
-	var vec LoadVector
+func parseLoadVector(t *testing.T, in string) mmaload.LoadVector {
+	var vec mmaload.LoadVector
 	parts := strings.Split(stripBrackets(t, in), ",")
-	require.Len(t, parts, int(NumLoadDimensions))
+	require.Len(t, parts, int(mmaload.NumLoadDimensions))
 	for dim := range vec {
-		vec[dim] = LoadValue(parseInt(t, parts[dim]))
+		vec[dim] = mmaload.LoadValue(parseInt(t, parts[dim]))
 	}
 	return vec
 }
@@ -62,7 +63,7 @@ func parseSecondaryLoadVector(t *testing.T, in string) SecondaryLoadVector {
 	parts := strings.Split(stripBrackets(t, in), ",")
 	require.LessOrEqual(t, len(parts), int(NumSecondaryLoadDimensions))
 	for dim := range parts {
-		vec[dim] = LoadValue(parseInt(t, parts[dim]))
+		vec[dim] = mmaload.LoadValue(parseInt(t, parts[dim]))
 	}
 	return vec
 }
@@ -178,7 +179,7 @@ func parseStoreLeaseholderMsg(t *testing.T, in string) StoreLeaseholderMsg {
 					rMsg.RangeLoad.Load = parseLoadVector(t, parts[1])
 					rMsg.MaybeSpanConfIsPopulated = true
 				case "raft-cpu":
-					rMsg.RangeLoad.RaftCPU = LoadValue(parseInt(t, parts[1]))
+					rMsg.RangeLoad.RaftCPU = mmaload.LoadValue(parseInt(t, parts[1]))
 					rMsg.MaybeSpanConfIsPopulated = true
 				case "not-populated":
 					notPopulatedOverride = true

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -26,57 +26,6 @@ const (
 	UnknownCapacity mmaload.LoadValue = math.MaxInt64
 )
 
-// SecondaryLoadDimension represents secondary load dimensions that should be
-// considered after we are done rebalancing using loadDimensions, since these
-// don't represent "real" resources. Currently, only lease and replica counts
-// are considered here. Lease rebalancing will see if there is scope to move
-// some leases between stores that do not have any pending changes and are not
-// overloaded (and will not get overloaded by the movement). This will happen
-// in a separate pass (i.e., not in clusterState.rebalanceStores) -- the
-// current plan is to continue using the leaseQueue and call from it into MMA.
-//
-// Note that lease rebalancing will only move leases and not replicas. Also,
-// the rebalancing will take into account the lease preferences, as discussed
-// in https://github.com/cockroachdb/cockroach/issues/93258, and the lease
-// counts among the current candidates (see
-// https://github.com/cockroachdb/cockroach/pull/98893).
-//
-// To use MMA for replica count rebalancing, done by the replicateQueue, we
-// also have a ReplicaCount load dimension.
-//
-// These are currently unused, since the initial integration of MMA is to
-// replace load-based rebalancing performed by the StoreRebalancer.
-type SecondaryLoadDimension uint8
-
-const (
-	LeaseCount SecondaryLoadDimension = iota
-	ReplicaCount
-	NumSecondaryLoadDimensions
-)
-
-type SecondaryLoadVector [NumSecondaryLoadDimensions]mmaload.LoadValue
-
-func (lv *SecondaryLoadVector) add(other SecondaryLoadVector) {
-	for i := range other {
-		(*lv)[i] += other[i]
-	}
-}
-
-func (lv *SecondaryLoadVector) subtract(other SecondaryLoadVector) {
-	for i := range other {
-		(*lv)[i] -= other[i]
-	}
-}
-
-func (lv SecondaryLoadVector) String() string {
-	return redact.StringWithoutMarkers(lv)
-}
-
-// SafeFormat implements the redact.SafeFormatter interface.
-func (lv SecondaryLoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("[lease:%d, replica:%d]", lv[LeaseCount], lv[ReplicaCount])
-}
-
 type RangeLoad struct {
 	Load mmaload.LoadVector
 	// Nanos per second. RaftCPU <= Load[cpu]. Handling this as a special case,
@@ -111,7 +60,7 @@ type storeLoad struct {
 	// provisioned disk bandwidth in the near future.
 	capacity mmaload.LoadVector
 
-	reportedSecondaryLoad SecondaryLoadVector
+	reportedSecondaryLoad mmaload.SecondaryLoadVector
 }
 
 // NodeLoad is the load information for a node.
@@ -130,7 +79,7 @@ type meanStoreLoad struct {
 	// Util is 0 for CPURate, WriteBandwidth. Non-zero for ByteSize.
 	util [mmaload.NumLoadDimensions]float64
 
-	secondaryLoad SecondaryLoadVector
+	secondaryLoad mmaload.SecondaryLoadVector
 }
 
 // The mean node load for a set of NodeLoad.

--- a/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
@@ -89,7 +89,7 @@ func TestMeansMemo(t *testing.T) {
 					reportedLoad: mmaload.LoadVector{mmaload.LoadValue(cpuLoad), mmaload.LoadValue(wbLoad), mmaload.LoadValue(bsLoad)},
 					capacity: mmaload.LoadVector{
 						mmaload.LoadValue(cpuCapacity), mmaload.LoadValue(wbCapacity), mmaload.LoadValue(bsCapacity)},
-					reportedSecondaryLoad: SecondaryLoadVector{leaseCountLoad},
+					reportedSecondaryLoad: mmaload.SecondaryLoadVector{leaseCountLoad},
 				}
 				for i := range sLoad.capacity {
 					if sLoad.capacity[i] < 0 {

--- a/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/dd"
 	"github.com/cockroachdb/datadriven"
@@ -83,11 +84,11 @@ func TestMeansMemo(t *testing.T) {
 				d.ScanArgs(t, "load", &cpuLoad, &wbLoad, &bsLoad)
 				var cpuCapacity, wbCapacity, bsCapacity int64
 				d.ScanArgs(t, "capacity", &cpuCapacity, &wbCapacity, &bsCapacity)
-				leaseCountLoad := dd.ScanArg[LoadValue](t, d, "secondary-load")
+				leaseCountLoad := dd.ScanArg[mmaload.LoadValue](t, d, "secondary-load")
 				sLoad := &storeLoad{
-					reportedLoad: LoadVector{LoadValue(cpuLoad), LoadValue(wbLoad), LoadValue(bsLoad)},
-					capacity: LoadVector{
-						LoadValue(cpuCapacity), LoadValue(wbCapacity), LoadValue(bsCapacity)},
+					reportedLoad: mmaload.LoadVector{mmaload.LoadValue(cpuLoad), mmaload.LoadValue(wbLoad), mmaload.LoadValue(bsLoad)},
+					capacity: mmaload.LoadVector{
+						mmaload.LoadValue(cpuCapacity), mmaload.LoadValue(wbCapacity), mmaload.LoadValue(bsCapacity)},
 					reportedSecondaryLoad: SecondaryLoadVector{leaseCountLoad},
 				}
 				for i := range sLoad.capacity {
@@ -105,8 +106,8 @@ func TestMeansMemo(t *testing.T) {
 			case "node-load":
 				nLoad := &NodeLoad{
 					NodeID:      dd.ScanArg[roachpb.NodeID](t, d, "node-id"),
-					ReportedCPU: dd.ScanArg[LoadValue](t, d, "cpu-load"),
-					CapacityCPU: dd.ScanArg[LoadValue](t, d, "cpu-capacity"),
+					ReportedCPU: dd.ScanArg[mmaload.LoadValue](t, d, "cpu-load"),
+					CapacityCPU: dd.ScanArg[mmaload.LoadValue](t, d, "cpu-capacity"),
 				}
 				loadProvider.nloads[nLoad.NodeID] = nLoad
 				return ""
@@ -127,12 +128,12 @@ func TestMeansMemo(t *testing.T) {
 				printPostingList(&b, mss.stores)
 				fmt.Fprintf(&b, "\nstore-means (load,cap,util): ")
 				for i := range mss.storeLoad.load {
-					switch LoadDimension(i) {
-					case CPURate:
+					switch mmaload.LoadDimension(i) {
+					case mmaload.CPURate:
 						fmt.Fprintf(&b, "cpu: ")
-					case WriteBandwidth:
+					case mmaload.WriteBandwidth:
 						fmt.Fprintf(&b, " write-bw: ")
-					case ByteSize:
+					case mmaload.ByteSize:
 						fmt.Fprintf(&b, " bytes: ")
 					}
 					capacity := mss.storeLoad.capacity[i]

--- a/pkg/kv/kvserver/allocator/mmaprototype/messages.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/messages.go
@@ -8,6 +8,7 @@ package mmaprototype
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
@@ -18,12 +19,12 @@ type StoreLoadMsg struct {
 	roachpb.NodeID
 	roachpb.StoreID
 
-	Load LoadVector
+	Load mmaload.LoadVector
 	// Capacity[CPURate] is derived based on considering the aggregate usage
 	// across all stores, and using the utilization observed at the node, to
 	// derive a node level capacity, and then dividing that by the number of
 	// stores.
-	Capacity      LoadVector
+	Capacity      mmaload.LoadVector
 	SecondaryLoad SecondaryLoadVector
 
 	LoadTime time.Time

--- a/pkg/kv/kvserver/allocator/mmaprototype/messages.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/messages.go
@@ -25,7 +25,7 @@ type StoreLoadMsg struct {
 	// derive a node level capacity, and then dividing that by the number of
 	// stores.
 	Capacity      mmaload.LoadVector
-	SecondaryLoad SecondaryLoadVector
+	SecondaryLoad mmaload.SecondaryLoadVector
 
 	LoadTime time.Time
 }

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "mmaload",
     srcs = [
+        "secondary.go",
         "signed.go",
         "unsigned.go",
     ],

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mmaload",
+    srcs = [
+        "signed.go",
+        "unsigned.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_cockroachdb_redact//:redact"],
+)

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/secondary.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/secondary.go
@@ -1,0 +1,59 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaload
+
+import "github.com/cockroachdb/redact"
+
+// SecondaryLoadDimension represents secondary load dimensions that should be
+// considered after we are done rebalancing using loadDimensions, since these
+// don't represent "real" resources. Currently, only lease and replica counts
+// are considered here. Lease rebalancing will see if there is scope to move
+// some leases between stores that do not have any pending changes and are not
+// overloaded (and will not get overloaded by the movement). This will happen
+// in a separate pass (i.e., not in clusterState.rebalanceStores) -- the
+// current plan is to continue using the leaseQueue and call from it into MMA.
+//
+// Note that lease rebalancing will only move leases and not replicas. Also,
+// the rebalancing will take into account the lease preferences, as discussed
+// in https://github.com/cockroachdb/cockroach/issues/93258, and the lease
+// counts among the current candidates (see
+// https://github.com/cockroachdb/cockroach/pull/98893).
+//
+// To use MMA for replica count rebalancing, done by the replicateQueue, we
+// also have a ReplicaCount load dimension.
+//
+// These are currently unused, since the initial integration of MMA is to
+// replace load-based rebalancing performed by the StoreRebalancer.
+type SecondaryLoadDimension uint8
+
+const (
+	LeaseCount SecondaryLoadDimension = iota
+	ReplicaCount
+	NumSecondaryLoadDimensions
+)
+
+type SecondaryLoadVector [NumSecondaryLoadDimensions]LoadValue
+
+func (lv *SecondaryLoadVector) Add(other SecondaryLoadVector) {
+	for i := range other {
+		(*lv)[i] += other[i]
+	}
+}
+
+func (lv *SecondaryLoadVector) Subtract(other SecondaryLoadVector) {
+	for i := range other {
+		(*lv)[i] -= other[i]
+	}
+}
+
+func (lv SecondaryLoadVector) String() string {
+	return redact.StringWithoutMarkers(lv)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (lv SecondaryLoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("[lease:%d, replica:%d]", lv[LeaseCount], lv[ReplicaCount])
+}

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/signed.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/signed.go
@@ -1,0 +1,24 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaload
+
+type SignedLoadValue struct {
+	n int64
+}
+
+type SignedLoadVector [NumLoadDimensions]SignedLoadValue
+
+func (v *SignedLoadVector) Add(o SignedLoadVector) {
+	for i := 0; i < int(NumLoadDimensions); i++ {
+		(*v)[i].n += o[i].n
+	}
+}
+
+func (v *SignedLoadVector) Subtract(o SignedLoadVector) {
+	for i := 0; i < int(NumLoadDimensions); i++ {
+		(*v)[i].n -= o[i].n
+	}
+}

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/signed.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/signed.go
@@ -7,10 +7,15 @@ package mmaload
 
 import "github.com/cockroachdb/redact"
 
+// SignedLoadValue is a load value that could become negative. It intentionally
+// does not expose its integer value directly to reduce the likelihood of
+// sign-unaware computation.
 type SignedLoadValue struct {
 	n int64
 }
 
+// Subtract returns a SignedLoadValue representing the difference between
+// the receiver and the argument.
 func (s SignedLoadValue) Subtract(lv LoadValue) SignedLoadValue {
 	return SignedLoadValue{n: s.n - int64(lv)}
 }
@@ -19,6 +24,8 @@ func (s SignedLoadValue) Abs() int64 {
 	return max(s.n, -s.n)
 }
 
+// Nonnegative returns the wrapped value as a LoadValue if it is non-negative,
+// and zero otherwise.
 func (s SignedLoadValue) Nonnegative() LoadValue {
 	if s.n > 0 {
 		return LoadValue(s.n)
@@ -35,14 +42,17 @@ func (s SignedLoadValue) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.SafeInt(redact.SafeInt(s.n))
 }
 
+// SignedLoadVector is a load vector that could have negative values.
 type SignedLoadVector [NumLoadDimensions]SignedLoadValue
 
+// Add updates the vector by adding the given LoadVector to it.
 func (v *SignedLoadVector) Add(o LoadVector) {
 	for i := 0; i < int(NumLoadDimensions); i++ {
 		(*v)[i].n += int64(o[i])
 	}
 }
 
+// Subtract updates the vector by subtracting the given LoadVector from it.
 func (v *SignedLoadVector) Subtract(o LoadVector) {
 	for i := 0; i < int(NumLoadDimensions); i++ {
 		(*v)[i].n -= int64(o[i])
@@ -57,6 +67,9 @@ func (v *SignedLoadVector) NonnegativeAt(dim LoadDimension) (LoadValue, bool) {
 	return LoadValue(max(0, val)), val > 0
 }
 
+// UnwrapAt returns the integer value for the given dimension. This should be
+// used sparingly. The boolean indicates whether the returned load is strictly
+// positive.
 func (v *SignedLoadVector) UnwrapAt(dim LoadDimension) (_ int64, positive bool) {
 	val := (*v)[int(dim)].n
 	return val, val > 0

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/signed.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/signed.go
@@ -5,20 +5,80 @@
 
 package mmaload
 
+import "github.com/cockroachdb/redact"
+
 type SignedLoadValue struct {
 	n int64
 }
 
+func (s SignedLoadValue) Subtract(lv LoadValue) SignedLoadValue {
+	return SignedLoadValue{n: s.n - int64(lv)}
+}
+
+func (s SignedLoadValue) Abs() int64 {
+	return max(s.n, -s.n)
+}
+
+func (s SignedLoadValue) Nonnegative() LoadValue {
+	if s.n > 0 {
+		return LoadValue(s.n)
+	}
+	return 0
+}
+
+func (s SignedLoadValue) String() string {
+	return redact.StringWithoutMarkers(s)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (s SignedLoadValue) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.SafeInt(redact.SafeInt(s.n))
+}
+
 type SignedLoadVector [NumLoadDimensions]SignedLoadValue
 
-func (v *SignedLoadVector) Add(o SignedLoadVector) {
+func (v *SignedLoadVector) Add(o LoadVector) {
 	for i := 0; i < int(NumLoadDimensions); i++ {
-		(*v)[i].n += o[i].n
+		(*v)[i].n += int64(o[i])
 	}
 }
 
-func (v *SignedLoadVector) Subtract(o SignedLoadVector) {
+func (v *SignedLoadVector) Subtract(o LoadVector) {
 	for i := 0; i < int(NumLoadDimensions); i++ {
-		(*v)[i].n -= o[i].n
+		(*v)[i].n -= int64(o[i])
 	}
+}
+
+// NonnegativeAt returns the load value at the given dimension if it is
+// non-negative, and zero otherwise. The boolean indicates whether the returned
+// load is strictly positive.
+func (v *SignedLoadVector) NonnegativeAt(dim LoadDimension) (LoadValue, bool) {
+	val := (*v)[int(dim)].n
+	return LoadValue(max(0, val)), val > 0
+}
+
+func (v *SignedLoadVector) UnwrapAt(dim LoadDimension) (_ int64, positive bool) {
+	val := (*v)[int(dim)].n
+	return val, val > 0
+}
+
+// Nonnegative returns a LoadVector which has zeroes for any dimension for which
+// the signed load is negative.
+func (v *SignedLoadVector) Nonnegative() LoadVector {
+	var lv LoadVector
+	for i := 0; i < int(NumLoadDimensions); i++ {
+		if val := (*v)[i].n; val > 0 {
+			lv[i] = LoadValue(val)
+		}
+	}
+	return lv
+}
+
+func (v SignedLoadVector) String() string {
+	return redact.StringWithoutMarkers(v)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (v SignedLoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("[cpu:%d, write-bandwidth:%d, byte-size:%d]", v[CPURate], v[WriteBandwidth], v[ByteSize])
 }

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
@@ -42,6 +42,10 @@ func (dim LoadDimension) String() string {
 // LoadValue is the load on a resource, represented as a *nonnegative* integer.
 type LoadValue int64
 
+func (lv LoadValue) Signed() SignedLoadValue {
+	return SignedLoadValue{n: int64(lv)}
+}
+
 // LoadVector represents a vector of loads, with one element for each resource
 // dimension.
 type LoadVector [NumLoadDimensions]LoadValue

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
@@ -8,9 +8,8 @@ package mmaload
 import "github.com/cockroachdb/redact"
 
 // LoadDimension is an enum of load dimensions corresponding to "real"
-// resources. Such resources can sometimes have a capacity. It is generally
-// important to rebalance based on these. The code in this package should be
-// structured that adding additional resource dimensions is easy.
+// resources that can be subject to rebalancing. This type is also used
+// to define capacities.
 type LoadDimension uint8
 
 const (
@@ -40,7 +39,7 @@ func (dim LoadDimension) String() string {
 	return redact.StringWithoutMarkers(dim)
 }
 
-// LoadValue is the load on a resource.
+// LoadValue is the load on a resource, represented as a *nonnegative* integer.
 type LoadValue int64
 
 // LoadVector represents a vector of loads, with one element for each resource
@@ -64,6 +63,7 @@ func (lv *LoadVector) Add(other LoadVector) {
 	}
 }
 
+// TODO(tbg): Subtract should be removed; LoadVector must be positive.
 func (lv *LoadVector) Subtract(other LoadVector) {
 	for i := range other {
 		(*lv)[i] -= other[i]

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
@@ -1,0 +1,69 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaload
+
+import "github.com/cockroachdb/redact"
+
+// LoadDimension is an enum of load dimensions corresponding to "real"
+// resources. Such resources can sometimes have a capacity. It is generally
+// important to rebalance based on these. The code in this package should be
+// structured that adding additional resource dimensions is easy.
+type LoadDimension uint8
+
+const (
+	// CPURate is in nanos per second.
+	CPURate LoadDimension = iota
+	// WriteBandwidth is the writes in bytes/s.
+	WriteBandwidth
+	// ByteSize is the size in bytes.
+	ByteSize
+	NumLoadDimensions
+)
+
+func (dim LoadDimension) SafeFormat(w redact.SafePrinter, _ rune) {
+	switch dim {
+	case CPURate:
+		w.Printf("CPURate")
+	case WriteBandwidth:
+		w.Print("WriteBandwidth")
+	case ByteSize:
+		w.Printf("ByteSize")
+	default:
+		panic("unknown LoadDimension")
+	}
+}
+
+func (dim LoadDimension) String() string {
+	return redact.StringWithoutMarkers(dim)
+}
+
+// LoadValue is the load on a resource.
+type LoadValue int64
+
+// LoadVector represents a vector of loads, with one element for each resource
+// dimension.
+type LoadVector [NumLoadDimensions]LoadValue
+
+func (lv LoadVector) String() string {
+	return redact.StringWithoutMarkers(lv)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (lv LoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("[cpu:%d, write-bandwidth:%d, byte-size:%d]", lv[CPURate], lv[WriteBandwidth], lv[ByteSize])
+}
+
+func (lv *LoadVector) Add(other LoadVector) {
+	for i := range other {
+		(*lv)[i] += other[i]
+	}
+}
+
+func (lv *LoadVector) Subtract(other LoadVector) {
+	for i := range other {
+		(*lv)[i] -= other[i]
+	}
+}

--- a/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/mmaload/unsigned.go
@@ -52,8 +52,10 @@ func (lv LoadVector) String() string {
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
-func (lv LoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("[cpu:%d, write-bandwidth:%d, byte-size:%d]", lv[CPURate], lv[WriteBandwidth], lv[ByteSize])
+func (lv LoadVector) SafeFormat(w redact.SafePrinter, r rune) {
+	var v SignedLoadVector
+	v.Add(lv)
+	v.SafeFormat(w, r)
 }
 
 func (lv *LoadVector) Add(other LoadVector) {

--- a/pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/rebalance_advisor.go
@@ -8,6 +8,7 @@ package mmaprototype
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -117,12 +118,12 @@ func (a *allocatorState) IsInConflictWithMMA(
 	// TODO(wenyihu6): unify the branches below by assigning based on sls.worstDim and cpuOnly.
 	var conflict bool
 	if cpuOnly {
-		conflict = candSLS.dimSummary[CPURate] > existingSLS.dimSummary[CPURate]
+		conflict = candSLS.dimSummary[mmaload.CPURate] > existingSLS.dimSummary[mmaload.CPURate]
 		if conflict {
 			log.KvDistribution.VEventf(
 				ctx, 2,
 				"mma rejected candidate s%d(cpu-only) as a replacement for s%d: candidate=%v(cpu) > existing=%v(cpu)",
-				cand, advisor.existingStoreID, candSLS.dimSummary[CPURate], existingSLS.dimSummary[CPURate],
+				cand, advisor.existingStoreID, candSLS.dimSummary[mmaload.CPURate], existingSLS.dimSummary[mmaload.CPURate],
 			)
 		}
 	} else {

--- a/pkg/kv/kvserver/allocator/mmaprototype/store_load_summary.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/store_load_summary.go
@@ -5,17 +5,20 @@
 
 package mmaprototype
 
-import "github.com/cockroachdb/redact"
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
+	"github.com/cockroachdb/redact"
+)
 
 // A storeLoadSummary is a classification of a store's load relative to the mean
 // load across a set of permissible stores (often, all that satisfy the
 // constraints for a given range). Sources and targets are primarily picked
 // based on the store and node level load summaries contained in this struct.
 type storeLoadSummary struct {
-	worstDim                                               LoadDimension // for logging only
+	worstDim                                               mmaload.LoadDimension // for logging only
 	sls                                                    loadSummary
 	nls                                                    loadSummary
-	dimSummary                                             [NumLoadDimensions]loadSummary
+	dimSummary                                             [mmaload.NumLoadDimensions]loadSummary
 	highDiskSpaceUtilization                               bool
 	maxFractionPendingIncrease, maxFractionPendingDecrease float64
 
@@ -28,7 +31,7 @@ func (sls storeLoadSummary) String() string {
 
 func (sls storeLoadSummary) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("(store=%v worst=%v cpu=%v writes=%v bytes=%v node=%v high_disk=%v frac_pending=%.2f,%.2f(%t))",
-		sls.sls, sls.worstDim, sls.dimSummary[CPURate], sls.dimSummary[WriteBandwidth], sls.dimSummary[ByteSize],
+		sls.sls, sls.worstDim, sls.dimSummary[mmaload.CPURate], sls.dimSummary[mmaload.WriteBandwidth], sls.dimSummary[mmaload.ByteSize],
 		sls.nls, sls.highDiskSpaceUtilization, sls.maxFractionPendingIncrease,
 		sls.maxFractionPendingDecrease,
 		sls.maxFractionPendingIncrease < epsilon && sls.maxFractionPendingDecrease < epsilon)

--- a/pkg/kv/kvserver/allocator/mmaprototype/top_k_replicas.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/top_k_replicas.go
@@ -9,14 +9,15 @@ import (
 	"container/heap"
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 type topKReplicas struct {
 	k         int
-	dim       LoadDimension
-	threshold LoadValue
+	dim       mmaload.LoadDimension
+	threshold mmaload.LoadValue
 	// Decreasing load.
 	replicas    []replicaLoad
 	replicaHeap replicaHeap
@@ -24,7 +25,7 @@ type topKReplicas struct {
 
 type replicaLoad struct {
 	roachpb.RangeID
-	load LoadValue
+	load mmaload.LoadValue
 }
 
 // Reset when using a StoreLeaseholderMsg to reevaluate from scratch.
@@ -35,7 +36,7 @@ func (t *topKReplicas) startInit() {
 func (t *topKReplicas) addReplica(
 	ctx context.Context,
 	rangeID roachpb.RangeID,
-	loadValue LoadValue,
+	loadValue mmaload.LoadValue,
 	replicaStoreID roachpb.StoreID,
 	msgStoreID roachpb.StoreID,
 ) {

--- a/pkg/kv/kvserver/asim/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/mmaintegration/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/allocator/mmaprototype",
+        "//pkg/kv/kvserver/allocator/mmaprototype/mmaload",
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/op",
         "//pkg/kv/kvserver/asim/state",

--- a/pkg/kv/kvserver/asim/mmaintegration/mma_integration.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_integration.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -71,10 +72,10 @@ func MakeStoreLeaseholderMsgFromState(
 
 		var rl mmaprototype.RangeLoad
 		load := s.RangeUsageInfo(rng.RangeID(), replica.StoreID())
-		rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(load.WriteBytesPerSecond)
-		rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(load.LogicalBytes)
-		rl.Load[mmaprototype.CPURate] = mmaprototype.LoadValue(load.RaftCPUNanosPerSecond + load.RequestCPUNanosPerSecond)
-		rl.RaftCPU = mmaprototype.LoadValue(load.RaftCPUNanosPerSecond)
+		rl.Load[mmaload.WriteBandwidth] = mmaload.LoadValue(load.WriteBytesPerSecond)
+		rl.Load[mmaload.ByteSize] = mmaload.LoadValue(load.LogicalBytes)
+		rl.Load[mmaload.CPURate] = mmaload.LoadValue(load.RaftCPUNanosPerSecond + load.RequestCPUNanosPerSecond)
+		rl.RaftCPU = mmaload.LoadValue(load.RaftCPUNanosPerSecond)
 
 		rangeMessages = append(rangeMessages, mmaprototype.RangeMsg{
 			RangeID:                  roachpb.RangeID(replica.Range()),

--- a/pkg/kv/kvserver/mma_replica_store.go
+++ b/pkg/kv/kvserver/mma_replica_store.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftutil"
 	"github.com/cockroachdb/cockroach/pkg/raft"
@@ -25,11 +26,11 @@ func mmaRangeLoad(
 	loadStats load.ReplicaLoadStats, mvccStats enginepb.MVCCStats,
 ) mmaprototype.RangeLoad {
 	var rl mmaprototype.RangeLoad
-	rl.Load[mmaprototype.CPURate] = mmaprototype.LoadValue(
+	rl.Load[mmaload.CPURate] = mmaload.LoadValue(
 		loadStats.RequestCPUNanosPerSecond + loadStats.RaftCPUNanosPerSecond)
-	rl.RaftCPU = mmaprototype.LoadValue(loadStats.RaftCPUNanosPerSecond)
-	rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(loadStats.WriteBytesPerSecond)
-	rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(mvccStats.Total())
+	rl.RaftCPU = mmaload.LoadValue(loadStats.RaftCPUNanosPerSecond)
+	rl.Load[mmaload.WriteBandwidth] = mmaload.LoadValue(loadStats.WriteBytesPerSecond)
+	rl.Load[mmaload.ByteSize] = mmaload.LoadValue(mvccStats.Total())
 	return rl
 }
 

--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/allocator/mmaprototype",
+        "//pkg/kv/kvserver/allocator/mmaprototype/mmaload",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/mmaintegration/allocator_sync.go
+++ b/pkg/kv/kvserver/mmaintegration/allocator_sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype/mmaload"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -107,13 +108,13 @@ func NewAllocatorSync(
 // can refactor to use the same helper function.
 func mmaRangeLoad(rangeUsageInfo allocator.RangeUsageInfo) mmaprototype.RangeLoad {
 	var rl mmaprototype.RangeLoad
-	rl.Load[mmaprototype.CPURate] = mmaprototype.LoadValue(
+	rl.Load[mmaload.CPURate] = mmaload.LoadValue(
 		rangeUsageInfo.RequestCPUNanosPerSecond + rangeUsageInfo.RaftCPUNanosPerSecond)
-	rl.RaftCPU = mmaprototype.LoadValue(rangeUsageInfo.RaftCPUNanosPerSecond)
-	rl.Load[mmaprototype.WriteBandwidth] = mmaprototype.LoadValue(rangeUsageInfo.WriteBytesPerSecond)
+	rl.RaftCPU = mmaload.LoadValue(rangeUsageInfo.RaftCPUNanosPerSecond)
+	rl.Load[mmaload.WriteBandwidth] = mmaload.LoadValue(rangeUsageInfo.WriteBytesPerSecond)
 	// Note that LogicalBytes is already populated as enginepb.MVCCStats.Total()
 	// in repl.RangeUsageInfo().
-	rl.Load[mmaprototype.ByteSize] = mmaprototype.LoadValue(rangeUsageInfo.LogicalBytes)
+	rl.Load[mmaload.ByteSize] = mmaload.LoadValue(rangeUsageInfo.LogicalBytes)
 	return rl
 }
 

--- a/pkg/kv/kvserver/mmaintegration/store_load_msg.go
+++ b/pkg/kv/kvserver/mmaintegration/store_load_msg.go
@@ -118,9 +118,9 @@ func MakeStoreLoadMsg(
 		// which is desirably pessimistic.
 		capacity[mmaload.ByteSize] = mmaload.LoadValue(desc.Capacity.Available)
 	}
-	var secondaryLoad mmaprototype.SecondaryLoadVector
-	secondaryLoad[mmaprototype.LeaseCount] = mmaload.LoadValue(desc.Capacity.LeaseCount)
-	secondaryLoad[mmaprototype.ReplicaCount] = mmaload.LoadValue(desc.Capacity.RangeCount)
+	var secondaryLoad mmaload.SecondaryLoadVector
+	secondaryLoad[mmaload.LeaseCount] = mmaload.LoadValue(desc.Capacity.LeaseCount)
+	secondaryLoad[mmaload.ReplicaCount] = mmaload.LoadValue(desc.Capacity.RangeCount)
 	// TODO(tbg): this triggers early in tests, probably we're making load messages
 	// before having received the first capacity. Still, this is bad, should fix.
 	// or handle properly by communicating an unknown capacity.


### PR DESCRIPTION
This introduces a SignedLoadVector which hides its underlying elements (primarly from the mmaprototype package). Load value arithmetic that could become negative now needs to go through helpers that make it difficult to "forget" that negative values can occur.

This isn't 100% yet, but it's a start.

Informs #157757.

Epic: CRDB-55052
