### PR TITLE
sql: ignore AdmissionWaitTime with DeterministicExplain test knob

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3034,6 +3034,12 @@ func populateQueryLevelStats(
 			}
 		}
 		ih.queryLevelStatsWithErr.Stats.ClientTime = topLevelStats.clientTime
+		if cfg.TestingKnobs.DeterministicExplain {
+			// We only show AdmissionWaitTime when it's non-zero, yet its value
+			// is non-deterministic, so if we need deterministic EXPLAIN, then
+			// we need to zero it out.
+			ih.queryLevelStatsWithErr.Stats.AdmissionWaitTime = 0
+		}
 	}
 	if ih.traceMetadata != nil && ih.explainPlan != nil {
 		ih.traceMetadata.annotateExplain(


### PR DESCRIPTION
We just merged a change to add AdmissionWaitTime to EXPLAIN ANALYZE output whenever it's non-zero. Waiting in AC system is non-deterministic, so if we have DeterministicExplain testing knob set (which we have in the logic tests), we actually need to explicitly zero it out for deterministic output.

Fixes: #158183.
Release note: None