### PR TITLE
ui: add 'Unreclaimed Disk Space' graph to storage dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -524,6 +524,45 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Unreclaimed Disk Space"
+      sources={storeSources}
+      isKvGraph={true}
+      tenantSource={tenantSource}
+      tooltip={
+        <div>
+          The estimated volume of physical bytes that are obsolete and should
+          eventually be reclaimed by compactions or other asynchronous
+          processes.
+        </div>
+      }
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        {multipleStoreMetrics(
+          [
+            {
+              prefix: "zombie sstables",
+              name: "cr.store.storage.sstable.zombie.bytes",
+              aggregateMax: true,
+            },
+            {
+              prefix: "range deletions",
+              name: "cr.store.storage.range_deletions.bytes",
+              aggregateMax: true,
+            },
+            {
+              prefix: "point deletions",
+              name: "cr.store.storage.point_deletions.bytes",
+              aggregateMax: true,
+            },
+          ],
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Blob File Sizes"
       sources={storeSources}
       isKvGraph={true}


### PR DESCRIPTION
Add an 'Unreclaimed Disk Space' graph to the storage dashboard showing estimates of common sources of space amplification:
- zombie sstables
- point tombstone estimated bytes
- range tombstone estimated bytes

<img width="986" height="428" alt="Screenshot 2025-11-19 at 11 59 44 AM" src="https://github.com/user-attachments/assets/917c9f1c-3b3a-4cb5-9def-441ea47edd44" />

Epic: none
Release note: none