### PR TITLE
sql/stats: miscellaneous minor cleanup

### DIFF
--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -151,10 +151,6 @@ const AutoStatsName = "__auto__"
 // automatically.
 const AutoPartialStatsName = "__auto_partial__"
 
-// ImportStatsName is the name to use for statistics created automatically
-// during import.
-const ImportStatsName = "__import__"
-
 // ForecastStatsName is the name to use for statistic forecasts.
 const ForecastStatsName = "__forecast__"
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -294,7 +294,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		virtColEnabled := statsOnVirtualCols.Get(n.p.ExecCfg().SV())
 		// Disable multi-column stats and deleting stats if partial statistics at
 		// the extremes are requested.
-		// TODO(faizaanmadhani): Add support for multi-column stats.
+		// TODO(#94076): add support for creating multi-column stats.
 		var multiColEnabled bool
 		if !n.Options.UsingExtremes {
 			multiColEnabled = stats.MultiColumnStatisticsClusterMode.Get(n.p.ExecCfg().SV())

--- a/pkg/sql/logictest/testdata/logic_test/constrained_stats
+++ b/pkg/sql/logictest/testdata/logic_test/constrained_stats
@@ -3,9 +3,6 @@
 # Tests for creating partial table statistics with a WHERE clause.
 
 statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
-
-statement ok
 CREATE TABLE products (
     id INT PRIMARY KEY,
     category_id INT,

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
@@ -2,10 +2,6 @@
 
 # Test a simple update and insert case for partial statistics
 
-# Disable automatic stats
-statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
-
 statement ok
 SET CLUSTER SETTING sql.stats.automatic_partial_collection.min_stale_rows = 5
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -680,15 +680,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 	// Make now and annotate the metadata table with it for next time.
 	stats = &props.Statistics{}
 
-	// Find the most recent full statistic. (Stats are ordered with most recent first.)
-	var first int
-	for first < tab.StatisticCount() &&
-		(tab.Statistic(first).IsPartial() ||
-			tab.Statistic(first).IsMerged() && !sb.evalCtx.SessionData().OptimizerUseMergedPartialStatistics ||
-			tab.Statistic(first).IsForecast() && !sb.evalCtx.SessionData().OptimizerUseForecasts) {
-		first++
-	}
-
+	first := cat.FindLatestFullStat(tab, sb.evalCtx.SessionData())
 	if first >= tab.StatisticCount() {
 		// No statistics.
 		stats.Available = false

--- a/pkg/sql/opt/optbuilder/misc_statements.go
+++ b/pkg/sql/opt/optbuilder/misc_statements.go
@@ -178,11 +178,9 @@ func (b *Builder) buildCreateStatistics(n *tree.CreateStats, inScope *scope) (ou
 		tabMeta := b.addTable(t, &tn)
 		tabID = tabMeta.MetaID
 	} else if _, ok = ds.(cat.View); ok {
-		panic(pgerror.New(
-			pgcode.WrongObjectType, "cannot create statistics on views"))
+		panic(pgerror.New(pgcode.WrongObjectType, "cannot create statistics on views"))
 	} else {
-		panic(pgerror.Newf(pgcode.WrongObjectType,
-			"cannot create statistics on %T", ds))
+		panic(pgerror.Newf(pgcode.WrongObjectType, "cannot create statistics on %T", ds))
 	}
 
 	indexOrd := cat.PrimaryIndex

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -292,7 +292,7 @@ func forecastColumnStatistics(
 	forecast = &TableStatistic{
 		TableStatisticProto: TableStatisticProto{
 			TableID:       tableID,
-			StatisticID:   0, // TODO(michae2): Add support for SHOW HISTOGRAM.
+			StatisticID:   0, // TODO(#86358): add support for SHOW HISTOGRAM.
 			Name:          jobspb.ForecastStatsName,
 			ColumnIDs:     columnIDs,
 			CreatedAt:     at,

--- a/pkg/sql/stats/merge.go
+++ b/pkg/sql/stats/merge.go
@@ -259,7 +259,7 @@ func mergePartialStatistic(
 	mergedTableStatistic := &TableStatistic{
 		TableStatisticProto: TableStatisticProto{
 			TableID:         fullStat.TableID,
-			StatisticID:     0, // TODO (faizaanmadhani): Add support for SHOW HISTOGRAM.
+			StatisticID:     0, // TODO(#86358): add support for SHOW HISTOGRAM.
 			Name:            jobspb.MergedStatsName,
 			ColumnIDs:       fullStat.ColumnIDs,
 			CreatedAt:       partialStat.CreatedAt,


### PR DESCRIPTION
**sql/opt: unify search for latest full stat**

This commit extracts the logic for iterating over all statistics on a table to find the most recent full stat that can be utilized (i.e. while paying attention to session variables that might disallow usage of forecasts and merged partial). In particular, this allows us to fix the bug where `OptimizerUseMergedPartialStatistics` was being ignored when building the scan - the impact of that is pretty minor though, so there is no release note (the variable is `true` by default, so only non-default configs would be affected, and only that `statsCreatedTime` would be reported newer than it should - only used in logs - as well as in the telemetry we'd have the wrong row count.

**sql/stats: miscellaneous minor cleanup**

This commit contains a bunch of minor cleanups I noticed while reading the stats related code:
- remove no longer used `ImportStatsName`
- remove redundant disabling of auto stats in logic tests (the framework itself does it already)
- fix the pre-allocation slice for out types
- update TODOs with Faizaan's name to the corresponding issue numbers
- wrap some comments, remove a couple stale / redundant ones, collapse some lines.

Epic: None
Release note: None