### PR TITLE
kvserver: disable latch assertions further down

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -106,7 +106,6 @@ func declareKeysGC(
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
 	// Needed for updating optional GC hint.
 	latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeGCHintKey(rs.GetRangeID())})
-	latchSpans.DisableUndeclaredAccessAssertions()
 	return nil
 }
 
@@ -138,6 +137,9 @@ func GC(
 ) (result.Result, error) {
 	args := cArgs.Args.(*kvpb.GCRequest)
 	h := cArgs.Header
+
+	// TODO(pav-kv): find out why and comment.
+	readWriter = spanset.DisableReadWriterAssertions(readWriter)
 
 	// We do not allow GC requests to bump the GC threshold at the same time that
 	// they GC individual keys. This is because performing both of these actions

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -23,10 +23,10 @@ func init() {
 }
 
 func declareKeysRequestLease(
-	rs ImmutableRangeState,
+	_ ImmutableRangeState,
 	_ *kvpb.Header,
 	_ kvpb.Request,
-	latchSpans *spanset.SpanSet,
+	_ *spanset.SpanSet,
 	_ *lockspanset.LockSpanSet,
 	_ time.Duration,
 ) error {
@@ -34,7 +34,6 @@ func declareKeysRequestLease(
 	// acquiring latches would not help synchronize with other requests. As
 	// such, the request does not declare latches. See also
 	// concurrency.shouldIgnoreLatches().
-	latchSpans.DisableUndeclaredAccessAssertions()
 	return nil
 }
 
@@ -53,6 +52,9 @@ func RequestLease(
 	args := cArgs.Args.(*kvpb.RequestLeaseRequest)
 	prevLease := args.PrevLease
 	newLease := args.Lease
+
+	// RequestLease does not hold latches by design.
+	readWriter = spanset.DisableReadWriterAssertions(readWriter)
 
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -83,8 +83,7 @@ type Span struct {
 // The Span slice for a particular access and scope contains non-overlapping
 // spans in increasing key order after calls to SortAndDedup.
 type SpanSet struct {
-	spans           [NumSpanAccess][NumSpanScope][]Span
-	allowUndeclared bool
+	spans [NumSpanAccess][NumSpanScope][]Span
 }
 
 var spanSetPool = sync.Pool{
@@ -113,7 +112,6 @@ func (s *SpanSet) Release() {
 			s.spans[sa][ss] = recycle
 		}
 	}
-	s.allowUndeclared = false
 	spanSetPool.Put(s)
 }
 
@@ -155,7 +153,6 @@ func (s *SpanSet) Copy() *SpanSet {
 			n.spans[sa][ss] = append(n.spans[sa][ss], s.spans[sa][ss]...)
 		}
 	}
-	n.allowUndeclared = s.allowUndeclared
 	return n
 }
 
@@ -208,7 +205,6 @@ func (s *SpanSet) Merge(s2 *SpanSet) {
 			s.spans[sa][ss] = append(s.spans[sa][ss], s2.spans[sa][ss]...)
 		}
 	}
-	s.allowUndeclared = s2.allowUndeclared
 	s.SortAndDedup()
 }
 
@@ -331,12 +327,6 @@ func (s *SpanSet) CheckAllowedAt(
 func (s *SpanSet) checkAllowed(
 	access SpanAccess, span roachpb.Span, check func(SpanAccess, Span) bool,
 ) error {
-	if s.allowUndeclared {
-		// If the request has specified that undeclared spans are allowed, do
-		// nothing.
-		return nil
-	}
-
 	scope := SpanGlobal
 	if (span.Key != nil && keys.IsLocal(span.Key)) ||
 		(span.EndKey != nil && keys.IsLocal(span.EndKey)) {
@@ -388,11 +378,4 @@ func (s *SpanSet) Validate() error {
 	}
 
 	return nil
-}
-
-// DisableUndeclaredAccessAssertions disables the assertions that prevent
-// undeclared access to spans. This is generally set by requests that rely on
-// other forms of synchronization for correctness (e.g. GCRequest).
-func (s *SpanSet) DisableUndeclaredAccessAssertions() {
-	s.allowUndeclared = true
 }


### PR DESCRIPTION
This commit moves disabling of the latch assertions from the latch declaration phase to the body of the corresponding commands. This serves two purposes:

1. Disabling of the assertions is now more targeted. It is per command rather than per batch.
2. The disabling behaviour is ephemeral, so we can remove the bool in `SpanSet` that doesn't belong there. It's a data structure that should have no opinion on whether the checks are enabled.

Epic: none
Release note: none