### PR TITLE
kvpb: add (*RangeFeedEvent).EventType method

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2185,6 +2185,28 @@ func (e *RangeFeedEvent) ShallowCopy() *RangeFeedEvent {
 	return &cpy
 }
 
+// EventType returns a string description of the type of event..
+func (e *RangeFeedEvent) EventType() string {
+	switch {
+	case e.Val != nil:
+		return "Value"
+	case e.Checkpoint != nil:
+		return "Checkpoint"
+	case e.SST != nil:
+		return "SST"
+	case e.DeleteRange != nil:
+		return "DeleteRange"
+	case e.Metadata != nil:
+		return "Metadata"
+	case e.Error != nil:
+		return "Error"
+	case e.BulkEvents != nil:
+		return "BulkEvents"
+	default:
+		return "Unknown"
+	}
+}
+
 // Timestamp is part of rangefeedbuffer.Event.
 func (e *RangeFeedValue) Timestamp() hlc.Timestamp {
 	return e.Value.Timestamp

--- a/pkg/kv/kvserver/rangefeed/sender_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/sender_helper_test.go
@@ -97,22 +97,7 @@ func (s *testServerStream) String() string {
 	for streamID, eventList := range s.streamEvents {
 		fmt.Fprintf(&str, "\tStreamID:%d, Len:%d", streamID, len(eventList))
 		for _, ev := range eventList {
-			switch {
-			case ev.Val != nil:
-				fmt.Fprintf(&str, "\t\tvalue")
-			case ev.Checkpoint != nil:
-				fmt.Fprintf(&str, "\t\tcheckpoint")
-			case ev.SST != nil:
-				fmt.Fprintf(&str, "\t\tsst")
-			case ev.DeleteRange != nil:
-				fmt.Fprintf(&str, "\t\tdelete")
-			case ev.Metadata != nil:
-				fmt.Fprintf(&str, "\t\tmetadata")
-			case ev.Error != nil:
-				fmt.Fprintf(&str, "\t\terror")
-			default:
-				panic("unknown event type")
-			}
+			fmt.Fprintf(&str, "\t\t%s", ev.EventType())
 		}
 		fmt.Fprintf(&str, "\n")
 	}


### PR DESCRIPTION
A small helper for printing the type of an event since this type is enum-like.

Informs #135332
Release note: None