### PR TITLE
ts: record child metrics with low frequency poller

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -3,6 +3,261 @@ layers:
   categories:
   - name: CHANGEFEEDS
     metrics:
+    - name: changefeed.admit_latency
+      exported_name: changefeed_admit_latency
+      description: 'Event admission latency: a difference between event MVCC timestamp and the time it was admitted into changefeed pipeline; Note: this metric includes the time spent waiting until event can be processed due to backpressure or time spent resolving schema descriptors. Also note, this metric excludes latency during backfill'
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.aggregator_progress
+      exported_name: changefeed_aggregator_progress
+      description: The earliest timestamp up to which any aggregator is guaranteed to have emitted all values for
+      y_axis_label: Unix Timestamp Nanoseconds
+      type: GAUGE
+      unit: TIMESTAMP_NS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.backfill_count
+      exported_name: changefeed_backfill_count
+      description: Number of changefeeds currently executing backfill
+      y_axis_label: Count
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+      visibility: SUPPORT
+    - name: changefeed.backfill_pending_ranges
+      exported_name: changefeed_backfill_pending_ranges
+      description: Number of ranges in an ongoing backfill that are yet to be fully emitted
+      y_axis_label: Count
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.batch_reduction_count
+      exported_name: changefeed_batch_reduction_count
+      description: Number of times a changefeed aggregator node attempted to reduce the size of message batches it emitted to the sink
+      y_axis_label: Batch Size Reductions
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.buffer_entries.allocated_mem
+      exported_name: changefeed_buffer_entries_allocated_mem
+      description: Current quota pool memory allocation
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.buffer_entries.flush.aggregator
+      exported_name: changefeed_buffer_entries_flush_aggregator
+      labeled_name: 'changefeed.buffer_entries.flush{buffer_type: aggregator}'
+      description: Number of flush elements added to the buffer - between the kvfeed and the sink
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.flush.rangefeed
+      exported_name: changefeed_buffer_entries_flush_rangefeed
+      labeled_name: 'changefeed.buffer_entries.flush{buffer_type: rangefeed}'
+      description: Number of flush elements added to the buffer - between the rangefeed and the kvfeed
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.in.aggregator
+      exported_name: changefeed_buffer_entries_in_aggregator
+      labeled_name: 'changefeed.buffer_entries.in{buffer_type: aggregator}'
+      description: Total entries entering the buffer between raft and changefeed sinks - between the kvfeed and the sink
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.in.rangefeed
+      exported_name: changefeed_buffer_entries_in_rangefeed
+      labeled_name: 'changefeed.buffer_entries.in{buffer_type: rangefeed}'
+      description: Total entries entering the buffer between raft and changefeed sinks - between the rangefeed and the kvfeed
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.kv.aggregator
+      exported_name: changefeed_buffer_entries_kv_aggregator
+      labeled_name: 'changefeed.buffer_entries.kv{buffer_type: aggregator}'
+      description: Number of kv elements added to the buffer - between the kvfeed and the sink
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.kv.rangefeed
+      exported_name: changefeed_buffer_entries_kv_rangefeed
+      labeled_name: 'changefeed.buffer_entries.kv{buffer_type: rangefeed}'
+      description: Number of kv elements added to the buffer - between the rangefeed and the kvfeed
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.out.aggregator
+      exported_name: changefeed_buffer_entries_out_aggregator
+      labeled_name: 'changefeed.buffer_entries.out{buffer_type: aggregator}'
+      description: Total entries leaving the buffer between raft and changefeed sinks - between the kvfeed and the sink
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.out.rangefeed
+      exported_name: changefeed_buffer_entries_out_rangefeed
+      labeled_name: 'changefeed.buffer_entries.out{buffer_type: rangefeed}'
+      description: Total entries leaving the buffer between raft and changefeed sinks - between the rangefeed and the kvfeed
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.released.aggregator
+      exported_name: changefeed_buffer_entries_released_aggregator
+      labeled_name: 'changefeed.buffer_entries.released{buffer_type: aggregator}'
+      description: Total entries processed, emitted and acknowledged by the sinks - between the kvfeed and the sink
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.released.rangefeed
+      exported_name: changefeed_buffer_entries_released_rangefeed
+      labeled_name: 'changefeed.buffer_entries.released{buffer_type: rangefeed}'
+      description: Total entries processed, emitted and acknowledged by the sinks - between the rangefeed and the kvfeed
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.resolved.aggregator
+      exported_name: changefeed_buffer_entries_resolved_aggregator
+      labeled_name: 'changefeed.buffer_entries.resolved{buffer_type: aggregator}'
+      description: Number of resolved elements added to the buffer - between the kvfeed and the sink
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries.resolved.rangefeed
+      exported_name: changefeed_buffer_entries_resolved_rangefeed
+      labeled_name: 'changefeed.buffer_entries.resolved{buffer_type: rangefeed}'
+      description: Number of resolved elements added to the buffer - between the rangefeed and the kvfeed
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries_mem.acquired
+      exported_name: changefeed_buffer_entries_mem_acquired
+      description: Total amount of memory acquired for entries as they enter the system
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_entries_mem.released
+      exported_name: changefeed_buffer_entries_mem_released
+      description: Total amount of memory released by the entries after they have been emitted
+      y_axis_label: Entries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_pushback_nanos.aggregator
+      exported_name: changefeed_buffer_pushback_nanos_aggregator
+      labeled_name: 'changefeed.buffer_pushback_nanos{buffer_type: aggregator}'
+      description: Total time spent waiting while the buffer was full - between the kvfeed and the sink
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.buffer_pushback_nanos.rangefeed
+      exported_name: changefeed_buffer_pushback_nanos_rangefeed
+      labeled_name: 'changefeed.buffer_pushback_nanos{buffer_type: rangefeed}'
+      description: Total time spent waiting while the buffer was full - between the rangefeed and the kvfeed
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.bytes.messages_pushback_nanos
+      exported_name: changefeed_bytes_messages_pushback_nanos
+      description: Total time spent throttled for bytes quota
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.checkpoint.create_nanos
+      exported_name: changefeed_checkpoint_create_nanos
+      description: Time it takes to create a changefeed checkpoint
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.checkpoint.span_count
+      exported_name: changefeed_checkpoint_span_count
+      description: Number of spans in a changefeed checkpoint
+      y_axis_label: Spans
+      type: HISTOGRAM
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.checkpoint.timestamp_count
+      exported_name: changefeed_checkpoint_timestamp_count
+      description: Number of unique timestamps in a changefeed checkpoint
+      y_axis_label: Timestamps
+      type: HISTOGRAM
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.checkpoint.total_bytes
+      exported_name: changefeed_checkpoint_total_bytes
+      description: Total size of a changefeed checkpoint
+      y_axis_label: Bytes
+      type: HISTOGRAM
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.checkpoint_hist_nanos
+      exported_name: changefeed_checkpoint_hist_nanos
+      description: Time spent checkpointing changefeed progress
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.checkpoint_progress
+      exported_name: changefeed_checkpoint_progress
+      description: The earliest timestamp of any changefeed's persisted checkpoint (values prior to this timestamp will never need to be re-emitted)
+      y_axis_label: Unix Timestamp Nanoseconds
+      type: GAUGE
+      unit: TIMESTAMP_NS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.cloudstorage_buffered_bytes
+      exported_name: changefeed_cloudstorage_buffered_bytes
+      description: The number of bytes buffered in cloudstorage sink files which have not been emitted yet
+      y_axis_label: Bytes
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
     - name: changefeed.commit_latency
       exported_name: changefeed_commit_latency
       description: 'Event commit latency: a difference between event MVCC timestamp and the time it was acknowledged by the downstream sink. If the sink batches events, then the difference between the oldest event in the batch and acknowledgement is recorded. Excludes latency during backfill.'
@@ -13,6 +268,14 @@ layers:
       derivative: NONE
       how_to_use: This metric provides a useful context when assessing the state of changefeeds. This metric characterizes the end-to-end lag between a committed change and that change applied at the destination.
       visibility: ESSENTIAL
+    - name: changefeed.emitted_batch_sizes
+      exported_name: changefeed_emitted_batch_sizes
+      description: Size of batches emitted emitted by all feeds
+      y_axis_label: Number of Messages in Batch
+      type: HISTOGRAM
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
     - name: changefeed.emitted_bytes
       exported_name: changefeed_emitted_bytes
       description: Bytes emitted by all feeds
@@ -53,6 +316,215 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric tracks the permanent changefeed job failures that the jobs system will not try to restart. Any increase in this counter should be investigated. An alert on this metric is recommended.
       visibility: ESSENTIAL
+    - name: changefeed.filtered_messages
+      exported_name: changefeed_filtered_messages
+      description: Messages filtered out by all feeds. This count does not include the number of messages that may be filtered due to the range constraints.
+      y_axis_label: Messages
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.flush.messages_pushback_nanos
+      exported_name: changefeed_flush_messages_pushback_nanos
+      description: Total time spent throttled for flush quota
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.flush_hist_nanos
+      exported_name: changefeed_flush_hist_nanos
+      description: Time spent flushing messages across all changefeeds
+      y_axis_label: Changefeeds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.flushed_bytes
+      exported_name: changefeed_flushed_bytes
+      description: Bytes emitted by all feeds; maybe different from changefeed.emitted_bytes when compression is enabled
+      y_axis_label: Bytes
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.flushes
+      exported_name: changefeed_flushes
+      description: Total flushes across all feeds.
+      y_axis_label: Flushes
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.forwarded_resolved_messages
+      exported_name: changefeed_forwarded_resolved_messages
+      description: Resolved timestamps forwarded from the change aggregator to the change frontier
+      y_axis_label: Messages
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.frontier_updates
+      exported_name: changefeed_frontier_updates
+      description: Number of change frontier updates across all feeds
+      y_axis_label: Updates
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.internal_retry_message_count
+      exported_name: changefeed_internal_retry_message_count
+      description: Number of messages for which an attempt to retry them within an aggregator node was made.
+      y_axis_label: Messages
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.kafka_throttling_hist_nanos
+      exported_name: changefeed_kafka_throttling_hist_nanos
+      description: Time spent in throttling due to exceeding kafka quota
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.lagging_ranges
+      exported_name: changefeed_lagging_ranges
+      description: The number of ranges considered to be lagging behind
+      y_axis_label: Ranges
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.max_behind_nanos
+      exported_name: changefeed_max_behind_nanos
+      description: The most any changefeed's persisted checkpoint is behind the present
+      y_axis_label: Nanoseconds
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      visibility: SUPPORT
+    - name: changefeed.message_size_hist
+      exported_name: changefeed_message_size_hist
+      description: Message size histogram
+      y_axis_label: Bytes
+      type: HISTOGRAM
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.messages.messages_pushback_nanos
+      exported_name: changefeed_messages_messages_pushback_nanos
+      description: Total time spent throttled for messages quota
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.network.bytes_in
+      exported_name: changefeed_network_bytes_in
+      description: The number of bytes received from the network by changefeeds
+      y_axis_label: Bytes
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.network.bytes_out
+      exported_name: changefeed_network_bytes_out
+      description: The number of bytes sent over the network by changefeeds
+      y_axis_label: Bytes
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.nprocs_consume_event_nanos
+      exported_name: changefeed_nprocs_consume_event_nanos
+      description: Total time spent waiting to add an event to the parallel consumer
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.nprocs_flush_nanos
+      exported_name: changefeed_nprocs_flush_nanos
+      description: Total time spent idle waiting for the parallel consumer to flush
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.nprocs_in_flight_count
+      exported_name: changefeed_nprocs_in_flight_count
+      description: Number of buffered events in the parallel consumer
+      y_axis_label: Count of Events
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.parallel_io_in_flight_keys
+      exported_name: changefeed_parallel_io_in_flight_keys
+      description: The number of keys currently in-flight which may contend with batches pending to be emitted
+      y_axis_label: Keys
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.parallel_io_pending_rows
+      exported_name: changefeed_parallel_io_pending_rows
+      description: Number of rows which are blocked from being sent due to conflicting in-flight keys.
+      y_axis_label: Messages
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.parallel_io_queue_nanos
+      exported_name: changefeed_parallel_io_queue_nanos
+      description: Time that outgoing requests to the sink spend waiting in a queue due to in-flight requests with conflicting keys.
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.parallel_io_result_queue_nanos
+      exported_name: changefeed_parallel_io_result_queue_nanos
+      description: Time that incoming results from the sink spend waiting in parallel io emitter before they are acknowledged by the changefeed
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.parallel_io_workers
+      exported_name: changefeed_parallel_io_workers
+      description: The number of workers in the ParallelIO
+      y_axis_label: Workers
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.progress_skew.span
+      exported_name: changefeed_progress_skew_span
+      description: The time difference between the fastest and slowest span's resolved timestamp
+      y_axis_label: Nanoseconds
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.progress_skew.table
+      exported_name: changefeed_progress_skew_table
+      description: The time difference between the fastest and slowest table's resolved timestamp
+      y_axis_label: Nanoseconds
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.queue_time_nanos
+      exported_name: changefeed_queue_time_nanos
+      description: Time KV event spent waiting to be processed
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: changefeed.running
       exported_name: changefeed_running
       description: Number of currently running changefeeds, including sinkless
@@ -63,6 +535,218 @@ layers:
       derivative: NONE
       how_to_use: This metric tracks the total number of all running changefeeds.
       visibility: ESSENTIAL
+    - name: changefeed.schema_registry.registrations
+      exported_name: changefeed_schema_registry_registrations
+      description: Number of registration attempts with the schema registry.
+      y_axis_label: Registrations
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.schema_registry.retry_count
+      exported_name: changefeed_schema_registry_retry_count
+      description: Number of retries encountered when sending requests to the schema registry.
+      y_axis_label: Retries
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.schemafeed.table_history_scans
+      exported_name: changefeed_schemafeed_table_history_scans
+      description: The number of table history scans during polling
+      y_axis_label: Counts
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.schemafeed.table_metadata_nanos
+      exported_name: changefeed_schemafeed_table_metadata_nanos
+      description: Time blocked while verifying table metadata histories
+      y_axis_label: Nanoseconds
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.sink_backpressure_nanos
+      exported_name: changefeed_sink_backpressure_nanos
+      description: Time spent waiting for quota when emitting to the sink (back-pressure). Only populated for sinks using the batching_sink wrapper. As of writing, this includes Kafka (v2), Pub/Sub (v2), and Webhook (v2).
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.sink_batch_hist_nanos
+      exported_name: changefeed_sink_batch_hist_nanos
+      description: Time spent batched in the sink buffer before being flushed and acknowledged.
+      y_axis_label: Changefeeds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.sink_errors
+      exported_name: changefeed_sink_errors
+      description: Number of changefeed errors caused by the sink
+      y_axis_label: Count
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.sink_io_inflight
+      exported_name: changefeed_sink_io_inflight
+      description: The number of keys currently inflight as IO requests being sent to the sink
+      y_axis_label: Messages
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.size_based_flushes
+      exported_name: changefeed_size_based_flushes
+      description: Total size based flushes across all feeds.
+      y_axis_label: Flushes
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.stage.checkpoint_job_progress.latency
+      exported_name: changefeed_stage_checkpoint_job_progress_latency
+      labeled_name: 'changefeed.stage.latency{name: checkpoint_job_progress}'
+      description: 'Latency of the changefeed stage: checkpointing job progress'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.downstream_client_send.latency
+      exported_name: changefeed_stage_downstream_client_send_latency
+      labeled_name: 'changefeed.stage.latency{name: downstream_client_send}'
+      description: 'Latency of the changefeed stage: flushing messages from the sink''s client to its downstream. This includes sends that failed for most but not all sinks.'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.emit_row.latency
+      exported_name: changefeed_stage_emit_row_latency
+      labeled_name: 'changefeed.stage.latency{name: emit_row}'
+      description: 'Latency of the changefeed stage: emitting row to sink'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.encode.latency
+      exported_name: changefeed_stage_encode_latency
+      labeled_name: 'changefeed.stage.latency{name: encode}'
+      description: 'Latency of the changefeed stage: encoding data'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.frontier_persistence.latency
+      exported_name: changefeed_stage_frontier_persistence_latency
+      labeled_name: 'changefeed.stage.latency{name: frontier_persistence}'
+      description: 'Latency of the changefeed stage: persisting frontier to job info'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.kv_feed_buffer.latency
+      exported_name: changefeed_stage_kv_feed_buffer_latency
+      labeled_name: 'changefeed.stage.latency{name: kv_feed_buffer}'
+      description: 'Latency of the changefeed stage: waiting to buffer kv events'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.kv_feed_wait_for_table_event.latency
+      exported_name: changefeed_stage_kv_feed_wait_for_table_event_latency
+      labeled_name: 'changefeed.stage.latency{name: kv_feed_wait_for_table_event}'
+      description: 'Latency of the changefeed stage: waiting for a table schema event to join to the kv event'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.pts.create.latency
+      exported_name: changefeed_stage_pts_create_latency
+      labeled_name: 'changefeed.stage.pts.latency{name: create}'
+      description: 'Latency of the changefeed stage: Time spent creating protected timestamp records on changefeed creation'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.pts.manage.latency
+      exported_name: changefeed_stage_pts_manage_latency
+      labeled_name: 'changefeed.stage.pts.latency{name: manage}'
+      description: 'Latency of the changefeed stage: Time spent successfully managing protected timestamp records on highwater advance, including time spent creating new protected timestamps when needed'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.pts.manage_error.latency
+      exported_name: changefeed_stage_pts_manage_error_latency
+      labeled_name: 'changefeed.stage.pts.latency{name: manage_error}'
+      description: 'Latency of the changefeed stage: Time spent managing protected timestamp when we eventually error'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.rangefeed_buffer_checkpoint.latency
+      exported_name: changefeed_stage_rangefeed_buffer_checkpoint_latency
+      labeled_name: 'changefeed.stage.latency{name: rangefeed_buffer_checkpoint}'
+      description: 'Latency of the changefeed stage: buffering rangefeed checkpoint events'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.stage.rangefeed_buffer_value.latency
+      exported_name: changefeed_stage_rangefeed_buffer_value_latency
+      labeled_name: 'changefeed.stage.latency{name: rangefeed_buffer_value}'
+      description: 'Latency of the changefeed stage: buffering rangefeed value events'
+      y_axis_label: Latency
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.total_ranges
+      exported_name: changefeed_total_ranges
+      description: The total number of ranges being watched by changefeed aggregators
+      y_axis_label: Ranges
+      type: GAUGE
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.usage.error_count
+      exported_name: changefeed_usage_error_count
+      description: Count of errors encountered while generating usage metrics for changefeeds
+      y_axis_label: Errors
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: changefeed.usage.query_duration
+      exported_name: changefeed_usage_query_duration
+      description: Time taken by the queries used to generate usage metrics for changefeeds
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+    - name: changefeed.usage.table_bytes
+      exported_name: changefeed_usage_table_bytes
+      description: Aggregated number of bytes of data per table watched by changefeeds
+      y_axis_label: Storage
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
     - name: jobs.changefeed.currently_paused
       exported_name: jobs_changefeed_currently_paused
       labeled_name: 'jobs{name: changefeed, status: currently_paused}'
@@ -1296,690 +1980,6 @@ layers:
       y_axis_label: Jobs
       type: GAUGE
       unit: TIMESTAMP_SEC
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.admit_latency
-      exported_name: changefeed_admit_latency
-      description: 'Event admission latency: a difference between event MVCC timestamp and the time it was admitted into changefeed pipeline; Note: this metric includes the time spent waiting until event can be processed due to backpressure or time spent resolving schema descriptors. Also note, this metric excludes latency during backfill'
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.aggregator_progress
-      exported_name: changefeed_aggregator_progress
-      description: The earliest timestamp up to which any aggregator is guaranteed to have emitted all values for
-      y_axis_label: Unix Timestamp Nanoseconds
-      type: GAUGE
-      unit: TIMESTAMP_NS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.backfill_count
-      exported_name: changefeed_backfill_count
-      description: Number of changefeeds currently executing backfill
-      y_axis_label: Count
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-      visibility: SUPPORT
-    - name: changefeed.backfill_pending_ranges
-      exported_name: changefeed_backfill_pending_ranges
-      description: Number of ranges in an ongoing backfill that are yet to be fully emitted
-      y_axis_label: Count
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.batch_reduction_count
-      exported_name: changefeed_batch_reduction_count
-      description: Number of times a changefeed aggregator node attempted to reduce the size of message batches it emitted to the sink
-      y_axis_label: Batch Size Reductions
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.buffer_entries.allocated_mem
-      exported_name: changefeed_buffer_entries_allocated_mem
-      description: Current quota pool memory allocation
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.buffer_entries.flush.aggregator
-      exported_name: changefeed_buffer_entries_flush_aggregator
-      labeled_name: 'changefeed.buffer_entries.flush{buffer_type: aggregator}'
-      description: Number of flush elements added to the buffer - between the kvfeed and the sink
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.flush.rangefeed
-      exported_name: changefeed_buffer_entries_flush_rangefeed
-      labeled_name: 'changefeed.buffer_entries.flush{buffer_type: rangefeed}'
-      description: Number of flush elements added to the buffer - between the rangefeed and the kvfeed
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.in.aggregator
-      exported_name: changefeed_buffer_entries_in_aggregator
-      labeled_name: 'changefeed.buffer_entries.in{buffer_type: aggregator}'
-      description: Total entries entering the buffer between raft and changefeed sinks - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.in.rangefeed
-      exported_name: changefeed_buffer_entries_in_rangefeed
-      labeled_name: 'changefeed.buffer_entries.in{buffer_type: rangefeed}'
-      description: Total entries entering the buffer between raft and changefeed sinks - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.kv.aggregator
-      exported_name: changefeed_buffer_entries_kv_aggregator
-      labeled_name: 'changefeed.buffer_entries.kv{buffer_type: aggregator}'
-      description: Number of kv elements added to the buffer - between the kvfeed and the sink
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.kv.rangefeed
-      exported_name: changefeed_buffer_entries_kv_rangefeed
-      labeled_name: 'changefeed.buffer_entries.kv{buffer_type: rangefeed}'
-      description: Number of kv elements added to the buffer - between the rangefeed and the kvfeed
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.out.aggregator
-      exported_name: changefeed_buffer_entries_out_aggregator
-      labeled_name: 'changefeed.buffer_entries.out{buffer_type: aggregator}'
-      description: Total entries leaving the buffer between raft and changefeed sinks - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.out.rangefeed
-      exported_name: changefeed_buffer_entries_out_rangefeed
-      labeled_name: 'changefeed.buffer_entries.out{buffer_type: rangefeed}'
-      description: Total entries leaving the buffer between raft and changefeed sinks - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.released.aggregator
-      exported_name: changefeed_buffer_entries_released_aggregator
-      labeled_name: 'changefeed.buffer_entries.released{buffer_type: aggregator}'
-      description: Total entries processed, emitted and acknowledged by the sinks - between the kvfeed and the sink
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.released.rangefeed
-      exported_name: changefeed_buffer_entries_released_rangefeed
-      labeled_name: 'changefeed.buffer_entries.released{buffer_type: rangefeed}'
-      description: Total entries processed, emitted and acknowledged by the sinks - between the rangefeed and the kvfeed
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.resolved.aggregator
-      exported_name: changefeed_buffer_entries_resolved_aggregator
-      labeled_name: 'changefeed.buffer_entries.resolved{buffer_type: aggregator}'
-      description: Number of resolved elements added to the buffer - between the kvfeed and the sink
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries.resolved.rangefeed
-      exported_name: changefeed_buffer_entries_resolved_rangefeed
-      labeled_name: 'changefeed.buffer_entries.resolved{buffer_type: rangefeed}'
-      description: Number of resolved elements added to the buffer - between the rangefeed and the kvfeed
-      y_axis_label: Events
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.acquired
-      exported_name: changefeed_buffer_entries_mem_acquired
-      description: Total amount of memory acquired for entries as they enter the system
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_entries_mem.released
-      exported_name: changefeed_buffer_entries_mem_released
-      description: Total amount of memory released by the entries after they have been emitted
-      y_axis_label: Entries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_pushback_nanos.aggregator
-      exported_name: changefeed_buffer_pushback_nanos_aggregator
-      labeled_name: 'changefeed.buffer_pushback_nanos{buffer_type: aggregator}'
-      description: Total time spent waiting while the buffer was full - between the kvfeed and the sink
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.buffer_pushback_nanos.rangefeed
-      exported_name: changefeed_buffer_pushback_nanos_rangefeed
-      labeled_name: 'changefeed.buffer_pushback_nanos{buffer_type: rangefeed}'
-      description: Total time spent waiting while the buffer was full - between the rangefeed and the kvfeed
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.bytes.messages_pushback_nanos
-      exported_name: changefeed_bytes_messages_pushback_nanos
-      description: Total time spent throttled for bytes quota
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.checkpoint.create_nanos
-      exported_name: changefeed_checkpoint_create_nanos
-      description: Time it takes to create a changefeed checkpoint
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.checkpoint.span_count
-      exported_name: changefeed_checkpoint_span_count
-      description: Number of spans in a changefeed checkpoint
-      y_axis_label: Spans
-      type: HISTOGRAM
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.checkpoint.timestamp_count
-      exported_name: changefeed_checkpoint_timestamp_count
-      description: Number of unique timestamps in a changefeed checkpoint
-      y_axis_label: Timestamps
-      type: HISTOGRAM
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.checkpoint.total_bytes
-      exported_name: changefeed_checkpoint_total_bytes
-      description: Total size of a changefeed checkpoint
-      y_axis_label: Bytes
-      type: HISTOGRAM
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.checkpoint_hist_nanos
-      exported_name: changefeed_checkpoint_hist_nanos
-      description: Time spent checkpointing changefeed progress
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.checkpoint_progress
-      exported_name: changefeed_checkpoint_progress
-      description: The earliest timestamp of any changefeed's persisted checkpoint (values prior to this timestamp will never need to be re-emitted)
-      y_axis_label: Unix Timestamp Nanoseconds
-      type: GAUGE
-      unit: TIMESTAMP_NS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.cloudstorage_buffered_bytes
-      exported_name: changefeed_cloudstorage_buffered_bytes
-      description: The number of bytes buffered in cloudstorage sink files which have not been emitted yet
-      y_axis_label: Bytes
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.emitted_batch_sizes
-      exported_name: changefeed_emitted_batch_sizes
-      description: Size of batches emitted emitted by all feeds
-      y_axis_label: Number of Messages in Batch
-      type: HISTOGRAM
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.filtered_messages
-      exported_name: changefeed_filtered_messages
-      description: Messages filtered out by all feeds. This count does not include the number of messages that may be filtered due to the range constraints.
-      y_axis_label: Messages
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.flush.messages_pushback_nanos
-      exported_name: changefeed_flush_messages_pushback_nanos
-      description: Total time spent throttled for flush quota
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.flush_hist_nanos
-      exported_name: changefeed_flush_hist_nanos
-      description: Time spent flushing messages across all changefeeds
-      y_axis_label: Changefeeds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.flushed_bytes
-      exported_name: changefeed_flushed_bytes
-      description: Bytes emitted by all feeds; maybe different from changefeed.emitted_bytes when compression is enabled
-      y_axis_label: Bytes
-      type: COUNTER
-      unit: BYTES
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.flushes
-      exported_name: changefeed_flushes
-      description: Total flushes across all feeds.
-      y_axis_label: Flushes
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.forwarded_resolved_messages
-      exported_name: changefeed_forwarded_resolved_messages
-      description: Resolved timestamps forwarded from the change aggregator to the change frontier
-      y_axis_label: Messages
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.frontier_updates
-      exported_name: changefeed_frontier_updates
-      description: Number of change frontier updates across all feeds
-      y_axis_label: Updates
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.internal_retry_message_count
-      exported_name: changefeed_internal_retry_message_count
-      description: Number of messages for which an attempt to retry them within an aggregator node was made.
-      y_axis_label: Messages
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.kafka_throttling_hist_nanos
-      exported_name: changefeed_kafka_throttling_hist_nanos
-      description: Time spent in throttling due to exceeding kafka quota
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.lagging_ranges
-      exported_name: changefeed_lagging_ranges
-      description: The number of ranges considered to be lagging behind
-      y_axis_label: Ranges
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.max_behind_nanos
-      exported_name: changefeed_max_behind_nanos
-      description: The most any changefeed's persisted checkpoint is behind the present
-      y_axis_label: Nanoseconds
-      type: GAUGE
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-      visibility: SUPPORT
-    - name: changefeed.message_size_hist
-      exported_name: changefeed_message_size_hist
-      description: Message size histogram
-      y_axis_label: Bytes
-      type: HISTOGRAM
-      unit: BYTES
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.messages.messages_pushback_nanos
-      exported_name: changefeed_messages_messages_pushback_nanos
-      description: Total time spent throttled for messages quota
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.network.bytes_in
-      exported_name: changefeed_network_bytes_in
-      description: The number of bytes received from the network by changefeeds
-      y_axis_label: Bytes
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.network.bytes_out
-      exported_name: changefeed_network_bytes_out
-      description: The number of bytes sent over the network by changefeeds
-      y_axis_label: Bytes
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.nprocs_consume_event_nanos
-      exported_name: changefeed_nprocs_consume_event_nanos
-      description: Total time spent waiting to add an event to the parallel consumer
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.nprocs_flush_nanos
-      exported_name: changefeed_nprocs_flush_nanos
-      description: Total time spent idle waiting for the parallel consumer to flush
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.nprocs_in_flight_count
-      exported_name: changefeed_nprocs_in_flight_count
-      description: Number of buffered events in the parallel consumer
-      y_axis_label: Count of Events
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.parallel_io_in_flight_keys
-      exported_name: changefeed_parallel_io_in_flight_keys
-      description: The number of keys currently in-flight which may contend with batches pending to be emitted
-      y_axis_label: Keys
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.parallel_io_pending_rows
-      exported_name: changefeed_parallel_io_pending_rows
-      description: Number of rows which are blocked from being sent due to conflicting in-flight keys.
-      y_axis_label: Messages
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.parallel_io_queue_nanos
-      exported_name: changefeed_parallel_io_queue_nanos
-      description: Time that outgoing requests to the sink spend waiting in a queue due to in-flight requests with conflicting keys.
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.parallel_io_result_queue_nanos
-      exported_name: changefeed_parallel_io_result_queue_nanos
-      description: Time that incoming results from the sink spend waiting in parallel io emitter before they are acknowledged by the changefeed
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.parallel_io_workers
-      exported_name: changefeed_parallel_io_workers
-      description: The number of workers in the ParallelIO
-      y_axis_label: Workers
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.progress_skew.span
-      exported_name: changefeed_progress_skew_span
-      description: The time difference between the fastest and slowest span's resolved timestamp
-      y_axis_label: Nanoseconds
-      type: GAUGE
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.progress_skew.table
-      exported_name: changefeed_progress_skew_table
-      description: The time difference between the fastest and slowest table's resolved timestamp
-      y_axis_label: Nanoseconds
-      type: GAUGE
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.queue_time_nanos
-      exported_name: changefeed_queue_time_nanos
-      description: Time KV event spent waiting to be processed
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.schema_registry.registrations
-      exported_name: changefeed_schema_registry_registrations
-      description: Number of registration attempts with the schema registry.
-      y_axis_label: Registrations
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.schema_registry.retry_count
-      exported_name: changefeed_schema_registry_retry_count
-      description: Number of retries encountered when sending requests to the schema registry.
-      y_axis_label: Retries
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.schemafeed.table_history_scans
-      exported_name: changefeed_schemafeed_table_history_scans
-      description: The number of table history scans during polling
-      y_axis_label: Counts
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.schemafeed.table_metadata_nanos
-      exported_name: changefeed_schemafeed_table_metadata_nanos
-      description: Time blocked while verifying table metadata histories
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.sink_backpressure_nanos
-      exported_name: changefeed_sink_backpressure_nanos
-      description: Time spent waiting for quota when emitting to the sink (back-pressure). Only populated for sinks using the batching_sink wrapper. As of writing, this includes Kafka (v2), Pub/Sub (v2), and Webhook (v2).
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.sink_batch_hist_nanos
-      exported_name: changefeed_sink_batch_hist_nanos
-      description: Time spent batched in the sink buffer before being flushed and acknowledged.
-      y_axis_label: Changefeeds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.sink_errors
-      exported_name: changefeed_sink_errors
-      description: Number of changefeed errors caused by the sink
-      y_axis_label: Count
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.sink_io_inflight
-      exported_name: changefeed_sink_io_inflight
-      description: The number of keys currently inflight as IO requests being sent to the sink
-      y_axis_label: Messages
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.size_based_flushes
-      exported_name: changefeed_size_based_flushes
-      description: Total size based flushes across all feeds.
-      y_axis_label: Flushes
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.stage.checkpoint_job_progress.latency
-      exported_name: changefeed_stage_checkpoint_job_progress_latency
-      labeled_name: 'changefeed.stage.latency{name: checkpoint_job_progress}'
-      description: 'Latency of the changefeed stage: checkpointing job progress'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.downstream_client_send.latency
-      exported_name: changefeed_stage_downstream_client_send_latency
-      labeled_name: 'changefeed.stage.latency{name: downstream_client_send}'
-      description: 'Latency of the changefeed stage: flushing messages from the sink''s client to its downstream. This includes sends that failed for most but not all sinks.'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.emit_row.latency
-      exported_name: changefeed_stage_emit_row_latency
-      labeled_name: 'changefeed.stage.latency{name: emit_row}'
-      description: 'Latency of the changefeed stage: emitting row to sink'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.encode.latency
-      exported_name: changefeed_stage_encode_latency
-      labeled_name: 'changefeed.stage.latency{name: encode}'
-      description: 'Latency of the changefeed stage: encoding data'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.frontier_persistence.latency
-      exported_name: changefeed_stage_frontier_persistence_latency
-      labeled_name: 'changefeed.stage.latency{name: frontier_persistence}'
-      description: 'Latency of the changefeed stage: persisting frontier to job info'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.kv_feed_buffer.latency
-      exported_name: changefeed_stage_kv_feed_buffer_latency
-      labeled_name: 'changefeed.stage.latency{name: kv_feed_buffer}'
-      description: 'Latency of the changefeed stage: waiting to buffer kv events'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.kv_feed_wait_for_table_event.latency
-      exported_name: changefeed_stage_kv_feed_wait_for_table_event_latency
-      labeled_name: 'changefeed.stage.latency{name: kv_feed_wait_for_table_event}'
-      description: 'Latency of the changefeed stage: waiting for a table schema event to join to the kv event'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.pts.create.latency
-      exported_name: changefeed_stage_pts_create_latency
-      labeled_name: 'changefeed.stage.pts.latency{name: create}'
-      description: 'Latency of the changefeed stage: Time spent creating protected timestamp records on changefeed creation'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.pts.manage.latency
-      exported_name: changefeed_stage_pts_manage_latency
-      labeled_name: 'changefeed.stage.pts.latency{name: manage}'
-      description: 'Latency of the changefeed stage: Time spent successfully managing protected timestamp records on highwater advance, including time spent creating new protected timestamps when needed'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.pts.manage_error.latency
-      exported_name: changefeed_stage_pts_manage_error_latency
-      labeled_name: 'changefeed.stage.pts.latency{name: manage_error}'
-      description: 'Latency of the changefeed stage: Time spent managing protected timestamp when we eventually error'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.rangefeed_buffer_checkpoint.latency
-      exported_name: changefeed_stage_rangefeed_buffer_checkpoint_latency
-      labeled_name: 'changefeed.stage.latency{name: rangefeed_buffer_checkpoint}'
-      description: 'Latency of the changefeed stage: buffering rangefeed checkpoint events'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.stage.rangefeed_buffer_value.latency
-      exported_name: changefeed_stage_rangefeed_buffer_value_latency
-      labeled_name: 'changefeed.stage.latency{name: rangefeed_buffer_value}'
-      description: 'Latency of the changefeed stage: buffering rangefeed value events'
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.total_ranges
-      exported_name: changefeed_total_ranges
-      description: The total number of ranges being watched by changefeed aggregators
-      y_axis_label: Ranges
-      type: GAUGE
-      unit: COUNT
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.usage.error_count
-      exported_name: changefeed_usage_error_count
-      description: Count of errors encountered while generating usage metrics for changefeeds
-      y_axis_label: Errors
-      type: COUNTER
-      unit: COUNT
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
-    - name: changefeed.usage.query_duration
-      exported_name: changefeed_usage_query_duration
-      description: Time taken by the queries used to generate usage metrics for changefeeds
-      y_axis_label: Nanoseconds
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
-    - name: changefeed.usage.table_bytes
-      exported_name: changefeed_usage_table_bytes
-      description: Aggregated number of bytes of data per table watched by changefeeds
-      y_axis_label: Storage
-      type: GAUGE
-      unit: BYTES
       aggregation: AVG
       derivative: NONE
     - name: clock-offset.medianabsdevnanos

--- a/pkg/ccl/changefeedccl/cdcutils/throttle.go
+++ b/pkg/ccl/changefeedccl/cdcutils/throttle.go
@@ -150,6 +150,7 @@ func MakeMetrics(histogramWindow time.Duration) Metrics {
 			Help:        fmt.Sprintf("Total time spent throttled for %s quota", n),
 			Measurement: "Nanoseconds",
 			Unit:        metric.Unit_NANOSECONDS,
+			Category:    metric.Metadata_CHANGEFEEDS,
 		}
 	}
 

--- a/pkg/ccl/changefeedccl/checkpoint/metrics.go
+++ b/pkg/ccl/changefeedccl/checkpoint/metrics.go
@@ -17,6 +17,7 @@ var (
 		Help:        "Time it takes to create a changefeed checkpoint",
 		Unit:        metric.Unit_NANOSECONDS,
 		Measurement: "Nanoseconds",
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 
 	metaTotalBytes = metric.Metadata{
@@ -24,6 +25,7 @@ var (
 		Help:        "Total size of a changefeed checkpoint",
 		Unit:        metric.Unit_BYTES,
 		Measurement: "Bytes",
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 
 	metaTimestampCount = metric.Metadata{
@@ -31,6 +33,7 @@ var (
 		Help:        "Number of unique timestamps in a changefeed checkpoint",
 		Unit:        metric.Unit_COUNT,
 		Measurement: "Timestamps",
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 
 	metaSpanCount = metric.Metadata{
@@ -38,6 +41,7 @@ var (
 		Help:        "Number of spans in a changefeed checkpoint",
 		Unit:        metric.Unit_COUNT,
 		Measurement: "Spans",
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 )
 

--- a/pkg/ccl/changefeedccl/kvevent/metrics.go
+++ b/pkg/ccl/changefeedccl/kvevent/metrics.go
@@ -18,42 +18,49 @@ var (
 		Help:        "Total entries entering the buffer between raft and changefeed sinks",
 		Measurement: "Entries",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBufferEntriesOut = metric.Metadata{
 		Name:        "changefeed.buffer_entries.out",
 		Help:        "Total entries leaving the buffer between raft and changefeed sinks",
 		Measurement: "Entries",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBufferEntriesReleased = metric.Metadata{
 		Name:        "changefeed.buffer_entries.released",
 		Help:        "Total entries processed, emitted and acknowledged by the sinks",
 		Measurement: "Entries",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBufferMemAcquired = metric.Metadata{
 		Name:        "changefeed.buffer_entries_mem.acquired",
 		Help:        "Total amount of memory acquired for entries as they enter the system",
 		Measurement: "Entries",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBufferMemReleased = metric.Metadata{
 		Name:        "changefeed.buffer_entries_mem.released",
 		Help:        "Total amount of memory released by the entries after they have been emitted",
 		Measurement: "Entries",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBufferPushbackNanos = metric.Metadata{
 		Name:        "changefeed.buffer_pushback_nanos",
 		Help:        "Total time spent waiting while the buffer was full",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedAllocatedMemory = metric.Metadata{
 		Name:        "changefeed.buffer_entries.allocated_mem",
 		Help:        "Current quota pool memory allocation",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 )
 
@@ -138,6 +145,7 @@ func MakeMetrics(histogramWindow time.Duration) Metrics {
 			Help:        fmt.Sprintf("Number of %s elements added to the buffer", eventTypeName),
 			Measurement: "Events",
 			Unit:        metric.Unit_COUNT,
+			Category:    metric.Metadata_CHANGEFEEDS,
 		}
 	}
 	commonBufferMetrics := CommonBufferMetrics{

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -759,6 +759,7 @@ var (
 		Help:        "Resolved timestamps forwarded from the change aggregator to the change frontier",
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedErrorRetries = metric.Metadata{
 		Name:        "changefeed.error_retries",
@@ -795,6 +796,7 @@ var (
 		Help:        "Time KV event spent waiting to be processed",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 
 	metaChangefeedCheckpointHistNanos = metric.Metadata{
@@ -802,6 +804,7 @@ var (
 		Help:        "Time spent checkpointing changefeed progress",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 
 	metaChangefeedFrontierUpdates = metric.Metadata{
@@ -809,54 +812,63 @@ var (
 		Help:        "Number of change frontier updates across all feeds",
 		Measurement: "Updates",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedEventConsumerFlushNanos = metric.Metadata{
 		Name:        "changefeed.nprocs_flush_nanos",
 		Help:        "Total time spent idle waiting for the parallel consumer to flush",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedEventConsumerConsumeNanos = metric.Metadata{
 		Name:        "changefeed.nprocs_consume_event_nanos",
 		Help:        "Total time spent waiting to add an event to the parallel consumer",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedEventConsumerInFlightEvents = metric.Metadata{
 		Name:        "changefeed.nprocs_in_flight_count",
 		Help:        "Number of buffered events in the parallel consumer",
 		Measurement: "Count of Events",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedTableBytes = metric.Metadata{
 		Name:        "changefeed.usage.table_bytes",
 		Help:        "Aggregated number of bytes of data per table watched by changefeeds",
 		Measurement: "Storage",
 		Unit:        metric.Unit_BYTES,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedUsageErrorCount = metric.Metadata{
 		Name:        "changefeed.usage.error_count",
 		Help:        "Count of errors encountered while generating usage metrics for changefeeds",
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedUsageQueryDuration = metric.Metadata{
 		Name:        "changefeed.usage.query_duration",
 		Help:        "Time taken by the queries used to generate usage metrics for changefeeds",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaNetworkBytesIn = metric.Metadata{
 		Name:        "changefeed.network.bytes_in",
 		Help:        "The number of bytes received from the network by changefeeds",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaNetworkBytesOut = metric.Metadata{
 		Name:        "changefeed.network.bytes_out",
 		Help:        "The number of bytes sent over the network by changefeeds",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 )
 
@@ -879,6 +891,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Help:        "Size of batches emitted emitted by all feeds",
 		Measurement: "Number of Messages in Batch",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedFilteredMessages := metric.Metadata{
 		Name: "changefeed.filtered_messages",
@@ -888,6 +901,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		`),
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedEmittedBytes := metric.Metadata{
 		Name:        "changefeed.emitted_bytes",
@@ -910,30 +924,35 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		`),
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedFlushes := metric.Metadata{
 		Name:        "changefeed.flushes",
 		Help:        "Total flushes across all feeds.",
 		Measurement: "Flushes",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaSizeBasedFlushes := metric.Metadata{
 		Name:        "changefeed.size_based_flushes",
 		Help:        "Total size based flushes across all feeds.",
 		Measurement: "Flushes",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBatchHistNanos := metric.Metadata{
 		Name:        "changefeed.sink_batch_hist_nanos",
 		Help:        "Time spent batched in the sink buffer before being flushed and acknowledged.",
 		Measurement: "Changefeeds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedFlushHistNanos := metric.Metadata{
 		Name:        "changefeed.flush_hist_nanos",
 		Help:        "Time spent flushing messages across all changefeeds",
 		Measurement: "Changefeeds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaCommitLatency := metric.Metadata{
 		Name: "changefeed.commit_latency",
@@ -964,6 +983,7 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		`),
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBackfillCount := metric.Metadata{
 		Name:        "changefeed.backfill_count",
@@ -971,12 +991,14 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Measurement: "Count",
 		Unit:        metric.Unit_COUNT,
 		Visibility:  metric.Metadata_SUPPORT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedBackfillPendingRanges := metric.Metadata{
 		Name:        "changefeed.backfill_pending_ranges",
 		Help:        "Number of ranges in an ongoing backfill that are yet to be fully emitted",
 		Measurement: "Count",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedRunning := metric.Metadata{
 		Name:        "changefeed.running",
@@ -992,30 +1014,35 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Help:        "Message size histogram",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaBatchReductionCount := metric.Metadata{
 		Name:        "changefeed.batch_reduction_count",
 		Help:        "Number of times a changefeed aggregator node attempted to reduce the size of message batches it emitted to the sink",
 		Measurement: "Batch Size Reductions",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaInternalRetryMessageCount := metric.Metadata{
 		Name:        "changefeed.internal_retry_message_count",
 		Help:        "Number of messages for which an attempt to retry them within an aggregator node was made.",
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaSchemaRegistryRetriesCount := metric.Metadata{
 		Name:        "changefeed.schema_registry.retry_count",
 		Help:        "Number of retries encountered when sending requests to the schema registry.",
 		Measurement: "Retries",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaSchemaRegistryRegistrations := metric.Metadata{
 		Name:        "changefeed.schema_registry.registrations",
 		Help:        "Number of registration attempts with the schema registry.",
 		Measurement: "Registrations",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedParallelIOQueueNanos := metric.Metadata{
 		Name: "changefeed.parallel_io_queue_nanos",
@@ -1025,12 +1052,14 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		`),
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedParallelIOPendingRows := metric.Metadata{
 		Name:        "changefeed.parallel_io_pending_rows",
 		Help:        "Number of rows which are blocked from being sent due to conflicting in-flight keys.",
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedParallelIOResultQueueNanos := metric.Metadata{
 		Name: "changefeed.parallel_io_result_queue_nanos",
@@ -1040,24 +1069,28 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		`),
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedParallelIOInFlightKeys := metric.Metadata{
 		Name:        "changefeed.parallel_io_in_flight_keys",
 		Help:        "The number of keys currently in-flight which may contend with batches pending to be emitted",
 		Measurement: "Keys",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedParallelIOWorkers := metric.Metadata{
 		Name:        "changefeed.parallel_io_workers",
 		Help:        "The number of workers in the ParallelIO",
 		Measurement: "Workers",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedSinkIOInflight := metric.Metadata{
 		Name:        "changefeed.sink_io_inflight",
 		Help:        "The number of keys currently inflight as IO requests being sent to the sink",
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedSinkBackpressureNanos := metric.Metadata{
 		Name: "changefeed.sink_backpressure_nanos",
@@ -1068,48 +1101,56 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		`),
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaAggregatorProgress := metric.Metadata{
 		Name:        "changefeed.aggregator_progress",
 		Help:        "The earliest timestamp up to which any aggregator is guaranteed to have emitted all values for",
 		Measurement: "Unix Timestamp Nanoseconds",
 		Unit:        metric.Unit_TIMESTAMP_NS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaCheckpointProgress := metric.Metadata{
 		Name:        "changefeed.checkpoint_progress",
 		Help:        "The earliest timestamp of any changefeed's persisted checkpoint (values prior to this timestamp will never need to be re-emitted)",
 		Measurement: "Unix Timestamp Nanoseconds",
 		Unit:        metric.Unit_TIMESTAMP_NS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaLaggingRanges := metric.Metadata{
 		Name:        "changefeed.lagging_ranges",
 		Help:        "The number of ranges considered to be lagging behind",
 		Measurement: "Ranges",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaTotalRanges := metric.Metadata{
 		Name:        "changefeed.total_ranges",
 		Help:        "The total number of ranges being watched by changefeed aggregators",
 		Measurement: "Ranges",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaCloudstorageBufferedBytes := metric.Metadata{
 		Name:        "changefeed.cloudstorage_buffered_bytes",
 		Help:        "The number of bytes buffered in cloudstorage sink files which have not been emitted yet",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedKafkaThrottlingNanos := metric.Metadata{
 		Name:        "changefeed.kafka_throttling_hist_nanos",
 		Help:        "Time spent in throttling due to exceeding kafka quota",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaSinkErrors := metric.Metadata{
 		Name:        "changefeed.sink_errors",
 		Help:        "Number of changefeed errors caused by the sink",
 		Measurement: "Count",
 		Unit:        metric.Unit_COUNT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	// TODO(dan): This was intended to be a measure of the minimum distance of
 	// any changefeed ahead of its gc ttl threshold, but keeping that correct in
@@ -1121,18 +1162,21 @@ func newAggregateMetrics(histogramWindow time.Duration, lookup *cidr.Lookup) *Ag
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 		Visibility:  metric.Metadata_SUPPORT,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedSpanProgressSkew := metric.Metadata{
 		Name:        "changefeed.progress_skew.span",
 		Help:        "The time difference between the fastest and slowest span's resolved timestamp",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 	metaChangefeedTableProgressSkew := metric.Metadata{
 		Name:        "changefeed.progress_skew.table",
 		Help:        "The time difference between the fastest and slowest table's resolved timestamp",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
+		Category:    metric.Metadata_CHANGEFEEDS,
 	}
 
 	functionalGaugeMinFn := func(childValues []int64) int64 {

--- a/pkg/ccl/changefeedccl/schemafeed/metrics.go
+++ b/pkg/ccl/changefeedccl/schemafeed/metrics.go
@@ -16,6 +16,7 @@ var metaChangefeedTableMetadataNanos = metric.Metadata{
 	Help:        "Time blocked while verifying table metadata histories",
 	Measurement: "Nanoseconds",
 	Unit:        metric.Unit_NANOSECONDS,
+	Category:    metric.Metadata_CHANGEFEEDS,
 }
 
 var metaChangefeedTableHistoryScans = metric.Metadata{
@@ -23,6 +24,7 @@ var metaChangefeedTableHistoryScans = metric.Metadata{
 	Help:        "The number of table history scans during polling",
 	Measurement: "Counts",
 	Unit:        metric.Unit_COUNT,
+	Category:    metric.Metadata_CHANGEFEEDS,
 }
 
 // Metrics is a metric.Struct for schemafeed metrics.

--- a/pkg/ccl/changefeedccl/timers/timers.go
+++ b/pkg/ccl/changefeedccl/timers/timers.go
@@ -50,6 +50,7 @@ func New(histogramWindow time.Duration) *Timers {
 				Measurement:  "Latency",
 				LabeledName:  labeledName,
 				StaticLabels: metric.MakeLabelPairs(metric.LabelName, labelName),
+				Category:     metric.Metadata_CHANGEFEEDS,
 			},
 			Duration: histogramWindow,
 			Buckets:  prometheus.ExponentialBucketsRange(float64(1*time.Microsecond), float64(1*time.Hour), 60),

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -451,18 +451,40 @@ func (mr *MetricsRecorder) GetTimeSeriesData(childMetrics bool) []tspb.TimeSerie
 		return nil
 	}
 
+	now := mr.clock.Now()
+	lastDataCount := atomic.LoadInt64(&mr.lastDataCount)
+	data := make([]tspb.TimeSeriesData, 0, lastDataCount)
+
 	if childMetrics {
 		if !ChildMetricsStorageEnabled.Get(&mr.settings.SV) {
 			return nil
 		}
-		return nil // TODO(jasonlmfong): to be implemented
+
+		// Record child metrics from app registry for system tenant only.
+		recorder := registryRecorder{
+			registry:       mr.mu.appRegistry,
+			format:         nodeTimeSeriesPrefix,
+			source:         mr.mu.desc.NodeID.String(),
+			timestampNanos: now.UnixNano(),
+		}
+		recorder.recordChangefeedChildMetrics(&data)
+
+		// Record child metrics from app-level registries for secondary tenants
+		for tenantID, r := range mr.mu.tenantRegistries {
+			tenantRecorder := registryRecorder{
+				registry:       r,
+				format:         nodeTimeSeriesPrefix,
+				source:         tsutil.MakeTenantSource(mr.mu.desc.NodeID.String(), tenantID.String()),
+				timestampNanos: now.UnixNano(),
+			}
+			tenantRecorder.recordChangefeedChildMetrics(&data)
+		}
+
+		atomic.CompareAndSwapInt64(&mr.lastDataCount, lastDataCount, int64(len(data)))
+		return data
 	}
 
-	lastDataCount := atomic.LoadInt64(&mr.lastDataCount)
-	data := make([]tspb.TimeSeriesData, 0, lastDataCount)
-
 	// Record time series from node-level registries.
-	now := mr.clock.Now()
 	recorder := registryRecorder{
 		registry:       mr.mu.nodeRegistry,
 		format:         nodeTimeSeriesPrefix,
@@ -902,6 +924,71 @@ func (rr registryRecorder) recordChild(
 					},
 				},
 			})
+		}
+		promIter.Each(m.Label, processChildMetric)
+	})
+}
+
+// recordChangefeedChildMetrics iterates through changefeed metrics in the registry and processes child metrics
+// for those that have TsdbRecordLabeled set to true in their metadata.
+// Records up to 1024 child metrics to prevent unbounded memory usage and performance issues.
+//
+// NB: Only available for Counter and Gauge metrics.
+func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesData) {
+	maxChildMetricsPerMetric := 1024
+
+	labels := rr.registry.GetLabels()
+	rr.registry.Each(func(name string, v interface{}) {
+		// Check if the metric has child collection enabled in its metadata
+		iterable, ok := v.(metric.Iterable)
+		if !ok {
+			// If we can't get metadata, skip child collection for safety
+			return
+		}
+		metadata := iterable.GetMetadata()
+		if !metadata.GetTsdbRecordLabeled() {
+			return // Skip this metric if child collection is not enabled
+		}
+		if metadata.Category != metric.Metadata_CHANGEFEEDS {
+			return
+		}
+
+		prom, ok := v.(metric.PrometheusExportable)
+		if !ok {
+			return
+		}
+		promIter, ok := v.(metric.PrometheusIterable)
+		if !ok {
+			return
+		}
+		m := prom.ToPrometheusMetric()
+		m.Label = append(labels, prom.GetLabels(false /* useStaticLabels */)...)
+
+		var childMetricsCount int
+		processChildMetric := func(childMetric *prometheusgo.Metric) {
+			if childMetricsCount >= maxChildMetricsPerMetric {
+				return // Stop processing once we hit the limit
+			}
+
+			var value float64
+			if childMetric.Gauge != nil {
+				value = *childMetric.Gauge.Value
+			} else if childMetric.Counter != nil {
+				value = *childMetric.Counter.Value
+			} else {
+				return
+			}
+			*dest = append(*dest, tspb.TimeSeriesData{
+				Name:   fmt.Sprintf(rr.format, prom.GetName(false /* useStaticLabels */)+metric.EncodeLabeledName(childMetric)),
+				Source: rr.source,
+				Datapoints: []tspb.TimeSeriesDatapoint{
+					{
+						TimestampNanos: rr.timestampNanos,
+						Value:          value,
+					},
+				},
+			})
+			childMetricsCount++
 		}
 		promIter.Each(m.Label, processChildMetric)
 	})

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -258,6 +259,172 @@ func TestMetricsRecorderLabels(t *testing.T) {
 	if a, e := actualData, expectedData; !reflect.DeepEqual(a, e) {
 		t.Errorf("recorder did not yield expected time series collection; diff:\n %v", pretty.Diff(e, a))
 	}
+
+	// ========================================
+	// Verify that GetTimeSeriesData with includeChildMetrics=true returns child labels
+	// ========================================
+
+	// Add aggmetrics with child labels to the app registry
+	aggCounter := aggmetric.NewCounter(
+		metric.Metadata{
+			Name:     "changefeed.agg_counter",
+			Category: metric.Metadata_CHANGEFEEDS,
+		},
+		"some-id", "feed_id",
+	)
+	appReg.AddMetric(aggCounter)
+	// Add child metrics with specific labels
+	child1 := aggCounter.AddChild("123", "feed-a")
+	child1.Inc(100)
+	child2 := aggCounter.AddChild("456", "feed-b")
+	child2.Inc(200)
+
+	aggGauge := aggmetric.NewGauge(
+		metric.Metadata{
+			Name:     "changefeed.agg_gauge",
+			Category: metric.Metadata_CHANGEFEEDS,
+		},
+		"db", "status!!",
+	)
+	appReg.AddMetric(aggGauge)
+	// Add child metrics with different label combinations
+	child3 := aggGauge.AddChild("mine", "active")
+	child3.Update(1)
+	child4 := aggGauge.AddChild("yours", "paused")
+	child4.Update(0)
+
+	// Enable the cluster setting for child metrics storage
+	ChildMetricsStorageEnabled.Override(context.Background(), &st.SV, true)
+
+	// Get time series data with child metrics enabled
+	childData := recorder.GetTimeSeriesData(true)
+
+	var foundCounterFeedA123 bool
+	var foundCounterFeedB456 bool
+	var foundGaugeMineActive bool
+	var foundGaugeYoursPaused bool
+
+	for _, ts := range childData {
+		// Check for changefeed.agg_counter with some_id and feed_id labels
+		if strings.Contains(ts.Name, "cr.node.changefeed.agg_counter") {
+			if strings.Contains(ts.Name, "feed_id=\"feed-a\"") && strings.Contains(ts.Name, "some_id=\"123\"") {
+				foundCounterFeedA123 = true
+				require.Equal(t, "7", ts.Source, "Expected source to be node ID 7")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(100), ts.Datapoints[0].Value)
+			}
+			if strings.Contains(ts.Name, "feed_id=\"feed-b\"") && strings.Contains(ts.Name, "some_id=\"456\"") {
+				foundCounterFeedB456 = true
+				require.Equal(t, "7", ts.Source, "Expected source to be node ID 7")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(200), ts.Datapoints[0].Value)
+			}
+		}
+
+		// Check for changefeed.agg_gauge with db and status labels
+		if strings.Contains(ts.Name, "cr.node.changefeed.agg_gauge") {
+			if strings.Contains(ts.Name, "db=\"mine\"") && strings.Contains(ts.Name, "status__=\"active\"") {
+				foundGaugeMineActive = true
+				require.Equal(t, "7", ts.Source, "Expected source to be node ID 7")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(1), ts.Datapoints[0].Value)
+			}
+			if strings.Contains(ts.Name, "db=\"yours\"") && strings.Contains(ts.Name, "status__=\"paused\"") {
+				foundGaugeYoursPaused = true
+				require.Equal(t, "7", ts.Source, "Expected source to be node ID 7")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(0), ts.Datapoints[0].Value)
+			}
+		}
+	}
+
+	require.True(t, foundCounterFeedA123, "Expected to find changefeed.agg_counter with some_id=123 and feed_id=feed-a")
+	require.True(t, foundCounterFeedB456, "Expected to find changefeed.agg_counter with some_id=456 and feed_id=feed-b")
+	require.True(t, foundGaugeMineActive, "Expected to find changefeed.agg_gauge with db=mine and status=active")
+	require.True(t, foundGaugeYoursPaused, "Expected to find changefeed.agg_gauge with db=yours and status=paused")
+
+	// ========================================
+	// Verify that tenant changefeed child metrics are collected with proper source
+	// ========================================
+
+	// Add changefeed aggmetrics to the tenant registry with TsdbRecordLabeled
+	tsdbRecordLabeled := true
+	tenantAggCounter := aggmetric.NewCounter(
+		metric.Metadata{
+			Name:              "changefeed.emitted_messages",
+			TsdbRecordLabeled: &tsdbRecordLabeled,
+			Category:          metric.Metadata_CHANGEFEEDS,
+		},
+		"scope", "feed_id",
+	)
+	regTenant.AddMetric(tenantAggCounter)
+
+	// Add child metrics for different changefeeds in the tenant
+	tenantChild1 := tenantAggCounter.AddChild("default", "tenant-feed-1")
+	tenantChild1.Inc(500)
+	tenantChild2 := tenantAggCounter.AddChild("user", "tenant-feed-2")
+	tenantChild2.Inc(750)
+
+	tenantAggGauge := aggmetric.NewGauge(
+		metric.Metadata{
+			Name:              "changefeed.running",
+			TsdbRecordLabeled: &tsdbRecordLabeled,
+			Category:          metric.Metadata_CHANGEFEEDS,
+		},
+		"scope",
+	)
+	regTenant.AddMetric(tenantAggGauge)
+
+	tenantChild3 := tenantAggGauge.AddChild("default")
+	tenantChild3.Update(2)
+	tenantChild4 := tenantAggGauge.AddChild("user")
+	tenantChild4.Update(1)
+
+	// Get time series data with child metrics enabled
+	tenantChildData := recorder.GetTimeSeriesData(true)
+
+	var foundTenantCounterFeed1 bool
+	var foundTenantCounterFeed2 bool
+	var foundTenantGaugeDefault bool
+	var foundTenantGaugeUser bool
+
+	for _, ts := range tenantChildData {
+		// Verify tenant changefeed metrics have correct source (7-123 for node 7, tenant 123)
+		if strings.Contains(ts.Name, "cr.node.changefeed.emitted_messages") {
+			if strings.Contains(ts.Name, `scope="default"`) && strings.Contains(ts.Name, `feed_id="tenant-feed-1"`) {
+				foundTenantCounterFeed1 = true
+				require.Equal(t, "7-123", ts.Source, "Expected tenant source format node-tenant")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(500), ts.Datapoints[0].Value)
+			}
+			if strings.Contains(ts.Name, `scope="user"`) && strings.Contains(ts.Name, `feed_id="tenant-feed-2"`) {
+				foundTenantCounterFeed2 = true
+				require.Equal(t, "7-123", ts.Source, "Expected tenant source format node-tenant")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(750), ts.Datapoints[0].Value)
+			}
+		}
+
+		if strings.Contains(ts.Name, "cr.node.changefeed.running") {
+			if strings.Contains(ts.Name, `scope="default"`) {
+				foundTenantGaugeDefault = true
+				require.Equal(t, "7-123", ts.Source, "Expected tenant source format node-tenant")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(2), ts.Datapoints[0].Value)
+			}
+			if strings.Contains(ts.Name, `scope="user"`) {
+				foundTenantGaugeUser = true
+				require.Equal(t, "7-123", ts.Source, "Expected tenant source format node-tenant")
+				require.Len(t, ts.Datapoints, 1)
+				require.Equal(t, float64(1), ts.Datapoints[0].Value)
+			}
+		}
+	}
+
+	require.True(t, foundTenantCounterFeed1, "Expected to find tenant changefeed.emitted_messages with scope=default and feed_id=tenant-feed-1")
+	require.True(t, foundTenantCounterFeed2, "Expected to find tenant changefeed.emitted_messages with scope=user and feed_id=tenant-feed-2")
+	require.True(t, foundTenantGaugeDefault, "Expected to find tenant changefeed.running with scope=default")
+	require.True(t, foundTenantGaugeUser, "Expected to find tenant changefeed.running with scope=user")
 }
 
 func TestRegistryRecorder_RecordChild(t *testing.T) {
@@ -763,4 +930,230 @@ func BenchmarkExtractValueAllocs(b *testing.B) {
 		}
 	}
 	b.ReportAllocs()
+}
+
+func TestRecordChangefeedChildMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 100))
+
+	t.Run("empty registry", func(t *testing.T) {
+		reg := metric.NewRegistry()
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		require.Empty(t, dest)
+	})
+
+	t.Run("non-changefeed metrics ignored", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		// Add non-changefeed metrics
+		gauge := metric.NewGauge(metric.Metadata{Name: "sql.connections"})
+		reg.AddMetric(gauge)
+		gauge.Update(10)
+
+		counter := metric.NewCounter(metric.Metadata{Name: "kv.requests"})
+		reg.AddMetric(counter)
+		counter.Inc(5)
+
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		require.Empty(t, dest)
+	})
+
+	t.Run("changefeed metrics without child collection", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		// Add changefeed aggmetric with child collection explicitly disabled
+		tsdbRecordLabeled := false
+		gauge := aggmetric.NewGauge(
+			metric.Metadata{
+				Name:              "changefeed.test_metric",
+				TsdbRecordLabeled: &tsdbRecordLabeled,
+				Category:          metric.Metadata_CHANGEFEEDS,
+			},
+			"job_id", "feed_id",
+		)
+		reg.AddMetric(gauge)
+
+		// Add child metrics with labels
+		child1 := gauge.AddChild("123", "abc")
+		child1.Update(50)
+
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		// Should be empty since TsdbRecordLabeled is false
+		require.Empty(t, dest)
+	})
+
+	t.Run("changefeed aggmetrics with child collection", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		// Create an aggmetric which supports child metrics
+		// Note: aggmetrics automatically have child collection capabilities
+		gauge := aggmetric.NewGauge(metric.Metadata{
+			Name:     "changefeed.test_metric",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "job_id", "feed_id")
+		reg.AddMetric(gauge)
+
+		// Add child metrics with labels
+		child1 := gauge.AddChild("123", "abc")
+		child1.Update(50)
+
+		child2 := gauge.AddChild("456", "def")
+		child2.Update(75)
+
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		// Should have data for child metrics (aggmetrics have child collection enabled by default)
+		require.Len(t, dest, 2)
+
+		// Verify the data structure
+		for _, data := range dest {
+			require.Contains(t, data.Name, "changefeed.test_metric")
+			require.Equal(t, "test-source", data.Source)
+			require.Len(t, data.Datapoints, 1)
+			require.Equal(t, manual.Now().UnixNano(), data.Datapoints[0].TimestampNanos)
+			require.Contains(t, []float64{50, 75}, data.Datapoints[0].Value)
+		}
+	})
+
+	t.Run("cardinality limit enforcement", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		gauge := aggmetric.NewGauge(metric.Metadata{
+			Name:     "changefeed.high_cardinality_metric",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "job_id")
+		reg.AddMetric(gauge)
+
+		// Add more than 1024 child metrics to test the limit
+		for i := 0; i < 1500; i++ {
+			child := gauge.AddChild(strconv.Itoa(i))
+			child.Update(int64(i))
+		}
+
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		// Should be limited to 1024 child metrics
+		require.Len(t, dest, 1024)
+	})
+
+	t.Run("label sanitization and sorting", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		gauge := aggmetric.NewGauge(metric.Metadata{
+			Name:     "changefeed.label_test",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "job-id", "feed.name")
+		reg.AddMetric(gauge)
+
+		// Add child with labels that need sanitization
+		child := gauge.AddChild("test@123", "my-feed!")
+		child.Update(42)
+
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		require.Len(t, dest, 1)
+
+		// Verify that the metric name contains sanitized labels
+		metricName := dest[0].Name
+		require.Contains(t, metricName, "changefeed.label_test{feed_name=\"my-feed!\", job_id=\"test@123\"}")
+	})
+
+	t.Run("counter and gauge support", func(t *testing.T) {
+		reg := metric.NewRegistry()
+
+		// Test with gauge
+		gauge := aggmetric.NewGauge(metric.Metadata{
+			Name:     "changefeed.gauge_metric",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "type")
+		reg.AddMetric(gauge)
+		gaugeChild := gauge.AddChild("gauge")
+		gaugeChild.Update(100)
+
+		// Test with counter
+		counter := aggmetric.NewCounter(metric.Metadata{
+			Name:     "changefeed.counter_metric",
+			Category: metric.Metadata_CHANGEFEEDS,
+		}, "type")
+		reg.AddMetric(counter)
+		counterChild := counter.AddChild("counter")
+		counterChild.Inc(50)
+
+		recorder := registryRecorder{
+			registry:       reg,
+			format:         nodeTimeSeriesPrefix,
+			source:         "test-source",
+			timestampNanos: manual.Now().UnixNano(),
+		}
+
+		var dest []tspb.TimeSeriesData
+		recorder.recordChangefeedChildMetrics(&dest)
+
+		require.Len(t, dest, 2)
+
+		// Find gauge and counter data points
+		var gaugeValue, counterValue float64
+		for _, data := range dest {
+			if data.Datapoints[0].Value == 100 {
+				gaugeValue = data.Datapoints[0].Value
+			} else if data.Datapoints[0].Value == 50 {
+				counterValue = data.Datapoints[0].Value
+			}
+		}
+
+		require.Equal(t, float64(100), gaugeValue)
+		require.Equal(t, float64(50), counterValue)
+	})
 }

--- a/pkg/ts/keys_test.go
+++ b/pkg/ts/keys_test.go
@@ -72,6 +72,14 @@ func TestDataKeys(t *testing.T) {
 			12,
 			"/System/tsd//1m/1924-09-18T08:00:00Z/",
 		},
+		{
+			"metric.with:special/chars{label=\"@@ αβ_ !星\",}",
+			"source:with/special-chars",
+			0,
+			Resolution10s,
+			83,
+			"/System/tsd/metric.with:special/chars{label=\"@@ αβ_ !星\",}/10s/1970-01-01T00:00:00Z/source:with/special-chars",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/graphite",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
+        "@com_github_prometheus_common//model",
         "@com_github_prometheus_prometheus//promql/parser",
         "@in_yaml_go_yaml_v4//:yaml",
     ],

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -233,11 +233,20 @@ func (m *Metadata) GetLabels(useStaticLabels bool) []*prometheusgo.LabelPair {
 	return lps
 }
 
+// Returns the value for TsdbRecordLabeled,
+// defaults to True when it is not supplied.
+func (m *Metadata) GetTsdbRecordLabeled() bool {
+	if m.TsdbRecordLabeled == nil {
+		return true
+	}
+	return *m.TsdbRecordLabeled
+}
+
 // AddLabel adds a label/value pair for this metric.
 func (m *Metadata) AddLabel(name, value string) {
 	m.Labels = append(m.Labels,
 		&LabelPair{
-			Name:  proto.String(exportedLabel(name)),
+			Name:  proto.String(ExportedLabel(name)),
 			Value: proto.String(value),
 		})
 }

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -148,6 +148,10 @@ message Metadata {
   // Currently this field is only output to metrics.yaml for documentation
   // purposes, with plans for future use in automated dashboard generation.
   required string how_to_use = 12 [(gogoproto.nullable) = false];
+  // tsdb_record_labeled enables child metrics to be collected
+  // in the low-frequency child metrics poller. When true, child metrics with
+  // labels will be recorded in the time series database.
+  optional bool tsdb_record_labeled = 13;
 
-  // Next ID: 13.
+  // Next ID: 14.
 }

--- a/pkg/util/metric/registry.go
+++ b/pkg/util/metric/registry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/gogo/protobuf/proto"
 	prometheusgo "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
 )
 
 var AppNameLabelEnabled = settings.RegisterBoolSetting(
@@ -79,7 +80,7 @@ func NewRegistry() *Registry {
 func (r *Registry) AddLabel(name string, value interface{}) {
 	r.Lock()
 	defer r.Unlock()
-	r.labels = append(r.labels, labelPair{name: exportedLabel(name), value: value})
+	r.labels = append(r.labels, labelPair{name: ExportedLabel(name), value: value})
 	r.computedLabels = append(r.computedLabels, &prometheusgo.LabelPair{})
 }
 
@@ -288,9 +289,21 @@ func ExportedName(name string) string {
 	return prometheusNameReplaceRE.ReplaceAllString(name, "_")
 }
 
-// exportedLabel takes a metric name and generates a valid prometheus name.
-func exportedLabel(name string) string {
+// ExportedLabel takes a metric label and generates a valid prometheus label name.
+func ExportedLabel(name string) string {
 	return prometheusLabelReplaceRE.ReplaceAllString(name, "_")
+}
+
+// EncodeLabeledName formats a metric name with labels in Prometheus format.
+// The labels are sanitized, sorted by key, and encoded as key="value" pairs
+// within curly braces. Example: metric_name{label1="value1", label2="value2"}
+func EncodeLabeledName(m *prometheusgo.Metric) string {
+	labels := make(model.LabelSet)
+	for _, l := range m.Label {
+		labels[model.LabelName(ExportedLabel(l.GetName()))] = model.LabelValue(l.GetValue())
+	}
+
+	return labels.String()
 }
 
 var panicHandler = log.Dev.Fatalf


### PR DESCRIPTION
This change adds the ability to get changefeed child metrics to be recorded. The child metrics have their names augmented with their labels.

Epic: CRDB-55079
Release: None