### PR TITLE
cloud: add random access support to ResumingReader

### DIFF
--- a/pkg/backup/backupinfo/BUILD.bazel
+++ b/pkg/backup/backupinfo/BUILD.bazel
@@ -96,7 +96,6 @@ go_test(
         "//pkg/util",
         "//pkg/util/bulk",
         "//pkg/util/hlc",
-        "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/backup/backupinfo/backup_index_test.go
+++ b/pkg/backup/backupinfo/backup_index_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -705,7 +704,7 @@ func (b *bytesReaderCtx) Close(_ context.Context) error {
 
 func (f *fakeExternalStorage) ReadFile(
 	ctx context.Context, filename string, _ cloud.ReadOptions,
-) (ioctx.ReadCloserCtx, int64, error) {
+) (cloud.ReadFile, int64, error) {
 	bytes, exists := f.files[filename]
 	if !exists {
 		return nil, 0, errors.Errorf("file %s does not exist", filename)

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -347,7 +347,6 @@ go_test(
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
-        "//pkg/util/ioctx",
         "//pkg/util/json",
         "//pkg/util/keysutil",
         "//pkg/util/leaktest",

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -989,7 +988,7 @@ func (n *mockSinkStorage) Settings() *cluster.Settings {
 
 func (n *mockSinkStorage) ReadFile(
 	_ context.Context, _ string, _ cloud.ReadOptions,
-) (ioctx.ReadCloserCtx, int64, error) {
+) (cloud.ReadFile, int64, error) {
 	return nil, 0, io.EOF
 }
 

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/envutil",
-        "//pkg/util/ioctx",
         "//pkg/util/log",
         "//pkg/util/metamorphic",
         "//pkg/util/syncutil",

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -887,7 +886,7 @@ func (s *s3Storage) openStreamAt(
 // ReadFile is part of the cloud.ExternalStorage interface.
 func (s *s3Storage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (_ ioctx.ReadCloserCtx, fileSize int64, _ error) {
+) (_ cloud.ReadFile, fileSize int64, _ error) {
 	ctx, sp := tracing.ChildSpan(ctx, "s3.ReadFile")
 	defer sp.Finish()
 

--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/envutil",
-        "//pkg/util/ioctx",
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -415,7 +414,7 @@ func isNotFoundErr(err error) bool {
 
 func (s *azureStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (_ ioctx.ReadCloserCtx, fileSize int64, _ error) {
+) (_ cloud.ReadFile, fileSize int64, _ error) {
 	object := path.Join(s.prefix, basename)
 
 	ctx, sp := tracing.ChildSpan(ctx, "azure.ReadFile")

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
@@ -251,7 +250,7 @@ type ResumingReader struct {
 	ErrFn func(error) time.Duration
 }
 
-var _ ioctx.ReadCloserCtx = &ResumingReader{}
+var _ RandomAccessFile = &ResumingReader{}
 
 // NewResumingReader returns a ResumingReader instance. Reader does not have to
 // be provided, and will be created with the opener if it's not provided. Size
@@ -376,6 +375,82 @@ func (r *ResumingReader) Close(ctx context.Context) error {
 	r.ReaderSpan.Finish()
 	r.Reader = nil
 	return err
+}
+
+// ReadAt implements ioctx.ReaderAtCtx using the Opener to create a reader at the specified offset.
+// This allows formats like Parquet that require random access to work efficiently with cloud storage.
+func (r *ResumingReader) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
+	if r.Opener == nil {
+		return 0, errors.New("ReadAt not supported: no Opener available")
+	}
+
+	originalLen := len(p)
+
+	// If we know the file size, check bounds before opening to avoid
+	// making an invalid range request to cloud storage.
+	if r.Size > 0 {
+		if off >= r.Size {
+			return 0, io.EOF
+		}
+		// Truncate read to available bytes
+		if off+int64(len(p)) > r.Size {
+			p = p[:r.Size-off]
+		}
+	}
+
+	reader, size, err := r.Opener(ctx, off)
+	if err != nil {
+		return 0, err
+	}
+	defer reader.Close()
+
+	// Update our size if we didn't know it before
+	if r.Size == 0 && size > 0 {
+		r.Size = size
+	}
+
+	n, err = io.ReadFull(reader, p)
+	// If we truncated the buffer and successfully read those bytes,
+	// return ErrUnexpectedEOF to match io.ReaderAt semantics
+	if err == nil && len(p) < originalLen {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+// Seek implements ioctx.SeekerCtx by tracking position without actually seeking the underlying reader.
+// Actual repositioning happens via the Opener when Read is called.
+func (r *ResumingReader) Seek(ctx context.Context, offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = r.Pos + offset
+	case io.SeekEnd:
+		if r.Size == 0 {
+			return 0, errors.New("Seek from end not supported: size unknown")
+		}
+		newPos = r.Size + offset
+	default:
+		return 0, errors.Newf("invalid whence: %d", whence)
+	}
+
+	if newPos < 0 {
+		return 0, errors.New("negative position")
+	}
+
+	// Close current reader if position changed
+	if r.Reader != nil && newPos != r.Pos {
+		r.Reader.Close()
+		if r.ReaderSpan != nil {
+			r.ReaderSpan.Finish()
+		}
+		r.Reader = nil
+	}
+
+	r.Pos = newPos
+	return newPos, nil
 }
 
 // CheckHTTPContentRangeHeader parses Content-Range header and ensures that

--- a/pkg/cloud/cloud_io_test.go
+++ b/pkg/cloud/cloud_io_test.go
@@ -302,7 +302,7 @@ func TestResumingReaderReadAt(t *testing.T) {
 		// Try to read more bytes than available
 		buf := make([]byte, 10)
 		n, err := reader.ReadAt(ctx, buf, 7)
-		require.Equal(t, io.ErrUnexpectedEOF, err)
+		require.Equal(t, io.EOF, err)
 		require.Equal(t, 4, n) // Should read "orld"
 		require.Equal(t, "orld", string(buf[:n]))
 	})

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/util/ioctx",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -291,7 +290,7 @@ func isNotExistErr(err error) bool {
 
 func (g *gcsStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (ioctx.ReadCloserCtx, int64, error) {
+) (cloud.ReadFile, int64, error) {
 	object := path.Join(g.prefix, basename)
 
 	ctx, sp := tracing.ChildSpan(ctx, "gcs.ReadFile")

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -137,7 +137,7 @@ func (h *httpStorage) openStreamAt(
 
 func (h *httpStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (_ ioctx.ReadCloserCtx, fileSize int64, _ error) {
+) (_ cloud.ReadFile, fileSize int64, _ error) {
 	stream, err := h.openStreamAt(ctx, basename, opts.Offset)
 	if err != nil {
 		return nil, 0, err

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -463,6 +463,28 @@ func (l *limitedReader) Close(ctx context.Context) error {
 	return l.r.Close(ctx)
 }
 
+// ReadAt implements ioctx.ReaderAtCtx by delegating to the underlying reader if it supports it.
+// This is needed for Parquet and other formats that require random access.
+func (l *limitedReader) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
+	if rf, ok := SupportsRandomAccess(l.r); ok {
+		n, err = rf.ReadAt(ctx, p, off)
+		if err := l.lim.WaitN(ctx, int64(n)); err != nil {
+			log.Dev.Warningf(ctx, "failed to throttle read: %+v", err)
+		}
+		return n, err
+	}
+	return 0, errors.New("ReadAt not supported by underlying reader")
+}
+
+// Seek implements ioctx.SeekerCtx by delegating to the underlying reader if it supports it.
+// This is needed for Parquet and other formats that require random access.
+func (l *limitedReader) Seek(ctx context.Context, offset int64, whence int) (int64, error) {
+	if rf, ok := SupportsRandomAccess(l.r); ok {
+		return rf.Seek(ctx, offset, whence)
+	}
+	return 0, errors.New("Seek not supported by underlying reader")
+}
+
 type limitedWriter struct {
 	w    io.WriteCloser
 	ctx  context.Context

--- a/pkg/cloud/nodelocal/BUILD.bazel
+++ b/pkg/cloud/nodelocal/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
         "//pkg/util/buildutil",
-        "//pkg/util/ioctx",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@org_golang_google_grpc//codes",

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"google.golang.org/grpc/codes"
@@ -155,7 +154,7 @@ func (l *localFileStorage) Writer(ctx context.Context, basename string) (io.Writ
 
 func (l *localFileStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (ioctx.ReadCloserCtx, int64, error) {
+) (cloud.ReadFile, int64, error) {
 	reader, size, err := l.blobClient.ReadFile(ctx, joinRelativePath(l.base, basename), opts.Offset)
 	if err != nil && isNotFoundErr(err) {
 		return nil, 0, cloud.WrapErrFileDoesNotExist(err, "nodelocal storage file does not exist")

--- a/pkg/cloud/nullsink/BUILD.bazel
+++ b/pkg/cloud/nullsink/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/cloud/cloudpb",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
-        "//pkg/util/ioctx",
     ],
 )
 

--- a/pkg/cloud/nullsink/nullsink_storage.go
+++ b/pkg/cloud/nullsink/nullsink_storage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 )
 
 func parseNullURL(_ cloud.ExternalStorageURIContext, _ *url.URL) (cloudpb.ExternalStorage, error) {
@@ -66,7 +65,7 @@ func (n *nullSinkStorage) Settings() *cluster.Settings {
 
 func (n *nullSinkStorage) ReadFile(
 	_ context.Context, _ string, _ cloud.ReadOptions,
-) (ioctx.ReadCloserCtx, int64, error) {
+) (cloud.ReadFile, int64, error) {
 	return nil, 0, io.EOF
 }
 

--- a/pkg/cloud/userfile/BUILD.bazel
+++ b/pkg/cloud/userfile/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
-        "//pkg/util/ioctx",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
     ],

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 )
@@ -217,7 +216,7 @@ func isNotExistErr(err error) bool {
 // the file stored in the user scoped FileToTableSystem.
 func (f *fileTableStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (ioctx.ReadCloserCtx, int64, error) {
+) (cloud.ReadFile, int64, error) {
 	filepath, err := checkBaseAndJoinFilePath(f.prefix, basename)
 	if err != nil {
 		return nil, 0, err

--- a/pkg/multitenant/multitenantio/BUILD.bazel
+++ b/pkg/multitenant/multitenantio/BUILD.bazel
@@ -9,6 +9,6 @@ go_library(
         "//pkg/cloud",
         "//pkg/multitenant",
         "//pkg/settings",
-        "//pkg/util/ioctx",
+        "//pkg/util/syncutil",
     ],
 )

--- a/pkg/sql/importer/testutils_test.go
+++ b/pkg/sql/importer/testutils_test.go
@@ -227,7 +227,7 @@ func (es *generatorExternalStorage) RequiresExternalIOAccounting() bool { return
 
 func (es *generatorExternalStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
-) (_ ioctx.ReadCloserCtx, fileSize int64, _ error) {
+) (_ cloud.ReadFile, fileSize int64, _ error) {
 	if opts.Offset != 0 || !opts.NoFileSize {
 		panic("unimplemented")
 	}


### PR DESCRIPTION
This commit adds ReadAt and Seek implementations to ResumingReader and its wrapper types (limitedReader, metricsReader), enabling random access to cloud-stored files.

Implementation details:
- ReadAt creates a new reader at the specified offset using the Opener
- Checks bounds against known file size before opening to avoid invalid
  range requests to cloud storage
- Uses cached Size field for efficient bounds checking on subsequent calls
- Seek tracks position logically without seeking the underlying reader
- Both methods implement the new RandomAccessFile interface
- SupportsRandomAccess() helper function for clean type checking
- Rate limiting uses batching for both Read() and ReadAt() to reduce
  overhead (128KB batches shared via l.pool)

This enables efficient reading of formats like Parquet that require random access, without buffering entire files to disk.

Release note: none

Epic: CRDB-23802