### PR TITLE
roachtest: increase Cleanup timeout for disk stall test

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -254,7 +254,7 @@ func runDiskStalledDetection(
 	// the disk stalled will prevent artifact collection, making debugging
 	// difficult.
 	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		s.Cleanup(ctx)
 	}()


### PR DESCRIPTION
In this test, cleanup involves running
`sudo apt-get install -y snapd`, which can take a while. Increase the
timeout to 5 minutes.

Informs: #157978
Release note: None