### PR TITLE
release-25.4: sql/stats: fix bounded memory leak around stats on virtual computed cols

### DIFF
--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -303,13 +303,13 @@ func (s *samplerProcessor) mainLoop(
 			}
 		}
 
+		if earlyExit, err = s.sampleRow(ctx, output, &s.sr, row, rng); earlyExit || err != nil {
+			return earlyExit, err
+		}
 		for i := range s.sketches {
 			if err := s.sketches[i].addRow(ctx, row, s.outTypes, &buf); err != nil {
 				return false, err
 			}
-		}
-		if earlyExit, err = s.sampleRow(ctx, output, &s.sr, row, rng); earlyExit || err != nil {
-			return earlyExit, err
 		}
 
 		for col, invSr := range s.invSr {
@@ -335,11 +335,11 @@ func (s *samplerProcessor) mainLoop(
 			for _, key := range invKeys {
 				d := tree.DBytes(key)
 				invRow[0].Datum = &d
-				if err := s.invSketch[col].addRow(ctx, invRow, bytesRowType, &buf); err != nil {
-					return false, err
-				}
 				if earlyExit, err = s.sampleRow(ctx, output, invSr, invRow, rng); earlyExit || err != nil {
 					return earlyExit, err
+				}
+				if err := s.invSketch[col].addRow(ctx, invRow, bytesRowType, &buf); err != nil {
+					return false, err
 				}
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #158370 on behalf of @yuzefovich.

----

This commit hardens the change in 283151155e6d4767ac267dd98523e4ab9d01eac1 to also apply to EncDatums that have been decoded by the tableReader (which uses non-nil DatumAlloc). The only scenario where this should occur in practice if we needed to decode some EncDatums in order to evaluate the virtual computed column expression. To fix the issue we now explicitly unset the decoded datum if EncDatum has the EncodedBytes set. The impact is that we'll have some duplicated work (between different processors) but we'll avoid the bounded memory leak.

Additionally, since we might decode the EncDatum ourselves for fingerprinting (which we use for distinct estimation), this commit switches the order of "sampling" and "sketching" the row - so that in case we do sample a row, we avoid decoding EncDatums in it for fingerprinting. (For inverted sketches this wasn't needed, but we still changed the order for consistency.)

An alternative idea of introducing a size cutoff at which point we stop sharing the underlying buffer in DatumAlloc has been mentioned, and it seems reasonable, but I chose the current approach since it's more targeted. After all, the sampling logic (where we keep only a subset of rows seen by a processor) is quite unique and doesn't have precedents in other processors.

Fixes: #147553.

Release note (bug fix): CockroachDB could previously hit a bounded memory leak when collecting table statistics on a table that had both very wide (10KiB or more) and relatively small (under 400B) BYTES-like values within the same row as well as virtual computed columns. This has been present since introduction of stats collection on virtual computed columns in 24.1.

----

Release justification: bug fix.