### PR TITLE
roachtest: add validation for row fragmentation in import tests

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -283,6 +283,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
         "//pkg/sql/ttl/ttlbase",
         "//pkg/sql/vecindex/cspann",


### PR DESCRIPTION
Previously, import tests did not verify whether tables with multiple column families were correctly handled during import, specifically whether rows were fragmented across range boundaries. This could lead to data corruption if import splits a row mid-family.

This commit adds validation logic that parses the output of SHOW RANGE FROM INDEX to ensure that all families for a given primary key value are located within a single range. This check is pretty cheap, so we do it for all datasets. We also add a test case that takes a random dataset and adds column families to the schema before beginning import as well as a smoke test that is locked to a small dataset for developer use.

Fixes: #157241
Release note: None