### PR TITLE
util/errorutil: centralize panic-catching logic

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -190,25 +190,15 @@ func emitExplain(
 	codec keys.SQLCodec,
 	explainPlan *explain.Plan,
 	createPostQueryPlanIfMissing bool,
-) (err error) {
+) (retErr error) {
 	// Guard against bugs in the explain code.
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate internal and runtime errors without
-			// having to add error checks everywhere throughout the code. This is only
-			// possible because the code does not update shared state and does not
-			// manipulate locks.
-			// Note that we don't catch anything in debug builds, so that failures are
-			// more visible.
-			if ok, e := errorutil.ShouldCatch(r); ok && !buildutil.CrdbTestBuild {
-				err = e
-			} else {
-				// Other panic objects can't be considered "safe" and thus are
-				// propagated as crashes that terminate the session.
-				panic(r)
-			}
+	defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
+		if buildutil.CrdbTestBuild && caughtErr != nil {
+			// Don't catch anything in debug builds, so that failures are more
+			// visible.
+			panic(caughtErr)
 		}
-	}()
+	})
 
 	if explainPlan == nil {
 		return errors.AssertionFailedf("no plan")

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1191,28 +1191,13 @@ func (b *Builder) buildRoutinePlanGenerator(
 		resultWriter tree.RoutineResultWriter,
 		args tree.Datums,
 		fn tree.RoutinePlanGeneratedFunc,
-	) (err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				// This code allows us to propagate internal errors without
-				// having to add error checks everywhere throughout the code.
-				// This is only possible because the code does not update shared
-				// state and does not manipulate locks.
-				//
-				// This is the same panic-catching logic that exists in
-				// o.Optimize() below. It's required here because it's possible
-				// for factory functions to panic below, like
-				// CopyAndReplaceDefault.
-				if ok, e := errorutil.ShouldCatch(r); ok {
-					err = e
-					log.VEventf(ctx, 1, "%v", err)
-				} else {
-					// Other panic objects can't be considered "safe" and thus
-					// are propagated as crashes that terminate the session.
-					panic(r)
-				}
-			}
-		}()
+	) (retErr error) {
+		// This is the same panic-catching logic that exists in o.Optimize()
+		// below. It's required here because it's possible for factory functions
+		// to panic below, like CopyAndReplaceDefault.
+		defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
+			log.VEventf(ctx, 1, "%v", caughtErr)
+		})
 
 		dbName := b.evalCtx.SessionData().Database
 		appName := b.evalCtx.SessionData().ApplicationName
@@ -1434,28 +1419,10 @@ func (b *Builder) buildTxnControl(
 	}
 	gen := func(
 		ctx context.Context, evalArgs tree.Datums,
-	) (con tree.StoredProcContinuation, err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				// This code allows us to propagate internal errors without
-				// having to add error checks everywhere throughout the code.
-				// This is only possible because the code does not update shared
-				// state and does not manipulate locks.
-				//
-				// This is the same panic-catching logic that exists in
-				// o.Optimize() below. It's required here because it's possible
-				// for factory functions to panic below, like
-				// CopyAndReplaceDefault.
-				if ok, e := errorutil.ShouldCatch(r); ok {
-					err = e
-					log.VEventf(ctx, 1, "%v", err)
-				} else {
-					// Other panic objects can't be considered "safe" and thus
-					// are propagated as crashes that terminate the session.
-					panic(r)
-				}
-			}
-		}()
+	) (con tree.StoredProcContinuation, retErr error) {
+		defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
+			log.VEventf(ctx, 1, "%v", caughtErr)
+		})
 		// Build the plan for the "continuation" procedure that will resume
 		// execution of the parent stored procedure in a new transaction.
 		var f norm.Factory

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -178,21 +178,7 @@ type planGistDecoder struct {
 func DecodePlanGistToRows(
 	ctx context.Context, evalCtx *eval.Context, gist string, catalog cat.Catalog,
 ) (_ []string, retErr error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate internal errors without having
-			// to add error checks everywhere throughout the code. This is only
-			// possible because the code does not update shared state and does
-			// not manipulate locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				retErr = e
-			} else {
-				// Other panic objects can't be considered "safe" and thus are
-				// propagated as crashes that terminate the session.
-				panic(r)
-			}
-		}
-	}()
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	flags := Flags{HideValues: true, Deflake: DeflakeAll, OnlyShape: true}
 	ob := NewOutputBuilder(flags)

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -22,18 +22,10 @@ import (
 // input exec.Nodes.
 func getResultColumns(
 	op execOperator, args interface{}, inputs ...colinfo.ResultColumns,
-) (out colinfo.ResultColumns, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// If we have a bug in the code below, it's easily possible to hit panic
-			// (like out-of-bounds). Catch these here and return as an error.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-			} else {
-				panic(r)
-			}
-		}
-	}()
+) (out colinfo.ResultColumns, retErr error) {
+	// If we have a bug in the code below, it's easily possible to hit panic
+	// (like out-of-bounds). Catch these here and return as an error.
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	switch op {
 	case filterOp, invertedFilterOp, limitOp, max1RowOp, sortOp, topKOp, bufferOp, hashSetOpOp,

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -340,20 +340,8 @@ func (f *Factory) CopyWithoutAssigningPlaceholders(e opt.Expr) opt.Expr {
 // assigned values. This can trigger additional normalization rules that can
 // substantially rewrite the tree. Once all placeholders are assigned, the
 // exploration phase can begin.
-func (f *Factory) AssignPlaceholders(from *memo.Memo) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate errors without adding lots of checks
-			// for `if err != nil` throughout the construction code. This is only
-			// possible because the code does not update shared state and does not
-			// manipulate locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-			} else {
-				panic(r)
-			}
-		}
-	}()
+func (f *Factory) AssignPlaceholders(from *memo.Memo) (retErr error) {
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	// Copy the "from" memo to this memo, replacing any Placeholder operators as
 	// the copy proceeds.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -240,23 +240,12 @@ func New(
 //
 // If any subroutines panic with a non-runtime error as part of the build
 // process, the panic is caught here and returned as an error.
-func (b *Builder) Build() (err error) {
+func (b *Builder) Build() (retErr error) {
 	log.VEventf(b.ctx, 1, "optbuilder start")
 	defer log.VEventf(b.ctx, 1, "optbuilder finish")
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate errors without adding lots of checks
-			// for `if err != nil` throughout the construction code. This is only
-			// possible because the code does not update shared state and does not
-			// manipulate locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-				log.VEventf(b.ctx, 1, "%v", err)
-			} else {
-				panic(r)
-			}
-		}
-	}()
+	defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
+		log.VEventf(b.ctx, 1, "%v", caughtErr)
+	})
 
 	// TODO (rohany): We shouldn't be modifying the semaCtx passed to the builder
 	//  but we unfortunately rely on mutation to the semaCtx. We modify the input

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -1071,7 +1071,7 @@ func buildTriggerCascadeHelper(
 	factoryI interface{},
 	stmtTreeInitFn func() statementTree,
 	fn func(b *Builder) memo.RelExpr,
-) (_ memo.RelExpr, err error) {
+) (_ memo.RelExpr, retErr error) {
 	factory := factoryI.(*norm.Factory)
 	b := New(ctx, semaCtx, evalCtx, catalog, factory, nil /* stmt */)
 	if stmtTreeInitFn != nil {
@@ -1082,15 +1082,7 @@ func buildTriggerCascadeHelper(
 	defer b.stmtTree.Pop()
 
 	// Enact panic handling similar to Builder.Build().
-	defer func() {
-		if r := recover(); r != nil {
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-			} else {
-				panic(r)
-			}
-		}
-	}()
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	return fn(b), nil
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -971,20 +971,8 @@ func NewScalar(
 
 // Build a memo structure from a TypedExpr: the root group represents a scalar
 // expression equivalent to expr.
-func (sb *ScalarBuilder) Build(expr tree.Expr) (_ opt.ScalarExpr, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate errors without adding lots of checks
-			// for `if err != nil` throughout the construction code. This is only
-			// possible because the code does not update shared state and does not
-			// manipulate locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-			} else {
-				panic(r)
-			}
-		}
-	}()
+func (sb *ScalarBuilder) Build(expr tree.Expr) (_ opt.ScalarExpr, retErr error) {
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	typedExpr := sb.scope.resolveType(expr, types.AnyElement)
 	scalar := sb.buildScalar(typedExpr, &sb.scope, nil, nil, nil)

--- a/pkg/sql/opt/xform/placeholder_fast_path.go
+++ b/pkg/sql/opt/xform/placeholder_fast_path.go
@@ -28,22 +28,8 @@ const maxRowCountForPlaceholderFastPath = 10
 // PlaceholderScan.
 //
 // If this function succeeds, the memo will be considered fully optimized.
-func (o *Optimizer) TryPlaceholderFastPath() (ok bool, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate internal errors without having to add
-			// error checks everywhere throughout the code. This is only possible
-			// because the code does not update shared state and does not manipulate
-			// locks.
-			if shouldCatch, e := errorutil.ShouldCatch(r); shouldCatch {
-				err = e
-			} else {
-				// Other panic objects can't be considered "safe" and thus are
-				// propagated as crashes that terminate the session.
-				panic(r)
-			}
-		}
-	}()
+func (o *Optimizer) TryPlaceholderFastPath() (ok bool, retErr error) {
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	root := o.mem.RootExpr()
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -1103,27 +1103,13 @@ func (p *planner) DecodeGist(ctx context.Context, gist string, external bool) ([
 // optimal plan.
 func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 	ctx context.Context,
-) (_ []indexrec.Rec, err error) {
+) (_ []indexrec.Rec, retErr error) {
 	origCtx := ctx
 	ctx, sp := tracing.EnsureChildSpan(ctx, opc.p.execCfg.AmbientCtx.Tracer, "index recommendation")
 	defer sp.Finish()
-
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate internal errors without having to add
-			// error checks everywhere throughout the code. This is only possible
-			// because the code does not update shared state and does not manipulate
-			// locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-				log.VEventf(ctx, 1, "%v", err)
-			} else {
-				// Other panic objects can't be considered "safe" and thus are
-				// propagated as crashes that terminate the session.
-				panic(r)
-			}
-		}
-	}()
+	defer errorutil.MaybeCatchPanic(&retErr, func(caughtErr error) {
+		log.VEventf(ctx, 1, "%v", caughtErr)
+	})
 
 	// Save the normalized memo created by the optbuilder.
 	savedMemo := opc.optimizer.DetachMemo(ctx)
@@ -1143,7 +1129,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 	opc.optimizer.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
 		return ruleName.IsNormalize()
 	})
-	if _, err = opc.optimizer.Optimize(); err != nil {
+	if _, err := opc.optimizer.Optimize(); err != nil {
 		return nil, err
 	}
 
@@ -1162,12 +1148,11 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 		f.CopyWithoutAssigningPlaceholders,
 	)
 	opc.optimizer.Memo().Metadata().UpdateTableMeta(ctx, f.EvalContext(), hypTables)
-	if _, err = opc.optimizer.Optimize(); err != nil {
+	if _, err := opc.optimizer.Optimize(); err != nil {
 		return nil, err
 	}
 
-	var indexRecs []indexrec.Rec
-	indexRecs, err = indexrec.FindRecs(ctx, f.Memo().RootExpr(), f.Metadata())
+	indexRecs, err := indexrec.FindRecs(ctx, f.Memo().RootExpr(), f.Metadata())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -38,7 +38,7 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 		name:    fmt.Sprintf("SHOW HISTOGRAM %d", n.HistogramID),
 		columns: showHistogramColumns,
 
-		constructor: func(ctx context.Context, p *planner) (_ planNode, err error) {
+		constructor: func(ctx context.Context, p *planner) (_ planNode, retErr error) {
 			row, err := p.InternalSQLTxn().QueryRowEx(
 				ctx,
 				"read-histogram",
@@ -63,21 +63,8 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 				return nil, fmt.Errorf("histogram %d not found", n.HistogramID)
 			}
 
-			// Guard against crashes in the code below .
-			defer func() {
-				if r := recover(); r != nil {
-					// Avoid crashing the process in case of a "safe" panic. This is only
-					// possible because the code does not update shared state and does not
-					// manipulate locks.
-					if ok, e := errorutil.ShouldCatch(r); ok {
-						err = e
-					} else {
-						// Other panic objects can't be considered "safe" and thus are
-						// propagated as crashes that terminate the session.
-						panic(r)
-					}
-				}
-			}()
+			// Guard against crashes in the code below.
+			defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 			histogram := &stats.HistogramData{}
 			histData := *row[0].(*tree.DBytes)

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -89,7 +89,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 	return &delayedNode{
 		name:    n.String(),
 		columns: columns,
-		constructor: func(ctx context.Context, p *planner) (_ planNode, err error) {
+		constructor: func(ctx context.Context, p *planner) (_ planNode, retErr error) {
 			// We need to query the table_statistics and then do some post-processing:
 			//  - convert column IDs to column names
 			//  - if the statistic has a histogram, we return the statistic ID as a
@@ -149,21 +149,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			nCols := numCols
 
 			// Guard against crashes in the code below (e.g. #56356).
-			defer func() {
-				if r := recover(); r != nil {
-					// This code allows us to propagate internal errors without having to add
-					// error checks everywhere throughout the code. This is only possible
-					// because the code does not update shared state and does not manipulate
-					// locks.
-					if ok, e := errorutil.ShouldCatch(r); ok {
-						err = e
-					} else {
-						// Other panic objects can't be considered "safe" and thus are
-						// propagated as crashes that terminate the session.
-						panic(r)
-					}
-				}
-			}()
+			defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 			_, withMerge := opts[showTableStatsOptMerge]
 			_, withForecast := opts[showTableStatsOptForecast]

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -988,12 +988,12 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 	forecast bool,
 	st *cluster.Settings,
 	typeResolver *descs.DistSQLTypeResolver,
-) (_ []*TableStatistic, _ map[descpb.ColumnID]*types.T, err error) {
-	it, err := sc.db.Executor().QueryIteratorEx(
+) (_ []*TableStatistic, _ map[descpb.ColumnID]*types.T, retErr error) {
+	it, queryErr := sc.db.Executor().QueryIteratorEx(
 		ctx, "get-table-statistics", nil /* txn */, sessiondata.NodeUserSessionDataOverride, getTableStatisticsStmt, tableID,
 	)
-	if err != nil {
-		return nil, nil, err
+	if queryErr != nil {
+		return nil, nil, queryErr
 	}
 
 	// Guard against crashes in the code below.
@@ -1004,7 +1004,7 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 			// possible because the code does not update shared state and does not
 			// manipulate locks.
 			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
+				retErr = e
 			} else {
 				// Other panic objects can't be considered "safe" and thus are
 				// propagated as crashes that terminate the session.
@@ -1016,10 +1016,10 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 	var statsList []*TableStatistic
 	var udts map[descpb.ColumnID]*types.T
 	var ok bool
-	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		stats, udt, err := sc.parseStats(ctx, it.Cur(), typeResolver)
-		if err != nil {
-			log.Dev.Warningf(ctx, "could not decode statistic for table %d: %v", tableID, err)
+	for ok, queryErr = it.Next(ctx); ok; ok, queryErr = it.Next(ctx) {
+		stats, udt, decodingErr := sc.parseStats(ctx, it.Cur(), typeResolver)
+		if decodingErr != nil {
+			log.Dev.Warningf(ctx, "could not decode statistic for table %d: %v", tableID, decodingErr)
 			continue
 		}
 		statsList = append(statsList, stats)
@@ -1039,8 +1039,8 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 			}
 		}
 	}
-	if err != nil {
-		return nil, nil, err
+	if queryErr != nil {
+		return nil, nil, queryErr
 	}
 
 	merged := MergedStatistics(ctx, statsList, st)
@@ -1066,12 +1066,12 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 // user-defined type that doesn't exist) and returns the rest (with no error).
 func getTableStatsProtosFromDB(
 	ctx context.Context, tableID descpb.ID, executor isql.Executor,
-) (statsProtos []*TableStatisticProto, err error) {
-	it, err := executor.QueryIteratorEx(
+) (statsProtos []*TableStatisticProto, retErr error) {
+	it, queryErr := executor.QueryIteratorEx(
 		ctx, "get-table-statistics-protos", nil /* txn */, sessiondata.NodeUserSessionDataOverride, getTableStatisticsStmt, tableID,
 	)
-	if err != nil {
-		return nil, err
+	if queryErr != nil {
+		return nil, queryErr
 	}
 
 	// Guard against crashes in the code below.
@@ -1082,7 +1082,7 @@ func getTableStatsProtosFromDB(
 			// possible because the code does not update shared state and does not
 			// manipulate locks.
 			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
+				retErr = e
 			} else {
 				// Other panic objects can't be considered "safe" and thus are
 				// propagated as crashes that terminate the session.
@@ -1092,14 +1092,16 @@ func getTableStatsProtosFromDB(
 	}()
 
 	var ok bool
-	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		var tsp *TableStatisticProto
-		tsp, err = NewTableStatisticProto(it.Cur())
-		if err != nil {
-			log.Dev.Warningf(ctx, "could not decode statistic for table %d: %v", tableID, err)
+	for ok, queryErr = it.Next(ctx); ok; ok, queryErr = it.Next(ctx) {
+		tsp, decodingErr := NewTableStatisticProto(it.Cur())
+		if decodingErr != nil {
+			log.Dev.Warningf(ctx, "could not decode statistic for table %d: %v", tableID, decodingErr)
 			continue
 		}
 		statsProtos = append(statsProtos, tsp)
+	}
+	if queryErr != nil {
+		return nil, queryErr
 	}
 	return statsProtos, nil
 }

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -125,16 +125,7 @@ func setupGenerator(
 				// (#135760). This should be safe since we assume that the
 				// generator functions do not update shared state and do not
 				// manipulate locks.
-				defer func() {
-					if r := recover(); r != nil {
-						if ok, e := errorutil.ShouldCatch(r); ok {
-							retErr = e
-						} else {
-							// Panic object that is not an error - unexpected.
-							panic(r)
-						}
-					}
-				}()
+				defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 				return worker(ctx, funcRowPusher(addRow))
 			}()
 			// Notify that we are done sending rows.

--- a/pkg/util/errorutil/catch.go
+++ b/pkg/util/errorutil/catch.go
@@ -11,11 +11,11 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// ShouldCatch is used for catching errors thrown as panics. Its argument is the
+// shouldCatch is used for catching errors thrown as panics. Its argument is the
 // object returned by recover(); it succeeds if the object is an error. If the
 // error is a runtime.Error, it is converted to an internal error (see
 // errors.AssertionFailedf).
-func ShouldCatch(obj interface{}) (ok bool, err error) {
+func shouldCatch(obj interface{}) (ok bool, err error) {
 	err, ok = obj.(error)
 	if ok {
 		if errors.HasInterface(err, (*runtime.Error)(nil)) {
@@ -25,4 +25,23 @@ func ShouldCatch(obj interface{}) (ok bool, err error) {
 		}
 	}
 	return ok, err
+}
+
+// MaybeCatchPanic is a helper function that can be deferred to catch errors
+// thrown as panics (retErr is updated with the caught error). The callback
+// function, if non-nil, will be called with the error if it is caught.
+//
+// NB: it can only be used when the code does not update shared state and does
+// not manipulate locks.
+func MaybeCatchPanic(retErr *error, errCallback func(caughtErr error)) {
+	if r := recover(); r != nil {
+		if ok, e := shouldCatch(r); ok {
+			*retErr = errors.CombineErrors(*retErr, e)
+			if errCallback != nil {
+				errCallback(e)
+			}
+		} else {
+			panic(r)
+		}
+	}
 }

--- a/pkg/util/pretty/pretty.go
+++ b/pkg/util/pretty/pretty.go
@@ -45,22 +45,8 @@ const (
 // (colors, etc.).
 func Pretty(
 	d Doc, n int, useTabs bool, tabWidth int, keywordTransform func(string) string,
-) (_ string, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			// This code allows us to propagate internal errors without having
-			// to add error checks everywhere throughout the code. This is only
-			// possible because the code does not update shared state and does
-			// not manipulate locks.
-			if ok, e := errorutil.ShouldCatch(r); ok {
-				err = e
-			} else {
-				// Other panic objects can't be considered "safe" and thus are
-				// propagated as panics.
-				panic(r)
-			}
-		}
-	}()
+) (_ string, retErr error) {
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
 	var sb strings.Builder
 	b := beExec{


### PR DESCRIPTION
**sql/stats: don't ignore query error when retrieving stats protos for backup**

This commit fixes a minor bug introduced in 0fdb44abdc6cab54eb94c4d03651fe3515cdcfaa where we would swallow the query error if it was returned while iterating over query results in `getTableStatsProtosFromDB`. That method i inspired by `getTableStatsFromDB` (which returns an error in this case correctly), and both have a special case where decoding errors should be ignored but query errors shouldn't. To make things clearer additionally this commit renames some error variables.

**util/errorutil: centralize panic-catching logic**

Previously, we duplicated the same recover-in-defer logic in many places to prevent process from crashing by catching "safe" panics. This commit exposes the helper method instead. There should be no behavior change.

Note that we introduced an optional function callback argument, and it should be inlined (as well as the catcher itself), so there should be performance impact either.

Epic: None
Release note: None