### PR TITLE
sql: add logic tests for `ALTER TABLE ALTER COLUMN` identity options

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4382,6 +4382,27 @@ ALTER TABLE t_alter_identity ALTER COLUMN z SET START WITH 5;
 
 # Verify sequence options are implemented on the identity
 
+statement error sequence option "AS" not supported here
+ALTER TABLE t_alter_identity ALTER COLUMN a SET AS INT4;
+
+statement error pq: unimplemented: CYCLE option is not supported
+ALTER TABLE t_alter_identity ALTER COLUMN a SET CYCLE;
+
+statement ok
+ALTER TABLE t_alter_identity ALTER COLUMN a SET NO CYCLE;
+
+statement error sequence option "OWNED BY" not supported here
+ALTER TABLE t_alter_identity ALTER COLUMN a SET OWNED BY NONE;
+
+statement ok
+ALTER TABLE t_alter_identity ALTER COLUMN a SET PER NODE CACHE 5;
+
+statement ok
+ALTER TABLE t_alter_identity ALTER COLUMN a SET PER SESSION CACHE 5;
+
+statement error sequence option "VIRTUAL" not supported here
+ALTER TABLE t_alter_identity ALTER COLUMN a SET VIRTUAL;
+
 statement ok
 INSERT INTO t_alter_identity DEFAULT VALUES;
 


### PR DESCRIPTION
The tests were incomplete. These options aren't supported so this is
for consistency between the legacy and declarative schema changers.

Epic: CRDB-31283
Part of: #142914

Release note: None
