### PR TITLE
pkg/sql/catalog/lease: make table creation push test resilient

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1768,7 +1768,7 @@ func TestTableCreationPushesTxnsInRecentPast(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
-					MaxOffset: time.Second,
+					MaxOffset: 2 * time.Second,
 				},
 			},
 		},


### PR DESCRIPTION
Retry an insert with testutils.SucceedsSoon. This helps to resolve a testflake where the insert fails because it runs with a timestamp from before the schema change that created the table. Normally, the transaction gets pushed, but it can flake in multi-tenant environments.

Release note: none
Closes #157251