### PR TITLE
mmaprototype: use voterIndex when selecting a voter to be removed

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_unused_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_unused_test.go
@@ -347,9 +347,9 @@ func (rac *rangeAnalyzedConstraints) candidatesToRemove() ([]roachpb.StoreID, er
 		}
 		// No constraints. Can remove any voter.
 		for i := range rac.replicas[voterIndex] {
-			cands = append(cands, rac.replicas[nonVoterIndex][i].StoreID)
+			cands = append(cands, rac.replicas[voterIndex][i].StoreID)
 		}
-		return cands, nil
+		panic("impossible to be here")
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none
Fixes: https://github.com/cockroachdb/cockroach/issues/157991

---
**mmaprototype: use voterIndex when selecting a voter to be removed**

Previously, we were incorrectly using nonVoterIndex when selecting a voter to
remove in over-satisfied scenarios. While attempting to write tests, it appears
that this code is actually unreachable under normal flow: for it to trigger,
both replica constraints and voter constraints would need to be empty, but
makeNormalizedSpanConfig ensures voter constraints is non-empty when all replica
constraint is empty. Things remain to be figured out, but this change does not
harm.

