### PR TITLE
release-25.2: build: reduce `shard_count` of `allccl_test` to 4

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -43,7 +43,7 @@ go_test(
         "main_test.go",
     ],
     embed = [":allccl"],
-    shard_count = 16,
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Backport 1/1 commits from #157845 on behalf of @rickystewart.

----

This package only has 4 tests.

Release note: none
Epic: none

----

Release justification: Non-production code changes