### PR TITLE
mma: make external caller mostly use an ExternalRangeChange

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "load.go",
         "memo_helper.go",
         "messages.go",
+        "range_change.go",
         "rebalance_advisor.go",
         "store_load_summary.go",
         "store_set.go",

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator.go
@@ -56,16 +56,16 @@ type Allocator interface {
 	// Calls to AdjustPendingChangeDisposition must be correctly sequenced with
 	// full state updates from the local node provided in
 	// ProcessNodeLoadResponse.
-	AdjustPendingChangeDisposition(change PendingRangeChange, success bool)
+	AdjustPendingChangeDisposition(change ExternalRangeChange, success bool)
 
 	// RegisterExternalChange informs this allocator about yet to complete
 	// changes to the cluster which were not initiated by this allocator. The
 	// ownership of all state inside change is handed off to the callee. If ok
-	// is true, the change was registered, and the caller should subsequently
-	// use the same change in a subsequent call to
+	// is true, the change was registered, and the caller is returned an
+	// ExternalRangeChange that it should subsequently use in a call to
 	// AdjustPendingChangeDisposition when the changes are completed, either
 	// successfully or not. If ok is false, the change was not registered.
-	RegisterExternalChange(change PendingRangeChange) (ok bool)
+	RegisterExternalChange(change PendingRangeChange) (_ ExternalRangeChange, ok bool)
 
 	// ComputeChanges is called periodically and frequently, say every 10s.
 	//
@@ -82,7 +82,7 @@ type Allocator interface {
 	// the allocator, to avoid re-proposing the same change and to make
 	// adjustments to the load.
 	ComputeChanges(
-		ctx context.Context, msg *StoreLeaseholderMsg, opts ChangeOptions) []PendingRangeChange
+		ctx context.Context, msg *StoreLeaseholderMsg, opts ChangeOptions) []ExternalRangeChange
 
 	// AdminRelocateOne is a helper for AdminRelocateRange.
 	//

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -505,38 +504,6 @@ func MakePendingRangeChange(rangeID roachpb.RangeID, changes []ReplicaChange) Pe
 	}
 }
 
-func (prc PendingRangeChange) String() string {
-	return redact.StringWithoutMarkers(prc)
-}
-
-// SafeFormat implements the redact.SafeFormatter interface.
-//
-// This is adhoc for debugging. A nicer string format would include the
-// previous state and next state.
-func (prc PendingRangeChange) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("r%v=[", prc.RangeID)
-	found := false
-	if prc.IsTransferLease() {
-		w.Printf("transfer_to=%v", prc.LeaseTransferTarget())
-		found = true
-	}
-	if prc.IsChangeReplicas() {
-		w.Printf("change_replicas=%v", prc.ReplicationChanges())
-		found = true
-	}
-	if !found {
-		panic("unknown change type")
-	}
-	w.Print(" cids=")
-	for i, c := range prc.pendingReplicaChanges {
-		if i > 0 {
-			w.Print(",")
-		}
-		w.Printf("%v", c.changeID)
-	}
-	w.Print("]")
-}
-
 // StringForTesting prints the untransformed internal state for testing.
 func (prc PendingRangeChange) StringForTesting() string {
 	var b strings.Builder
@@ -555,158 +522,6 @@ func (prc PendingRangeChange) SortForTesting() {
 	slices.SortFunc(prc.pendingReplicaChanges, func(a, b *pendingReplicaChange) int {
 		return cmp.Compare(a.target.StoreID, b.target.StoreID)
 	})
-}
-
-// TODO(sumeer): A single PendingRangeChange can model a bunch of replica
-// changes and a lease transfer. Classifying the change as either
-// IsChangeReplicas or IsTransferLease is unnecessarily limiting. The only
-// code that really relies on this is integration code:
-// mma_store_rebalancer.go, allocator_sync.go, asim. We should fix those and
-// consider removing these methods.
-
-// IsChangeReplicas returns true if the pending range change is a change
-// replicas operation.
-func (prc PendingRangeChange) IsChangeReplicas() bool {
-	for _, c := range prc.pendingReplicaChanges {
-		if c.isAddition() || c.isRemoval() || c.isPromoDemo() {
-			continue
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
-// IsTransferLease returns true if the pending range change is a transfer lease
-// operation.
-func (prc PendingRangeChange) IsTransferLease() bool {
-	if len(prc.pendingReplicaChanges) != 2 {
-		return false
-	}
-	var foundAddLease, foundRemoveLease bool
-	for _, c := range prc.pendingReplicaChanges {
-		if c.isAddition() || c.isRemoval() || c.isPromoDemo() {
-			// Any changes to the replica type or replicaID are not lease transfers,
-			// since they require a replication change.
-			return false
-		}
-		if c.prev.IsLeaseholder && !c.next.IsLeaseholder {
-			foundRemoveLease = true
-		} else if !c.prev.IsLeaseholder && c.next.IsLeaseholder {
-			foundAddLease = true
-		} else {
-			return false
-		}
-	}
-	return foundAddLease && foundRemoveLease
-}
-
-// ReplicationChanges returns the replication changes for the pending range
-// change. It panics if the pending range change is not a change replicas
-// operation.
-//
-// TODO(tbg): The ReplicationChanges can include a new leaseholder replica,
-// but the incoming leaseholder is not explicitly represented in
-// kvpb.ReplicationChanges. This is an existing modeling deficiency in the
-// kvserver code. In Replica.maybeTransferLeaseDuringLeaveJoint the first
-// VOTER_INCOMING is considered the new leaseholder. So the code below places
-// the new leaseholder (an ADD_VOTER) at index 0. It is not clear whether this
-// is sufficient for all integration use-cases. Verify and fix as needed.
-//
-// TODO(sumeer): this method is limiting, since a single PendingRangeChange
-// should be allowed to model any set of changes (see the existing TODO on
-// IsChangeReplicas).
-func (prc PendingRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
-	if !prc.IsChangeReplicas() {
-		panic("RangeChange is not a change replicas")
-	}
-	chgs := make([]kvpb.ReplicationChange, 0, len(prc.pendingReplicaChanges))
-	newLeaseholderIndex := -1
-	for _, c := range prc.pendingReplicaChanges {
-		switch c.replicaChangeType {
-		case ChangeReplica, AddReplica, RemoveReplica:
-			// These are the only permitted cases.
-		default:
-			panic(errors.AssertionFailedf("change type %v is not a change replicas", c.replicaChangeType))
-		}
-		// The kvserver code represents a change in replica type as an
-		// addition and a removal of the same replica. For example, if a
-		// replica changes from VOTER_FULL to NON_VOTER, we will emit a pair
-		// of {ADD_NON_VOTER, REMOVE_VOTER} for the replica. The ordering of
-		// this pair does not matter.
-		//
-		// TODO(tbg): confirm that the ordering does not matter.
-		if c.replicaChangeType == ChangeReplica || c.replicaChangeType == AddReplica {
-			chg := kvpb.ReplicationChange{Target: c.target}
-			isNewLeaseholder := false
-			switch c.next.ReplicaType.ReplicaType {
-			case roachpb.VOTER_FULL:
-				chg.ChangeType = roachpb.ADD_VOTER
-				if c.next.IsLeaseholder {
-					isNewLeaseholder = true
-				}
-			case roachpb.NON_VOTER:
-				chg.ChangeType = roachpb.ADD_NON_VOTER
-			default:
-				panic(errors.AssertionFailedf("unexpected replica type %s", c.next.ReplicaType.ReplicaType))
-			}
-			if isNewLeaseholder {
-				if newLeaseholderIndex >= 0 {
-					panic(errors.AssertionFailedf(
-						"multiple new leaseholders in change replicas"))
-				}
-				newLeaseholderIndex = len(chgs)
-			}
-			chgs = append(chgs, chg)
-		}
-		if c.replicaChangeType == ChangeReplica || c.replicaChangeType == RemoveReplica {
-			chg := kvpb.ReplicationChange{Target: c.target}
-			prevType := mapReplicaTypeToVoterOrNonVoter(c.prev.ReplicaType.ReplicaType)
-			switch prevType {
-			case roachpb.VOTER_FULL:
-				chg.ChangeType = roachpb.REMOVE_VOTER
-			case roachpb.NON_VOTER:
-				chg.ChangeType = roachpb.REMOVE_NON_VOTER
-			default:
-				panic(errors.AssertionFailedf("unexpected replica type %s", c.prev.ReplicaType.ReplicaType))
-			}
-			chgs = append(chgs, chg)
-		}
-	}
-	if newLeaseholderIndex >= 0 {
-		// Move the new leaseholder to index 0.
-		chgs[0], chgs[newLeaseholderIndex] = chgs[newLeaseholderIndex], chgs[0]
-	}
-	return chgs
-}
-
-// LeaseTransferTarget returns the store ID of the store that is the target of
-// the lease transfer. It panics if the pending range change is not a transfer
-// lease operation.
-func (prc PendingRangeChange) LeaseTransferTarget() roachpb.StoreID {
-	if !prc.IsTransferLease() {
-		panic("pendingRangeChange is not a lease transfer")
-	}
-	for _, c := range prc.pendingReplicaChanges {
-		if !c.prev.IsLeaseholder && c.next.IsLeaseholder {
-			return c.target.StoreID
-		}
-	}
-	panic("unreachable")
-}
-
-// LeaseTransferFrom returns the store ID of the store that is the source of
-// the lease transfer. It panics if the pending range change is not a
-func (prc PendingRangeChange) LeaseTransferFrom() roachpb.StoreID {
-	if !prc.IsTransferLease() {
-		panic("pendingRangeChange is not a lease transfer")
-	}
-	for _, c := range prc.pendingReplicaChanges {
-		if c.prev.IsLeaseholder && !c.next.IsLeaseholder {
-			return c.target.StoreID
-		}
-	}
-	panic("unreachable")
 }
 
 // pendingReplicaChange is a proposed change to a single replica. Some

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -35,7 +35,7 @@ type rebalanceEnv struct {
 	// dsm is the diversity scoring memo for computing diversity scores.
 	dsm *diversityScoringMemo
 	// changes accumulates the pending range changes made during rebalancing.
-	changes []PendingRangeChange
+	changes []ExternalRangeChange
 	// rangeMoveCount tracks the number of range moves made.
 	rangeMoveCount int
 	// maxRangeMoveCount is the maximum number of range moves allowed in the
@@ -121,7 +121,7 @@ type sheddingStore struct {
 // chance to shed leases.
 func (re *rebalanceEnv) rebalanceStores(
 	ctx context.Context, localStoreID roachpb.StoreID,
-) []PendingRangeChange {
+) []ExternalRangeChange {
 	re.mmaid++
 	id := re.mmaid
 	ctx = logtags.AddTag(ctx, "mmaid", id)
@@ -501,11 +501,11 @@ func (re *rebalanceEnv) rebalanceReplicas(
 				replicaChanges, rangeID))
 		}
 		re.addPendingRangeChange(rangeChange)
-		re.changes = append(re.changes, rangeChange)
+		re.changes = append(re.changes, MakeExternalRangeChange(rangeChange))
 		re.rangeMoveCount++
 		log.KvDistribution.VEventf(ctx, 2,
 			"result(success): rebalancing r%v from s%v to s%v [change: %v] with resulting loads source: %v target: %v",
-			rangeID, removeTarget.StoreID, addTarget.StoreID, re.changes[len(re.changes)-1], ss.adjusted.load, targetSS.adjusted.load)
+			rangeID, removeTarget.StoreID, addTarget.StoreID, &re.changes[len(re.changes)-1], ss.adjusted.load, targetSS.adjusted.load)
 	}
 }
 
@@ -674,14 +674,11 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			panic(errors.Wrapf(err, "pre-check failed for lease transfer %v", leaseChange))
 		}
 		re.addPendingRangeChange(leaseChange)
-		re.changes = append(re.changes, leaseChange)
-		if re.changes[len(re.changes)-1].IsChangeReplicas() || !re.changes[len(re.changes)-1].IsTransferLease() {
-			panic(fmt.Sprintf("lease transfer is invalid: %v", re.changes[len(re.changes)-1]))
-		}
+		re.changes = append(re.changes, MakeExternalRangeChange(leaseChange))
 		log.KvDistribution.Infof(ctx,
 			"result(success): shedding r%v lease from s%v to s%v [change:%v] with "+
 				"resulting loads source:%v target:%v (means: %v) (frac_pending: (src:%.2f,target:%.2f) (src:%.2f,target:%.2f))",
-			rangeID, removeTarget.StoreID, addTarget.StoreID, re.changes[len(re.changes)-1],
+			rangeID, removeTarget.StoreID, addTarget.StoreID, &re.changes[len(re.changes)-1],
 			ss.adjusted.load, targetSS.adjusted.load, means.storeLoad.load,
 			ss.maxFractionPendingIncrease, ss.maxFractionPendingDecrease,
 			targetSS.maxFractionPendingIncrease, targetSS.maxFractionPendingDecrease)

--- a/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
@@ -1,0 +1,197 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mmaprototype
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+func (prc PendingRangeChange) String() string {
+	return redact.StringWithoutMarkers(prc)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+//
+// This is adhoc for debugging. A nicer string format would include the
+// previous state and next state.
+func (prc PendingRangeChange) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("r%v=[", prc.RangeID)
+	found := false
+	if prc.IsTransferLease() {
+		w.Printf("transfer_to=%v", prc.LeaseTransferTarget())
+		found = true
+	}
+	if prc.IsChangeReplicas() {
+		w.Printf("change_replicas=%v", prc.ReplicationChanges())
+		found = true
+	}
+	if !found {
+		panic("unknown change type")
+	}
+	w.Print(" cids=")
+	for i, c := range prc.pendingReplicaChanges {
+		if i > 0 {
+			w.Print(",")
+		}
+		w.Printf("%v", c.changeID)
+	}
+	w.Print("]")
+}
+
+// TODO(sumeer): A single PendingRangeChange can model a bunch of replica
+// changes and a lease transfer. Classifying the change as either
+// IsChangeReplicas or IsTransferLease is unnecessarily limiting. The only
+// code that really relies on this is integration code:
+// mma_store_rebalancer.go, allocator_sync.go, asim. We should fix those and
+// consider removing these methods.
+
+// IsChangeReplicas returns true if the pending range change is a change
+// replicas operation.
+func (prc PendingRangeChange) IsChangeReplicas() bool {
+	for _, c := range prc.pendingReplicaChanges {
+		if c.isAddition() || c.isRemoval() || c.isPromoDemo() {
+			continue
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// IsTransferLease returns true if the pending range change is a transfer lease
+// operation.
+func (prc PendingRangeChange) IsTransferLease() bool {
+	if len(prc.pendingReplicaChanges) != 2 {
+		return false
+	}
+	var foundAddLease, foundRemoveLease bool
+	for _, c := range prc.pendingReplicaChanges {
+		if c.isAddition() || c.isRemoval() || c.isPromoDemo() {
+			// Any changes to the replica type or replicaID are not lease transfers,
+			// since they require a replication change.
+			return false
+		}
+		if c.prev.IsLeaseholder && !c.next.IsLeaseholder {
+			foundRemoveLease = true
+		} else if !c.prev.IsLeaseholder && c.next.IsLeaseholder {
+			foundAddLease = true
+		} else {
+			return false
+		}
+	}
+	return foundAddLease && foundRemoveLease
+}
+
+// ReplicationChanges returns the replication changes for the pending range
+// change. It panics if the pending range change is not a change replicas
+// operation.
+//
+// TODO(tbg): The ReplicationChanges can include a new leaseholder replica,
+// but the incoming leaseholder is not explicitly represented in
+// kvpb.ReplicationChanges. This is an existing modeling deficiency in the
+// kvserver code. In Replica.maybeTransferLeaseDuringLeaveJoint the first
+// VOTER_INCOMING is considered the new leaseholder. So the code below places
+// the new leaseholder (an ADD_VOTER) at index 0. It is not clear whether this
+// is sufficient for all integration use-cases. Verify and fix as needed.
+//
+// TODO(sumeer): this method is limiting, since a single PendingRangeChange
+// should be allowed to model any set of changes (see the existing TODO on
+// IsChangeReplicas).
+func (prc PendingRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
+	if !prc.IsChangeReplicas() {
+		panic("RangeChange is not a change replicas")
+	}
+	chgs := make([]kvpb.ReplicationChange, 0, len(prc.pendingReplicaChanges))
+	newLeaseholderIndex := -1
+	for _, c := range prc.pendingReplicaChanges {
+		switch c.replicaChangeType {
+		case ChangeReplica, AddReplica, RemoveReplica:
+			// These are the only permitted cases.
+		default:
+			panic(errors.AssertionFailedf("change type %v is not a change replicas", c.replicaChangeType))
+		}
+		// The kvserver code represents a change in replica type as an
+		// addition and a removal of the same replica. For example, if a
+		// replica changes from VOTER_FULL to NON_VOTER, we will emit a pair
+		// of {ADD_NON_VOTER, REMOVE_VOTER} for the replica. The ordering of
+		// this pair does not matter.
+		//
+		// TODO(tbg): confirm that the ordering does not matter.
+		if c.replicaChangeType == ChangeReplica || c.replicaChangeType == AddReplica {
+			chg := kvpb.ReplicationChange{Target: c.target}
+			isNewLeaseholder := false
+			switch c.next.ReplicaType.ReplicaType {
+			case roachpb.VOTER_FULL:
+				chg.ChangeType = roachpb.ADD_VOTER
+				if c.next.IsLeaseholder {
+					isNewLeaseholder = true
+				}
+			case roachpb.NON_VOTER:
+				chg.ChangeType = roachpb.ADD_NON_VOTER
+			default:
+				panic(errors.AssertionFailedf("unexpected replica type %s", c.next.ReplicaType.ReplicaType))
+			}
+			if isNewLeaseholder {
+				if newLeaseholderIndex >= 0 {
+					panic(errors.AssertionFailedf(
+						"multiple new leaseholders in change replicas"))
+				}
+				newLeaseholderIndex = len(chgs)
+			}
+			chgs = append(chgs, chg)
+		}
+		if c.replicaChangeType == ChangeReplica || c.replicaChangeType == RemoveReplica {
+			chg := kvpb.ReplicationChange{Target: c.target}
+			prevType := mapReplicaTypeToVoterOrNonVoter(c.prev.ReplicaType.ReplicaType)
+			switch prevType {
+			case roachpb.VOTER_FULL:
+				chg.ChangeType = roachpb.REMOVE_VOTER
+			case roachpb.NON_VOTER:
+				chg.ChangeType = roachpb.REMOVE_NON_VOTER
+			default:
+				panic(errors.AssertionFailedf("unexpected replica type %s", c.prev.ReplicaType.ReplicaType))
+			}
+			chgs = append(chgs, chg)
+		}
+	}
+	if newLeaseholderIndex >= 0 {
+		// Move the new leaseholder to index 0.
+		chgs[0], chgs[newLeaseholderIndex] = chgs[newLeaseholderIndex], chgs[0]
+	}
+	return chgs
+}
+
+// LeaseTransferTarget returns the store ID of the store that is the target of
+// the lease transfer. It panics if the pending range change is not a transfer
+// lease operation.
+func (prc PendingRangeChange) LeaseTransferTarget() roachpb.StoreID {
+	if !prc.IsTransferLease() {
+		panic("pendingRangeChange is not a lease transfer")
+	}
+	for _, c := range prc.pendingReplicaChanges {
+		if !c.prev.IsLeaseholder && c.next.IsLeaseholder {
+			return c.target.StoreID
+		}
+	}
+	panic("unreachable")
+}
+
+// LeaseTransferFrom returns the store ID of the store that is the source of
+// the lease transfer. It panics if the pending range change is not a
+func (prc PendingRangeChange) LeaseTransferFrom() roachpb.StoreID {
+	if !prc.IsTransferLease() {
+		panic("pendingRangeChange is not a lease transfer")
+	}
+	for _, c := range prc.pendingReplicaChanges {
+		if c.prev.IsLeaseholder && !c.next.IsLeaseholder {
+			return c.target.StoreID
+		}
+	}
+	panic("unreachable")
+}

--- a/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
@@ -12,30 +12,78 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-func (prc PendingRangeChange) String() string {
-	return redact.StringWithoutMarkers(prc)
+// ExternalRangeChange is a proposed set of change(s) to a range. It can
+// consist of multiple replica changes, such as adding or removing replicas,
+// or transferring the lease. There is at most one change per store in the
+// set.
+type ExternalRangeChange struct {
+	roachpb.RangeID
+	Changes []ExternalReplicaChange
+}
+
+// ExternalReplicaChange is a proposed change to a single replica. Some
+// external entity (the leaseholder of the range) may choose to enact this
+// change.
+type ExternalReplicaChange struct {
+	changeID
+	// Target is the target {store, node} for the change.
+	Target roachpb.ReplicationTarget
+	// Prev is the state before the change. See the detailed comment in
+	// ReplicaChange.prev, which is shared by this field (except that this is
+	// immutable).
+	Prev ReplicaIDAndType
+	// Next is the state after the change. See the detailed comment in
+	// ReplicaChange.next, which is shared by this field.
+	Next ReplicaIDAndType
+	// ChangeType is a function of (Prev, Next) and a convenience.
+	ChangeType ReplicaChangeType
+}
+
+func MakeExternalRangeChange(change PendingRangeChange) ExternalRangeChange {
+	changes := make([]ExternalReplicaChange, len(change.pendingReplicaChanges))
+	for i, rc := range change.pendingReplicaChanges {
+		changeType := rc.replicaChangeType()
+		if changeType == Unknown {
+			panic(errors.AssertionFailedf("unknown replica change type"))
+		}
+		changes[i] = ExternalReplicaChange{
+			changeID:   rc.changeID,
+			Target:     rc.target,
+			Prev:       rc.prev.ReplicaIDAndType,
+			Next:       rc.next,
+			ChangeType: changeType,
+		}
+	}
+	return ExternalRangeChange{
+		RangeID: change.RangeID,
+		Changes: changes,
+	}
+}
+
+func (rc *ExternalRangeChange) String() string {
+	return redact.StringWithoutMarkers(rc)
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
 //
 // This is adhoc for debugging. A nicer string format would include the
 // previous state and next state.
-func (prc PendingRangeChange) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("r%v=[", prc.RangeID)
+func (rc *ExternalRangeChange) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("r%v=[", rc.RangeID)
 	found := false
-	if prc.IsTransferLease() {
-		w.Printf("transfer_to=%v", prc.LeaseTransferTarget())
+	if rc.IsPureTransferLease() {
+		w.Printf("transfer_to=%v", rc.LeaseTransferTarget())
 		found = true
 	}
-	if prc.IsChangeReplicas() {
-		w.Printf("change_replicas=%v", prc.ReplicationChanges())
+	if rc.IsChangeReplicas() {
+		w.Printf("change_replicas=%v", rc.ReplicationChanges())
 		found = true
 	}
 	if !found {
 		panic("unknown change type")
 	}
 	w.Print(" cids=")
-	for i, c := range prc.pendingReplicaChanges {
+	for i, c := range rc.Changes {
 		if i > 0 {
 			w.Print(",")
 		}
@@ -44,53 +92,53 @@ func (prc PendingRangeChange) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Print("]")
 }
 
-// TODO(sumeer): A single PendingRangeChange can model a bunch of replica
+// TODO(sumeer): A single ExternalRangeChange can model a bunch of replica
 // changes and a lease transfer. Classifying the change as either
-// IsChangeReplicas or IsTransferLease is unnecessarily limiting. The only
+// IsChangeReplicas or IsPureTransferLease is unnecessarily limiting. The only
 // code that really relies on this is integration code:
 // mma_store_rebalancer.go, allocator_sync.go, asim. We should fix those and
 // consider removing these methods.
 
-// IsChangeReplicas returns true if the pending range change is a change
-// replicas operation.
-func (prc PendingRangeChange) IsChangeReplicas() bool {
-	for _, c := range prc.pendingReplicaChanges {
-		if c.isAddition() || c.isRemoval() || c.isPromoDemo() {
-			continue
-		} else {
+// IsChangeReplicas returns true if the range change is a change replicas
+// operation.
+func (rc *ExternalRangeChange) IsChangeReplicas() bool {
+	for _, c := range rc.Changes {
+		if c.ChangeType == AddLease || c.ChangeType == RemoveLease {
 			return false
 		}
 	}
 	return true
 }
 
-// IsTransferLease returns true if the pending range change is a transfer lease
-// operation.
-func (prc PendingRangeChange) IsTransferLease() bool {
-	if len(prc.pendingReplicaChanges) != 2 {
+// IsPureTransferLease returns true if the range change is purely a transfer
+// lease operation (i.e., it is not a combined replication change and lease
+// transfer).
+func (rc *ExternalRangeChange) IsPureTransferLease() bool {
+	if len(rc.Changes) != 2 {
 		return false
 	}
-	var foundAddLease, foundRemoveLease bool
-	for _, c := range prc.pendingReplicaChanges {
-		if c.isAddition() || c.isRemoval() || c.isPromoDemo() {
-			// Any changes to the replica type or replicaID are not lease transfers,
-			// since they require a replication change.
-			return false
-		}
-		if c.prev.IsLeaseholder && !c.next.IsLeaseholder {
-			foundRemoveLease = true
-		} else if !c.prev.IsLeaseholder && c.next.IsLeaseholder {
-			foundAddLease = true
-		} else {
+	var addLease, removeLease int
+	for _, c := range rc.Changes {
+		switch c.ChangeType {
+		case AddLease:
+			addLease++
+		case RemoveLease:
+			removeLease++
+		default:
+			// Any other change type is not a pure lease transfer (e.g. they
+			// require a replication change).
 			return false
 		}
 	}
-	return foundAddLease && foundRemoveLease
+	if addLease != 1 || removeLease != 1 {
+		panic(errors.AssertionFailedf("unexpected add (%d) or remove lease (%d) in lease transfer",
+			addLease, removeLease))
+	}
+	return true
 }
 
-// ReplicationChanges returns the replication changes for the pending range
-// change. It panics if the pending range change is not a change replicas
-// operation.
+// ReplicationChanges returns the replication changes for the range change. It
+// panics if the range change is not a change replicas operation.
 //
 // TODO(tbg): The ReplicationChanges can include a new leaseholder replica,
 // but the incoming leaseholder is not explicitly represented in
@@ -103,18 +151,18 @@ func (prc PendingRangeChange) IsTransferLease() bool {
 // TODO(sumeer): this method is limiting, since a single PendingRangeChange
 // should be allowed to model any set of changes (see the existing TODO on
 // IsChangeReplicas).
-func (prc PendingRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
-	if !prc.IsChangeReplicas() {
+func (rc *ExternalRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
+	if !rc.IsChangeReplicas() {
 		panic("RangeChange is not a change replicas")
 	}
-	chgs := make([]kvpb.ReplicationChange, 0, len(prc.pendingReplicaChanges))
+	chgs := make([]kvpb.ReplicationChange, 0, len(rc.Changes))
 	newLeaseholderIndex := -1
-	for _, c := range prc.pendingReplicaChanges {
-		switch c.replicaChangeType {
+	for _, c := range rc.Changes {
+		switch c.ChangeType {
 		case ChangeReplica, AddReplica, RemoveReplica:
 			// These are the only permitted cases.
 		default:
-			panic(errors.AssertionFailedf("change type %v is not a change replicas", c.replicaChangeType))
+			panic(errors.AssertionFailedf("change type %v is not a change replicas", c.ChangeType))
 		}
 		// The kvserver code represents a change in replica type as an
 		// addition and a removal of the same replica. For example, if a
@@ -123,19 +171,19 @@ func (prc PendingRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
 		// this pair does not matter.
 		//
 		// TODO(tbg): confirm that the ordering does not matter.
-		if c.replicaChangeType == ChangeReplica || c.replicaChangeType == AddReplica {
-			chg := kvpb.ReplicationChange{Target: c.target}
+		if c.ChangeType == ChangeReplica || c.ChangeType == AddReplica {
+			chg := kvpb.ReplicationChange{Target: c.Target}
 			isNewLeaseholder := false
-			switch c.next.ReplicaType.ReplicaType {
+			switch c.Next.ReplicaType.ReplicaType {
 			case roachpb.VOTER_FULL:
 				chg.ChangeType = roachpb.ADD_VOTER
-				if c.next.IsLeaseholder {
+				if c.Next.IsLeaseholder {
 					isNewLeaseholder = true
 				}
 			case roachpb.NON_VOTER:
 				chg.ChangeType = roachpb.ADD_NON_VOTER
 			default:
-				panic(errors.AssertionFailedf("unexpected replica type %s", c.next.ReplicaType.ReplicaType))
+				panic(errors.AssertionFailedf("unexpected replica type %s", c.Next.ReplicaType.ReplicaType))
 			}
 			if isNewLeaseholder {
 				if newLeaseholderIndex >= 0 {
@@ -146,16 +194,16 @@ func (prc PendingRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
 			}
 			chgs = append(chgs, chg)
 		}
-		if c.replicaChangeType == ChangeReplica || c.replicaChangeType == RemoveReplica {
-			chg := kvpb.ReplicationChange{Target: c.target}
-			prevType := mapReplicaTypeToVoterOrNonVoter(c.prev.ReplicaType.ReplicaType)
+		if c.ChangeType == ChangeReplica || c.ChangeType == RemoveReplica {
+			chg := kvpb.ReplicationChange{Target: c.Target}
+			prevType := mapReplicaTypeToVoterOrNonVoter(c.Prev.ReplicaType.ReplicaType)
 			switch prevType {
 			case roachpb.VOTER_FULL:
 				chg.ChangeType = roachpb.REMOVE_VOTER
 			case roachpb.NON_VOTER:
 				chg.ChangeType = roachpb.REMOVE_NON_VOTER
 			default:
-				panic(errors.AssertionFailedf("unexpected replica type %s", c.prev.ReplicaType.ReplicaType))
+				panic(errors.AssertionFailedf("unexpected replica type %s", c.Prev.ReplicaType.ReplicaType))
 			}
 			chgs = append(chgs, chg)
 		}
@@ -168,29 +216,29 @@ func (prc PendingRangeChange) ReplicationChanges() kvpb.ReplicationChanges {
 }
 
 // LeaseTransferTarget returns the store ID of the store that is the target of
-// the lease transfer. It panics if the pending range change is not a transfer
-// lease operation.
-func (prc PendingRangeChange) LeaseTransferTarget() roachpb.StoreID {
-	if !prc.IsTransferLease() {
+// the lease transfer. It panics if the range change is not a transfer lease
+// operation.
+func (rc *ExternalRangeChange) LeaseTransferTarget() roachpb.StoreID {
+	if !rc.IsPureTransferLease() {
 		panic("pendingRangeChange is not a lease transfer")
 	}
-	for _, c := range prc.pendingReplicaChanges {
-		if !c.prev.IsLeaseholder && c.next.IsLeaseholder {
-			return c.target.StoreID
+	for _, c := range rc.Changes {
+		if !c.Prev.IsLeaseholder && c.Next.IsLeaseholder {
+			return c.Target.StoreID
 		}
 	}
 	panic("unreachable")
 }
 
 // LeaseTransferFrom returns the store ID of the store that is the source of
-// the lease transfer. It panics if the pending range change is not a
-func (prc PendingRangeChange) LeaseTransferFrom() roachpb.StoreID {
-	if !prc.IsTransferLease() {
+// the lease transfer. It panics if the range change is not a transfer lease.
+func (rc *ExternalRangeChange) LeaseTransferFrom() roachpb.StoreID {
+	if !rc.IsPureTransferLease() {
 		panic("pendingRangeChange is not a lease transfer")
 	}
-	for _, c := range prc.pendingReplicaChanges {
-		if c.prev.IsLeaseholder && !c.next.IsLeaseholder {
-			return c.target.StoreID
+	for _, c := range rc.Changes {
+		if c.Prev.IsLeaseholder && !c.Next.IsLeaseholder {
+			return c.Target.StoreID
 		}
 	}
 	panic("unreachable")

--- a/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_store_rebalancer.go
@@ -56,7 +56,7 @@ type MMAStoreRebalancer struct {
 }
 
 type pendingChangeAndRangeUsageInfo struct {
-	change       mmaprototype.PendingRangeChange
+	change       mmaprototype.ExternalRangeChange
 	usage        allocator.RangeUsageInfo
 	syncChangeID mmaintegration.SyncChangeID
 }
@@ -174,7 +174,7 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 
 			// Record the last time a lease transfer was requested.
 			for _, change := range msr.pendingChanges {
-				if change.change.IsTransferLease() {
+				if change.change.IsPureTransferLease() {
 					msr.lastLeaseTransfer = tick
 				}
 			}
@@ -187,7 +187,7 @@ func (msr *MMAStoreRebalancer) Tick(ctx context.Context, tick time.Time, s state
 		}
 
 		var curOp op.ControlledOperation
-		if msr.pendingChanges[msr.pendingChangeIdx].change.IsTransferLease() {
+		if msr.pendingChanges[msr.pendingChangeIdx].change.IsPureTransferLease() {
 			curOp = op.NewTransferLeaseOp(
 				tick,
 				curChange.change.RangeID,

--- a/pkg/kv/kvserver/mma_store_rebalancer.go
+++ b/pkg/kv/kvserver/mma_store_rebalancer.go
@@ -150,7 +150,7 @@ func (m *mmaStoreRebalancer) rebalance(ctx context.Context) bool {
 // applyChange safely applies a single change to the store. It handles the case
 // where the replica might not exist and provides proper error handling.
 func (m *mmaStoreRebalancer) applyChange(
-	ctx context.Context, change mmaprototype.PendingRangeChange,
+	ctx context.Context, change mmaprototype.ExternalRangeChange,
 ) error {
 	repl := m.store.GetReplicaIfExists(change.RangeID)
 	if repl == nil {
@@ -160,7 +160,7 @@ func (m *mmaStoreRebalancer) applyChange(
 	changeID := m.as.MMAPreApply(ctx, repl.RangeUsageInfo(), change)
 	var err error
 	switch {
-	case change.IsTransferLease():
+	case change.IsPureTransferLease():
 		err = m.applyLeaseTransfer(ctx, repl, change)
 	case change.IsChangeReplicas():
 		err = m.applyReplicaChanges(ctx, repl, change)
@@ -175,7 +175,7 @@ func (m *mmaStoreRebalancer) applyChange(
 
 // applyLeaseTransfer applies a lease transfer change.
 func (m *mmaStoreRebalancer) applyLeaseTransfer(
-	ctx context.Context, repl replicaToApplyChanges, change mmaprototype.PendingRangeChange,
+	ctx context.Context, repl replicaToApplyChanges, change mmaprototype.ExternalRangeChange,
 ) error {
 	return repl.AdminTransferLease(
 		ctx,
@@ -186,7 +186,7 @@ func (m *mmaStoreRebalancer) applyLeaseTransfer(
 
 // applyReplicaChanges applies replica membership changes.
 func (m *mmaStoreRebalancer) applyReplicaChanges(
-	ctx context.Context, repl replicaToApplyChanges, change mmaprototype.PendingRangeChange,
+	ctx context.Context, repl replicaToApplyChanges, change mmaprototype.ExternalRangeChange,
 ) error {
 	// TODO(mma): We should be setting a timeout on the ctx here, in the case
 	// where rebalancing takes a long time (stuck behind other snapshots).

--- a/pkg/kv/kvserver/mmaintegration/BUILD.bazel
+++ b/pkg/kv/kvserver/mmaintegration/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/allocator",
+        "//pkg/kv/kvserver/allocator/mmaprototype",
         "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/mmaintegration/allocator_op.go
+++ b/pkg/kv/kvserver/mmaintegration/allocator_op.go
@@ -22,7 +22,7 @@ type trackedAllocatorChange struct {
 	// change could not be registered with mma, in which case PostApply must not
 	// inform mma.
 	isMMARegistered bool
-	mmaChange       mmaprototype.PendingRangeChange
+	mmaChange       mmaprototype.ExternalRangeChange
 	// Usage is range load usage.
 	usage allocator.RangeUsageInfo
 	// Exactly one of the following two fields will be set.


### PR DESCRIPTION
An ExternalRangeChange does not have the currently mutable fields of PendingRangeChange (and the set of mutable fields is going to expand in the near future). Todos related to limitation of viewing a change as a "change replicas" or "lease transfer" etc., are moved to ExternalRangeChange, so compartmentalized to methods that are called by integration code outside the mma package.

There is still some potential future cleanup involving unexporting PendingRangeChange, which is not in scope for this PR.

The PendingRangeChange becomes a temporary container for a slice of []*pendingReplicaChanges. Printing this struct no longer involves viewing it as a "change replicas" or "lease transfer". Furthermore, the ReplicaChange.replicaChangeType field is removed and the change type is now a function of prev and next. This sets us up for making prev mutable in a future PR.

Informs #157049

Epic: CRDB-55052

Release note: None