### PR TITLE
cli: filter standalone NOTICE lines in debug zip test output

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -698,6 +698,10 @@ func eraseNonDeterministicZipOutput(out string) string {
 	re = regexp.MustCompile(`(?m)^\[node \d+\] \d+ execution traces found$`)
 	out = re.ReplaceAllString(out, `[node ?] ? execution traces found`)
 
+	// Remove license-related NOTICE messages that may appear intermittently.
+	re = regexp.MustCompile(`(?m)^NOTICE: No license is installed.*\n?`)
+	out = re.ReplaceAllString(out, ``)
+
 	return out
 }
 


### PR DESCRIPTION
Remove intermittent license-related NOTICE messages from zip output in tests.

Resolves: #157888, #157889
Epic: None

Release note: None