### PR TITLE
build: exclude .git from go_sdk archives

### DIFF
--- a/build/teamcity/internal/release/build-and-publish-patched-go/impl.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go/impl.sh
@@ -117,7 +117,7 @@ for CONFIG in $CONFIGS; do
         mv go/bin/${GOOS}_$GOARCH/* go/bin
         rm -r go/bin/${GOOS}_$GOARCH
     fi
-    tar cf - go | gzip -9 > /artifacts/go$GOVERS.$GOOS-$GOARCH.tar.gz
+    tar --exclude='.git' -cf - go | gzip -9 > /artifacts/go$GOVERS.$GOOS-$GOARCH.tar.gz
     rm -rf go/bin
 done
 

--- a/build/teamcity/internal/release/sign-patched-go.sh
+++ b/build/teamcity/internal/release/sign-patched-go.sh
@@ -41,7 +41,7 @@ sign() {
           --code-signature-flags runtime \
           "darwin-$1/go/bin/$bin"
     done
-    tar cf - -C "darwin-$1" go | gzip -9 > "artifacts/$archive"
+    tar --exclude='.git' -cf - -C "darwin-$1" go | gzip -9 > "artifacts/$archive"
     mkdir staging
     cp "darwin-$1/go/bin/gofmt" staging
     cp "darwin-$1/go/bin/go"    staging


### PR DESCRIPTION
The ~400mb .git directory isn't a *build* dep and makes the artifact about 2x bigger.

Release note: none.
Epic: none.