### PR TITLE
kvserver: split state/raft engines in testContext

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -5499,7 +5499,7 @@ func TestStoreMergeGCHint(t *testing.T) {
 				require.Greater(t, gcHint.LatestRangeDeleteTimestamp.WallTime, beforeSecondDel,
 					"highest timestamp wasn't picked up")
 			}
-			repl.AssertState(ctx, store.TODOEngine())
+			repl.AssertState(ctx, store.StateEngine(), store.LogEngine())
 		})
 	}
 }

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2389,7 +2389,7 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 		t.Fatalf("expected RHS's GCThreshold is equal to %v, but got %v", specifiedGCThreshold, gcThreshold)
 	}
 
-	repl.AssertState(ctx, store.TODOEngine())
+	repl.AssertState(ctx, store.StateEngine(), store.LogEngine())
 }
 
 func TestStoreSplitGCHint(t *testing.T) {
@@ -2451,7 +2451,7 @@ func TestStoreSplitGCHint(t *testing.T) {
 	gcHint = repl.GetGCHint()
 	require.False(t, gcHint.IsEmpty(), "GC hint is empty after range delete")
 
-	repl.AssertState(ctx, store.TODOEngine())
+	repl.AssertState(ctx, store.StateEngine(), store.LogEngine())
 }
 
 // TestStoreRangeSplitRaceUninitializedRHS reproduces #7600 (before it was

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
@@ -317,12 +318,14 @@ func (r *Replica) Breaker() *circuit.Breaker {
 	return r.breaker.wrapped
 }
 
-func (r *Replica) AssertState(ctx context.Context, reader storage.Reader) {
+func (r *Replica) AssertState(
+	ctx context.Context, stateRO kvstorage.StateRO, raftRO kvstorage.RaftRO,
+) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, reader)
+	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, stateRO, raftRO)
 }
 
 func (r *Replica) RaftLock() {

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1236,11 +1236,9 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 			"but only %d are left", exp, count)
 	}
 
-	batch := tc.engine.NewSnapshot()
-	defer batch.Close()
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.RLock()
-	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, batch) // check that in-mem and on-disk state were updated
+	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.stateEng, tc.raftEng) // check that in-mem and on-disk state were updated
 	tc.repl.mu.RUnlock()
 	tc.repl.raftMu.Unlock()
 }

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -255,7 +255,7 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 			require.Equal(t, expectedSize, ls.shMu.size)
 			require.Equal(t, accurate, ls.shMu.sizeTrusted)
 			truncState, err := logstore.NewStateLoader(r.RangeID).LoadRaftTruncatedState(
-				context.Background(), tc.engine)
+				context.Background(), tc.raftEng)
 			require.NoError(t, err)
 			require.Equal(t, ls.shMu.trunc.Index, truncState.Index)
 		}()

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1283,9 +1283,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 
 	if shouldAssert {
 		sm.r.mu.RLock()
-		// TODO(sep-raft-log): either check only statemachine invariants or
-		// pass both engines in.
-		sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
+		sm.r.assertStateRaftMuLockedReplicaMuRLocked(
+			ctx, sm.r.store.StateEngine(), sm.r.store.LogEngine())
 		sm.r.mu.RUnlock()
 	}
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6538,7 +6538,7 @@ func TestReplicaCorruption(t *testing.T) {
 	}
 
 	// Should have laid down marker file to prevent startup.
-	_, err := tc.engine.Env().Stat(base.PreventedStartupFile(tc.engine.GetAuxiliaryDir()))
+	_, err := tc.raftEng.Env().Stat(base.PreventedStartupFile(tc.raftEng.GetAuxiliaryDir()))
 	require.NoError(t, err)
 
 	// Should have triggered fatal error.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -311,7 +311,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 	tc.repl.raftMu.Lock()
 	tc.repl.setDescRaftMuLocked(ctx, &newDesc)
 	tc.repl.mu.RLock()
-	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
+	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.stateEng, tc.raftEng)
 	tc.repl.mu.RUnlock()
 	tc.repl.raftMu.Unlock()
 	return newReplica, nil
@@ -10267,7 +10267,7 @@ func TestReplicaRecomputeStats(t *testing.T) {
 	disturbMS.ContainsEstimates = 0
 	ms.Add(*disturbMS)
 	err := repl.raftMu.stateLoader.SetMVCCStats(ctx, tc.stateEng, ms)
-	repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.stateEng)
+	repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.stateEng, tc.raftEng)
 	repl.mu.Unlock()
 	repl.raftMu.Unlock()
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -151,7 +151,6 @@ type testContext struct {
 	repl        *Replica
 	rangeID     roachpb.RangeID
 	gossip      *gossip.Gossip
-	engine      storage.Engine // TODO(sep-raft-log): remove this
 	stateEng    storage.Engine
 	raftEng     storage.Engine
 	manualClock *timeutil.ManualTime
@@ -193,7 +192,6 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 	tc.TB = t
 	require.Nil(t, tc.gossip)
 	require.Nil(t, tc.transport)
-	require.Nil(t, tc.engine)
 	require.Nil(t, tc.stateEng)
 	require.Nil(t, tc.raftEng)
 	require.Nil(t, tc.store)
@@ -226,9 +224,6 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 	tc.rangeID = repl.RangeID
 	tc.gossip = store.cfg.Gossip
 	tc.transport = store.cfg.Transport
-	// TODO(sep-raft-log): may need to update our various test harnesses to
-	// support two engines, do metamorphic stuff, etc.
-	tc.engine = store.TODOEngine()
 	tc.stateEng = store.StateEngine()
 	tc.raftEng = store.LogEngine()
 	tc.store = store

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -151,7 +151,9 @@ type testContext struct {
 	repl        *Replica
 	rangeID     roachpb.RangeID
 	gossip      *gossip.Gossip
-	engine      storage.Engine
+	engine      storage.Engine // TODO(sep-raft-log): remove this
+	stateEng    storage.Engine
+	raftEng     storage.Engine
 	manualClock *timeutil.ManualTime
 }
 
@@ -192,6 +194,8 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 	require.Nil(t, tc.gossip)
 	require.Nil(t, tc.transport)
 	require.Nil(t, tc.engine)
+	require.Nil(t, tc.stateEng)
+	require.Nil(t, tc.raftEng)
 	require.Nil(t, tc.store)
 	require.Nil(t, tc.repl)
 
@@ -225,6 +229,8 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 	// TODO(sep-raft-log): may need to update our various test harnesses to
 	// support two engines, do metamorphic stuff, etc.
 	tc.engine = store.TODOEngine()
+	tc.stateEng = store.StateEngine()
+	tc.raftEng = store.LogEngine()
 	tc.store = store
 }
 

--- a/pkg/kv/kvserver/stats_test.go
+++ b/pkg/kv/kvserver/stats_test.go
@@ -7,7 +7,6 @@ package kvserver
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
@@ -15,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRangeStatsInit(t *testing.T) {
@@ -44,14 +44,8 @@ func TestRangeStatsInit(t *testing.T) {
 		LastUpdateNanos: 11,
 	}
 	rsl := kvstorage.MakeStateLoader(tc.repl.RangeID)
-	if err := rsl.SetMVCCStats(ctx, tc.engine, &ms); err != nil {
-		t.Fatal(err)
-	}
-	loadMS, err := rsl.LoadMVCCStats(ctx, tc.engine)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(ms, loadMS) {
-		t.Errorf("mvcc stats mismatch %+v != %+v", ms, loadMS)
-	}
+	require.NoError(t, rsl.SetMVCCStats(ctx, tc.stateEng, &ms))
+	loadMS, err := rsl.LoadMVCCStats(ctx, tc.stateEng)
+	require.NoError(t, err)
+	require.Equal(t, ms, loadMS)
 }


### PR DESCRIPTION
This PR makes tests using `testContext` aware of the separated engines.

Part of #97627