### PR TITLE
roachprod-microbench: list benchmarks from repo

### DIFF
--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "executor.go",
         "export.go",
         "github.go",
+        "list.go",
         "main.go",
         "metadata.go",
         "report.go",
@@ -26,6 +27,7 @@ go_library(
         "//pkg/cmd/roachprod-microbench/model",
         "//pkg/cmd/roachprod-microbench/parser",
         "//pkg/cmd/roachprod-microbench/util",
+        "//pkg/internal/codeowners",
         "//pkg/roachprod",
         "//pkg/roachprod/config",
         "//pkg/roachprod/install",
@@ -58,6 +60,7 @@ go_test(
         "executor_test.go",
         "export_test.go",
         "github_test.go",
+        "list_test.go",
     ],
     data = glob(["testdata/**"]) + [
         "//:TEAMS.yaml",

--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "@org_golang_x_exp//maps",
         "@org_golang_x_perf//benchfmt",
         "@org_golang_x_perf//benchseries",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 
@@ -72,6 +73,7 @@ go_test(
         "//pkg/cmd/roachprod-microbench/cluster",
         "//pkg/cmd/roachprod-microbench/model",
         "//pkg/cmd/roachprod-microbench/parser",
+        "//pkg/internal/codeowners",
         "//pkg/testutils/datapathutils",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/cmd/roachprod-microbench/list.go
+++ b/pkg/cmd/roachprod-microbench/list.go
@@ -1,0 +1,180 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/codeowners"
+)
+
+type (
+	BenchmarkInfo struct {
+		Name    string
+		Package string
+		Team    string
+		Args    RunArgs
+	}
+
+	RunArgs struct {
+		Suite     string
+		Timeout   time.Duration
+		Count     int
+		BenchTime string
+	}
+)
+
+const docMarker = "benchmark-ci:"
+
+func listBenchmarks(pkgDir string) ([]BenchmarkInfo, error) {
+	absPkgDir, err := filepath.Abs(pkgDir)
+	if err != nil {
+		return nil, err
+	}
+	co, err := codeowners.DefaultLoadCodeOwners()
+	if err != nil {
+		return nil, err
+	}
+
+	benchmarkInfoList := make([]BenchmarkInfo, 0)
+	err = filepath.WalkDir(absPkgDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return parseErr
+		}
+		bi, analyzeErr := analyzeBenchmarkAST(co, f, absPkgDir, path)
+		if analyzeErr != nil {
+			return analyzeErr
+		}
+		benchmarkInfoList = append(benchmarkInfoList, bi...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return benchmarkInfoList, nil
+}
+
+func isTestingB(t ast.Expr) bool {
+	// Accept "*testing.B" or an identifier named "B" (best-effort)
+	switch x := t.(type) {
+	case *ast.StarExpr:
+		if se, ok := x.X.(*ast.SelectorExpr); ok {
+			if id, ok := se.X.(*ast.Ident); ok && id.Name == "testing" && se.Sel.Name == "B" {
+				return true
+			}
+		}
+		if id, ok := x.X.(*ast.Ident); ok && id.Name == "B" {
+			return true
+		}
+	}
+	return false
+}
+
+func analyzeBenchmarkAST(
+	co *codeowners.CodeOwners, f *ast.File, absPkgDir, filename string,
+) (benchmarkInfoList []BenchmarkInfo, err error) {
+	ast.Inspect(f, func(n ast.Node) bool {
+		fd, ok := n.(*ast.FuncDecl)
+		if !ok || fd.Recv != nil || fd.Name == nil || !strings.HasPrefix(fd.Name.Name, "Benchmark") {
+			return true
+		}
+		if len(fd.Type.Params.List) != 1 {
+			return true
+		}
+		if fd.Type.Results != nil {
+			return true
+		}
+		if !isTestingB(fd.Type.Params.List[0].Type) {
+			return true
+		}
+		var benchmarkInfo BenchmarkInfo
+		benchmarkInfo, err = analyzeBenchmarkFunc(co, fd, absPkgDir, filename)
+		if err != nil {
+			return false
+		}
+		benchmarkInfoList = append(benchmarkInfoList, benchmarkInfo)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return benchmarkInfoList, nil
+}
+
+func analyzeBenchmarkFunc(
+	co *codeowners.CodeOwners, fn *ast.FuncDecl, absolutePkgDir, filename string,
+) (BenchmarkInfo, error) {
+	relFilename, err := filepath.Rel(absolutePkgDir, filename)
+	if err != nil {
+		return BenchmarkInfo{}, err
+	}
+
+	var benchmarkInfo BenchmarkInfo
+	benchmarkInfo.Name = fn.Name.Name
+	benchmarkInfo.Package = filepath.Join("pkg", filepath.Dir(relFilename))
+	teams := co.Match(filepath.Join("pkg", relFilename))
+	if len(teams) > 0 {
+		team := teams[0]
+		teamName := strings.TrimPrefix(string(team.TeamName), "cockroachdb/")
+		benchmarkInfo.Team = teamName
+	}
+
+	// Parsing of the benchmark function document is best-effort and lenient.
+	// Any malformed lines will be ignored.
+	if fn.Doc != nil {
+		for _, line := range strings.Split(fn.Doc.Text(), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, docMarker) {
+				config := strings.TrimPrefix(line, docMarker)
+				config = strings.TrimSpace(config)
+				parts := strings.Split(config, ",")
+				for _, part := range parts {
+					part = strings.TrimSpace(part)
+					if part == "" {
+						continue
+					}
+					kv := strings.SplitN(part, "=", 2)
+					if len(kv) != 2 {
+						continue
+					}
+					key := strings.TrimSpace(kv[0])
+					val := strings.TrimSpace(kv[1])
+					switch key {
+					case "count":
+						_, _ = fmt.Sscanf(val, "%d", &benchmarkInfo.Args.Count)
+					case "benchtime":
+						benchmarkInfo.Args.BenchTime = val
+					case "timeout":
+						if d, parseErr := time.ParseDuration(val); parseErr == nil {
+							benchmarkInfo.Args.Timeout = d
+						}
+					case "suite":
+						benchmarkInfo.Args.Suite = val
+					}
+				}
+			}
+		}
+	}
+
+	return benchmarkInfo, nil
+}

--- a/pkg/cmd/roachprod-microbench/list_test.go
+++ b/pkg/cmd/roachprod-microbench/list_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/codeowners"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeBenchmark(t *testing.T) {
+	f, err := parseFile(datapathutils.TestDataPath(t, "benchdoc", "bench_test_go"))
+	require.NoError(t, err)
+	co, err := codeowners.DefaultLoadCodeOwners()
+	require.NoError(t, err)
+	benchmarks, err := analyzeBenchmarkAST(co, f, "/abc/pkg", "/abc/pkg/some_pkg/sub_pkg/bench_test_go")
+	require.NoError(t, err)
+	require.Equal(t, []BenchmarkInfo{
+		{
+			Name:    "BenchmarkDocTest",
+			Package: "pkg/some_pkg/sub_pkg",
+			Team:    "unowned",
+			Args: RunArgs{
+				Suite:     "manual",
+				Count:     10,
+				BenchTime: "50x",
+				Timeout:   20 * time.Minute,
+			},
+		},
+	}, benchmarks)
+}
+
+func parseFile(filename string) (*ast.File, error) {
+	tokenSet := token.NewFileSet()
+	f, err := parser.ParseFile(tokenSet, filename, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -6,13 +6,16 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/util"
 	roachprodConfig "github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +51,7 @@ Typical usage:
 	command.AddCommand(makeCleanCommand())
 	command.AddCommand(makeCompressCommand())
 	command.AddCommand(makeStageCommand())
+	command.AddCommand(makeListCommand())
 
 	return command
 }
@@ -241,6 +245,36 @@ func makeCompressCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE:  runCmdFunc,
 	}
+	return cmd
+}
+
+func makeListCommand() *cobra.Command {
+	repoDir := ""
+	runCmdFunc := func(cmd *cobra.Command, args []string) error {
+		pkgPath := filepath.Join(repoDir, "pkg")
+		info, statErr := os.Stat(pkgPath)
+		if statErr != nil {
+			return errors.Wrapf(statErr, "inavlid pkg path %q", pkgPath)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("pkg path is not a directory: %s", pkgPath)
+		}
+		benchmarkInfoList, err := listBenchmarks(pkgPath)
+		if err != nil {
+			return err
+		}
+		for _, benchmarkInfo := range benchmarkInfoList {
+			fmt.Printf("%s/%s [%s]\n", benchmarkInfo.Package, benchmarkInfo.Name, benchmarkInfo.Team)
+		}
+		return nil
+	}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all microbenchmarks",
+		Args:  cobra.NoArgs,
+		RunE:  runCmdFunc,
+	}
+	cmd.Flags().StringVar(&repoDir, "repo-dir", repoDir, "path to the CockroachDB repository root directory")
 	return cmd
 }
 

--- a/pkg/cmd/roachprod-microbench/testdata/benchdoc/bench_test_go
+++ b/pkg/cmd/roachprod-microbench/testdata/benchdoc/bench_test_go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+
+package benchdoc
+
+import (
+	"testing"
+)
+
+// benchmark-ci: count=10, benchtime=50x, timeout=20m, suite=manual
+func BenchmarkDocTest(b *testing.B) {
+	// noop
+}


### PR DESCRIPTION
Currently, the microbenchmark job uses the `go -test.list` functionality on each test binary to get a full list of the available microbenchmarks to run. This has worked well, but we want to add some new functionality that allows microbenchmakrs to determine a run configuration from the `doc` or `comment` on the microbenchmark function.

This change is the first step to have a list functionality to list microbenchmarks via the repo rather than the binaries and to also parse the doc for an additional run configuration.

Epic: None
Release Note: None