### PR TITLE
roachtest/tpcc/large-schema-benchmark: deflake multiregion test

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -423,11 +423,12 @@ func ImportFixture(
 	for _, t := range tables {
 		table := t
 		paths := csvServerPaths(pathPrefix, gen, table, numNodes*filesPerNode)
+		// Wait for there to be a slot ready.
+		res, err := concurrentImportLimit.Begin(ctx)
+		if err != nil {
+			return 0, err
+		}
 		g.GoCtx(func(ctx context.Context) error {
-			res, err := concurrentImportLimit.Begin(ctx)
-			if err != nil {
-				return err
-			}
 			defer res.Release()
 			tableBytes, err := importFixtureTable(
 				ctx, sqlDB, dbName, table, paths, `` /* output */, injectStats)
@@ -600,14 +601,19 @@ func injectStatistics(qualifiedTableName string, table *workload.Table, sqlDB *g
 // makeQualifiedTableName constructs a qualified table name from the specified
 // database name and table.
 func makeQualifiedTableName(dbName string, table *workload.Table) string {
-	if dbName == "" {
+	// If a table prefix is specified, use it.
+	if table.ObjectPrefix != nil {
 		name := table.GetResolvedName()
 		if name.ObjectNamePrefix.ExplicitCatalog ||
 			name.ObjectNamePrefix.ExplicitSchema {
 			return name.FQString()
 		}
-		return fmt.Sprintf(`"%s"`, name.ObjectName)
 	}
+	// If no database name is specified, use the name directly.
+	if dbName == "" {
+		return fmt.Sprintf(`"%s"`, table.Name)
+	}
+	// Otherwise, use the database name and the table name directly.
 	return fmt.Sprintf(`"%s"."%s"`, dbName, table.Name)
 }
 

--- a/pkg/workload/tpcc/tpcc_multi_db.go
+++ b/pkg/workload/tpcc/tpcc_multi_db.go
@@ -303,8 +303,10 @@ func (t *tpccMultiDB) Tables() []workload.Table {
 	// Take the normal TPCC tables and make a copy for each
 	// database in the list.
 	tablesPerDb := make([]workload.Table, 0, len(existingTables)*len(t.dbList))
-	for _, db := range t.dbList {
-		for _, tbl := range existingTables {
+	// We are going to order the list such that we are working on different
+	// databases in a round-robin fashion.
+	for _, tbl := range existingTables {
+		for _, db := range t.dbList {
 			tbl.ObjectPrefix = db
 			tablesPerDb = append(tablesPerDb, tbl)
 		}
@@ -326,7 +328,10 @@ func (t *tpccMultiDB) runInit() error {
 			if v := len(strDbList); v > 0 && len(strDbList[v-1]) == 0 {
 				strDbList = strDbList[:v-1]
 			}
-
+			// First, sort the prefixes by database name.
+			dbToBucket := make(map[string]int)
+			var dbNameListBuckets [][]*tree.ObjectNamePrefix
+			maxBucketLen := 0
 			for _, dbAndSchema := range strDbList {
 				parts := strings.Split(dbAndSchema, ".")
 				prefix := &tree.ObjectNamePrefix{
@@ -338,7 +343,27 @@ func (t *tpccMultiDB) runInit() error {
 				if len(parts) > 1 {
 					prefix.SchemaName = tree.Name(parts[1])
 				}
-				t.dbList = append(t.dbList, prefix)
+				// Assign an index based on the database bucket.
+				if _, exists := dbToBucket[parts[0]]; !exists {
+					dbNameListBuckets = append(dbNameListBuckets, nil)
+					dbToBucket[parts[0]] = len(dbNameListBuckets) - 1
+				}
+				bucket := dbToBucket[parts[0]]
+				dbNameListBuckets[bucket] = append(dbNameListBuckets[bucket], prefix)
+				maxBucketLen = max(maxBucketLen, len(dbNameListBuckets[bucket]))
+			}
+			// Next, generate the dbList slice by doing a round-robin across the
+			// databases in the map. This minimizes deadlocks by ensuring we are
+			// concurrently working on separate databases.
+			t.dbList = make([]*tree.ObjectNamePrefix, 0, len(strDbList))
+			for range maxBucketLen {
+				for idx := range dbNameListBuckets {
+					if len(dbNameListBuckets[idx]) == 0 {
+						continue
+					}
+					t.dbList = append(t.dbList, dbNameListBuckets[idx][0])
+					dbNameListBuckets[idx] = dbNameListBuckets[idx][1:]
+				}
 			}
 		}
 		// Validate that both options must be specified together.


### PR DESCRIPTION
Previously, the multi region versions of this test were susceptible to timing out because object creation took a long time. This happened because the order in which objects were created in multi-region were sub-optimal and could lead to deadlocks (leading to transaction retries). Specifically, when concurrently loading tables in the same database deadlock risk is increased because the descriptor validation for the multiregion type fetches all tables references. To address this, this patch re-orders the table creation, so that tables in different databases are more likely to be processed concurrently.

Additionally, the precreate for the database was incorrectly running on all schemas in multi-region which also took a lot of time.

Fixes: #156413