### PR TITLE
catalog/lease: add support for bulk leasing

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -101,6 +101,8 @@ go_test(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
+        "//pkg/rpc",
+        "//pkg/rpc/nodedialer",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -58,6 +58,9 @@ type descriptorState struct {
 		// acquisition finishes but indicate that that new lease is expired are not
 		// ignored.
 		acquisitionsInProgress int
+
+		// acquisitionChannel indicates that a bulk acquisition is in progress.
+		acquisitionChannel chan struct{}
 	}
 }
 

--- a/pkg/sql/catalog/lease/ie_writer_test.go
+++ b/pkg/sql/catalog/lease/ie_writer_test.go
@@ -61,4 +61,13 @@ func (w *ieWriter) insertLease(ctx context.Context, txn *kv.Txn, l leaseFields) 
 	return nil
 }
 
+func (w *ieWriter) insertLeases(ctx context.Context, txn *kv.Txn, leases []leaseFields) error {
+	for _, l := range leases {
+		if err := w.insertLease(ctx, txn, l); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var _ writer = (*ieWriter)(nil)

--- a/pkg/sql/catalog/lease/kv_writer_test.go
+++ b/pkg/sql/catalog/lease/kv_writer_test.go
@@ -282,4 +282,11 @@ func (t teeWriter) insertLease(ctx context.Context, txn *kv.Txn, fields leaseFie
 	)
 }
 
+func (t teeWriter) insertLeases(ctx context.Context, txn *kv.Txn, leases []leaseFields) error {
+	return errors.CombineErrors(
+		t.a.insertLeases(ctx, txn, leases),
+		t.b.insertLeases(ctx, txn, leases),
+	)
+}
+
 var _ writer = (*teeWriter)(nil)

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -573,12 +573,15 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 	}
 	expiration := lease.Expiration(context.Background())
 	// Acquire another lease.
-	if _, err := leaseManager.acquireNodeLease(
-		context.Background(), tableDesc.GetID(), AcquireBlock,
-	); err != nil {
-		t.Fatal(err)
-	}
-
+	func() {
+		lease.t.markAcquisitionStart(context.Background())
+		defer lease.t.markAcquisitionDone(context.Background())
+		if _, err := leaseManager.acquireNodeLease(
+			context.Background(), tableDesc.GetID(), AcquireBlock,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	// Check the name resolves to the new lease.
 	newLease, _ := leaseManager.names.get(context.Background(), tableDesc.GetParentID(), tableDesc.GetParentSchemaID(), tableName, s.Clock().Now())
 	if newLease == nil {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1849,6 +1849,10 @@ func (t *logicTest) newCluster(
 			); err != nil {
 				t.Fatal(err)
 			}
+			if _, err := conn.Exec(
+				"SET CLUSTER SETTING sql.catalog.allow_leased_descriptors.prefetch.enabled = true"); err != nil {
+				t.Fatal(err)
+			}
 		}
 		// We disable the automatic stats collection in order to have
 		// deterministic tests.

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -206,6 +206,11 @@ func (f fakeLeaseManager) Acquire(
 	return ld, nil
 }
 
+func (f fakeLeaseManager) EnsureBatch(ctx context.Context, ids []descpb.ID) error {
+	// Nothing needs to be cached in memory for this implementation.
+	return nil
+}
+
 func (f fakeLeaseManager) IncGaugeAfterLeaseDuration(gauge lease.AfterLeaseDurationGauge) func() {
 	return func() {}
 }


### PR DESCRIPTION
This patch does the following to help support bulk leasing in the crdb_internal / pg_catalog / information_schema views:

1. Refactor the storage layer for the lease manager to support bulk acquisitions by introducing a new `acquireBatch` API, which allows the lease manager to acquire multiple leases in a transaction. This also is used to implement `acquire`
2. Add a new `EnsureBatch` public method in the lease manager, which allows the lease manager to acquire multiple leases into memory, which acts as a prefetch mechanism. If a normal acquisition occurs concurrently it will correctly wait for the bulk acquisition to complete.
3. Modification to descriptor collection API to use EnsureBatch in the GetAll.* API.


New benchmarks for these change and leased descriptors vs KV in GetAll.*:

```
Cold
======================
BenchmarkLargeDatabaseColdPgClass/pg_class/leased_descriptors=true/use_prefetch=true/tables=8192         	1000000000	         0.7835 ns/op	       0 B/op	       0 allocs/op
BenchmarkLargeDatabaseColdPgClass/pg_class/leased_descriptors=true/use_prefetch=false/tables=8192        	       1	8642132499 ns/op	1731154008 B/op	12307123 allocs/op
BenchmarkLargeDatabaseColdPgClass/pg_class/leased_descriptors=false/use_prefetch=false/tables=8192       	1000000000	         0.3063 ns/op	       0 B/op	       0 allocs/op

Warm
======================
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=true/use_prefetch=true/tables=8192         	       6	 170890458 ns/op	90846753 B/op	  428243 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=true/use_prefetch=false/tables=8192        	       7	 192905720 ns/op	91194598 B/op	  431132 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=false/use_prefetch=false/tables=8192       	       4	 269645802 ns/op	243010064 B/op	 1401622 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=true/use_prefetch=true/tables=16384        	       3	 352242778 ns/op	182838792 B/op	  847251 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=true/use_prefetch=false/tables=16384       	       3	 399849806 ns/op	182671565 B/op	  847271 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=false/use_prefetch=false/tables=16384      	       2	 582772520 ns/op	488168660 B/op	 2793079 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=true/use_prefetch=true/tables=32768        	       2	 778396542 ns/op	365770676 B/op	 1690881 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=true/use_prefetch=false/tables=32768       	       2	 803655520 ns/op	364708036 B/op	 1685706 allocs/op
BenchmarkLargeDatabaseWarmPgClass/pg_class/leased_descriptors=false/use_prefetch=false/tables=32768      	       1	1300587666 ns/op	977227432 B/op	 5585049 allocs/tp

```

fixes https://github.com/cockroachdb/cockroach/issues/154565