### PR TITLE
roachprod: add ability to stage libs separately

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale_300.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_300.yaml
@@ -62,6 +62,11 @@ targets:
         skip_notification: true
         args:
           - $CLUSTER
+          - lib # for libgeos
+      - command: stage
+        skip_notification: true
+        args:
+          - $CLUSTER
           - release
           - $VERSION
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"

--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -71,6 +71,8 @@ components match. For example, the tag "a/b" will match both "a/b" and
   local      - Use a provided local binary, must provide the path to the binary.`
 	workloadApp = `
   workload   - Cockroach workload application.`
+	libHelp = `
+  lib        - Supplementary Cockroach libraries (libgeos).`
 )
 
 var bashCompletion = os.ExpandEnv("$HOME/.roachprod/bash-completion.sh")
@@ -1330,7 +1332,10 @@ Some examples of usage:
 
   -- Stage customized binary of CockroachDB at version v23.2.0-alpha.2-4375-g7cd2b76ed00
   roachprod stage my-cluster customized v23.2.0-alpha.2-4375-g7cd2b76ed00
-`, strings.TrimSpace(cockroachApp+workloadApp+releaseApp+customizedApp)),
+
+  -- Stage the most recent edge build of the libraries (libgeos):
+  roachprod stage my-cluster lib
+`, strings.TrimSpace(cockroachApp+workloadApp+releaseApp+customizedApp+libHelp)),
 		Args: cobra.RangeArgs(2, 3),
 		Run: Wrap(func(cmd *cobra.Command, args []string) error {
 			versionArg := ""


### PR DESCRIPTION
Previously, we were only able to stage the optional libs when staging the
cockroach application. But in certain scenarios if we want to stage a specific
release, we may also want to stage the libraries.

This change adds the ability to stage the optional libraries separately.

Epic: None
Release note: None
