### PR TITLE
sql: stop retrying temp schema cleanup on poisoned transactions

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2033,6 +2033,9 @@ type ExecutorTestingKnobs struct {
 	// OnTempObjectsCleanupDone will trigger when the temporary objects cleanup
 	// job is done.
 	OnTempObjectsCleanupDone func()
+	// TempObjectCleanupErrorInjection, if set, will be called during temp object
+	// cleanup and can return an error to inject into the cleanup process.
+	TempObjectCleanupErrorInjection func() error
 
 	// WithStatementTrace is called after the statement is executed in
 	// execStmtInOpenState.


### PR DESCRIPTION
Previously, the temporary schema cleanup job would retry up to five times on any error, including those that irreversibly poisoned the transaction. This caused unnecessary log noise (e.g., "txn already encountered an error; cannot be used anymore").

This change improves the retry logic by detecting for TxnAlreadyEncounteredErrorError and aborting immediately.

Fixes #158152
Epic: none
Release note (bug fix): Temporary schema cleanup no longer retries after poisoned transaction errors, reducing log noise.