### PR TITLE
sql/pgwire: explicitly check context cancellation in server loop

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1455,10 +1455,12 @@ func (s *Server) serveImpl(
 			// If we can't read data because of any one of the following conditions,
 			// then we should break:
 			// 1. the connection was closed.
-			// 2. the context was canceled (e.g. during authentication).
-			// 3. we reached an arbitrary threshold of repeated errors.
+			// 2. a returned error maps to context.Canceled (e.g. during authentication).
+			// 3. the context was canceled or exceeded its deadline (checked directly).
+			// 4. we reached an arbitrary threshold of repeated errors.
 			if netutil.IsClosedConnection(err) ||
 				errors.Is(err, context.Canceled) ||
+				ctx.Err() != nil ||
 				repeatedErrorCount > int(maxRepeatedErrorCount.Get(&s.execCfg.Settings.SV)) {
 				break
 			}


### PR DESCRIPTION
Previously, serveImpl in sql/pgwire/server.go relied on upstream callers to check for context cancellation. This could result in continuing to process repeated errors even after the context had been canceled, which we say delay a drain.

This change introduces an explicit context cancellation check within the main server loop. If the context has been canceled, the loop now exits early.

I didn't have any luck reproducing this in a unit test. I was able to do manual validation following the steps here:
https://github.com/cockroachdb/cockroach/issues/158196#issuecomment-3570934196

Closes #158196
Epic: none
Release note (bug fix): pgwire server now exits promptly on context cancellation