### PR TITLE
mmaprototype: extract analyzeFunc

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -703,6 +703,14 @@ func sortTargetCandidateSetAndPick(
 	return cands.candidates[j].StoreID
 }
 
+// ensureAnalyzedConstraints populates the constraints for the given range.
+// It should be called when computing lease-transfers / rebalancing candidates
+// for a range.
+//
+// NB: given rstate.conf should already be normalized using
+// makeNormalizedSpanConfig. The caller is responsible for calling
+// clearAnalyzedConstraints when rstate or the rstate.constraints is no longer
+// needed.
 func (cs *clusterState) ensureAnalyzedConstraints(rstate *rangeState) {
 	if rstate.constraints != nil {
 		return

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -703,14 +703,11 @@ func sortTargetCandidateSetAndPick(
 	return cands.candidates[j].StoreID
 }
 
-// ensureAnalyzedConstraints populates the constraints for the given range.
-// It should be called when computing lease-transfers / rebalancing candidates
-// for a range.
+// ensureAnalyzedConstraints ensures that the constraints field of rangeState is
+// populated. It uses rangeState.{replicas,conf} as inputs to the computation.
 //
-// NB: given rstate.conf should already be normalized using
-// makeNormalizedSpanConfig. The caller is responsible for calling
-// clearAnalyzedConstraints when rstate or the rstate.constraints is no longer
-// needed.
+// NB: Caller is responsible for calling clearAnalyzedConstraints when rstate or
+// the rstate.constraints is no longer needed.
 func (cs *clusterState) ensureAnalyzedConstraints(rstate *rangeState) {
 	if rstate.constraints != nil {
 		return

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -1052,22 +1052,17 @@ func diversityScore(
 		return sumScore / float64(numSamples)
 	}
 
-	// Calculate voter diversity (V × V, no self-pairs)
 	voterSum, voterSamples := diversityFunc(replicas[voterIndex], replicas[voterIndex], true)
-	// Calculate replica diversity over all pairs:
-	// (voter, voter), (nonvoter, nonvoter), (voter, nonvoter)
-	totalSum, totalSamples := 0.0, 0
-	vs, ns := diversityFunc(replicas[voterIndex], replicas[voterIndex], true)
-	totalSum += vs
-	totalSamples += ns
+	totalSum := voterSum
+	totalSamples := voterSamples
 
-	vs, ns = diversityFunc(replicas[nonVoterIndex], replicas[nonVoterIndex], true)
-	totalSum += vs
-	totalSamples += ns
+	nonVoterSum, nonVoterSamples := diversityFunc(replicas[nonVoterIndex], replicas[nonVoterIndex], true)
+	totalSum += nonVoterSum
+	totalSamples += nonVoterSamples
 
-	vs, ns = diversityFunc(replicas[voterIndex], replicas[nonVoterIndex], false)
-	totalSum += vs
-	totalSamples += ns
+	voterNonVoterSum, voterNonVoterSamples := diversityFunc(replicas[voterIndex], replicas[nonVoterIndex], false)
+	totalSum += voterNonVoterSum
+	totalSamples += voterNonVoterSamples
 	return scoreFromSumAndSamples(voterSum, voterSamples), scoreFromSumAndSamples(totalSum, totalSamples)
 }
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -1002,6 +1002,75 @@ func (ac *analyzedConstraints) analyzeFunc(
 	}
 }
 
+// diversityFunc computes the diversity score between two sets of stores.
+//
+// When sameStores is false, intersection between this and other is empty and no
+// de-duplication is needed. For example, given two sets of stores [1, 2, 3] and
+// [4, 5, 6], diversity score is computed among all pairs (1, 4), (1, 5), (1,
+// 6), (2, 4), (2, 5), (2, 6), (3, 4), (3, 5), (3, 6).
+//
+// When sameStores is true, this and other are the same set and de-duplication
+// is needed. For example, given two sets of stores [1, 2, 3] and [1, 2, 3],
+// diversity score should be computed among pairs (1, 2), (1, 3), (2, 3) only.
+func diversityFunc(
+	this []storeAndLocality, other []storeAndLocality, sameStores bool,
+) (sumScore float64, numSamples int) {
+	for i := range this {
+		s1 := this[i]
+		for j := range other {
+			s2 := other[j]
+			// Only compare pairs of replicas where s2.StoreID > s1.StoreID to avoid
+			// computing the diversity score between each pair of stores twice.
+			if sameStores && s2.StoreID <= s1.StoreID {
+				continue
+			}
+			sumScore += s1.localityTiers.diversityScore(s2.localityTiers)
+			numSamples++
+		}
+	}
+	return sumScore, numSamples
+}
+
+// diversityScore returns the voter and replica diversity scores of the given replicas sets.
+//
+// voterDiversityScore: sum of diversity scores over all pairs from V×V(voter-voter pairs).
+// replicaDiversityScore: sum of diversity scores over all pairs from:
+// V×V(voter–voter pairs), N×N(non-voter–non-voter pairs), V×N(voter–non-voter
+// pairs).
+//
+// diversity score of a single pair is computed using
+// localityTiers.diversityScore which finds the longest common prefix of two
+// localities.
+func diversityScore(
+	replicas [numReplicaKinds][]storeAndLocality,
+) (voterDiversityScore, replicaDiversityScore float64) {
+	// Helper to calculate average, or a max-value if no samples (represents lowest possible diversity)
+	scoreFromSumAndSamples := func(sumScore float64, numSamples int) float64 {
+		if numSamples == 0 {
+			return roachpb.MaxDiversityScore
+		}
+		return sumScore / float64(numSamples)
+	}
+
+	// Calculate voter diversity (V × V, no self-pairs)
+	voterSum, voterSamples := diversityFunc(replicas[voterIndex], replicas[voterIndex], true)
+	// Calculate replica diversity over all pairs:
+	// (voter, voter), (nonvoter, nonvoter), (voter, nonvoter)
+	totalSum, totalSamples := 0.0, 0
+	vs, ns := diversityFunc(replicas[voterIndex], replicas[voterIndex], true)
+	totalSum += vs
+	totalSamples += ns
+
+	vs, ns = diversityFunc(replicas[nonVoterIndex], replicas[nonVoterIndex], true)
+	totalSum += vs
+	totalSamples += ns
+
+	vs, ns = diversityFunc(replicas[voterIndex], replicas[nonVoterIndex], false)
+	totalSum += vs
+	totalSamples += ns
+	return scoreFromSumAndSamples(voterSum, voterSamples), scoreFromSumAndSamples(totalSum, totalSamples)
+}
+
 // finishInit analyzes the span config and the range’s current replica set. It
 // prepares the MMA to compute lease-transfer and rebalancing candidates while
 // satisfying both constraint requirements and leaseholder preferences.
@@ -1061,42 +1130,7 @@ func (rac *rangeAnalyzedConstraints) finishInit(
 	rac.replicaLocalityTiers = makeReplicasLocalityTiers(replicaLocalityTiers)
 	rac.voterLocalityTiers = makeReplicasLocalityTiers(voterLocalityTiers)
 
-	diversityFunc := func(
-		stores1 []storeAndLocality, stores2 []storeAndLocality, sameStores bool,
-	) (sumScore float64, numSamples int) {
-		for i := range stores1 {
-			s1 := stores1[i]
-			for j := range stores2 {
-				s2 := stores2[j]
-				// Only compare pairs of replicas where s2.StoreID > s1.StoreID to avoid
-				// computing the diversity score between each pair of stores twice.
-				if sameStores && s2.StoreID <= s1.StoreID {
-					continue
-				}
-				sumScore += s1.localityTiers.diversityScore(s2.localityTiers)
-				numSamples++
-			}
-		}
-		return sumScore, numSamples
-	}
-	scoreFromSumAndSamples := func(sumScore float64, numSamples int) float64 {
-		if numSamples == 0 {
-			return roachpb.MaxDiversityScore
-		}
-		return sumScore / float64(numSamples)
-	}
-	sumVoterScore, numVoterSamples := diversityFunc(
-		rac.replicas[voterIndex], rac.replicas[voterIndex], true)
-	rac.votersDiversityScore = scoreFromSumAndSamples(sumVoterScore, numVoterSamples)
-
-	sumReplicaScore, numReplicaSamples := sumVoterScore, numVoterSamples
-	srs, nrs := diversityFunc(rac.replicas[nonVoterIndex], rac.replicas[nonVoterIndex], true)
-	sumReplicaScore += srs
-	numReplicaSamples += nrs
-	srs, nrs = diversityFunc(rac.replicas[voterIndex], rac.replicas[nonVoterIndex], false)
-	sumReplicaScore += srs
-	numReplicaSamples += nrs
-	rac.replicasDiversityScore = scoreFromSumAndSamples(sumReplicaScore, numReplicaSamples)
+	rac.votersDiversityScore, rac.replicasDiversityScore = diversityScore(rac.replicas)
 }
 
 // Disjunction of conjunctions.

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -1002,7 +1002,8 @@ func (ac *analyzedConstraints) analyzeFunc(
 	}
 }
 
-// diversityFunc computes the diversity score between two sets of stores.
+// diversityOfTwoStoreSets computes the diversity score between two sets of
+// stores.
 //
 // When sameStores is false, intersection between this and other is empty and no
 // de-duplication is needed. For example, given two sets of stores [1, 2, 3] and
@@ -1012,7 +1013,7 @@ func (ac *analyzedConstraints) analyzeFunc(
 // When sameStores is true, this and other are the same set and de-duplication
 // is needed. For example, given two sets of stores [1, 2, 3] and [1, 2, 3],
 // diversity score should be computed among pairs (1, 2), (1, 3), (2, 3) only.
-func diversityFunc(
+func diversityOfTwoStoreSets(
 	this []storeAndLocality, other []storeAndLocality, sameStores bool,
 ) (sumScore float64, numSamples int) {
 	for i := range this {
@@ -1052,15 +1053,15 @@ func diversityScore(
 		return sumScore / float64(numSamples)
 	}
 
-	voterSum, voterSamples := diversityFunc(replicas[voterIndex], replicas[voterIndex], true)
+	voterSum, voterSamples := diversityOfTwoStoreSets(replicas[voterIndex], replicas[voterIndex], true)
 	totalSum := voterSum
 	totalSamples := voterSamples
 
-	nonVoterSum, nonVoterSamples := diversityFunc(replicas[nonVoterIndex], replicas[nonVoterIndex], true)
+	nonVoterSum, nonVoterSamples := diversityOfTwoStoreSets(replicas[nonVoterIndex], replicas[nonVoterIndex], true)
 	totalSum += nonVoterSum
 	totalSamples += nonVoterSamples
 
-	voterNonVoterSum, voterNonVoterSamples := diversityFunc(replicas[voterIndex], replicas[nonVoterIndex], false)
+	voterNonVoterSum, voterNonVoterSamples := diversityOfTwoStoreSets(replicas[voterIndex], replicas[nonVoterIndex], false)
 	totalSum += voterNonVoterSum
 	totalSamples += voterNonVoterSamples
 	return scoreFromSumAndSamples(voterSum, voterSamples), scoreFromSumAndSamples(totalSum, totalSamples)


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: extract analyzeFunc**

This commit moves analyzeFunc out of finishInit into its own helper improve
readability.

---
**mmaprototype: extract doneFunc**

This commit moves doneFunc out of analyzeFunc into its own helper function to
improve readability.

---
**mmaprototype: add more comments for finishInit**

This commit adds more comments for rangeAnalyzedConstraints.finishInit.

---
**mmaprototype: extract diversity score computation**

This commit moves diversity score computation out of analyzeFunc into its own
helper function to improve readability.

---
**mmaprototype: clean up diversityScore**

Previously, we were inefficiently invoking diversityFunc twice over voters X
voters diversity score calculation when refactoring the code. This change
reverts it back so diversity score is computed once and reused.

---
**mmaprototype: rename diversityFunc to diversityOfTwoStoreSets**


---
**mmaprototype: rename ac.analyzeFunc to ac.initialize**

This commit renames ac.analyzeFunc to ac.initialize and updates the
signature so constraints are passed directly to initialize, rather than
being populated by caller.

---
**mmaprototype: move isConstraintSatisfied to a closure**

This commit moves isConstraintSatisfied from a struct method to a helper closure
inside ac.initialize.

---
**mmaprototype: clean up comments**


