### PR TITLE
mmaprototype: panic for no leaseholders

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -285,10 +285,7 @@ func (re *rebalanceEnv) rebalanceReplicas(
 			log.KvDistribution.VInfof(ctx, 2, "skipping r%d: too soon after failed change", rangeID)
 			continue
 		}
-		if !re.ensureAnalyzedConstraints(rstate) {
-			log.KvDistribution.VInfof(ctx, 2, "skipping r%d: constraints analysis failed", rangeID)
-			continue
-		}
+		re.ensureAnalyzedConstraints(rstate)
 		isVoter, isNonVoter := rstate.constraints.replicaRole(store.StoreID)
 		if !isVoter && !isNonVoter {
 			// Due to REQUIREMENT(change-computation), the top-k is up to date, so
@@ -486,10 +483,7 @@ func (re *rebalanceEnv) rebalanceLeases(
 			log.KvDistribution.VInfof(ctx, 2, "skipping r%d: too soon after failed change", rangeID)
 			continue
 		}
-		if !re.ensureAnalyzedConstraints(rstate) {
-			log.KvDistribution.VInfof(ctx, 2, "skipping r%d: constraints analysis failed", rangeID)
-			continue
-		}
+		re.ensureAnalyzedConstraints(rstate)
 		if rstate.constraints.leaseholderID != store.StoreID {
 			// We should not panic here since the leaseQueue may have shed the
 			// lease and informed MMA, since the last time MMA computed the


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: panic for no leaseholders**

This change commit ensureAnalyzedConstraints to panic when no leaseholder is
found instead of returning a bool that errors. This state of no leaseholder
should not occur — range messages are expected to include a leaseholder, and we
validate that pending changes to the range state should not result in a range
with no leaseholders.

