### PR TITLE
roachtest: set ulimit for TPC-E workload runner

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -105,7 +105,7 @@ func initTPCESpec(ctx context.Context, l *logger.Logger, c cluster.Cluster) (*tp
 }
 
 func (ts *tpceSpec) newCmd(o tpceCmdOptions) *roachtestutil.Command {
-	cmd := roachtestutil.NewCommand(`sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:master`)
+	cmd := roachtestutil.NewCommand(`sudo docker run --ulimit nofile=1048576 us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:master`)
 	o.AddCommandOptions(cmd)
 	return cmd
 }


### PR DESCRIPTION
A recent version upgrade of docker changed the default of LimitNOFILE:

> containerd v2.1.5 now uses systemd's default LimitNOFILE for containers,
> changing the open file descriptor limit (ulimit -n) from 1048576 to 1024. This
> extends a change introduced in Docker Engine v25.0 for build containers to all
> containers.

Here, I explicitly set the `ulimit` when launcing the container.

According to the release note, an alternative here is to update our docker configuration on install:

```
{
  "default-ulimits": {
    "nofile": {
      "Name": "nofile",
      "Soft": 1048576,
      "Hard": 1048576
    }
  }
}
```

Fixes #158243

Release note: None