### PR TITLE
release-25.4: changefeedccl: remove DB-level syntax from docs

### DIFF
--- a/docs/generated/sql/bnf/create_changefeed_stmt.bnf
+++ b/docs/generated/sql/bnf/create_changefeed_stmt.bnf
@@ -4,11 +4,6 @@ create_changefeed_stmt ::=
 	| 'CREATE' 'CHANGEFEED' for_with_lookahead_variants changefeed_table_target ( ( ',' changefeed_table_target ) )* 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
 	| 'CREATE' 'CHANGEFEED' for_with_lookahead_variants changefeed_table_target ( ( ',' changefeed_table_target ) )* 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
 	| 'CREATE' 'CHANGEFEED' for_with_lookahead_variants changefeed_table_target ( ( ',' changefeed_table_target ) )* 'INTO' sink 
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )*
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_option db_level_changefeed_filter_option 'INTO' sink 
 	| 'CREATE' 'CHANGEFEED' 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )* 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause
 	| 'CREATE' 'CHANGEFEED' 'INTO' sink 'WITH' option ( ( ',' ( option '=' value | option | option '=' value | option ) ) )* 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause
 	| 'CREATE' 'CHANGEFEED' 'INTO' sink 'WITH' option '=' value ( ( ',' ( option '=' value | option | option '=' value | option ) ) )* 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -648,7 +648,6 @@ create_stats_stmt ::=
 
 create_changefeed_stmt ::=
 	'CREATE' 'CHANGEFEED' for_with_lookahead_variants changefeed_table_targets opt_changefeed_sink opt_with_options
-	| 'CREATE_CHANGEFEED_FOR_DATABASE' 'CHANGEFEED' 'FOR' 'DATABASE' database_name db_level_changefeed_filter_option opt_changefeed_sink opt_with_options
 	| 'CREATE' 'CHANGEFEED' opt_changefeed_sink opt_with_options 'AS' 'SELECT' target_list 'FROM' changefeed_target_expr opt_where_clause
 
 create_extension_stmt ::=
@@ -1961,11 +1960,6 @@ changefeed_table_targets ::=
 opt_changefeed_sink ::=
 	'INTO' string_or_placeholder
 
-db_level_changefeed_filter_option ::=
-	'EXCLUDE' 'TABLES' table_name_list
-	| 'INCLUDE' 'TABLES' table_name_list
-	| 
-
 target_list ::=
 	( target_elem ) ( ( ',' target_elem ) )*
 
@@ -2883,9 +2877,6 @@ create_stats_option_list ::=
 changefeed_table_target ::=
 	opt_table_prefix table_name opt_changefeed_family
 
-table_name_list ::=
-	db_object_name_list
-
 target_elem ::=
 	a_expr 'AS' target_name
 	| a_expr bare_col_label
@@ -2969,6 +2960,9 @@ row_or_rows ::=
 
 table_index_name_list ::=
 	( table_index_name ) ( ( ',' table_index_name ) )*
+
+table_name_list ::=
+	db_object_name_list
 
 view_name_list ::=
 	db_object_name_list
@@ -3560,9 +3554,6 @@ opt_changefeed_family ::=
 	'FAMILY' family_name
 	| 
 
-db_object_name_list ::=
-	( db_object_name ) ( ( ',' db_object_name ) )*
-
 target_name ::=
 	unrestricted_name
 
@@ -3635,6 +3626,9 @@ sortby_index ::=
 only_signed_fconst ::=
 	'+' 'FCONST'
 	| '-' 'FCONST'
+
+db_object_name_list ::=
+	( db_object_name ) ( ( ',' db_object_name ) )*
 
 inspect_option ::=
 	'INDEX' 'ALL'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6278,6 +6278,7 @@ create_changefeed_stmt:
   }
 | CREATE_CHANGEFEED_FOR_DATABASE CHANGEFEED FOR DATABASE database_name db_level_changefeed_filter_option opt_changefeed_sink opt_with_options
   {
+    /* SKIP DOC */
     $$.val = &tree.CreateChangefeed{
       DatabaseTarget: tree.ChangefeedDatabaseTarget($5),
       FilterOption: $6.changefeedFilterOption(),


### PR DESCRIPTION
DB-level feed is not available for public use yet and 
so it should not be documented.

Release note: None

Fixes: #158028
Release justification:  Removal of documentation for an unreleased feature.