### PR TITLE
sql: set the default to allow_unsafe_internals to false

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           path: examples-orms
           repository: cockroachdb/examples-orms
-          ref: 876b2d52ae2b63aa9cc1741c8d189ff0b66ab0d7
+          ref: 4422aff128585c3e0558b530558daa31972c3a40
       - name: compute metadata
         run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
       - run: ./cockroach/build/github/get-engflow-keys.sh

--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach
     environment:
-      - COCKROACH_ACCEPTANCE_ALLOW_UNSAFE=true
+      - COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS=true
     volumes:
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   flyway:

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -13,7 +13,7 @@ services:
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach
     environment:
       - KRB5_KTNAME=/keytab/crdb.keytab
-      - COCKROACH_ACCEPTANCE_ALLOW_UNSAFE=true
+      - COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS=true
     volumes:
       - ${CERTS_DIR:-../../.localcluster.certs}:/certs
       - keytab:/keytab

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach
     environment:
       - KRB5_KTNAME=/keytab/crdb.keytab
-      - COCKROACH_ACCEPTANCE_ALLOW_UNSAFE=true
+      - COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS=true
     volumes:
       - ${CERTS_DIR:-../../.localcluster.certs}:/certs
       - keytab:/keytab

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -964,6 +964,11 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		args.SSLCertsDir = demoDir
 	}
 
+	// Allow access to system and crdb_internal tables in demo mode.
+	// Demo mode is for development/testing, so we want to allow access
+	// to these tables for debugging and introspection.
+	serverutils.SetUnsafeOverride(&args.Knobs)
+
 	return args
 }
 

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -140,6 +140,10 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			actual.StoreSpecs = nil
 			actual.Knobs.JobsTestingKnobs = nil
 
+			// Copy the SQLEvalContext from actual to expected since it's set by SetUnsafeOverride
+			// and contains function pointers that we can't predict
+			tc.expected.Knobs.SQLEvalContext = actual.Knobs.SQLEvalContext
+
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -9,7 +9,7 @@ system "mkdir -p logs"
 set histfile "cockroach_sql_history"
 
 set ::env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
-set ::env(COCKROACH_ACCEPTANCE_ALLOW_UNSAFE) "true"
+set ::env(COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS) "true"
 set ::env(COCKROACH_CONNECT_TIMEOUT) 15
 set ::env(COCKROACH_SQL_CLI_HISTORY) $histfile
 # Set client commands as insecure. The server uses --insecure.

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -83,6 +84,16 @@ func (s *topLevelServer) newTenantServer(
 
 	// Apply the TestTenantArgs, if any.
 	baseCfg.TestingKnobs = testArgs.Knobs
+
+	// If we're in a test environment (the parent server has testing knobs), apply unsafe override
+	// for dynamically started tenants to allow access to crdb_internal and system tables.
+	// This is needed because tests might start tenants via SQL (ALTER TENANT ... START SERVICE SHARED)
+	// without explicitly setting up test args.
+	if s.cfg.TestingKnobs != (base.TestingKnobs{}) && baseCfg.TestingKnobs == (base.TestingKnobs{}) {
+		// Only set unsafe override if no testing knobs were provided through testArgs.
+		// This ensures we don't override explicitly set test knobs.
+		serverutils.SetUnsafeOverride(&baseCfg.TestingKnobs)
+	}
 
 	tenantServer, err := newTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer, s.db.AdmissionPacerFactory)
 	if err != nil {

--- a/pkg/server/tenant_delayed_id_set_test.go
+++ b/pkg/server/tenant_delayed_id_set_test.go
@@ -73,6 +73,9 @@ func TestStartTenantWithDelayedID(t *testing.T) {
 		}, nil
 	}
 
+	// Allow unsafe introspection.
+	serverutils.SetUnsafeOverride(&baseCfg.TestingKnobs)
+
 	go func() {
 		sw, err := NewSeparateProcessTenantServer(
 			ctx,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -700,6 +700,7 @@ func (ts *testServer) setupTenantTestingKnobs(tenantKnobs *base.TestingKnobs) {
 		}
 		tenantKnobs.Server.(*TestingKnobs).StubTimeNow = ts.params.Knobs.Server.(*TestingKnobs).StubTimeNow
 	}
+	serverutils.SetUnsafeOverride(tenantKnobs)
 	if ts.params.Knobs.UpgradeManager != nil {
 		tenantKnobs.UpgradeManager.(*upgradebase.TestingKnobs).SkipSomeUpgradeSteps = ts.params.Knobs.UpgradeManager.(*upgradebase.TestingKnobs).SkipSomeUpgradeSteps
 	}
@@ -1394,6 +1395,10 @@ func (ts *testServer) StartSharedProcessTenant(
 		_, err := ie.ExecEx(ctx, opName, nil /* txn */, sessiondata.NodeUserSessionDataOverride, stmt, qargs...)
 		return err
 	}
+
+	// Allow access to unsafe internals for the tenant server in test environments.
+	serverutils.SetUnsafeOverride(&args.Knobs)
+
 	// Save the args for use if the server needs to be created.
 	func() {
 		ts.topLevelServer.serverController.mu.Lock()
@@ -1772,6 +1777,9 @@ func (ts *testServer) StartTenant(
 		}
 		stopper.SetTracer(tr)
 	}
+
+	// Allow access to unsafe internals on this tenant.
+	serverutils.SetUnsafeOverride(&params.TestingKnobs)
 
 	baseCfg := makeTestBaseConfig(st, stopper.Tracer())
 	baseCfg.TestingKnobs = params.TestingKnobs

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -110,6 +110,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -793,6 +794,15 @@ var CreateTableWithSchemaLocked = settings.RegisterBoolSetting(
 		"default value for the create_table_with_schema_locked session setting; controls "+
 		"if new created tables will have schema_locked set",
 	true)
+
+var defaultAllowUnsafeInternals = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.override.allow_unsafe_internals.enabled",
+	"overrides the allow_unsafe_internals session variable default settings"+
+		" as a failsafe in case of emergencies. This setting should not be"+
+		" externally visible.",
+	envutil.EnvOrDefaultBool("COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS", false),
+	settings.WithUnsafe)
 
 // createTableWithSchemaLockedDefault override for the schema_locked
 var createTableWithSchemaLockedDefault = true

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1357,6 +1357,9 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath, upgradeBinaryPath 
 	var envVars []string
 	// Set crash reporting URL to the empty string to disable Sentry crash reports.
 	envVars = append(envVars, "COCKROACH_CRASH_REPORTS=")
+	// Allow access to crdb_internal for mixed-version tests that need to check versions
+	// and for the framework's object validation queries.
+	envVars = append(envVars, "COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS=true")
 	if strings.Contains(upgradeBinaryPath, "cockroach-short") {
 		// If we're using a cockroach-short binary, that means it was
 		// locally built, so we need to opt-out of version offsetting to

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4077,7 +4077,7 @@ variable                                                         value
 allow_create_trigger_function_with_argv_references               off
 allow_ordinal_column_references                                  off
 allow_role_memberships_to_change_during_transaction              off
-allow_unsafe_internals                                           on
+allow_unsafe_internals                                           off
 alter_primary_region_super_region_override                       off
 always_distribute_full_scans                                     off
 application_name                                                 ·

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3023,7 +3023,7 @@ name                                                             setting        
 allow_create_trigger_function_with_argv_references               off                 NULL      NULL        NULL        string
 allow_ordinal_column_references                                  off                 NULL      NULL        NULL        string
 allow_role_memberships_to_change_during_transaction              off                 NULL      NULL        NULL        string
-allow_unsafe_internals                                           on                  NULL      NULL        NULL        string
+allow_unsafe_internals                                           off                 NULL      NULL        NULL        string
 alter_primary_region_super_region_override                       off                 NULL      NULL        NULL        string
 always_distribute_full_scans                                     off                 NULL      NULL        NULL        string
 application_name                                                 ·                   NULL      NULL        NULL        string
@@ -3272,7 +3272,7 @@ name                                                             setting        
 allow_create_trigger_function_with_argv_references               off                 NULL  user     NULL      off                 off
 allow_ordinal_column_references                                  off                 NULL  user     NULL      off                 off
 allow_role_memberships_to_change_during_transaction              off                 NULL  user     NULL      off                 off
-allow_unsafe_internals                                           on                  NULL  user     NULL      on                  on
+allow_unsafe_internals                                           off                 NULL  user     NULL      off                 off
 alter_primary_region_super_region_override                       off                 NULL  user     NULL      off                 off
 always_distribute_full_scans                                     off                 NULL  user     NULL      off                 off
 application_name                                                 ·                   NULL  user     NULL      ·                   ·

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -40,7 +40,7 @@ variable                                                         value
 allow_create_trigger_function_with_argv_references               off
 allow_ordinal_column_references                                  off
 allow_role_memberships_to_change_during_transaction              off
-allow_unsafe_internals                                           on
+allow_unsafe_internals                                           off
 alter_primary_region_super_region_override                       off
 always_distribute_full_scans                                     off
 application_name                                                 ·

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -895,7 +895,8 @@ func (b *Builder) constructUnary(
 var SupportedCRDBInternalBuiltins = map[string]struct{}{
 	// LOCKED: Do not add to this list.
 	// Supported builtins should now be added to information_schema.
-	`crdb_internal.datums_to_bytes`: {},
+	`crdb_internal.datums_to_bytes`:           {},
+	`crdb_internal.increment_feature_counter`: {},
 }
 
 // isUnsafeBuiltin returns true if the given function definition

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -300,6 +300,7 @@ func New(catalog cat.Catalog, sqlStr string) *OptTester {
 	// Set non-default session settings.
 	ot.evalCtx.SessionData().UserProto = username.MakeSQLUsernameFromPreNormalizedString("opttester").EncodeProto()
 	ot.evalCtx.SessionData().Database = "defaultdb"
+	ot.evalCtx.SessionData().AllowUnsafeInternals = true
 	ot.evalCtx.SessionData().ZigzagJoinEnabled = true
 
 	return ot

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionmutator"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -4395,12 +4394,11 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowUnsafeInternals), nil
 		},
-		GlobalDefault: func(_ *settings.Values) string {
-			if envutil.EnvOrDefaultBool("COCKROACH_ACCEPTANCE_ALLOW_UNSAFE", false) {
+		GlobalDefault: func(sv *settings.Values) string {
+			if defaultAllowUnsafeInternals.Get(sv) {
 				return "on"
 			}
-			// In 26.1 we will change the default to false/off.
-			return "on"
+			return "off"
 		},
 	},
 


### PR DESCRIPTION
The system and crdb_internal namespaces have historically been open access for anyone who wants to use them. This has caused problems in the past, as many of the objects in these namespaces were developed for internal use only, and have been discovered and misused by operators, which have created difficult to recover from failures.

To avoid this in the future, and provide better visibility into use of these objects, we'll begin gating access to them, requiring customers to manually override access to these records, and auditing visibly on their usage.

This PR is the final step in this process, changing the default of this already existing gate, and merging a few utilities for testing and extenuating overrides.

Fixes: #149595
Epic: CRDB-55276
Release note (ops change): All queries to system and crdb_internal by default will begin failing, notifying users that they must override the access gate if they wish to use those namespaces.