### PR TITLE
kvnemesis: report splits to raft asserter

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -170,6 +170,9 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 			}
 			return 0, nil
 		}
+		storeKnobs.AfterSplitApplication = func(desc roachpb.ReplicaDescriptor, state kvserverpb.ReplicaState) {
+			// TODO(pav-kv): notify the asserter.
+		}
 		storeKnobs.AfterSnapshotApplication = func(
 			desc roachpb.ReplicaDescriptor, state kvserverpb.ReplicaState, snap kvserver.IncomingSnapshot,
 		) {

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -171,7 +171,11 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 			return 0, nil
 		}
 		storeKnobs.AfterSplitApplication = func(desc roachpb.ReplicaDescriptor, state kvserverpb.ReplicaState) {
-			// TODO(pav-kv): notify the asserter.
+			asserter.ApplySplitRHS(
+				state.Desc.RangeID, desc.ReplicaID,
+				state.RaftAppliedIndex, state.RaftAppliedIndexTerm,
+				state.LeaseAppliedIndex, state.RaftClosedTimestamp,
+			)
 		}
 		storeKnobs.AfterSnapshotApplication = func(
 			desc roachpb.ReplicaDescriptor, state kvserverpb.ReplicaState, snap kvserver.IncomingSnapshot,

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -313,6 +313,15 @@ func prepareRightReplicaForSplit(
 	// Raft group, there might not be any Raft traffic for quite a while.
 	rightRepl.maybeUnquiesceLocked(true /* wakeLeader */, true /* mayCampaign */)
 
+	if fn := r.store.TestingKnobs().AfterSplitApplication; fn != nil {
+		// TODO(pav-kv): we have already checked up the stack that rightDesc exists,
+		// but maybe it would be better to carry a "bus" struct with these kinds of
+		// data post checks so that we (a) don't need to repeat the computation /
+		// validation, (b) can be sure that it's consistent.
+		rightDesc, _ := split.RightDesc.GetReplicaDescriptor(r.StoreID())
+		fn(rightDesc, rightRepl.shMu.state)
+	}
+
 	return rightRepl
 }
 

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -379,6 +379,9 @@ type StoreTestingKnobs struct {
 	// BeforeSnapshotSSTIngestion is run just before the SSTs are ingested when
 	// applying a snapshot.
 	BeforeSnapshotSSTIngestion func(IncomingSnapshot, []string) error
+	// AfterSplitApplication is called on the newly created replica's state after
+	// a split is applied. Called iff the RHS replica is not already destroyed.
+	AfterSplitApplication func(roachpb.ReplicaDescriptor, kvserverpb.ReplicaState)
 	// AfterSnapshotApplication is run after a snapshot is applied, before
 	// releasing the replica mutex.
 	AfterSnapshotApplication func(roachpb.ReplicaDescriptor, kvserverpb.ReplicaState, IncomingSnapshot)


### PR DESCRIPTION
This PR passes the information about newly created replicas into the raft asserter. This helps tracking the applied state more accurately. Previously, there was a window of time (between a replica splits out and applies the first non-trivial command) during which its tracked applied state is zero while the real one is not.

Resolves #157765, #158624
Informs #158247