### PR TITLE
kvserver: skip flaky TestReplicateQueueRebalanceMultiStore

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -177,6 +177,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 // rebalances the replicas and leases.
 func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 156293)
 	skip.UnderDuress(t) // eight stores is too much under duress
 	scope := log.Scope(t)
 	defer scope.Close(t)


### PR DESCRIPTION
Updates #156293.

Release note: none.
Epic: none.