### PR TITLE
mmaprototype: filter ineligible lease targets before computing means

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -74,8 +74,7 @@ func parseSecondaryLoadVector(t *testing.T, in string) SecondaryLoadVector {
 	return vec
 }
 
-func parseStatusFromArgs(t *testing.T, d *datadriven.TestData) Status {
-	var status Status
+func parseStatusFromArgs(t *testing.T, d *datadriven.TestData, status *Status) {
 	if d.HasArg("health") {
 		healthStr := dd.ScanArg[string](t, d, "health")
 		found := false
@@ -118,7 +117,6 @@ func parseStatusFromArgs(t *testing.T, d *datadriven.TestData) Status {
 			t.Fatalf("unknown replica disposition: %s", replicaStr)
 		}
 	}
-	return status
 }
 
 func parseStoreLoadMsg(t *testing.T, in string) StoreLoadMsg {
@@ -215,6 +213,18 @@ func parseStoreLeaseholderMsg(t *testing.T, in string) StoreLeaseholderMsg {
 					replType, err := parseReplicaType(parts[1])
 					require.NoError(t, err)
 					repl.ReplicaType.ReplicaType = replType
+				case "lease-disposition":
+					found := false
+					for i := LeaseDisposition(0); i < leaseDispositionCount; i++ {
+						if i.String() == parts[1] {
+							repl.LeaseDisposition = i
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Fatalf("unknown lease disposition: %s", parts[1])
+					}
 				default:
 					t.Fatalf("unknown argument: %s", parts[0])
 				}
@@ -485,8 +495,11 @@ func TestClusterState(t *testing.T) {
 					if !ok {
 						t.Fatalf("store %d not found", storeID)
 					}
-					status := parseStatusFromArgs(t, d)
-					ss.status = MakeStatus(status.Health, status.Disposition.Lease, status.Disposition.Replica)
+					// NB: we intentionall bypass the assertion in MakeStatus
+					// here so that we can test all combinations of health,
+					// lease, and replica dispositions, even those that we never
+					// want to see in production.
+					parseStatusFromArgs(t, d, &ss.status)
 					return ss.status.String()
 
 				case "store-load-msg":
@@ -606,6 +619,15 @@ func TestClusterState(t *testing.T) {
 					seconds := dd.ScanArg[int](t, d, "seconds")
 					ts.Advance(time.Second * time.Duration(seconds))
 					return fmt.Sprintf("t=%v", ts.Now().Sub(testingBaseTime))
+
+				case "retain-ready-lease-target-stores-only":
+					in := dd.ScanArg[[]roachpb.StoreID](t, d, "in")
+					rangeID := dd.ScanArg[roachpb.RangeID](t, d, "range-id")
+					out := retainReadyLeaseTargetStoresOnly(ctx, storeSet(in), cs.stores, rangeID)
+					rec := finishAndGet()
+					var sb redact.StringBuilder
+					rec.SafeFormatMinimal(&sb)
+					return fmt.Sprintf("%s%v\n", sb.String(), out)
 
 				default:
 					panic(fmt.Sprintf("unknown command: %v", d.Cmd))

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/lease_disposition.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/lease_disposition.txt
@@ -1,0 +1,139 @@
+# Test retainReadyLeaseTargetStoresOnly which filters stores based on:
+# 1. Store-level lease disposition (must be LeaseDispositionOK)
+# 2. Per-replica lease disposition (must be LeaseDispositionOK)
+#
+# Note: Health is handled indirectly via disposition. Unhealthy stores always
+# have non-OK disposition, so we don't need a separate health check.
+
+set-store
+  store-id=1 node-id=1 locality-tiers=region=us
+  store-id=2 node-id=2 locality-tiers=region=us
+  store-id=3 node-id=3 locality-tiers=region=us
+----
+node-id=1 locality-tiers=region=us,node=1
+  store-id=1 attrs=
+node-id=2 locality-tiers=region=us,node=2
+  store-id=2 attrs=
+node-id=3 locality-tiers=region=us,node=3
+  store-id=3 attrs=
+
+# Set up some stores. The specifics don't matter since we're only testing
+# the lease health checks.
+store-load-msg
+  store-id=1 node-id=1 load=[100,0,0] capacity=[200,100,100] load-time=0s
+  store-id=2 node-id=2 load=[50,0,0] capacity=[200,100,100] load-time=0s
+  store-id=3 node-id=3 load=[50,0,0] capacity=[200,100,100] load-time=0s
+----
+
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[10,0,0]
+  config=(num_replicas=3)
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=false
+    store-id=3 replica-id=3 type=VOTER_FULL leaseholder=false
+----
+
+# All stores healthy and accepting leases - all retained.
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+[1 2 3]
+
+# Only input stores matter.
+retain-ready-lease-target-stores-only in=(1,3) range-id=1
+----
+[1 3]
+
+# Mark s2 as shedding replicas, which should have no effect
+# since we're looking at leases.
+set-store-status store-id=2 replicas=shedding
+----
+ok shedding=replicas
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+[1 2 3]
+
+# Make store 2 unhealthy - it should be filtered out via disposition.
+# Unhealthy stores must have non-OK disposition (invariant).
+set-store-status store-id=2 health=unhealthy leases=shedding replicas=shedding
+----
+unhealthy shedding=leases,replicas
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+skipping s2 for lease transfer: lease disposition shedding (health unhealthy)
+[1 3]
+
+# Different kind of unhealthy. Same result.
+set-store-status store-id=2 health=unknown leases=shedding replicas=shedding
+----
+unknown shedding=leases,replicas
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+skipping s2 for lease transfer: lease disposition shedding (health unknown)
+[1 3]
+
+# Restore store 2, make store 3 refuse leases at store level.
+set-store-status store-id=2 health=ok leases=ok replicas=ok
+----
+ok accepting all
+
+set-store-status store-id=3 leases=refusing
+----
+ok refusing=leases
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition refusing (health ok)
+[1 2]
+
+# Shedding and refusing are treated the same.
+set-store-status store-id=3 health=ok leases=shedding
+----
+ok shedding=leases
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+skipping s3 for lease transfer: lease disposition shedding (health ok)
+[1 2]
+
+# Restore store 3.
+set-store-status store-id=3 leases=ok
+----
+ok accepting all
+
+# All stores ready again.
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+[1 2 3]
+
+# Mark r1 as not accepting leases targeting s2 via per-replica disposition.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[10,0,0]
+  config=(num_replicas=3)
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=false lease-disposition=refusing
+    store-id=3 replica-id=3 type=VOTER_FULL leaseholder=false
+----
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+skipping s2 for lease transfer: replica lease disposition refusing (health ok)
+[1 3]
+
+# Restore s2's replica disposition.
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[10,0,0]
+  config=(num_replicas=3)
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=false lease-disposition=ok
+    store-id=3 replica-id=3 type=VOTER_FULL leaseholder=false
+----
+
+retain-ready-lease-target-stores-only in=(1,2,3) range-id=1
+----
+[1 2 3]

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
@@ -1,0 +1,71 @@
+# This test verifies that the multi-metric allocator skips stores that aren't
+# ready to receive leases when considering lease transfers.
+#
+# Setup: s1 holds the lease for r1, with replicas on s1, s2, s3.
+# - s1: overloaded (wants to shed leases)
+# - s2: low load (would be ideal target) but marked as refusing leases
+# - s3: also overloaded (not a good target)
+#
+# Expected: s2 is filtered out. With only overloaded stores remaining,
+# no lease transfer occurs.
+
+set-store
+  store-id=1 node-id=1
+  store-id=2 node-id=2
+  store-id=3 node-id=3
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=2 locality-tiers=node=2
+  store-id=2 attrs=
+node-id=3 locality-tiers=node=3
+  store-id=3 attrs=
+
+store-load-msg
+  store-id=1 node-id=1 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=2 node-id=2 load=[100,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+  store-id=3 node-id=3 load=[1000,0,0] capacity=[1000,1000,1000] secondary-load=0 load-time=0s
+----
+
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[100,0,0] raft-cpu=10
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+----
+
+# Mark s2 as refusing leases.
+set-store-status store-id=2 leases=refusing
+----
+ok refusing=leases
+
+# s1 tries to shed leases but s2 is filtered out, leaving only [1 3].
+# Since s1 and s3 are equally loaded, no lease transfer occurs.
+rebalance-stores store-id=1
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:700, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 700) (nodes-cpu-capacity 1000)
+[mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s1 was added to shedding store list
+[mmaid=1] evaluating s2: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s3 was added to shedding store list
+[mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100, write-bandwidth:0, byte-size:0]
+[mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] skipping s2 for lease transfer: lease disposition refusing (health ok)
+[mmaid=1] considering lease-transfer r1 from s1: candidates are [1 3]
+[mmaid=1] result(failed): skipping r1 since store not overloaded relative to candidates
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] excluding all stores on n1 due to overload/fd status
+[mmaid=1] considering replica-transfer r1 from s1: store load [cpu:1000, write-bandwidth:0, byte-size:0]
+[mmaid=1] result(failed): no candidates found for r1 after exclusions
+[mmaid=1] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
+[mmaid=1] no top-K[CPURate] ranges found for s3 with lease on local s1
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] skipping remote store s3: in lease shedding grace period
+pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status.txt
@@ -16,6 +16,6 @@ get-load-info
 ----
 store-id=1 node-id=1 status=unhealthy shedding=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
-set-store-status store-id=1 health=ok
+set-store-status store-id=1 health=ok replicas=ok leases=ok
 ----
 ok accepting all


### PR DESCRIPTION
Add health and store-level disposition checks to lease target filtering,
and move all eligibility filtering (including the existing per-replica
disposition check) to happen before computing load means.

Computing means only over eligible targets is semantically correct: when
asking "is store X above or below average?", we mean among stores that
could actually receive the lease. Including ineligible stores (dead,
unhealthy, refusing) distorts the average.

Example: with eligible targets at 30/40/50 QPS and a dead store at 0 QPS:
- Including dead store: mean=30, so 50 QPS looks "significantly above average"
- Excluding dead store: mean=40, so 50 QPS is "slightly above average"

The latter correctly reflects reality among viable candidates.

Add a datadriven directive and testdata file to exercise the new
retainReadyLeaseTargetStoresOnly function, covering health, store-level
disposition, and per-replica disposition filtering. Also extend the test
DSL to support lease-disposition on replica lines and allow set-store-status
to set individual status fields without triggering validation assertions.

- [ ] TODO: dig up the pre/post-means-ness of the SMA and highlight differences to reviewers.

Part of #156776.

Epic: CRDB-55052