### PR TITLE
logictest: adjust recent test for high vmodule config

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/canary_stats
+++ b/pkg/sql/logictest/testdata/logic_test/canary_stats
@@ -64,7 +64,7 @@ SET TRACING = "off";
 
 # The first execution should miss the query cache.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache miss
 query cache add
@@ -80,7 +80,7 @@ SET TRACING = "off";
 
 # The second execution should hit the query cache.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache hit
 
@@ -99,7 +99,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 not using query cache
 
@@ -113,7 +113,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 not using query cache
 
@@ -133,7 +133,7 @@ SET TRACING = "off";
 
 # We should see the original cache is still there.
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 ----
 query cache hit
 
@@ -188,7 +188,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
 query cache miss (prepare)
 query cache hit (prepare)
@@ -210,7 +210,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
 reusing cached memo
 reusing cached memo
@@ -243,7 +243,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
 query cache hit (prepare)
 query cache hit (prepare)
@@ -272,7 +272,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
 not using query cache
 not using query cache
@@ -304,7 +304,7 @@ statement ok
 SET TRACING = "off";
 
 query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
+SELECT split_part(message, ':', 1) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%' OR message LIKE '%cached memo%';
 ----
 reusing cached memo
 reusing cached memo


### PR DESCRIPTION
As it turns out, with high vmodule on `plan_opt` file we include the query string into each logging message. We recently added some tests for canary stats that verify the query cache behavior, and we need to adjust those to ignore the optional suffix that contains the stmt.

Fixes: #157981
Fixes: #157982
Fixes: #157983
Fixes: #157984
Fixes: #157985
Fixes: #157986
Fixes: #157987
Fixes: #157988
Fixes: #157989

Release note: None