### PR TITLE
sql: add ALTER TABLE ... SET SCHEMA to the declerative schema changer 

### DIFF
--- a/pkg/backup/testdata/backup-restore/plpgsql_procedures
+++ b/pkg/backup/testdata/backup-restore/plpgsql_procedures
@@ -188,11 +188,10 @@ ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
 pq: cannot rename relation "db1_new.sc1.tbl1" because procedure "p1" depends on it
 HINT: consider dropping "p1" first.
 
-# TODO(mgartner): The error message should say "procedure".
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "p1" depends on it
+pq: cannot set schema on relation "db1_new.sc1.tbl1" because procedure "p1" depends on it
 HINT: consider dropping "p1" first.
 
 exec-sql
@@ -389,7 +388,7 @@ HINT: consider dropping "p1" first.
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "p1" depends on it
+pq: cannot set schema on relation "db1.sc1.tbl1" because procedure "p1" depends on it
 HINT: consider dropping "p1" first.
 
 exec-sql

--- a/pkg/backup/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/backup/testdata/backup-restore/plpgsql_user_defined_functions
@@ -253,7 +253,7 @@ HINT: consider dropping "f1" first.
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "f1" depends on it
+pq: cannot set schema on relation "db1_new.sc1.tbl1" because function "f1" depends on it
 HINT: consider dropping "f1" first.
 
 exec-sql
@@ -469,7 +469,7 @@ HINT: consider dropping "f1" first.
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "f1" depends on it
+pq: cannot set schema on relation "db1.sc1.tbl1" because function "f1" depends on it
 HINT: consider dropping "f1" first.
 
 exec-sql

--- a/pkg/backup/testdata/backup-restore/procedures
+++ b/pkg/backup/testdata/backup-restore/procedures
@@ -174,11 +174,10 @@ ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
 pq: cannot rename relation "db1_new.sc1.tbl1" because procedure "p1" depends on it
 HINT: consider dropping "p1" first.
 
-# TODO(mgartner): The error message should say "procedure".
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "p1" depends on it
+pq: cannot set schema on relation "db1_new.sc1.tbl1" because procedure "p1" depends on it
 HINT: consider dropping "p1" first.
 
 exec-sql
@@ -361,7 +360,7 @@ HINT: consider dropping "p1" first.
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "p1" depends on it
+pq: cannot set schema on relation "db1.sc1.tbl1" because procedure "p1" depends on it
 HINT: consider dropping "p1" first.
 
 exec-sql

--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -223,7 +223,7 @@ pq: cannot rename relation "db1_new.sc1.tbl1" because trigger "tr1" on table "tb
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because trigger "tr1" on table "tbl1" depends on it
+pq: cannot set schema on relation "db1_new.sc1.tbl1" because trigger "tr1" on table "tbl1" depends on it
 
 exec-sql
 DROP TYPE sc1.enum1

--- a/pkg/backup/testdata/backup-restore/user-defined-functions
+++ b/pkg/backup/testdata/backup-restore/user-defined-functions
@@ -171,7 +171,7 @@ HINT: consider dropping "f1" first.
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "f1" depends on it
+pq: cannot set schema on relation "db1_new.sc1.tbl1" because function "f1" depends on it
 HINT: consider dropping "f1" first.
 
 exec-sql
@@ -358,7 +358,7 @@ HINT: consider dropping "f1" first.
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because function "f1" depends on it
+pq: cannot set schema on relation "db1.sc1.tbl1" because function "f1" depends on it
 HINT: consider dropping "f1" first.
 
 exec-sql

--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -491,6 +491,13 @@ func TestBackupRollbacks_base_alter_table_rename_multiple_columns(t *testing.T) 
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1279,6 +1286,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_rename_multiple_columns(t 
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_multiple_columns"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2073,6 +2087,13 @@ func TestBackupSuccess_base_alter_table_rename_multiple_columns(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2861,6 +2882,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_rename_multiple_columns(t *t
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_multiple_columns"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
@@ -19,7 +19,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → DROPPED Database:{DescID: 104 (multi_region_test_db-)}
  │         │    ├── PUBLIC → ABSENT  DatabaseRoleSetting:{DescID: 104 (multi_region_test_db-), Name: "__placeholder_role_name__"}
  │         │    ├── PUBLIC → ABSENT  DatabaseRegionConfig:{DescID: 104 (multi_region_test_db-), ReferencedDescID: 106 (crdb_internal_region-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (crdb_internal_region-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "public"}
@@ -29,21 +29,21 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → ABSENT  EnumTypeValue:{DescID: 106 (crdb_internal_region-), Name: "us-east2"}
  │         │    ├── PUBLIC → ABSENT  EnumTypeValue:{DescID: 106 (crdb_internal_region-), Name: "us-east3"}
  │         │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 106 (crdb_internal_region-), ReferencedDescID: 105 (public-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "root"}
  │         │    ├── PUBLIC → DROPPED Schema:{DescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  SchemaParent:{DescID: 105 (public-), ReferencedDescID: 104 (multi_region_test_db-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (_crdb_internal_region-), Name: "_crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (_crdb_internal_region-), Name: "_crdb_internal_region", ReferencedDescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (_crdb_internal_region-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "root"}
  │         │    ├── PUBLIC → DROPPED AliasType:{DescID: 107 (_crdb_internal_region-), ReferencedTypeIDs: [106 (crdb_internal_region-), 107 (_crdb_internal_region-)]}
  │         │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 107 (_crdb_internal_region-), ReferencedDescID: 105 (public-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_table-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "root"}
@@ -108,10 +108,12 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"root"}
  │              ├── MarkDescriptorAsDropped {"DescriptorID":105}
  │              ├── RemoveSchemaParent {"Parent":{"ParentDatabaseID":104,"SchemaID":105}}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_crdb_internal_r...","SchemaID":105}}
  │              ├── NotImplementedForPublicObjects {"DescID":107,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"root"}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"table_regional_b...","SchemaID":105}}
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
@@ -127,8 +129,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
- │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_crdb_internal_r...","SchemaID":105}}
- │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"table_regional_b...","SchemaID":105}}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
  │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
@@ -157,7 +157,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │    │    │    ├── DROPPED → PUBLIC Database:{DescID: 104 (multi_region_test_db-)}
  │    │    │    ├── ABSENT  → PUBLIC DatabaseRoleSetting:{DescID: 104 (multi_region_test_db-), Name: "__placeholder_role_name__"}
  │    │    │    ├── ABSENT  → PUBLIC DatabaseRegionConfig:{DescID: 104 (multi_region_test_db-), ReferencedDescID: 106 (crdb_internal_region-)}
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 105 (public-)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 106 (crdb_internal_region-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "public"}
@@ -167,21 +167,21 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │    │    │    ├── ABSENT  → PUBLIC EnumTypeValue:{DescID: 106 (crdb_internal_region-), Name: "us-east2"}
  │    │    │    ├── ABSENT  → PUBLIC EnumTypeValue:{DescID: 106 (crdb_internal_region-), Name: "us-east3"}
  │    │    │    ├── ABSENT  → PUBLIC SchemaChild:{DescID: 106 (crdb_internal_region-), ReferencedDescID: 105 (public-)}
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 105 (public-), Name: "public", ReferencedDescID: 104 (multi_region_test_db-)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 105 (public-), Name: "public"}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 105 (public-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (public-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (public-), Name: "public"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (public-), Name: "root"}
  │    │    │    ├── DROPPED → PUBLIC Schema:{DescID: 105 (public-)}
  │    │    │    ├── ABSENT  → PUBLIC SchemaParent:{DescID: 105 (public-), ReferencedDescID: 104 (multi_region_test_db-)}
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (_crdb_internal_region-), Name: "_crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (_crdb_internal_region-), Name: "_crdb_internal_region", ReferencedDescID: 105 (public-)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 107 (_crdb_internal_region-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "public"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "root"}
  │    │    │    ├── DROPPED → PUBLIC AliasType:{DescID: 107 (_crdb_internal_region-), ReferencedTypeIDs: [106 (crdb_internal_region-), 107 (_crdb_internal_region-)]}
  │    │    │    ├── ABSENT  → PUBLIC SchemaChild:{DescID: 107 (_crdb_internal_region-), ReferencedDescID: 105 (public-)}
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db-)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 105 (public-)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 108 (table_regional_by_table-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "root"}
@@ -225,7 +225,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → DROPPED Database:{DescID: 104 (multi_region_test_db-)}
  │         │    ├── PUBLIC → ABSENT  DatabaseRoleSetting:{DescID: 104 (multi_region_test_db-), Name: "__placeholder_role_name__"}
  │         │    ├── PUBLIC → ABSENT  DatabaseRegionConfig:{DescID: 104 (multi_region_test_db-), ReferencedDescID: 106 (crdb_internal_region-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (crdb_internal_region-), Name: "crdb_internal_region", ReferencedDescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (crdb_internal_region-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (crdb_internal_region-), Name: "public"}
@@ -235,21 +235,21 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → ABSENT  EnumTypeValue:{DescID: 106 (crdb_internal_region-), Name: "us-east2"}
  │         │    ├── PUBLIC → ABSENT  EnumTypeValue:{DescID: 106 (crdb_internal_region-), Name: "us-east3"}
  │         │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 106 (crdb_internal_region-), ReferencedDescID: 105 (public-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "root"}
  │         │    ├── PUBLIC → DROPPED Schema:{DescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  SchemaParent:{DescID: 105 (public-), ReferencedDescID: 104 (multi_region_test_db-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (_crdb_internal_region-), Name: "_crdb_internal_region", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (_crdb_internal_region-), Name: "_crdb_internal_region", ReferencedDescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (_crdb_internal_region-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (_crdb_internal_region-), Name: "root"}
  │         │    ├── PUBLIC → DROPPED AliasType:{DescID: 107 (_crdb_internal_region-), ReferencedTypeIDs: [106 (crdb_internal_region-), 107 (_crdb_internal_region-)]}
  │         │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 107 (_crdb_internal_region-), ReferencedDescID: 105 (public-)}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_table-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "root"}
@@ -314,10 +314,12 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":106,"User":"root"}
  │              ├── MarkDescriptorAsDropped {"DescriptorID":105}
  │              ├── RemoveSchemaParent {"Parent":{"ParentDatabaseID":104,"SchemaID":105}}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_crdb_internal_r...","SchemaID":105}}
  │              ├── NotImplementedForPublicObjects {"DescID":107,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":107,"User":"root"}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"table_regional_b...","SchemaID":105}}
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
@@ -334,8 +336,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
- │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_crdb_internal_r...","SchemaID":105}}
- │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"table_regional_b...","SchemaID":105}}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
  │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion/drop_table_multiregion.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion/drop_table_multiregion.explain
@@ -11,7 +11,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 41 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 104 (multi_region_test_db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 105 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_row-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "root"}
@@ -108,7 +108,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 41 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 104 (multi_region_test_db)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 105 (public)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 108 (table_regional_by_row-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "root"}
@@ -153,7 +153,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 41 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 104 (multi_region_test_db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_row-), Name: "table_regional_by_row", ReferencedDescID: 105 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_row-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_row-), Name: "root"}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region/drop_table_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region/drop_table_multiregion_primary_region.explain
@@ -11,7 +11,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 32 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 105 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_table-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "root"}
@@ -87,7 +87,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 32 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 105 (public)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 108 (table_regional_by_table-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "root"}
@@ -123,7 +123,7 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 32 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 104 (multi_region_test_db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 108 (table_regional_by_table-), Name: "table_regional_by_table", ReferencedDescID: 105 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 108 (table_regional_by_table-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 108 (table_regional_by_table-), Name: "root"}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.explain
@@ -8,7 +8,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 46 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (t-), Name: "t", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (t-), Name: "t", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (t-), Name: "root"}
@@ -115,7 +115,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 46 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 104 (t-), Name: "t", ReferencedDescID: 100 (defaultdb)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 104 (t-), Name: "t", ReferencedDescID: 101 (public)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 104 (t-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 104 (t-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 104 (t-), Name: "root"}
@@ -165,7 +165,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 46 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (t-), Name: "t", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (t-), Name: "t", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (t-), Name: "root"}

--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -249,8 +249,9 @@ USE defaultdb;
 			dscExpectedErr: `pq: cannot rename relation "defaultdb.public.t" because function "f" depends on it`,
 		},
 		{
-			stmt:        "ALTER TABLE t SET SCHEMA test_sc",
-			expectedErr: `pq: cannot set schema on relation "t" because function "f" depends on it`,
+			stmt:           "ALTER TABLE t SET SCHEMA test_sc",
+			expectedErr:    `pq: cannot set schema on relation "t" because function "f" depends on it`,
+			dscExpectedErr: `pq: cannot set schema on relation "defaultdb.public.t" because function "f" depends on it`,
 		},
 		{
 			stmt:        "ALTER TABLE t DROP COLUMN d",

--- a/pkg/sql/logictest/testdata/logic_test/set_schema
+++ b/pkg/sql/logictest/testdata/logic_test/set_schema
@@ -24,11 +24,13 @@ ALTER TABLE t SET SCHEMA does_not_exist
 statement ok
 CREATE TABLE s2.t();
 
-statement error pq: relation "t" already exists
+# use regex to accept both the legacy and the declarative schema changer format
+statement error pq: relation "(test.s2.)?t" already exists
 ALTER TABLE t SET SCHEMA s2
 
 # Ensure we cannot set schema to a virtual schema.
-statement error pq: cannot move objects into or out of virtual schemas
+# use regex to accept both the legacy and the declarative schema changer format
+statement error pq: (cannot move objects into or out of virtual schemas)?(user root does not have CREATE privilege on schema information_schema)?
 ALTER TABLE t SET SCHEMA information_schema
 
 # Ensure we cannot set schema for a table in a virtual schema.
@@ -180,7 +182,8 @@ statement error pq: "seq_not_view" is not a view
 ALTER VIEW seq_not_view SET SCHEMA s1
 
 # Set schema should not work for a table that is depended on by a view.
-statement error pq: cannot set schema on relation "for_view" because view "vx" depends on it
+# use regex to accept both the legacy and the declarative schema changer format
+statement error pq: cannot set schema on relation "(test.public.)?for_view" because view "vx" depends on it
 ALTER TABLE for_view SET SCHEMA s2
 
 statement ok

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "alter_table_rename_column.go",
         "alter_table_rename_constraint.go",
         "alter_table_set_rls_mode.go",
+        "alter_table_set_schema.go",
         "alter_table_validate_constraint.go",
         "comment_on.go",
         "configure_zone.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_schema.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+)
+
+// AlterTableSetSchema implements ALTER TABLE ... SET SCHEMA ... for the declarative schema changer.
+// It sets the schema for a table, view, or sequence.
+// Requires privileges: DROP on source table/view/sequence, CREATE on destination schema.
+func AlterTableSetSchema(b BuildCtx, n *tree.AlterTableSetSchema) {
+	// Resolve any type of object
+	elts := b.ResolveRelation(n.Name, ResolveParams{
+		IsExistenceOptional: n.IfExists,
+		RequiredPrivilege:   privilege.DROP,
+	})
+	// IF EXISTS was specified, and the object doesn't exist, so this is a no-op.
+	if elts == nil && n.IfExists {
+		return
+	}
+	// Validate the object type matches what was requested.
+	objName := n.Name.ToTableName().ObjectName
+	validateObjectType(elts, objName, n.IsSequence, n.IsView, n.IsMaterialized)
+
+	// get descId based on type to retrieve the namespace
+	descID, element, isTemp := getRelationElement(elts)
+	// Ensure that table is not temporary
+	if isTemp {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of temporary schemas"))
+	}
+	// Get the fully qualified object name.
+	currName := tree.MakeTableNameFromPrefix(b.NamePrefix(element), objName)
+	newName := currName
+	newName.SchemaName = n.Schema
+	// Check for name-based dependencies
+	checkNameBasedDependencies(b, descID, element, currName, "set schema on")
+
+	// Get the schema ID directly from the namespace element
+	currNamespace := mustRetrieveNamespaceElem(b, descID)
+	currSchemaID := currNamespace.SchemaID
+	newSchema := resolveSchemaByName(b, n.Schema, currNamespace.DatabaseID)
+	newSchemaID := newSchema.SchemaID
+	// Ensure that new schema is not temporary or virtual
+	panicIfSchemaIsTemporaryOrVirtual(newSchema)
+	// If new schema is the same as the curr schema, do a no-op
+	if currSchemaID == newSchemaID {
+		return
+	}
+
+	// Increment telemetry counter
+	b.IncrementSchemaChangeAlterCounter(tree.GetTableType(n.IsSequence, n.IsView, n.IsMaterialized), n.TelemetryName())
+	// Check for name conflicts
+	checkTableNameConflicts(b, currName, newName, currNamespace)
+
+	// drop the old namespace and add a new one
+	newNamespace := *currNamespace
+	newNamespace.SchemaID = newSchemaID
+	b.Drop(currNamespace)
+	b.Add(&newNamespace)
+
+	// drop old schema child and add new one
+	currSchemaChild := b.QueryByID(descID).FilterSchemaChild().MustGetOneElement()
+	newSchemaChild := scpb.SchemaChild{
+		ChildObjectID: descID,
+		SchemaID:      newSchemaID,
+	}
+	b.Drop(currSchemaChild)
+	b.Add(&newSchemaChild)
+
+	// Log event for audit logging.
+	kind := tree.GetTableType(n.IsSequence, n.IsView, n.IsMaterialized)
+	setSchemaEvent := &eventpb.SetSchema{
+		DescriptorName:    currName.FQString(),
+		NewDescriptorName: newName.FQString(),
+		DescriptorType:    kind,
+	}
+	b.LogEventForExistingPayload(&newNamespace, setSchemaEvent)
+}
+
+func resolveSchemaByName(b BuildCtx, schemaName tree.Name, databaseID catid.DescID) *scpb.Schema {
+	dbElts := b.QueryByID(databaseID)
+	dbNamespace := dbElts.FilterNamespace().MustGetOneElement()
+	// Resolve the new schema to get its elements
+	newSchemaPrefix := tree.ObjectNamePrefix{
+		CatalogName:     tree.Name(dbNamespace.Name),
+		SchemaName:      schemaName,
+		ExplicitCatalog: true,
+		ExplicitSchema:  true,
+	}
+	newSchema := b.ResolveSchema(newSchemaPrefix, ResolveParams{
+		RequiredPrivilege: privilege.CREATE,
+	}).FilterSchema().MustGetOneElement()
+	return newSchema
+}
+
+func panicIfSchemaIsTemporaryOrVirtual(newSchema *scpb.Schema) {
+	if newSchema.IsTemporary {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of temporary schemas"))
+	}
+	if newSchema.IsVirtual {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported,
+			"cannot move objects into or out of virtual schemas"))
+	}
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -73,6 +73,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: true, checks: isV251Active},
 	reflect.TypeOf((*tree.Truncate)(nil)):            {fn: Truncate, statementTags: []string{tree.TruncateTag}, on: true, checks: isV254Active},
 	reflect.TypeOf((*tree.RenameTable)(nil)):         {fn: RenameTable, statementTags: []string{tree.AlterTableTag}, on: true, checks: isV254Active},
+	reflect.TypeOf((*tree.AlterTableSetSchema)(nil)): {fn: AlterTableSetSchema, statementTags: []string{tree.AlterTableTag}, on: true, checks: isV261Active},
 }
 
 // supportedStatementTags tracks statement tags which are implemented

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/rename_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/rename_table.go
@@ -32,43 +32,16 @@ func RenameTable(b BuildCtx, n *tree.RenameTable) {
 	}
 
 	// Validate the object type matches what was requested.
-	validateObjectType(elts, n)
-
-	// Get the fully qualified object name.
-	objectName := n.Name.ToTableName()
-	dbElts, scElts := b.ResolveTargetObject(n.Name, privilege.CREATE /* this should be 0 */)
-	_, _, scName := scpb.FindNamespace(scElts)
-	_, _, dbname := scpb.FindNamespace(dbElts)
-	objectName.SchemaName = tree.Name(scName.Name)
-	objectName.CatalogName = tree.Name(dbname.Name)
-	objectName.ExplicitCatalog = true
-	objectName.ExplicitSchema = true
+	currName := n.Name.ToTableName().ObjectName
+	validateObjectType(elts, currName, n.IsSequence, n.IsView, n.IsMaterialized)
 
 	// Get the descriptor ID for further processing.
-	var targetDescriptorID catid.DescID
-	var targetElement scpb.Element
-	_, _, tbl := scpb.FindTable(elts)
-	if tbl != nil {
-		targetElement = tbl
-		targetDescriptorID = tbl.TableID
-	}
-	if n.IsView || targetDescriptorID == 0 {
-		_, _, view := scpb.FindView(elts)
-		if view != nil {
-			targetElement = view
-			targetDescriptorID = view.ViewID
-		}
-	}
-	if n.IsSequence || targetDescriptorID == 0 {
-		_, _, seq := scpb.FindSequence(elts)
-		if seq != nil {
-			targetElement = seq
-			targetDescriptorID = seq.SequenceID
-		}
-	}
+	targetDescriptorID, targetElement, _ := getRelationElement(elts)
+	// Get the fully qualified object name.
+	objectName := tree.MakeTableNameFromPrefix(b.NamePrefix(targetElement), currName)
 
 	// Check for name-based dependencies that would prevent renaming.
-	checkNameBasedDependencies(b, targetDescriptorID, targetElement, objectName)
+	checkNameBasedDependencies(b, targetDescriptorID, targetElement, objectName, "rename")
 
 	// Need CREATE privilege on database to match legacy schema changer behavior.
 	b.ResolveDatabase(objectName.CatalogName, ResolveParams{RequiredPrivilege: privilege.CREATE})
@@ -104,6 +77,7 @@ func RenameTable(b BuildCtx, n *tree.RenameTable) {
 	newName.ExplicitCatalog = true
 	newName.ExplicitSchema = true
 	checkTableNameConflicts(b, objectName, newName, currentNS)
+	validateTableRename(b, objectName, newName)
 
 	// Check if the new name is the same as the old name (no-op case).
 	if currentNS.Name == string(newName.ObjectName) {
@@ -187,34 +161,51 @@ func checkTableNameConflicts(
 		}
 		panic(sqlerrors.NewRelationAlreadyExistsError(newName.String()))
 	}
+}
 
-	validateTableRename(b, currentName, newName)
+func getRelationElement(
+	elts ElementResultSet,
+) (descID catid.DescID, element scpb.Element, isTemp bool) {
+	if tbl := elts.FilterTable().MustGetZeroOrOneElement(); tbl != nil {
+		element = tbl
+		descID = tbl.TableID
+		isTemp = tbl.IsTemporary
+	} else if view := elts.FilterView().MustGetZeroOrOneElement(); view != nil {
+		element = view
+		descID = view.ViewID
+		isTemp = view.IsTemporary
+	} else if seq := elts.FilterSequence().MustGetZeroOrOneElement(); seq != nil {
+		element = seq
+		descID = seq.SequenceID
+		isTemp = seq.IsTemporary
+	}
+	return descID, element, isTemp
 }
 
 // validateObjectType validates that the resolved object type matches what was
 // requested in the statement. Note that we allow ALTER TABLE to be used for
 // views or sequences, just like in Postgres.
-func validateObjectType(elts ElementResultSet, n *tree.RenameTable) {
+func validateObjectType(
+	elts ElementResultSet, objectName tree.Name, isSequence bool, isView bool, isMaterialized bool,
+) {
 	_, _, view := scpb.FindView(elts)
 	_, _, seq := scpb.FindSequence(elts)
 
-	objectName := n.Name.ToTableName().ObjectName
-
-	if n.IsView && view == nil {
+	if isView && view == nil {
 		// User asked for view but we found something else.
 		panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not a view", objectName))
-	} else if n.IsSequence && seq == nil {
+	} else if isSequence && seq == nil {
 		// User asked for sequence but we found something else.
 		panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not a sequence", objectName))
 	}
 
 	if view != nil {
 		// Validate view type (materialized vs non-materialized).
-		if view.IsMaterialized && !n.IsMaterialized {
+		if view.IsMaterialized && !isMaterialized {
 			panic(errors.WithHint(pgerror.Newf(pgcode.WrongObjectType, "%q is a materialized view", objectName),
 				"use the corresponding MATERIALIZED VIEW command"))
 		}
-		if !view.IsMaterialized && n.IsMaterialized {
+		if !view.IsMaterialized && isMaterialized {
 			panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not a materialized view", objectName))
 		}
 	}
@@ -223,7 +214,7 @@ func validateObjectType(elts ElementResultSet, n *tree.RenameTable) {
 // checkNameBasedDependencies validates that no objects depend on this object
 // via its name.
 func checkNameBasedDependencies(
-	b BuildCtx, descriptorID catid.DescID, element scpb.Element, objectName tree.TableName,
+	b BuildCtx, descriptorID catid.DescID, element scpb.Element, objectName tree.TableName, op string,
 ) {
 	switch element.(type) {
 	case *scpb.Sequence:
@@ -238,14 +229,14 @@ func checkNameBasedDependencies(
 			// blocked.
 			viewElts := b.QueryByID(backRefElem.ViewID)
 			_, _, viewNS := scpb.FindNamespace(viewElts)
-			panic(sqlerrors.NewDependentBlocksOpError("rename", "relation", objectName.String(), "view", viewNS.Name))
+			panic(sqlerrors.NewDependentBlocksOpError(op, "relation", objectName.String(), "view", viewNS.Name))
 		case *scpb.FunctionName:
 			funcElem := b.QueryByID(backRefElem.FunctionID).FilterFunction().MustGetOneElement()
 			funcType := "function"
 			if funcElem.IsProcedure {
 				funcType = "procedure"
 			}
-			panic(sqlerrors.NewDependentBlocksOpError("rename", "relation", objectName.String(), funcType, backRefElem.Name))
+			panic(sqlerrors.NewDependentBlocksOpError(op, "relation", objectName.String(), funcType, backRefElem.Name))
 		case *scpb.TriggerDeps:
 			for _, usesRelation := range backRefElem.UsesRelations {
 				if usesRelation.ID == descriptorID {
@@ -256,8 +247,8 @@ func checkNameBasedDependencies(
 						return e.TriggerID == dependentTriggerID && e.TableID == dependentTableID
 					}).MustGetOneElement()
 					panic(sqlerrors.NewDependentObjectErrorf(
-						"cannot rename relation %q because trigger %q on table %q depends on it",
-						objectName.String(), dependentTriggerName.Name, dependentTableNS.Name,
+						"cannot %s relation %q because trigger %q on table %q depends on it",
+						op, objectName.String(), dependentTriggerName.Name, dependentTableNS.Name,
 					))
 				}
 			}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
@@ -325,7 +325,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT GENERATED ALWAYS AS IDENTITY
   {databaseId: 100, tableId: 104}
 - [[Sequence:{DescID: 107}, PUBLIC], ABSENT]
   {sequenceId: 107}
-- [[Namespace:{DescID: 107, Name: foo_j_seq, ReferencedDescID: 100}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 107, Name: foo_j_seq, ReferencedDescID: 101}, PUBLIC], ABSENT]
   {databaseId: 100, descriptorId: 107, name: foo_j_seq, schemaId: 101}
 - [[SchemaChild:{DescID: 107, ReferencedDescID: 101}, PUBLIC], ABSENT]
   {childObjectId: 107, schemaId: 101}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
@@ -158,7 +158,7 @@ ALTER TABLE defaultdb.t DROP COLUMN k, DROP COLUMN l
   {columnId: 2, indexId: 5, kind: STORED, tableId: 104}
 - [[IndexData:{DescID: 104, IndexID: 5}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 5, tableId: 104}
-- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: t_l_seq, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -208,7 +208,7 @@ ALTER TABLE defaultdb.t DROP COLUMN l
   {indexId: 3, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
-- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: t_l_seq, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: t_l_seq, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_database
@@ -21,7 +21,7 @@ CREATE DATABASE db OWNER roacher;
   {descriptorId: 104, privileges: "2", userName: root, withGrantOption: "2"}
 - [[Schema:{DescID: 105}, PUBLIC], ABSENT]
   {isPublic: true, schemaId: 105}
-- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, PUBLIC], ABSENT]
   {databaseId: 104, descriptorId: 105, name: public}
 - [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], ABSENT]
   {parentDatabaseId: 104, schemaId: 105}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_schema
@@ -1,9 +1,9 @@
-build
+ build
 CREATE SCHEMA testsc
 ----
 - [[Schema:{DescID: 104}, PUBLIC], ABSENT]
   {schemaId: 104}
-- [[Namespace:{DescID: 104, Name: testsc, ReferencedDescID: 100}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 104, Name: testsc, ReferencedDescID: 0}, PUBLIC], ABSENT]
   {databaseId: 100, descriptorId: 104, name: testsc}
 - [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT]
   {parentDatabaseId: 100, schemaId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_sequence
@@ -8,7 +8,7 @@ CREATE SEQUENCE db.public.sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 
 ----
 - [[Sequence:{DescID: 107}, PUBLIC], ABSENT]
   {sequenceId: 107}
-- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, PUBLIC], ABSENT]
+- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, PUBLIC], ABSENT]
   {databaseId: 104, descriptorId: 107, name: sq1, schemaId: 105}
 - [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, PUBLIC], ABSENT]
   {childObjectId: 107, schemaId: 105}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_database
@@ -39,7 +39,7 @@ DROP DATABASE db1 CASCADE
   {comment: db1 is good, databaseId: 104}
 - [[DatabaseData:{DescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104}
-- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 105, name: public}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -53,7 +53,7 @@ DROP DATABASE db1 CASCADE
   {isPublic: true, schemaId: 105}
 - [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {parentDatabaseId: 104, schemaId: 105}
-- [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 0}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 106, name: sc1}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -67,7 +67,7 @@ DROP DATABASE db1 CASCADE
   {parentDatabaseId: 104, schemaId: 106}
 - [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], PUBLIC]
   {comment: sc1 is good, schemaId: 106}
-- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 107, name: sq1, schemaId: 105}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}
@@ -81,7 +81,7 @@ DROP DATABASE db1 CASCADE
   {childObjectId: 107, schemaId: 105}
 - [[TableData:{DescID: 107, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 107}
-- [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 110, name: t1, schemaId: 105}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: root}
@@ -163,7 +163,7 @@ DROP DATABASE db1 CASCADE
   {indexId: 1, tableId: 110}
 - [[TableData:{DescID: 110, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 110}
-- [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 108, name: sq1, schemaId: 106}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: root}
@@ -177,7 +177,7 @@ DROP DATABASE db1 CASCADE
   {childObjectId: 108, schemaId: 106}
 - [[TableData:{DescID: 108, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 108}
-- [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 109, name: t1, schemaId: 106}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: root}
@@ -265,7 +265,7 @@ DROP DATABASE db1 CASCADE
   {indexId: 1, tableId: 109}
 - [[TableData:{DescID: 109, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 104, tableId: 109}
-- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 111, name: v1, schemaId: 106}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}
@@ -315,7 +315,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 111, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 111}
-- [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 112, name: v2, schemaId: 106}
 - [[Owner:{DescID: 112}, ABSENT], PUBLIC]
   {descriptorId: 112, owner: root}
@@ -371,7 +371,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 112, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 112}
-- [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 113, name: v3, schemaId: 106}
 - [[Owner:{DescID: 113}, ABSENT], PUBLIC]
   {descriptorId: 113, owner: root}
@@ -427,7 +427,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 113, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 113}
-- [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 114, name: v4, schemaId: 106}
 - [[Owner:{DescID: 114}, ABSENT], PUBLIC]
   {descriptorId: 114, owner: root}
@@ -483,7 +483,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 114, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 114}
-- [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 115, name: typ, schemaId: 106}
 - [[Owner:{DescID: 115}, ABSENT], PUBLIC]
   {descriptorId: 115, owner: root}
@@ -499,7 +499,7 @@ DROP DATABASE db1 CASCADE
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 115}
 - [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {childObjectId: 115, schemaId: 106}
-- [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 116, name: _typ, schemaId: 106}
 - [[Owner:{DescID: 116}, ABSENT], PUBLIC]
   {descriptorId: 116, owner: root}
@@ -513,7 +513,7 @@ DROP DATABASE db1 CASCADE
   {closedTypeIds: [115, 116], type: {arrayContents: {family: EnumFamily, oid: 100115, udtMetadata: {arrayTypeOid: 100116}}, family: ArrayFamily, oid: 100116}, typeId: 116, typeName: 'sc1.typ[]'}
 - [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {childObjectId: 116, schemaId: 106}
-- [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {databaseId: 104, descriptorId: 117, name: v5, schemaId: 106}
 - [[Owner:{DescID: 117}, ABSENT], PUBLIC]
   {descriptorId: 117, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_index
@@ -105,7 +105,7 @@ DROP INDEX idx3 CASCADE
   {constraintId: 3, name: check_crdb_internal_i_shard_16, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
-- [[Namespace:{DescID: 105, Name: v, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: v, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: v, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -173,7 +173,7 @@ DROP INDEX v2@idx CASCADE
   {indexId: 2, tableId: 106}
 - [[TableData:{DescID: 106, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 106}
-- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: v3, schemaId: 101}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
@@ -20,7 +20,7 @@ DROP OWNED BY r
 ----
 - [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], PUBLIC]
   {descriptorId: 100, privileges: "4", userName: r, withGrantOption: "4"}
-- [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 0}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: s}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: r}
@@ -38,7 +38,7 @@ DROP OWNED BY r
   {indexId: 1, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
-- [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: sq, schemaId: 101}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: r}
@@ -52,7 +52,7 @@ DROP OWNED BY r
   {childObjectId: 106, schemaId: 101}
 - [[TableData:{DescID: 106, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 106}
-- [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 109, name: t, schemaId: 101}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: r}
@@ -134,7 +134,7 @@ DROP OWNED BY r
   {indexId: 1, tableId: 109}
 - [[TableData:{DescID: 109, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 109}
-- [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: sq, schemaId: 105}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: r}
@@ -148,7 +148,7 @@ DROP OWNED BY r
   {childObjectId: 107, schemaId: 105}
 - [[TableData:{DescID: 107, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 107}
-- [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 108, name: t, schemaId: 105}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: r}
@@ -230,7 +230,7 @@ DROP OWNED BY r
   {indexId: 1, tableId: 108}
 - [[TableData:{DescID: 108, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 108}
-- [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 110, name: v1, schemaId: 105}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: r}
@@ -280,7 +280,7 @@ DROP OWNED BY r
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 110, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 110}
-- [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: typ, schemaId: 105}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: r}
@@ -296,7 +296,7 @@ DROP OWNED BY r
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 111}
 - [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {childObjectId: 111, schemaId: 105}
-- [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 112, name: _typ, schemaId: 105}
 - [[Owner:{DescID: 112}, ABSENT], PUBLIC]
   {descriptorId: 112, owner: r}
@@ -310,7 +310,7 @@ DROP OWNED BY r
   {closedTypeIds: [111, 112], type: {arrayContents: {family: EnumFamily, oid: 100111, udtMetadata: {arrayTypeOid: 100112}}, family: ArrayFamily, oid: 100112}, typeId: 112, typeName: 's.typ[]'}
 - [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {childObjectId: 112, schemaId: 105}
-- [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 113, name: v2, schemaId: 105}
 - [[Owner:{DescID: 113}, ABSENT], PUBLIC]
   {descriptorId: 113, owner: r}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_schema
@@ -19,7 +19,7 @@ COMMENT ON INDEX sc1.t1@t1_pkey IS 't1_pkey is good';
 build
 DROP SCHEMA defaultdb.SC1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 0}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: sc1}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -33,7 +33,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {parentDatabaseId: 100, schemaId: 104}
 - [[SchemaComment:{DescID: 104, Value: sc1 is good}, ABSENT], PUBLIC]
   {comment: sc1 is good, schemaId: 104}
-- [[Namespace:{DescID: 106, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: sq1, schemaId: 104}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -47,7 +47,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {childObjectId: 106, schemaId: 104}
 - [[TableData:{DescID: 106, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 106}
-- [[Namespace:{DescID: 107, Name: t1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: t1, schemaId: 104}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}
@@ -135,7 +135,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {indexId: 1, tableId: 107}
 - [[TableData:{DescID: 107, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 107}
-- [[Namespace:{DescID: 108, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: v1, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 108, name: v1, schemaId: 104}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: root}
@@ -185,7 +185,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 108, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 108}
-- [[Namespace:{DescID: 109, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: v2, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 109, name: v2, schemaId: 104}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: root}
@@ -241,7 +241,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 109, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 109}
-- [[Namespace:{DescID: 110, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: v3, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 110, name: v3, schemaId: 104}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: root}
@@ -297,7 +297,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 110, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 110}
-- [[Namespace:{DescID: 111, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v4, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: v4, schemaId: 104}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}
@@ -353,7 +353,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 111, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 111}
-- [[Namespace:{DescID: 112, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 112, Name: typ, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 112, name: typ, schemaId: 104}
 - [[Owner:{DescID: 112}, ABSENT], PUBLIC]
   {descriptorId: 112, owner: root}
@@ -369,7 +369,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 112}
 - [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {childObjectId: 112, schemaId: 104}
-- [[Namespace:{DescID: 113, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 113, Name: _typ, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 113, name: _typ, schemaId: 104}
 - [[Owner:{DescID: 113}, ABSENT], PUBLIC]
   {descriptorId: 113, owner: root}
@@ -383,7 +383,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {closedTypeIds: [112, 113], type: {arrayContents: {family: EnumFamily, oid: 100112, udtMetadata: {arrayTypeOid: 100113}}, family: ArrayFamily, oid: 100113}, typeId: 113, typeName: 'sc1.typ[]'}
 - [[SchemaChild:{DescID: 113, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {childObjectId: 113, schemaId: 104}
-- [[Namespace:{DescID: 114, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 114, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 114, name: v5, schemaId: 104}
 - [[Owner:{DescID: 114}, ABSENT], PUBLIC]
   {descriptorId: 114, owner: root}
@@ -445,7 +445,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 114, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 114}
-- [[Namespace:{DescID: 115, Name: v6, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 115, Name: v6, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 115, name: v6, schemaId: 105}
 - [[Owner:{DescID: 115}, ABSENT], PUBLIC]
   {descriptorId: 115, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
@@ -5,7 +5,7 @@ CREATE SEQUENCE defaultdb.SQ1
 build
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: sq1, schemaId: 101}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -30,7 +30,7 @@ CREATE TABLE defaultdb.blog_posts3 (id INT PRIMARY KEY, val typ DEFAULT CAST(chr
 build
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: sq1, schemaId: 101}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -71,7 +71,7 @@ CREATE SEQUENCE defaultdb.ownedseq OWNED BY defaultdb.ownertbl.id;
 build
 DROP SEQUENCE defaultdb.ownedseq CASCADE
 ----
-- [[Namespace:{DescID: 111, Name: ownedseq, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: ownedseq, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: ownedseq, schemaId: 101}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_table
@@ -29,7 +29,7 @@ COMMENT ON CONSTRAINT fk_customers ON defaultdb.shipments IS 'customer is import
 build
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-- [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 109, name: shipments, schemaId: 101}
 - [[Owner:{DescID: 109}, ABSENT], PUBLIC]
   {descriptorId: 109, owner: root}
@@ -157,7 +157,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   {constraintId: 3, name: fk_orders, tableId: 109}
 - [[TableData:{DescID: 109, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 109}
-- [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 110, name: sq1, schemaId: 101}
 - [[Owner:{DescID: 110}, ABSENT], PUBLIC]
   {descriptorId: 110, owner: root}
@@ -171,7 +171,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   {childObjectId: 110, schemaId: 101}
 - [[TableData:{DescID: 110, ReferencedDescID: 100}, ABSENT], PUBLIC]
   {databaseId: 100, tableId: 110}
-- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: v1, schemaId: 101}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_type
@@ -6,7 +6,7 @@ CREATE TYPE defaultdb.ctyp AS (a INT, b INT)
 build
 DROP TYPE defaultdb.typ
 ----
-- [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 104, name: typ, schemaId: 101}
 - [[Owner:{DescID: 104}, ABSENT], PUBLIC]
   {descriptorId: 104, owner: root}
@@ -22,7 +22,7 @@ DROP TYPE defaultdb.typ
   {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 104}
 - [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {childObjectId: 104, schemaId: 101}
-- [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: _typ, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -40,7 +40,7 @@ DROP TYPE defaultdb.typ
 build
 DROP TYPE defaultdb.ctyp
 ----
-- [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: ctyp, schemaId: 101}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -60,7 +60,7 @@ DROP TYPE defaultdb.ctyp
   {compositeTypeId: 106, name: b}
 - [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {childObjectId: 106, schemaId: 101}
-- [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: _ctyp, schemaId: 101}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_view
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_view
@@ -6,7 +6,7 @@ CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1);
 build
 DROP VIEW defaultdb.v1
 ----
-- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: v1, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -68,7 +68,7 @@ CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb
 build
 DROP VIEW defaultdb.v1 CASCADE
 ----
-- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 105, name: v1, schemaId: 101}
 - [[Owner:{DescID: 105}, ABSENT], PUBLIC]
   {descriptorId: 105, owner: root}
@@ -118,7 +118,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 105, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 105}
-- [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 106, name: v2, schemaId: 101}
 - [[Owner:{DescID: 106}, ABSENT], PUBLIC]
   {descriptorId: 106, owner: root}
@@ -174,7 +174,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 106, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 106}
-- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 107, name: v3, schemaId: 101}
 - [[Owner:{DescID: 107}, ABSENT], PUBLIC]
   {descriptorId: 107, owner: root}
@@ -230,7 +230,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 107, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 107}
-- [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 108, name: v4, schemaId: 101}
 - [[Owner:{DescID: 108}, ABSENT], PUBLIC]
   {descriptorId: 108, owner: root}
@@ -286,7 +286,7 @@ DROP VIEW defaultdb.v1 CASCADE
   {columnId: 4.294967292e+09, elementCreationMetadata: {in243OrLater: true, in261OrLater: true}, tableId: 108, type: {family: DecimalFamily, oid: 1700}, typeName: DECIMAL}
 - [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC]
   {columnId: 4.294967292e+09, tableId: 108}
-- [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC]
+- [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {databaseId: 100, descriptorId: 111, name: v5, schemaId: 101}
 - [[Owner:{DescID: 111}, ABSENT], PUBLIC]
   {descriptorId: 111, owner: root}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
@@ -8,7 +8,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT GENERATED ALWAYS AS IDENTITY
 StatementPhase stage 1 of 1 with 37 MutationType ops
   transitions:
     [[Sequence:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Column:{DescID: 105, ColumnID: 1}, PUBLIC], ABSENT] -> PUBLIC
@@ -211,7 +211,7 @@ StatementPhase stage 1 of 1 with 37 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Sequence:{DescID: 105}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
     [[Column:{DescID: 105, ColumnID: 1}, PUBLIC], PUBLIC] -> ABSENT
@@ -243,7 +243,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 43 MutationType ops
   transitions:
     [[Sequence:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: foo_j_seq, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Column:{DescID: 105, ColumnID: 1}, PUBLIC], ABSENT] -> PUBLIC

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -22,7 +22,7 @@ StatementPhase stage 1 of 1 with 53 MutationType ops
     [[Column:{DescID: 107, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 107, Name: v1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -262,7 +262,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Column:{DescID: 107, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 107, Name: v1, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -514,7 +514,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 61 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 107, Name: foo_v2_key, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1270,7 +1270,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1587,7 +1587,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -1618,7 +1618,7 @@ StatementPhase stage 1 of 1 with 52 MutationType ops
   transitions:
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1853,7 +1853,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -2114,7 +2114,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 64 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 107, Name: foo_v2_key, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2918,7 +2918,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -3239,7 +3239,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/create_database
+++ b/pkg/sql/schemachanger/scplan/testdata/create_database
@@ -11,7 +11,7 @@ StatementPhase stage 1 of 1 with 17 MutationType ops
     [[UserPrivileges:{DescID: 104, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, PUBLIC], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -97,7 +97,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[UserPrivileges:{DescID: 104, Name: public}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, PUBLIC], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
@@ -116,7 +116,7 @@ PreCommitPhase stage 2 of 2 with 17 MutationType ops
     [[UserPrivileges:{DescID: 104, Name: public}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, PUBLIC], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -228,11 +228,11 @@ CREATE DATABASE db;
   to:   [Database:{DescID: 106}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106}, PUBLIC]
+- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 0}, PUBLIC]
   to:   [Schema:{DescID: 107}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106}, PUBLIC]
+- from: [Namespace:{DescID: 107, Name: public, ReferencedDescID: 0}, PUBLIC]
   to:   [SchemaParent:{DescID: 107, ReferencedDescID: 106}, PUBLIC]
   kind: Precedence
   rule: namespace exist before schema parent
@@ -245,7 +245,7 @@ CREATE DATABASE db;
   kind: Precedence
   rule: dependents exist before descriptor becomes public
 - from: [Schema:{DescID: 107}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 107, Name: public, ReferencedDescID: 106}, PUBLIC]
+  to:   [Namespace:{DescID: 107, Name: public, ReferencedDescID: 0}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Schema:{DescID: 107}, DESCRIPTOR_ADDED]

--- a/pkg/sql/schemachanger/scplan/testdata/create_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/create_schema
@@ -4,7 +4,7 @@ CREATE SCHEMA sc;
 StatementPhase stage 1 of 1 with 8 MutationType ops
   transitions:
     [[Schema:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -45,7 +45,7 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Schema:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 0}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], PUBLIC] -> ABSENT
@@ -56,7 +56,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 8 MutationType ops
   transitions:
     [[Schema:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sc, ReferencedDescID: 0}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, PUBLIC], ABSENT] -> PUBLIC
@@ -98,11 +98,11 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
 deps
 CREATE SCHEMA sc;
 ----
-- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100}, PUBLIC]
+- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 0}, PUBLIC]
   to:   [Schema:{DescID: 105}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100}, PUBLIC]
+- from: [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 0}, PUBLIC]
   to:   [SchemaParent:{DescID: 105, ReferencedDescID: 100}, PUBLIC]
   kind: Precedence
   rule: namespace exist before schema parent
@@ -111,7 +111,7 @@ CREATE SCHEMA sc;
   kind: Precedence
   rule: dependents exist before descriptor becomes public
 - from: [Schema:{DescID: 105}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 100}, PUBLIC]
+  to:   [Namespace:{DescID: 105, Name: sc, ReferencedDescID: 0}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Schema:{DescID: 105}, DESCRIPTOR_ADDED]

--- a/pkg/sql/schemachanger/scplan/testdata/create_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/create_sequence
@@ -4,7 +4,7 @@ CREATE SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
 StatementPhase stage 1 of 1 with 24 MutationType ops
   transitions:
     [[Sequence:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[SequenceOption:{DescID: 104, Name: START}, PUBLIC], ABSENT] -> PUBLIC
@@ -119,7 +119,7 @@ StatementPhase stage 1 of 1 with 24 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[Sequence:{DescID: 104}, PUBLIC], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, PUBLIC], PUBLIC] -> ABSENT
     [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC] -> ABSENT
     [[SequenceOption:{DescID: 104, Name: START}, PUBLIC], PUBLIC] -> ABSENT
@@ -139,7 +139,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 25 MutationType ops
   transitions:
     [[Sequence:{DescID: 104}, PUBLIC], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, PUBLIC], ABSENT] -> PUBLIC
     [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], ABSENT] -> PUBLIC
     [[SequenceOption:{DescID: 104, Name: START}, PUBLIC], ABSENT] -> PUBLIC
@@ -335,7 +335,7 @@ CREATE SEQUENCE sq1  MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 3
   to:   [Sequence:{DescID: 105}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
-- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, PUBLIC]
+- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 101}, PUBLIC]
   to:   [Sequence:{DescID: 105}, PUBLIC]
   kind: Precedence
   rule: dependents exist before descriptor becomes public
@@ -384,7 +384,7 @@ CREATE SEQUENCE sq1  MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 3
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Sequence:{DescID: 105}, DESCRIPTOR_ADDED]
-  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, PUBLIC]
+  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 101}, PUBLIC]
   kind: Precedence
   rule: descriptor existence precedes dependents
 - from: [Sequence:{DescID: 105}, DESCRIPTOR_ADDED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -29,27 +29,27 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[Database:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[DatabaseRoleSetting:{DescID: 104, Name: __placeholder_role_name__}, ABSENT], PUBLIC] -> ABSENT
     [[DatabaseComment:{DescID: 104, Value: db1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 106, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -88,13 +88,13 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[IndexColumn:{DescID: 110, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 110, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 110, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 108}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 108, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -134,7 +134,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -159,7 +159,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 111, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -187,7 +187,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 112, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 112, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -215,7 +215,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 113, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 114}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -243,7 +243,7 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[ColumnName:{DescID: 114, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 115}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -251,14 +251,14 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     [[EnumType:{DescID: 115}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 115, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 117}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -804,6 +804,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
         SchemaID: 106
     *scop.RemoveSchemaComment
       SchemaID: 106
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 107
+        Name: sq1
+        SchemaID: 105
     *scop.NotImplementedForPublicObjects
       DescID: 107
       ElementType: scpb.Owner
@@ -813,6 +819,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 107
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 110
+        Name: t1
+        SchemaID: 105
     *scop.NotImplementedForPublicObjects
       DescID: 110
       ElementType: scpb.Owner
@@ -843,6 +855,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 110
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 108
+        Name: sq1
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 108
       ElementType: scpb.Owner
@@ -852,6 +870,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 108
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 109
+        Name: t1
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 109
       ElementType: scpb.Owner
@@ -882,6 +906,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 109
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 111
+        Name: v1
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 111
       ElementType: scpb.Owner
@@ -906,6 +936,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 111
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 112
+        Name: v2
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 112
       ElementType: scpb.Owner
@@ -933,6 +969,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 112
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 113
+        Name: v3
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 113
       ElementType: scpb.Owner
@@ -960,6 +1002,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 113
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 114
+        Name: v4
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 114
       ElementType: scpb.Owner
@@ -987,6 +1035,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 114
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 115
+        Name: typ
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 115
       ElementType: scpb.Owner
@@ -999,6 +1053,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 115
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 116
+        Name: _typ
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 116
       ElementType: scpb.Owner
@@ -1011,6 +1071,12 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 116
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 117
+        Name: v5
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 117
       ElementType: scpb.Owner
@@ -1076,18 +1142,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 106
       User: root
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 107
-        Name: sq1
-        SchemaID: 105
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 110
-        Name: t1
-        SchemaID: 105
     *scop.MakePublicColumnWriteOnly
       ColumnID: 1
       TableID: 110
@@ -1110,18 +1164,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 110
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 108
-        Name: sq1
-        SchemaID: 106
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 109
-        Name: t1
-        SchemaID: 106
     *scop.MakePublicColumnWriteOnly
       ColumnID: 1
       TableID: 109
@@ -1144,12 +1186,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 109
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 111
-        Name: v1
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 111
@@ -1165,12 +1201,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 111
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 112
-        Name: v2
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 112
@@ -1189,12 +1219,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 112
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 113
-        Name: v3
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 113
@@ -1213,12 +1237,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 113
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 114
-        Name: v4
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 114
@@ -1237,24 +1255,6 @@ StatementPhase stage 1 of 1 with 325 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 114
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 115
-        Name: typ
-        SchemaID: 106
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 116
-        Name: _typ
-        SchemaID: 106
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 117
-        Name: v5
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 117
@@ -1366,27 +1366,27 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[Database:{DescID: 104}, ABSENT], DROPPED] -> PUBLIC
     [[DatabaseRoleSetting:{DescID: 104, Name: __placeholder_role_name__}, ABSENT], ABSENT] -> PUBLIC
     [[DatabaseComment:{DescID: 104, Value: db1 is good}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 106}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 106, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 107}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1425,13 +1425,13 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 110, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 110, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 110, Name: t1_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 108}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 108, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1471,7 +1471,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 109, Name: t1_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1496,7 +1496,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 111, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 112}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1524,7 +1524,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 112, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 112, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1552,7 +1552,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 113, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 114}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 114, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 114, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1580,7 +1580,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 114, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 115}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 115, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 115, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -1588,14 +1588,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 115}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 115, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 116}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 117}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 117, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 117, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1639,27 +1639,27 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[Database:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[DatabaseRoleSetting:{DescID: 104, Name: __placeholder_role_name__}, ABSENT], PUBLIC] -> ABSENT
     [[DatabaseComment:{DescID: 104, Value: db1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 106, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 106, Value: sc1 is good}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1698,13 +1698,13 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[IndexColumn:{DescID: 110, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 110, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 110, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 108}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 108, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1744,7 +1744,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1769,7 +1769,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 111, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 111, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1797,7 +1797,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 112, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 112, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 112, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1825,7 +1825,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 113, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 113, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 114}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 114, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1853,7 +1853,7 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[ColumnName:{DescID: 114, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 114, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 115}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 115, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -1861,14 +1861,14 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     [[EnumType:{DescID: 115}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 115, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 115, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 117}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 117, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2414,6 +2414,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
         SchemaID: 106
     *scop.RemoveSchemaComment
       SchemaID: 106
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 107
+        Name: sq1
+        SchemaID: 105
     *scop.NotImplementedForPublicObjects
       DescID: 107
       ElementType: scpb.Owner
@@ -2423,6 +2429,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 107
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 110
+        Name: t1
+        SchemaID: 105
     *scop.NotImplementedForPublicObjects
       DescID: 110
       ElementType: scpb.Owner
@@ -2453,6 +2465,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 110
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 108
+        Name: sq1
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 108
       ElementType: scpb.Owner
@@ -2462,6 +2480,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 108
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 109
+        Name: t1
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 109
       ElementType: scpb.Owner
@@ -2492,6 +2516,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 109
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 111
+        Name: v1
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 111
       ElementType: scpb.Owner
@@ -2516,6 +2546,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 111
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 112
+        Name: v2
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 112
       ElementType: scpb.Owner
@@ -2543,6 +2579,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 112
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 113
+        Name: v3
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 113
       ElementType: scpb.Owner
@@ -2570,6 +2612,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 113
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 114
+        Name: v4
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 114
       ElementType: scpb.Owner
@@ -2597,6 +2645,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967292
       TableID: 114
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 115
+        Name: typ
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 115
       ElementType: scpb.Owner
@@ -2609,6 +2663,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 115
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 116
+        Name: _typ
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 116
       ElementType: scpb.Owner
@@ -2621,6 +2681,12 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 116
       User: root
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 104
+        DescriptorID: 117
+        Name: v5
+        SchemaID: 106
     *scop.NotImplementedForPublicObjects
       DescID: 117
       ElementType: scpb.Owner
@@ -2688,18 +2754,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 106
       User: root
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 107
-        Name: sq1
-        SchemaID: 105
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 110
-        Name: t1
-        SchemaID: 105
     *scop.MakePublicColumnWriteOnly
       ColumnID: 1
       TableID: 110
@@ -2722,18 +2776,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 110
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 108
-        Name: sq1
-        SchemaID: 106
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 109
-        Name: t1
-        SchemaID: 106
     *scop.MakePublicColumnWriteOnly
       ColumnID: 1
       TableID: 109
@@ -2756,12 +2798,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 109
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 111
-        Name: v1
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 111
@@ -2777,12 +2813,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 111
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 112
-        Name: v2
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 112
@@ -2801,12 +2831,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 112
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 113
-        Name: v3
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 113
@@ -2825,12 +2849,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 113
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 114
-        Name: v4
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 114
@@ -2849,24 +2867,6 @@ PreCommitPhase stage 2 of 2 with 341 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967292
       TableID: 114
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 115
-        Name: typ
-        SchemaID: 106
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 116
-        Name: _typ
-        SchemaID: 106
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 104
-        DescriptorID: 117
-        Name: v5
-        SchemaID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
       TableID: 117
@@ -3183,7 +3183,7 @@ DROP DATABASE db1 CASCADE
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
-  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
@@ -4939,58 +4939,6 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with attr ref
-- from: [Database:{DescID: 104}, DROPPED]
   to:   [Owner:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
@@ -5023,7 +4971,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 115}, DROPPED]
-  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 115}, DROPPED]
@@ -5142,55 +5090,55 @@ DROP DATABASE db1 CASCADE
   to:   [Database:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, ABSENT]
   to:   [Schema:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 0}, ABSENT]
   to:   [Schema:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT]
   to:   [Sequence:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT]
   to:   [Sequence:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT]
   to:   [Table:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT]
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT]
   to:   [View:{DescID: 112}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT]
   to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT]
   to:   [View:{DescID: 114}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT]
   to:   [EnumType:{DescID: 115}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT]
   to:   [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT]
+- from: [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT]
   to:   [View:{DescID: 117}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -5299,9 +5247,17 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: index no longer public before dependents, excluding columns
 - from: [Schema:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: public, ReferencedDescID: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
+- from: [Schema:{DescID: 105}, DROPPED]
+  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 105}, DROPPED]
+  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
 - from: [Schema:{DescID: 105}, DROPPED]
   to:   [Owner:{DescID: 105}, ABSENT]
   kind: Precedence
@@ -5327,9 +5283,45 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Schema:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: sc1, ReferencedDescID: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 115, Name: typ, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
 - from: [Schema:{DescID: 106}, DROPPED]
   to:   [Owner:{DescID: 106}, ABSENT]
   kind: Precedence
@@ -5471,7 +5463,7 @@ DROP DATABASE db1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 105}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 107}, DROPPED]
@@ -5503,7 +5495,7 @@ DROP DATABASE db1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 108}, DROPPED]
@@ -5659,7 +5651,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: t1, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -5823,7 +5815,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 110}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: t1, ReferencedDescID: 105}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 110}, DROPPED]
@@ -6067,7 +6059,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
@@ -6179,7 +6171,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 112}, DROPPED]
-  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 112, Name: v2, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 112}, DROPPED]
@@ -6291,7 +6283,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
-  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 113, Name: v3, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
@@ -6403,7 +6395,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 114}, DROPPED]
-  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 114, Name: v4, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 114}, DROPPED]
@@ -6527,7 +6519,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 117}, DROPPED]
-  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT]
+  to:   [Namespace:{DescID: 117, Name: v5, ReferencedDescID: 106}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 117}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -708,7 +708,7 @@ DROP INDEX idx4 CASCADE
 StatementPhase stage 1 of 1 with 32 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -841,7 +841,7 @@ StatementPhase stage 1 of 1 with 32 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -872,7 +872,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 35 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1280,7 +1280,7 @@ DROP INDEX idx4 CASCADE
   to:   [SecondaryIndex:{DescID: 105, IndexID: 8, ConstraintID: 4, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [Namespace:{DescID: 106, Name: v, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: v, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1417,7 +1417,7 @@ DROP INDEX idx4 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: v, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: v, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
@@ -1451,7 +1451,7 @@ DROP INDEX v2@idx CASCADE;
 StatementPhase stage 1 of 1 with 47 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1644,7 +1644,7 @@ StatementPhase stage 1 of 1 with 47 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1686,7 +1686,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 50 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0, RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v3, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -20,20 +20,20 @@ DROP OWNED BY r
 StatementPhase stage 1 of 1 with 202 MutationType ops
   transitions:
     [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -72,13 +72,13 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -117,7 +117,7 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -142,7 +142,7 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -150,14 +150,14 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -858,20 +858,20 @@ StatementPhase stage 1 of 1 with 202 MutationType ops
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: r}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 106}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -910,13 +910,13 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 109, Name: t_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 107}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -955,7 +955,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 108, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -980,7 +980,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -988,14 +988,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 111}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 112}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1029,20 +1029,20 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
 PreCommitPhase stage 2 of 2 with 214 MutationType ops
   transitions:
     [[UserPrivileges:{DescID: 100, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: r}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1081,13 +1081,13 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 109, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1126,7 +1126,7 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1151,7 +1151,7 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -1159,14 +1159,14 @@ PreCommitPhase stage 2 of 2 with 214 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -20,7 +20,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
-  to:   [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
@@ -1448,7 +1448,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 111}, DROPPED]
@@ -1519,43 +1519,43 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   to:   [Table:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 0}, ABSENT]
   to:   [Schema:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 104}, ABSENT]
   to:   [Sequence:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 104}, ABSENT]
   to:   [Table:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 104}, ABSENT]
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 104}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 104}, ABSENT]
   to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 104}, ABSENT]
   to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 104}, ABSENT]
   to:   [EnumType:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 104}, ABSENT]
   to:   [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 104}, ABSENT]
   to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1624,9 +1624,45 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: index no longer public before dependents, excluding columns
 - from: [Schema:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 0}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 111, Name: typ, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
+- from: [Schema:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with attr ref
 - from: [Schema:{DescID: 104}, DROPPED]
   to:   [Owner:{DescID: 104}, ABSENT]
   kind: Precedence
@@ -1740,7 +1776,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 105}, DROPPED]
@@ -1896,7 +1932,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: t1, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 106}, DROPPED]
@@ -2100,7 +2136,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
@@ -2212,7 +2248,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -2324,7 +2360,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 109}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 109}, DROPPED]
@@ -2436,7 +2472,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 110}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 110}, DROPPED]
@@ -2560,7 +2596,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
-  to:   [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 104}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 113}, DROPPED]
@@ -2589,20 +2625,20 @@ DROP SCHEMA defaultdb.SC1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 255 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 104, Value: sc1 is good schema}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2642,7 +2678,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 106, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2667,7 +2703,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2695,7 +2731,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2723,7 +2759,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 109, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2751,7 +2787,7 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -2759,14 +2795,14 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3636,20 +3672,20 @@ StatementPhase stage 1 of 1 with 255 MutationType ops
       TableID: 106
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 0}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Schema:{DescID: 104}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaComment:{DescID: 104, Value: sc1 is good schema}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 105, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3689,7 +3725,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 106, Name: t1_pkey, IndexID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3714,7 +3750,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3742,7 +3778,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3770,7 +3806,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 109, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3798,7 +3834,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -3806,14 +3842,14 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 111}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 111, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 112}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -3849,20 +3885,20 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 267 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sc1, ReferencedDescID: 0}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaParent:{DescID: 104, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaComment:{DescID: 104, Value: sc1 is good schema}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 105, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: t1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3902,7 +3938,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexName:{DescID: 106, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3927,7 +3963,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3955,7 +3991,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3983,7 +4019,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 109, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 109, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -4011,7 +4047,7 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[ColumnName:{DescID: 110, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 110, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -4019,14 +4055,14 @@ PreCommitPhase stage 2 of 2 with 267 MutationType ops
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 111, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -7,7 +7,7 @@ DROP SEQUENCE defaultdb.SQ1
 ----
 StatementPhase stage 1 of 1 with 6 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -36,7 +36,7 @@ StatementPhase stage 1 of 1 with 6 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -47,7 +47,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 8 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -119,7 +119,7 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 10 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -166,7 +166,7 @@ StatementPhase stage 1 of 1 with 10 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -179,7 +179,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 14 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -279,7 +279,7 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
 deps
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
-- from: [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT]
   to:   [Sequence:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -304,7 +304,7 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 104}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -44,7 +44,7 @@ DROP TABLE defaultdb.shipments CASCADE;
 ----
 StatementPhase stage 1 of 1 with 150 MutationType ops
   transitions:
-    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -122,13 +122,13 @@ StatementPhase stage 1 of 1 with 150 MutationType ops
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 110}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -682,7 +682,7 @@ StatementPhase stage 1 of 1 with 150 MutationType ops
       TableID: 109
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -760,13 +760,13 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[Sequence:{DescID: 110}, ABSENT], DROPPED] -> PUBLIC
     [[SchemaChild:{DescID: 110, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -799,7 +799,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 161 MutationType ops
   transitions:
-    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -877,13 +877,13 @@ PreCommitPhase stage 2 of 2 with 161 MutationType ops
     [[TriggerEvents:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerFunctionCall:{DescID: 109, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerDeps:{DescID: 109, ReferencedTypeIDs: [107 108], TriggerID: 1, ReferencedFunctionIDs: [113]}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 110}, ABSENT], PUBLIC] -> DROPPED
     [[SchemaChild:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -2487,15 +2487,15 @@ DROP TABLE defaultdb.shipments CASCADE;
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 101}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 101}, ABSENT]
   to:   [Sequence:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -2596,7 +2596,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: SameStagePrecedence
   rule: table removed right before garbage collection
 - from: [Sequence:{DescID: 110}, DROPPED]
-  to:   [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 110, Name: sq1, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Sequence:{DescID: 110}, DROPPED]
@@ -2852,7 +2852,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -3096,7 +3096,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v1, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
@@ -3187,7 +3187,7 @@ PreCommitPhase stage 2 of 2 with 7 MutationType ops
         statementtag: DROP TABLE
 PostCommitNonRevertiblePhase stage 1 of 2 with 59 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: customers, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3839,7 +3839,7 @@ DROP TABLE defaultdb.customers CASCADE;
   to:   [Table:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 101}, ABSENT]
   to:   [Table:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -4020,7 +4020,7 @@ DROP TABLE defaultdb.customers CASCADE;
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: customers, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [Table:{DescID: 104}, DROPPED]
@@ -4083,7 +4083,7 @@ DROP TABLE defaultdb.greeter
 ----
 StatementPhase stage 1 of 1 with 68 MutationType ops
   transitions:
-    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -4366,7 +4366,7 @@ StatementPhase stage 1 of 1 with 68 MutationType ops
       TableID: 116
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 116}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -4419,7 +4419,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 72 MutationType ops
   transitions:
-    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 116, Name: greeter, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 116}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -8,7 +8,7 @@ DROP TYPE defaultdb.typ
 ----
 StatementPhase stage 1 of 1 with 15 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -16,7 +16,7 @@ StatementPhase stage 1 of 1 with 15 MutationType ops
     [[EnumType:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -75,7 +75,7 @@ StatementPhase stage 1 of 1 with 15 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 104}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -83,7 +83,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[EnumType:{DescID: 104}, ABSENT], DROPPED] -> PUBLIC
     [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -95,7 +95,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 18 MutationType ops
   transitions:
-    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -103,7 +103,7 @@ PreCommitPhase stage 2 of 2 with 18 MutationType ops
     [[EnumType:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
     [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -210,7 +210,7 @@ DROP TYPE defaultdb.typ
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
@@ -242,7 +242,7 @@ DROP TYPE defaultdb.typ
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 104}, DROPPED]
-  to:   [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [EnumType:{DescID: 104}, DROPPED]
@@ -269,11 +269,11 @@ DROP TYPE defaultdb.typ
   to:   [EnumType:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 104, Name: typ, ReferencedDescID: 101}, ABSENT]
   to:   [EnumType:{DescID: 104}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 101}, ABSENT]
   to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -323,7 +323,7 @@ DROP TYPE defaultdb.ctyp
 ----
 StatementPhase stage 1 of 1 with 16 MutationType ops
   transitions:
-    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -333,7 +333,7 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
     [[CompositeTypeAttrType:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -395,7 +395,7 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -405,7 +405,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[CompositeTypeAttrType:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], ABSENT] -> PUBLIC
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], ABSENT] -> PUBLIC
@@ -417,7 +417,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 19 MutationType ops
   transitions:
-    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -427,7 +427,7 @@ PreCommitPhase stage 2 of 2 with 19 MutationType ops
     [[CompositeTypeAttrType:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], PUBLIC] -> ABSENT
     [[SchemaChild:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], PUBLIC] -> ABSENT
@@ -537,7 +537,7 @@ DROP TYPE defaultdb.ctyp
   kind: PreviousTransactionPrecedence
   rule: descriptor dropped in transaction before removal
 - from: [AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, DROPPED]
@@ -577,7 +577,7 @@ DROP TYPE defaultdb.ctyp
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [CompositeType:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [CompositeType:{DescID: 106}, DROPPED]
@@ -612,11 +612,11 @@ DROP TYPE defaultdb.ctyp
   to:   [CompositeType:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 101}, ABSENT]
   to:   [CompositeType:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 101}, ABSENT]
   to:   [AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -8,7 +8,7 @@ DROP VIEW defaultdb.v1
 ----
 StatementPhase stage 1 of 1 with 31 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -137,7 +137,7 @@ StatementPhase stage 1 of 1 with 31 MutationType ops
       TableID: 105
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -167,7 +167,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 34 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -524,7 +524,7 @@ DROP VIEW defaultdb.v1
   to:   [View:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -621,7 +621,7 @@ DROP VIEW defaultdb.v1
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
@@ -658,7 +658,7 @@ DROP VIEW defaultdb.v1 CASCADE
 ----
 StatementPhase stage 1 of 1 with 176 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -683,7 +683,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 105, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -711,7 +711,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 106, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -739,7 +739,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -767,7 +767,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1377,7 +1377,7 @@ StatementPhase stage 1 of 1 with 176 MutationType ops
       TableID: 111
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1402,7 +1402,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 105, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1430,7 +1430,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 106, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1458,7 +1458,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1486,7 +1486,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -1522,7 +1522,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
       {}
 PreCommitPhase stage 2 of 2 with 185 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1547,7 +1547,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 105, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 105, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1575,7 +1575,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 106, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 106, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1603,7 +1603,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 107, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 107, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -1631,7 +1631,7 @@ PreCommitPhase stage 2 of 2 with 185 MutationType ops
     [[ColumnName:{DescID: 108, Name: crdb_internal_origin_timestamp, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967292, TypeName: DECIMAL}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnHidden:{DescID: 108, ColumnID: 4294967292}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -3421,23 +3421,23 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 105}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 106}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT]
+- from: [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 101}, ABSENT]
   to:   [View:{DescID: 111}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -3598,7 +3598,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 105}, DROPPED]
@@ -3710,7 +3710,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 106}, DROPPED]
@@ -3822,7 +3822,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
@@ -3934,7 +3934,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -4058,7 +4058,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT]
+  to:   [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 101}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 111}, DROPPED]

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -429,7 +429,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	// Common elements.
 	rel.EntityMapping(t((*scpb.Namespace)(nil)),
 		rel.EntityAttr(DescID, "DescriptorID"),
-		rel.EntityAttr(ReferencedDescID, "DatabaseID"),
+		rel.EntityAttr(ReferencedDescID, "SchemaID"),
 		rel.EntityAttr(Name, "Name"),
 	),
 	rel.EntityMapping(t((*scpb.Owner)(nil)),

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -491,6 +491,13 @@ func TestEndToEndSideEffects_alter_table_rename_multiple_columns(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1279,6 +1286,13 @@ func TestExecuteWithDMLInjection_alter_table_rename_multiple_columns(t *testing.
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_multiple_columns"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2073,6 +2087,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_rename_multiple_columns(t *testi
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2861,6 +2882,13 @@ func TestPause_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_multiple_columns"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3655,6 +3683,13 @@ func TestPauseMixedVersion_alter_table_rename_multiple_columns(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4443,6 +4478,13 @@ func TestRollback_alter_table_rename_multiple_columns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename_multiple_columns"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated.explain
@@ -10,7 +10,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 27 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "INCREMENT"}
@@ -88,7 +88,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 27 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "INCREMENT"}
@@ -125,7 +125,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 27 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "INCREMENT"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_1_of_7.explain
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 29 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_2_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_3_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_4_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_5_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 23 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_6_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 23 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_generated/add_column_generated__rollback_7_of_7.explain
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 22 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "INCREMENT"}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "MINVALUE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 23 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        Column:{DescID: 107 (tbl_serial_id_seq+), ColumnID: 1 (value+)}
@@ -81,7 +81,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 23 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT Column:{DescID: 107 (tbl_serial_id_seq+), ColumnID: 1 (value+)}
@@ -114,7 +114,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 23 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        Column:{DescID: 107 (tbl_serial_id_seq+), ColumnID: 1 (value+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 25 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC        → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence/add_column_serial_simple_sequence__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 107 (tbl_serial_id_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER SESSION CACHE"}
@@ -83,7 +83,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 24 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER SESSION CACHE"}
@@ -117,7 +117,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER SESSION CACHE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 26 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached/add_column_serial_simple_sequence_cached__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER SESSION CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER NODE CACHE"}
@@ -83,7 +83,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 24 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER NODE CACHE"}
@@ -117,7 +117,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "PER NODE CACHE"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 26 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_cached_node/add_column_serial_simple_sequence_cached_node__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "PER NODE CACHE"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "VIRTUAL"}
@@ -83,7 +83,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 24 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC        → ABSENT Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │    │    │    ├── PUBLIC        → ABSENT TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │    │    │    ├── PUBLIC        → ABSENT SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "VIRTUAL"}
@@ -117,7 +117,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 24 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 107 (tbl_serial_id_seq+)}
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 107 (tbl_serial_id_seq+), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 105 (public)}
  │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 107 (tbl_serial_id_seq+), ReferencedDescID: 104 (db)}
  │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 107 (tbl_serial_id_seq+), Name: "VIRTUAL"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_1_of_7.explain
@@ -12,7 +12,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 26 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_2_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_3_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_4_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_5_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_6_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 21 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_serial_simple_sequence_virtual/add_column_serial_simple_sequence_virtual__rollback_7_of_7.explain
@@ -42,7 +42,7 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN serial_
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 107 (tbl_serial_id_seq-)}
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 104 (#104)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 107 (tbl_serial_id_seq-), Name: "tbl_serial_id_seq", ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 107 (tbl_serial_id_seq-), ReferencedDescID: 105 (#105)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 107 (tbl_serial_id_seq-), Name: "VIRTUAL"}
       │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 107 (tbl_serial_id_seq-), ColumnID: 1 (value-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity.explain
@@ -12,7 +12,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 17 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (t_j_seq+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (t_j_seq+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (t_j_seq+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Column:{DescID: 105 (t_j_seq+), ColumnID: 1 (value+)}
@@ -64,7 +64,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 17 elements transitioning toward PUBLIC
  │    │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (t_j_seq+)}
- │    │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb)}
+ │    │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 101 (public)}
  │    │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (t_j_seq+), ReferencedDescID: 101 (public)}
  │    │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (t_j_seq+), ReferencedDescID: 100 (defaultdb)}
  │    │    │    ├── PUBLIC → ABSENT Column:{DescID: 105 (t_j_seq+), ColumnID: 1 (value+)}
@@ -87,7 +87,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 17 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (t_j_seq+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (t_j_seq+), Name: "t_j_seq", ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (t_j_seq+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (t_j_seq+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Column:{DescID: 105 (t_j_seq+), ColumnID: 1 (value+)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_add_identity/alter_table_alter_column_add_identity__rollback_1_of_1.explain
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER COLUMN 
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 16 elements transitioning toward ABSENT
       │    │    ├── PUBLIC → DROPPED Sequence:{DescID: 105 (t_j_seq-)}
-      │    │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t_j_seq-), Name: "t_j_seq", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t_j_seq-), Name: "t_j_seq", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC → ABSENT  SchemaChild:{DescID: 105 (t_j_seq-), ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC → ABSENT  Column:{DescID: 105 (t_j_seq-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC → ABSENT  ColumnType:{DescID: 105 (t_j_seq-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain
@@ -8,9 +8,9 @@ Schema change plan for ALTER TABLE ‹t1› RENAME TO ‹t1_renamed›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb)}
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 101 (public)}
  │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb)}
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 101 (public)}
  │         └── 3 Mutation operations
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t1","SchemaID":101}}
  │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"t1_renamed"}
@@ -18,16 +18,16 @@ Schema change plan for ALTER TABLE ‹t1› RENAME TO ‹t1_renamed›;
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb)}
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 101 (public)}
       │    ├── 1 element transitioning toward ABSENT
-      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb)}
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 101 (public)}
       │    └── 1 Mutation operation
       │         └── UndoAllInTxnImmediateMutationOpSideEffects
       └── Stage 2 of 2 in PreCommitPhase
            ├── 1 element transitioning toward PUBLIC
-           │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 100 (defaultdb)}
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1_renamed", ReferencedDescID: 101 (public)}
            ├── 1 element transitioning toward ABSENT
-           │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 100 (defaultdb)}
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 104 (t1-t1_renamed+), Name: "t1", ReferencedDescID: 101 (public)}
            └── 4 Mutation operations
                 ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t1","SchemaID":101}}
                 ├── SetNameInDescriptor {"DescriptorID":104,"Name":"t1_renamed"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.definition
@@ -1,0 +1,8 @@
+setup
+CREATE TABLE t (i int, j int);
+CREATE SCHEMA sc;
+----
+
+test
+ALTER TABLE t SET SCHEMA sc;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.explain
@@ -1,0 +1,46 @@
+/* setup */
+CREATE TABLE t (i int, j int);
+CREATE SCHEMA sc;
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE t SET SCHEMA sc;
+----
+Schema change plan for ALTER TABLE ‹t› SET SCHEMA ‹sc›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 105 (sc)}
+ │         │    └── ABSENT → PUBLIC SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 105 (sc)}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 101 (public)}
+ │         │    └── PUBLIC → ABSENT SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 101 (public)}
+ │         └── 5 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":101}}
+ │              ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
+ │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"t"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":105}}
+ │              └── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":105}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 105 (sc)}
+      │    │    └── PUBLIC → ABSENT SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 105 (sc)}
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 101 (public)}
+      │    │    └── ABSENT → PUBLIC SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 101 (public)}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 105 (sc)}
+           │    └── ABSENT → PUBLIC SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 105 (sc)}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (t-t+), Name: "t", ReferencedDescID: 101 (public)}
+           │    └── PUBLIC → ABSENT SchemaChild:{DescID: 104 (t-t+), ReferencedDescID: 101 (public)}
+           └── 6 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":101}}
+                ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
+                ├── SetNameInDescriptor {"DescriptorID":104,"Name":"t"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":105}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"t","TableID":104}
+                └── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":105}}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE TABLE t (i int, j int);
+CREATE SCHEMA sc;
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE t SET SCHEMA sc;
+----
+Schema change plan for ALTER TABLE ‹t› SET SCHEMA ‹sc›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_schema/alter_table_set_schema.side_effects
@@ -1,0 +1,55 @@
+/* setup */
+CREATE TABLE t (i int, j int);
+CREATE SCHEMA sc;
+----
+...
++object {100 101 t} -> 104
++schema {100 0 sc} -> 105
+
+/* test */
+ALTER TABLE t SET SCHEMA sc;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table.set_schema
+write *eventpb.SetSchema to event log:
+  descriptorName: defaultdb.public.t
+  descriptorType: table
+  newDescriptorName: defaultdb.sc.t
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹t› SET SCHEMA ‹sc›
+    tag: ALTER TABLE
+    user: root
+## StatementPhase stage 1 of 1 with 5 MutationType ops
+delete object namespace entry {100 101 t} -> 104
+add object namespace entry {100 105 t} -> 104
+upsert descriptor #104
+  ...
+       time: {}
+     schemaLocked: true
+  -  unexposedParentSchemaId: 101
+  -  version: "1"
+  +  unexposedParentSchemaId: 105
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 6 MutationType ops
+delete object namespace entry {100 101 t} -> 104
+add object namespace entry {100 105 t} -> 104
+upsert descriptor #104
+  ...
+       time: {}
+     schemaLocked: true
+  -  unexposedParentSchemaId: 101
+  -  version: "1"
+  +  unexposedParentSchemaId: 105
+  +  version: "2"
+persist all catalog changes to storage
+update ttl schedule label #104
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_1_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_1_of_4.explain
@@ -16,7 +16,7 @@ Schema change plan for CREATE DATABASE ‹db›;
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -51,7 +51,7 @@ Schema change plan for CREATE DATABASE ‹db›;
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -69,7 +69,7 @@ Schema change plan for CREATE DATABASE ‹db›;
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_2_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_2_of_4.explain
@@ -10,7 +10,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 106 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 106 (sc+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
@@ -34,7 +34,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "public"}
@@ -42,7 +42,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 106 (sc+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc"}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 106 (sc+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
@@ -58,7 +58,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "public"}
@@ -66,7 +66,7 @@ Schema change plan for CREATE SCHEMA ‹db›.‹sc› AUTHORIZATION foo; follow
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 106 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 106 (sc+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_3_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_3_of_4.explain
@@ -43,14 +43,14 @@ Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹t›()
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc"}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "root"}
@@ -75,14 +75,14 @@ Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹t›()
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc"}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_4_of_4.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex__statement_4_of_4.explain
@@ -15,7 +15,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 108 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 106 (sc+)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 108 (sq1+), ReferencedDescID: 106 (sc+)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 108 (sq1+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 108 (sq1+), Name: "START"}
@@ -64,14 +64,14 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Database:{DescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT DatabaseData:{DescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (sc+), Name: "sc"}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (sc+), Name: "root"}
@@ -86,7 +86,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
       │    │    ├── PUBLIC → ABSENT FunctionName:{DescID: 107 (t+)}
       │    │    ├── PUBLIC → ABSENT FunctionBody:{DescID: 107 (t+)}
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 108 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 108 (sq1+), ReferencedDescID: 106 (sc+)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 108 (sq1+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 108 (sq1+), Name: "START"}
@@ -111,14 +111,14 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Database:{DescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC DatabaseData:{DescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (sc+), Name: "sc"}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "admin"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (sc+), Name: "root"}
@@ -133,7 +133,7 @@ Schema change plan for CREATE SEQUENCE ‹db›.‹sc›.‹sq1› MINVALUE 1 MA
            │    ├── ABSENT → PUBLIC FunctionName:{DescID: 107 (t+)}
            │    ├── ABSENT → PUBLIC FunctionBody:{DescID: 107 (t+)}
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 108 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 108 (sq1+), Name: "sq1", ReferencedDescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 108 (sq1+), ReferencedDescID: 106 (sc+)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 108 (sq1+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 108 (sq1+), Name: "START"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database/create_database.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database/create_database.explain
@@ -15,7 +15,7 @@ Schema change plan for CREATE DATABASE ‹db›;
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -50,7 +50,7 @@ Schema change plan for CREATE DATABASE ‹db›;
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -68,7 +68,7 @@ Schema change plan for CREATE DATABASE ‹db›;
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_1_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_1_of_3.explain
@@ -15,7 +15,7 @@ Schema change plan for CREATE DATABASE ‹db›;
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -50,7 +50,7 @@ Schema change plan for CREATE DATABASE ‹db›;
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (db+), Name: "root"}
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 105 (public+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (public+), Name: "public"}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (public+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (public+), Name: "admin"}
@@ -68,7 +68,7 @@ Schema change plan for CREATE DATABASE ‹db›;
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public", ReferencedDescID: 104 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (public+), ReferencedDescID: 104 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_2_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_2_of_3.explain
@@ -15,7 +15,7 @@ Schema change plan for DROP DATABASE ‹db›; following CREATE DATABASE ‹db�
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (db-), Name: "root"}
  │         │    ├── PUBLIC → DROPPED Database:{DescID: 104 (db-)}
  │         │    ├── PUBLIC → ABSENT  DatabaseRoleSetting:{DescID: 104 (db-), Name: "__placeholder_role_name__"}
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public", ReferencedDescID: 104 (db-)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (public-), Name: "public"}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (public-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (public-), Name: "public"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_3_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_database_drop_database_separate_statements/create_database_drop_database_separate_statements__statement_3_of_3.explain
@@ -17,7 +17,7 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE DATABASE ‹db
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 107 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 107 (public+), ReferencedDescID: 106 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 107 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 107 (public+), Name: "admin"}
@@ -52,7 +52,7 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE DATABASE ‹db
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 106 (db+), Name: "public"}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 106 (db+), Name: "root"}
       │    │    ├── PUBLIC  → ABSENT Schema:{DescID: 107 (public+)}
-      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+)}
+      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 107 (public+), Name: "public"}
       │    │    ├── PUBLIC  → ABSENT SchemaParent:{DescID: 107 (public+), ReferencedDescID: 106 (db+)}
       │    │    ├── PUBLIC  → ABSENT Owner:{DescID: 107 (public+)}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 107 (public+), Name: "admin"}
@@ -75,7 +75,7 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE DATABASE ‹db
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "public"}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (db+), Name: "root"}
            │    ├── ABSENT → PUBLIC Schema:{DescID: 107 (public+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public", ReferencedDescID: 106 (db+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 107 (public+), Name: "public"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 107 (public+), ReferencedDescID: 106 (db+)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 107 (public+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 107 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_database_separate_statements/create_index_create_database_separate_statements__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_database_separate_statements/create_index_create_database_separate_statements__statement_2_of_2.explain
@@ -18,7 +18,7 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE UNIQUE INDEX �
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (db+), Name: "root"}
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 106 (public+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (public+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 106 (public+), ReferencedDescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (public+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (public+), Name: "admin"}
@@ -58,7 +58,7 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE UNIQUE INDEX �
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (db+), Name: "public"}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (db+), Name: "root"}
  │    │    │    ├── PUBLIC        → ABSENT Schema:{DescID: 106 (public+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 106 (public+), Name: "public"}
  │    │    │    ├── PUBLIC        → ABSENT SchemaParent:{DescID: 106 (public+), ReferencedDescID: 105 (db+)}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 106 (public+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 106 (public+), Name: "admin"}
@@ -86,7 +86,7 @@ Schema change plan for CREATE DATABASE ‹db›; following CREATE UNIQUE INDEX �
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (db+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (db+), Name: "root"}
  │         │    ├── ABSENT → DESCRIPTOR_ADDED Schema:{DescID: 106 (public+)}
- │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 106 (public+), Name: "public", ReferencedDescID: 105 (db+)}
+ │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 106 (public+), Name: "public"}
  │         │    ├── ABSENT → PUBLIC           SchemaParent:{DescID: 106 (public+), ReferencedDescID: 105 (db+)}
  │         │    ├── ABSENT → PUBLIC           Owner:{DescID: 106 (public+)}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 106 (public+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_1_of_7.explain
@@ -20,7 +20,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── BACKFILL_ONLY    → ABSENT  SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── DELETE_ONLY      → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT  Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC           → ABSENT  Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC           → ABSENT  SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT  Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT  UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_2_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── BACKFILL_ONLY    → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_3_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── BACKFILL_ONLY    → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_4_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── DELETE_ONLY      → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_5_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── MERGE_ONLY       → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_6_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── MERGE_ONLY       → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC           → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC           → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC           → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC           → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__rollback_7_of_7.explain
@@ -19,7 +19,7 @@ Schema change plan for rolling back CREATE SCHEMA defaultdb.sc; following CREATE
       │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3 (crdb_internal_index_3_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── DESCRIPTOR_ADDED      → DROPPED     Schema:{DescID: 105 (sc-)}
-      │    │    ├── PUBLIC                → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC                → ABSENT      Namespace:{DescID: 105 (sc-), Name: "sc"}
       │    │    ├── PUBLIC                → ABSENT      SchemaParent:{DescID: 105 (sc-), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC                → ABSENT      Owner:{DescID: 105 (sc-)}
       │    │    ├── PUBLIC                → ABSENT      UserPrivileges:{DescID: 105 (sc-), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index_create_schema_separate_statements/create_index_create_schema_separate_statements__statement_2_of_2.explain
@@ -11,7 +11,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -34,7 +34,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (idx+)}
  │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx+), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │    │    │    ├── PUBLIC        → ABSENT Schema:{DescID: 105 (sc+)}
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc"}
  │    │    │    ├── PUBLIC        → ABSENT SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 105 (sc+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -55,7 +55,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 104 (t), IndexID: 2 (idx+)}
  │         │    ├── ABSENT → BACKFILL_ONLY    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx+), ConstraintID: 2, TemporaryIndexID: 3 (crdb_internal_index_3_name_placeholder), SourceIndexID: 1 (t_pkey), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
  │         │    ├── ABSENT → DESCRIPTOR_ADDED Schema:{DescID: 105 (sc+)}
- │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (sc+), Name: "sc"}
  │         │    ├── ABSENT → PUBLIC           SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC           Owner:{DescID: 105 (sc+)}
  │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain
@@ -9,7 +9,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -27,7 +27,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (sc+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc"}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -37,7 +37,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 6 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_1_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_1_of_3.explain
@@ -8,7 +8,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -26,7 +26,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (sc+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sc+), Name: "sc"}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT Owner:{DescID: 104 (sc+)}
       │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 104 (sc+), Name: "admin"}
@@ -36,7 +36,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
       └── Stage 2 of 2 in PreCommitPhase
            ├── 6 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sc+), Name: "sc"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (sc+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 104 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 104 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_2_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_2_of_3.explain
@@ -8,7 +8,7 @@ Schema change plan for DROP SCHEMA ‹""›.‹sc›; following CREATE SCHEMA �
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sc-), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sc-), Name: "sc"}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (sc-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sc-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sc-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_3_of_3.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema_drop_schema_separate_statements/create_schema_drop_schema_separate_statements__statement_3_of_3.explain
@@ -10,7 +10,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (sc+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc"}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sc+)}
  │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -28,7 +28,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC  → ABSENT Schema:{DescID: 105 (sc+)}
-      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC  → ABSENT Namespace:{DescID: 105 (sc+), Name: "sc"}
       │    │    ├── PUBLIC  → ABSENT SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC  → ABSENT Owner:{DescID: 105 (sc+)}
       │    │    ├── PUBLIC  → ABSENT UserPrivileges:{DescID: 105 (sc+), Name: "admin"}
@@ -40,7 +40,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›; following CREATE 
       └── Stage 2 of 2 in PreCommitPhase
            ├── 6 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 105 (sc+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sc+), Name: "sc"}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 105 (sc+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sc+)}
            │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sc+), Name: "admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.explain
@@ -8,7 +8,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START"}
@@ -51,7 +51,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 15 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 104 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 104 (sq1+), Name: "START"}
@@ -70,7 +70,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       └── Stage 2 of 2 in PreCommitPhase
            ├── 15 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
@@ -10,7 +10,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 25 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC        → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC        → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC        → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 20 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN j 
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 19 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC      → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (#101)}
       │    │    ├── PUBLIC      → ABSENT  Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_1_of_2.explain
@@ -9,7 +9,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START"}
@@ -52,7 +52,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 15 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 105 (sq1+), Name: "START"}
@@ -71,7 +71,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       └── Stage 2 of 2 in PreCommitPhase
            ├── 15 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
@@ -39,7 +39,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 23 elements transitioning toward PUBLIC
- │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │    │    │    ├── PUBLIC        → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
  │    │    │    ├── PUBLIC        → ABSENT Owner:{DescID: 105 (sq1+)}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
  │    │    │    ├── PUBLIC        → ABSENT UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
@@ -72,7 +72,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 23 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC        Owner:{DescID: 105 (sq1+)}
  │         │    ├── ABSENT → PUBLIC        UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
  │         │    ├── ABSENT → PUBLIC        UserPrivileges:{DescID: 105 (sq1+), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_1_of_2.explain
@@ -8,7 +8,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 15 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START"}
@@ -51,7 +51,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 15 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 104 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 104 (sq1+), Name: "START"}
@@ -70,7 +70,7 @@ Schema change plan for CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MI
       └── Stage 2 of 2 in PreCommitPhase
            ├── 15 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 104 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (sq1+), Name: "sq1", ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (sq1+), ReferencedDescID: 101 (public)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 104 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 104 (sq1+), Name: "START"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_2_of_2.explain
@@ -8,7 +8,7 @@ Schema change plan for DROP SEQUENCE ‹defaultdb›.‹public›.‹sq1›; fol
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 14 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sq1-), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 104 (sq1-), Name: "sq1", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 104 (sq1-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sq1-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 104 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
@@ -10,9 +10,9 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
  │         ├── 18 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (pg_temp_123_456+)}
  │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456"}
  │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
- │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 104 (pg_temp_123_456+)}
  │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
  │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
  │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START"}
@@ -59,9 +59,9 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
       │    ├── 18 elements transitioning toward PUBLIC
       │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (pg_temp_123_456+)}
       │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456"}
       │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (sq1+)}
-      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 104 (pg_temp_123_456+)}
       │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
       │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
       │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 105 (sq1+), Name: "START"}
@@ -81,9 +81,9 @@ Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_
            ├── 18 elements transitioning toward PUBLIC
            │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (pg_temp_123_456+)}
            │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456"}
            │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
-           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 104 (pg_temp_123_456+)}
            │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
            │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
            │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_sequence_owner/drop_column_sequence_owner.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_sequence_owner/drop_column_sequence_owner.explain
@@ -190,7 +190,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC      → ABSENT           SequenceOwner:{DescID: 104 (t), ColumnID: 2 (j-), ReferencedDescID: 105 (sq1-)}
       │    │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT           Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC      → ABSENT           Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 101 (public)}
       │    │    ├── PUBLIC      → ABSENT           Owner:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
       │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105 (sq1-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep/drop_index_with_materialized_view_dep.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep/drop_index_with_materialized_view_dep.explain
@@ -12,7 +12,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 37 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → VALIDATED SecondaryIndex:{DescID: 105 (v2), IndexID: 2 (idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT    Owner:{DescID: 106 (v3-)}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "root"}
@@ -100,7 +100,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 37 elements transitioning toward ABSENT
  │    │    │    ├── VALIDATED → PUBLIC SecondaryIndex:{DescID: 105 (v2), IndexID: 2 (idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │    │    │    ├── ABSENT    → PUBLIC Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb)}
+ │    │    │    ├── ABSENT    → PUBLIC Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 101 (public)}
  │    │    │    ├── ABSENT    → PUBLIC Owner:{DescID: 106 (v3-)}
  │    │    │    ├── ABSENT    → PUBLIC UserPrivileges:{DescID: 106 (v3-), Name: "admin"}
  │    │    │    ├── ABSENT    → PUBLIC UserPrivileges:{DescID: 106 (v3-), Name: "root"}
@@ -141,7 +141,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 37 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → VALIDATED SecondaryIndex:{DescID: 105 (v2), IndexID: 2 (idx-), RecreateSourceIndexID: 0, RecreateTargetIndexID: 0}
- │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT    Namespace:{DescID: 106 (v3-), Name: "v3", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT    Owner:{DescID: 106 (v3-)}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT    UserPrivileges:{DescID: 106 (v3-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_schema/drop_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_schema/drop_schema.explain
@@ -9,7 +9,7 @@ Schema change plan for DROP SCHEMA ‹db›.‹sc›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc"}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (sc-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "root"}
@@ -25,7 +25,7 @@ Schema change plan for DROP SCHEMA ‹db›.‹sc›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 6 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 106 (sc-), Name: "sc"}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 106 (sc-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (sc-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 106 (sc-), Name: "root"}
@@ -35,7 +35,7 @@ Schema change plan for DROP SCHEMA ‹db›.‹sc›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc", ReferencedDescID: 104 (db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 106 (sc-), Name: "sc"}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 106 (sc-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 106 (sc-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table/drop_table.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table/drop_table.explain
@@ -12,7 +12,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 42 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 106 (sc)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "root"}
@@ -110,7 +110,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 42 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 106 (sc)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 107 (t-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (t-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 107 (t-), Name: "root"}
@@ -156,7 +156,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 42 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 104 (db)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 107 (t-), Name: "t", ReferencedDescID: 106 (sc)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 107 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 107 (t-), Name: "root"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default/drop_table_udf_default.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default/drop_table_udf_default.explain
@@ -9,7 +9,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 36 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "root"}
@@ -95,7 +95,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 36 elements transitioning toward ABSENT
- │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb)}
+ │    │    │    ├── ABSENT  → PUBLIC Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 101 (public)}
  │    │    │    ├── ABSENT  → PUBLIC Owner:{DescID: 105 (t-)}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (t-), Name: "admin"}
  │    │    │    ├── ABSENT  → PUBLIC UserPrivileges:{DescID: 105 (t-), Name: "root"}
@@ -135,7 +135,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 36 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── PUBLIC → ABSENT  Namespace:{DescID: 105 (t-), Name: "t", ReferencedDescID: 101 (public)}
  │         │    ├── PUBLIC → ABSENT  Owner:{DescID: 105 (t-)}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "admin"}
  │         │    ├── PUBLIC → ABSENT  UserPrivileges:{DescID: 105 (t-), Name: "root"}


### PR DESCRIPTION
This change adds support for `ALTER TABLE ... SET SCHEMA` to the
declarative schema changer. Before, this operation was ran by the
legacy schema changer.

Epic [CRDB-31281](https://cockroachlabs.atlassian.net/browse/CRDB-31281)

Fixes https://github.com/cockroachdb/cockroach/issues/155989
Release note (sql change): `ALTER TABLE ... SET SCHEMA` is supported by
the declerative schema changer.