### PR TITLE
changefeedccl: add metamorphic testing for db-level feeds

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -641,7 +641,9 @@ func TestAvroSchemaNaming(t *testing.T) {
 		)
 
 		movrFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s`, changefeedbase.OptFormatAvro))
+			`WITH format=%s`, changefeedbase.OptFormatAvro), optOutOfMetamorphicDBLevelChangefeed{
+			reason: "changefeed watches tables not in the default database",
+		})
 		defer closeFeed(t, movrFeed)
 
 		foo := movrFeed.(*kafkaFeed)
@@ -656,7 +658,10 @@ func TestAvroSchemaNaming(t *testing.T) {
 		})
 
 		fqnFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s, full_table_name`, changefeedbase.OptFormatAvro))
+			`WITH format=%s, full_table_name`, changefeedbase.OptFormatAvro),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			})
 		defer closeFeed(t, fqnFeed)
 
 		foo = fqnFeed.(*kafkaFeed)
@@ -671,8 +676,10 @@ func TestAvroSchemaNaming(t *testing.T) {
 		})
 
 		prefixFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s, avro_schema_prefix=super`,
-			changefeedbase.OptFormatAvro))
+			`WITH format=%s, avro_schema_prefix=super`, changefeedbase.OptFormatAvro),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			})
 		defer closeFeed(t, prefixFeed)
 
 		foo = prefixFeed.(*kafkaFeed)
@@ -687,7 +694,10 @@ func TestAvroSchemaNaming(t *testing.T) {
 		})
 
 		prefixFQNFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s, avro_schema_prefix=super, full_table_name`, changefeedbase.OptFormatAvro))
+			`WITH format=%s, avro_schema_prefix=super, full_table_name`, changefeedbase.OptFormatAvro),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			})
 		defer closeFeed(t, prefixFQNFeed)
 
 		foo = prefixFQNFeed.(*kafkaFeed)
@@ -707,7 +717,10 @@ func TestAvroSchemaNaming(t *testing.T) {
 
 		sqlDB.Exec(t, `ALTER TABLE movr.drivers ADD COLUMN vehicle_id int CREATE FAMILY volatile`)
 		multiFamilyFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s, %s`, changefeedbase.OptFormatAvro, changefeedbase.OptSplitColumnFamilies))
+			`WITH format=%s, %s`, changefeedbase.OptFormatAvro, changefeedbase.OptSplitColumnFamilies),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			})
 		defer closeFeed(t, multiFamilyFeed)
 		foo = multiFamilyFeed.(*kafkaFeed)
 
@@ -744,8 +757,15 @@ func TestAvroSchemaNamespace(t *testing.T) {
 			`INSERT INTO movr.drivers VALUES (1, 'Alice')`,
 		)
 
-		noNamespaceFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s`, changefeedbase.OptFormatAvro))
+		noNamespaceFeed := feed(t, f,
+			fmt.Sprintf(
+				`CREATE CHANGEFEED FOR movr.drivers WITH format=%s`,
+				changefeedbase.OptFormatAvro,
+			),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			},
+		)
 		defer closeFeed(t, noNamespaceFeed)
 
 		assertPayloads(t, noNamespaceFeed, []string{
@@ -758,7 +778,10 @@ func TestAvroSchemaNamespace(t *testing.T) {
 		require.NotContains(t, foo.registry.SchemaForSubject(`drivers-value`), `namespace`)
 
 		namespaceFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s, avro_schema_prefix=super`, changefeedbase.OptFormatAvro))
+			`WITH format=%s, avro_schema_prefix=super`, changefeedbase.OptFormatAvro),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			})
 		defer closeFeed(t, namespaceFeed)
 
 		foo = namespaceFeed.(*kafkaFeed)
@@ -787,7 +810,10 @@ func TestAvroSchemaHasExpectedTopLevelFields(t *testing.T) {
 		)
 
 		foo := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR movr.drivers `+
-			`WITH format=%s`, changefeedbase.OptFormatAvro))
+			`WITH format=%s`, changefeedbase.OptFormatAvro),
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "changefeed watches tables not in the default database",
+			})
 		defer closeFeed(t, foo)
 
 		assertPayloads(t, foo, []string{

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -68,7 +68,11 @@ func TestShowChangefeedJobsDatabaseLevel(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `INSERT INTO bar VALUES (1, 'initial')`)
 
-		tcf := feed(t, f, `CREATE CHANGEFEED FOR d.foo, d.bar`)
+		tcf := feed(t, f, `CREATE CHANGEFEED FOR d.foo, d.bar`,
+			optOutOfMetamorphicDBLevelChangefeed{
+				reason: "test asserts how DB-level and table-level changefeeds differ",
+			},
+		)
 		defer closeFeed(t, tcf)
 		assertPayloads(t, tcf, []string{
 			`foo: [0]->{"after": {"a": 0, "b": "initial"}}`,
@@ -159,7 +163,11 @@ func TestShowChangefeedJobsBasic(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 
-		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH format='json'`)
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH format='json'`,
+			optOutOfMetamorphicDBLevelChangefeed{
+				// NB: We test WITH WATCHED_TABLES in another test. This one specifically does not.
+				reason: "db level changefeeds don't have full_table_names without WITH WATCHED_TABLES",
+			})
 		defer closeFeed(t, foo)
 
 		type row struct {
@@ -290,7 +298,9 @@ func TestShowChangefeedJobsRedacted(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				foo := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR TABLE foo INTO '%s'`, tc.uri),
-					optOutOfMetamorphicEnrichedEnvelope{reason: "compares text of changefeed statement"})
+					optOutOfMetamorphicEnrichedEnvelope{reason: "compares text of changefeed statement"},
+					optOutOfMetamorphicDBLevelChangefeed{reason: "compares text of changefeed statement"},
+				)
 				defer closeFeed(t, foo)
 
 				efoo, ok := foo.(cdctest.EnterpriseTestFeed)
@@ -552,7 +562,10 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
 
-		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`, optOutOfMetamorphicEnrichedEnvelope{reason: "compares text of changefeed statement"})
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`,
+			optOutOfMetamorphicEnrichedEnvelope{reason: "compares text of changefeed statement"},
+			optOutOfMetamorphicDBLevelChangefeed{reason: "compares text of changefeed statement"},
+		)
 		defer closeFeed(t, foo)
 
 		feed, ok := foo.(cdctest.EnterpriseTestFeed)
@@ -649,7 +662,8 @@ func TestShowChangefeedJobsAuthorization(t *testing.T) {
 
 		var jobID jobspb.JobID
 		createFeed := func(stmt string) {
-			successfulFeed := feed(t, f, stmt)
+			successfulFeed := feed(t, f, stmt, optOutOfMetamorphicDBLevelChangefeed{
+				reason: "tests table level changefeed permissions"})
 			defer closeFeed(t, successfulFeed)
 			_, err := successfulFeed.Next()
 			require.NoError(t, err)


### PR DESCRIPTION
This adds metamorphic testing of db-level feeds, making table level feeds into db-level feeds unless the test explicitly opts out or is otherwise setting changefeed options that aren't compatible with db-level feeds.

Epic: CRDB-1421
Fixes: #148858