### PR TITLE
sql/bulkingest: use larger machine type for TestSplitAndScatterSpans

### DIFF
--- a/pkg/sql/bulkingest/BUILD.bazel
+++ b/pkg/sql/bulkingest/BUILD.bazel
@@ -26,6 +26,10 @@ go_test(
         "split_test.go",
     ],
     embed = [":bulkingest"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
TestSplitAndScatterSpans was observed to OOM during race builds on EngFlow. This change updates the test configuration to request a larger machine when executed under race.

Closes #158139
Release note: none