### PR TITLE
batchevel: make cmd_truncate_log use the log engine

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1409,6 +1409,11 @@ func (r *Replica) StoreID() roachpb.StoreID {
 	return r.store.StoreID()
 }
 
+// LogEngine returns the log engine.
+func (r *Replica) LogEngine() storage.Engine {
+	return r.store.LogEngine()
+}
+
 // EvalKnobs returns the EvalContext's Knobs.
 func (r *Replica) EvalKnobs() kvserverbase.BatchEvalTestingKnobs {
 	return r.store.cfg.TestingKnobs.EvalKnobs

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -93,6 +94,11 @@ func (rec *SpanSetReplicaEvalContext) GetTerm(i kvpb.RaftIndex) (kvpb.RaftTerm, 
 // GetLeaseAppliedIndex returns the lease index of the last applied command.
 func (rec *SpanSetReplicaEvalContext) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
 	return rec.i.GetLeaseAppliedIndex()
+}
+
+// LogEngine returns the log engine.
+func (rec *SpanSetReplicaEvalContext) LogEngine() storage.Engine {
+	return rec.i.LogEngine()
 }
 
 // IsFirstRange returns true iff the replica belongs to the first range.


### PR DESCRIPTION
This is the last known place where touch the unreplicated rangeID local keyspace. This commit provides the LogEngine through EvalCtx so that cmd_truncate_log can use it to compute the stats.

Fixes: #157895

Release note: None