### PR TITLE
mmaprototype: fix out of bounds check on index bump

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint.go
@@ -467,7 +467,7 @@ func doStructuralNormalization(conf *normalizedSpanConfig) error {
 	// don't know the semantics of regions, zones or the universe of possible
 	// values of the zone.
 	index := 0
-	for rels[index].voterAndAllRel == conjPossiblyIntersecting {
+	for index < len(rels) && rels[index].voterAndAllRel == conjPossiblyIntersecting {
 		index++
 	}
 	var err error
@@ -691,7 +691,7 @@ func doStructuralNormalization(conf *normalizedSpanConfig) error {
 		})
 		// Ignore conjPossiblyIntersecting.
 		index = 0
-		for rels[index].voterAndAllRel == conjPossiblyIntersecting {
+		for index < len(rels) && rels[index].voterAndAllRel == conjPossiblyIntersecting {
 			index++
 		}
 		voterConstraintHasEqualityWithConstraint := make([]bool, len(conf.voterConstraints))

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/normalize_config
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/normalize_config
@@ -634,3 +634,25 @@ output:
    +region=a,+zone=a1:1
    +region=a,+zone=a2:1
    :1
+
+# Regression test for out-of-bounds access bug when all relationships are
+# conjPossiblyIntersecting. The voter constraint (+region=a,+zone=a1) and the
+# all-replica constraint (+region=a,+zone=a2) share +region=a but differ in
+# zone constraints, creating the only possibly intersecting relationship.
+normalize num-replicas=3 num-voters=3
+constraint num-replicas=3 +region=a +zone=a2
+voter-constraint num-replicas=3 +region=a +dc=dc1
+----
+input:
+ num-replicas=3 num-voters=3
+ constraints:
+   +region=a,+zone=a2:3
+ voter-constraints:
+   +region=a,+dc=dc1:3
+err=could not satisfy all voter constraints due to non-intersecting conjunctions in voter and all replica constraints
+output:
+ num-replicas=3 num-voters=3
+ constraints:
+   +region=a,+zone=a2:3
+ voter-constraints:
+   +region=a,+dc=dc1:3


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: fix out of bounds check on index bump**


