### PR TITLE
storage: remove Engine.PreIngestDelay

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10598,14 +10598,6 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
-    - name: addsstable.delay.enginebackpressure
-      exported_name: addsstable_delay_enginebackpressure
-      description: Amount by which evaluation of AddSSTable requests was delayed by storage-engine backpressure
-      y_axis_label: Nanoseconds
-      type: COUNTER
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NON_NEGATIVE_DERIVATIVE
     - name: addsstable.delay.total
       exported_name: addsstable_delay_total
       description: Amount by which evaluation of AddSSTable requests was delayed

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2621,12 +2621,6 @@ throttled they do count towards 'delay.total' and 'delay.enginebackpressure'.
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-	metaAddSSTableEvalEngineDelay = metric.Metadata{
-		Name:        "addsstable.delay.enginebackpressure",
-		Help:        "Amount by which evaluation of AddSSTable requests was delayed by storage-engine backpressure",
-		Measurement: "Nanoseconds",
-		Unit:        metric.Unit_NANOSECONDS,
-	}
 
 	// Export request counter.
 	metaExportEvalTotalDelay = metric.Metadata{
@@ -3402,12 +3396,11 @@ type StoreMetrics struct {
 
 	// AddSSTable stats: how many AddSSTable commands were proposed and how many
 	// were applied? How many applications required writing a copy?
-	AddSSTableProposals           *metric.Counter
-	AddSSTableApplications        *metric.Counter
-	AddSSTableApplicationCopies   *metric.Counter
-	AddSSTableAsWrites            *metric.Counter
-	AddSSTableProposalTotalDelay  *metric.Counter
-	AddSSTableProposalEngineDelay *metric.Counter
+	AddSSTableProposals          *metric.Counter
+	AddSSTableApplications       *metric.Counter
+	AddSSTableApplicationCopies  *metric.Counter
+	AddSSTableAsWrites           *metric.Counter
+	AddSSTableProposalTotalDelay *metric.Counter
 
 	// Export request stats.
 	ExportRequestProposalTotalDelay *metric.Counter
@@ -4214,12 +4207,11 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		BackpressuredOnSplitRequests: metric.NewGauge(metaBackpressuredOnSplitRequests),
 
 		// AddSSTable proposal + applications counters.
-		AddSSTableProposals:           metric.NewCounter(metaAddSSTableProposals),
-		AddSSTableApplications:        metric.NewCounter(metaAddSSTableApplications),
-		AddSSTableAsWrites:            metric.NewCounter(metaAddSSTableAsWrites),
-		AddSSTableApplicationCopies:   metric.NewCounter(metaAddSSTableApplicationCopies),
-		AddSSTableProposalTotalDelay:  metric.NewCounter(metaAddSSTableEvalTotalDelay),
-		AddSSTableProposalEngineDelay: metric.NewCounter(metaAddSSTableEvalEngineDelay),
+		AddSSTableProposals:          metric.NewCounter(metaAddSSTableProposals),
+		AddSSTableApplications:       metric.NewCounter(metaAddSSTableApplications),
+		AddSSTableAsWrites:           metric.NewCounter(metaAddSSTableAsWrites),
+		AddSSTableApplicationCopies:  metric.NewCounter(metaAddSSTableApplicationCopies),
+		AddSSTableProposalTotalDelay: metric.NewCounter(metaAddSSTableEvalTotalDelay),
 
 		// ExportRequest proposal.
 		ExportRequestProposalTotalDelay: metric.NewCounter(metaExportEvalTotalDelay),

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -330,18 +330,11 @@ func (s *Store) maybeThrottleBatch(
 		if err != nil {
 			return nil, err
 		}
+		waited := timeutil.Since(before)
 
-		beforeEngineDelay := timeutil.Now()
-		// TODO(sep-raft-log): can we get rid of this?
-		s.TODOEngine().PreIngestDelay(ctx)
-		after := timeutil.Now()
-
-		waited, waitedEngine := after.Sub(before), after.Sub(beforeEngineDelay)
 		s.metrics.AddSSTableProposalTotalDelay.Inc(waited.Nanoseconds())
-		s.metrics.AddSSTableProposalEngineDelay.Inc(waitedEngine.Nanoseconds())
 		if waited > time.Second {
-			log.KvExec.Infof(ctx, "SST ingestion was delayed by %v (%v for storage engine back-pressure)",
-				waited, waitedEngine)
+			log.KvExec.Infof(ctx, "SST ingestion was delayed by %v", waited)
 		}
 		return res, nil
 

--- a/pkg/roachprod/agents/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/agents/opentelemetry/cockroachdb_metrics.go
@@ -34,7 +34,6 @@ var cockroachdbMetrics = map[string]string{
     "addsstable_applications": "addsstable.applications",
     "addsstable_aswrites": "addsstable.aswrites",
     "addsstable_copies": "addsstable.copies",
-    "addsstable_delay_enginebackpressure": "addsstable.delay.enginebackpressure",
     "addsstable_delay_total": "addsstable.delay.total",
     "addsstable_proposals": "addsstable.proposals",
     "admission_admitted_elastic_cpu": "admission.admitted.elastic_cpu",

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -276,7 +276,10 @@ var retiredSettings = map[InternalKey]struct{}{
 	"storage.columnar_blocks.enabled": {},
 
 	// removed as of 26.1
-	"sql.distsql_planning.use_gossip.enabled": {},
+	"sql.distsql_planning.use_gossip.enabled":             {},
+	"rocksdb.ingest_backpressure.l0_file_count_threshold": {},
+	"rocksdb.ingest_backpressure.max_delay":               {},
+	"pebble.pre_ingest_delay.enabled":                     {},
 }
 
 // grandfatheredDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
@@ -1183,34 +1182,6 @@ func TestCreateCheckpoint_SpanConstrained(t *testing.T) {
 		span := roachpb.Span{Key: key(start), EndKey: key(end)}
 		dir := checkpointSpan(span)
 		verifyCheckpoint(dir, start, end)
-	}
-}
-
-func TestIngestDelayLimit(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	s := cluster.MakeTestingClusterSettings()
-
-	max, ramp := time.Second*5, time.Second*5/10
-
-	for _, tc := range []struct {
-		exp           time.Duration
-		fileCount     uint64
-		sublevelCount int32
-	}{
-		{0, 0, 0},
-		{0, 19, -1},
-		{0, 20, -1},
-		{ramp, 21, -1},
-		{ramp * 2, 22, -1},
-		{ramp * 2, 22, 22},
-		{ramp * 2, 55, 22},
-		{max, 55, -1},
-	} {
-		var m pebble.Metrics
-		m.Levels[0].Tables.Count = tc.fileCount
-		m.Levels[0].Sublevels = tc.sublevelCount
-		require.Equal(t, tc.exp, calculatePreIngestDelay(s, &m))
 	}
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2255,11 +2255,6 @@ func (p *Pebble) IngestExternalFiles(
 	return p.db.IngestExternalFiles(ctx, external)
 }
 
-// PreIngestDelay implements the Engine interface.
-func (p *Pebble) PreIngestDelay(ctx context.Context) {
-	preIngestDelay(ctx, p, p.cfg.settings)
-}
-
 // GetTableMetrics implements the Engine interface.
 func (p *Pebble) GetTableMetrics(start, end roachpb.Key) ([]enginepb.SSTableMetricsInfo, error) {
 	filterOpt := pebble.WithKeyRangeFilter(


### PR DESCRIPTION
Previously the Engine exposed a method that would block a variable amount of time depending on the health of the LSM. This was a rudimentary backpressure mechanism that predated admission control (and quorum replication flow control). We no longer require this mechanism and can remove it and the corresponding cluster settings.

Release note: none
Epic: none