### PR TITLE
roachprod: fix service registry unit test name collision

### DIFF
--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -138,7 +138,7 @@ func (t *serviceRegistryTest) makeVM(clusterName string, i int) vm.VM {
 }
 
 func (t *serviceRegistryTest) newCluster(nodeCount int) *SyncedCluster {
-	clusterName := fmt.Sprintf("cluster-%d", t.rng.Uint32())
+	clusterName := fmt.Sprintf("cluster-%s", randutil.RandString(t.rng, 10, randutil.PrintableKeyAlphabet))
 	c := &SyncedCluster{
 		Cluster: cloud.Cluster{
 			Name: clusterName,


### PR DESCRIPTION
We were previously generating cluster names with Uint32, which is not sufficient enough to prevent naming collisions after 1000 iterations. Instead, use a RandString of length 10.

Fixes: #157884
Release note: none