### PR TITLE
parquet: actually delete test files

### DIFF
--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -654,7 +654,7 @@ func optionsTest(t *testing.T, opt Option, testFn func(t *testing.T, reader *fil
 
 func removeFileUnlessFailed(t *testing.T, f *os.File) {
 	t.Helper()
-	if !t.Failed() {
+	if t.Failed() {
 		return
 	}
 	if err := os.Remove(f.Name()); err != nil {


### PR DESCRIPTION
I think I reversed this conditional when testing out the change and then failed to change it back.

Epic: none
Release note: None