### PR TITLE
kvserver: skip `TestAdminScatterWithDrainingNodes` test in DRPC mode

### DIFF
--- a/pkg/kv/kvserver/scatter_test.go
+++ b/pkg/kv/kvserver/scatter_test.go
@@ -45,6 +45,11 @@ func TestAdminScatterWithDrainingNodes(t *testing.T) {
 	const drainingNodeID = drainingServerIdx + 1
 	tc := testcluster.StartTestCluster(
 		t, 2, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				// TODO(server): test is timing out when DRPC is enabled.
+				// Investigate and re-enable once the issue is resolved.
+				DefaultDRPCOption: base.TestDRPCDisabled,
+			},
 			ReplicationMode: base.ReplicationManual,
 		},
 	)


### PR DESCRIPTION
`TestAdminScatterWithDrainingNodes` is failing at random when DRPC is enabled. The issue is specific to DRPC and the failure is reproducible once every 25 runs. The issue is not reproducible with cluster setting `SET CLUSTER SETTING sql.stats.flush.enabled=false` set to false to turn off stats flush.

Re-enable the test once the underlying issue is resolved.

Fixes: #156372
Epic: None
Release note: None