### PR TITLE
sql/bulkingest: switch BulkMergeSpec keys from string to roachpb.Key

### DIFF
--- a/pkg/sql/bulkingest/split_picker.go
+++ b/pkg/sql/bulkingest/split_picker.go
@@ -43,7 +43,7 @@ func pickSplits(
 
 	// Validate SSTs are ordered and non-overlapping.
 	for i := 1; i < len(ssts); i++ {
-		prev, curr := roachpb.Key(ssts[i-1].StartKey), roachpb.Key(ssts[i].StartKey)
+		prev, curr := ssts[i-1].StartKey, ssts[i].StartKey
 		if !less(prev, curr) {
 			return nil, errors.Newf("SSTs not in order: %s >= %s", prev, curr)
 		}
@@ -58,12 +58,12 @@ func pickSplits(
 	for _, span := range spans {
 		spanSSTStartIdx := sstIdx
 		for ; sstIdx < len(ssts); sstIdx++ {
-			sstStart := roachpb.Key(ssts[sstIdx].StartKey)
+			sstStart := ssts[sstIdx].StartKey
 			if !less(sstStart, span.EndKey) {
 				break
 			}
 
-			sstEnd := roachpb.Key(ssts[sstIdx].EndKey)
+			sstEnd := ssts[sstIdx].EndKey
 			if !less(sstEnd, span.EndKey) && !sstEnd.Equal(span.EndKey) {
 				return nil, errors.Newf("SST ending at %s extends beyond containing span ending at %s",
 					sstEnd, span.EndKey)
@@ -112,7 +112,7 @@ func pickSplitsForSpan(
 	spanStart := span.Key
 
 	for i := 1; i < len(ssts); i++ {
-		splitPoint := roachpb.Key(ssts[i].StartKey)
+		splitPoint := ssts[i].StartKey
 
 		// Validate that the split point is already at a safe split point.
 		safeSplitPoint, err := keys.EnsureSafeSplitKey(splitPoint)
@@ -156,7 +156,7 @@ func overlaps(a, b roachpb.Span) bool {
 // spanFromSST returns the span that matches the SST's start and end keys.
 func spanFromSST(sst execinfrapb.BulkMergeSpec_SST) roachpb.Span {
 	return roachpb.Span{
-		Key:    roachpb.Key(sst.StartKey),
-		EndKey: roachpb.Key(sst.EndKey),
+		Key:    sst.StartKey,
+		EndKey: sst.EndKey,
 	}
 }

--- a/pkg/sql/bulkingest/split_picker_test.go
+++ b/pkg/sql/bulkingest/split_picker_test.go
@@ -37,7 +37,7 @@ func TestPickSplits(t *testing.T) {
 		{
 			name:          "empty spans",
 			spans:         nil,
-			ssts:          []execinfrapb.BulkMergeSpec_SST{{StartKey: "a", EndKey: "b"}},
+			ssts:          []execinfrapb.BulkMergeSpec_SST{{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
 			expectedError: "no spans provided",
 		},
 		{
@@ -46,7 +46,7 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
 			},
-			ssts:          []execinfrapb.BulkMergeSpec_SST{{StartKey: "a", EndKey: "b"}},
+			ssts:          []execinfrapb.BulkMergeSpec_SST{{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
 			expectedError: "spans not ordered: \"c\" >= \"a\"",
 		},
 		{
@@ -55,7 +55,7 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
 				{Key: roachpb.Key("b"), EndKey: roachpb.Key("d")},
 			},
-			ssts:          []execinfrapb.BulkMergeSpec_SST{{StartKey: "a", EndKey: "b"}},
+			ssts:          []execinfrapb.BulkMergeSpec_SST{{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
 			expectedError: "spans are overlapping: \"c\" overlaps with \"b\"",
 		},
 		{
@@ -64,8 +64,8 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "a", EndKey: "b"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")},
 			},
 			expectedError: "SSTs not in order",
 		},
@@ -75,8 +75,8 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "c"},
-				{StartKey: "b", EndKey: "d"},
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+				{StartKey: roachpb.Key("b"), EndKey: roachpb.Key("d")},
 			},
 			expectedError: "overlapping SSTs",
 		},
@@ -86,7 +86,7 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "d"},
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("d")},
 			},
 			expectedError: "SST ending at \"d\" extends beyond containing span ending at \"c\"",
 		},
@@ -96,7 +96,7 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("b"), EndKey: roachpb.Key("d")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "c"},
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("c")},
 			},
 			expectedError: "SST starting at \"a\" begins before containing span starting at \"b\"",
 		},
@@ -116,7 +116,7 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
@@ -128,9 +128,9 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "f", EndKey: "g"},
-				{StartKey: "i", EndKey: "j"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("f"), EndKey: roachpb.Key("g")},
+				{StartKey: roachpb.Key("i"), EndKey: roachpb.Key("j")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("f")},
@@ -145,10 +145,10 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("m"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "f", EndKey: "g"},
-				{StartKey: "o", EndKey: "p"},
-				{StartKey: "r", EndKey: "s"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("f"), EndKey: roachpb.Key("g")},
+				{StartKey: roachpb.Key("o"), EndKey: roachpb.Key("p")},
+				{StartKey: roachpb.Key("r"), EndKey: roachpb.Key("s")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("f")},
@@ -164,8 +164,8 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("e"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "f", EndKey: "g"},
-				{StartKey: "i", EndKey: "j"},
+				{StartKey: roachpb.Key("f"), EndKey: roachpb.Key("g")},
+				{StartKey: roachpb.Key("i"), EndKey: roachpb.Key("j")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("e")},
@@ -180,8 +180,8 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("k"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "f", EndKey: "g"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("f"), EndKey: roachpb.Key("g")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("f")},
@@ -196,9 +196,9 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("k"), EndKey: roachpb.Key("z")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "b"},
-				{StartKey: "j", EndKey: "k"},
-				{StartKey: "k", EndKey: "l"},
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+				{StartKey: roachpb.Key("j"), EndKey: roachpb.Key("k")},
+				{StartKey: roachpb.Key("k"), EndKey: roachpb.Key("l")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("j")},
@@ -213,11 +213,11 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("c"), EndKey: roachpb.Key("f")},
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "b"},
-				{StartKey: "d", EndKey: "e"},
-				{StartKey: "x", EndKey: "z"}, // This SST is completely outside all spans
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+				{StartKey: roachpb.Key("d"), EndKey: roachpb.Key("e")},
+				{StartKey: roachpb.Key("x"), EndKey: roachpb.Key("z")}, // This SST is completely outside all spans
 			},
-			expectedError: "SST starting at x not contained in any span",
+			expectedError: "SST starting at \"x\" not contained in any span",
 		},
 		{
 			name: "sst in gap between non-contiguous spans",
@@ -226,8 +226,8 @@ func TestPickSplits(t *testing.T) {
 				{Key: roachpb.Key("e"), EndKey: roachpb.Key("g")}, // Gap from [c, e)
 			},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "b"},
-				{StartKey: "c", EndKey: "d"}, // This SST is in the gap [c, e)
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")}, // This SST is in the gap [c, e)
 			},
 			expectedError: "SST starting at \"c\" begins before containing span starting at \"e\"",
 		},
@@ -269,7 +269,7 @@ func TestPickSplitsForSpan(t *testing.T) {
 			name: "single sst",
 			span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
@@ -279,8 +279,8 @@ func TestPickSplitsForSpan(t *testing.T) {
 			name: "two ssts",
 			span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "f", EndKey: "g"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("f"), EndKey: roachpb.Key("g")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("f")},
@@ -291,9 +291,9 @@ func TestPickSplitsForSpan(t *testing.T) {
 			name: "three ssts",
 			span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "f", EndKey: "g"},
-				{StartKey: "i", EndKey: "j"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("f"), EndKey: roachpb.Key("g")},
+				{StartKey: roachpb.Key("i"), EndKey: roachpb.Key("j")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("f")},
@@ -305,8 +305,8 @@ func TestPickSplitsForSpan(t *testing.T) {
 			name: "sst at span boundary",
 			span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "a", EndKey: "b"},
-				{StartKey: "y", EndKey: "z"},
+				{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+				{StartKey: roachpb.Key("y"), EndKey: roachpb.Key("z")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("y")},
@@ -317,9 +317,9 @@ func TestPickSplitsForSpan(t *testing.T) {
 			name: "adjacent ssts",
 			span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")},
 			ssts: []execinfrapb.BulkMergeSpec_SST{
-				{StartKey: "c", EndKey: "d"},
-				{StartKey: "d", EndKey: "e"},
-				{StartKey: "e", EndKey: "f"},
+				{StartKey: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				{StartKey: roachpb.Key("d"), EndKey: roachpb.Key("e")},
+				{StartKey: roachpb.Key("e"), EndKey: roachpb.Key("f")},
 			},
 			expected: []roachpb.Span{
 				{Key: roachpb.Key("a"), EndKey: roachpb.Key("d")},
@@ -369,8 +369,8 @@ func TestPickSplitsForSpanErrors(t *testing.T) {
 				sst2End := codec.IndexPrefix(50, 2)
 
 				return []execinfrapb.BulkMergeSpec_SST{
-					{StartKey: string(sst1Start), EndKey: string(sst1End)},
-					{StartKey: string(sst2Start), EndKey: string(sst2End)},
+					{StartKey: sst1Start, EndKey: sst1End},
+					{StartKey: sst2Start, EndKey: sst2End},
 				}
 			}(),
 			expectedError: "SST 1 start key .* is not at a safe split point.*SST writer should have ensured safe boundaries",
@@ -395,8 +395,8 @@ func TestPickSplitsForSpanErrors(t *testing.T) {
 				sst2End := codec.IndexPrefix(50, 2)
 
 				return []execinfrapb.BulkMergeSpec_SST{
-					{StartKey: string(sst1Start), EndKey: string(sst1End)},
-					{StartKey: string(sst2Start), EndKey: string(sst2End)},
+					{StartKey: sst1Start, EndKey: sst1End},
+					{StartKey: sst2Start, EndKey: sst2End},
 				}
 			}(),
 			expectedError: "SST 1 has unsafe start key",

--- a/pkg/sql/bulksst/combine_file_info.go
+++ b/pkg/sql/bulksst/combine_file_info.go
@@ -43,8 +43,8 @@ func CombineFileInfo(
 	for _, file := range files {
 		for _, sst := range file.SST {
 			result = append(result, execinfrapb.BulkMergeSpec_SST{
-				StartKey: string(sst.StartKey),
-				EndKey:   string(sst.EndKey),
+				StartKey: sst.StartKey,
+				EndKey:   sst.EndKey,
 				URI:      sst.URI,
 			})
 		}

--- a/pkg/sql/bulksst/combine_file_info_test.go
+++ b/pkg/sql/bulksst/combine_file_info_test.go
@@ -53,7 +53,7 @@ func TestCombineFileInfo(t *testing.T) {
 			},
 			schemaSpans: []roachpb.Span{span("a", "z")},
 			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
-				{URI: "file1.sst", StartKey: "b", EndKey: "d"},
+				{URI: "file1.sst", StartKey: roachpb.Key("b"), EndKey: roachpb.Key("d")},
 			},
 			expectedMergeSpan: []roachpb.Span{span("a", "z")},
 		},
@@ -73,8 +73,8 @@ func TestCombineFileInfo(t *testing.T) {
 			},
 			schemaSpans: []roachpb.Span{span("a", "z")},
 			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
-				{URI: "file1.sst", StartKey: "a", EndKey: "e"},
-				{URI: "file2.sst", StartKey: "e", EndKey: "z"},
+				{URI: "file1.sst", StartKey: roachpb.Key("a"), EndKey: roachpb.Key("e")},
+				{URI: "file2.sst", StartKey: roachpb.Key("e"), EndKey: roachpb.Key("z")},
 			},
 			expectedMergeSpan: []roachpb.Span{
 				span("a", "c"),
@@ -102,8 +102,8 @@ func TestCombineFileInfo(t *testing.T) {
 				span("m", "z"),
 			},
 			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
-				{URI: "file1.sst", StartKey: "a", EndKey: "m"},
-				{URI: "file2.sst", StartKey: "m", EndKey: "z"},
+				{URI: "file1.sst", StartKey: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+				{URI: "file2.sst", StartKey: roachpb.Key("m"), EndKey: roachpb.Key("z")},
 			},
 			expectedMergeSpan: []roachpb.Span{
 				span("a", "c"),
@@ -133,8 +133,8 @@ func TestCombineFileInfo(t *testing.T) {
 				span("m", "z"),
 			},
 			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
-				{URI: "file1.sst", StartKey: "a", EndKey: "m"},
-				{URI: "file2.sst", StartKey: "m", EndKey: "z"},
+				{URI: "file1.sst", StartKey: roachpb.Key("a"), EndKey: roachpb.Key("m")},
+				{URI: "file2.sst", StartKey: roachpb.Key("m"), EndKey: roachpb.Key("z")},
 			},
 			expectedMergeSpan: []roachpb.Span{
 				span("a", "c"),
@@ -159,8 +159,8 @@ func TestCombineFileInfo(t *testing.T) {
 			},
 			schemaSpans: []roachpb.Span{span("a", "z")},
 			expectedSSTs: []execinfrapb.BulkMergeSpec_SST{
-				{URI: "file1a.sst", StartKey: "a", EndKey: "e"},
-				{URI: "file1b.sst", StartKey: "e", EndKey: "m"},
+				{URI: "file1a.sst", StartKey: roachpb.Key("a"), EndKey: roachpb.Key("e")},
+				{URI: "file1b.sst", StartKey: roachpb.Key("e"), EndKey: roachpb.Key("m")},
 			},
 			expectedMergeSpan: []roachpb.Span{
 				span("a", "c"),

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -589,9 +589,9 @@ message BulkMergeSpec {
 	message SST {
 		optional string uri = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "URI"];
 		// start_key is the first key in the SST.
-		optional string start_key = 2 [(gogoproto.nullable) = false];
+		optional bytes start_key = 2 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 		// end_key is the last key in the SST.
-		optional string end_key = 3 [(gogoproto.nullable) = false];
+		optional bytes end_key = 3 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 	}
 
 	// ssts is the list of input SSTs to merge.


### PR DESCRIPTION
The fields StartKey and EndKey in execinfrapb.BulkMergeSpec were previously typed as strings. However, they are logically roachpb.Key, and using the correct type simplifies downstream usage.

This change is a preparatory refactor to ease the integration of upcoming ingest processor changes.

Informs: #156659
Release note: none