### PR TITLE
roachprod: add support for GCE Cloud Profiler

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1526,8 +1526,11 @@ func setupAndInitializeLoggingAndProfiling(
 	initMutexProfile()
 
 	var gceContinuousProfilerEnabled = envutil.EnvOrDefaultBool("COCKROACH_GOOGLE_CONTINUOUS_PROFILER_ENABLED", false)
+	// N.B. service name must be globally unique since it's used for aggregating profiles.
+	// When using roachprod (with --cloud-profiler), this will typically correspond to the "cluster" VM label.
+	var serviceName = envutil.EnvOrDefaultString("COCKROACH_GOOGLE_CONTINUOUS_PROFILER_SERVICE_NAME", "")
 	if gceContinuousProfilerEnabled {
-		profiler.InitGoogleProfiler(ctx)
+		profiler.InitGoogleProfiler(ctx, serviceName)
 	}
 
 	log.Event(ctx, "initialized profiles")

--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -461,6 +461,42 @@ func initFlagsStartOpsForCmd(cmd *cobra.Command) {
 		"whether to enable the fluent-servers attribute in the CockroachDB logging configuration")
 	cmd.Flags().BoolVar(&startOpts.AutoRestart,
 		"auto-restart", startOpts.AutoRestart, "automatically restart cockroach processes that die")
+	cmd.Flags().BoolVar(&startOpts.EnableCloudProfiler,
+		"cloud-profiler", envutil.EnvOrDefaultBool("COCKROACH_GOOGLE_CONTINUOUS_PROFILER_ENABLED", false),
+		"Enable Continuous Cloud Profiler (CPU & Memory); use --cloud-profiler-probability=1 to enable for _all_ nodes",
+	)
+	cmd.Flags().Float64Var(&startOpts.CloudProfilerProbability,
+		"cloud-profiler-probability", 0.1,
+		"Probability that a specific node should have the Cloud Profiler Enabled",
+	)
+	validate := func(cmd *cobra.Command, args []string) error {
+		probChanged := cmd.Flags().Changed("cloud-profiler-probability")
+		enabled := startOpts.EnableCloudProfiler
+
+		// If the user set a probability but profiling isn't enabled, that's a misuse.
+		if probChanged && !enabled {
+			return fmt.Errorf("--cloud-profiler-probability requires --cloud-profiler (or env COCKROACH_GOOGLE_CONTINUOUS_PROFILER_ENABLED=true)")
+		}
+		// If profiling is enabled, sanity-check the probability.
+		if enabled {
+			if startOpts.CloudProfilerProbability < 0 || startOpts.CloudProfilerProbability > 1 {
+				return fmt.Errorf("--cloud-profiler-probability must be in [0,1]")
+			}
+		}
+		return nil
+	}
+
+	pre := cmd.PreRunE
+	if pre == nil {
+		cmd.PreRunE = validate
+		return
+	}
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := pre(cmd, args); err != nil {
+			return err
+		}
+		return validate(cmd, args)
+	}
 }
 
 func initFlagInsecureIgnoreHostKeyForCmd(cmd *cobra.Command) {

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/testutils",
         "//pkg/util/intsets",
         "//pkg/util/log",
+        "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/server/profiler/google_cloud_profiler.go
+++ b/pkg/server/profiler/google_cloud_profiler.go
@@ -19,16 +19,20 @@ import (
 //
 // The profiler initialization should be done as early as possible in the
 // server startup process for best results.
-func InitGoogleProfiler(ctx context.Context) {
+func InitGoogleProfiler(ctx context.Context, serviceName string) {
+	if serviceName == "" {
+		log.Dev.Warningf(ctx, "Google Cloud Profiler disabled (serviceName cannot be empty)")
+		return
+	}
 	// Detect cloud provider as profiler is only supported on GCP.
 	provider, _ := cloudinfo.GetInstanceRegion(ctx)
 	if provider != "gcp" {
-		log.Dev.Infof(ctx, "Google Cloud Profiler disabled (detected cloud: %s)", provider)
+		log.Dev.Warningf(ctx, "Google Cloud Profiler disabled (detected cloud: %s)", provider)
 		return
 	}
 
 	cfg := gcprofiler.Config{
-		Service:        "cockroachdb",
+		Service:        serviceName,
 		ServiceVersion: build.BinaryVersion(),
 	}
 	if err := gcprofiler.Start(cfg); err != nil {

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -7,9 +7,11 @@ package randutil
 
 import (
 	crypto_rand "crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"log" // Don't bring cockroach/util/log into this low-level package.
+	"math"
 	"math/rand"
 	"runtime"
 	"strings"
@@ -257,6 +259,35 @@ func RandString(rng *rand.Rand, length int, alphabet string) string {
 		buf.WriteRune(runes[rng.Intn(len(runes))])
 	}
 	return buf.String()
+}
+
+// DeterministicChoice returns true deterministically with probability p for the given key and salt.
+// Choose 'key' to be whatever you want determinism over (e.g., fingerprint,
+// tenant ID, range ID, CLI flag).
+func DeterministicChoice(p float64, key []byte, salt uint64) bool {
+	if math.IsNaN(p) || p <= 0 {
+		return false
+	}
+	if p >= 1 {
+		return true
+	}
+	// Hash key || salt (use little-endian since the actual byte order is immaterial)
+	buf := make([]byte, len(key)+8)
+	copy(buf, key)
+	binary.LittleEndian.PutUint64(buf[len(key):], salt)
+	sum := sha256.Sum256(buf)
+
+	// Take 53 uniformly random bits from the hash.
+	v := binary.LittleEndian.Uint64(sum[:8]) >> 11
+
+	// N.B. 2^53 fits in float64 with no rounding.
+	threshold := uint64(p * (1 << 53))
+	return v < threshold
+}
+
+func Salt(s string) uint64 {
+	sum := sha256.Sum256([]byte(s))
+	return binary.LittleEndian.Uint64(sum[:8])
 }
 
 // SeedForTests seeds the random number generator and prints the seed


### PR DESCRIPTION
Integration with GCE Cloud Profiler was
previously implemented in [1]. This PR
adds support for `--cloud-profiler` in
`roachprod start`.

To reduce the overhead of profiling a
large cluster, `--cloud-profiler-probability`
defaults to 10% of the number of nodes. Once
the profiler is enabled on a given node, the
choice persists even if that node is restarted.

[1] https://github.com/cockroachdb/cockroach/pull/149242

Epic: none
Release note: None