### PR TITLE
release-24.1: roachtest: link on `large` pool

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -73,6 +73,7 @@ go_binary(
     name = "roachtest",
     testonly = 1,
     embed = [":roachtest_lib"],
+    exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #157927 on behalf of @rickystewart.

----

Release note: none
Epic: none

----

Release justification: Non-production code changes