### PR TITLE
sql/logictest: skip distsql_inspect test under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_inspect
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_inspect
@@ -1,5 +1,7 @@
 # LogicTest: 5node-default-configs
 
+skip under race
+
 subtest setup
 
 statement ok


### PR DESCRIPTION
The distsql_inspect logic test was flaky while running under race. This change skips that test in that mode.

Informs #157826.

Release note: none