### PR TITLE
release-25.2: roachtest: route more schema change workload flakes to foundations

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -44,6 +44,19 @@ var (
 	}
 )
 
+func handleSchemaChangeWorkloadError(err error) error {
+	// If the UNEXPECTED ERROR detail appears, the workload likely flaked.
+	// Otherwise, the workload could have failed due to other reasons like a node
+	// crash.
+	if err != nil {
+		flattenedErr := errors.FlattenDetails(err)
+		if strings.Contains(flattenedErr, "UNEXPECTED ERROR") || strings.Contains(flattenedErr, "UNEXPECTED COMMIT ERROR") {
+			return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "schema change workload failed"))
+		}
+	}
+	return err
+}
+
 const numFullBackups = 3
 
 type roundTripSpecs struct {
@@ -256,18 +269,9 @@ func startBackgroundWorkloads(
 		return nil, err
 	}
 
-	handleChemaChangeError := func(err error) error {
-		// If the UNEXPECTED ERROR detail appears, the workload likely flaked.
-		// Otherwise, the workload could have failed due to other reasons like a node
-		// crash.
-		if err != nil && strings.Contains(errors.FlattenDetails(err), "UNEXPECTED ERROR") {
-			return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "schema change workload failed"))
-		}
-		return err
-	}
 	err = c.RunE(ctx, option.WithNodes(workloadNode), scInit.String())
 	if err != nil {
-		return nil, handleChemaChangeError(err)
+		return nil, handleSchemaChangeWorkloadError(err)
 	}
 
 	run := func() (func(), error) {
@@ -284,7 +288,7 @@ func startBackgroundWorkloads(
 		})
 		stopSC := workloadWithCancel(m, func(ctx context.Context) error {
 			if err := c.RunE(ctx, option.WithNodes(workloadNode), scRun.String()); err != nil {
-				return handleChemaChangeError(err)
+				return handleSchemaChangeWorkloadError(err)
 			}
 			return nil
 		})


### PR DESCRIPTION
Backport 1/1 commits from #155399.

/cc @cockroachdb/release

---

It appears that errors prefaced with "UNEXPECTED COMMIT ERRORS" also signal a workload flake.

Informs #155141

Release note: none
