### PR TITLE
taskpacer,kvclient: remove more uses of timeutil.Now

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 )
 
 var running int32 // atomically updated
@@ -107,7 +107,7 @@ func GRPCTransportFactory(nodeDialer *nodedialer.Dialer) TransportFactory {
 					encoder := json.NewEncoder(io.Discard)
 					for {
 						iters++
-						start := timeutil.Now()
+						start := crtime.NowMono()
 						for _, ba := range bas {
 							if ba != nil {
 								if err := encoder.Encode(ba); err != nil {
@@ -119,7 +119,7 @@ func GRPCTransportFactory(nodeDialer *nodedialer.Dialer) TransportFactory {
 						// times skyrocket. Sleep on average for as long as we worked
 						// on the last iteration so we spend no more than half our CPU
 						// time on this task.
-						jittered := time.After(jitter(timeutil.Since(start)))
+						jittered := time.After(jitter(start.Elapsed()))
 						// Collect incoming requests until the jittered timer fires,
 						// then access everything we have.
 						for {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -564,7 +564,7 @@ func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 	// bypass AC.
 	ba.AdmissionHeader = kvpb.AdmissionHeader{
 		Priority:   txn.AdmissionPriority,
-		CreateTime: timeutil.Now().UnixNano(),
+		CreateTime: h.clock.PhysicalTime().UnixNano(),
 		Source:     kvpb.AdmissionHeader_OTHER,
 	}
 

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
-        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -198,7 +198,7 @@ func Start[E rangefeedbuffer.Event](
 
 		const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
 		for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
-			started := timeutil.Now()
+			started := crtime.NowMono()
 			if err := c.Run(ctx); err != nil {
 				if errors.Is(err, context.Canceled) {
 					return // we're done here
@@ -207,7 +207,7 @@ func Start[E rangefeedbuffer.Event](
 					onError(err)
 				}
 
-				if timeutil.Since(started) > aWhile {
+				if started.Elapsed() > aWhile {
 					r.Reset()
 				}
 

--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/taskpacer",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -105,6 +105,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -2552,12 +2553,12 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 		var timer timeutil.Timer
 		defer timer.Stop()
 		errInterrupted := errors.New("waiting interrupted")
-		wait := func(ctx context.Context, until time.Time, interrupt <-chan struct{}) error {
-			now := timeutil.Now()
-			if !now.Before(until) {
+		wait := func(ctx context.Context, until crtime.Mono, interrupt <-chan struct{}) error {
+			wait := until.Sub(crtime.NowMono())
+			if wait <= 0 {
 				return nil
 			}
-			timer.Reset(until.Sub(now))
+			timer.Reset(wait)
 			select {
 			case <-timer.C:
 				return nil
@@ -2601,7 +2602,7 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 				return // context canceled
 			}
 			// Aim to complete this run in exactly refresh interval.
-			now := timeutil.Now()
+			now := crtime.NowMono()
 			pacer.StartTask(now)
 
 			// We're about to perform one work cycle, where we go through all replicas
@@ -2619,7 +2620,7 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 					break
 				}
 
-				todo, by := pacer.Pace(timeutil.Now(), len(work))
+				todo, by := pacer.Pace(crtime.NowMono(), len(work))
 				for _, id := range work[:todo] {
 					if r := s.GetReplicaIfExists(id); r != nil {
 						cts := r.GetCurrentClosedTimestamp(ctx)

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/taskpacer",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@io_storj_drpc//:drpc",

--- a/pkg/kv/kvserver/storeliveness/transport.go
+++ b/pkg/kv/kvserver/storeliveness/transport.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/taskpacer"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"storj.io/drpc"
@@ -274,10 +275,10 @@ func (t *Transport) smearingSenderLoop(ctx context.Context) {
 			// pick it up in the next iteration of the for loop.
 
 			// Pace the signalling of the channels.
-			pacer.StartTask(timeutil.Now())
+			pacer.StartTask(crtime.NowMono())
 			workLeft := len(toSignal)
 			for workLeft > 0 {
-				todo, by := pacer.Pace(timeutil.Now(), workLeft)
+				todo, by := pacer.Pace(crtime.NowMono(), workLeft)
 
 				// Pop todo items off the toSignal slice and signal them.
 				for i := 0; i < todo && workLeft > 0; i++ {
@@ -291,7 +292,7 @@ func (t *Transport) smearingSenderLoop(ctx context.Context) {
 				}
 
 				if workLeft > 0 {
-					if wait := timeutil.Until(by); wait > 0 {
+					if wait := by.Sub(crtime.NowMono()); wait > 0 {
 						time.Sleep(wait)
 					}
 				}

--- a/pkg/util/taskpacer/BUILD.bazel
+++ b/pkg/util/taskpacer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["pacer.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/taskpacer",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_cockroachdb_crlib//crtime"],
 )
 
 go_test(
@@ -15,7 +16,7 @@ go_test(
     deps = [
         "//pkg/util/leaktest",
         "//pkg/util/log",
-        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/taskpacer/pacer_test.go
+++ b/pkg/util/taskpacer/pacer_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,7 +140,7 @@ func TestPacer(t *testing.T) {
 			gotWork := make([]int, 0, len(tc.wantWork))
 			gotBy := make([]time.Duration, 0, len(tc.wantBy))
 
-			start := timeutil.Unix(946684800, 0) // Jan 1, 2000
+			start := crtime.NowMono()
 			now := start
 
 			conf := newMockConfig(tc.deadline, tc.smear)
@@ -148,7 +148,7 @@ func TestPacer(t *testing.T) {
 			pacer.StartTask(now)
 
 			for work, startAt := tc.work, now; work != 0; {
-				if startAt.After(now) { // imitate waiting
+				if startAt > now { // imitate waiting
 					now = startAt
 				}
 				todo, by := pacer.Pace(now, work)
@@ -239,7 +239,7 @@ func TestPacerAccommodatesConfChanges(t *testing.T) {
 			gotWork := make([]int, 0, len(tc.wantWork))
 			gotBy := make([]time.Duration, 0, len(tc.wantBy))
 
-			start := timeutil.Unix(946684800, 0) // Jan 1, 2000
+			start := crtime.NowMono()
 			now := start
 
 			conf := newMockConfig(tc.refreshes[0], tc.smears[0])
@@ -252,7 +252,7 @@ func TestPacerAccommodatesConfChanges(t *testing.T) {
 				conf.refresh = tc.refreshes[index]
 				conf.smear = tc.smears[index]
 
-				if startAt.After(now) { // imitate waiting
+				if startAt > now { // imitate waiting
 					now = startAt
 				}
 				todo, by := pacer.Pace(now, work)


### PR DESCRIPTION
This removes a few more uses of timeutil.Now. The biggest of the changes
is to the taskpacer which is used in multiple places.

Overall, my goal in this and other PRs is to slowly reduce the number of places
using timeutil.Now() since ideally anything taking a time reading for anything
other than measuring elapsed time would use an hlc.Clock.

Epic: none
Release note: none