### PR TITLE
kvserver: use StateEngine in executeReadOnlyBatch

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -71,7 +71,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// TODO(irfansharif): It's unfortunate that in this read-only code path,
 	// we're stuck with a ReadWriter because of the way evaluateBatch is
 	// designed.
-	rw := r.store.TODOEngine().NewReadOnly(storage.StandardDurability)
+	rw := r.store.StateEngine().NewReadOnly(storage.StandardDurability)
 	if !rw.ConsistentIterators() {
 		// This is not currently needed for correctness, but future optimizations
 		// may start relying on this, so we assert here.


### PR DESCRIPTION
We have verified (with #158204) that read-only requests don't access log engine keys, so we can now resolve its `ReadWriter` to the `StateEngine`.

Part of #97627