### PR TITLE
jwtauthccl: check HTTP status code in getHttpResponse

### DIFF
--- a/pkg/security/jwtauth/authentication_jwt.go
+++ b/pkg/security/jwtauth/authentication_jwt.go
@@ -549,6 +549,18 @@ var getHttpResponse = func(
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		bodySnippet := string(body)
+		if len(bodySnippet) > 200 {
+			bodySnippet = bodySnippet[:200] + "..."
+		}
+		return nil, errors.WithDetailf(
+			errors.Newf("JWT authentication: HTTP request failed"),
+			"GET %s returned %s: %s", url, resp.Status, bodySnippet,
+		)
+	}
+
 	return body, nil
 }
 

--- a/pkg/security/jwtauth/authentication_jwt_test.go
+++ b/pkg/security/jwtauth/authentication_jwt_test.go
@@ -1206,3 +1206,21 @@ func TestVerifyAndExtractIssuer(t *testing.T) {
 	require.ErrorContains(t, err, "JWT authentication: invalid token")
 	require.Empty(t, detail)
 }
+
+func TestGetHTTPResponseNon2xx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	authenticator := &jwtAuthenticator{}
+	authenticator.mu.conf.httpClient = httputil.NewClientWithTimeout(httputil.StandardHTTPTimeout)
+
+	_, err := getHttpResponse(context.Background(), ts.URL, authenticator)
+	require.Error(t, err)
+	require.Equal(t, "JWT authentication: HTTP request failed", err.Error())
+	require.Contains(t, errors.FlattenDetails(err), "403 Forbidden")
+	require.Contains(t, errors.FlattenDetails(err), "boom")
+}


### PR DESCRIPTION
check HTTP status in getHttpResponse and include body snippet

Epic: None

### Overview
Previously, `getHttpResponse` ignored non-2xx HTTP responses. 
As a result, JWKS/userinfo/discovery requests could return 4xx or 5xx pages, 
and the caller would only fail when JSON parsing encountered an error. 
This made it difficult to quickly identify the root cause of HTTP failures.

### What this change does
- Adds a check for non-2xx HTTP status codes.
- Returns a clear error including:
  - HTTP status
  - Requested URL
  - Up to 200 bytes of the response body for context
- Maintains existing behavior for successful 2xx responses.

### Example
A 403 Forbidden response will now return an error like:
`GET https://issuer.example.com/.well-known/jwks returned 403 Forbidden: <body snippet>`

### Testing
- Added `TestGetHTTPResponseNon2xx` to cover non-2xx responses.
- Verified that errors include both status and body snippet.
- Ran existing tests to ensure no regressions.

### Why this is useful
This change improves debuggability and observability for JWT authentication issues. 
Telemetry and logs will now clearly show the actual HTTP failure instead of failing later in JSON parsing.
