### PR TITLE
release-25.4: cloud/azure: add optional azure client caching

### DIFF
--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/envutil",
         "//pkg/util/ioctx",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//:azcore",


### PR DESCRIPTION
Backport 1/1 commits from #157150.

/cc @cockroachdb/release

---

This adds a signle-slot, process-wide in-memory cache of the most recently used azure SDK storage client allowing subsequent attempts to open clients with the same configuration to reuse the already open client. This can allow the SDK's internal caching of things like IMDS tokens to be used across separate CRDB operations on separate files which currently each open their own client.

This can be particularly impactful for avoiding hitting the IMDS rate limit.

Release note: none.
Epic: none.

Release justification: supportability.
