### PR TITLE
roachtest/vecindex: Always download datasets when testing

### DIFF
--- a/pkg/cmd/roachtest/tests/vecindex.go
+++ b/pkg/cmd/roachtest/tests/vecindex.go
@@ -253,6 +253,7 @@ func runVectorIndex(ctx context.Context, t test.Test, c cluster.Cluster, opts ve
 	t.L().Printf("Loading dataset %s", opts.dataset)
 	loader := vecann.DatasetLoader{
 		DatasetName: opts.dataset,
+		ResetCache:  true,
 		OnProgress: func(ctx context.Context, format string, args ...any) {
 			t.L().Printf(format, args...)
 		},

--- a/pkg/workload/vecann/datasets.go
+++ b/pkg/workload/vecann/datasets.go
@@ -90,6 +90,8 @@ type DatasetLoader struct {
 	// CacheFolder is the path to the temporary folder where datasets will be
 	// cached. It defaults to ~/.cache/workload-datasets.
 	CacheFolder string
+	// ResetCache indicates that the cache should be re-populated.
+	ResetCache bool
 
 	// OnProgress logs the progress of the loading process.
 	OnProgress func(ctx context.Context, format string, args ...any)
@@ -128,12 +130,12 @@ func (dl *DatasetLoader) loadFiles(ctx context.Context) error {
 	neighbors := fmt.Sprintf("%s/%s-neighbors-%s.ibin", baseDir, baseName, metric)
 
 	// Download test and neighbors files if missing.
-	if !fileExists(test) {
+	if dl.ResetCache || !fileExists(test) {
 		if err := dl.downloadAndUnzip(ctx, baseName, baseName+"-test.fbin.zip", test); err != nil {
 			return err
 		}
 	}
-	if !fileExists(neighbors) {
+	if dl.ResetCache || !fileExists(neighbors) {
 		fileName := baseName + "-neighbors-" + metric + ".ibin.zip"
 		if err := dl.downloadAndUnzip(ctx, baseName, fileName, neighbors); err != nil {
 			return err
@@ -179,7 +181,7 @@ func (dl *DatasetLoader) downloadTrainFiles(
 	// First, check for files in the cache.
 	onlyFileName := fmt.Sprintf("%s/%s.fbin", baseDir, baseName)
 	firstPartName := fmt.Sprintf("%s/%s-1.fbin", baseDir, baseName)
-	if !fileExists(onlyFileName) && !fileExists(firstPartName) {
+	if dl.ResetCache || (!fileExists(onlyFileName) && !fileExists(firstPartName)) {
 		// No files in cache, download them.
 		partNum := 0
 		for {


### PR DESCRIPTION
Previously, the vecindex roachtest would use the vecann default of attempting to reuse cached dataset files. This led to a situation where a test runner apparently cached a truncated file, causing the test to fail repeatedly when run from that runner. This patch changes the behavior to always download the dataset, so the test doesn't repeatedly flake.

Fixes: #157119
Release note: None