### PR TITLE
decommission: retry on errors for AllocatorCheckRange

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3965,6 +3965,13 @@ func (s *Store) AllocatorCheckRange(
 	collectTraces bool,
 	overrideStorePool storepool.AllocatorStorePool,
 ) (allocatorimpl.AllocatorAction, roachpb.ReplicationTarget, tracingpb.Recording, error) {
+	// Testing knob to inject errors.
+	if interceptor := s.cfg.TestingKnobs.AllocatorCheckRangeInterceptor; interceptor != nil {
+		if err := interceptor(); err != nil {
+			return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, tracingpb.Recording{}, err
+		}
+	}
+
 	var spanOptions []tracing.SpanOption
 	if collectTraces {
 		spanOptions = append(spanOptions, tracing.WithRecording(tracingpb.RecordingVerbose))

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -483,6 +483,12 @@ type StoreTestingKnobs struct {
 	// EnqueueReplicaInterceptor intercepts calls to `store.Enqueue()`.
 	EnqueueReplicaInterceptor func(queueName string, replica *Replica)
 
+	// AllocatorCheckRangeInterceptor intercepts calls to
+	// `Store.AllocatorCheckRange()` and can be used to inject errors for testing.
+	// If returns non-nil error, the error is returned instead of calling the
+	// actual AllocatorCheckRange logic.
+	AllocatorCheckRangeInterceptor func() error
+
 	// GlobalMVCCRangeTombstone will write a global MVCC range tombstone across
 	// the entire user keyspace during cluster bootstrapping. This will be written
 	// below all other data, and thus won't affect query results, but it does

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -237,7 +238,22 @@ func (s *topLevelServer) DecommissionPreCheck(
 				continue
 			}
 
-			action, _, recording, rErr := evalStore.AllocatorCheckRange(ctx, &desc, collectTraces, overrideStorePool)
+			// Retry for transient errors such as stores throttling. Throttled stores
+			// typically lasts FailedReservationsTimeout (5 seconds by default).
+			var action allocatorimpl.AllocatorAction
+			var recording tracingpb.Recording
+			var rErr error
+			retryOpts := retry.Options{
+				InitialBackoff: 2 * time.Second,
+				MaxBackoff:     5 * time.Second,
+				MaxRetries:     5,
+			}
+			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+				action, _, recording, rErr = evalStore.AllocatorCheckRange(ctx, &desc, collectTraces, overrideStorePool)
+				if rErr == nil {
+					break
+				}
+			}
 			rangesChecked += 1
 			actionCounts[action.String()] += 1
 

--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1049,4 +1050,52 @@ func checkRangeCheckResult(
 			checkResult.RangeID, checkResult.Error)
 	}
 	passed = true
+}
+
+// TestDecommissionPreCheckRetryThrottledStores tests that the decommission
+// pre-check retries when it encounters transient throttled errors. Regression
+// test for #156849.
+func TestDecommissionPreCheckRetryThrottledStores(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var returnedError atomic.Bool
+	returnError := func() error {
+		if returnedError.CompareAndSwap(false, true) {
+			return errors.New("injected error")
+		}
+		return nil
+	}
+
+	tc := serverutils.StartCluster(t, 4, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					AllocatorCheckRangeInterceptor: returnError,
+				},
+			},
+		},
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	scratchKey := tc.ScratchRange(t)
+
+	// Add replicas to the scratch range on nodes 2 and 3.
+	scratchDesc := tc.AddVotersOrFatal(t, scratchKey, tc.Target(1), tc.Target(2))
+	require.Len(t, scratchDesc.InternalReplicas, 3)
+
+	// Perform decommission pre-check on node 3. AllocatorCheckRange will fail
+	// once due to the injected error, then succeed after retries.
+	decommissioningNodeIDs := []roachpb.NodeID{tc.Server(2).NodeID()}
+	result, err := tc.Server(0).DecommissionPreCheck(ctx, decommissioningNodeIDs,
+		true /* strictReadiness */, false /* collectTraces */, 0 /* maxErrors */)
+
+	require.NoError(t, err)
+	require.Greater(t, result.RangesChecked, 0)
+	require.Empty(t, result.RangesNotReady)
+	require.True(t, returnedError.Load())
 }


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/156849
Release note: decommission pre-check may have failed on transient errors; this
is now fixed with a retry loop.

---

**decommission: retry on errors for AllocatorCheckRange**

Previously, the decommission pre-check would fail for a range if
evalStore.AllocatorCheckRange returned an error. However, transient errors, such
as throttled stores, are only expected to last about 5 seconds
(FailedReservationsTimeout) and can cause the pre-check to fail. This commit
adds a retry loop around AllocatorCheckRange to retry on any errors.

Alternatively, we could check for throttling errors specifically and retry only
on throttling stores, but that would require string or error comparisons, which
complicates the code. So we retry just on all errors here given this only
affects the decommission pre-check.

---

**kv: add TestDecommissionPreCheckRetryThrottledStores**

Previously, we made decommission prechecks retry on errors, since some transient
issues resolve quickly and shouldn’t cause the precheck to fail. This commit
adds a test that verifies the precheck retries when it encounters transient
throttled errors.



