### PR TITLE
release-25.2: release: fix redhat preflight component ID

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
@@ -80,7 +80,7 @@ docker run \
   --env PFLT_LOGLEVEL=error \
   --env PFLT_ARTIFACTS=/artifacts \
   --env PFLT_LOGFILE=/artifacts/preflight.log \
-  --env PFLT_CERTIFICATION_PROJECT_ID="$rhel_project_id" \
+  --env PFLT_CERTIFICATION_COMPONENT_ID="$rhel_project_id" \
   --env PFLT_PYXIS_API_TOKEN="$REDHAT_API_TOKEN" \
   --env PFLT_DOCKERCONFIG=/temp-authfile.json \
   --env DOCKER_CONFIG=/tmp/docker \


### PR DESCRIPTION
Backport 1/1 commits from #158064 on behalf of @rail.

----

Previously, the publish script was using PFLT_CERTIFICATION_PROJECT_ID to set the Red Hat preflight component ID, but it should be using PFLT_CERTIFICATION_COMPONENT_ID instead. This change corrects that environment variable to ensure proper functionality when publishing Red Hat releases.

See
https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1318 for the details.

Epic: none
Release note: none

----

Release justification: release automation changes