### PR TITLE
opt: implement optimizer_omit_routine_params_in_outer_cols

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4194,6 +4194,7 @@ optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
+optimizer_omit_routine_params_in_outer_cols                      off
 optimizer_plan_lookup_joins_with_reverse_scans                   on
 optimizer_prefer_bounded_cardinality                             on
 optimizer_prove_implication_with_virtual_computed_columns        on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3146,6 +3146,7 @@ optimizer_enable_lock_elision                                    on             
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
+optimizer_omit_routine_params_in_outer_cols                      off                 NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
 optimizer_prefer_bounded_cardinality                             on                  NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns        on                  NULL      NULL        NULL        string
@@ -3395,6 +3396,7 @@ optimizer_enable_lock_elision                                    on             
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
+optimizer_omit_routine_params_in_outer_cols                      off                 NULL  user     NULL      off                 off
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on
 optimizer_prefer_bounded_cardinality                             on                  NULL  user     NULL      on                  on
 optimizer_prove_implication_with_virtual_computed_columns        on                  NULL  user     NULL      on                  on
@@ -3635,6 +3637,7 @@ optimizer_enable_lock_elision                                    NULL    NULL   
 optimizer_hoist_uncorrelated_equality_subqueries                 NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                                    NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                          NULL    NULL     NULL     NULL        NULL
+optimizer_omit_routine_params_in_outer_cols                      NULL    NULL     NULL     NULL        NULL
 optimizer_plan_lookup_joins_with_reverse_scans                   NULL    NULL     NULL     NULL        NULL
 optimizer_prefer_bounded_cardinality                             NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -163,6 +163,7 @@ optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
+optimizer_omit_routine_params_in_outer_cols                      off
 optimizer_plan_lookup_joins_with_reverse_scans                   on
 optimizer_prefer_bounded_cardinality                             on
 optimizer_prove_implication_with_virtual_computed_columns        on

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -123,7 +123,7 @@ func TestIndexConstraints(t *testing.T) {
 						}
 						computedCols[col] = computedColExpr
 						var sharedProps props.Shared
-						memo.BuildSharedProps(computedColExpr, &sharedProps, &evalCtx)
+						memo.BuildSharedProps(computedColExpr, &sharedProps, &evalCtx, md)
 						colsInComputedColsExpressions.UnionWith(sharedProps.OuterCols)
 					}
 				}

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -290,7 +290,7 @@ func (g *geoJoinPlanner) extractGeoJoinCondition(
 
 	// The first argument should either come from the input or be a constant.
 	var p props.Shared
-	memo.BuildSharedProps(arg1, &p, g.factory.EvalContext())
+	memo.BuildSharedProps(arg1, &p, g.factory.EvalContext(), g.factory.Metadata())
 	if !p.OuterCols.Empty() {
 		if !p.OuterCols.SubsetOf(g.inputCols) {
 			return nil

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -502,7 +502,7 @@ func TryJoinInvertedIndex(
 
 	// The resulting expression must contain at least one column from the input.
 	var p props.Shared
-	memo.BuildSharedProps(invertedExpr, &p, factory.EvalContext())
+	memo.BuildSharedProps(invertedExpr, &p, factory.EvalContext(), factory.Metadata())
 	if !p.OuterCols.Intersects(inputCols) {
 		return nil
 	}

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -109,7 +109,7 @@ func (j *jsonOrArrayJoinPlanner) extractJSONOrArrayJoinCondition(
 	// The non-indexed argument should either come from the input or be a
 	// constant.
 	var p props.Shared
-	memo.BuildSharedProps(val, &p, j.factory.EvalContext())
+	memo.BuildSharedProps(val, &p, j.factory.EvalContext(), j.factory.Metadata())
 	if !p.OuterCols.Empty() {
 		if !p.OuterCols.SubsetOf(j.inputCols) {
 			return nil

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -530,7 +530,7 @@ func (b *ConstraintBuilder) findComputedColJoinEquality(
 		return nil, false
 	}
 	var sharedProps props.Shared
-	memo.BuildSharedProps(expr, &sharedProps, b.evalCtx)
+	memo.BuildSharedProps(expr, &sharedProps, b.evalCtx, b.md)
 	if !sharedProps.OuterCols.SubsetOf(eqCols) {
 		return nil, false
 	}

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -104,7 +104,7 @@ func TestLookupConstraints(t *testing.T) {
 							return 0, opt.ColSet{}, err
 						}
 						var sharedProps props.Shared
-						memo.BuildSharedProps(compExpr, &sharedProps, &evalCtx)
+						memo.BuildSharedProps(compExpr, &sharedProps, &evalCtx, md)
 						md.TableMeta(tableID).AddComputedCol(colID, compExpr, sharedProps.OuterCols)
 					}
 				}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -215,6 +215,7 @@ type Memo struct {
 	clampLowHistogramSelectivity               bool
 	clampInequalitySelectivity                 bool
 	useMaxFrequencySelectivity                 bool
+	omitRoutineParamsInOuterCols               bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -330,6 +331,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		clampLowHistogramSelectivity:               evalCtx.SessionData().OptimizerClampLowHistogramSelectivity,
 		clampInequalitySelectivity:                 evalCtx.SessionData().OptimizerClampInequalitySelectivity,
 		useMaxFrequencySelectivity:                 evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity,
+		omitRoutineParamsInOuterCols:               evalCtx.SessionData().OptimizerOmitRoutineParamsInOuterCols,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -509,6 +511,7 @@ func (m *Memo) IsStale(
 		m.clampLowHistogramSelectivity != evalCtx.SessionData().OptimizerClampLowHistogramSelectivity ||
 		m.clampInequalitySelectivity != evalCtx.SessionData().OptimizerClampInequalitySelectivity ||
 		m.useMaxFrequencySelectivity != evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity ||
+		m.omitRoutineParamsInOuterCols != evalCtx.SessionData().OptimizerOmitRoutineParamsInOuterCols ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -611,6 +611,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerClampInequalitySelectivity = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerOmitRoutineParamsInOuterCols = true
+	stale()
+	evalCtx.SessionData().OptimizerOmitRoutineParamsInOuterCols = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -851,7 +851,7 @@ func (sb *statisticsBuilder) colStatTable(
 	tabID opt.TableID, colSet opt.ColSet,
 ) *props.ColumnStatistic {
 	tableStats := sb.makeTableStatistics(tabID)
-	tableFD := MakeTableFuncDep(sb.md, tabID)
+	tableFD := MakeTableFuncDep(sb.evalCtx, sb.md, tabID)
 	tableNotNullCols := makeTableNotNullCols(sb.md, tabID)
 	return sb.colStatLeaf(colSet, tableStats, tableFD, tableNotNullCols)
 }
@@ -904,7 +904,9 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 				c.ExtractNotNullCols(sb.ctx, sb.evalCtx, &notNullCols)
 			}
 		}
-		sb.filterRelExpr(pred, scan, notNullCols, relProps, s, MakeTableFuncDep(sb.md, scan.Table))
+		sb.filterRelExpr(
+			pred, scan, notNullCols, relProps, s, MakeTableFuncDep(sb.evalCtx, sb.md, scan.Table),
+		)
 		sb.finalizeFromCardinality(relProps)
 		return
 	}
@@ -1069,7 +1071,9 @@ func (sb *statisticsBuilder) constrainScan(
 			panic(errors.AssertionFailedf("unexpected placeholder equality columns in partial index predicate"))
 		}
 		constrainedCols.UnionWith(predConstrainedCols)
-		constrainedCols = sb.tryReduceCols(constrainedCols, s, MakeTableFuncDep(sb.md, scan.Table))
+		constrainedCols = sb.tryReduceCols(
+			constrainedCols, s, MakeTableFuncDep(sb.evalCtx, sb.md, scan.Table),
+		)
 		histCols.UnionWith(predHistCols)
 	}
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -125,6 +125,9 @@ type Metadata struct {
 	// dataSourceDeps stores each data source object that the query depends on.
 	dataSourceDeps map[cat.StableID]cat.DataSource
 
+	// paramCols is the set of column IDs that are routine parameter references.
+	paramCols ColSet
+
 	// routineDeps stores each user-defined function and stored procedure overload
 	// (as well as the invocation signature) that the query depends on.
 	routineDeps map[cat.StableID]routineDep
@@ -940,6 +943,14 @@ func (md *Metadata) AddColumn(alias string, typ *types.T) ColumnID {
 	}
 	colID := ColumnID(len(md.cols) + 1)
 	md.cols = append(md.cols, ColumnMeta{MetaID: colID, Alias: alias, Type: typ})
+	return colID
+}
+
+// AddParameterColumn is similar to AddColumn, but is specifically for adding a
+// column that represents a reference to a routine parameter.
+func (md *Metadata) AddParameterColumn(alias string, typ *types.T) ColumnID {
+	colID := md.AddColumn(alias, typ)
+	md.paramCols.Add(colID)
 	return colID
 }
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -964,6 +964,12 @@ func (md *Metadata) MaxColumn() ColumnID {
 	return ColumnID(len(md.cols))
 }
 
+// ParameterColumns returns the set of column IDs that represent references
+// to routine parameters. The returned set must not be mutated.
+func (md *Metadata) ParameterColumns() ColSet {
+	return md.paramCols
+}
+
 // ColumnMeta looks up the metadata for the column associated with the given
 // column id. The same column can be added multiple times to the query metadata
 // and associated with multiple column ids.

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -79,7 +79,7 @@ func TestMetadata(t *testing.T) {
 	tabMeta := md.TableMeta(tabID)
 	tabMeta.SetConstraints(scalar)
 	var sharedProps props.Shared
-	memo.BuildSharedProps(scalar, &sharedProps, &evalCtx)
+	memo.BuildSharedProps(scalar, &sharedProps, &evalCtx, md)
 	tabMeta.AddComputedCol(cmpID, scalar, sharedProps.OuterCols)
 	tabMeta.AddPartialIndexPredicate(0, scalar)
 	if md.AddSequence(&testcat.Sequence{SeqID: 100}) != seqID {
@@ -401,7 +401,7 @@ func TestDuplicateTable(t *testing.T) {
 	tabMeta.SetConstraints(&memo.VariableExpr{Col: b})
 	scalar := &memo.VariableExpr{Col: b}
 	var sharedProps props.Shared
-	memo.BuildSharedProps(scalar, &sharedProps, &evalCtx)
+	memo.BuildSharedProps(scalar, &sharedProps, &evalCtx, md)
 	tabMeta.AddComputedCol(b2, scalar, sharedProps.OuterCols)
 	tabMeta.AddPartialIndexPredicate(1, &memo.VariableExpr{Col: b})
 

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -643,7 +643,7 @@ func (c *CustomFuncs) sharedProps(e opt.Expr) *props.Shared {
 		return &t.ScalarProps().Shared
 	default:
 		var p props.Shared
-		memo.BuildSharedProps(e, &p, c.f.evalCtx)
+		memo.BuildSharedProps(e, &p, c.f.evalCtx, c.mem.Metadata())
 		return &p
 	}
 }

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -514,8 +514,8 @@ func (c *CustomFuncs) CanExtractJoinComparison(
 
 	// Recursively compute properties for left and right sides.
 	var leftProps, rightProps props.Shared
-	memo.BuildSharedProps(a, &leftProps, c.f.evalCtx)
-	memo.BuildSharedProps(b, &rightProps, c.f.evalCtx)
+	memo.BuildSharedProps(a, &leftProps, c.f.evalCtx, c.mem.Metadata())
+	memo.BuildSharedProps(b, &rightProps, c.f.evalCtx, c.mem.Metadata())
 
 	// Disallow cases when one side has a correlated subquery.
 	// TODO(radu): investigate relaxing this.
@@ -558,7 +558,7 @@ func (c *CustomFuncs) ExtractJoinComparison(
 	op := cmp.Op()
 
 	var cmpLeftProps props.Shared
-	memo.BuildSharedProps(condLeft, &cmpLeftProps, c.f.evalCtx)
+	memo.BuildSharedProps(condLeft, &cmpLeftProps, c.f.evalCtx, c.mem.Metadata())
 	if cmpLeftProps.OuterCols.SubsetOf(rightCols) {
 		a, b = b, a
 		op = opt.CommuteEqualityOrInequalityOp(op)
@@ -880,7 +880,7 @@ func (c *CustomFuncs) GetEquijoinStrictKeyCols(
 		return opt.ColSet{}, opt.ColList{}, opt.ColList{}, false
 	}
 	md := c.mem.Metadata()
-	funcDeps := memo.MakeTableFuncDep(md, sp.Table)
+	funcDeps := memo.MakeTableFuncDep(c.f.evalCtx, md, sp.Table)
 
 	// If there is no strict key, no need to proceed further.
 	_, ok = funcDeps.StrictKey()

--- a/pkg/sql/opt/norm/set_funcs.go
+++ b/pkg/sql/opt/norm/set_funcs.go
@@ -131,7 +131,7 @@ func (c *CustomFuncs) CanConvertUnionToDistinctUnionAll(
 
 	// Now find a subset of the columns that forms a strict key over the base
 	// table.
-	leftFDs := memo.MakeTableFuncDep(md, leftTableID)
+	leftFDs := memo.MakeTableFuncDep(c.f.evalCtx, md, leftTableID)
 	leftColSet := leftCols.ToSet()
 	if !leftFDs.ColsAreStrictKey(leftColSet) {
 		// The columns must form a strict key over the base table.
@@ -147,7 +147,7 @@ func (c *CustomFuncs) CanConvertUnionToDistinctUnionAll(
 		// transformation is not worth it.
 		return opt.ColSet{}, false
 	}
-	rightFDs := memo.MakeTableFuncDep(md, rightTableID)
+	rightFDs := memo.MakeTableFuncDep(c.f.evalCtx, md, rightTableID)
 	if !rightFDs.ColsAreStrictKey(c.TranslateColSet(keyCols, leftCols, rightCols)) {
 		// The columns must form a strict key over both meta tables. The meta tables
 		// can have different functional dependencies when the

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -669,6 +669,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateSelect
 # --------------------------------------------------
+
 norm expect=TryDecorrelateSelect
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (k), (i)) WHERE column1=k)
 ----
@@ -8775,3 +8776,191 @@ semi-join-apply
  │         ├── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
  │         └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
  └── filters (true)
+
+
+# --------------------------------------------------
+# Routine-related decorrelation regression tests
+# --------------------------------------------------
+
+# Regression tests for #157840.
+exec-ddl
+CREATE PROCEDURE p157840a(abs ab[]) LANGUAGE SQL AS $$
+    WITH vals AS (
+        SELECT (v).a, (v).b
+        FROM ROWS FROM (unnest(abs)) AS v
+    )
+    SELECT * FROM xy JOIN vals ON x = a
+$$
+----
+
+# Join filters with parameter columns are not pull up above the join.
+norm format=show-scalars set=(optimizer_omit_routine_params_in_outer_cols=true)
+CALL p157840a(ARRAY[
+    ROW(1, 'one')::ab,
+    ROW(2, 'two')::ab,
+    ROW(3, 'three')::ab
+])
+----
+call
+ ├── cardinality: [0 - 0]
+ ├── volatile
+ └── procedure: p157840a
+      ├── args
+      │    └── array:
+      │         ├── cast: RECORD
+      │         │    └── tuple
+      │         │         ├── const: 1
+      │         │         └── const: 'one'
+      │         ├── cast: RECORD
+      │         │    └── tuple
+      │         │         ├── const: 2
+      │         │         └── const: 'two'
+      │         └── cast: RECORD
+      │              └── tuple
+      │                   ├── const: 3
+      │                   └── const: 'three'
+      ├── params: abs:1
+      └── body
+           ├── inner-join (hash)
+           │    ├── columns: x:5!null y:6 a:9!null b:10
+           │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+           │    ├── immutable
+           │    ├── fd: (5)-->(6), (5)==(9), (9)==(5)
+           │    ├── scan xy
+           │    │    ├── columns: x:5!null y:6
+           │    │    ├── key: (5)
+           │    │    └── fd: (5)-->(6)
+           │    ├── project
+           │    │    ├── columns: a:9 b:10
+           │    │    ├── immutable
+           │    │    ├── project-set
+           │    │    │    ├── columns: unnest:2
+           │    │    │    ├── immutable
+           │    │    │    ├── values
+           │    │    │    │    ├── cardinality: [1 - 1]
+           │    │    │    │    ├── key: ()
+           │    │    │    │    └── tuple
+           │    │    │    └── zip
+           │    │    │         └── function: unnest [immutable]
+           │    │    │              └── variable: abs:1
+           │    │    └── projections
+           │    │         ├── column-access: 0 [as=a:9, outer=(2)]
+           │    │         │    └── variable: unnest:2
+           │    │         └── column-access: 1 [as=b:10, outer=(2)]
+           │    │              └── variable: unnest:2
+           │    └── filters
+           │         └── eq [outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ]), fd=(5)==(9), (9)==(5)]
+           │              ├── variable: x:5
+           │              └── variable: a:9
+           └── values
+                ├── columns: column1:11
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(11)
+                └── tuple
+                     └── null
+
+# The x=5 filter can be pushed above the xy scan and the y=b filter remains in
+# the lowest join filters possible.
+exec-ddl
+CREATE PROCEDURE p157840b(abs ab[]) LANGUAGE SQL AS $$
+    WITH vals AS (
+        SELECT (v).a, (v).b
+        FROM ROWS FROM (unnest(abs)) AS v
+    )
+    SELECT * FROM xy
+    JOIN vals ON true
+    JOIN LATERAL (SELECT u, u/1.1 AS div FROM uv WHERE x=5 AND y=b) ON true
+$$
+----
+
+norm format=show-scalars set=(optimizer_omit_routine_params_in_outer_cols=true)
+CALL p157840b(ARRAY[
+    ROW(1, 'one')::ab,
+    ROW(2, 'two')::ab,
+    ROW(3, 'three')::ab
+])
+----
+call
+ ├── cardinality: [0 - 0]
+ ├── volatile
+ └── procedure: p157840b
+      ├── args
+      │    └── array:
+      │         ├── cast: RECORD
+      │         │    └── tuple
+      │         │         ├── const: 1
+      │         │         └── const: 'one'
+      │         ├── cast: RECORD
+      │         │    └── tuple
+      │         │         ├── const: 2
+      │         │         └── const: 'two'
+      │         └── cast: RECORD
+      │              └── tuple
+      │                   ├── const: 3
+      │                   └── const: 'three'
+      ├── params: abs:1
+      └── body
+           ├── project
+           │    ├── columns: div:15!null x:5!null y:6!null a:9 b:10!null u:11!null
+           │    ├── immutable
+           │    ├── fd: ()-->(5,6,10), (11)-->(15), (6)==(10), (10)==(6)
+           │    ├── inner-join (cross)
+           │    │    ├── columns: x:5!null y:6!null a:9 b:10!null u:11!null
+           │    │    ├── immutable
+           │    │    ├── fd: ()-->(5,6,10), (6)==(10), (10)==(6)
+           │    │    ├── inner-join (hash)
+           │    │    │    ├── columns: x:5!null y:6!null a:9 b:10!null
+           │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+           │    │    │    ├── immutable
+           │    │    │    ├── fd: ()-->(5,6,10), (6)==(10), (10)==(6)
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: x:5!null y:6
+           │    │    │    │    ├── cardinality: [0 - 1]
+           │    │    │    │    ├── key: ()
+           │    │    │    │    ├── fd: ()-->(5,6)
+           │    │    │    │    ├── scan xy
+           │    │    │    │    │    ├── columns: x:5!null y:6
+           │    │    │    │    │    ├── key: (5)
+           │    │    │    │    │    └── fd: (5)-->(6)
+           │    │    │    │    └── filters
+           │    │    │    │         └── eq [outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+           │    │    │    │              ├── variable: x:5
+           │    │    │    │              └── const: 5
+           │    │    │    ├── project
+           │    │    │    │    ├── columns: a:9 b:10
+           │    │    │    │    ├── immutable
+           │    │    │    │    ├── project-set
+           │    │    │    │    │    ├── columns: unnest:2
+           │    │    │    │    │    ├── immutable
+           │    │    │    │    │    ├── values
+           │    │    │    │    │    │    ├── cardinality: [1 - 1]
+           │    │    │    │    │    │    ├── key: ()
+           │    │    │    │    │    │    └── tuple
+           │    │    │    │    │    └── zip
+           │    │    │    │    │         └── function: unnest [immutable]
+           │    │    │    │    │              └── variable: abs:1
+           │    │    │    │    └── projections
+           │    │    │    │         ├── column-access: 0 [as=a:9, outer=(2)]
+           │    │    │    │         │    └── variable: unnest:2
+           │    │    │    │         └── column-access: 1 [as=b:10, outer=(2)]
+           │    │    │    │              └── variable: unnest:2
+           │    │    │    └── filters
+           │    │    │         └── eq [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
+           │    │    │              ├── variable: y:6
+           │    │    │              └── variable: b:10
+           │    │    ├── scan uv
+           │    │    │    ├── columns: u:11!null
+           │    │    │    └── key: (11)
+           │    │    └── filters (true)
+           │    └── projections
+           │         └── div [as=div:15, outer=(11)]
+           │              ├── variable: u:11
+           │              └── const: 1.1
+           └── values
+                ├── columns: column1:16
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(16)
+                └── tuple
+                     └── null

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -758,6 +758,59 @@ project
  └── projections
       └── f:3 + 1.1 [as=r:9, outer=(3), immutable]
 
+# Regression test for #157840.
+exec-ddl
+CREATE PROCEDURE p157840(INT) LANGUAGE SQL AS $$
+    SELECT * FROM (
+        SELECT *, i/2
+        FROM a
+    )
+    WHERE i = $1
+$$
+----
+
+# With optimizer_omit_routine_params_in_outer_cols enabled, the filter on i is
+# push into the project.
+norm format=show-scalars set=(optimizer_omit_routine_params_in_outer_cols=true) expect=PushSelectIntoProject
+CALL p157840(10)
+----
+call
+ ├── cardinality: [0 - 0]
+ ├── volatile
+ └── procedure: p157840
+      ├── args
+      │    └── const: 10
+      ├── params: arg1:1
+      └── body
+           ├── project
+           │    ├── columns: "?column?":9!null k:2!null i:3!null f:4 s:5 j:6
+           │    ├── key: (2)
+           │    ├── fd: (2)-->(3-6), (3)-->(9)
+           │    ├── select
+           │    │    ├── columns: k:2!null i:3!null f:4 s:5 j:6
+           │    │    ├── key: (2)
+           │    │    ├── fd: (2)-->(3-6)
+           │    │    ├── scan a
+           │    │    │    ├── columns: k:2!null i:3 f:4 s:5 j:6
+           │    │    │    ├── key: (2)
+           │    │    │    └── fd: (2)-->(3-6)
+           │    │    └── filters
+           │    │         └── eq [outer=(3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+           │    │              ├── variable: i:3
+           │    │              └── variable: arg1:1
+           │    └── projections
+           │         └── div [as="?column?":9, outer=(3)]
+           │              ├── variable: i:3
+           │              └── const: 2
+           └── values
+                ├── columns: column1:10
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(10)
+                └── tuple
+                     └── null
+
+
 # --------------------------------------
 # PushSelectCondLeftIntoJoinLeftAndRight
 # --------------------------------------

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -261,8 +261,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// Add all input parameters to the base scope of the body.
 		if tree.IsInParamClass(param.Class) {
 			paramColName := funcParamColName(param.Name, i)
-			col := b.synthesizeColumn(bodyScope, paramColName, typ, nil /* expr */, nil /* scalar */)
-			col.setParamOrd(i)
+			_ = b.synthesizeParameterColumn(bodyScope, paramColName, typ, i, nil /* scalar */)
 		}
 
 		// Collect the user defined type dependencies.
@@ -440,10 +439,9 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			for i := range createTriggerFuncParams {
 				param := &createTriggerFuncParams[i]
 				paramColName := funcParamColName(param.name, i)
-				col := b.synthesizeColumn(
-					bodyScope, paramColName, param.typ, nil /* expr */, nil, /* scalar */
+				_ = b.synthesizeParameterColumn(
+					bodyScope, paramColName, param.typ, i, nil, /* scalar */
 				)
-				col.setParamOrd(i)
 			}
 			routineParams = createTriggerFuncParams
 

--- a/pkg/sql/opt/optbuilder/create_trigger.go
+++ b/pkg/sql/opt/optbuilder/create_trigger.go
@@ -223,8 +223,7 @@ func (b *Builder) buildFunctionForTrigger(
 	triggerFuncParams = append(triggerFuncParams, triggerFuncStaticParams...)
 	for i, param := range triggerFuncParams {
 		paramColName := funcParamColName(param.name, i)
-		col := b.synthesizeColumn(funcScope, paramColName, param.typ, nil /* expr */, nil /* scalar */)
-		col.setParamOrd(i)
+		col := b.synthesizeParameterColumn(funcScope, paramColName, param.typ, i, nil /* scalar */)
 		if i == triggerArgvColIdx {
 			// Due to #135311, we disallow references to the TG_ARGV param for now.
 			if !b.evalCtx.SessionData().AllowCreateTriggerFunctionWithArgvReferences {

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -198,7 +198,7 @@ func (mb *mutationBuilder) tryNewOnDeleteFastCascadeBuilder(
 			return nil, false
 		}
 		var p props.Shared
-		memo.BuildSharedProps(&sel.Filters, &p, mutationInputScope.builder.evalCtx)
+		memo.BuildSharedProps(&sel.Filters, &p, mutationInputScope.builder.evalCtx, mb.md)
 		if p.VolatilitySet.HasVolatile() {
 			return nil, false
 		}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -863,7 +863,7 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(
 				refCols.Add(newCol)
 			} else {
 				var p props.Shared
-				memo.BuildSharedProps(scalar, &p, mb.b.evalCtx)
+				memo.BuildSharedProps(scalar, &p, mb.b.evalCtx, mb.md)
 				refCols = p.OuterCols
 			}
 			if !refCols.Intersects(updatedColSet) {

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2398,7 +2398,7 @@ func (b *plpgsqlBuilder) addBarrierIfVolatile(s *scope, expr opt.ScalarExpr) {
 		return
 	}
 	var p props.Shared
-	memo.BuildSharedProps(expr, &p, b.ob.evalCtx)
+	memo.BuildSharedProps(expr, &p, b.ob.evalCtx, b.ob.factory.Metadata())
 	if p.VolatilitySet.HasVolatile() {
 		b.ob.addBarrier(s)
 	}

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -338,8 +338,9 @@ func (b *Builder) buildRoutine(
 				args[i] = b.factory.ConstructCast(args[i], desiredTyp)
 			}
 			argColName := funcParamColName(tree.Name(paramTypes[i].Name), i)
-			col := b.synthesizeColumn(bodyScope, argColName, desiredTyp, nil /* expr */, nil /* scalar */)
-			col.setParamOrd(i)
+			col := b.synthesizeParameterColumn(
+				bodyScope, argColName, desiredTyp, i, nil, /* scalar */
+			)
 			params[i] = col.id
 		}
 	}

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -121,19 +119,6 @@ const maxFuncParams = 100
 
 // funcParamOrd is a 1-based ordinal of a function parameter.
 type funcParamOrd int8
-
-// setParamOrd sets the column's 1-based function parameter ordinal to the given
-// 0-based ordinal. Panics if the given ordinal is not in the range
-// [0, maxFuncParams).
-func (c *scopeColumn) setParamOrd(ord int) {
-	if ord < 0 {
-		panic(errors.AssertionFailedf("expected non-negative argument ordinal"))
-	}
-	if ord >= maxFuncParams {
-		panic(pgerror.New(pgcode.TooManyArguments, "functions cannot have more than 100 arguments"))
-	}
-	c.paramOrd = funcParamOrd(ord + 1)
-}
 
 // getParamOrd retrieves the 0-based ordinal from the column's 1-based function
 // parameter ordinal. Panics if the function ordinal is unset.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -876,7 +876,7 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 		if memo.ExprIsNeverNull(condition, notNullCols) {
 			// Check if the expression contains non-immutable operators.
 			var sharedProps props.Shared
-			memo.BuildSharedProps(condition, &sharedProps, b.evalCtx)
+			memo.BuildSharedProps(condition, &sharedProps, b.evalCtx, b.factory.Metadata())
 			if !sharedProps.VolatilitySet.HasStable() && !sharedProps.VolatilitySet.HasVolatile() {
 				filters = append(filters, b.factory.ConstructFiltersItem(condition))
 			}
@@ -951,7 +951,7 @@ func (b *Builder) addComputedColsForTable(
 			})
 			// Check if the expression contains non-immutable operators.
 			var sharedProps props.Shared
-			memo.BuildSharedProps(scalar, &sharedProps, b.evalCtx)
+			memo.BuildSharedProps(scalar, &sharedProps, b.evalCtx, b.factory.Metadata())
 			if !sharedProps.VolatilitySet.HasStable() && !sharedProps.VolatilitySet.HasVolatile() {
 				tabMeta.AddComputedCol(colID, scalar, sharedProps.OuterCols)
 			}

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -801,11 +801,12 @@ func (b *Builder) buildTriggerFunction(
 		{name: triggerColOld, typ: tableTyp, class: tree.RoutineParamIn},
 	}, triggerFuncStaticParams...)
 	paramCols := make(opt.ColList, len(params))
-	for colOrd, param := range params {
-		paramColName := funcParamColName(param.name, colOrd)
-		col := b.synthesizeColumn(triggerFuncScope, paramColName, param.typ, nil /* expr */, nil /* scalar */)
-		col.setParamOrd(colOrd)
-		paramCols[colOrd] = col.id
+	for ord, param := range params {
+		paramColName := funcParamColName(param.name, ord)
+		col := b.synthesizeParameterColumn(
+			triggerFuncScope, paramColName, param.typ, ord, nil, /* scalar */
+		)
+		paramCols[ord] = col.id
 	}
 
 	// Initialize and cache the UDF definition before building the function body.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -218,7 +218,7 @@ func (b *Builder) synthesizeParameterColumn(
 	if ord >= maxFuncParams {
 		panic(pgerror.New(pgcode.TooManyArguments, "functions cannot have more than 100 arguments"))
 	}
-	colID := b.factory.Metadata().AddColumn(name.MetadataName(), typ)
+	colID := b.factory.Metadata().AddParameterColumn(name.MetadataName(), typ)
 	scope.cols = append(scope.cols, scopeColumn{
 		name:     name,
 		typ:      typ,

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -432,7 +432,7 @@ func makeComputedCols(
 		}
 		computedCols[col] = computedColExpr
 		var sharedProps props.Shared
-		memo.BuildSharedProps(computedColExpr, &sharedProps, evalCtx)
+		memo.BuildSharedProps(computedColExpr, &sharedProps, evalCtx, f.Metadata())
 	}
 	return computedCols, nil
 }

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -95,6 +95,9 @@ type Shared struct {
 	// expression's location in the query. For example, while the b.x and b.y
 	// columns are not outer columns on the EXISTS expression, they *are* outer
 	// columns on the inner WHERE condition.
+	//
+	// Also note that if optimizer_omit_routine_params_in_outer_cols is enabled,
+	// OuterCols will not include columns that are routine parameters.
 	OuterCols opt.ColSet
 
 	// Rule props are lazily calculated and typically only apply to a single

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -468,7 +468,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 			)
 		}
 
-		tableFDs := memo.MakeTableFuncDep(md, scanPrivate.Table)
+		tableFDs := memo.MakeTableFuncDep(c.e.evalCtx, md, scanPrivate.Table)
 		// A lookup join will drop any input row which contains NULLs, so a lax key
 		// is sufficient.
 		rightKeyCols := lookupConstraint.RightSideCols.ToSet()

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -759,6 +759,10 @@ message LocalOnlySessionData {
   // canary statistics (mode == on), stable statistics (mode == off), or
   // let the system decide based on random selection (mode == auto).
   int64 canary_stats_mode = 193 [(gogoproto.casttype) = "CanaryStatsMode"];
+  // OptimizerOmitRoutineParamsInOuterCols, when true, causes the optimizer
+  // to omit routine parameters from the set of outer columns tracked during
+  // query optimization.
+  bool optimizer_omit_routine_params_in_outer_cols = 194;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1110,3 +1110,7 @@ func (m *SessionDataMutator) SetDisableWaitForJobsNotice(val bool) {
 func (m *SessionDataMutator) SetCanaryStatsMode(val sessiondatapb.CanaryStatsMode) {
 	m.Data.CanaryStatsMode = val
 }
+
+func (m *SessionDataMutator) SetOptimizerOmitRoutineParamsInOuterCols(val bool) {
+	m.Data.OptimizerOmitRoutineParamsInOuterCols = val
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4492,6 +4492,24 @@ var varGen = map[string]sessionVar{
 			return sessiondatapb.CanaryStatsModeAuto.String()
 		},
 	},
+
+	`optimizer_omit_routine_params_in_outer_cols`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_omit_routine_params_in_outer_cols`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_omit_routine_params_in_outer_cols", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerOmitRoutineParamsInOuterCols(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerOmitRoutineParamsInOuterCols,
+			), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### opt: refactor parameter column synthesis

`optbuilder.Builder` has a new method for synthesizing columns that
represent reference to routine parameters, called
`synthesizeParameterColumn`. It supersedes the `scope.setParamOrd`
method.

Release note: None

#### opt: track parameter reference columns in metadata

`opt.Metadata` now tracks the set of columns that represent references
to routine parameters. This set will be used in future commits.

Release note: None

#### sql: add optimizer_omit_routine_params_in_outer_cols

The `optimizer_omit_routine_params_in_outer_cols` session setting has
been added. It currently has no effect on any behavior. It will be fully
implemented in a future commit.

Release note: None

#### opt: implement optimizer_omit_routine_params_in_outer_cols

Routine parameter references have always been represented as columns in
optimizer expressions. They are considered outer columns because no
expression within a routine statement produces them. One consequence of
this is that, when a routine statement is built, normalization rules
might leave the expression tree in a state that cannot be fully
optimized later.

For example, decorrelation rules can pull filters with parameter
references up and away from base relations. As another example, filter
push-down rules may fail to push a filter referencing a parameter down
towards a scan. In both cases, when the parameter references are
replaced with constant values, those filters cannot be pushed into scans
and lookup joins because that are not adjacent to based relations.

The `optimizer_omit_routine_params_in_outer_cols` session setting, when enabled,
causes parameter reference columns to be omitted from `props.Shared.OuterCols`.
This prevents rules from treating parameter references as outer columns and
misguidedly transforming the expression tree.

I've audited the usage of these outer columns and this change should be safe, as
far as I can tell. However, it is difficult to prove there is nothing relying on
a strict definition of outer columns. For now, the new setting remains disabled
by default.

Informs #157840

Release note (performance improvement): The
`optimizer_omit_routine_params_in_outer_cols` session setting has been
added. It is disabled by default. When enabled, it may lead to better
query plans for statements within user-defined functions and
stored-procedures.
