### PR TITLE
mmaprototype: add set_store test and allow attrs/localities to  change

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -243,7 +243,7 @@ func (a *allocatorState) LoadSummaryForAllStores(ctx context.Context) string {
 func (a *allocatorState) SetStore(store StoreAttributesAndLocality) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.cs.setStore(store)
+	a.cs.setStore(store.withNodeTier())
 }
 
 // ProcessStoreLoadMsg implements the Allocator interface.

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state_test.go
@@ -38,7 +38,7 @@ func TestDiversityScoringMemo(t *testing.T) {
 			printReplicaLocalities := func(b *strings.Builder, rls *existingReplicaLocalities) {
 				b.WriteString("replicas:\n")
 				for _, rl := range rls.replicasLocalityTiers.replicas {
-					fmt.Fprintf(b, "  %s\n", ltInterner.unintern(rl).String())
+					fmt.Fprintf(b, "  %v\n", ltInterner.unintern(rl))
 				}
 				b.WriteString("score-sums:\n")
 				var keys []string
@@ -63,7 +63,7 @@ func TestDiversityScoringMemo(t *testing.T) {
 				locality := parseLocalityTiers(t, lts)
 				lt := ltInterner.intern(locality)
 				storeLocalities[storeID] = lt
-				return fmt.Sprintf("locality: %s str: %s", ltInterner.unintern(lt).String(), lt.str)
+				return fmt.Sprintf("locality: %s str: %v", ltInterner.unintern(lt), lt.str)
 
 			case "existing-replica-localities":
 				storeTiers := scanStores()

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -2167,10 +2167,6 @@ func (cs *clusterState) undoChangeLoadDelta(change ReplicaChange) {
 
 // setStore updates the store attributes and locality in the cluster state. If
 // the store hasn't been seen before, it is also added to the cluster state.
-//
-// TODO: We currently assume that the locality and attributes associated with a
-// store/node are fixed. This is a reasonable assumption for the locality,
-// however it is not for the attributes.
 func (cs *clusterState) setStore(sal StoreAttributesAndLocality) {
 	ns, ok := cs.nodes[sal.NodeID]
 	if !ok {
@@ -2187,13 +2183,29 @@ func (cs *clusterState) setStore(sal StoreAttributesAndLocality) {
 		// replicas on it (nor will we try to shed any that are already reported to
 		// have replicas on it).
 		ss.status = MakeStatus(HealthUnknown, LeaseDispositionRefusing, ReplicaDispositionRefusing)
-		ss.localityTiers = cs.localityTierInterner.intern(sal.locality())
 		ss.overloadStartTime = cs.ts.Now()
 		ss.overloadEndTime = cs.ts.Now()
-		ss.StoreAttributesAndLocality = sal
-		cs.constraintMatcher.setStore(sal)
 		cs.stores[sal.StoreID] = ss
 		ns.stores = append(ns.stores, sal.StoreID)
+	}
+
+	// If the store is new or the locality/attributes changed, we need to update
+	// the locality and attributes.
+	loc := sal.locality()
+	oldAttrs := cs.stores[sal.StoreID].StoreAttributesAndLocality
+	locsChanged := cs.localityTierInterner.changed(cs.stores[sal.StoreID].localityTiers, loc)
+	attrsChanged := !slices.Equal(
+		oldAttrs.StoreAttrs.Attrs,
+		sal.StoreAttrs.Attrs,
+	) || !slices.Equal(
+		oldAttrs.NodeAttrs.Attrs,
+		sal.NodeAttrs.Attrs,
+	)
+
+	if !ok || attrsChanged || locsChanged {
+		cs.stores[sal.StoreID].localityTiers = cs.localityTierInterner.intern(sal.locality())
+		cs.stores[sal.StoreID].StoreAttributesAndLocality = sal
+		cs.constraintMatcher.setStore(sal)
 	}
 }
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -358,8 +358,8 @@ func TestClusterState(t *testing.T) {
 					var nodeLine string
 					for _, storeID := range ns.stores {
 						ss := cs.stores[storeID]
-						sal := ss.StoreAttributesAndLocality
-						loc := sal.locality()
+						sal := ss.storeAttributesAndLocalityWithNodeTier
+						loc := sal.NodeLocality
 
 						// Compute the "node" line for each store and print it again
 						// each time it changes. Usually it's printed only once per node,
@@ -464,7 +464,7 @@ func TestClusterState(t *testing.T) {
 					for _, next := range strings.Split(d.Input, "\n") {
 						sal := parseStoreAttributedAndLocality(t, next)
 						t.Logf("set-store: %v from %s", sal, next)
-						cs.setStore(sal)
+						cs.setStore(sal.withNodeTier()) // see allocatorState.SetStore
 						// For convenience, in these tests, stores start out
 						// healthy.
 						cs.stores[sal.StoreID].status = Status{Health: HealthOK}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -346,7 +346,7 @@ func TestClusterState(t *testing.T) {
 			ts := timeutil.NewManualTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 			cs := newClusterState(ts, newStringInterner())
 
-			printNodeListMeta := func() string {
+			printNodeListMeta := func(t *testing.T) string {
 				nodeList := []int{}
 				for nodeID := range cs.nodes {
 					nodeList = append(nodeList, int(nodeID))
@@ -355,12 +355,44 @@ func TestClusterState(t *testing.T) {
 				var buf strings.Builder
 				for _, nodeID := range nodeList {
 					ns := cs.nodes[roachpb.NodeID(nodeID)]
-					fmt.Fprintf(&buf, "node-id=%s locality-tiers=%s\n",
-						ns.NodeID, cs.stores[ns.stores[0]].StoreAttributesAndLocality.locality())
+					var nodeLine string
 					for _, storeID := range ns.stores {
 						ss := cs.stores[storeID]
-						fmt.Fprintf(&buf, "  store-id=%v attrs=%s locality-code=%s\n",
-							ss.StoreID, ss.StoreAttrs, ss.localityTiers.str)
+						sal := ss.StoreAttributesAndLocality
+						loc := sal.locality()
+
+						// Compute the "node" line for each store and print it again
+						// each time it changes. Usually it's printed only once per node,
+						// but if there are multiple stores with a different view of node
+						// attributes, it would print multiple times.
+						var nodeLineBuf strings.Builder
+						fmt.Fprintf(&nodeLineBuf, "node-id=%s locality-tiers=%s",
+							ns.NodeID, loc)
+						if len(sal.NodeAttrs.Attrs) > 0 {
+							fmt.Fprintf(&nodeLineBuf, " node-attrs=%s", strings.Join(sal.NodeAttrs.Attrs, ","))
+						}
+						fmt.Fprintln(&nodeLineBuf)
+
+						if nodeLine != nodeLineBuf.String() {
+							nodeLine = nodeLineBuf.String()
+							fmt.Fprint(&buf, nodeLine)
+						}
+
+						fmt.Fprintf(&buf, "  store-id=%v attrs=%s", ss.StoreID, ss.StoreAttrs)
+
+						storeTierVals := cs.localityTierInterner.unintern(ss.localityTiers)
+						{
+							// The interned locality tier values must match the uninterned original.
+							var expVals []string
+							for _, tier := range loc.Tiers {
+								expVals = append(expVals, tier.Value)
+							}
+							require.EqualValues(t, expVals, storeTierVals)
+						}
+						// Make sure that the constraintMatcher reflects the same attrs and
+						// locality as the store.
+						require.Equal(t, sal, cs.constraintMatcher.stores[ss.StoreID].sal)
+						fmt.Fprintln(&buf)
 					}
 				}
 				return buf.String()
@@ -431,12 +463,13 @@ func TestClusterState(t *testing.T) {
 				case "set-store":
 					for _, next := range strings.Split(d.Input, "\n") {
 						sal := parseStoreAttributedAndLocality(t, next)
+						t.Logf("set-store: %v from %s", sal, next)
 						cs.setStore(sal)
 						// For convenience, in these tests, stores start out
 						// healthy.
 						cs.stores[sal.StoreID].status = Status{Health: HealthOK}
 					}
-					return printNodeListMeta()
+					return printNodeListMeta(t)
 
 				case "set-store-status":
 					storeID := dd.ScanArg[roachpb.StoreID](t, d, "store-id")

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher.go
@@ -39,7 +39,7 @@ type constraintMatcher struct {
 
 type matchedConstraints struct {
 	matched map[internedConstraint]struct{}
-	sal     StoreAttributesAndLocality
+	sal     storeAttributesAndLocalityWithNodeTier
 }
 
 type matchedSet struct {
@@ -56,7 +56,7 @@ func newConstraintMatcher(interner *stringInterner) *constraintMatcher {
 }
 
 // setStore is called for a new store, or when the attributes and locality changes.
-func (cm *constraintMatcher) setStore(sal StoreAttributesAndLocality) {
+func (cm *constraintMatcher) setStore(sal storeAttributesAndLocalityWithNodeTier) {
 	mc := cm.stores[sal.StoreID]
 	if mc == nil {
 		mc = &matchedConstraints{
@@ -95,7 +95,7 @@ func (cm *constraintMatcher) setStore(sal StoreAttributesAndLocality) {
 
 // storeMatchesConstraint is an internal helper method.
 func (cm *constraintMatcher) storeMatchesConstraint(
-	sal StoreAttributesAndLocality, c internedConstraint,
+	sal storeAttributesAndLocalityWithNodeTier, c internedConstraint,
 ) bool {
 	matches := false
 	if c.key == emptyStringCode {

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
@@ -101,7 +101,7 @@ func TestConstraintMatcher(t *testing.T) {
 			switch d.Cmd {
 			case "store":
 				sal := parseStoreAttributedAndLocality(t, d.Input)
-				cm.setStore(sal)
+				cm.setStore(sal.withNodeTier())
 				var b strings.Builder
 				printMatcher(&b)
 				return b.String()

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
@@ -32,6 +32,11 @@ func parseStoreAttributedAndLocality(t *testing.T, in string) StoreAttributesAnd
 				sal.StoreAttrs.Attrs,
 				strings.Split(parts[1], ",")...,
 			)
+		case "node-attrs":
+			sal.NodeAttrs.Attrs = append(
+				sal.NodeAttrs.Attrs,
+				strings.Split(parts[1], ",")...,
+			)
 		case "locality-tiers":
 			sal.NodeLocality = parseLocalityTiers(t, parts[1])
 		default:

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
@@ -353,7 +353,7 @@ func TestRangeAnalyzedConstraints(t *testing.T) {
 	cm := newConstraintMatcher(interner)
 	ltInterner := newLocalityTierInterner(interner)
 	configs := map[string]*normalizedSpanConfig{}
-	stores := map[roachpb.StoreID]StoreAttributesAndLocality{}
+	stores := map[roachpb.StoreID]storeAttributesAndLocalityWithNodeTier{}
 	var lastRangeAnalyzedConstraints *rangeAnalyzedConstraints
 
 	datadriven.RunTest(t, "testdata/range_analyzed_constraints",
@@ -362,8 +362,8 @@ func TestRangeAnalyzedConstraints(t *testing.T) {
 			case "store":
 				for _, line := range strings.Split(d.Input, "\n") {
 					sal := parseStoreAttributedAndLocality(t, strings.TrimSpace(line))
-					cm.setStore(sal)
-					stores[sal.StoreID] = sal
+					cm.setStore(sal.withNodeTier())
+					stores[sal.StoreID] = sal.withNodeTier()
 				}
 				return ""
 
@@ -407,7 +407,7 @@ func TestRangeAnalyzedConstraints(t *testing.T) {
 						}
 					}
 					buf.tryAddingStore(roachpb.StoreID(storeID), typ,
-						ltInterner.intern(stores[roachpb.StoreID(storeID)].locality()))
+						ltInterner.intern(stores[roachpb.StoreID(storeID)].NodeLocality))
 				}
 				rac.finishInit(nConf, cm, leaseholder)
 				var b strings.Builder

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
@@ -264,7 +264,7 @@ func printRangeAnalyzedConstraints(
 	printStoreAndLocality := func(prefix string, sAndL []storeAndLocality) {
 		fmt.Fprintf(b, "%s", prefix)
 		for _, elem := range sAndL {
-			fmt.Fprintf(b, " %s(%s)", elem.StoreID.String(), lti.unintern(elem.localityTiers).String())
+			fmt.Fprintf(b, " %s(%v)", elem.StoreID.String(), lti.unintern(elem.localityTiers))
 		}
 		fmt.Fprintf(b, "\n")
 	}

--- a/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load_test.go
@@ -70,7 +70,7 @@ func TestMeansMemo(t *testing.T) {
 			case "store":
 				for _, line := range strings.Split(d.Input, "\n") {
 					sal := parseStoreAttributedAndLocality(t, strings.TrimSpace(line))
-					cm.setStore(sal)
+					cm.setStore(sal.withNodeTier())
 					storeMap[sal.StoreID] = sal
 				}
 				return ""

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges.txt
@@ -3,9 +3,9 @@ set-store
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow
 
 # Both stores are more constrained wrt CPURate.
 store-load-msg

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
@@ -22,9 +22,9 @@ set-store
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow
 
 store-load-msg
   store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
@@ -23,14 +23,14 @@
 # 7. Rebalances back from s2 to s1 and verifies changes are GC'd after the
 #    normal GC duration.
 #
-# Two stores on the same node.
+# Two stores on the same node (thus necessarily same locality tiers).
 set-store
-  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
-  store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=anywhere
+  store-id=2 node-id=1 attrs=yellow locality-tiers=region=anywhere
 ----
-node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
-  store-id=2 attrs=yellow locality-code=4:5:3:
+node-id=1 locality-tiers=region=anywhere,node=1
+  store-id=1 attrs=purple
+  store-id=2 attrs=yellow
 
 store-load-msg
   store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
@@ -13,25 +13,25 @@
 # - A second rebalance is carried out on the same range, while an enacted remnant
 #   of the first operation remains.
 set-store
-  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
-  store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=anywhere
+  store-id=2 node-id=1 attrs=yellow locality-tiers=region=anywhere
 ----
-node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
-  store-id=2 attrs=yellow locality-code=4:5:3:
+node-id=1 locality-tiers=region=anywhere,node=1
+  store-id=1 attrs=purple
+  store-id=2 attrs=yellow
 
 # Two other stores.
 set-store
   store-id=3 node-id=3 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
   store-id=4 node-id=4 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
-node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
-  store-id=2 attrs=yellow locality-code=4:5:3:
+node-id=1 locality-tiers=region=anywhere,node=1
+  store-id=1 attrs=purple
+  store-id=2 attrs=yellow
 node-id=3 locality-tiers=region=us-west-1,zone=us-west-1a,node=3
-  store-id=3 attrs=purple locality-code=1:2:6:
+  store-id=3 attrs=purple
 node-id=4 locality-tiers=region=us-east-1,zone=us-east-1a,node=4
-  store-id=4 attrs=yellow locality-code=4:5:7:
+  store-id=4 attrs=yellow
 
 # Store s1 is the leaseholder for range r1.
 store-leaseholder-msg 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_include.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_include.txt
@@ -7,11 +7,11 @@ set-store
   store-id=3 node-id=3 attrs=green locality-tiers=region=us-central-1,zone=us-central-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow
 node-id=3 locality-tiers=region=us-central-1,zone=us-central-1a,node=3
-  store-id=3 attrs=green locality-code=7:8:9:
+  store-id=3 attrs=green
 
 store-load-msg
   store-id=1 node-id=1 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
@@ -8,13 +8,13 @@ set-store
   store-id=4 node-id=4
 ----
 node-id=1 locality-tiers=node=1
-  store-id=1 attrs= locality-code=1:
+  store-id=1 attrs=
 node-id=2 locality-tiers=node=2
-  store-id=2 attrs= locality-code=2:
+  store-id=2 attrs=
 node-id=3 locality-tiers=node=3
-  store-id=3 attrs= locality-code=3:
+  store-id=3 attrs=
 node-id=4 locality-tiers=node=4
-  store-id=4 attrs= locality-code=4:
+  store-id=4 attrs=
 
 store-load-msg
   store-id=1 node-id=1 load=[500,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica.txt
@@ -3,9 +3,9 @@ set-store
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow
 
 store-load-msg
   store-id=2 node-id=2 load=[20,80,80] capacity=[100,100,100] secondary-load=0 load-time=0s

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges.txt
@@ -6,9 +6,9 @@ set-store
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow
 
 store-leaseholder-msg 
 store-id=1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/set_store.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/set_store.txt
@@ -1,0 +1,29 @@
+set-store
+  store-id=1 node-id=1 attrs=orange,black locality-tiers=region=europe
+----
+node-id=1 locality-tiers=region=europe,node=1
+  store-id=1 attrs=orange,black locality-code=1:2:
+
+# Different attributes (though one is present in both).
+set-store
+  store-id=1 node-id=1 attrs=silver,black,tan locality-tiers=region=europe
+----
+node-id=1 locality-tiers=region=europe,node=1
+  store-id=1 attrs=orange,black locality-code=1:2:
+
+# Different locality.
+set-store
+  store-id=1 node-id=1 attrs=silver,black,tan locality-tiers=region=asia
+----
+node-id=1 locality-tiers=region=europe,node=1
+  store-id=1 attrs=orange,black locality-code=1:2:
+
+# Both change. Throw in another store just for good measure.
+set-store
+  store-id=1 node-id=1 attrs=rainbow locality-tiers=planet=earth,island=kiribati
+  store-id=2 node-id=2 attrs=magenta locality-tiers=region=us-east1
+----
+node-id=1 locality-tiers=region=europe,node=1
+  store-id=1 attrs=orange,black locality-code=1:2:
+node-id=2 locality-tiers=region=us-east1,node=2
+  store-id=2 attrs=magenta locality-code=3:4:

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/set_store.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/set_store.txt
@@ -2,28 +2,53 @@ set-store
   store-id=1 node-id=1 attrs=orange,black locality-tiers=region=europe
 ----
 node-id=1 locality-tiers=region=europe,node=1
-  store-id=1 attrs=orange,black locality-code=1:2:
+  store-id=1 attrs=orange,black
 
 # Different attributes (though one is present in both).
 set-store
   store-id=1 node-id=1 attrs=silver,black,tan locality-tiers=region=europe
 ----
 node-id=1 locality-tiers=region=europe,node=1
-  store-id=1 attrs=orange,black locality-code=1:2:
+  store-id=1 attrs=silver,black,tan
 
 # Different locality.
 set-store
   store-id=1 node-id=1 attrs=silver,black,tan locality-tiers=region=asia
 ----
-node-id=1 locality-tiers=region=europe,node=1
-  store-id=1 attrs=orange,black locality-code=1:2:
+node-id=1 locality-tiers=region=asia,node=1
+  store-id=1 attrs=silver,black,tan
 
-# Both change. Throw in another store just for good measure.
+# Node attributes change from nothing to something.
 set-store
-  store-id=1 node-id=1 attrs=rainbow locality-tiers=planet=earth,island=kiribati
-  store-id=2 node-id=2 attrs=magenta locality-tiers=region=us-east1
+  store-id=1 node-id=1 node-attrs=hicpu,himem locality-tiers=planet=earth,island=kiribati
 ----
-node-id=1 locality-tiers=region=europe,node=1
-  store-id=1 attrs=orange,black locality-code=1:2:
-node-id=2 locality-tiers=region=us-east1,node=2
-  store-id=2 attrs=magenta locality-code=3:4:
+node-id=1 locality-tiers=planet=earth,island=kiribati,node=1 node-attrs=hicpu,himem
+  store-id=1 attrs=
+
+# Node attributes change from something to something else.
+set-store
+  store-id=1 node-id=1 node-attrs=locpu locality-tiers=planet=earth,island=kiribati
+----
+node-id=1 locality-tiers=planet=earth,island=kiribati,node=1 node-attrs=locpu
+  store-id=1 attrs=
+
+# Node attributes change from something to nothing.
+set-store
+  store-id=1 node-id=1 locality-tiers=planet=earth,island=kiribati
+----
+node-id=1 locality-tiers=planet=earth,island=kiribati,node=1
+  store-id=1 attrs=
+
+# Create new store while changing existing store.
+set-store
+  store-id=1 node-id=1 attrs=justanattrlocality-tiers=justaloc
+  store-id=2 node-id=2 attrs=twotwo locality-tiers=region=us-two
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=justanattrlocality-tiers=justaloc
+node-id=2 locality-tiers=region=us-two,node=2
+  store-id=2 attrs=twotwo
+
+# TODO(during review): we should also be able to print the state of the constraintMatcher
+# here. I only noticed at the end that I wasn't updating the constraintMatcher on changes,
+# but this test didn't realize.

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/set_store_locality_drift_between_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/set_store_locality_drift_between_stores.txt
@@ -1,0 +1,38 @@
+# In this test, two stores on a single node change locality locality-tiers
+# one by one, so temporarily we are in a state in which stores on the same
+# node differ in in attributes that are usually shared across nodes.
+
+# In the initial state, stores agree on node-attrs and locality.
+set-store
+  store-id=1 node-id=1 node-attrs=himem attrs=orange,black locality-tiers=region=europe
+  store-id=2 node-id=1 node-attrs=himem attrs=purple,white locality-tiers=region=europe
+----
+node-id=1 locality-tiers=region=europe,node=1 node-attrs=himem
+  store-id=1 attrs=orange,black
+  store-id=2 attrs=purple,white
+
+# An update arrives that gives s2 a different node-attrs and locality.
+set-store
+  store-id=2 node-id=1 node-attrs=lomem attrs=teal locality-tiers=region=apac
+----
+node-id=1 locality-tiers=region=europe,node=1 node-attrs=himem
+  store-id=1 attrs=orange,black
+node-id=1 locality-tiers=region=apac,node=1 node-attrs=lomem
+  store-id=2 attrs=teal
+
+# An update arrives for s1, but still not in sync (lomem vs empty)
+set-store
+  store-id=1 node-id=1 attrs=orange,black locality-tiers=region=apac
+----
+node-id=1 locality-tiers=region=apac,node=1
+  store-id=1 attrs=orange,black
+node-id=1 locality-tiers=region=apac,node=1 node-attrs=lomem
+  store-id=2 attrs=teal
+
+# Synchronized again.
+set-store
+  store-id=1 node-id=1 attrs=orange,black locality-tiers=region=apac node-attrs=lomem
+----
+node-id=1 locality-tiers=region=apac,node=1 node-attrs=lomem
+  store-id=1 attrs=orange,black
+  store-id=2 attrs=teal

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status.txt
@@ -2,7 +2,7 @@ set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=foo
 ----
 node-id=1 locality-tiers=region=foo,node=1
-  store-id=1 attrs=purple locality-code=1:2:
+  store-id=1 attrs=purple
 
 set-store-status store-id=1 health=unhealthy replicas=refusing leases=shedding
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease.txt
@@ -3,9 +3,9 @@ set-store
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow
 
 store-load-msg
   store-id=1 node-id=1 load=[80,80,80] capacity=[100,100,100] secondary-load=1 load-time=0s
@@ -89,6 +89,6 @@ set-store
   store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
 ----
 node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
-  store-id=1 attrs=purple locality-code=1:2:3:
+  store-id=1 attrs=purple
 node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
-  store-id=2 attrs=yellow locality-code=4:5:6:
+  store-id=2 attrs=yellow


### PR DESCRIPTION
This updates cs.setStore so that it reacts correctly to changed store/node attributes or locality tiers by updating its internal state accordingly.

Closes https://github.com/cockroachdb/cockroach/issues/157831.

Epic: CRDB-55052