### PR TITLE
roachtest: kv with long-running writer

### DIFF
--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -85,6 +85,7 @@ func RegisterTests(r registry.Registry) {
 	registerKV(r)
 	registerKVBench(r)
 	registerKVContention(r)
+	registerKVLongRunningTxn(r)
 	registerKVGracefulDraining(r)
 	registerKVRangefeed(r)
 	registerKVRangeLookups(r)


### PR DESCRIPTION
This commit includes a new roachtest that measures the latency of read-only non-locking requests in the presence of a long-running write-only transaction. The test maximizes contention by using a zipfian distribution on a small set of keys. It runs two concurrent KV workloads:

1. Long-running low-priority write-only transactions (running one at a time). Each transaction writes 100 keys and commits.

2. Read-only requests at normal priority. When a read encounters an intent, it will push the transaction based on priority and resolve (rewrite) the intent.

Measuring the latency of the reads will help expose their blocking behavior, which we expect to change with future improvements in intent resolution, latching and transaction pushing (all part of non-blocking reads work).

Fixes: #158348

Release note: None