### PR TITLE
mma: fix minor todos related to pending changes

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -291,7 +291,10 @@ func (a *allocatorState) AdjustPendingChangeDisposition(change PendingRangeChang
 	}
 	if !success {
 		// Check that we can undo these changes.
-		if err := a.cs.preCheckOnUndoReplicaChanges(changes); err != nil {
+		if err := a.cs.preCheckOnUndoReplicaChanges(PendingRangeChange{
+			RangeID:               change.RangeID,
+			pendingReplicaChanges: changes,
+		}); err != nil {
 			panic(err)
 		}
 	}
@@ -308,7 +311,7 @@ func (a *allocatorState) AdjustPendingChangeDisposition(change PendingRangeChang
 func (a *allocatorState) RegisterExternalChange(change PendingRangeChange) (ok bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if err := a.cs.preCheckOnApplyReplicaChanges(change.pendingReplicaChanges); err != nil {
+	if err := a.cs.preCheckOnApplyReplicaChanges(change); err != nil {
 		a.mmaMetrics.ExternalFailedToRegister.Inc(1)
 		log.KvDistribution.Infof(context.Background(),
 			"did not register external changes: due to %v", err)

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -413,7 +413,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		replicaChanges := makeRebalanceReplicaChanges(
 			rangeID, rstate.replicas, rstate.load, addTarget, removeTarget)
 		rangeChange := MakePendingRangeChange(rangeID, replicaChanges[:])
-		if err = re.preCheckOnApplyReplicaChanges(rangeChange.pendingReplicaChanges); err != nil {
+		if err = re.preCheckOnApplyReplicaChanges(rangeChange); err != nil {
 			panic(errors.Wrapf(err, "pre-check failed for replica changes: %v for %v",
 				replicaChanges, rangeID))
 		}
@@ -591,7 +591,7 @@ func (re *rebalanceEnv) rebalanceLeases(
 		replicaChanges := MakeLeaseTransferChanges(
 			rangeID, rstate.replicas, rstate.load, addTarget, removeTarget)
 		leaseChange := MakePendingRangeChange(rangeID, replicaChanges[:])
-		if err := re.preCheckOnApplyReplicaChanges(leaseChange.pendingReplicaChanges); err != nil {
+		if err := re.preCheckOnApplyReplicaChanges(leaseChange); err != nil {
 			panic(errors.Wrapf(err, "pre-check failed for lease transfer %v", leaseChange))
 		}
 		re.addPendingRangeChange(leaseChange)


### PR DESCRIPTION
Some methods now take a PendingRangeChange as parameter, insted of a slice
of pendingReplicaChanges, to make it clearer that these are changes for
the same range.

Also removed two todos:
- The RangeID continues to be a field in pendingReplicaChange, since it is
  convenient (mainly for logging and testing), despite redundancy with the
  containing PendingRangeChange. This is because the contained relationship
  is not maintained in various maps keyed by the changeID.
- The changes in a rangeState are not modeled as a PendingRangeChange since
  the concept is redundant -- they are already contained in a range specific
  container.

Informs https://github.com/cockroachdb/cockroach/issues/157049

Epic: CRDB-55052

Release note: None