### PR TITLE
release-25.4: storage,kv: propagate iterator ReadCategory more broadly

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -16723,6 +16723,30 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storage.iterator.category-consistency-checker.block-load.bytes
+      exported_name: storage_iterator_category_consistency_checker_block_load_bytes
+      description: Bytes loaded by storage sstable iterators (possibly cached).
+      y_axis_label: Bytes
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storage.iterator.category-consistency-checker.block-load.cached-bytes
+      exported_name: storage_iterator_category_consistency_checker_block_load_cached_bytes
+      description: Bytes loaded by storage sstable iterators from the block cache
+      y_axis_label: Bytes
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storage.iterator.category-consistency-checker.block-load.latency-sum
+      exported_name: storage_iterator_category_consistency_checker_block_load_latency_sum
+      description: Cumulative latency for loading bytes not in the block cache, by storage sstable iterators
+      y_axis_label: Latency
+      type: COUNTER
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: storage.iterator.category-crdb-unknown.block-load.bytes
       exported_name: storage_iterator_category_crdb_unknown_block_load_bytes
       description: Bytes loaded by storage sstable iterators (possibly cached).

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -495,7 +495,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	defer snapshot.Close()
 
 	var results int
-	return rditer.IterateReplicaKeySpans(cmd.Context(), &desc, snapshot, rditer.SelectOpts{
+	return rditer.IterateReplicaKeySpans(cmd.Context(), &desc, snapshot, fs.UnknownReadCategory, rditer.SelectOpts{
 		Ranged: rditer.SelectRangedOptions{
 			SystemKeys: true,
 			LockTable:  true,

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -126,7 +126,7 @@ func worker(ctx context.Context, in checkInput) checkResult {
 		res.err = err
 		return res
 	}
-	ms, err := rditer.ComputeStatsForRange(ctx, desc, eng, claimedMS.LastUpdateNanos)
+	ms, err := rditer.ComputeStatsForRange(ctx, desc, eng, fs.UnknownReadCategory, claimedMS.LastUpdateNanos)
 	if err != nil {
 		res.err = err
 		return res

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -189,7 +189,7 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled, compute stats
 	// across the key span to be cleared.
 	if !entireRange || util.RaceEnabled {
-		computed, err := storage.ComputeStats(ctx, readWriter, from, to, delta.LastUpdateNanos)
+		computed, err := storage.ComputeStats(ctx, readWriter, fs.BatchEvalReadCategory, from, to, delta.LastUpdateNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -411,7 +412,7 @@ func computeStats(
 	if len(to) == 0 {
 		to = keys.MaxKey
 	}
-	ms, err := storage.ComputeStats(context.Background(), reader, from, to, nowNanos)
+	ms, err := storage.ComputeStats(context.Background(), reader, fs.UnknownReadCategory, from, to, nowNanos)
 	require.NoError(t, err)
 	return ms
 }

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1236,7 +1236,7 @@ func makeScanStatsFn(
 		computeStatsFn = rditer.ComputeStatsForRangeExcludingUser
 	}
 	return func() (enginepb.MVCCStats, error) {
-		sideMS, err := computeStatsFn(ctx, sideDesc, reader, ts.WallTime)
+		sideMS, err := computeStatsFn(ctx, sideDesc, reader, fs.BatchEvalReadCategory, ts.WallTime)
 		if err != nil {
 			return enginepb.MVCCStats{}, errors.Wrapf(err,
 				"unable to compute stats for %s range after split", sideName)

--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -75,7 +76,8 @@ func RecomputeStats(
 
 	args = nil // avoid accidental use below
 
-	actualMS, err := rditer.ComputeStatsForRange(ctx, desc, reader, cArgs.Header.Timestamp.WallTime)
+	actualMS, err := rditer.ComputeStatsForRange(ctx, desc, reader,
+		fs.BatchEvalReadCategory, cArgs.Header.Timestamp.WallTime)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -119,7 +119,8 @@ func TestCmdRevertRange(t *testing.T) {
 		Stats:           stats,
 	}
 	cArgs.EvalCtx = evalCtx.EvalContext()
-	afterStats, err := storage.ComputeStats(ctx, eng, keys.LocalMax, keys.MaxKey, 0)
+	afterStats, err := storage.ComputeStats(ctx, eng, fs.BatchEvalReadCategory,
+		keys.LocalMax, keys.MaxKey, 0)
 	require.NoError(t, err)
 	for _, tc := range []struct {
 		name     string
@@ -174,7 +175,8 @@ func TestCmdRevertRange(t *testing.T) {
 			}
 			evalStats := afterStats
 			evalStats.Add(*cArgs.Stats)
-			realStats, err := storage.ComputeStats(ctx, batch, keys.LocalMax, keys.MaxKey, evalStats.LastUpdateNanos)
+			realStats, err := storage.ComputeStats(ctx, batch, fs.BatchEvalReadCategory,
+				keys.LocalMax, keys.MaxKey, evalStats.LastUpdateNanos)
 			require.NoError(t, err)
 			require.Equal(t, realStats, evalStats)
 		})

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -231,7 +231,8 @@ func Subsume(
 	// rather than introducing additional synchronization complexity.
 	ridPrefix := keys.MakeRangeIDReplicatedPrefix(desc.RangeID)
 	reply.RangeIDLocalMVCCStats, err = storage.ComputeStats(
-		ctx, readWriter, ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
+		ctx, readWriter, fs.BatchEvalReadCategory,
+		ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -118,7 +119,7 @@ func TruncateLog(
 	// are not tracked in the raft log delta. The delta will be adjusted below
 	// raft.
 	// We can pass zero as nowNanos because we're only interested in SysBytes.
-	ms, err := storage.ComputeStats(ctx, readWriter, start, end, 0 /* nowNanos */)
+	ms, err := storage.ComputeStats(ctx, readWriter, fs.ReplicationReadCategory, start, end, 0 /* nowNanos */)
 	if err != nil {
 		return result.Result{}, errors.Wrap(err, "while computing stats of Raft log freed by truncation")
 	}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3913,7 +3913,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 				}
 			}
 
-			if err := rditer.IterateReplicaKeySpans(ctx, inSnap.Desc, snapReader, rditer.SelectOpts{
+			if err := rditer.IterateReplicaKeySpans(ctx, inSnap.Desc, snapReader, fs.ReplicationReadCategory, rditer.SelectOpts{
 				Ranged: rditer.SelectRangedOptions{
 					SystemKeys: true,
 					LockTable:  true,

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/stretchr/testify/require"
@@ -192,7 +193,7 @@ func assertRecomputedStats(
 ) {
 	t.Helper()
 
-	ms, err := rditer.ComputeStatsForRange(context.Background(), desc, r, nowNanos)
+	ms, err := rditer.ComputeStatsForRange(context.Background(), desc, r, fs.UnknownReadCategory, nowNanos)
 	require.NoError(t, err)
 
 	// When used with a real wall clock these will not be the same, since it

--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -89,7 +90,7 @@ func (ds dataDistribution) setupTest(
 	require.NoError(t, eng.Flush())
 	snap := eng.NewSnapshot()
 	defer snap.Close()
-	ms, err := rditer.ComputeStatsForRange(ctx, &desc, snap, maxTs.WallTime)
+	ms, err := rditer.ComputeStatsForRange(ctx, &desc, snap, fs.UnknownReadCategory, maxTs.WallTime)
 	require.NoError(t, err)
 	return ms
 }

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -96,7 +97,7 @@ func (s *Store) ComputeMVCCStats(reader storage.Reader) (enginepb.MVCCStats, err
 	now := s.Clock().PhysicalNow()
 	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
 		var stats enginepb.MVCCStats
-		stats, err = rditer.ComputeStatsForRange(context.Background(), r.Desc(), reader, now)
+		stats, err = rditer.ComputeStatsForRange(context.Background(), r.Desc(), reader, fs.UnknownReadCategory, now)
 		if err != nil {
 			return false
 		}

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -407,7 +408,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 		}
 		return err
 	}
-	if err := rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, rditer.SelectOpts{
+	if err := rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, fs.RangeSnapshotReadCategory, rditer.SelectOpts{
 		Ranged: rditer.SelectRangedOptions{
 			SystemKeys: true,
 			LockTable:  true,
@@ -539,7 +540,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 			//
 			// See: https://github.com/cockroachdb/cockroach/issues/142673
 			transitionFromSharedToRegularReplicate = true
-			err = rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, rditer.SelectOpts{
+			err = rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, fs.RangeSnapshotReadCategory, rditer.SelectOpts{
 				Ranged: rditer.SelectRangedOptions{
 					UserKeys: true,
 				},

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -531,7 +531,8 @@ func Compact(
 func (s *LogStore) ComputeSize(ctx context.Context) (int64, error) {
 	prefix := keys.RaftLogPrefix(s.RangeID)
 	prefixEnd := prefix.PrefixEnd()
-	ms, err := storage.ComputeStats(ctx, s.Engine, prefix, prefixEnd, 0 /* nowNanos */)
+	ms, err := storage.ComputeStats(ctx, s.Engine, fs.ReplicationReadCategory,
+		prefix, prefixEnd, 0 /* nowNanos */)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +55,8 @@ func TestRaftStorageWrites(t *testing.T) {
 		t.Helper()
 		prefix := keys.RaftLogPrefix(rangeID)
 		prefixEnd := prefix.PrefixEnd()
-		ms, err := storage.ComputeStats(ctx, eng, prefix, prefixEnd, 0 /* nowNanos */)
+		ms, err := storage.ComputeStats(ctx, eng, fs.ReplicationReadCategory,
+			prefix, prefixEnd, 0 /* nowNanos */)
 		require.NoError(t, err)
 		return ms.SysBytes
 	}

--- a/pkg/kv/kvserver/raftlog/BUILD.bazel
+++ b/pkg/kv/kvserver/raftlog/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/iterutil",

--- a/pkg/kv/kvserver/raftlog/iterator.go
+++ b/pkg/kv/kvserver/raftlog/iterator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
 
@@ -78,7 +79,8 @@ func NewIterator(
 		upperBound = prefixBuf.RaftLogKey(opts.Hi)
 	}
 	iter, err := eng.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
-		UpperBound: upperBound,
+		UpperBound:   upperBound,
+		ReadCategory: fs.ReplicationReadCategory,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -282,9 +282,10 @@ func (ri *ReplicaMVCCDataIterator) tryCloseAndCreateIter() {
 		}
 		var err error
 		ri.it, err = ri.reader.NewMVCCIterator(ri.ctx, ri.IterKind, storage.IterOptions{
-			LowerBound: ri.spans[ri.curIndex].Key,
-			UpperBound: ri.spans[ri.curIndex].EndKey,
-			KeyTypes:   ri.KeyTypes,
+			LowerBound:   ri.spans[ri.curIndex].Key,
+			UpperBound:   ri.spans[ri.curIndex].EndKey,
+			KeyTypes:     ri.KeyTypes,
+			ReadCategory: ri.ReadCategory,
 		})
 		if err != nil {
 			ri.err = err

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -421,6 +421,7 @@ func IterateReplicaKeySpans(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
 	reader storage.Reader,
+	readCategory fs.ReadCategory,
 	opts SelectOpts,
 	visitor func(storage.EngineIterator, roachpb.Span) error,
 ) error {
@@ -433,9 +434,10 @@ func IterateReplicaKeySpans(
 	for _, span := range spans {
 		err := func() error {
 			iter, err := reader.NewEngineIterator(ctx, storage.IterOptions{
-				KeyTypes:   storage.IterKeyTypePointsAndRanges,
-				LowerBound: span.Key,
-				UpperBound: span.EndKey,
+				KeyTypes:     storage.IterKeyTypePointsAndRanges,
+				LowerBound:   span.Key,
+				UpperBound:   span.EndKey,
+				ReadCategory: readCategory,
 			})
 			if err != nil {
 				return err

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -169,7 +169,7 @@ func verifyIterateReplicaKeySpans(
 	})
 
 	require.NoError(t, IterateReplicaKeySpans(
-		context.Background(), desc, readWriter, selOpts,
+		context.Background(), desc, readWriter, fs.UnknownReadCategory, selOpts,
 		func(iter storage.EngineIterator, span roachpb.Span) error {
 			var err error
 			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
@@ -497,7 +497,7 @@ func TestReplicaDataIteratorGlobalRangeKey(t *testing.T) {
 
 				var actualSpans []roachpb.Span
 				require.NoError(t, IterateReplicaKeySpans(
-					context.Background(), &desc, snapshot, selOpts,
+					context.Background(), &desc, snapshot, fs.UnknownReadCategory, selOpts,
 					func(iter storage.EngineIterator, span roachpb.Span) error {
 						// We should never see any point keys.
 						hasPoint, hasRange := iter.HasPointAndRange()
@@ -554,7 +554,7 @@ func BenchmarkReplicaEngineDataIterator(b *testing.B) {
 }
 
 func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, valueSize int) {
-	ctx := context.Background()
+	ctx := b.Context()
 
 	// Set up ranges.
 	var descs []roachpb.RangeDescriptor
@@ -586,7 +586,7 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 	for _, desc := range descs {
 		var keyBuf roachpb.Key
 		keySpans := MakeAllKeySpans(&desc)
-		for i := 0; i < numKeysPerRange; i++ {
+		for i := range numKeysPerRange {
 			keyBuf = append(keyBuf[:0], keySpans[i%len(keySpans)].Key...)
 			keyBuf = append(keyBuf, 0, 0, 0, 0)
 			binary.BigEndian.PutUint32(keyBuf[len(keyBuf)-4:], uint32(i))
@@ -602,11 +602,9 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 	snapshot := eng.NewSnapshot()
 	defer snapshot.Close()
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, desc := range descs {
-			err := IterateReplicaKeySpans(context.Background(), &desc, snapshot,
+			err := IterateReplicaKeySpans(b.Context(), &desc, snapshot, fs.UnknownReadCategory,
 				SelectOpts{
 					Ranged: SelectRangedOptions{
 						RSpan:      desc.RSpan(),

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -554,7 +554,7 @@ func BenchmarkReplicaEngineDataIterator(b *testing.B) {
 }
 
 func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, valueSize int) {
-	ctx := b.Context()
+	ctx := context.Background()
 
 	// Set up ranges.
 	var descs []roachpb.RangeDescriptor
@@ -602,9 +602,11 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 	snapshot := eng.NewSnapshot()
 	defer snapshot.Close()
 
-	for b.Loop() {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
 		for _, desc := range descs {
-			err := IterateReplicaKeySpans(b.Context(), &desc, snapshot, fs.UnknownReadCategory,
+			err := IterateReplicaKeySpans(context.Background(), &desc, snapshot, fs.UnknownReadCategory,
 				SelectOpts{
 					Ranged: SelectRangedOptions{
 						RSpan:      desc.RSpan(),

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -11,33 +11,46 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 )
 
 // ComputeStatsForRange computes the stats for a given range by iterating over
 // all key spans for the given range that should be accounted for in its stats.
 func ComputeStatsForRange(
-	ctx context.Context, d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
+	ctx context.Context,
+	d *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	readCategory fs.ReadCategory,
+	nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	return ComputeStatsForRangeWithVisitors(
-		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
+		ctx, d, reader, readCategory, nowNanos, storage.ComputeStatsVisitors{})
 }
 
 // ComputeStatsForRangeUserOnly is like ComputeStatsForRange but iterates only
 // over spans corresponding to user keys.
 func ComputeStatsForRangeUserOnly(
-	ctx context.Context, d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
+	ctx context.Context,
+	d *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	readCategory fs.ReadCategory,
+	nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	return ComputeStatsForRangeWithVisitorsUserOnly(
-		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
+		ctx, d, reader, readCategory, nowNanos, storage.ComputeStatsVisitors{})
 }
 
 // ComputeStatsForRangeExcludingUser is like ComputeStatsForRange but iterates
 // only over spans *not* corresponding to user keys.
 func ComputeStatsForRangeExcludingUser(
-	ctx context.Context, d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
+	ctx context.Context,
+	d *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	readCategory fs.ReadCategory,
+	nowNanos int64,
 ) (enginepb.MVCCStats, error) {
 	return ComputeStatsForRangeWithVisitorsExcludingUser(
-		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
+		ctx, d, reader, readCategory, nowNanos, storage.ComputeStatsVisitors{})
 }
 
 // ComputeStatsForRangeWithVisitors is like ComputeStatsForRange but also
@@ -46,10 +59,12 @@ func ComputeStatsForRangeWithVisitors(
 	ctx context.Context,
 	d *roachpb.RangeDescriptor,
 	reader storage.Reader,
+	readCategory fs.ReadCategory,
 	nowNanos int64,
 	visitors storage.ComputeStatsVisitors,
 ) (enginepb.MVCCStats, error) {
-	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpans(d), reader, nowNanos, visitors)
+	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpans(d),
+		reader, readCategory, nowNanos, visitors)
 }
 
 // ComputeStatsForRangeWithVisitorsUserOnly is like
@@ -59,10 +74,12 @@ func ComputeStatsForRangeWithVisitorsUserOnly(
 	ctx context.Context,
 	d *roachpb.RangeDescriptor,
 	reader storage.Reader,
+	readCategory fs.ReadCategory,
 	nowNanos int64,
 	visitors storage.ComputeStatsVisitors,
 ) (enginepb.MVCCStats, error) {
-	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpansUserOnly(d), reader, nowNanos, visitors)
+	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpansUserOnly(d),
+		reader, readCategory, nowNanos, visitors)
 }
 
 // ComputeStatsForRangeWithVisitorsExcludingUser is like
@@ -72,23 +89,26 @@ func ComputeStatsForRangeWithVisitorsExcludingUser(
 	ctx context.Context,
 	d *roachpb.RangeDescriptor,
 	reader storage.Reader,
+	readCategory fs.ReadCategory,
 	nowNanos int64,
 	visitors storage.ComputeStatsVisitors,
 ) (enginepb.MVCCStats, error) {
-	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpansExcludingUser(d), reader, nowNanos, visitors)
+	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpansExcludingUser(d),
+		reader, readCategory, nowNanos, visitors)
 }
 
 func computeStatsForSpansWithVisitors(
 	ctx context.Context,
 	spans []roachpb.Span,
 	reader storage.Reader,
+	readCategory fs.ReadCategory,
 	nowNanos int64,
 	visitors storage.ComputeStatsVisitors,
 ) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
 	for _, keySpan := range spans {
 		msDelta, err := storage.ComputeStatsWithVisitors(
-			ctx, reader, keySpan.Key, keySpan.EndKey, nowNanos, visitors)
+			ctx, reader, readCategory, keySpan.Key, keySpan.EndKey, nowNanos, visitors)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}

--- a/pkg/kv/kvserver/rditer/stats_test.go
+++ b/pkg/kv/kvserver/rditer/stats_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -36,11 +37,11 @@ func TestComputeStats(t *testing.T) {
 	createRangeData(t, eng, desc)
 	nowNanos := time.Now().UnixNano()
 
-	userOnly, err := ComputeStatsForRangeUserOnly(context.Background(), &desc, eng, nowNanos)
+	userOnly, err := ComputeStatsForRangeUserOnly(context.Background(), &desc, eng, fs.UnknownReadCategory, nowNanos)
 	require.NoError(t, err)
-	nonUserOnly, err := ComputeStatsForRangeExcludingUser(context.Background(), &desc, eng, nowNanos)
+	nonUserOnly, err := ComputeStatsForRangeExcludingUser(context.Background(), &desc, eng, fs.UnknownReadCategory, nowNanos)
 	require.NoError(t, err)
-	all, err := ComputeStatsForRange(context.Background(), &desc, eng, nowNanos)
+	all, err := ComputeStatsForRange(context.Background(), &desc, eng, fs.UnknownReadCategory, nowNanos)
 	require.NoError(t, err)
 
 	userPlusNonUser := userOnly

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -538,7 +539,8 @@ func (r *Replica) adminSplitWithDescriptor(
 		// post-split LHS stats by combining these stats with the non-user stats
 		// computed in splitTrigger. More details in makeEstimatedSplitStatsHelper.
 		userOnlyLeftStats, err = rditer.ComputeStatsForRangeUserOnly(
-			ctx, leftDesc, r.store.TODOEngine(), r.store.Clock().NowAsClockTimestamp().WallTime)
+			ctx, leftDesc, r.store.TODOEngine(), fs.BatchEvalReadCategory,
+			r.store.Clock().NowAsClockTimestamp().WallTime)
 		if err != nil {
 			return reply, errors.Wrapf(err, "unable to compute user-only pre-split stats for LHS range")
 		}

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -622,7 +622,7 @@ func CalcReplicaDigest(
 	var result ReplicaDigest
 	if !statsOnly {
 		ms, err := rditer.ComputeStatsForRangeWithVisitors(
-			ctx, &desc, snap, 0 /* nowNanos */, visitors)
+			ctx, &desc, snap, fs.ConsistencyCheckerReadCategory, 0 /* nowNanos */, visitors)
 		// Consume the remaining quota borrowed in the visitors. Do it even on
 		// iteration error, but prioritize returning the latter if it occurs.
 		if wErr := limiter.WaitN(ctx, batchSize); wErr != nil && err == nil {

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -2234,7 +2235,7 @@ func getExpectedSnapshotSizeBytes(
 		ReplicatedByRangeID:   true,
 		UnreplicatedByRangeID: false,
 	}
-	err = rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, selOpts, func(iter storage.EngineIterator, _ roachpb.Span) error {
+	err = rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, fs.ReplicationReadCategory, selOpts, func(iter storage.EngineIterator, _ roachpb.Span) error {
 		var err error
 		for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
 			hasPoint, hasRange := iter.HasPointAndRange()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
@@ -7017,7 +7018,7 @@ func TestReplicaDestroy(t *testing.T) {
 		UnreplicatedByRangeID: true,
 	}
 	require.NoError(t, rditer.IterateReplicaKeySpans(
-		ctx, tc.repl.Desc(), engSnapshot, selOpts,
+		ctx, tc.repl.Desc(), engSnapshot, fs.ReplicationReadCategory, selOpts,
 		func(iter storage.EngineIterator, _ roachpb.Span) error {
 			var err error
 			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -228,7 +229,7 @@ func WriteInitialClusterData(
 				ctx, batch, *desc, firstReplicaID, initialReplicaVersion); err != nil {
 				return err
 			}
-			computedStats, err := rditer.ComputeStatsForRange(ctx, desc, batch, now.WallTime)
+			computedStats, err := rditer.ComputeStatsForRange(ctx, desc, batch, fs.UnknownReadCategory, now.WallTime)
 			if err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -532,7 +533,8 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		memMS := repl.GetMVCCStats()
 		// Stats should agree with a recomputation.
 		now := store.Clock().Now()
-		diskMS, err := rditer.ComputeStatsForRange(ctx, repl.Desc(), store.TODOEngine(), now.WallTime)
+		diskMS, err := rditer.ComputeStatsForRange(ctx, repl.Desc(), store.TODOEngine(),
+			fs.UnknownReadCategory, now.WallTime)
 		require.NoError(t, err)
 		memMS.AgeTo(diskMS.LastUpdateNanos)
 		require.Equal(t, memMS, diskMS)

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
@@ -314,6 +315,7 @@ func (s *systemStatusServer) statsForSpan(
 				stats, err := storage.ComputeStats(
 					ctx,
 					s.TODOEngine(),
+					fs.UnknownReadCategory,
 					scanStart.AsRawKey(),
 					scanEnd.AsRawKey(),
 					timeutil.Now().UnixNano(),

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1127,7 +1127,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, opts benchScanOptions) {
 		// Pull all of the sstables into the RocksDB cache in order to make the
 		// timings more stable. Otherwise, the first run will be penalized pulling
 		// data into the cache while later runs will not.
-		if _, err := ComputeStats(ctx, eng, keys.LocalMax, roachpb.KeyMax, 0); err != nil {
+		if _, err := ComputeStats(ctx, eng, fs.UnknownReadCategory, keys.LocalMax, roachpb.KeyMax, 0); err != nil {
 			b.Fatalf("stats failed: %s", err)
 		}
 	}
@@ -1524,7 +1524,7 @@ func runMVCCDeleteRangeUsingTombstone(
 			eng := getInitialStateEngine(ctx, b, opts, false /* inMemory */)
 			defer eng.Close()
 
-			ms, err := ComputeStats(ctx, eng, keys.LocalMax, keys.MaxKey, 0)
+			ms, err := ComputeStats(ctx, eng, fs.UnknownReadCategory, keys.LocalMax, keys.MaxKey, 0)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -1668,7 +1668,7 @@ func runMVCCComputeStats(ctx context.Context, b *testing.B, valueBytes int, numR
 	var stats enginepb.MVCCStats
 	var err error
 	for i := 0; i < b.N; i++ {
-		stats, err = ComputeStats(ctx, eng, keys.LocalMax, keys.MaxKey, 0)
+		stats, err = ComputeStats(ctx, eng, fs.UnknownReadCategory, keys.LocalMax, keys.MaxKey, 0)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/storage/fs/category.go
+++ b/pkg/storage/fs/category.go
@@ -44,6 +44,8 @@ const (
 	IntentResolutionReadCategory
 	// BackupReadCategory are reads for backups.
 	BackupReadCategory
+	// ConsistencyCheckerReadCategory are reads for consistency checking.
+	ConsistencyCheckerReadCategory
 )
 
 var readCategoryMap = [...]block.Category{
@@ -59,6 +61,7 @@ var readCategoryMap = [...]block.Category{
 	ReplicationReadCategory:             block.RegisterCategory("replication", block.LatencySensitiveQoSLevel),
 	IntentResolutionReadCategory:        block.RegisterCategory("intent-resolution", block.LatencySensitiveQoSLevel),
 	BackupReadCategory:                  block.RegisterCategory("backup", block.NonLatencySensitiveQoSLevel),
+	ConsistencyCheckerReadCategory:      block.RegisterCategory("consistency-checker", block.NonLatencySensitiveQoSLevel),
 }
 
 // PebbleCategory returns the block.Category associated with the given ReadCategory.

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1549,7 +1549,7 @@ func runIncrementalBenchmark(b *testing.B, ts hlc.Timestamp, opts mvccBenchData)
 		// Pull all of the sstables into the cache.  This
 		// probably defeats a lot of the benefits of the
 		// time-based optimization.
-		_, err := ComputeStats(context.Background(), eng, keys.LocalMax, roachpb.KeyMax, 0)
+		_, err := ComputeStats(context.Background(), eng, fs.UnknownReadCategory, keys.LocalMax, roachpb.KeyMax, 0)
 		if err != nil {
 			b.Fatalf("stats failed: %s", err)
 		}

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -67,7 +68,7 @@ func assertEqImpl(
 		// NOTE: we use ComputeStats for the lock table stats because it is not
 		// supported by ComputeStatsForIter.
 		compLockMS, err := ComputeStats(
-			context.Background(), rw, lockKeyMin, lockKeyMax, ms.LastUpdateNanos)
+			context.Background(), rw, fs.UnknownReadCategory, lockKeyMin, lockKeyMax, ms.LastUpdateNanos)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1741,7 +1742,7 @@ var mvccStatsTests = []struct {
 	{
 		name: "ComputeStats",
 		fn: func(r Reader, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
-			return ComputeStats(context.Background(), r, start, end, nowNanos)
+			return ComputeStats(context.Background(), r, fs.UnknownReadCategory, start, end, nowNanos)
 		},
 	},
 	{

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -2314,7 +2315,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 	ms.AgeTo(2000)
 
 	// Sanity check starting stats.
-	msComputed, err := ComputeStats(ctx, e, localMax, keyMax, 2000)
+	msComputed, err := ComputeStats(ctx, e, fs.UnknownReadCategory, localMax, keyMax, 2000)
 	require.NoError(t, err)
 	require.Equal(t, msComputed, ms)
 
@@ -2352,7 +2353,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 				batch.Close()
 			}
 
-			msComputed, err := ComputeStats(ctx, e, localMax, keyMax, 2000)
+			msComputed, err := ComputeStats(ctx, e, fs.UnknownReadCategory, localMax, keyMax, 2000)
 			require.NoError(t, err)
 			require.Equal(t, msComputed, ms)
 			// Scanning at "now" post-revert should yield the same result as scanning
@@ -5839,7 +5840,7 @@ func TestMVCCGarbageCollectRanges(t *testing.T) {
 				"not all range tombstone expectations were consumed")
 
 			ms.AgeTo(tsMax.WallTime)
-			expMs, err := ComputeStats(ctx, engine, d.rangeStart, d.rangeEnd, tsMax.WallTime)
+			expMs, err := ComputeStats(ctx, engine, fs.UnknownReadCategory, d.rangeStart, d.rangeEnd, tsMax.WallTime)
 			require.NoError(t, err, "failed to compute stats for range")
 			require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")
 
@@ -6169,7 +6170,7 @@ func TestMVCCGarbageCollectClearPointsInRange(t *testing.T) {
 	require.EqualValues(t, expKs, ks)
 
 	ms.AgeTo(tsMax.WallTime)
-	expMs, err := ComputeStats(ctx, engine, rangeStart, rangeEnd, tsMax.WallTime)
+	expMs, err := ComputeStats(ctx, engine, fs.UnknownReadCategory, rangeStart, rangeEnd, tsMax.WallTime)
 	require.NoError(t, err, "failed to compute stats for range")
 	require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")
 

--- a/pkg/storage/sst_stats_diff_test.go
+++ b/pkg/storage/sst_stats_diff_test.go
@@ -198,7 +198,7 @@ func TestMVCCComputeSSTStatsDiff(t *testing.T) {
 
 				now := int64(timeutil.Now().Nanosecond())
 
-				baseStats, err := storage.ComputeStats(ctx, engine, keys.LocalMax, roachpb.KeyMax, now)
+				baseStats, err := storage.ComputeStats(ctx, engine, fs.UnknownReadCategory, keys.LocalMax, roachpb.KeyMax, now)
 				require.NoError(t, err)
 
 				sstEncoded, startUnversioned, endUnversioned := storageutils.MakeSST(t, st, sst)
@@ -213,7 +213,7 @@ func TestMVCCComputeSSTStatsDiff(t *testing.T) {
 				require.NoError(t, fs.WriteFile(engine.Env(), "sst", sstEncoded, fs.UnspecifiedWriteCategory))
 				require.NoError(t, engine.IngestLocalFiles(ctx, []string{"sst"}))
 
-				expStats, err := storage.ComputeStats(ctx, engine, keys.LocalMax, roachpb.KeyMax, updateTime)
+				expStats, err := storage.ComputeStats(ctx, engine, fs.UnknownReadCategory, keys.LocalMax, roachpb.KeyMax, updateTime)
 				require.NoError(t, err)
 
 				baseStats.Add(statsDelta)

--- a/pkg/testutils/storageutils/BUILD.bazel
+++ b/pkg/testutils/storageutils/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/storage/mvccencoding",
         "//pkg/util/hlc",
         "//pkg/util/protoutil",

--- a/pkg/testutils/storageutils/stats.go
+++ b/pkg/testutils/storageutils/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,7 @@ func EngineStats(t *testing.T, engine storage.Reader, nowNanos int64) *enginepb.
 	t.Helper()
 
 	stats, err := storage.ComputeStats(
-		context.Background(), engine, keys.LocalMax, keys.MaxKey, nowNanos)
+		context.Background(), engine, fs.UnknownReadCategory, keys.LocalMax, keys.MaxKey, nowNanos)
 	require.NoError(t, err)
 	return &stats
 }


### PR DESCRIPTION
These commits expand the propagation of the ReadCategory enum across more of the iterator-constructing codepaths, hoping to fix gaps in categorization observed in #158017.

Release justification: Fixes a critical observability gap