### PR TITLE
sql/inspect: use historical descriptors for INSPECT AS OF

### DIFF
--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -351,7 +351,6 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				ctx,
 				fmt.Sprintf("import-validation-%s", tableName),
 				p.ExecCfg(),
-				nil, /* txn */
 				checks,
 				setPublicTimestamp,
 			)


### PR DESCRIPTION
Fix a bug in `INSPECT ... AS OF` that incorrectly used the latest table descriptor instead of a historical one. This could result in incorrect index ID usage if a schema change occurred after the specified AS OF time.

Since this tests schema changes interleaved with INSPECT, this will also create/start the INSPECT job in a separate transaction. This was needed to avoid getting transaction retry errors.

Informs: #158197
Release note: none