### PR TITLE
sql/inspect: record table version in INSPECT job to detect schema drift

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1474,6 +1474,14 @@ message InspectDetails {
       (gogoproto.customname) = "IndexID",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.IndexID"
     ];
+
+    // TableVersion records the descriptor version observed when the check was
+    // planned. It is used at execution time to detect concurrent schema changes
+    // and abort the job before running inconsistent checks.
+    uint64 table_version = 4 [
+      (gogoproto.customname) = "TableVersion",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.DescriptorVersion"
+    ];
   }
 
   // Checks is the list of individual checks this job will perform.

--- a/pkg/sql/inspect/inspect_job_entry.go
+++ b/pkg/sql/inspect/inspect_job_entry.go
@@ -148,7 +148,12 @@ func ChecksForTable(
 			}
 			continue
 		}
-		check := jobspb.InspectDetails_Check{Type: jobspb.InspectCheckIndexConsistency, TableID: table.GetID(), IndexID: index.GetID()}
+		check := jobspb.InspectDetails_Check{
+			Type:         jobspb.InspectCheckIndexConsistency,
+			TableID:      table.GetID(),
+			IndexID:      index.GetID(),
+			TableVersion: table.GetVersion(),
+		}
 		checks = append(checks, &check)
 	}
 
@@ -184,7 +189,12 @@ func checksByIndexNames(
 			return nil, pgerror.Newf(pgcode.InvalidName, "index %q on table %q is not supported for index consistency checking", index.GetName(), table.GetName())
 		}
 
-		checks = append(checks, &jobspb.InspectDetails_Check{Type: jobspb.InspectCheckIndexConsistency, TableID: table.GetID(), IndexID: index.GetID()})
+		checks = append(checks, &jobspb.InspectDetails_Check{
+			Type:         jobspb.InspectCheckIndexConsistency,
+			TableID:      table.GetID(),
+			IndexID:      index.GetID(),
+			TableVersion: table.GetVersion(),
+		})
 	}
 
 	return checks, nil

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -452,6 +452,7 @@ func buildInspectCheckFactories(
 	for _, specCheck := range spec.InspectDetails.Checks {
 		tableID := specCheck.TableID
 		indexID := specCheck.IndexID
+		tableVersion := specCheck.TableVersion
 		switch specCheck.Type {
 		case jobspb.InspectCheckIndexConsistency:
 			checkFactories = append(checkFactories, func(asOf hlc.Timestamp) inspectCheck {
@@ -459,9 +460,10 @@ func buildInspectCheckFactories(
 					indexConsistencyCheckApplicability: indexConsistencyCheckApplicability{
 						tableID: tableID,
 					},
-					flowCtx: flowCtx,
-					indexID: indexID,
-					asOf:    asOf,
+					flowCtx:      flowCtx,
+					indexID:      indexID,
+					tableVersion: tableVersion,
+					asOf:         asOf,
 				}
 			})
 


### PR DESCRIPTION
Previously, the INSPECT job only recorded the table IDs involved in the job. However, there is a time gap between when the job record is created and when the job is executed, during which schema changes amy occur. These changes can invalidate assumptions made at job creation (e.g. index ID existence).

This change introduces table version tracking into the job record. Before executing any checks, the job will verify that the current table versions match those stored at creation. If a mismatch is detected, the job will fail early.

This mechanism mirrors similar protections implemented in other jobs, such as TTL jobs.

Informs #158197
Release note: none