### PR TITLE
sql,kv: add per-lookup limit support to lookup joins

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -225,6 +225,11 @@ type Streamer struct {
 	mode          OperationMode
 	hints         Hints
 	maxKeysPerRow int32
+	// perScanRequestKeyLimit is a best-effort limit on the number of keys that
+	// will be returned for each scan request issued by the Streamer. The Streamer
+	// is allowed to return KVs in excess of this limit, for example, when a scan
+	// spans range boundaries.
+	perScanRequestKeyLimit int64
 	// eagerMemUsageLimitBytes determines the maximum memory used from the
 	// budget at which point the streamer stops sending non-head-of-the-line
 	// requests eagerly.
@@ -457,9 +462,16 @@ func NewStreamer(
 // maxKeysPerRow indicates the maximum number of KV pairs that comprise a single
 // SQL row (i.e. the number of column families in the index being scanned).
 //
+// perScanRequestKeyLimit indicates a best-effort limit on the number of KVs
+// that should be returned for a given Scan or ReverseScan request. This is only
+// an optimization, so callers must be prepared to handle excess KVs.
+//
 // In InOrder mode, diskBuffer argument must be non-nil.
 func (s *Streamer) Init(
-	mode OperationMode, hints Hints, maxKeysPerRow int, diskBuffer ResultDiskBuffer,
+	mode OperationMode,
+	hints Hints,
+	maxKeysPerRow, perScanRequestKeyLimit int,
+	diskBuffer ResultDiskBuffer,
 ) {
 	s.mode = mode
 	// s.sd can be nil in tests, so use almost all the budget eagerly then.
@@ -491,6 +503,7 @@ func (s *Streamer) Init(
 	}
 	s.hints = hints
 	s.maxKeysPerRow = int32(maxKeysPerRow)
+	s.perScanRequestKeyLimit = int64(perScanRequestKeyLimit)
 }
 
 // Enqueue dispatches multiple requests for execution. Results are delivered
@@ -1398,6 +1411,7 @@ func (w *workerCoordinator) performRequestAsync(
 		ba.Header.TargetBytes = targetBytes
 		ba.Header.AllowEmpty = !headOfLine
 		ba.Header.WholeRowsOfSize = w.s.maxKeysPerRow
+		ba.Header.MaxPerScanRequestKeys = w.s.perScanRequestKeyLimit
 		ba.Header.IsReverse = w.s.reverse
 		// TODO(yuzefovich): consider setting MaxSpanRequestKeys whenever
 		// applicable (#67885).

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -104,7 +104,9 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 			lock.Unreplicated,
 			reverse,
 		)
-		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
+		s.Init(OutOfOrder, Hints{UniqueRequests: true},
+			1 /* maxKeysPerRow */, 0 /* perScanRequestKeyLimit */, nil, /* diskBuffer */
+		)
 		return s
 	}
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -73,7 +73,7 @@ enum ResumeReason {
   option (gogoproto.goproto_enum_prefix) = false;
   // Zero value; no resume, or an unknown reason from a future or past cockroachdb version.
   RESUME_UNKNOWN = 0;
-  // A key limit was exceeded, i.e. MaxSpanRequestKeys.
+  // A key limit was exceeded, i.e. MaxSpanRequestKeys or MaxPerScanRequestKeys.
   RESUME_KEY_LIMIT = 1;
   // A byte limit was exceeded, i.e. TargetBytes.
   // NB: 21.2 and below will return RESUME_KEY_LIMIT instead.
@@ -3022,9 +3022,26 @@ message Header {
   // evaluated in descending range order.
   bool is_reverse = 38;
 
+  // If positive, applies a best-effort limit to the number of KVs returned to
+  // serve individual Scan and ReverseScan requests. This is different from
+  // MaxSpanRequestKeys, which applies at the level of the batch. Callers must
+  // be prepared for partial responses for any Scan or ReverseScan requests in
+  // the batch if this limit is set.
+  //
+  // Note that requests that span range boundaries could be split across
+  // single-range batches, each with its own per-scan limit. This means that
+  // the limit can be exceeded in some cases (hence best-effort). A caller that
+  // sets this limit should be able to handle extra KVs in the response.
+  //
+  // Also note that this limit does *not* result in resume spans being returned,
+  // unlike MaxSpanRequestKeys. Instead, the result is considered complete once
+  // the per-scan limit is hit. This behavior significantly simplifies combining
+  // results for scans that span multiple ranges.
+  int64 max_per_scan_request_keys = 39;
+
   reserved 7, 10, 12, 14, 20, 24;
 
-  // Next ID: 39
+  // Next ID: 40
 }
 
 message WriteOptions {

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -43,13 +43,20 @@ func ReverseScan(
 	var err error
 
 	readCategory := ScanReadCategory(cArgs.EvalCtx.AdmissionHeader())
+	maxKeys := h.MaxSpanRequestKeys
+	skipResumeSpanForKeyLimit := false
+	if h.MaxPerScanRequestKeys > 0 && (maxKeys == 0 || h.MaxPerScanRequestKeys < maxKeys) {
+		maxKeys = h.MaxPerScanRequestKeys
+		skipResumeSpanForKeyLimit = true
+	}
+
 	opts := storage.MVCCScanOptions{
 		Inconsistent:            h.ReadConsistency != kvpb.CONSISTENT,
 		SkipLocked:              h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:                     h.Txn,
 		ScanStats:               cArgs.ScanStats,
 		Uncertainty:             cArgs.Uncertainty,
-		MaxKeys:                 h.MaxSpanRequestKeys,
+		MaxKeys:                 maxKeys,
 		MaxLockConflicts:        storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetLockConflictBytes: storage.TargetBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:             h.TargetBytes,
@@ -100,9 +107,13 @@ func ReverseScan(
 	reply.NumBytes = scanRes.NumBytes
 
 	if scanRes.ResumeSpan != nil {
-		reply.ResumeSpan = scanRes.ResumeSpan
-		reply.ResumeReason = scanRes.ResumeReason
-		reply.ResumeNextBytes = scanRes.ResumeNextBytes
+    // Swallow the resume span if we stopped due to MaxPerScanRequestKeys, since
+    // the caller does not expect a resume span in that case.
+		if scanRes.ResumeReason != kvpb.RESUME_KEY_LIMIT || !skipResumeSpanForKeyLimit {
+			reply.ResumeSpan = scanRes.ResumeSpan
+			reply.ResumeReason = scanRes.ResumeReason
+			reply.ResumeNextBytes = scanRes.ResumeNextBytes
+		}
 	}
 
 	if h.ReadConsistency == kvpb.READ_UNCOMMITTED {

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -613,6 +613,7 @@ func NewColIndexJoin(
 			maintainOrdering,
 			true, /* singleRowLookup */
 			int(spec.FetchSpec.MaxKeysPerRow),
+			0,     /* perScanRequestKeyLimit */
 			false, /* reverse */
 			diskBuffer,
 			kvFetcherMemAcc,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3408,6 +3408,7 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 		RemoteOnlyLookups:                 planInfo.remoteOnlyLookups,
 		ReverseScans:                      planInfo.reverseScans,
 		Parallelize:                       planInfo.parallelize,
+		PerLookupLimit:                    planInfo.perLookupLimit,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(planInfo.fetch.catalogCols))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -920,6 +920,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	remoteOnlyLookups bool,
 	reverseScans bool,
 	parallelize bool,
+	perLookupLimit int64,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(input)
 	var planNodesToClose []planNode
@@ -969,6 +970,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 			remoteOnlyLookups:          remoteOnlyLookups,
 			reverseScans:               reverseScans,
 			parallelize:                parallelize,
+			perLookupLimit:             perLookupLimit,
 		}
 		if onCond != tree.DBoolTrue {
 			planInfo.onCond = onCond

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -373,6 +373,17 @@ message JoinReaderSpec {
   // Note that this field has no effect when the Streamer API is used.
   optional bool parallelize = 26 [(gogoproto.nullable) = false];
 
+  // If nonzero, limits the number of rows returned by each individual lookup.
+  // This is useful for cases where there are many matches for each input row,
+  // but only a subset of those is needed.
+  //
+  // The limit will respect the index ordering if maintain_lookup_ordering is
+  // also set, although the ascending column limitation still applies. If the
+  // ordering is not maintained, the first 'limit' matching rows that are found
+  // will be returned. This may cause nondeterministic results in the unordered
+  // case.
+  optional int64 per_lookup_limit = 27 [(gogoproto.nullable) = false];
+
   reserved 5, 7, 12, 13, 18;
 }
 

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -92,6 +92,10 @@ type lookupJoinPlanningInfo struct {
 	// Streamer API is used.
 	parallelize bool
 
+	// If greater than zero, perLookupLimit limits the number of rows returned by
+	// each lookup. This is useful when only a subset of looked-up rows is needed.
+	perLookupLimit int64
+
 	// finalizeLastStageCb will be nil in the spec factory.
 	finalizeLastStageCb func(*physicalplan.PhysicalPlan)
 }

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3028,7 +3028,6 @@ func (b *Builder) buildLookupJoin(
 	if !ok {
 		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("lookup join can't provide required ordering")
 	}
-	reverse := requiredDirection == ordering.ReverseDirection
 	parallelize := b.shouldParallelizeLookupJoin(join, lookupOrdinals)
 	for _, c := range reqOrdering {
 		if c.ColIdx >= numInputCols {
@@ -3038,6 +3037,16 @@ func (b *Builder) buildLookupJoin(
 			break
 		}
 	}
+	if join.Direction != opt.ScanEitherDirection && requiredDirection != opt.ScanEitherDirection {
+		// If both the join and the required ordering specify a particular scan
+		// direction, the directions must match.
+		if join.Direction != requiredDirection {
+			return execPlan{}, colOrdMap{}, errors.AssertionFailedf(
+				"lookup join can't provide required ordering")
+		}
+	}
+	reverse := requiredDirection == opt.ScanReverseDirection ||
+		join.Direction == opt.ScanReverseDirection
 	var res execPlan
 	res.root, err = b.factory.ConstructLookupJoin(
 		joinType,
@@ -3058,6 +3067,7 @@ func (b *Builder) buildLookupJoin(
 		join.RemoteOnlyLookups,
 		reverse,
 		parallelize,
+		join.PerLookupLimit,
 	)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -329,6 +329,7 @@ define LookupJoin {
     RemoteOnlyLookups bool
     ReverseScans bool
     Parallelize bool
+    PerLookupLimit int64
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -591,6 +591,14 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if t.IsSecondJoinInPairedJoiner {
 			tp.Childf("second join in paired joiner")
 		}
+		if t.Direction == opt.ScanForwardDirection {
+			tp.Childf("forward scans required")
+		} else if t.Direction == opt.ScanReverseDirection {
+			tp.Childf("reverse scans required")
+		}
+		if t.PerLookupLimit > 0 {
+			tp.Childf("per-lookup-limit: %d", t.PerLookupLimit)
+		}
 		f.formatLocking(tp, t.Locking)
 
 	case *InvertedJoinExpr:

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -484,6 +484,10 @@ func (h *hasher) HashOrderingChoice(val props.OrderingChoice) {
 	}
 }
 
+func (h *hasher) HashScanDirection(val opt.ScanDirection) {
+	h.HashInt(int(val))
+}
+
 func (h *hasher) HashSchemaID(val opt.SchemaID) {
 	h.HashUint64(uint64(val))
 }
@@ -977,6 +981,10 @@ func (h *hasher) IsOrderingEqual(l, r opt.Ordering) bool {
 
 func (h *hasher) IsOrderingChoiceEqual(l, r props.OrderingChoice) bool {
 	return l.Equals(&r)
+}
+
+func (h *hasher) IsScanDirectionEqual(l, r opt.ScanDirection) bool {
+	return l == r
 }
 
 func (h *hasher) IsSchemaIDEqual(l, r opt.SchemaID) bool {

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1618,6 +1618,13 @@ func (sb *statisticsBuilder) buildJoin(
 		colStat.Histogram = nil
 	}
 
+	// Adjust for a lookup-join with a per-lookup limit.
+	if lookup, ok := h.join.(*LookupJoinExpr); ok && lookup.PerLookupLimit > 0 {
+		// The PerLookupLimit is the maximum number of rows that can be generated
+		// per input row.
+		s.RowCount = min(s.RowCount, leftStats.RowCount*float64(lookup.PerLookupLimit))
+	}
+
 	sb.finalizeFromCardinality(relProps)
 }
 

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -523,6 +523,25 @@ define LookupJoinPrivate {
     # that read into remote regions, though the lookups are defined in
     # LookupExpr, not RemoteLookupExpr.
     RemoteOnlyLookups bool
+
+    # Direction, if non-default, indicates that the lookup join must perform
+    # either forward or reverse scans of the index. The default value indicates
+    # that the scan direction is not fixed, and can be chosen based on the
+    # required ordering. Note that an ascending scan direction cannot be used
+    # when the lookup expression has an open lower bound (e.g. inequality),
+    # and vice-versa for a descending scan direction.
+    #
+    # This is useful in conjunction with PerLookupLimit to select either the
+    # first or the last row of each lookup range.
+    Direction ScanDirection
+
+    # PerLookupLimit, if nonzero, represents an enforced limit on the number of
+    # rows returned by each lookup. This is useful when only a subset of
+    # matching rows is needed, for example by a foreign-key check. Note that
+    # PerLookupLimit can be combined with a default Direction to indicate that
+    # "PerLookupLimit" rows are required for each input row in no particular
+    # order.
+    PerLookupLimit int64
     _ JoinPrivate
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -195,6 +195,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"TransactionModes":     {fullName: "tree.TransactionModes", passByVal: true},
 		"Ordering":             {fullName: "opt.Ordering", passByVal: true},
 		"OrderingChoice":       {fullName: "props.OrderingChoice", passByVal: true},
+		"ScanDirection":        {fullName: "opt.ScanDirection", passByVal: true},
 		"GroupingOrder":        {fullName: "memo.GroupingOrder", passByVal: true},
 		"TupleOrdinal":         {fullName: "memo.TupleOrdinal", passByVal: true},
 		"ScanLimit":            {fullName: "memo.ScanLimit", passByVal: true},

--- a/pkg/sql/opt/ordering.go
+++ b/pkg/sql/opt/ordering.go
@@ -113,3 +113,30 @@ func (o Ordering) Equals(rhs Ordering) bool {
 	}
 	return true
 }
+
+// ScanDirection represents the direction of a scan, either for a Scan operator
+// or a LookupJoin.
+type ScanDirection uint8
+
+const (
+	// ScanEitherDirection indicates that the scan can be in either direction.
+	ScanEitherDirection ScanDirection = iota
+	// ScanForwardDirection indicates a forward scan.
+	ScanForwardDirection
+	// ScanReverseDirection indicates a reverse scan.
+	ScanReverseDirection
+)
+
+// String implements the fmt.Stringer interface.
+func (d ScanDirection) String() string {
+	switch d {
+	case ScanEitherDirection:
+		return "either"
+	case ScanForwardDirection:
+		return "forward"
+	case ScanReverseDirection:
+		return "reverse"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -729,6 +729,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	remoteOnlyLookups bool,
 	reverseScans bool,
 	parallelize bool,
+	perLookupLimit int64,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return constructVirtualTableLookupJoin(
@@ -773,6 +774,7 @@ func (ef *execFactory) ConstructLookupJoin(
 			remoteOnlyLookups:          remoteOnlyLookups,
 			reverseScans:               reverseScans,
 			parallelize:                parallelize,
+			perLookupLimit:             perLookupLimit,
 		},
 	}
 	if onCond != tree.DBoolTrue {

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -162,6 +162,14 @@ type txnKVFetcher struct {
 	// doesn't result in too much data), and wants to preserve concurrency for
 	// this scans inside of DistSender.
 	batchBytesLimit rowinfra.BytesLimit
+	// perScanRequestKeyLimit is a best-effort limit on the number of keys that
+	// will be returned for each scan request issued by the fetcher. The fetcher
+	// may return extra KV pairs beyond this limit.
+	perScanRequestKeyLimit rowinfra.KeyLimit
+	// wholeRowsOfSize, if set to a non-zero value, indicates the maximum number
+	// of KVs corresponding to a SQL row. It must be set if perScanRequestKeyLimit
+	// is set, since otherwise we could return only a partial SQL row.
+	wholeRowsOfSize int32
 
 	// scanFormat indicates the scan format that should be used for Scans and
 	// ReverseScans. With COL_BATCH_RESPONSE scan format, indexFetchSpec must be
@@ -351,6 +359,8 @@ type newTxnKVFetcherArgs struct {
 	kvPairsRead                *int64
 	batchRequestsIssued        *int64
 	rawMVCCValues              bool
+	perScanRequestKeyLimit     rowinfra.KeyLimit
+	wholeRowsOfSize            int32
 
 	admission struct { // groups AC-related fields
 		requestHeader  kvpb.AdmissionHeader
@@ -381,6 +391,8 @@ func newTxnKVFetcherInternal(args newTxnKVFetcherArgs) *txnKVFetcher {
 		forceProductionKVBatchSize: args.forceProductionKVBatchSize,
 		requestAdmissionHeader:     args.admission.requestHeader,
 		responseAdmissionQ:         args.admission.responseQ,
+		perScanRequestKeyLimit:     args.perScanRequestKeyLimit,
+		wholeRowsOfSize:            args.wholeRowsOfSize,
 	}
 
 	f.maybeInitAdmissionPacer(
@@ -602,6 +614,8 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	ba.Header.DeadlockTimeout = f.deadlockTimeout
 	ba.Header.TargetBytes = int64(f.batchBytesLimit)
 	ba.Header.MaxSpanRequestKeys = int64(f.getBatchKeyLimit())
+	ba.Header.MaxPerScanRequestKeys = int64(f.perScanRequestKeyLimit)
+	ba.Header.WholeRowsOfSize = f.wholeRowsOfSize
 	ba.Header.IsReverse = f.reverse
 	if buildutil.CrdbTestBuild {
 		if f.scanFormat == kvpb.COL_BATCH_RESPONSE && f.indexFetchSpec == nil {

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -198,6 +198,7 @@ func NewStreamingKVFetcher(
 	maintainOrdering bool,
 	singleRowLookup bool,
 	maxKeysPerRow int,
+	perScanRequestKeyLimit int,
 	reverse bool,
 	diskBuffer kvstreamer.ResultDiskBuffer,
 	kvFetcherMemAcc *mon.BoundAccount,
@@ -234,6 +235,7 @@ func NewStreamingKVFetcher(
 			SingleRowLookup: singleRowLookup,
 		},
 		maxKeysPerRow,
+		perScanRequestKeyLimit,
 		diskBuffer,
 	)
 	return newKVFetcher(newTxnKVStreamer(

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -253,6 +253,16 @@ type joinReader struct {
 	// of hard and soft limits.
 	limitHintHelper execinfra.LimitHintHelper
 
+	// perLookupRowLimit is the max number of matching looked-up rows that will be
+	// returned for each input row. This is useful for cases when only a subset
+	// of matching rows are needed; for example, existence checks.
+	//
+	// Note that perLookupRowLimit can only be set in the case when the join ON
+	// condition is empty. This ensures that the number of matches an input rows
+	// receives is equivalent to the number of looked up rows for that input row,
+	// which simplifies the implementation.
+	perLookupRowLimit int
+
 	// Set errorOnLookup to true to cause the join to error out just prior to
 	// performing a lookup. This is currently only set when the join contains
 	// only lookups to rows in remote regions and remote accesses are set to
@@ -367,6 +377,18 @@ func newJoinReader(
 		return nil, err
 	}
 
+	perLookupRowLimit := int(spec.PerLookupLimit)
+	if perLookupRowLimit != 0 && !spec.OnExpr.Empty() {
+		// See the joinReader.perLookupLimit comment for why this check is needed.
+		return nil, errors.Errorf("PerLookupLimit cannot be set with a nonempty ON condition")
+	}
+	if spec.OnExpr.Empty() && (spec.Type == descpb.LeftSemiJoin || spec.Type == descpb.LeftAntiJoin) {
+		// SemiJoins and AntiJoins only need to look up one row for each input row.
+		// The ON condition must be empty; otherwise, the first looked up row may
+		// not actually be a match.
+		perLookupRowLimit = 1
+	}
+
 	errorOnLookup := spec.RemoteOnlyLookups &&
 		flowCtx.EvalCtx.Planner != nil && flowCtx.EvalCtx.Planner.EnforceHomeRegion()
 
@@ -384,6 +406,7 @@ func newJoinReader(
 		txn:                               txn,
 		usesStreamer:                      useStreamer,
 		limitHintHelper:                   execinfra.MakeLimitHintHelper(spec.LimitHint, post),
+		perLookupRowLimit:                 perLookupRowLimit,
 		errorOnLookup:                     errorOnLookup,
 	}
 	if readerType != indexJoinReaderType {
@@ -495,6 +518,8 @@ func newJoinReader(
 	if memoryLimit < minMemoryLimit {
 		memoryLimit = minMemoryLimit
 	}
+	perLookupKeyLimit := perLookupRowLimit * int(spec.FetchSpec.MaxKeysPerRow)
+
 	var streamingKVFetcher *row.KVFetcher
 	if jr.usesStreamer {
 		// NOTE: this comment should only be considered in a case of low workmem
@@ -590,7 +615,7 @@ func newJoinReader(
 			jr.streamerInfo.maintainOrdering,
 			singleRowLookup,
 			int(spec.FetchSpec.MaxKeysPerRow),
-			0, /* perScanRequestKeyLimit */
+			perLookupKeyLimit,
 			spec.ReverseScans,
 			diskBuffer,
 			&jr.streamerInfo.txnKVStreamerMemAcc,
@@ -625,6 +650,7 @@ func newJoinReader(
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
 			SpansCanOverlap:            jr.spansCanOverlap,
+			PerScanRequestKeyLimit:     rowinfra.KeyLimit(perLookupKeyLimit),
 		},
 	); err != nil {
 		return nil, err
@@ -742,6 +768,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 			isPartialJoin:           jr.joinType == descpb.LeftSemiJoin || jr.joinType == descpb.LeftAntiJoin,
 			groupingState:           jr.groupingState,
 			strategyMemAcc:          &strategyMemAcc,
+			perLookupRowLimit:       jr.perLookupRowLimit,
 		}
 		return nil
 	}
@@ -780,6 +807,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		groupingState:                     jr.groupingState,
 		outputGroupContinuationForLeftRow: jr.outputGroupContinuationForLeftRow,
 		strategyMemAcc:                    &strategyMemAcc,
+		perLookupRowLimit:                 jr.perLookupRowLimit,
 	}
 	return nil
 }
@@ -1469,8 +1497,8 @@ type inputBatchGroupingState struct {
 }
 
 type groupState struct {
-	// Whether the group matched.
-	matched bool
+	// The number of times the group has been matched.
+	matched int
 	// The last row index in the group. Only valid when doGrouping = true.
 	lastRow int
 }
@@ -1489,7 +1517,7 @@ func (ib *inputBatchGroupingState) addContinuationValForRow(cont bool) {
 		// First row in input batch or the start of a new group. We need to
 		// add entries in the group indexed slices.
 		ib.groupState = append(ib.groupState,
-			groupState{matched: false, lastRow: len(ib.batchRowToGroupIndex)})
+			groupState{matched: 0, lastRow: len(ib.batchRowToGroupIndex)})
 	}
 	if ib.doGrouping {
 		groupIndex := len(ib.groupState) - 1
@@ -1499,40 +1527,44 @@ func (ib *inputBatchGroupingState) addContinuationValForRow(cont bool) {
 }
 
 func (ib *inputBatchGroupingState) setFirstGroupMatched() {
-	ib.groupState[0].matched = true
+	ib.groupState[0].matched++
 }
 
-// setMatched records that the given rowIndex has matched. It returns the
-// previous value of the matched field.
-func (ib *inputBatchGroupingState) setMatched(rowIndex int) bool {
-	groupIndex := rowIndex
+func (ib *inputBatchGroupingState) groupIndex(rowIndex int) int {
 	if ib.doGrouping {
-		groupIndex = ib.batchRowToGroupIndex[rowIndex]
+		return ib.batchRowToGroupIndex[rowIndex]
 	}
-	rv := ib.groupState[groupIndex].matched
-	ib.groupState[groupIndex].matched = true
+	return rowIndex
+}
+
+// addMatched records that the given rowIndex has matched. The return value
+// indicates whether the rowIndex was previously matched.
+func (ib *inputBatchGroupingState) addMatched(rowIndex int) bool {
+	groupIndex := ib.groupIndex(rowIndex)
+	rv := ib.groupState[groupIndex].matched > 0
+	ib.groupState[groupIndex].matched++
 	return rv
 }
 
 func (ib *inputBatchGroupingState) getMatched(rowIndex int) bool {
-	groupIndex := rowIndex
-	if ib.doGrouping {
-		groupIndex = ib.batchRowToGroupIndex[rowIndex]
-	}
-	return ib.groupState[groupIndex].matched
+	return ib.groupState[ib.groupIndex(rowIndex)].matched > 0
+}
+
+func (ib *inputBatchGroupingState) getMatchedCount(rowIndex int) int {
+	return ib.groupState[ib.groupIndex(rowIndex)].matched
 }
 
 func (ib *inputBatchGroupingState) lastGroupMatched() bool {
 	if !ib.doGrouping || len(ib.groupState) == 0 {
 		return false
 	}
-	return ib.groupState[len(ib.groupState)-1].matched
+	return ib.groupState[len(ib.groupState)-1].matched > 0
 }
 
 func (ib *inputBatchGroupingState) isUnmatched(rowIndex int) bool {
 	if !ib.doGrouping {
 		// The rowIndex is also the groupIndex.
-		return !ib.groupState[rowIndex].matched
+		return ib.groupState[rowIndex].matched == 0
 	}
 	groupIndex := ib.batchRowToGroupIndex[rowIndex]
 	if groupIndex == len(ib.groupState)-1 {
@@ -1547,7 +1579,7 @@ func (ib *inputBatchGroupingState) isUnmatched(rowIndex int) bool {
 	// saying that there is no match for the group until the last row in the
 	// group since for earlier rows, when at step (b), one does not know the
 	// match state of later rows in the group.
-	return !ib.groupState[groupIndex].matched && ib.groupState[groupIndex].lastRow == rowIndex
+	return ib.groupState[groupIndex].matched == 0 && ib.groupState[groupIndex].lastRow == rowIndex
 }
 
 func (ib *inputBatchGroupingState) memUsage() int64 {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -590,6 +590,7 @@ func newJoinReader(
 			jr.streamerInfo.maintainOrdering,
 			singleRowLookup,
 			int(spec.FetchSpec.MaxKeysPerRow),
+			0, /* perScanRequestKeyLimit */
 			spec.ReverseScans,
 			diskBuffer,
 			&jr.streamerInfo.txnKVStreamerMemAcc,

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -117,6 +117,9 @@ func TestJoinReader(t *testing.T) {
 		lookupCols       []uint32
 		joinType         descpb.JoinType
 		inputTypes       []*types.T
+		perLookupLimit   int64
+		lookupOrdering   bool
+		reverse          bool
 		// The output types for the case without continuation. The test adds the
 		// bool type for the case with continuation.
 		outputTypes            []*types.T
@@ -1047,6 +1050,88 @@ func TestJoinReader(t *testing.T) {
 			outputTypes:      types.TwoIntCols,
 			expected:         "[[0 1]]",
 		},
+		{
+			description: "Test unique lookups with per-row limit",
+			post: execinfrapb.PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 3},
+			},
+			input: [][]tree.Datum{
+				{aFn(2), bFn(2)},
+				{aFn(2), bFn(2)},
+				{aFn(5), bFn(5)},
+				{aFn(10), bFn(10)},
+				{aFn(15), bFn(15)},
+			},
+			fetchCols:      []uint32{0, 1, 2},
+			lookupCols:     []uint32{0, 1},
+			inputTypes:     types.TwoIntCols,
+			outputTypes:    types.ThreeIntCols,
+			perLookupLimit: 1,
+			expected:       "[[0 2 2] [0 2 2] [0 5 5] [1 0 0] [1 5 5]]",
+		},
+		{
+			description: "Test non-unique ordered lookups with per-row limit",
+			post: execinfrapb.PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 2, 4},
+			},
+			input: [][]tree.Datum{
+				{aFn(2), bFn(2)},
+				// No match for this row.
+				{aFn(200), bFn(200)},
+				{aFn(12), bFn(12)},
+			},
+			fetchCols:      []uint32{0, 1, 2},
+			lookupCols:     []uint32{0},
+			inputTypes:     types.TwoIntCols,
+			outputTypes:    types.FourIntCols,
+			perLookupLimit: 1,
+			lookupOrdering: true,
+			expected:       "[[0 2 0 1] [1 2 1 1]]",
+		},
+		{
+			description: "Test non-unique ordered reverse lookups with per-row limit",
+			post: execinfrapb.PostProcessSpec{
+				Projection:    true,
+				OutputColumns: []uint32{0, 1, 2, 4},
+			},
+			input: [][]tree.Datum{
+				{aFn(2), bFn(2)},
+				// No match for this row.
+				{aFn(200), bFn(200)},
+				{aFn(12), bFn(12)},
+			},
+			fetchCols:      []uint32{0, 1, 2},
+			lookupCols:     []uint32{0},
+			inputTypes:     types.TwoIntCols,
+			outputTypes:    types.FourIntCols,
+			perLookupLimit: 1,
+			lookupOrdering: true,
+			reverse:        true,
+			expected:       "[[0 2 0 9] [1 2 1 10]]",
+		},
+		{
+			description: "Test non-unique unordered lookups with per-row limit",
+			post: execinfrapb.PostProcessSpec{
+				Projection: true,
+				// Only the equality column is emitted from the join, so the ordering
+				// doesn't matter despite the limit.
+				OutputColumns: []uint32{0, 1, 2},
+			},
+			input: [][]tree.Datum{
+				{aFn(2), bFn(2)},
+				// No match for this row.
+				{aFn(200), bFn(200)},
+				{aFn(12), bFn(12)},
+			},
+			fetchCols:      []uint32{0, 1, 2},
+			lookupCols:     []uint32{0},
+			inputTypes:     types.TwoIntCols,
+			outputTypes:    types.ThreeIntCols,
+			perLookupLimit: 1,
+			expected:       "[[0 2 0] [1 2 1]]",
+		},
 	}
 	st := s.ClusterSettings()
 	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), nil /* statsCollector */)
@@ -1135,9 +1220,12 @@ func TestJoinReader(t *testing.T) {
 									RemoteLookupExpr:                  execinfrapb.Expression{Expr: c.remoteLookupExpr},
 									OnExpr:                            execinfrapb.Expression{Expr: c.onExpr},
 									Type:                              c.joinType,
-									MaintainOrdering:                  reqOrdering,
+									MaintainOrdering:                  reqOrdering || c.lookupOrdering,
 									LeftJoinWithPairedJoiner:          c.secondJoinInPairedJoin,
 									OutputGroupContinuationForLeftRow: outputContinuation,
+									PerLookupLimit:                    c.perLookupLimit,
+									MaintainLookupOrdering:            c.lookupOrdering,
+									ReverseScans:                      c.reverse,
 								},
 								in,
 								&post,

--- a/pkg/sql/rowinfra/base.go
+++ b/pkg/sql/rowinfra/base.go
@@ -14,7 +14,7 @@ import (
 
 // RowLimit represents a response limit expressed in terms of number of result
 // rows. RowLimits get ultimately converted to KeyLimits and are translated into
-// BatchRequest.MaxSpanRequestKeys.
+// BatchRequest.MaxSpanRequestKeys or BatchRequest.MaxPerScanRequestKeys.
 type RowLimit uint64
 
 // KeyLimit represents a response limit expressed in terms of number of keys.


### PR DESCRIPTION
#### sql,kv: add support for best-effort per-scan request limit

This commit adds support for limiting the number of KVs returned for
individual `Scan` and `ReverseScan` requests in a batch. This is a
best effort limit to simplify splitting scans that span multiple
ranges, as well as simplify handling for SQL rows that map to multiple
KVs. Users of the limit should be prepared to handle extra KVs.
Following commits will use this limit to optimize lookup joins which
only need a limited number of rows from each lookup.

NOTE: unlike the batch-level key limit, the per-scan key limit does
not include resume spans in the results. This significantly simplifies
handling of requests that span multiple ranges, and is sufficient for
most use cases.

Informs #62471
Informs #128704

Release note: None

#### rowexec: add per-lookup limit support to lookup joins

This commit adds execution support for a "per-lookup" hard limit in
lookup joins. This required adding some additional state to the joinReader
to track how many matches each input row has found in order to enforce the
limit. In addition, scans are now issued with the best effort per-scan
limit from the previous commit.

As of this commit, semi- and anti-joins with no ON condition will already
take advantage of this new functionality, since they only need to lookup up
one row for each input row. A follow-up PR will add optimizer rules to apply
the per-lookup limit to other query patterns. This will significantly improve
performance for some queries that perform a lookup-join on a non-unique join
key followed by a limit or aggregation.

Informs #62471
Informs #128704

Release note: None