### PR TITLE
sql/catalog/lease: skip dropped regions when counting leases

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
     name = "lease_test",
     size = "large",
     srcs = [
+        "count_test.go",
         "helpers_test.go",
         "ie_writer_test.go",
         "kv_writer_test.go",

--- a/pkg/sql/catalog/lease/count_test.go
+++ b/pkg/sql/catalog/lease/count_test.go
@@ -1,0 +1,26 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package lease
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleRegionLivenessErrorsSkipsMissingRegion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	skip, err := handleRegionLivenessErrors(ctx, nil /* prober */, "us-east2", types.EnumValueNotYetPublicError)
+	require.NoError(t, err)
+	require.True(t, skip)
+}


### PR DESCRIPTION
countLeasesByRegion now skips regions that were just dropped instead of reporting “failed to count leases”. This was found in the TestMultiRegionTenantRegions test. We did have pre-existing logic to handle missing regions in handleRegionLivenessErrors, but it wasn't handled correctly by all the callers.

Resolves: #157122
Release note: none