### PR TITLE
sql: fix dRPC-related flake in TestTrace

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -52,6 +52,7 @@ func TestTrace(t *testing.T) {
 		"local proposal",
 		"admissionWorkQueueWait",
 		"index recommendation",
+		"/cockroach.roachpb.KVBatch/Batch", // present with dRPC, absent with gRPC
 	}
 	// Depending on whether the data is local or not, we may not see these
 	// spans. Only applicable with distsql=on.


### PR DESCRIPTION
When we use dRPC, there is an additional tracing span `/cockroach.roachpb.KVBatch/Batch` that we don't create with gRPC, so mark it as optional in the test.

Informs: #158323.
Epic: None
Release note: None