### PR TITLE
colfetcher: emit periodic query progress update metadata

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -867,6 +867,7 @@ go_test(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/clusterunique",
+        "//pkg/sql/colfetcher",
         "//pkg/sql/contentionpb",
         "//pkg/sql/distsql",
         "//pkg/sql/execinfra",


### PR DESCRIPTION
This commit extends the query progress reporting that we do in the row-by-row tableReader to the vectorized scan operators too. Namely, after about 20k rows have been output, we'll emit the RowsRead metadata that we then use in DistSQLReceiver to update progressAtomic. Then the result shows up in `phase` column of SHOW QUERIES.

Fixes: #26639.

Release note (sql change): Queries executed via the vectorized engine now display their progress in `phase` column of SHOW QUERIES. Previously, this feature was only available in the row-by-row engine.