### PR TITLE
release-25.4: sql/schemachanger: add sampling for pause / rollback tests

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -52,7 +52,8 @@ func BackupSuccess(t *testing.T, path string, factory TestServerFactory) {
 		backupArgs = backupSuccessPrepare(t, factory, spec, dbName)
 	}, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		backupSuccess(t, backupArgs, cs)
-	})
+	},
+		nil /*samplingFn */)
 }
 
 // BackupRollbacks tests that the schema changer can handle being backed up
@@ -70,7 +71,8 @@ func BackupRollbacks(t *testing.T, path string, factory TestServerFactory) {
 	factory = factory.WithSchemaLockDisabled()
 	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		backupRollbacks(t, factory, cs)
-	})
+	},
+		nil /* samplingFn */)
 }
 
 // BackupSuccessMixedVersion is like BackupSuccess but in a mixed-version
@@ -96,7 +98,8 @@ func BackupSuccessMixedVersion(t *testing.T, path string, factory TestServerFact
 		backupArgs = backupSuccessPrepare(t, factory, spec, dbName)
 	}, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		backupSuccess(t, backupArgs, cs)
-	})
+	},
+		nil /* samplingFn */)
 }
 
 // BackupRollbacksMixedVersion is like BackupRollbacks but in a mixed-version
@@ -116,7 +119,7 @@ func BackupRollbacksMixedVersion(t *testing.T, path string, factory TestServerFa
 	factory = factory.WithSchemaLockDisabled()
 	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		backupRollbacks(t, factory, cs)
-	})
+	}, nil /* samplingFn */)
 }
 
 // runAllBackups runs all the backup tests, disabling the random skipping.

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -117,7 +117,7 @@ func Rollback(t *testing.T, relPath string, factory TestServerFactory) {
 		}
 		factory.WithSchemaChangerKnobs(knobs).Run(ctx, t, runfn)
 	}
-	cumulativeTestForEachPostCommitStage(t, relPath, factory, nil, testRollbackCase)
+	cumulativeTestForEachPostCommitStage(t, relPath, factory, nil, testRollbackCase, sampleAllPostCommitRevertible /* enableSampling */)
 }
 
 // ExecuteWithDMLInjection tests that the schema changer behaviour is sane
@@ -335,7 +335,8 @@ func Pause(t *testing.T, path string, factory TestServerFactory) {
 
 	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		pause(t, factory, cs)
-	})
+	},
+		sampleAllPostCommitStages /* enableSampling */)
 }
 
 // PauseMixedVersion is like Pause but in a mixed-version cluster which gets
@@ -349,7 +350,8 @@ func PauseMixedVersion(t *testing.T, path string, factory TestServerFactory) {
 	factory.WithMixedVersion()
 	cumulativeTestForEachPostCommitStage(t, path, factory, nil, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		pause(t, factory, cs)
-	})
+	},
+		sampleAllPostCommitStages /* enableSampling */)
 }
 
 func pause(t *testing.T, factory TestServerFactory, cs CumulativeTestCaseSpec) {


### PR DESCRIPTION
Backport 1/1 commits from #156111 on behalf of @fqazi.

----

Previously, the pause and rollback tests for the declarative schema changer could timeout due to the number of stages being tested. To address this, this patch adds supports for sampling stages in plans for rollback / pause testing.

Fixes: #155668
Fixes: #155502

Release note: None

----

Release justification: test only change