### PR TITLE
mmaprototype: fail on unknown TestClusterState args

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_matcher_test.go
@@ -34,6 +34,8 @@ func parseStoreAttributedAndLocality(t *testing.T, in string) StoreAttributesAnd
 			)
 		case "locality-tiers":
 			sal.NodeLocality = parseLocalityTiers(t, parts[1])
+		default:
+			t.Fatalf("unknown argument: %s", parts[0])
 		}
 	}
 	return sal

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges.txt
@@ -19,16 +19,20 @@ store-load-msg
 # Range 4 has the highest cpu on the leaseholder, and range 3 the highest cpu on a follower.
 store-leaseholder-msg num-top-k-replicas=2
 store-id=1
-  range-id=1 load=[10,10,20] raft-cpu=5 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[10,10,20] raft-cpu=5
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
-  range-id=2 load=[20,10,15] raft-cpu=10 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=2 load=[20,10,15] raft-cpu=10
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
-  range-id=3 load=[30,10,10] raft-cpu=25 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=3 load=[30,10,10] raft-cpu=25
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
-  range-id=4 load=[40,10,5] raft-cpu=5 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=4 load=[40,10,5] raft-cpu=5
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
@@ -37,7 +37,8 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0,
 
 store-leaseholder-msg 
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 ----
 
@@ -89,7 +90,8 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0,
 # Store leaseholder msg from s1 showing that s2 has a replica but not the lease.
 store-leaseholder-msg
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=2 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
@@ -44,7 +44,8 @@ store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0,
 # Store s1 has the single replica and lease for r1.
 store-leaseholder-msg 
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 ----
 
@@ -94,7 +95,8 @@ t=5s
 # lease.
 store-leaseholder-msg
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=2 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----
@@ -113,7 +115,8 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # Store leaseholder msg from s2, showing that s2 is now the leaseholder.
 store-leaseholder-msg
 store-id=2
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=2 type=VOTER_FULL
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 ----
@@ -217,7 +220,8 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # Store leaseholder msg from s2, showing that s1 is no longer a replica.
 store-leaseholder-msg
 store-id=2
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 ----
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
@@ -36,7 +36,8 @@ node-id=4 locality-tiers=region=us-east-1,zone=us-east-1a,node=4
 # Store s1 is the leaseholder for range r1.
 store-leaseholder-msg 
 store-id=1
-  range-id=1 load=[2,2,2] raft-cpu=1 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[2,2,2] raft-cpu=1
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=3 replica-id=3 type=VOTER_FULL
 ----
@@ -85,7 +86,8 @@ t=5s
 # and s1 still has a replica.
 store-leaseholder-msg
 store-id=2
-  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[3,3,3] raft-cpu=2
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL
     store-id=3 replica-id=3 type=VOTER_FULL
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
@@ -127,7 +129,8 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:
 # that the message originates from s2 and not s1.
 store-leaseholder-msg
 store-id=2
-  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[3,3,3] raft-cpu=2
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL
     store-id=3 replica-id=3 type=VOTER_FULL
     store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
@@ -194,7 +197,8 @@ store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0,
 # replica has not been removed.
 store-leaseholder-msg
 store-id=2
-  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[3,3,3] raft-cpu=2
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL
     store-id=3 replica-id=3 type=VOTER_FULL
     store-id=4 replica-id=4 type=VOTER_FULL
@@ -234,7 +238,8 @@ change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:
 # Same store leaseholder msg from s2. The pending change for s3 is gc'd.
 store-leaseholder-msg
 store-id=2
-  range-id=1 load=[3,3,3] raft-cpu=2 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[3,3,3] raft-cpu=2
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL
     store-id=3 replica-id=3 type=VOTER_FULL
     store-id=4 replica-id=4 type=VOTER_FULL

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica.txt
@@ -18,7 +18,8 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 store-leaseholder-msg 
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----
@@ -62,7 +63,8 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 store-leaseholder-msg
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 ----
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges.txt
@@ -12,7 +12,8 @@ node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
 
 store-leaseholder-msg 
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 ----
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease.txt
@@ -22,7 +22,8 @@ store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:8
 
 store-leaseholder-msg 
 store-id=1
-  range-id=1 load=[80,80,80] raft-cpu=20 config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
+  range-id=1 load=[80,80,80] raft-cpu=20
+  config=(num_replicas=3 constraints={'+region=us-west-1:1'} voter_constraints={'+region=us-west-1:1'})
     store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
     store-id=2 replica-id=2 type=VOTER_FULL
 ----


### PR DESCRIPTION
Previously, unknown args to the store leaseholder msg and store commands were ignored which lead to issues where commands were incorrectly specified and were silently ignored, leading to confusion. Now, when an unexpected arg is seen, the test fails immediately allowing the developer to correct the input.

Fixes #158191
Epic: CRDB-55052
Release note: none