### PR TITLE
mma: eliminate pendingChangeNoRollback

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -257,16 +257,12 @@ func (a *allocatorState) ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoad
 func (a *allocatorState) AdjustPendingChangeDisposition(change ExternalRangeChange, success bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	rs, ok := a.cs.ranges[change.RangeID]
+	_, ok := a.cs.ranges[change.RangeID]
 	if !ok {
 		// Range no longer exists. This can happen if the StoreLeaseholderMsg
 		// which included the effect of the change that transferred the lease away
 		// was already processed, causing the range to no longer be tracked by the
 		// allocator.
-		return
-	}
-	if !success && rs.pendingChangeNoRollback {
-		// Not allowed to undo.
 		return
 	}
 	// NB: It is possible that some of the changes have already been enacted via

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -207,12 +207,12 @@ type ReplicaChange struct {
 	//     replica being demoted cannot retain the lease).
 	//
 	// NB: The prev value is always the state before the change. This is the
-	// source of truth provided by the leaseholder in the RangeMsg, so will
-	// have real ReplicaIDs (if already a replica) and real ReplicaTypes
+	// latest source of truth provided by the leaseholder in the RangeMsg, so
+	// will have real ReplicaIDs (if already a replica) and real ReplicaTypes
 	// (including types beyond VOTER_FULL and NON_VOTER). This source-of-truth
 	// claim is guaranteed by REQUIREMENT(change-computation) documented
-	// elsewhere, and the fact that new changes are computed only when there
-	// are no pending changes for a range.
+	// elsewhere, and the fact that new changes are computed only when there are
+	// no pending changes for a range.
 	//
 	// The ReplicaType in next is either the zero value (for removals), or
 	// {VOTER_FULL, NON_VOTER} for additions/change, i.e., it represents the
@@ -221,6 +221,9 @@ type ReplicaChange struct {
 	// TODO(tbg): in MakeLeaseTransferChanges, next.ReplicaType.ReplicaType is
 	// simply the current value, and not necessarily {VOTER_FULL, NON_VOTER}.
 	// So the above comment is incorrect. We should clean this up.
+	//
+	// The prev field is mutable after creation, to ensure that an undo restores
+	// the state to the latest source of truth from the leaseholder.
 	prev ReplicaState
 	next ReplicaIDAndType
 }
@@ -251,6 +254,9 @@ func (rc ReplicaChange) isUpdate() bool {
 	return changeType == AddLease || changeType == RemoveLease || changeType == ChangeReplica
 }
 
+// replicaChangeType returns the type of change currently represented by prev
+// and next. Since prev is mutable, the result of this method can change over
+// time.
 func (rc ReplicaChange) replicaChangeType() ReplicaChangeType {
 	prevExists := replicaExists(rc.prev.ReplicaID)
 	nextExists := replicaExists(rc.next.ReplicaID)
@@ -630,21 +636,17 @@ type pendingReplicaChange struct {
 	// expiry. All replica changes in a PendingRangeChange have the same
 	// startTime.
 	startTime time.Time
-	// gcTime represents a time when the unenacted change should be GC'd, either
-	// using the normal GC undo path, or if rangeState.pendingChangeNoRollback
-	// is true, when processing a RangeMsg from the leaseholder.
+	// gcTime represents a time when the unenacted change should be GC'd.
+	//
+	// Mutable after creation.
 	gcTime time.Time
-
-	// TODO(kvoli,sumeerbhola): Consider adopting an explicit expiration time,
-	// after which the change is considered to have been rejected. This would
-	// allow a different expiration time for different types of changes, e.g.,
-	// lease transfers would have a smaller expiration time than replica
-	// additions.
 
 	// When the change is known to be enacted based on the authoritative
 	// information received from the leaseholder, this value is set, so that even
 	// if the store with a replica affected by this pending change does not tell
 	// us about the enactment, we can garbage collect this change.
+	//
+	// Mutable after creation.
 	enactedAtTime time.Time
 }
 
@@ -955,7 +957,7 @@ type rangeState struct {
 	// that are still at the initial state, or an intermediate state, it can
 	// continue anticipating that these pending changes will happen. Tracking
 	// what is pending also allows for undo in the case of explicit failure,
-	// notified by AdjustPendingChangesDisposition.
+	// notified by AdjustPendingChangesDisposition, or GC.
 	//
 	// 2. Lifecycle
 	// pendingChanges track proposed modifications to a range's replicas or
@@ -981,17 +983,9 @@ type rangeState struct {
 	// has been enacted in this case.
 	//
 	// 2. Undone as failed: corresponding replica and load change is rolled back.
-	// Note that for replica changes that originate from one action, all changes
-	// would be undone together.
-	// NB: pending changes of a range state originate from one decision.
-	// Therefore, when one pending change is enacted successfully, we mark this
-	// range state's pending changes as no rollback (read more about this in 3).
-	// If we are here trying to undo a pending change but the range state has
-	// already been marked as no rollback, we do not undo the remaining pending
-	// changes. Instead, we wait for a StoreLeaseholderMsg to discard the pending
-	// changes and revert the load adjustments after the
-	// partiallyEnactedGCDuration has elapsed since the first enacted change. The
-	// modeling here is imperfect (read more about this in 3).
+	// Note that for replica changes that originate from one action, some changes
+	// can be considered done because of the leaseholder msg, and others can be
+	// rolled back (say due to GC).
 	//
 	// This happens when:
 	// - The pending change failed to apply via
@@ -1052,14 +1046,10 @@ type rangeState struct {
 	// the replica and leaseholder to s4. An intermediate state that can be
 	// observed is {s1, s2, s3, s4} with the lease still at s3. But the pending
 	// change for adding s4 includes both that it has a replica, and it has the
-	// lease, so we will not mark it done, and keep pretending that the whole
-	// change is pending. Since lease transfers are fast, we accept this
-	// imperfect modeling fidelity. One consequence of this imperfect modeling
-	// is that if in this example there are no further changes observed until
-	// GC, the allocator will undo both changes and go back to the state {s1,
-	// s2, s3} with s3 as the leaseholder. That is, it has forgotten that s4 was
-	// added. This is unavoidable and will be fixed by the first
-	// StoreLeaseholderMsg post-GC.
+	// lease, so we will not mark it done, and keep pretending that the change
+	// is pending. However, we will change the prev state to indicate that s4
+	// has a replica, so that undo (say due to GC) rolls back to the latest
+	// source-of-truth from the leaseholder.
 	//
 	// 4. Non Atomicity Hazard
 	//
@@ -1068,20 +1058,19 @@ type rangeState struct {
 	// to contend with the hazard of having two leaseholders or no leaseholders.
 	// In the earlier example, say s3 and s4 were both local stores (a
 	// multi-store node), it may be possible to observe an intermediate state
-	// {s1, s2, s3, s4} where s4 is the leaseholder. If we subsequently get a
-	// spurious AdjustPendingChangesDisposition(success=false) call, or
-	// time-based GC causes the s3 removal to be undone, there will be two
-	// replicas marked as the leaseholder. The other extreme is believing that
-	// the s3 transfer is done and the s4 incoming replica (and lease) failed
-	// (this may not actually be possible because of the surrounding code).
+	// {s1, s2, s3, s4} where s4 is the leaseholder. We need to ensure that if
+	// we subsequently get a spurious
+	// AdjustPendingChangesDisposition(success=false) call, or time-based GC
+	// causes the s3 removal to be undone, there will not be two replicas marked
+	// as the leaseholder. The other extreme is believing that the s3 transfer
+	// is done and the s4 incoming replica (and lease) failed (this may not
+	// actually be possible because of the surrounding code).
 	//
-	// We deal with this hazard by observing that we've constructed multiple
-	// pending changes in order to observe intermediate changes in the common
-	// case of success. Once one change in the set of changes is considered
-	// enacted, we mark the whole remaining group as no-rollback. In the above
-	// case, if we see s4 has become the leaseholder, the s1 removal can't undo
-	// itself -- it can be dropped if it is considered subsumed when processing
-	// a RangeMsg, or it can be GC'd.
+	// This hazard is dealt with in the same way outlined in the earlier
+	// example: when the leaseholder msg from s4 arrives that lists {s1, s2, s3,
+	// s4} as replicas, the prev state for the s3 change is updated to indicate
+	// that it is not the leaseholder. This means that if the change is undone,
+	// it will return to a prev state where it has a replica but not the lease.
 	//
 	// Additionally, when processing a RangeMsg, if any of the pending changes
 	// is considered inconsistent, all the pending changes are discarded. This
@@ -1101,11 +1090,6 @@ type rangeState struct {
 	// rangeState.pendingChanges across all ranges in clusterState.ranges will
 	// be identical to clusterState.pendingChanges.
 	pendingChanges []*pendingReplicaChange
-	// When set, the pendingChanges can not be rolled back anymore. They have
-	// to be enacted, or discarded wholesale in favor of the latest RangeMsg
-	// from the leaseholder. It is reset to false when pendingChanges
-	// transitions from empty to non-empty.
-	pendingChangeNoRollback bool
 
 	// If non-nil, it is up-to-date. Typically, non-nil for a range that has no
 	// pendingChanges and is not satisfying some constraint, since we don't want
@@ -1449,27 +1433,15 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 				// The change has been enacted according to the leaseholder.
 				enactedChanges = append(enactedChanges, change)
 			} else {
+				// Not subsumed. Replace the prev with the latest source of truth from
+				// the leaseholder. Note, this can be the noReplicaID case from above.
+				change.prev = adjustedReplica
 				remainingChanges = append(remainingChanges, change)
 			}
 		}
-		gcRemainingChanges := false
-		if rs.pendingChangeNoRollback {
-			// A previous StoreLeaseholderMsg has enacted some changes, so the
-			// remainingChanges may be GC'able. All of them share the same GC time.
-			// Note that normal GC will not GC these, since normal GC needs to undo,
-			// and we are not allowed to undo these.
-			if len(remainingChanges) > 0 {
-				gcTime := remainingChanges[0].gcTime
-				if gcTime.Before(now) {
-					gcRemainingChanges = true
-				}
-			}
-		} else if len(enactedChanges) > 0 && len(remainingChanges) > 0 {
-			// First time this set of changes is seeing something enacted, and there
-			// are remaining changes.
+		if len(enactedChanges) > 0 && len(remainingChanges) > 0 {
+			// There are remaining changes, so potentially update their gcTime.
 			//
-			// No longer permitted to rollback.
-			rs.pendingChangeNoRollback = true
 			// All remaining changes have the same gcTime.
 			curGCTime := remainingChanges[0].gcTime
 			revisedGCTime := now.Add(partiallyEnactedGCDuration)
@@ -1513,27 +1485,19 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 			// preCheckOnApplyReplicaChanges returns false if there are any pending
 			// changes, and these are the changes that are pending. This is hacky
 			// and should be cleaned up.
-			var valid bool
-			var reason redact.RedactableString
-			if gcRemainingChanges {
-				reason = "GCing remaining changes after partial enactment"
-			} else {
-				// NB: rs.pendingChanges contains the same changes as
-				// remainingChanges, but they are not the same slice.
-				rc := rs.pendingChanges
-				rs.pendingChanges = nil
-				err := cs.preCheckOnApplyReplicaChanges(PendingRangeChange{
-					RangeID:               rangeMsg.RangeID,
-					pendingReplicaChanges: remainingChanges,
-				})
-				valid = err == nil
-				if err != nil {
-					reason = redact.Sprint(err)
-				}
-				// Restore it.
-				rs.pendingChanges = rc
-			}
-			if valid {
+			//
+			// NB: rs.pendingChanges contains the same changes as
+			// remainingChanges, but they are not the same slice.
+			rc := rs.pendingChanges
+			rs.pendingChanges = nil
+			err := cs.preCheckOnApplyReplicaChanges(PendingRangeChange{
+				RangeID:               rangeMsg.RangeID,
+				pendingReplicaChanges: remainingChanges,
+			})
+			// Restore it.
+			rs.pendingChanges = rc
+
+			if err == nil {
 				// Re-apply the remaining changes. Note that the load change was not
 				// undone above, so we pass !applyLoadChange, to avoid applying it
 				// again. Also note that applyReplicaChange does not add to the various
@@ -1543,6 +1507,7 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 					cs.applyReplicaChange(change.ReplicaChange, false)
 				}
 			} else {
+				reason := redact.Sprint(err)
 				// The current state provided by the leaseholder does not permit these
 				// changes, so we need to drop them. This should be rare, but can happen
 				// if the leaseholder executed a change that MMA was completely unaware
@@ -1787,7 +1752,6 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		topk := ss.adjusted.topKRanges[msg.StoreID]
 		topk.doneInit()
 	}
-
 }
 
 // If the pending replica change does not happen within this GC duration, we
@@ -1820,15 +1784,6 @@ func (cs *clusterState) gcPendingChanges(now time.Time) {
 		rs, ok := cs.ranges[rangeID]
 		if !ok {
 			panic(errors.AssertionFailedf("range %v not found in cluster state", rangeID))
-		}
-
-		// Unlike normal GC that reverts changes, we want to discard these pending
-		// changes. Do nothing here; processStoreLeaseholderMsgInternal will later
-		// detect and discard these pending changes. Note that
-		// processStoreLeaseholderMsgInternal will not revert the pending load
-		// change.
-		if rs.pendingChangeNoRollback {
-			continue
 		}
 		if len(rs.pendingChanges) == 0 {
 			panic(errors.AssertionFailedf("no pending changes in range %v", rangeID))
@@ -1871,8 +1826,6 @@ func (cs *clusterState) pendingChangeEnacted(cid changeID, enactedAt time.Time) 
 }
 
 // undoPendingChange reverses the change with ID cid.
-//
-// REQUIRES: the change is not marked as no-rollback.
 func (cs *clusterState) undoPendingChange(cid changeID) {
 	change, ok := cs.pendingChanges[cid]
 	if !ok {
@@ -1881,10 +1834,6 @@ func (cs *clusterState) undoPendingChange(cid changeID) {
 	rs, ok := cs.ranges[change.rangeID]
 	if !ok {
 		panic(errors.AssertionFailedf("range %v not found in cluster state", change.rangeID))
-	}
-	if rs.pendingChangeNoRollback {
-		// One cannot undo changes once no-rollback is true.
-		panic(errors.AssertionFailedf("pending change is marked as no-rollback"))
 	}
 	// Wipe the analyzed constraints, as the range has changed.
 	rs.clearAnalyzedConstraints()
@@ -1944,9 +1893,8 @@ func (cs *clusterState) addPendingRangeChange(change PendingRangeChange) {
 		// Only the lease is being transferred.
 		gcDuration = pendingLeaseTransferGCDuration
 	}
-	pendingChanges := change.pendingReplicaChanges
 	now := cs.ts.Now()
-	for _, pendingChange := range pendingChanges {
+	for _, pendingChange := range change.pendingReplicaChanges {
 		cs.applyReplicaChange(pendingChange.ReplicaChange, true)
 		cs.changeSeqGen++
 		cid := cs.changeSeqGen
@@ -1959,11 +1907,9 @@ func (cs *clusterState) addPendingRangeChange(change PendingRangeChange) {
 		cs.pendingChanges[cid] = pendingChange
 		storeState.adjusted.loadPendingChanges[cid] = pendingChange
 		rangeState.pendingChanges = append(rangeState.pendingChanges, pendingChange)
-		rangeState.pendingChangeNoRollback = false
 		log.KvDistribution.VEventf(context.Background(), 3,
 			"addPendingRangeChange: change_id=%v, range_id=%v, change=%v",
 			cid, rangeID, pendingChange.ReplicaChange)
-		pendingChanges = append(pendingChanges, pendingChange)
 	}
 }
 
@@ -2030,8 +1976,6 @@ func (cs *clusterState) preCheckOnApplyReplicaChanges(rangeChange PendingRangeCh
 
 // preCheckOnUndoReplicaChanges does some validation of the changes being
 // proposed for undo.
-//
-// REQUIRES: the rangeState.pendingChangeNoRollback is false.
 //
 // This method is defensive since if we always check against the current state
 // before allowing a change to be added (including re-addition after a

--- a/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
@@ -15,7 +15,10 @@ import (
 // ExternalRangeChange is a proposed set of change(s) to a range. It can
 // consist of multiple replica changes, such as adding or removing replicas,
 // or transferring the lease. There is at most one change per store in the
-// set.
+// set. It is immutable after creation.
+//
+// It is a partial external representation of a set of changes that are
+// internally modeled using a slice of *pendingReplicaChanges.
 type ExternalRangeChange struct {
 	roachpb.RangeID
 	Changes []ExternalReplicaChange
@@ -23,6 +26,12 @@ type ExternalRangeChange struct {
 
 // ExternalReplicaChange is a proposed change to a single replica. Some
 // external entity (the leaseholder of the range) may choose to enact this
+// change.
+//
+// It is a partial external representation of a pendingReplicaChange that is
+// internal to MMA. While pendingReplicaChange has fields that are mutable,
+// since partial changes can be observed to a store, the ExternalReplicaChange
+// is immutable and represents the original before and after state of the
 // change.
 type ExternalReplicaChange struct {
 	changeID

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
@@ -92,7 +92,7 @@ store-leaseholder-msg
 store-id=1
   range-id=1 load=[80,80,80] raft-cpu=20
   config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
-    store-id=1 replica-id=2 type=VOTER_FULL leaseholder=true
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----
 
@@ -101,7 +101,7 @@ get-pending-changes
 ----
 pending(2)
 change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
-  prev=(replica-id=none type=VOTER_FULL)
+  prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
@@ -122,7 +122,7 @@ get-pending-changes
 ----
 pending(2)
 change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
-  prev=(replica-id=none type=VOTER_FULL)
+  prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s enacted=5s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
@@ -162,7 +162,7 @@ get-pending-changes
 ----
 pending(2)
 change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
-  prev=(replica-id=none type=VOTER_FULL)
+  prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s enacted=5s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
@@ -12,14 +12,11 @@
 #    s1) remains pending until s1 is removed from the replica set.
 # 3. Verifies enacted changes cannot be rejected (they're removed from
 #    pendingChanges).
-# 4. Verifies no-rollback changes cannot be rejected once any change in the
-#    set is enacted.
-# 5. Tracks load adjustments: pending changes adjust load until store-reported
+# 4. Tracks load adjustments: pending changes adjust load until store-reported
 #    load reflects the change (after 10s of enactment). After that, the change
 #    is removed from load tracking but may remain for GC.
-# 6. Tests GC: changes marked no-rollback cannot be GC'd via normal GC (which
-#    requires undo). They're only removed once store-reported load reflects the
-#    change.
+# 5. Tests GC and update of gcTime.
+# 6. Test update of ReplicaChange.prev based on latest leaseholder info.
 # 7. Rebalances back from s2 to s1 and verifies changes are GC'd after the
 #    normal GC duration.
 #
@@ -97,7 +94,7 @@ store-leaseholder-msg
 store-id=1
   range-id=1 load=[80,80,80] raft-cpu=20
   config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
-    store-id=1 replica-id=2 type=VOTER_FULL leaseholder=true
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----
 
@@ -106,7 +103,7 @@ get-pending-changes
 ----
 pending(2)
 change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
-  prev=(replica-id=none type=VOTER_FULL)
+  prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
@@ -117,7 +114,7 @@ store-leaseholder-msg
 store-id=2
   range-id=1 load=[80,80,80] raft-cpu=20
   config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
-    store-id=1 replica-id=2 type=VOTER_FULL
+    store-id=1 replica-id=1 type=VOTER_FULL
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 ----
 
@@ -128,17 +125,24 @@ range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 
 # The addition of replica and lease on s2 is considered enacted. The removal
-# of replica and lease from s1 is not yet enacted. The gc time is changes to
-# be 30s after the enactment.
+# of replica and lease from s1 is not yet enacted. The gc time is changed to
+# be 30s after the enactment. Note that the prev state of change 2 no longer
+# shows leaseholder=true since the lease has already been transferred.
 get-pending-changes
 ----
 pending(2)
 change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
-  prev=(replica-id=none type=VOTER_FULL)
+  prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 tick seconds=5
 ----
@@ -149,21 +153,10 @@ reject-pending-changes change-ids=(1) expect-panic
 ----
 pending(2)
 change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
-  prev=(replica-id=none type=VOTER_FULL)
+  prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
-  next=(replica-id=none type=VOTER_FULL)
-
-# Change 2 is found, but is no-rollback, so can't be rejected.
-reject-pending-changes change-ids=(2) expect-panic
-----
-pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
-  prev=(replica-id=none type=VOTER_FULL)
-  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 # Store load msg from s2, showing its new load.
@@ -191,7 +184,7 @@ get-pending-changes
 ----
 pending(1)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 # The adjusted load on s2 no longer reflects the addition of the replica and
@@ -203,21 +196,26 @@ store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:8
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
-# Advance time enough for change 2 to be eligible for undo GC.
-tick seconds=300
+# Advance time, but not enough to GC change 2.
+tick seconds=10
 ----
-t=5m10s
+t=20s
 
-# Even after the undo based GC time has elapsed change 2 cannot be undone
-# since it is no-rollback.
+# Change 2 is not undone.
 gc-pending-changes
 ----
 pending(1)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
-# Store leaseholder msg from s2, showing that s1 is no longer a replica.
+ranges
+----
+range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+
+# Store leaseholder msg from s2, showing that s1 is no longer a replica, so
+# change 2 is considered enacted.
 store-leaseholder-msg
 store-id=2
   range-id=1 load=[80,80,80] raft-cpu=20
@@ -225,12 +223,11 @@ store-id=2
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 ----
 
-# Now change 2 is considered enacted.
 get-pending-changes
 ----
 pending(1)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s enacted=5m10s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s enacted=20s
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 # Change 2 is still serving the purpose of adjusting the load on s1.
@@ -240,10 +237,9 @@ store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:8
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
-# Store load msg from s2, showing its new load. The enacted change is still
-# needed because the enactment time is equal to the load-time.
+# Store load msg from s2, showing its new load.
 store-load-msg
-  store-id=2 node-id=1 load=[85,85,85] capacity=[100,100,100] secondary-load=1 load-time=310s
+  store-id=2 node-id=1 load=[85,85,85] capacity=[100,100,100] secondary-load=1 load-time=20s
 ----
 
 get-load-info
@@ -254,13 +250,13 @@ store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:8
 
 tick seconds=20
 ----
-t=5m30s
+t=40s
 
 # Store load msg from s1, showing its new load. The enacted change is no
 # longer needed for load adjustment since load-time is 20s after the enactment
 # time (and lagForChangeReflectedInLoad is 10s).
 store-load-msg
-  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=330s
+  store-id=1 node-id=1 load=[5,5,5] capacity=[100,100,100] secondary-load=1 load-time=40s
 ----
 
 # No longer tracking change 2 for the sake of load.
@@ -279,10 +275,10 @@ make-pending-changes range-id=1
   rebalance-replica: remove-store-id=2 add-store-id=1
 ----
 pending(2)
-change-id=3 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m30s gc=10m30s
+change-id=3 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=40s gc=5m40s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=4 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m30s gc=10m30s
+change-id=4 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=40s gc=5m40s
   prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -296,7 +292,7 @@ store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:8
 # Enough time elapses to GC the changes.
 tick seconds=310
 ----
-t=10m40s
+t=5m50s
 
 gc-pending-changes
 ----
@@ -313,3 +309,81 @@ get-load-info
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=7
   top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+# Transfer the replica from s2 back to s1. The lease will also be transferred.
+make-pending-changes range-id=1
+  rebalance-replica: remove-store-id=2 add-store-id=1
+----
+pending(2)
+change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m50s gc=10m50s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m50s gc=10m50s
+  prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+ranges
+----
+range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=1 replica-id=unknown type=VOTER_FULL leaseholder=true
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=8
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+# Store leaseholder msg from s1, showing that s1 is a replica and has the lease, so
+# change 5 is considered enacted.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=3 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+----
+
+# Change 6 is not yet enacted, but the prev state no longer shows
+# leaseholder=true.
+get-pending-changes
+----
+pending(2)
+change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m50s gc=10m50s enacted=5m50s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m50s gc=6m20s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+ranges
+----
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=1 replica-id=3 type=VOTER_FULL leaseholder=true
+
+# store-id=2 still has top-k-ranges for local store s2 populated, since we
+# haven't yet received a store leaseholder msg from s2 indicating it no longer
+# is the leaseholder for r1.
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+  top-k-ranges (local-store-id=1) dim=ByteSize: r1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=8
+  top-k-ranges (local-store-id=2) dim=CPURate: r1
+
+# Change 6 is garbage collected since enough time has elapsed.
+gc-pending-changes
+----
+pending(2)
+change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m50s gc=10m50s enacted=5m50s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m50s gc=6m20s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=none type=VOTER_FULL)
+
+# So one change enacted and one was rolled back. This one leaseholder
+# invariant is still satisfied.
+ranges
+----
+range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+  store-id=1 replica-id=3 type=VOTER_FULL leaseholder=true

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
@@ -5,13 +5,13 @@
 # - The range initially initially sits on (n1s1,n3s3), and is then rebalanced to
 #   (n1s2,n3s4), i.e. moved between n1's two stores.
 # - The second half of the pending change (removal of s1) never gets enacted.
-# - That change is pending is no-rollback due to the first half having been enacted.
-#   After 30s (partiallyEnactedGCDuration) has elapsed since the partial
-#   enactment, the removal is GC'd with the next leaseholder message. In
-#   particular, this change does not have to wait for the much longer regular GC
-#   timeout.
+# - That pending change is gc'd after 30s (partiallyEnactedGCDuration) has
+#   elapsed since the partial enactment. In particular, this change does not
+#   have to wait for the much longer regular GC timeout.
 # - A second rebalance is carried out on the same range, while an enacted remnant
 #   of the first operation remains.
+# - A third rebalance is carried out between two non-leaseholder stores, and
+#   is partially enacted and partially gc'd.
 set-store
   store-id=1 node-id=1 attrs=purple locality-tiers=region=anywhere
   store-id=2 node-id=1 attrs=yellow locality-tiers=region=anywhere
@@ -93,7 +93,8 @@ store-id=2
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 ----
 
-# One change is considered enacted.
+# One change is considered enacted. The prev value of the second change is
+# updated, since the source-of-truth is the latest store leaseholder message.
 get-pending-changes
 ----
 pending(2)
@@ -101,7 +102,7 @@ change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 ranges
@@ -109,6 +110,20 @@ ranges
 range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
   store-id=3 replica-id=3 type=VOTER_FULL
+
+# store-id={1,3} still have top-k-ranges for local store s1 populated with r1,
+# since we haven't yet received a store leaseholder msg from s1 indicating it
+# no longer is the leaseholder for r1.
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 tick seconds=35
 ----
@@ -121,7 +136,7 @@ change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=35s
-  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 # Same store leaseholder msg from s2. The pending change for s1 is gc'd because
@@ -150,6 +165,9 @@ change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 
+# store-id={1,3} still have top-k-ranges for local store s1 populated with r1,
+# since we haven't yet received a store leaseholder msg from s1 indicating it
+# no longer is the leaseholder for r1.
 get-load-info
 ----
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
@@ -159,6 +177,22 @@ store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0,
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+
+# Store leaseholder msg from s1, indicating no leases.
+store-leaseholder-msg
+store-id=1
+----
+
+# No top-k ranges for local store s1 anymore.
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+  top-k-ranges (local-store-id=2) dim=ByteSize: r1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
@@ -184,12 +218,10 @@ t=45s
 get-load-info
 ----
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
-  top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-3, byte-size:-3] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
-  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
 
@@ -235,18 +267,8 @@ change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
-# Same store leaseholder msg from s2. The pending change for s3 is gc'd.
-store-leaseholder-msg
-store-id=2
-  range-id=1 load=[3,3,3] raft-cpu=2
-  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
-    store-id=1 replica-id=1 type=VOTER_FULL
-    store-id=3 replica-id=3 type=VOTER_FULL
-    store-id=4 replica-id=4 type=VOTER_FULL
-    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
-----
-
-get-pending-changes
+# The pending change for s3 is gc'd.
+gc-pending-changes
 ----
 pending(2)
 change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
@@ -256,15 +278,20 @@ change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
 
+ranges
+----
+range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+  store-id=1 replica-id=1 type=VOTER_FULL
+  store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+  store-id=4 replica-id=4 type=VOTER_FULL
+  store-id=3 replica-id=3 type=VOTER_FULL
+
 get-load-info
 ----
 store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
-  top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
-  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
-  top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
 store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_fail_lease_transfer.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_fail_lease_transfer.txt
@@ -1,0 +1,84 @@
+# Tests rebalancing a replica from one local store to another local store
+# (note, the test happens to use a second local store, but it can also be a
+# remote store and will have the same behavior). The lease transfer fails due
+# to GC.
+set-store
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1
+  store-id=2 node-id=1 attrs=yellow locality-tiers=region=us-west-1
+----
+node-id=1 locality-tiers=region=us-west-1,node=1
+  store-id=1 attrs=purple
+  store-id=2 attrs=yellow
+
+# Store s1 is the leaseholder and only replica for range r1.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[2,2,2] raft-cpu=1
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+----
+
+ranges
+----
+range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+
+# Transfer the replica from s1 to s2. The lease will also be transferred.
+make-pending-changes range-id=1
+  rebalance-replica: remove-store-id=1 add-store-id=2
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s
+  prev=(replica-id=none type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=5m0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+# Store leaseholder msg from s1, showing that s1 still has the replica and
+# lease, and s2 also has a replica.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[3,3,3] raft-cpu=2
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+----
+
+# Both pending changes are still not enacted. The prev state for change-id=1
+# reflects that s2 has a voter replica.
+get-pending-changes
+----
+pending(2)
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s
+  prev=(replica-id=2 type=VOTER_FULL)
+  next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=5m0s
+  prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
+  next=(replica-id=none type=VOTER_FULL)
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+
+# Advance time enough that the pending changes are GC'd.
+tick seconds=330
+----
+t=5m30s
+
+gc-pending-changes
+----
+pending(0)
+
+get-pending-changes
+----
+pending(0)
+
+# The GC rolls back to the last source-of-truth from the leaseholder,
+# indicating that s2 has a replica.
+ranges
+----
+range-id=1 local-store=1 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+  store-id=2 replica-id=2 type=VOTER_FULL
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true


### PR DESCRIPTION
Instead, the ReplicaChange.prev field is updated to reflect the latest state reported by the leaseholder.

In addition to simplifyin the code, it fixes an existing issue where an undo could rollback to a state preceding the latest leaseholder state.

Informs #157049

Epic: CRDB-55052

Release note: None