### PR TITLE
sql: add init validation for element attribute mapping

### DIFF
--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -6,6 +6,7 @@
 package screl
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
@@ -606,3 +607,14 @@ var (
 			}
 		})
 )
+
+func init() {
+	// Ensure that the element schema options are updated when new element
+	// protos are added.
+	// The options are one longer because of the `Element` attribute at the
+	// start.
+	if len(elementSchemaOptions)-1 != len(scpb.GetElementOneOfProtos()) {
+		panic(fmt.Sprintf("mismatched element schema options length %d and element protos length %d",
+			len(elementSchemaOptions), len(scpb.GetElementOneOfProtos())))
+	}
+}


### PR DESCRIPTION
The server hangs during startup if a mapping is missing.
After overlooking this twice when updating the proto with a new element
type it seems worth adding a validation step.
This change panics if the attribute mapping is out of step with the
element types

Epic: none
Part of: #142914
Epic: CRDB-31283

Release note: None
