### PR TITLE
release-25.4: kvserver: deflake TestReplicateRestartAfterTruncationWithRemoveAndReAdd

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2293,6 +2293,12 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 					StickyVFSRegistry: fs.NewStickyRegistry(),
 					WallClock:         manualClock,
 				},
+				// In this test, under duress, we can occasionally fail enough
+				// heartbeats to exceed the 10s timeout in execChangeReplicasTxn to
+				// verify liveness of a post-change quorum.
+				//
+				// See: https://github.com/cockroachdb/cockroach/issues/156689
+				Store: &kvserver.StoreTestingKnobs{AllowDangerousReplicationChanges: true},
 			},
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #157827.

/cc @cockroachdb/release

Release justification: fixes test flake that becomes more prevalent with an important bug fix that was also backported.

---

This test could spend >10s with non-live nodes (at least under stress), so it
would trip the timeout in a check in `executeChangeReplicasTxn` that tries to
ensure that we don't replicate into an unavailable configuration.

Instead of skipping these tests under stress, we enable the testing knob that
disables the check.

This passed 2k iters of

```
./dev test pkg/kv/kvserver -f TestReplicateRestartAfterTruncationWithRemoveAndReAdd --stress
```

which before (the one time I tried before fixing) failed after maybe 25% of that.

Closes https://github.com/cockroachdb/cockroach/issues/157203.
Closes https://github.com/cockroachdb/cockroach/issues/156689.
