### PR TITLE
mma: additional case for non-intersecting conjunctions

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/normalize_config
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/normalize_config
@@ -314,7 +314,6 @@ input:
  voter-constraints:
    +region=b,+zone=b1:1
    +region=a,-zone=a1:1
-err=intersecting conjunctions in constraints and voter constraints
 output:
  num-replicas=5 num-voters=3
  constraints:


### PR DESCRIPTION
A=[+region=a, +zone=a1], B=[+region=a, +zone=a2] is now classified as non-intersecting. This fixes an existing todo.

Epic: CRDB-55052

Release note: None