### PR TITLE
kvserver: verbose Raft logging for TestLeaseRequestBumpsEpoch

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1728,6 +1728,9 @@ func TestLeaseRequestBumpsEpoch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// This is to help investigate failures like #157128.
+	testutils.SetVModule(t, "raft=4")
+
 	testutils.RunValues(t, "lease-type", roachpb.TestingAllLeaseTypes(), func(t *testing.T, leaseType roachpb.LeaseType) {
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()


### PR DESCRIPTION
See #157128 for details about the test failure.

Closes: #157128

Release note: None