### PR TITLE
opt: build routine parameter references as placeholders

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3865,6 +3865,7 @@ on_update_rehome_row_enabled                                     on
 opt_split_scan_limit                                             2048
 optimizer                                                        on
 optimizer_always_use_histograms                                  on
+optimizer_build_routine_params_as_placeholders                   on
 optimizer_check_input_min_row_count                              1
 optimizer_clamp_inequality_selectivity                           on
 optimizer_clamp_low_histogram_selectivity                        on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3139,6 +3139,7 @@ null_ordered_last                                                off            
 on_update_rehome_row_enabled                                     on                  NULL      NULL        NULL        string
 opt_split_scan_limit                                             2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                                  on                  NULL      NULL        NULL        string
+optimizer_build_routine_params_as_placeholders                   on                  NULL      NULL        NULL        string
 optimizer_check_input_min_row_count                              1                   NULL      NULL        NULL        string
 optimizer_clamp_inequality_selectivity                           on                  NULL      NULL        NULL        string
 optimizer_clamp_low_histogram_selectivity                        on                  NULL      NULL        NULL        string
@@ -3391,6 +3392,7 @@ null_ordered_last                                                off            
 on_update_rehome_row_enabled                                     on                  NULL  user     NULL      on                  on
 opt_split_scan_limit                                             2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                                  on                  NULL  user     NULL      on                  on
+optimizer_build_routine_params_as_placeholders                   on                  NULL  user     NULL      on                  on
 optimizer_check_input_min_row_count                              1                   NULL  user     NULL      1                   1
 optimizer_clamp_inequality_selectivity                           on                  NULL  user     NULL      on                  on
 optimizer_clamp_low_histogram_selectivity                        on                  NULL  user     NULL      on                  on
@@ -3634,6 +3636,7 @@ on_update_rehome_row_enabled                                     NULL    NULL   
 opt_split_scan_limit                                             NULL    NULL     NULL     NULL        NULL
 optimizer                                                        NULL    NULL     NULL     NULL        NULL
 optimizer_always_use_histograms                                  NULL    NULL     NULL     NULL        NULL
+optimizer_build_routine_params_as_placeholders                   NULL    NULL     NULL     NULL        NULL
 optimizer_check_input_min_row_count                              NULL    NULL     NULL     NULL        NULL
 optimizer_clamp_inequality_selectivity                           NULL    NULL     NULL     NULL        NULL
 optimizer_clamp_low_histogram_selectivity                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -153,6 +153,7 @@ null_ordered_last                                                off
 on_update_rehome_row_enabled                                     on
 opt_split_scan_limit                                             2048
 optimizer_always_use_histograms                                  on
+optimizer_build_routine_params_as_placeholders                   on
 optimizer_check_input_min_row_count                              1
 optimizer_clamp_inequality_selectivity                           on
 optimizer_clamp_low_histogram_selectivity                        on

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1245,6 +1245,11 @@ func (b *Builder) buildRoutinePlanGenerator(
 					if ord, ok := argOrd(t.Col); ok {
 						return f.ConstructConstVal(args[ord], t.Typ)
 					}
+				case *memo.PlaceholderExpr:
+					ord := int(t.Value.(*tree.Placeholder).Idx)
+					if ord < len(args) {
+						return f.ConstructConstVal(args[ord], t.Typ)
+					}
 
 				case *memo.WithScanExpr:
 					// Allow referring to "outer" With expressions, if

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -731,6 +731,8 @@ type UDFDefinition struct {
 	// i-th column in the list corresponds to the i-th parameter of the function.
 	// During execution of the UDF, these columns are replaced with the arguments
 	// of the function invocation.
+	// TODO(mgartner): This can be replaced with the number of params if we
+	// always build parameter columns as placeholders instead of variables.
 	Params opt.ColList
 
 	// Body contains a relational expression for each statement in the function

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -219,6 +219,7 @@ type Memo struct {
 	useSwapMutations                           bool
 	preventUpdateSetColumnDrop                 bool
 	useImprovedRoutineDepsTriggersComputedCols bool
+	buildRoutineParamsAsPlaceholders           bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -338,6 +339,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useSwapMutations:                           evalCtx.SessionData().UseSwapMutations,
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
+		buildRoutineParamsAsPlaceholders:           evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -521,6 +523,7 @@ func (m *Memo) IsStale(
 		m.useSwapMutations != evalCtx.SessionData().UseSwapMutations ||
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
+		m.buildRoutineParamsAsPlaceholders != evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -621,6 +621,10 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = true
 	stale()
 	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = false
+
+	evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders = true
+	stale()
+	evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders = false
 	notStale()
 
 	// User no longer has access to view.

--- a/pkg/sql/opt/memo/testdata/logprops/call
+++ b/pkg/sql/opt/memo/testdata/logprops/call
@@ -146,9 +146,8 @@ call
                 │                   │         └── const: 1 [as="?column?":8, type=int]
                 │                   └── project
                 │                        ├── columns: "_implicit_return":9(tuple{int AS a, int AS b})
-                │                        ├── outer: (6,7)
                 │                        ├── cardinality: [1 - 1]
-                │                        ├── immutable
+                │                        ├── immutable, has-placeholder
                 │                        ├── key: ()
                 │                        ├── fd: ()-->(9)
                 │                        ├── values
@@ -156,8 +155,8 @@ call
                 │                        │    ├── key: ()
                 │                        │    └── tuple [type=tuple]
                 │                        └── projections
-                │                             └── cast: RECORD [as="_implicit_return":9, type=tuple{int AS a, int AS b}, outer=(6,7), immutable]
+                │                             └── cast: RECORD [as="_implicit_return":9, type=tuple{int AS a, int AS b}, immutable]
                 │                                  └── tuple [type=tuple{int, int}]
-                │                                       ├── variable: a:6 [type=int]
-                │                                       └── variable: b:7 [type=int]
+                │                                       ├── placeholder: $1 [type=int]
+                │                                       └── placeholder: $2 [type=int]
                 └── const: 1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/tail-calls
+++ b/pkg/sql/opt/memo/testdata/logprops/tail-calls
@@ -468,7 +468,7 @@ values
                                                         │              └── const: '00000'
                                                         └── values
                                                              └── tuple
-                                                                  └── variable: x
+                                                                  └── placeholder: $1
 
 # Tail-call with an argument.
 exec-ddl
@@ -542,7 +542,7 @@ values
                                                                                       └── udf: nested_arg
                                                                                            ├── tail-call
                                                                                            ├── args
-                                                                                           │    └── variable: x
+                                                                                           │    └── placeholder: $1
                                                                                            ├── params: x
                                                                                            └── body
                                                                                                 └── values
@@ -653,7 +653,7 @@ values
                                │                                       └── udf: nested_arg
                                │                                            ├── tail-call
                                │                                            ├── args
-                               │                                            │    └── variable: x
+                               │                                            │    └── placeholder: $1
                                │                                            ├── params: x
                                │                                            └── body
                                │                                                 └── values
@@ -678,7 +678,7 @@ values
                                                                   └── udf: nested_arg
                                                                        ├── tail-call
                                                                        ├── args
-                                                                       │    └── variable: x
+                                                                       │    └── placeholder: $1
                                                                        ├── params: x
                                                                        └── body
                                                                             └── values
@@ -726,7 +726,7 @@ values
                                                    ├── true
                                                    ├── when
                                                    │    ├── lt
-                                                   │    │    ├── variable: i
+                                                   │    │    ├── placeholder: $1
                                                    │    │    └── const: 10
                                                    │    └── subquery
                                                    │         ├── tail-call
@@ -736,7 +736,7 @@ values
                                                    │                        ├── true
                                                    │                        ├── when
                                                    │                        │    ├── eq
-                                                   │                        │    │    ├── variable: i
+                                                   │                        │    │    ├── placeholder: $1
                                                    │                        │    │    └── const: 5
                                                    │                        │    └── udf: nested
                                                    │                        │         ├── tail-call

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
@@ -458,10 +459,10 @@ func (c *CustomFuncs) IsInlinableUDF(args memo.ScalarListExpr, udfp *memo.UDFCal
 func (c *CustomFuncs) ConvertUDFToSubquery(
 	args memo.ScalarListExpr, udfp *memo.UDFCallPrivate,
 ) opt.ScalarExpr {
-	// argForParam returns the argument that can be substituted for the given
+	// argForParamCol returns the argument that can be substituted for the given
 	// column, if the column is a parameter of the UDF. It returns ok=false if
 	// the column is not a UDF parameter.
-	argForParam := func(col opt.ColumnID) (e opt.Expr, ok bool) {
+	argForParamCol := func(col opt.ColumnID) (e opt.Expr, ok bool) {
 		for i := range udfp.Def.Params {
 			if udfp.Def.Params[i] == col {
 				return args[i], true
@@ -469,15 +470,27 @@ func (c *CustomFuncs) ConvertUDFToSubquery(
 		}
 		return nil, false
 	}
+	// argForParam returns the argument that can be substituted for the given
+	// placeholder.
+	argForParam := func(idx tree.PlaceholderIdx) opt.Expr {
+		if int(idx) > len(args) {
+			panic(errors.AssertionFailedf("routine parameter out of range"))
+		}
+		return args[int(idx)]
+	}
 
 	// replace substitutes variables that are UDF parameters with the
 	// corresponding argument from the invocation of the UDF.
 	var replace ReplaceFunc
 	replace = func(nd opt.Expr) opt.Expr {
-		if t, ok := nd.(*memo.VariableExpr); ok {
-			if arg, ok := argForParam(t.Col); ok {
+		switch t := nd.(type) {
+		case *memo.VariableExpr:
+			if arg, ok := argForParamCol(t.Col); ok {
 				return arg
 			}
+		case *memo.PlaceholderExpr:
+			p := t.Value.(*tree.Placeholder)
+			return argForParam(p.Idx)
 		}
 		return c.f.Replace(nd, replace)
 	}

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1711,19 +1711,19 @@ select
                      └── limit
                           ├── columns: x:14!null
                           ├── internal-ordering: +14
-                          ├── outer: (13)
                           ├── cardinality: [0 - 1]
+                          ├── has-placeholder
                           ├── key: ()
                           ├── fd: ()-->(14)
                           ├── select
                           │    ├── columns: x:14!null
-                          │    ├── outer: (13)
+                          │    ├── has-placeholder
                           │    ├── key: (14)
                           │    ├── scan xy
                           │    │    ├── columns: x:14!null
                           │    │    └── key: (14)
                           │    └── filters
-                          │         └── x:14 > i:13 [outer=(13,14), constraints=(/13: (/NULL - ]; /14: (/NULL - ])]
+                          │         └── x:14 > $1 [outer=(14), constraints=(/14: (/NULL - ])]
                           └── 1
 
 # UDFs with volatile arguments are not inlined.

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -758,6 +758,61 @@ project
  └── projections
       └── f:3 + 1.1 [as=r:9, outer=(3), immutable]
 
+# Regression test for #157840.
+exec-ddl
+CREATE PROCEDURE p157840(INT) LANGUAGE SQL AS $$
+    SELECT * FROM (
+        SELECT *, i/2
+        FROM a
+    )
+    WHERE i = $1
+$$
+----
+
+# With optimizer_build_routine_params_as_placeholders enabled, the filter on i
+# is pushed into the project.
+norm format=show-scalars set=(optimizer_build_routine_params_as_placeholders=true) expect=PushSelectIntoProject
+CALL p157840(10)
+----
+call
+ ├── cardinality: [0 - 0]
+ ├── volatile
+ └── procedure: p157840
+      ├── args
+      │    └── const: 10
+      ├── params: arg1:1
+      └── body
+           ├── project
+           │    ├── columns: "?column?":9!null k:2!null i:3!null f:4 s:5 j:6
+           │    ├── has-placeholder
+           │    ├── key: (2)
+           │    ├── fd: ()-->(3,9), (2)-->(4-6)
+           │    ├── select
+           │    │    ├── columns: k:2!null i:3!null f:4 s:5 j:6
+           │    │    ├── has-placeholder
+           │    │    ├── key: (2)
+           │    │    ├── fd: ()-->(3), (2)-->(4-6)
+           │    │    ├── scan a
+           │    │    │    ├── columns: k:2!null i:3 f:4 s:5 j:6
+           │    │    │    ├── key: (2)
+           │    │    │    └── fd: (2)-->(3-6)
+           │    │    └── filters
+           │    │         └── eq [outer=(3), constraints=(/3: (/NULL - ]), fd=()-->(3)]
+           │    │              ├── variable: i:3
+           │    │              └── placeholder: $1
+           │    └── projections
+           │         └── div [as="?column?":9, outer=(3)]
+           │              ├── variable: i:3
+           │              └── const: 2
+           └── values
+                ├── columns: column1:10
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(10)
+                └── tuple
+                     └── null
+
+
 # --------------------------------------
 # PushSelectCondLeftIntoJoinLeftAndRight
 # --------------------------------------

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -261,8 +261,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// Add all input parameters to the base scope of the body.
 		if tree.IsInParamClass(param.Class) {
 			paramColName := funcParamColName(param.Name, i)
-			col := b.synthesizeColumn(bodyScope, paramColName, typ, nil /* expr */, nil /* scalar */)
-			col.setParamOrd(i)
+			_ = b.synthesizeParameterColumn(bodyScope, paramColName, typ, i, nil /* scalar */)
 		}
 
 		// Collect the user defined type dependencies.
@@ -440,10 +439,9 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			for i := range createTriggerFuncParams {
 				param := &createTriggerFuncParams[i]
 				paramColName := funcParamColName(param.name, i)
-				col := b.synthesizeColumn(
-					bodyScope, paramColName, param.typ, nil /* expr */, nil, /* scalar */
+				_ = b.synthesizeParameterColumn(
+					bodyScope, paramColName, param.typ, i, nil, /* scalar */
 				)
-				col.setParamOrd(i)
 			}
 			routineParams = createTriggerFuncParams
 

--- a/pkg/sql/opt/optbuilder/create_trigger.go
+++ b/pkg/sql/opt/optbuilder/create_trigger.go
@@ -223,8 +223,7 @@ func (b *Builder) buildFunctionForTrigger(
 	triggerFuncParams = append(triggerFuncParams, triggerFuncStaticParams...)
 	for i, param := range triggerFuncParams {
 		paramColName := funcParamColName(param.name, i)
-		col := b.synthesizeColumn(funcScope, paramColName, param.typ, nil /* expr */, nil /* scalar */)
-		col.setParamOrd(i)
+		_ = b.synthesizeParameterColumn(funcScope, paramColName, param.typ, i, nil /* scalar */)
 	}
 
 	// Now that the transition relations and table type are known, fully build and

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -318,14 +318,31 @@ func (b *Builder) finishBuildScalarRef(
 		b.subquery.outerCols.Add(col.id)
 	}
 
-	// If this is not a projection context, then wrap the column reference with
-	// a Variable expression that can be embedded in outer expression(s).
+	// If this is not a projection context, then build a variable reference that
+	// can be embedded in outer expression(s).
 	if outScope == nil {
+		a := col.isParam()
+		d := b.evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders
+		c := isOuterColumn
+		_, _, _ = a, d, c
+		if col.isParam() &&
+			b.evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders &&
+			isOuterColumn {
+			// (inScope == nil || inScope.maxParamOrd >= col.getParamOrd()) {
+			// TODO(mgartner): Do I need this?
+			if colRefs != nil {
+				colRefs.Remove(col.id)
+			}
+			return b.factory.ConstructPlaceholder(
+				tree.NewTypedPlaceholder(tree.PlaceholderIdx(col.getParamOrd()), col.typ),
+			)
+		}
 		return b.factory.ConstructVariable(col.id)
 	}
 
-	// Outer columns must be wrapped in a variable expression and assigned a new
-	// column id before projection.
+	// Outer columns and routine parameters (with no column IDs and which will
+	// be built as placeholders) must be wrapped in a variable expression and
+	// assigned a new column id before projection.
 	if isOuterColumn {
 		// Avoid synthesizing a new column if possible.
 		existing := outScope.findExistingCol(col, false /* allowSideEffects */)

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -338,8 +338,9 @@ func (b *Builder) buildRoutine(
 				args[i] = b.factory.ConstructCast(args[i], desiredTyp)
 			}
 			argColName := funcParamColName(tree.Name(paramTypes[i].Name), i)
-			col := b.synthesizeColumn(bodyScope, argColName, desiredTyp, nil /* expr */, nil /* scalar */)
-			col.setParamOrd(i)
+			col := b.synthesizeParameterColumn(
+				bodyScope, argColName, desiredTyp, i, nil, /* scalar */
+			)
 			params[i] = col.id
 		}
 	}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -539,7 +539,9 @@ func (s *scope) colSet() opt.ColSet {
 func (s *scope) colSetWithExtraCols() opt.ColSet {
 	colSet := s.colSet()
 	for i := range s.extraCols {
-		colSet.Add(s.extraCols[i].id)
+		if s.extraCols[i].id != 0 {
+			colSet.Add(s.extraCols[i].id)
+		}
 	}
 	return colSet
 }

--- a/pkg/sql/opt/optbuilder/testdata/procedure
+++ b/pkg/sql/opt/optbuilder/testdata/procedure
@@ -139,3 +139,147 @@ call
                 │    └── tuple
                 │         └── null
                 └── const: 1
+
+# Regression tests for #157840.
+exec-ddl
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b STRING
+)
+----
+
+exec-ddl
+CREATE TABLE xy (
+  x INT PRIMARY KEY,
+  y STRING
+)
+----
+
+exec-ddl
+CREATE TABLE uv (
+  u INT PRIMARY KEY,
+  v STRING
+)
+----
+
+exec-ddl
+CREATE PROCEDURE p157840a(abs ab[]) LANGUAGE SQL AS $$
+  WITH vals AS (
+    SELECT (v).a, (v).b
+    FROM ROWS FROM (unnest(abs)) AS v
+  )
+SELECT * FROM xy JOIN vals ON x = a
+$$
+----
+
+# Join filters with parameter columns are not pull up above the join.
+norm format=show-scalars
+CALL p157840a(ARRAY[
+  ROW(1, 'one')::ab,
+  ROW(2, 'two')::ab,
+  ROW(3, 'three')::ab
+])
+----
+call
+ └── procedure: p157840a
+      ├── args
+      │    └── const: ARRAY[((1, 'one') AS a, b),((2, 'two') AS a, b),((3, 'three') AS a, b)]
+      ├── params: abs:1
+      └── body
+           ├── inner-join (hash)
+           │    ├── columns: x:5!null y:6 a:9!null b:10
+           │    ├── scan xy
+           │    │    └── columns: x:5!null y:6
+           │    ├── project
+           │    │    ├── columns: a:9 b:10
+           │    │    ├── project-set
+           │    │    │    ├── columns: unnest:2
+           │    │    │    ├── values
+           │    │    │    │    └── tuple
+           │    │    │    └── zip
+           │    │    │         └── function: unnest
+           │    │    │              └── placeholder: $1
+           │    │    └── projections
+           │    │         ├── column-access: 0 [as=a:9]
+           │    │         │    └── variable: unnest:2
+           │    │         └── column-access: 1 [as=b:10]
+           │    │              └── variable: unnest:2
+           │    └── filters
+           │         └── eq
+           │              ├── variable: x:5
+           │              └── variable: a:9
+           └── values
+                ├── columns: column1:11
+                └── tuple
+                     └── null
+
+exec-ddl
+CREATE PROCEDURE p157840b(abs ab[]) LANGUAGE SQL AS $$
+  WITH vals AS (
+    SELECT (v).a, (v).b
+    FROM ROWS FROM (unnest(abs)) AS v
+  )
+  SELECT * FROM xy
+  JOIN vals ON true
+  JOIN LATERAL (SELECT u, u/1.1 AS div FROM uv WHERE x=5 AND y=b) ON true
+$$
+----
+
+# The x=5 filter can be pushed above the xy scan and the y=b filter remains in
+# the lowest join filters possible.
+norm format=show-scalars
+CALL p157840b(ARRAY[
+  ROW(1, 'one')::ab,
+  ROW(2, 'two')::ab,
+  ROW(3, 'three')::ab
+])
+----
+call
+ └── procedure: p157840b
+      ├── args
+      │    └── const: ARRAY[((1, 'one') AS a, b),((2, 'two') AS a, b),((3, 'three') AS a, b)]
+      ├── params: abs:1
+      └── body
+           ├── project
+           │    ├── columns: div:15!null x:5!null y:6!null a:9 b:10!null u:11!null
+           │    ├── inner-join (cross)
+           │    │    ├── columns: x:5!null y:6!null a:9 b:10!null u:11!null
+           │    │    ├── inner-join (hash)
+           │    │    │    ├── columns: x:5!null y:6!null a:9 b:10!null
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: x:5!null y:6
+           │    │    │    │    ├── scan xy
+           │    │    │    │    │    └── columns: x:5!null y:6
+           │    │    │    │    └── filters
+           │    │    │    │         └── eq
+           │    │    │    │              ├── variable: x:5
+           │    │    │    │              └── const: 5
+           │    │    │    ├── project
+           │    │    │    │    ├── columns: a:9 b:10
+           │    │    │    │    ├── project-set
+           │    │    │    │    │    ├── columns: unnest:2
+           │    │    │    │    │    ├── values
+           │    │    │    │    │    │    └── tuple
+           │    │    │    │    │    └── zip
+           │    │    │    │    │         └── function: unnest
+           │    │    │    │    │              └── placeholder: $1
+           │    │    │    │    └── projections
+           │    │    │    │         ├── column-access: 0 [as=a:9]
+           │    │    │    │         │    └── variable: unnest:2
+           │    │    │    │         └── column-access: 1 [as=b:10]
+           │    │    │    │              └── variable: unnest:2
+           │    │    │    └── filters
+           │    │    │         └── eq
+           │    │    │              ├── variable: y:6
+           │    │    │              └── variable: b:10
+           │    │    ├── scan uv
+           │    │    │    └── columns: u:11!null
+           │    │    └── filters (true)
+           │    └── projections
+           │         └── div [as=div:15]
+           │              ├── variable: u:11
+           │              └── const: 1.1
+           └── values
+                ├── columns: column1:16
+                └── tuple
+                     └── null

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -74,7 +74,7 @@ call
                 │                        │         │    │    │    │         └── filters
                 │                        │         │    │    │    │              └── eq
                 │                        │         │    │    │    │                   ├── variable: k:9
-                │                        │         │    │    │    │                   └── variable: arg_k:5
+                │                        │         │    │    │    │                   └── placeholder: $1
                 │                        │         │    │    │    └── aggregations
                 │                        │         │    │    │         └── count-rows [as=count_rows:14]
                 │                        │         │    │    └── const: 1
@@ -102,7 +102,7 @@ call
                 │                                                      ├── true
                 │                                                      ├── when
                 │                                                      │    ├── gt
-                │                                                      │    │    ├── variable: c:18
+                │                                                      │    │    ├── placeholder: $4
                 │                                                      │    │    └── const: 0
                 │                                                      │    └── subquery
                 │                                                      │         ├── tail-call
@@ -136,7 +136,7 @@ call
                 │                                                      │                             │         │    └── filters
                 │                                                      │                             │         │         └── eq
                 │                                                      │                             │         │              ├── variable: k:33
-                │                                                      │                             │         │              └── variable: arg_k:24
+                │                                                      │                             │         │              └── placeholder: $1
                 │                                                      │                             │         └── projections
                 │                                                      │                             │              ├── variable: new_i:25 [as=i_new:38]
                 │                                                      │                             │              └── variable: new_s:26 [as=s_new:39]
@@ -263,7 +263,7 @@ call
                 │    │         │    │         └── const: 10 [as=y:2]
                 │    │         │    └── projections
                 │    │         │         └── plus [as=x:3]
-                │    │         │              ├── variable: x:1
+                │    │         │              ├── placeholder: $1
                 │    │         │              └── const: 1
                 │    │         └── projections
                 │    │              └── plus [as=y:4]
@@ -319,11 +319,11 @@ call
                 │                        │         │    │    │         └── const: 100 [as=z:17]
                 │                        │         │    │    └── projections
                 │                        │         │    │         └── plus [as=x:18]
-                │                        │         │    │              ├── variable: x:5
+                │                        │         │    │              ├── placeholder: $1
                 │                        │         │    │              └── const: 1
                 │                        │         │    └── projections
                 │                        │         │         └── plus [as=y:19]
-                │                        │         │              ├── variable: y:6
+                │                        │         │              ├── placeholder: $2
                 │                        │         │              └── const: 1
                 │                        │         └── projections
                 │                        │              └── plus [as=z:20]
@@ -394,11 +394,11 @@ call
                 │                                                                │         │    │    └── tuple
                 │                                                                │         │    └── projections
                 │                                                                │         │         └── plus [as=x:10]
-                │                                                                │         │              ├── variable: x:8
+                │                                                                │         │              ├── placeholder: $1
                 │                                                                │         │              └── const: 1
                 │                                                                │         └── projections
                 │                                                                │              └── plus [as=y:11]
-                │                                                                │                   ├── variable: y:9
+                │                                                                │                   ├── placeholder: $2
                 │                                                                │                   └── const: 1
                 │                                                                └── projections
                 │                                                                     └── udf: _stmt_raise_4 [as="_stmt_raise_4":16]
@@ -707,8 +707,8 @@ call
                 │              │                                  └── projections
                 │              │                                       └── cast: RECORD [as="_implicit_return":8]
                 │              │                                            └── tuple
-                │              │                                                 ├── variable: x:6
-                │              │                                                 └── variable: y:7
+                │              │                                                 ├── placeholder: $1
+                │              │                                                 └── placeholder: $2
                 │              └── subquery
                 │                   └── project
                 │                        ├── columns: stmt_if_1:11
@@ -729,8 +729,8 @@ call
                 │                                            └── projections
                 │                                                 └── cast: RECORD [as="_implicit_return":8]
                 │                                                      └── tuple
-                │                                                           ├── variable: x:6
-                │                                                           └── variable: y:7
+                │                                                           ├── placeholder: $1
+                │                                                           └── placeholder: $2
                 └── const: 1
 
 exec-ddl
@@ -857,7 +857,7 @@ call
                 │                        │    │                             │                                            └── projections
                 │                        │    │                             │                                                 └── cast: RECORD [as="_implicit_return":15]
                 │                        │    │                             │                                                      └── tuple
-                │                        │    │                             │                                                           └── variable: foo:14
+                │                        │    │                             │                                                           └── placeholder: $1
                 │                        │    │                             └── const: 1
                 │                        │    └── projections
                 │                        │         └── column-access: 0 [as=foo:19]

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -814,7 +814,7 @@ insert ab
       │         │                                       └── values
       │         │                                            ├── columns: stmt_return_2:46
       │         │                                            └── tuple
-      │         │                                                 └── variable: new:22
+      │         │                                                 └── placeholder: $1
       │         └── filters
       │              └── is-not
       │                   ├── variable: insert_ab:48

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -211,8 +211,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":3]
-                     │              ├── variable: x:1
-                     │              └── variable: y:2
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -239,8 +239,8 @@ project
            │    │              │    │    └── tuple
            │    │              │    └── projections
            │    │              │         └── plus [as="?column?":3]
-           │    │              │              ├── variable: x:1
-           │    │              │              └── variable: y:2
+           │    │              │              ├── placeholder: $1
+           │    │              │              └── placeholder: $2
            │    │              └── const: 1
            │    └── const: 3
            ├── params: x:4 y:5
@@ -253,8 +253,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":6]
-                     │              ├── variable: x:4
-                     │              └── variable: y:5
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -279,8 +279,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":8]
-                     │              ├── variable: x:6
-                     │              └── variable: y:7
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -309,8 +309,8 @@ project
                                │    │    └── tuple
                                │    └── projections
                                │         └── plus [as="?column?":8]
-                               │              ├── variable: x:6
-                               │              └── variable: y:7
+                               │              ├── placeholder: $1
+                               │              └── placeholder: $2
                                └── const: 1
 
 build format=show-scalars
@@ -341,8 +341,8 @@ project
                      │    │              │    │    └── tuple
                      │    │              │    └── projections
                      │    │              │         └── plus [as="?column?":8]
-                     │    │              │              ├── variable: x:6
-                     │    │              │              └── variable: y:7
+                     │    │              │              ├── placeholder: $1
+                     │    │              │              └── placeholder: $2
                      │    │              └── const: 1
                      │    └── const: 3
                      ├── params: x:9 y:10
@@ -355,8 +355,8 @@ project
                                │    │    └── tuple
                                │    └── projections
                                │         └── plus [as="?column?":11]
-                               │              ├── variable: x:9
-                               │              └── variable: y:10
+                               │              ├── placeholder: $1
+                               │              └── placeholder: $2
                                └── const: 1
 
 exec-ddl
@@ -389,7 +389,7 @@ project
                      │         └── filters
                      │              └── eq
                      │                   ├── variable: a:2
-                     │                   └── variable: a_arg:1
+                     │                   └── placeholder: $1
                      └── const: 1
 
 build format=show-scalars
@@ -416,8 +416,8 @@ project
            │                   │    │    └── tuple
            │                   │    └── projections
            │                   │         └── plus [as="?column?":3]
-           │                   │              ├── variable: x:1
-           │                   │              └── variable: y:2
+           │                   │              ├── placeholder: $1
+           │                   │              └── placeholder: $2
            │                   └── const: 1
            ├── params: a_arg:4
            └── body
@@ -432,7 +432,7 @@ project
                      │         └── filters
                      │              └── eq
                      │                   ├── variable: a:5
-                     │                   └── variable: a_arg:4
+                     │                   └── placeholder: $1
                      └── const: 1
 
 build format=show-scalars
@@ -463,7 +463,7 @@ project
                                │         └── filters
                                │              └── eq
                                │                   ├── variable: a:7
-                               │                   └── variable: a_arg:6
+                               │                   └── placeholder: $1
                                └── const: 1
 
 exec-ddl
@@ -528,8 +528,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":3]
-                     │              ├── variable: x:1
-                     │              └── variable: y:2
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -556,8 +556,8 @@ project
            │    │              │    │    └── tuple
            │    │              │    └── projections
            │    │              │         └── plus [as="?column?":3]
-           │    │              │              ├── variable: x:1
-           │    │              │              └── variable: y:2
+           │    │              │              ├── placeholder: $1
+           │    │              │              └── placeholder: $2
            │    │              └── const: 1
            │    └── const: 3
            ├── params: x:4 y:5
@@ -570,8 +570,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":6]
-                     │              ├── variable: x:4
-                     │              └── variable: y:5
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -602,8 +602,8 @@ project
                      │    │              │    │    └── tuple
                      │    │              │    └── projections
                      │    │              │         └── plus [as="?column?":8]
-                     │    │              │              ├── variable: x:6
-                     │    │              │              └── variable: y:7
+                     │    │              │              ├── placeholder: $1
+                     │    │              │              └── placeholder: $2
                      │    │              └── const: 1
                      │    └── const: 3
                      ├── params: x:9 y:10
@@ -616,8 +616,8 @@ project
                                │    │    └── tuple
                                │    └── projections
                                │         └── plus [as="?column?":11]
-                               │              ├── variable: x:9
-                               │              └── variable: y:10
+                               │              ├── placeholder: $1
+                               │              └── placeholder: $2
                                └── const: 1
 
 assign-placeholders-build query-args=(33) format=show-scalars
@@ -646,8 +646,8 @@ project
  │                             │    │    └── tuple
  │                             │    └── projections
  │                             │         └── plus [as="?column?":8]
- │                             │              ├── variable: x:6
- │                             │              └── variable: y:7
+ │                             │              ├── placeholder: $1
+ │                             │              └── placeholder: $2
  │                             └── const: 1
  └── projections
       └── udf: add_num_args [as=add_num_args:12]
@@ -664,8 +664,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":11]
-                     │              ├── variable: x:9
-                     │              └── variable: y:10
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 # --------------------------------------------------
@@ -700,8 +700,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":3]
-                     │              ├── variable: arg1:1
-                     │              └── variable: arg2:2
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -728,8 +728,8 @@ project
            │    │              │    │    └── tuple
            │    │              │    └── projections
            │    │              │         └── plus [as="?column?":3]
-           │    │              │              ├── variable: arg1:1
-           │    │              │              └── variable: arg2:2
+           │    │              │              ├── placeholder: $1
+           │    │              │              └── placeholder: $2
            │    │              └── const: 1
            │    └── const: 3
            ├── params: arg1:4 arg2:5
@@ -742,8 +742,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":6]
-                     │              ├── variable: arg1:4
-                     │              └── variable: arg2:5
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 build format=show-scalars
@@ -774,8 +774,8 @@ project
                      │    │              │    │    └── tuple
                      │    │              │    └── projections
                      │    │              │         └── plus [as="?column?":8]
-                     │    │              │              ├── variable: arg1:6
-                     │    │              │              └── variable: arg2:7
+                     │    │              │              ├── placeholder: $1
+                     │    │              │              └── placeholder: $2
                      │    │              └── const: 1
                      │    └── const: 3
                      ├── params: arg1:9 arg2:10
@@ -788,8 +788,8 @@ project
                                │    │    └── tuple
                                │    └── projections
                                │         └── plus [as="?column?":11]
-                               │              ├── variable: arg1:9
-                               │              └── variable: arg2:10
+                               │              ├── placeholder: $1
+                               │              └── placeholder: $2
                                └── const: 1
 
 assign-placeholders-build query-args=(33) format=show-scalars
@@ -818,8 +818,8 @@ project
  │                             │    │    └── tuple
  │                             │    └── projections
  │                             │         └── plus [as="?column?":8]
- │                             │              ├── variable: arg1:6
- │                             │              └── variable: arg2:7
+ │                             │              ├── placeholder: $1
+ │                             │              └── placeholder: $2
  │                             └── const: 1
  └── projections
       └── udf: add_anon [as=add_anon:12]
@@ -836,8 +836,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as="?column?":11]
-                     │              ├── variable: arg1:9
-                     │              └── variable: arg2:10
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 
@@ -880,7 +880,7 @@ project
                      │    │    │         └── filters
                      │    │    │              └── gt
                      │    │    │                   ├── variable: c:4
-                     │    │    │                   └── variable: i:1
+                     │    │    │                   └── placeholder: $1
                      │    │    └── const: 1
                      │    └── projections
                      │         └── tuple [as=column7:7]
@@ -926,7 +926,7 @@ project
                      │    │    │         └── filters
                      │    │    │              └── gt
                      │    │    │                   ├── variable: c:4
-                     │    │    │                   └── variable: i:1
+                     │    │    │                   └── placeholder: $1
                      │    │    └── const: 1
                      │    └── projections
                      │         └── tuple [as=column7:7]
@@ -968,7 +968,7 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── column-access: 1 [as=b:2]
-                     │              └── variable: i:1
+                     │              └── placeholder: $1
                      └── const: 1
 
 
@@ -1400,7 +1400,7 @@ project-set
                           └── filters
                                └── gt
                                     ├── variable: a:2
-                                    └── variable: i:1
+                                    └── placeholder: $1
 
 build format=show-scalars
 SELECT * FROM set_fn(1)
@@ -1424,7 +1424,7 @@ project-set
                           └── filters
                                └── gt
                                     ├── variable: a:2
-                                    └── variable: i:1
+                                    └── placeholder: $1
 
 build format=show-scalars
 SELECT a, set_fn(a) FROM abc
@@ -1450,7 +1450,7 @@ project
                                └── filters
                                     └── gt
                                          ├── variable: a:7
-                                         └── variable: i:6
+                                         └── placeholder: $1
 
 
 # --------------------------------------------------
@@ -1497,7 +1497,7 @@ project
                      │                   │    │    │    └── filters
                      │                   │    │    │         └── is-not
                      │                   │    │    │              ├── eq
-                     │                   │    │    │              │    ├── variable: i:1
+                     │                   │    │    │              │    ├── placeholder: $1
                      │                   │    │    │              │    └── variable: a:2
                      │                   │    │    │              └── false
                      │                   │    │    └── projections
@@ -1514,7 +1514,7 @@ project
                      │                             │    ├── and
                      │                             │    │    ├── variable: bool_or:8
                      │                             │    │    └── is-not
-                     │                             │    │         ├── variable: i:1
+                     │                             │    │         ├── placeholder: $1
                      │                             │    │         └── null
                      │                             │    └── true
                      │                             ├── when
@@ -1568,11 +1568,11 @@ project
                      │                        │    │    │    │         └── filters
                      │                        │    │    │    │              └── gt
                      │                        │    │    │    │                   ├── variable: b:3
-                     │                        │    │    │    │                   └── variable: i:1
+                     │                        │    │    │    │                   └── placeholder: $1
                      │                        │    │    │    └── filters
                      │                        │    │    │         └── is-not
                      │                        │    │    │              ├── ge
-                     │                        │    │    │              │    ├── variable: i:1
+                     │                        │    │    │              │    ├── placeholder: $1
                      │                        │    │    │              │    └── variable: a:2
                      │                        │    │    │              └── false
                      │                        │    │    └── projections
@@ -1589,7 +1589,7 @@ project
                      │                                  │    ├── and
                      │                                  │    │    ├── variable: bool_or:8
                      │                                  │    │    └── is-not
-                     │                                  │    │         ├── variable: i:1
+                     │                                  │    │         ├── placeholder: $1
                      │                                  │    │         └── null
                      │                                  │    └── true
                      │                                  ├── when
@@ -1648,8 +1648,8 @@ project
                      │                   │    │    │         └── is-not
                      │                   │    │    │              ├── eq
                      │                   │    │    │              │    ├── tuple
-                     │                   │    │    │              │    │    ├── variable: i:1
-                     │                   │    │    │              │    │    └── variable: j:2
+                     │                   │    │    │              │    │    ├── placeholder: $1
+                     │                   │    │    │              │    │    └── placeholder: $2
                      │                   │    │    │              │    └── variable: column8:8
                      │                   │    │    │              └── false
                      │                   │    │    └── projections
@@ -1666,8 +1666,8 @@ project
                      │                             │    │    ├── variable: bool_or:10
                      │                             │    │    └── is-tuple-not-null
                      │                             │    │         └── tuple
-                     │                             │    │              ├── variable: i:1
-                     │                             │    │              └── variable: j:2
+                     │                             │    │              ├── placeholder: $1
+                     │                             │    │              └── placeholder: $2
                      │                             │    └── true
                      │                             ├── when
                      │                             │    ├── is

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -39,7 +39,7 @@ project
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── variable: a:1 [as=stmt_return_1:3]
+                     │         └── placeholder: $1 [as=stmt_return_1:3]
                      └── const: 1
 
 exec-ddl
@@ -72,8 +72,8 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── plus [as=stmt_return_1:3]
-                     │              ├── variable: a:1
-                     │              └── variable: b:2
+                     │              ├── placeholder: $1
+                     │              └── placeholder: $2
                      └── const: 1
 
 exec-ddl
@@ -240,8 +240,8 @@ project
                      │              ├── true
                      │              ├── when
                      │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
+                     │              │    │    ├── placeholder: $1
+                     │              │    │    └── placeholder: $2
                      │              │    └── subquery
                      │              │         └── project
                      │              │              ├── columns: stmt_if_1:9
@@ -250,7 +250,7 @@ project
                      │              │              │    ├── values
                      │              │              │    │    └── tuple
                      │              │              │    └── projections
-                     │              │              │         └── variable: a:1 [as=c:8]
+                     │              │              │         └── placeholder: $1 [as=c:8]
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
                      │              │                        ├── tail-call
@@ -265,7 +265,7 @@ project
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
+                     │              │                                       └── placeholder: $3 [as=stmt_return_2:7]
                      │              └── subquery
                      │                   └── project
                      │                        ├── columns: stmt_if_1:10
@@ -285,7 +285,7 @@ project
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │                                                 └── placeholder: $3 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -333,8 +333,8 @@ project
                      │              ├── true
                      │              ├── when
                      │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
+                     │              │    │    ├── placeholder: $1
+                     │              │    │    └── placeholder: $2
                      │              │    └── subquery
                      │              │         └── project
                      │              │              ├── columns: stmt_if_1:9
@@ -343,7 +343,7 @@ project
                      │              │              │    ├── values
                      │              │              │    │    └── tuple
                      │              │              │    └── projections
-                     │              │              │         └── variable: a:1 [as=c:8]
+                     │              │              │         └── placeholder: $1 [as=c:8]
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
                      │              │                        ├── tail-call
@@ -358,7 +358,7 @@ project
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
+                     │              │                                       └── placeholder: $3 [as=stmt_return_2:7]
                      │              └── subquery
                      │                   └── project
                      │                        ├── columns: stmt_if_1:11
@@ -367,7 +367,7 @@ project
                      │                        │    ├── values
                      │                        │    │    └── tuple
                      │                        │    └── projections
-                     │                        │         └── variable: b:2 [as=c:10]
+                     │                        │         └── placeholder: $2 [as=c:10]
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
                      │                                  ├── tail-call
@@ -382,7 +382,7 @@ project
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │                                                 └── placeholder: $3 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -430,8 +430,8 @@ project
                      │              ├── true
                      │              ├── when
                      │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
+                     │              │    │    ├── placeholder: $1
+                     │              │    │    └── placeholder: $2
                      │              │    └── subquery
                      │              │         └── project
                      │              │              ├── columns: stmt_if_1:9
@@ -440,7 +440,7 @@ project
                      │              │              │    ├── values
                      │              │              │    │    └── tuple
                      │              │              │    └── projections
-                     │              │              │         └── variable: a:1 [as=c:8]
+                     │              │              │         └── placeholder: $1 [as=c:8]
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
                      │              │                        ├── tail-call
@@ -455,7 +455,7 @@ project
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
+                     │              │                                       └── placeholder: $3 [as=stmt_return_2:7]
                      │              └── subquery
                      │                   └── project
                      │                        ├── columns: stmt_return_3:10!null
@@ -510,8 +510,8 @@ project
                      │              ├── true
                      │              ├── when
                      │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
+                     │              │    │    ├── placeholder: $1
+                     │              │    │    └── placeholder: $2
                      │              │    └── subquery
                      │              │         └── project
                      │              │              ├── columns: stmt_return_3:8!null
@@ -527,7 +527,7 @@ project
                      │                        │    ├── values
                      │                        │    │    └── tuple
                      │                        │    └── projections
-                     │                        │         └── variable: b:2 [as=c:9]
+                     │                        │         └── placeholder: $2 [as=c:9]
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:10]
                      │                                  ├── tail-call
@@ -542,7 +542,7 @@ project
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │                                                 └── placeholder: $3 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -589,8 +589,8 @@ project
                      │              ├── true
                      │              ├── when
                      │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
+                     │              │    │    ├── placeholder: $1
+                     │              │    │    └── placeholder: $2
                      │              │    └── subquery
                      │              │         └── project
                      │              │              ├── columns: stmt_return_5:13!null
@@ -642,7 +642,7 @@ project
                      │    │    ├── values
                      │    │    │    └── tuple
                      │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    │         └── placeholder: $1 [as=i:3]
                      │    └── projections
                      │         └── udf: stmt_loop_5 [as=stmt_loop_5:17]
                      │              ├── args
@@ -697,7 +697,7 @@ project
                      │    │    ├── values
                      │    │    │    └── tuple
                      │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    │         └── placeholder: $1 [as=i:3]
                      │    └── projections
                      │         └── udf: stmt_loop_5 [as=stmt_loop_5:23]
                      │              ├── args
@@ -715,8 +715,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── lt
-                     │                                  │    │    ├── variable: a:13
-                     │                                  │    │    └── variable: b:14
+                     │                                  │    │    ├── placeholder: $1
+                     │                                  │    │    └── placeholder: $2
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -786,7 +786,7 @@ project
                      │    │    ├── values
                      │    │    │    └── tuple
                      │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    │         └── placeholder: $1 [as=i:3]
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:25]
                      │              ├── args
@@ -804,8 +804,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: b:9
+                     │                                  │    │    ├── placeholder: $3
+                     │                                  │    │    └── placeholder: $2
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -826,7 +826,7 @@ project
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: i:6 [as=stmt_return_2:7]
+                     │                                  │                                       └── placeholder: $3 [as=stmt_return_2:7]
                      │                                  └── subquery
                      │                                       ├── tail-call
                      │                                       └── project
@@ -851,7 +851,7 @@ project
                      │                                                                          ├── true
                      │                                                                          ├── when
                      │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:13
+                     │                                                                          │    │    ├── placeholder: $3
                      │                                                                          │    │    └── const: 8
                      │                                                                          │    └── subquery
                      │                                                                          │         ├── tail-call
@@ -884,7 +884,7 @@ project
                      │                                                                                                        │    │    └── tuple
                      │                                                                                                        │    └── projections
                      │                                                                                                        │         └── plus [as=i:17]
-                     │                                                                                                        │              ├── variable: i:16
+                     │                                                                                                        │              ├── placeholder: $3
                      │                                                                                                        │              └── const: 1
                      │                                                                                                        └── projections
                      │                                                                                                             └── udf: stmt_loop_3 [as=stmt_loop_3:18]
@@ -933,7 +933,7 @@ project
                      │    │    ├── values
                      │    │    │    └── tuple
                      │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    │         └── placeholder: $1 [as=i:3]
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:19]
                      │              ├── args
@@ -951,8 +951,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: b:9
+                     │                                  │    │    ├── placeholder: $3
+                     │                                  │    │    └── placeholder: $2
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -973,7 +973,7 @@ project
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: i:6 [as=stmt_return_2:7]
+                     │                                  │                                       └── placeholder: $3 [as=stmt_return_2:7]
                      │                                  └── subquery
                      │                                       ├── tail-call
                      │                                       └── project
@@ -997,7 +997,7 @@ project
                      │                                                                │    │    └── tuple
                      │                                                                │    └── projections
                      │                                                                │         └── plus [as=i:14]
-                     │                                                                │              ├── variable: i:13
+                     │                                                                │              ├── placeholder: $3
                      │                                                                │              └── const: 1
                      │                                                                └── projections
                      │                                                                     └── udf: stmt_loop_3 [as=stmt_loop_3:15]
@@ -1054,17 +1054,17 @@ project
                      │    │    │    └── projections
                      │    │    │         └── const: 0 [as=sum:3]
                      │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:4]
+                     │    │         └── placeholder: $1 [as=i:4]
                      │    └── projections
                      │         └── case [as=stmt_if_7:31]
                      │              ├── true
                      │              ├── when
                      │              │    ├── and
                      │              │    │    ├── is-not
-                     │              │    │    │    ├── variable: a:1
+                     │              │    │    │    ├── placeholder: $1
                      │              │    │    │    └── null
                      │              │    │    └── is-not
-                     │              │    │         ├── variable: b:2
+                     │              │    │         ├── placeholder: $2
                      │              │    │         └── null
                      │              │    └── subquery
                      │              │         └── project
@@ -1090,8 +1090,8 @@ project
                      │              │                                            ├── true
                      │              │                                            ├── when
                      │              │                                            │    ├── ge
-                     │              │                                            │    │    ├── variable: i:18
-                     │              │                                            │    │    └── variable: b:16
+                     │              │                                            │    │    ├── placeholder: $4
+                     │              │                                            │    │    └── placeholder: $2
                      │              │                                            │    └── subquery
                      │              │                                            │         ├── tail-call
                      │              │                                            │         └── project
@@ -1127,7 +1127,7 @@ project
                      │              │                                            │                                                      ├── values
                      │              │                                            │                                                      │    └── tuple
                      │              │                                            │                                                      └── projections
-                     │              │                                            │                                                           └── variable: sum:7 [as=stmt_return_2:9]
+                     │              │                                            │                                                           └── placeholder: $3 [as=stmt_return_2:9]
                      │              │                                            └── subquery
                      │              │                                                 ├── tail-call
                      │              │                                                 └── project
@@ -1154,11 +1154,11 @@ project
                      │              │                                                                          │    │    │    └── tuple
                      │              │                                                                          │    │    └── projections
                      │              │                                                                          │    │         └── plus [as=sum:23]
-                     │              │                                                                          │    │              ├── variable: sum:21
-                     │              │                                                                          │    │              └── variable: i:22
+                     │              │                                                                          │    │              ├── placeholder: $3
+                     │              │                                                                          │    │              └── placeholder: $4
                      │              │                                                                          │    └── projections
                      │              │                                                                          │         └── plus [as=i:24]
-                     │              │                                                                          │              ├── variable: i:22
+                     │              │                                                                          │              ├── placeholder: $4
                      │              │                                                                          │              └── const: 1
                      │              │                                                                          └── projections
                      │              │                                                                               └── udf: stmt_loop_4 [as=stmt_loop_4:25]
@@ -1189,7 +1189,7 @@ project
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: sum:7 [as=stmt_return_2:9]
+                     │                                                 └── placeholder: $3 [as=stmt_return_2:9]
                      └── const: 1
 
 exec-ddl
@@ -1239,7 +1239,7 @@ project
                      │    │    │    └── projections
                      │    │    │         └── const: 0 [as=sum:3]
                      │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:4]
+                     │    │         └── placeholder: $1 [as=i:4]
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:32]
                      │              ├── args
@@ -1258,8 +1258,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:13
-                     │                                  │    │    └── variable: b:11
+                     │                                  │    │    ├── placeholder: $4
+                     │                                  │    │    └── placeholder: $2
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -1281,7 +1281,7 @@ project
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:7 [as=stmt_return_2:9]
+                     │                                  │                                       └── placeholder: $3 [as=stmt_return_2:9]
                      │                                  └── subquery
                      │                                       ├── tail-call
                      │                                       └── project
@@ -1307,7 +1307,7 @@ project
                      │                                                                          ├── true
                      │                                                                          ├── when
                      │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:17
+                     │                                                                          │    │    ├── placeholder: $4
                      │                                                                          │    │    └── const: 2
                      │                                                                          │    └── subquery
                      │                                                                          │         ├── tail-call
@@ -1319,7 +1319,7 @@ project
                      │                                                                          │              │    │    └── tuple
                      │                                                                          │              │    └── projections
                      │                                                                          │              │         └── plus [as=i:25]
-                     │                                                                          │              │              ├── variable: i:17
+                     │                                                                          │              │              ├── placeholder: $4
                      │                                                                          │              │              └── const: 1
                      │                                                                          │              └── projections
                      │                                                                          │                   └── udf: stmt_loop_3 [as=stmt_loop_3:26]
@@ -1356,11 +1356,11 @@ project
                      │                                                                                                        │    │    │    └── tuple
                      │                                                                                                        │    │    └── projections
                      │                                                                                                        │    │         └── plus [as=sum:22]
-                     │                                                                                                        │    │              ├── variable: sum:20
-                     │                                                                                                        │    │              └── variable: i:21
+                     │                                                                                                        │    │              ├── placeholder: $3
+                     │                                                                                                        │    │              └── placeholder: $4
                      │                                                                                                        │    └── projections
                      │                                                                                                        │         └── plus [as=i:23]
-                     │                                                                                                        │              ├── variable: i:21
+                     │                                                                                                        │              ├── placeholder: $4
                      │                                                                                                        │              └── const: 1
                      │                                                                                                        └── projections
                      │                                                                                                             └── udf: stmt_loop_3 [as=stmt_loop_3:24]
@@ -1424,7 +1424,7 @@ project
                      │    │    │    │    └── projections
                      │    │    │    │         └── const: 0 [as=sum:3]
                      │    │    │    └── projections
-                     │    │    │         └── variable: a:1 [as=i:4]
+                     │    │    │         └── placeholder: $1 [as=i:4]
                      │    │    └── projections
                      │    │         └── cast: INT8 [as=j:5]
                      │    │              └── null
@@ -1447,8 +1447,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:15
-                     │                                  │    │    └── variable: b:13
+                     │                                  │    │    ├── placeholder: $4
+                     │                                  │    │    └── placeholder: $2
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -1471,7 +1471,7 @@ project
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:8 [as=stmt_return_2:11]
+                     │                                  │                                       └── placeholder: $3 [as=stmt_return_2:11]
                      │                                  └── subquery
                      │                                       ├── tail-call
                      │                                       └── project
@@ -1517,8 +1517,8 @@ project
                      │                                                                                              ├── true
                      │                                                                                              ├── when
                      │                                                                                              │    ├── ge
-                     │                                                                                              │    │    ├── variable: j:34
-                     │                                                                                              │    │    └── variable: i:33
+                     │                                                                                              │    │    ├── placeholder: $5
+                     │                                                                                              │    │    └── placeholder: $4
                      │                                                                                              │    └── subquery
                      │                                                                                              │         ├── tail-call
                      │                                                                                              │         └── project
@@ -1544,7 +1544,7 @@ project
                      │                                                                                              │                                  │    │    └── tuple
                      │                                                                                              │                                  │    └── projections
                      │                                                                                              │                                  │         └── plus [as=i:28]
-                     │                                                                                              │                                  │              ├── variable: i:26
+                     │                                                                                              │                                  │              ├── placeholder: $4
                      │                                                                                              │                                  │              └── const: 1
                      │                                                                                              │                                  └── projections
                      │                                                                                              │                                       └── udf: stmt_loop_3 [as=stmt_loop_3:29]
@@ -1583,11 +1583,11 @@ project
                      │                                                                                                                            │    │    │    └── tuple
                      │                                                                                                                            │    │    └── projections
                      │                                                                                                                            │    │         └── plus [as=sum:40]
-                     │                                                                                                                            │    │              ├── variable: sum:37
-                     │                                                                                                                            │    │              └── variable: j:39
+                     │                                                                                                                            │    │              ├── placeholder: $3
+                     │                                                                                                                            │    │              └── placeholder: $5
                      │                                                                                                                            │    └── projections
                      │                                                                                                                            │         └── plus [as=j:41]
-                     │                                                                                                                            │              ├── variable: j:39
+                     │                                                                                                                            │              ├── placeholder: $5
                      │                                                                                                                            │              └── const: 1
                      │                                                                                                                            └── projections
                      │                                                                                                                                 └── udf: stmt_loop_6 [as=stmt_loop_6:42]
@@ -1660,8 +1660,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── lt
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: n:8
+                     │                                  │    │    ├── placeholder: $3
+                     │                                  │    │    └── placeholder: $1
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -1674,11 +1674,11 @@ project
                      │                                  │              │    │    │    └── tuple
                      │                                  │              │    │    └── projections
                      │                                  │              │    │         └── plus [as=sum:15]
-                     │                                  │              │    │              ├── variable: sum:9
-                     │                                  │              │    │              └── variable: i:10
+                     │                                  │              │    │              ├── placeholder: $2
+                     │                                  │              │    │              └── placeholder: $3
                      │                                  │              │    └── projections
                      │                                  │              │         └── plus [as=i:16]
-                     │                                  │              │              ├── variable: i:10
+                     │                                  │              │              ├── placeholder: $3
                      │                                  │              │              └── const: 1
                      │                                  │              └── projections
                      │                                  │                   └── udf: stmt_if_4 [as=stmt_if_4:17]
@@ -1721,7 +1721,7 @@ project
                      │                                                                ├── values
                      │                                                                │    └── tuple
                      │                                                                └── projections
-                     │                                                                     └── variable: sum:5 [as=stmt_return_2:7]
+                     │                                                                     └── placeholder: $2 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -1784,8 +1784,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── gt
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: n:8
+                     │                                  │    │    ├── placeholder: $3
+                     │                                  │    │    └── placeholder: $1
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
                      │                                  │         └── project
@@ -1806,7 +1806,7 @@ project
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:5 [as=stmt_return_2:7]
+                     │                                  │                                       └── placeholder: $2 [as=stmt_return_2:7]
                      │                                  └── subquery
                      │                                       ├── tail-call
                      │                                       └── project
@@ -1832,11 +1832,11 @@ project
                      │                                                                │    │    │    └── tuple
                      │                                                                │    │    └── projections
                      │                                                                │    │         └── plus [as=sum:14]
-                     │                                                                │    │              ├── variable: sum:12
-                     │                                                                │    │              └── variable: i:13
+                     │                                                                │    │              ├── placeholder: $2
+                     │                                                                │    │              └── placeholder: $3
                      │                                                                │    └── projections
                      │                                                                │         └── plus [as=i:15]
-                     │                                                                │              ├── variable: i:13
+                     │                                                                │              ├── placeholder: $3
                      │                                                                │              └── const: 1
                      │                                                                └── projections
                      │                                                                     └── udf: stmt_loop_3 [as=stmt_loop_3:16]
@@ -1909,7 +1909,7 @@ project
                      │                                  ├── when
                      │                                  │    ├── eq
                      │                                  │    │    ├── mod
-                     │                                  │    │    │    ├── variable: i:10
+                     │                                  │    │    │    ├── placeholder: $3
                      │                                  │    │    │    └── const: 2
                      │                                  │    │    └── const: 0
                      │                                  │    └── subquery
@@ -1951,11 +1951,11 @@ project
                      │                                                                │    │    │    └── tuple
                      │                                                                │    │    └── projections
                      │                                                                │    │         └── plus [as=sum:14]
-                     │                                                                │    │              ├── variable: sum:12
-                     │                                                                │    │              └── variable: i:13
+                     │                                                                │    │              ├── placeholder: $2
+                     │                                                                │    │              └── placeholder: $3
                      │                                                                │    └── projections
                      │                                                                │         └── plus [as=i:15]
-                     │                                                                │              ├── variable: i:13
+                     │                                                                │              ├── placeholder: $3
                      │                                                                │              └── const: 1
                      │                                                                └── projections
                      │                                                                     └── udf: stmt_loop_3 [as=stmt_loop_3:16]
@@ -2838,7 +2838,7 @@ project
                      │                                                                                    ├── values
                      │                                                                                    │    └── tuple
                      │                                                                                    └── projections
-                     │                                                                                         └── variable: i:16 [as=stmt_return_9:24]
+                     │                                                                                         └── placeholder: $1 [as=stmt_return_9:24]
                      └── const: 1
 
 exec-ddl
@@ -2894,7 +2894,7 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:7
+                     │                                  │    │    ├── placeholder: $1
                      │                                  │    │    └── const: 5
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
@@ -2994,7 +2994,7 @@ project
                      │                                                                                    │    │    └── tuple
                      │                                                                                    │    └── projections
                      │                                                                                    │         └── plus [as=i:11]
-                     │                                                                                    │              ├── variable: i:9
+                     │                                                                                    │              ├── placeholder: $1
                      │                                                                                    │              └── const: 1
                      │                                                                                    └── projections
                      │                                                                                         └── udf: stmt_loop_5 [as=stmt_loop_5:12]
@@ -3202,7 +3202,7 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:7
+                     │                                  │    │    ├── placeholder: $1
                      │                                  │    │    └── const: 5
                      │                                  │    └── subquery
                      │                                  │         ├── tail-call
@@ -3274,7 +3274,7 @@ project
                      │                                                                          ├── true
                      │                                                                          ├── when
                      │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:8
+                     │                                                                          │    │    ├── placeholder: $1
                      │                                                                          │    │    └── const: 3
                      │                                                                          │    └── subquery
                      │                                                                          │         ├── tail-call
@@ -3355,7 +3355,7 @@ project
                      │                                                                          │                                                                          │    │    └── tuple
                      │                                                                          │                                                                          │    └── projections
                      │                                                                          │                                                                          │         └── plus [as=i:12]
-                     │                                                                          │                                                                          │              ├── variable: i:10
+                     │                                                                          │                                                                          │              ├── placeholder: $1
                      │                                                                          │                                                                          │              └── const: 1
                      │                                                                          │                                                                          └── projections
                      │                                                                          │                                                                               └── udf: stmt_loop_5 [as=stmt_loop_5:13]
@@ -3413,7 +3413,7 @@ project
                      │                                                                                                                            │    │    └── tuple
                      │                                                                                                                            │    └── projections
                      │                                                                                                                            │         └── plus [as=i:12]
-                     │                                                                                                                            │              ├── variable: i:10
+                     │                                                                                                                            │              ├── placeholder: $1
                      │                                                                                                                            │              └── const: 1
                      │                                                                                                                            └── projections
                      │                                                                                                                                 └── udf: stmt_loop_5 [as=stmt_loop_5:13]
@@ -3658,7 +3658,7 @@ project
                      │              ├── true
                      │              ├── when
                      │              │    ├── eq
-                     │              │    │    ├── variable: n:1
+                     │              │    │    ├── placeholder: $1
                      │              │    │    └── const: 0
                      │              │    └── subquery
                      │              │         └── project
@@ -3669,7 +3669,7 @@ project
                      │              │                   └── const: 0 [as=stmt_return_3:6]
                      │              ├── when
                      │              │    ├── eq
-                     │              │    │    ├── variable: n:1
+                     │              │    │    ├── placeholder: $1
                      │              │    │    └── const: 1
                      │              │    └── subquery
                      │              │         └── project
@@ -3693,10 +3693,10 @@ project
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: i:4 [as=stmt_return_2:5]
+                     │              │                                       └── placeholder: $2 [as=stmt_return_2:5]
                      │              ├── when
                      │              │    ├── eq
-                     │              │    │    ├── variable: n:1
+                     │              │    │    ├── placeholder: $1
                      │              │    │    └── const: 2
                      │              │    └── subquery
                      │              │         └── project
@@ -3727,7 +3727,7 @@ project
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: i:4 [as=stmt_return_2:5]
+                     │                                                 └── placeholder: $2 [as=stmt_return_2:5]
                      └── const: 1
 
 # Testing EXCEPTION blocks.
@@ -3846,7 +3846,7 @@ project
                      │              │                   ├── true
                      │              │                   ├── when
                      │              │                   │    ├── gt
-                     │              │                   │    │    ├── variable: i:4
+                     │              │                   │    │    ├── placeholder: $1
                      │              │                   │    │    └── const: 0
                      │              │                   │    └── subquery
                      │              │                   │         ├── tail-call
@@ -3868,7 +3868,7 @@ project
                      │              │                                  └── cast: INT8 [as=stmt_return_9:11]
                      │              │                                       └── function: sqrt
                      │              │                                            └── cast: FLOAT8
-                     │              │                                                 └── variable: i:4
+                     │              │                                                 └── placeholder: $1
                      │              └── exception-handler
                      │                   ├── SQLSTATE '22012'
                      │                   │    └── project
@@ -3937,7 +3937,7 @@ project
                      │              │                   ├── true
                      │              │                   ├── when
                      │              │                   │    ├── gt
-                     │              │                   │    │    ├── variable: i:6
+                     │              │                   │    │    ├── placeholder: $1
                      │              │                   │    │    └── const: 0
                      │              │                   │    └── subquery
                      │              │                   │         ├── tail-call
@@ -3959,7 +3959,7 @@ project
                      │              │                                  └── cast: INT8 [as=stmt_return_11:13]
                      │              │                                       └── function: sqrt
                      │              │                                            └── cast: FLOAT8
-                     │              │                                                 └── variable: i:6
+                     │              │                                                 └── placeholder: $1
                      │              └── exception-handler
                      │                   ├── SQLSTATE '22012'
                      │                   │    └── project
@@ -4101,7 +4101,7 @@ project
                      │    │         └── projections
                      │    │              └── floor-div [as=i:2]
                      │    │                   ├── const: 100
-                     │    │                   └── variable: n:1
+                     │    │                   └── placeholder: $1
                      │    └── projections
                      │         └── udf: nested_block_3 [as=nested_block_3:9]
                      │              ├── args
@@ -4114,7 +4114,7 @@ project
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── variable: i:7 [as=stmt_return_4:8]
+                     │              │              └── placeholder: $2 [as=stmt_return_4:8]
                      │              └── exception-handler
                      │                   └── SQLSTATE '22012'
                      │                        └── project
@@ -4189,7 +4189,7 @@ project
                      │              │         │         └── projections
                      │              │         │              └── floor-div [as=x:14]
                      │              │         │                   ├── const: 1
-                     │              │         │                   └── variable: i:10
+                     │              │         │                   └── placeholder: $1
                      │              │         └── projections
                      │              │              └── udf: assign_exception_block_4 [as=assign_exception_block_4:32]
                      │              │                   ├── tail-call
@@ -4211,7 +4211,7 @@ project
                      │              │                             │         └── projections
                      │              │                             │              └── floor-div [as=x:19]
                      │              │                             │                   ├── const: 2
-                     │              │                             │                   └── variable: j:16
+                     │              │                             │                   └── placeholder: $2
                      │              │                             └── projections
                      │              │                                  └── udf: assign_exception_block_5 [as=assign_exception_block_5:31]
                      │              │                                       ├── tail-call
@@ -4233,7 +4233,7 @@ project
                      │              │                                                 │         └── projections
                      │              │                                                 │              └── floor-div [as=x:24]
                      │              │                                                 │                   ├── const: 3
-                     │              │                                                 │                   └── variable: k:22
+                     │              │                                                 │                   └── placeholder: $3
                      │              │                                                 └── projections
                      │              │                                                      └── udf: assign_exception_block_6 [as=assign_exception_block_6:30]
                      │              │                                                           ├── tail-call
@@ -4249,7 +4249,7 @@ project
                      │              │                                                                     ├── values
                      │              │                                                                     │    └── tuple
                      │              │                                                                     └── projections
-                     │              │                                                                          └── variable: x:28 [as=stmt_return_7:29]
+                     │              │                                                                          └── placeholder: $4 [as=stmt_return_7:29]
                      │              └── exception-handler
                      │                   └── SQLSTATE '22012'
                      │                        └── project
@@ -4257,7 +4257,7 @@ project
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: x:8 [as=stmt_return_2:9]
+                     │                                  └── placeholder: $4 [as=stmt_return_2:9]
                      └── const: 1
 
 exec-ddl
@@ -4322,7 +4322,7 @@ project
                      │              │                   ├── true
                      │              │                   ├── when
                      │              │                   │    ├── eq
-                     │              │                   │    │    ├── variable: i:6
+                     │              │                   │    │    ├── placeholder: $1
                      │              │                   │    │    └── const: 0
                      │              │                   │    └── subquery
                      │              │                   │         ├── tail-call
@@ -4453,7 +4453,7 @@ project
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: x:4 [as=stmt_return_2:5]
+                     │                                  └── placeholder: $2 [as=stmt_return_2:5]
                      └── const: 1
 
 exec-ddl
@@ -4537,8 +4537,8 @@ project
                      │              │                                       ├── true
                      │              │                                       ├── when
                      │              │                                       │    ├── ge
-                     │              │                                       │    │    ├── variable: i:22
-                     │              │                                       │    │    └── variable: n:19
+                     │              │                                       │    │    ├── placeholder: $4
+                     │              │                                       │    │    └── placeholder: $1
                      │              │                                       │    └── subquery
                      │              │                                       │         ├── tail-call
                      │              │                                       │         └── project
@@ -4589,8 +4589,8 @@ project
                      │              │                                                                     │              └── floor-div [as=x:27]
                      │              │                                                                     │                   ├── const: 1
                      │              │                                                                     │                   └── minus
-                     │              │                                                                     │                        ├── variable: i:26
-                     │              │                                                                     │                        └── variable: a:24
+                     │              │                                                                     │                        ├── placeholder: $4
+                     │              │                                                                     │                        └── placeholder: $2
                      │              │                                                                     └── projections
                      │              │                                                                          └── udf: assign_exception_block_8 [as=assign_exception_block_8:39]
                      │              │                                                                               ├── tail-call
@@ -4611,7 +4611,7 @@ project
                      │              │                                                                                         │         │    └── tuple
                      │              │                                                                                         │         └── projections
                      │              │                                                                                         │              └── plus [as=i:32]
-                     │              │                                                                                         │                   ├── variable: i:31
+                     │              │                                                                                         │                   ├── placeholder: $4
                      │              │                                                                                         │                   └── const: 1
                      │              │                                                                                         └── projections
                      │              │                                                                                              └── udf: assign_exception_block_9 [as=assign_exception_block_9:38]
@@ -4643,7 +4643,7 @@ project
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: i:8 [as=stmt_return_2:9]
+                     │                                  └── placeholder: $4 [as=stmt_return_2:9]
                      └── const: 1
 
 # Testing SQL statement execution.
@@ -4828,8 +4828,8 @@ project
                      │                                            │    └── tuple
                      │                                            └── projections
                      │                                                 └── plus [as=stmt_return_3:12]
-                     │                                                      ├── variable: i:10
-                     │                                                      └── variable: j:11
+                     │                                                      ├── placeholder: $1
+                     │                                                      └── placeholder: $2
                      └── const: 1
 
 # It is possible to reference a previous value of a target variable in a
@@ -4965,7 +4965,7 @@ project
                      │                                                                                    │         │    │    │         └── filters
                      │                                                                                    │         │    │    │              └── lt
                      │                                                                                    │         │    │    │                   ├── variable: x:12
-                     │                                                                                    │         │    │    │                   └── variable: i:11
+                     │                                                                                    │         │    │    │                   └── placeholder: $1
                      │                                                                                    │         │    │    └── const: 1
                      │                                                                                    │         │    ├── values
                      │                                                                                    │         │    │    └── tuple
@@ -5163,7 +5163,7 @@ project
                      │                                       │              └── filters
                      │                                       │                   └── eq
                      │                                       │                        ├── variable: x:5
-                     │                                       │                        └── variable: i:3
+                     │                                       │                        └── placeholder: $1
                      │                                       └── project
                      │                                            ├── columns: stmt_return_2:10!null
                      │                                            ├── values
@@ -5866,8 +5866,8 @@ project
                      │                                                                          └── body
                      │                                                                               └── project
                      │                                                                                    ├── columns: stmt_return_5:16(int)
-                     │                                                                                    ├── outer: (15)
                      │                                                                                    ├── cardinality: [1 - 1]
+                     │                                                                                    ├── has-placeholder
                      │                                                                                    ├── stats: [rows=1]
                      │                                                                                    ├── key: ()
                      │                                                                                    ├── fd: ()-->(16)
@@ -5877,7 +5877,7 @@ project
                      │                                                                                    │    ├── key: ()
                      │                                                                                    │    └── tuple [type=tuple]
                      │                                                                                    └── projections
-                     │                                                                                         └── variable: x:15 [as=stmt_return_5:16, type=int, outer=(15)]
+                     │                                                                                         └── placeholder: $2 [as=stmt_return_5:16, type=int]
                      └── const: 1 [type=int]
 
 exec-ddl
@@ -6094,7 +6094,7 @@ project
                      │                                                                                    ├── values
                      │                                                                                    │    └── tuple [type=tuple]
                      │                                                                                    └── projections
-                     │                                                                                         └── variable: foo:11 [as=stmt_return_5:13, type=tuple{int AS x, int AS y}]
+                     │                                                                                         └── placeholder: $1 [as=stmt_return_5:13, type=tuple{int AS x, int AS y}]
                      └── const: 1 [type=int]
 
 # Correctly display the OTHERS branch.
@@ -6259,7 +6259,7 @@ project
                      │                                  ├── true [type=bool]
                      │                                  ├── when [type=int]
                      │                                  │    ├── lt [type=bool]
-                     │                                  │    │    ├── variable: i:7 [type=int]
+                     │                                  │    │    ├── placeholder: $1 [type=int]
                      │                                  │    │    └── const: 10 [type=int]
                      │                                  │    └── subquery [type=int]
                      │                                  │         ├── tail-call
@@ -6271,7 +6271,7 @@ project
                      │                                  │              │    │    └── tuple [type=tuple]
                      │                                  │              │    └── projections
                      │                                  │              │         └── plus [as=i:10, type=int]
-                     │                                  │              │              ├── variable: i:7 [type=int]
+                     │                                  │              │              ├── placeholder: $1 [type=int]
                      │                                  │              │              └── const: 1 [type=int]
                      │                                  │              └── projections
                      │                                  │                   └── udf: stmt_if_6 [as=stmt_if_6:11, type=int]
@@ -6761,7 +6761,7 @@ project
                      │                                                                                                        ├── values
                      │                                                                                                        │    └── tuple
                      │                                                                                                        └── projections
-                     │                                                                                                             └── variable: outer_quantity:6 [as=stmt_return_6:8]
+                     │                                                                                                             └── placeholder: $1 [as=stmt_return_6:8]
                      └── const: 1
 
 # Use TxnControlExpr to COMMIT or ROLLBACK the current transaction, then
@@ -7040,7 +7040,7 @@ project-set
                      │    │    │                                  │    │    │    └── tuple
                      │    │    │                                  │    │    └── projections
                      │    │    │                                  │    │         └── mult [as=x:3]
-                     │    │    │                                  │    │              ├── variable: x:2
+                     │    │    │                                  │    │              ├── placeholder: $1
                      │    │    │                                  │    │              └── const: 2
                      │    │    │                                  │    └── projections
                      │    │    │                                  │         └── variable: x:3 [as=stmt_return_1:4]
@@ -7068,9 +7068,9 @@ project-set
                      │    │                        │    └── tuple
                      │    │                        └── projections
                      │    │                             └── tuple [as=stmt_return_3:8]
-                     │    │                                  ├── variable: a:6
+                     │    │                                  ├── placeholder: $1
                      │    │                                  └── unary-minus
-                     │    │                                       └── variable: a:6
+                     │    │                                       └── placeholder: $1
                      │    └── const: 1
                      └── projections
                           ├── column-access: 0 [as=column10:10]
@@ -7136,8 +7136,8 @@ values
                                                    ├── true
                                                    ├── when
                                                    │    ├── le
-                                                   │    │    ├── variable: "_loop_counter":14
-                                                   │    │    └── variable: "_loop_upper":12
+                                                   │    │    ├── placeholder: $5
+                                                   │    │    └── placeholder: $3
                                                    │    └── udf: _stmt_raise_9
                                                    │         ├── tail-call
                                                    │         ├── args
@@ -7187,8 +7187,8 @@ values
                                                    │                                       │         │    ├── columns: "_loop_counter":36
                                                    │                                       │         │    └── tuple
                                                    │                                       │         │         └── plus
-                                                   │                                       │         │              ├── variable: "_loop_counter":19
-                                                   │                                       │         │              └── variable: "_loop_step":18
+                                                   │                                       │         │              ├── placeholder: $5
+                                                   │                                       │         │              └── placeholder: $4
                                                    │                                       │         └── projections
                                                    │                                       │              └── variable: "_loop_counter":36 [as=i:37]
                                                    │                                       └── projections
@@ -7412,16 +7412,16 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:89
+ ├── columns: f:91
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:89]
+      └── udf: f [as=f:91]
            └── body
                 └── limit
-                     ├── columns: "_stmt_exec_1":88
+                     ├── columns: "_stmt_exec_1":90
                      ├── project
-                     │    ├── columns: "_stmt_exec_1":88
+                     │    ├── columns: "_stmt_exec_1":90
                      │    ├── barrier
                      │    │    ├── columns: x:4
                      │    │    └── barrier
@@ -7453,7 +7453,7 @@ project
                      │    │                                                           └── mapping:
                      │    │                                                                └──  random:1 => random:2
                      │    └── projections
-                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":88]
+                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":90]
                      │              ├── args
                      │              │    └── variable: x:4
                      │              ├── params: x:5
@@ -7477,39 +7477,39 @@ project
                      │                   │                   ├──  x:10 => x:11
                      │                   │                   └──  x:10 => x:12
                      │                   └── project
-                     │                        ├── columns: stmt_loop_6:87
+                     │                        ├── columns: stmt_loop_6:89
                      │                        ├── barrier
-                     │                        │    ├── columns: "_loop_lower":26!null "_loop_upper":27!null "_loop_step":28!null "_loop_counter":30!null i:31!null
+                     │                        │    ├── columns: "_loop_lower":27!null "_loop_upper":28!null "_loop_step":29!null "_loop_counter":31!null i:32!null
                      │                        │    └── project
-                     │                        │         ├── columns: i:31!null "_loop_lower":26!null "_loop_upper":27!null "_loop_step":28!null "_loop_counter":30!null
+                     │                        │         ├── columns: i:32!null "_loop_lower":27!null "_loop_upper":28!null "_loop_step":29!null "_loop_counter":31!null
                      │                        │         ├── project
-                     │                        │         │    ├── columns: "_loop_counter":30!null "_loop_lower":26!null "_loop_upper":27!null "_loop_step":28!null
+                     │                        │         │    ├── columns: "_loop_counter":31!null "_loop_lower":27!null "_loop_upper":28!null "_loop_step":29!null
                      │                        │         │    ├── project
-                     │                        │         │    │    ├── columns: "_loop_lower":26!null "_loop_upper":27!null "_loop_step":28!null
+                     │                        │         │    │    ├── columns: "_loop_lower":27!null "_loop_upper":28!null "_loop_step":29!null
                      │                        │         │    │    └── barrier
-                     │                        │         │    │         ├── columns: "_loop_lower":26!null "_loop_upper":27!null "_loop_step":28!null "_plpgsql_runtime_check_5":29
+                     │                        │         │    │         ├── columns: "_loop_lower":27!null "_loop_upper":28!null "_loop_step":29!null "_plpgsql_runtime_check_5":30
                      │                        │         │    │         └── project
-                     │                        │         │    │              ├── columns: "_plpgsql_runtime_check_5":29 "_loop_lower":26!null "_loop_upper":27!null "_loop_step":28!null
+                     │                        │         │    │              ├── columns: "_plpgsql_runtime_check_5":30 "_loop_lower":27!null "_loop_upper":28!null "_loop_step":29!null
                      │                        │         │    │              ├── project
-                     │                        │         │    │              │    ├── columns: "_loop_step":28!null "_loop_lower":26!null "_loop_upper":27!null
+                     │                        │         │    │              │    ├── columns: "_loop_step":29!null "_loop_lower":27!null "_loop_upper":28!null
                      │                        │         │    │              │    ├── project
-                     │                        │         │    │              │    │    ├── columns: "_loop_upper":27!null "_loop_lower":26!null
+                     │                        │         │    │              │    │    ├── columns: "_loop_upper":28!null "_loop_lower":27!null
                      │                        │         │    │              │    │    ├── project
-                     │                        │         │    │              │    │    │    ├── columns: "_loop_lower":26!null
+                     │                        │         │    │              │    │    │    ├── columns: "_loop_lower":27!null
                      │                        │         │    │              │    │    │    ├── values
                      │                        │         │    │              │    │    │    │    └── tuple
                      │                        │         │    │              │    │    │    └── projections
-                     │                        │         │    │              │    │    │         └── const: 1 [as="_loop_lower":26]
+                     │                        │         │    │              │    │    │         └── const: 1 [as="_loop_lower":27]
                      │                        │         │    │              │    │    └── projections
-                     │                        │         │    │              │    │         └── const: 3 [as="_loop_upper":27]
+                     │                        │         │    │              │    │         └── const: 3 [as="_loop_upper":28]
                      │                        │         │    │              │    └── projections
-                     │                        │         │    │              │         └── const: 1 [as="_loop_step":28]
+                     │                        │         │    │              │         └── const: 1 [as="_loop_step":29]
                      │                        │         │    │              └── projections
-                     │                        │         │    │                   └── case [as="_plpgsql_runtime_check_5":29]
+                     │                        │         │    │                   └── case [as="_plpgsql_runtime_check_5":30]
                      │                        │         │    │                        ├── true
                      │                        │         │    │                        ├── when
                      │                        │         │    │                        │    ├── is
-                     │                        │         │    │                        │    │    ├── variable: "_loop_lower":26
+                     │                        │         │    │                        │    │    ├── variable: "_loop_lower":27
                      │                        │         │    │                        │    │    └── null
                      │                        │         │    │                        │    └── function: crdb_internal.plpgsql_raise
                      │                        │         │    │                        │         ├── const: 'ERROR'
@@ -7519,7 +7519,7 @@ project
                      │                        │         │    │                        │         └── const: '22004'
                      │                        │         │    │                        ├── when
                      │                        │         │    │                        │    ├── is
-                     │                        │         │    │                        │    │    ├── variable: "_loop_upper":27
+                     │                        │         │    │                        │    │    ├── variable: "_loop_upper":28
                      │                        │         │    │                        │    │    └── null
                      │                        │         │    │                        │    └── function: crdb_internal.plpgsql_raise
                      │                        │         │    │                        │         ├── const: 'ERROR'
@@ -7529,7 +7529,7 @@ project
                      │                        │         │    │                        │         └── const: '22004'
                      │                        │         │    │                        ├── when
                      │                        │         │    │                        │    ├── is
-                     │                        │         │    │                        │    │    ├── variable: "_loop_step":28
+                     │                        │         │    │                        │    │    ├── variable: "_loop_step":29
                      │                        │         │    │                        │    │    └── null
                      │                        │         │    │                        │    └── function: crdb_internal.plpgsql_raise
                      │                        │         │    │                        │         ├── const: 'ERROR'
@@ -7539,7 +7539,7 @@ project
                      │                        │         │    │                        │         └── const: '22004'
                      │                        │         │    │                        ├── when
                      │                        │         │    │                        │    ├── le
-                     │                        │         │    │                        │    │    ├── variable: "_loop_step":28
+                     │                        │         │    │                        │    │    ├── variable: "_loop_step":29
                      │                        │         │    │                        │    │    └── const: 0
                      │                        │         │    │                        │    └── function: crdb_internal.plpgsql_raise
                      │                        │         │    │                        │         ├── const: 'ERROR'
@@ -7549,252 +7549,260 @@ project
                      │                        │         │    │                        │         └── const: '22023'
                      │                        │         │    │                        └── null
                      │                        │         │    └── projections
-                     │                        │         │         └── variable: "_loop_lower":26 [as="_loop_counter":30]
+                     │                        │         │         └── variable: "_loop_lower":27 [as="_loop_counter":31]
                      │                        │         └── projections
-                     │                        │              └── variable: "_loop_lower":26 [as=i:31]
+                     │                        │              └── variable: "_loop_lower":27 [as=i:32]
                      │                        └── projections
-                     │                             └── udf: stmt_loop_6 [as=stmt_loop_6:87]
+                     │                             └── udf: stmt_loop_6 [as=stmt_loop_6:89]
                      │                                  ├── tail-call
                      │                                  ├── args
                      │                                  │    ├── variable: x:5
-                     │                                  │    ├── variable: i:31
-                     │                                  │    ├── variable: "_loop_lower":26
-                     │                                  │    ├── variable: "_loop_upper":27
-                     │                                  │    ├── variable: "_loop_step":28
-                     │                                  │    └── variable: "_loop_counter":30
-                     │                                  ├── params: x:32 i:33 "_loop_lower":34 "_loop_upper":35 "_loop_step":36 "_loop_counter":37
+                     │                                  │    ├── variable: i:32
+                     │                                  │    ├── variable: "_loop_lower":27
+                     │                                  │    ├── variable: "_loop_upper":28
+                     │                                  │    ├── variable: "_loop_step":29
+                     │                                  │    └── variable: "_loop_counter":31
+                     │                                  ├── params: x:33 i:34 "_loop_lower":35 "_loop_upper":36 "_loop_step":37 "_loop_counter":38
                      │                                  └── body
                      │                                       └── project
-                     │                                            ├── columns: stmt_if_12:83
+                     │                                            ├── columns: stmt_if_12:85
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── case [as=stmt_if_12:83]
+                     │                                                 └── case [as=stmt_if_12:85]
                      │                                                      ├── true
                      │                                                      ├── when
                      │                                                      │    ├── le
-                     │                                                      │    │    ├── variable: "_loop_counter":37
-                     │                                                      │    │    └── variable: "_loop_upper":35
+                     │                                                      │    │    ├── placeholder: $6
+                     │                                                      │    │    └── placeholder: $4
                      │                                                      │    └── subquery
                      │                                                      │         ├── tail-call
                      │                                                      │         └── project
-                     │                                                      │              ├── columns: "_stmt_raise_9":81
+                     │                                                      │              ├── columns: "_stmt_raise_9":83
                      │                                                      │              ├── values
                      │                                                      │              │    └── tuple
                      │                                                      │              └── projections
-                     │                                                      │                   └── udf: _stmt_raise_9 [as="_stmt_raise_9":81]
+                     │                                                      │                   └── udf: _stmt_raise_9 [as="_stmt_raise_9":83]
                      │                                                      │                        ├── tail-call
                      │                                                      │                        ├── args
-                     │                                                      │                        │    ├── variable: x:32
-                     │                                                      │                        │    ├── variable: i:33
-                     │                                                      │                        │    ├── variable: "_loop_lower":34
-                     │                                                      │                        │    ├── variable: "_loop_upper":35
-                     │                                                      │                        │    ├── variable: "_loop_step":36
-                     │                                                      │                        │    └── variable: "_loop_counter":37
-                     │                                                      │                        ├── params: x:51 i:52 "_loop_lower":53 "_loop_upper":54 "_loop_step":55 "_loop_counter":56
+                     │                                                      │                        │    ├── variable: x:33
+                     │                                                      │                        │    ├── variable: i:34
+                     │                                                      │                        │    ├── variable: "_loop_lower":35
+                     │                                                      │                        │    ├── variable: "_loop_upper":36
+                     │                                                      │                        │    ├── variable: "_loop_step":37
+                     │                                                      │                        │    └── variable: "_loop_counter":38
+                     │                                                      │                        ├── params: x:52 i:53 "_loop_lower":54 "_loop_upper":55 "_loop_step":56 "_loop_counter":57
                      │                                                      │                        └── body
                      │                                                      │                             ├── project
-                     │                                                      │                             │    ├── columns: stmt_raise_10:57
+                     │                                                      │                             │    ├── columns: stmt_raise_10:58
                      │                                                      │                             │    ├── values
                      │                                                      │                             │    │    └── tuple
                      │                                                      │                             │    └── projections
-                     │                                                      │                             │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:57]
+                     │                                                      │                             │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:58]
                      │                                                      │                             │              ├── const: 'NOTICE'
                      │                                                      │                             │              ├── const: 'hello'
                      │                                                      │                             │              ├── const: ''
                      │                                                      │                             │              ├── const: ''
                      │                                                      │                             │              └── const: '00000'
                      │                                                      │                             └── project
-                     │                                                      │                                  ├── columns: "_stmt_exec_11":80
+                     │                                                      │                                  ├── columns: "_stmt_exec_11":82
                      │                                                      │                                  ├── barrier
-                     │                                                      │                                  │    ├── columns: x:60
+                     │                                                      │                                  │    ├── columns: x:62
                      │                                                      │                                  │    └── barrier
-                     │                                                      │                                  │         ├── columns: x:60
+                     │                                                      │                                  │         ├── columns: x:62
                      │                                                      │                                  │         └── project
-                     │                                                      │                                  │              ├── columns: x:60
+                     │                                                      │                                  │              ├── columns: x:62
                      │                                                      │                                  │              ├── values
                      │                                                      │                                  │              │    └── tuple
                      │                                                      │                                  │              └── projections
-                     │                                                      │                                  │                   └── subquery [as=x:60]
-                     │                                                      │                                  │                        └── max1-row
-                     │                                                      │                                  │                             ├── columns: "?column?":59
-                     │                                                      │                                  │                             └── with &4 (foo)
-                     │                                                      │                                  │                                  ├── columns: "?column?":59
-                     │                                                      │                                  │                                  ├── materialized
-                     │                                                      │                                  │                                  ├── project
-                     │                                                      │                                  │                                  │    ├── columns: "?column?":58
-                     │                                                      │                                  │                                  │    ├── values
-                     │                                                      │                                  │                                  │    │    └── tuple
-                     │                                                      │                                  │                                  │    └── projections
-                     │                                                      │                                  │                                  │         └── plus [as="?column?":58]
-                     │                                                      │                                  │                                  │              ├── variable: i:52
-                     │                                                      │                                  │                                  │              └── cast: INT8
-                     │                                                      │                                  │                                  │                   └── function: random
-                     │                                                      │                                  │                                  └── with-scan &4 (foo)
-                     │                                                      │                                  │                                       ├── columns: "?column?":59
-                     │                                                      │                                  │                                       └── mapping:
-                     │                                                      │                                  │                                            └──  "?column?":58 => "?column?":59
+                     │                                                      │                                  │                   └── subquery [as=x:62]
+                     │                                                      │                                  │                        └── with &4 (foo)
+                     │                                                      │                                  │                             ├── columns: column61:61
+                     │                                                      │                                  │                             ├── materialized
+                     │                                                      │                                  │                             ├── project
+                     │                                                      │                                  │                             │    ├── columns: "?column?":59
+                     │                                                      │                                  │                             │    ├── values
+                     │                                                      │                                  │                             │    │    └── tuple
+                     │                                                      │                                  │                             │    └── projections
+                     │                                                      │                                  │                             │         └── plus [as="?column?":59]
+                     │                                                      │                                  │                             │              ├── placeholder: $2
+                     │                                                      │                                  │                             │              └── cast: INT8
+                     │                                                      │                                  │                             │                   └── function: random
+                     │                                                      │                                  │                             └── values
+                     │                                                      │                                  │                                  ├── columns: column61:61
+                     │                                                      │                                  │                                  └── tuple
+                     │                                                      │                                  │                                       └── subquery
+                     │                                                      │                                  │                                            └── max1-row
+                     │                                                      │                                  │                                                 ├── columns: "?column?":60
+                     │                                                      │                                  │                                                 └── with-scan &4 (foo)
+                     │                                                      │                                  │                                                      ├── columns: "?column?":60
+                     │                                                      │                                  │                                                      └── mapping:
+                     │                                                      │                                  │                                                           └──  "?column?":59 => "?column?":60
                      │                                                      │                                  └── projections
-                     │                                                      │                                       └── udf: _stmt_exec_11 [as="_stmt_exec_11":80]
+                     │                                                      │                                       └── udf: _stmt_exec_11 [as="_stmt_exec_11":82]
                      │                                                      │                                            ├── tail-call
                      │                                                      │                                            ├── args
-                     │                                                      │                                            │    ├── variable: x:60
-                     │                                                      │                                            │    ├── variable: i:52
-                     │                                                      │                                            │    ├── variable: "_loop_lower":53
-                     │                                                      │                                            │    ├── variable: "_loop_upper":54
-                     │                                                      │                                            │    ├── variable: "_loop_step":55
-                     │                                                      │                                            │    └── variable: "_loop_counter":56
-                     │                                                      │                                            ├── params: x:61 i:62 "_loop_lower":63 "_loop_upper":64 "_loop_step":65 "_loop_counter":66
+                     │                                                      │                                            │    ├── variable: x:62
+                     │                                                      │                                            │    ├── variable: i:53
+                     │                                                      │                                            │    ├── variable: "_loop_lower":54
+                     │                                                      │                                            │    ├── variable: "_loop_upper":55
+                     │                                                      │                                            │    ├── variable: "_loop_step":56
+                     │                                                      │                                            │    └── variable: "_loop_counter":57
+                     │                                                      │                                            ├── params: x:63 i:64 "_loop_lower":65 "_loop_upper":66 "_loop_step":67 "_loop_counter":68
                      │                                                      │                                            └── body
                      │                                                      │                                                 ├── with &5 (foo)
                      │                                                      │                                                 │    ├── insert kv
-                     │                                                      │                                                 │    │    ├── columns: kv.k:67!null kv.v:68
+                     │                                                      │                                                 │    │    ├── columns: kv.k:69!null kv.v:70
                      │                                                      │                                                 │    │    ├── insert-mapping:
-                     │                                                      │                                                 │    │    │    ├── column1:71 => kv.k:67
-                     │                                                      │                                                 │    │    │    └── column2:72 => kv.v:68
+                     │                                                      │                                                 │    │    │    ├── column1:73 => kv.k:69
+                     │                                                      │                                                 │    │    │    └── column2:74 => kv.v:70
                      │                                                      │                                                 │    │    ├── return-mapping:
-                     │                                                      │                                                 │    │    │    ├── column1:71 => kv.k:67
-                     │                                                      │                                                 │    │    │    └── column2:72 => kv.v:68
+                     │                                                      │                                                 │    │    │    ├── column1:73 => kv.k:69
+                     │                                                      │                                                 │    │    │    └── column2:74 => kv.v:70
                      │                                                      │                                                 │    │    └── values
-                     │                                                      │                                                 │    │         ├── columns: column1:71 column2:72
+                     │                                                      │                                                 │    │         ├── columns: column1:73 column2:74
                      │                                                      │                                                 │    │         └── tuple
-                     │                                                      │                                                 │    │              ├── variable: x:61
-                     │                                                      │                                                 │    │              └── variable: x:61
+                     │                                                      │                                                 │    │              ├── placeholder: $1
+                     │                                                      │                                                 │    │              └── placeholder: $1
                      │                                                      │                                                 │    └── insert kv
                      │                                                      │                                                 │         ├── columns: <none>
                      │                                                      │                                                 │         ├── insert-mapping:
-                     │                                                      │                                                 │         │    ├── k:77 => kv.k:73
-                     │                                                      │                                                 │         │    └── v:78 => kv.v:74
+                     │                                                      │                                                 │         │    ├── k:79 => kv.k:75
+                     │                                                      │                                                 │         │    └── v:80 => kv.v:76
                      │                                                      │                                                 │         └── with-scan &5 (foo)
-                     │                                                      │                                                 │              ├── columns: k:77!null v:78
+                     │                                                      │                                                 │              ├── columns: k:79!null v:80
                      │                                                      │                                                 │              └── mapping:
-                     │                                                      │                                                 │                   ├──  kv.k:67 => k:77
-                     │                                                      │                                                 │                   └──  kv.v:68 => v:78
+                     │                                                      │                                                 │                   ├──  kv.k:69 => k:79
+                     │                                                      │                                                 │                   └──  kv.v:70 => v:80
                      │                                                      │                                                 └── project
-                     │                                                      │                                                      ├── columns: stmt_if_8:79
+                     │                                                      │                                                      ├── columns: stmt_if_8:81
                      │                                                      │                                                      ├── values
                      │                                                      │                                                      │    └── tuple
                      │                                                      │                                                      └── projections
-                     │                                                      │                                                           └── udf: stmt_if_8 [as=stmt_if_8:79]
+                     │                                                      │                                                           └── udf: stmt_if_8 [as=stmt_if_8:81]
                      │                                                      │                                                                ├── tail-call
                      │                                                      │                                                                ├── args
-                     │                                                      │                                                                │    ├── variable: x:61
-                     │                                                      │                                                                │    ├── variable: i:62
-                     │                                                      │                                                                │    ├── variable: "_loop_lower":63
-                     │                                                      │                                                                │    ├── variable: "_loop_upper":64
-                     │                                                      │                                                                │    ├── variable: "_loop_step":65
-                     │                                                      │                                                                │    └── variable: "_loop_counter":66
-                     │                                                      │                                                                ├── params: x:44 i:45 "_loop_lower":46 "_loop_upper":47 "_loop_step":48 "_loop_counter":49
+                     │                                                      │                                                                │    ├── variable: x:63
+                     │                                                      │                                                                │    ├── variable: i:64
+                     │                                                      │                                                                │    ├── variable: "_loop_lower":65
+                     │                                                      │                                                                │    ├── variable: "_loop_upper":66
+                     │                                                      │                                                                │    ├── variable: "_loop_step":67
+                     │                                                      │                                                                │    └── variable: "_loop_counter":68
+                     │                                                      │                                                                ├── params: x:45 i:46 "_loop_lower":47 "_loop_upper":48 "_loop_step":49 "_loop_counter":50
                      │                                                      │                                                                └── body
                      │                                                      │                                                                     └── project
-                     │                                                      │                                                                          ├── columns: stmt_loop_inc_7:50
+                     │                                                      │                                                                          ├── columns: stmt_loop_inc_7:51
                      │                                                      │                                                                          ├── values
                      │                                                      │                                                                          │    └── tuple
                      │                                                      │                                                                          └── projections
-                     │                                                      │                                                                               └── udf: stmt_loop_inc_7 [as=stmt_loop_inc_7:50]
+                     │                                                      │                                                                               └── udf: stmt_loop_inc_7 [as=stmt_loop_inc_7:51]
                      │                                                      │                                                                                    ├── tail-call
                      │                                                      │                                                                                    ├── args
-                     │                                                      │                                                                                    │    ├── variable: x:44
-                     │                                                      │                                                                                    │    ├── variable: i:45
-                     │                                                      │                                                                                    │    ├── variable: "_loop_lower":46
-                     │                                                      │                                                                                    │    ├── variable: "_loop_upper":47
-                     │                                                      │                                                                                    │    ├── variable: "_loop_step":48
-                     │                                                      │                                                                                    │    └── variable: "_loop_counter":49
-                     │                                                      │                                                                                    ├── params: x:38 i:39 "_loop_lower":40 "_loop_upper":41 "_loop_step":42 "_loop_counter":43
+                     │                                                      │                                                                                    │    ├── variable: x:45
+                     │                                                      │                                                                                    │    ├── variable: i:46
+                     │                                                      │                                                                                    │    ├── variable: "_loop_lower":47
+                     │                                                      │                                                                                    │    ├── variable: "_loop_upper":48
+                     │                                                      │                                                                                    │    ├── variable: "_loop_step":49
+                     │                                                      │                                                                                    │    └── variable: "_loop_counter":50
+                     │                                                      │                                                                                    ├── params: x:39 i:40 "_loop_lower":41 "_loop_upper":42 "_loop_step":43 "_loop_counter":44
                      │                                                      │                                                                                    └── body
                      │                                                      │                                                                                         └── project
-                     │                                                      │                                                                                              ├── columns: stmt_loop_6:86
+                     │                                                      │                                                                                              ├── columns: stmt_loop_6:88
                      │                                                      │                                                                                              ├── barrier
-                     │                                                      │                                                                                              │    ├── columns: "_loop_counter":84 i:85
+                     │                                                      │                                                                                              │    ├── columns: "_loop_counter":86 i:87
                      │                                                      │                                                                                              │    └── project
-                     │                                                      │                                                                                              │         ├── columns: i:85 "_loop_counter":84
+                     │                                                      │                                                                                              │         ├── columns: i:87 "_loop_counter":86
                      │                                                      │                                                                                              │         ├── project
-                     │                                                      │                                                                                              │         │    ├── columns: "_loop_counter":84
+                     │                                                      │                                                                                              │         │    ├── columns: "_loop_counter":86
                      │                                                      │                                                                                              │         │    ├── values
                      │                                                      │                                                                                              │         │    │    └── tuple
                      │                                                      │                                                                                              │         │    └── projections
-                     │                                                      │                                                                                              │         │         └── plus [as="_loop_counter":84]
-                     │                                                      │                                                                                              │         │              ├── variable: "_loop_counter":43
-                     │                                                      │                                                                                              │         │              └── variable: "_loop_step":42
+                     │                                                      │                                                                                              │         │         └── plus [as="_loop_counter":86]
+                     │                                                      │                                                                                              │         │              ├── placeholder: $6
+                     │                                                      │                                                                                              │         │              └── placeholder: $5
                      │                                                      │                                                                                              │         └── projections
-                     │                                                      │                                                                                              │              └── variable: "_loop_counter":84 [as=i:85]
+                     │                                                      │                                                                                              │              └── variable: "_loop_counter":86 [as=i:87]
                      │                                                      │                                                                                              └── projections
-                     │                                                      │                                                                                                   └── udf: stmt_loop_6 [as=stmt_loop_6:86]
+                     │                                                      │                                                                                                   └── udf: stmt_loop_6 [as=stmt_loop_6:88]
                      │                                                      │                                                                                                        ├── tail-call
                      │                                                      │                                                                                                        ├── args
-                     │                                                      │                                                                                                        │    ├── variable: x:38
-                     │                                                      │                                                                                                        │    ├── variable: i:85
-                     │                                                      │                                                                                                        │    ├── variable: "_loop_lower":40
-                     │                                                      │                                                                                                        │    ├── variable: "_loop_upper":41
-                     │                                                      │                                                                                                        │    ├── variable: "_loop_step":42
-                     │                                                      │                                                                                                        │    └── variable: "_loop_counter":84
+                     │                                                      │                                                                                                        │    ├── variable: x:39
+                     │                                                      │                                                                                                        │    ├── variable: i:87
+                     │                                                      │                                                                                                        │    ├── variable: "_loop_lower":41
+                     │                                                      │                                                                                                        │    ├── variable: "_loop_upper":42
+                     │                                                      │                                                                                                        │    ├── variable: "_loop_step":43
+                     │                                                      │                                                                                                        │    └── variable: "_loop_counter":86
                      │                                                      │                                                                                                        └── recursive-call
                      │                                                      └── subquery
                      │                                                           ├── tail-call
                      │                                                           └── project
-                     │                                                                ├── columns: loop_exit_2:82
+                     │                                                                ├── columns: loop_exit_2:84
                      │                                                                ├── values
                      │                                                                │    └── tuple
                      │                                                                └── projections
-                     │                                                                     └── udf: loop_exit_2 [as=loop_exit_2:82]
+                     │                                                                     └── udf: loop_exit_2 [as=loop_exit_2:84]
                      │                                                                          ├── tail-call
                      │                                                                          ├── args
-                     │                                                                          │    └── variable: x:32
+                     │                                                                          │    └── variable: x:33
                      │                                                                          ├── params: x:13
                      │                                                                          └── body
                      │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_exec_3":25
+                     │                                                                                    ├── columns: "_stmt_exec_3":26
                      │                                                                                    ├── barrier
-                     │                                                                                    │    ├── columns: x:16
+                     │                                                                                    │    ├── columns: x:17
                      │                                                                                    │    └── barrier
-                     │                                                                                    │         ├── columns: x:16
+                     │                                                                                    │         ├── columns: x:17
                      │                                                                                    │         └── project
-                     │                                                                                    │              ├── columns: x:16
+                     │                                                                                    │              ├── columns: x:17
                      │                                                                                    │              ├── values
                      │                                                                                    │              │    └── tuple
                      │                                                                                    │              └── projections
-                     │                                                                                    │                   └── subquery [as=x:16]
-                     │                                                                                    │                        └── max1-row
-                     │                                                                                    │                             ├── columns: "?column?":15
-                     │                                                                                    │                             └── with &3 (foo)
-                     │                                                                                    │                                  ├── columns: "?column?":15
-                     │                                                                                    │                                  ├── materialized
-                     │                                                                                    │                                  ├── project
-                     │                                                                                    │                                  │    ├── columns: "?column?":14
-                     │                                                                                    │                                  │    ├── values
-                     │                                                                                    │                                  │    │    └── tuple
-                     │                                                                                    │                                  │    └── projections
-                     │                                                                                    │                                  │         └── mult [as="?column?":14]
-                     │                                                                                    │                                  │              ├── cast: INT8
-                     │                                                                                    │                                  │              │    └── function: random
-                     │                                                                                    │                                  │              └── variable: x:13
-                     │                                                                                    │                                  └── with-scan &3 (foo)
-                     │                                                                                    │                                       ├── columns: "?column?":15
-                     │                                                                                    │                                       └── mapping:
-                     │                                                                                    │                                            └──  "?column?":14 => "?column?":15
+                     │                                                                                    │                   └── subquery [as=x:17]
+                     │                                                                                    │                        └── with &3 (foo)
+                     │                                                                                    │                             ├── columns: column16:16
+                     │                                                                                    │                             ├── materialized
+                     │                                                                                    │                             ├── project
+                     │                                                                                    │                             │    ├── columns: "?column?":14
+                     │                                                                                    │                             │    ├── values
+                     │                                                                                    │                             │    │    └── tuple
+                     │                                                                                    │                             │    └── projections
+                     │                                                                                    │                             │         └── mult [as="?column?":14]
+                     │                                                                                    │                             │              ├── cast: INT8
+                     │                                                                                    │                             │              │    └── function: random
+                     │                                                                                    │                             │              └── placeholder: $1
+                     │                                                                                    │                             └── values
+                     │                                                                                    │                                  ├── columns: column16:16
+                     │                                                                                    │                                  └── tuple
+                     │                                                                                    │                                       └── subquery
+                     │                                                                                    │                                            └── max1-row
+                     │                                                                                    │                                                 ├── columns: "?column?":15
+                     │                                                                                    │                                                 └── with-scan &3 (foo)
+                     │                                                                                    │                                                      ├── columns: "?column?":15
+                     │                                                                                    │                                                      └── mapping:
+                     │                                                                                    │                                                           └──  "?column?":14 => "?column?":15
                      │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_exec_3 [as="_stmt_exec_3":25]
+                     │                                                                                         └── udf: _stmt_exec_3 [as="_stmt_exec_3":26]
                      │                                                                                              ├── tail-call
                      │                                                                                              ├── args
-                     │                                                                                              │    └── variable: x:16
-                     │                                                                                              ├── params: x:17
+                     │                                                                                              │    └── variable: x:17
+                     │                                                                                              ├── params: x:18
                      │                                                                                              └── body
                      │                                                                                                   ├── insert kv
                      │                                                                                                   │    ├── columns: <none>
                      │                                                                                                   │    ├── insert-mapping:
-                     │                                                                                                   │    │    ├── column1:22 => kv.k:18
-                     │                                                                                                   │    │    └── column2:23 => kv.v:19
+                     │                                                                                                   │    │    ├── column1:23 => kv.k:19
+                     │                                                                                                   │    │    └── column2:24 => kv.v:20
                      │                                                                                                   │    └── values
-                     │                                                                                                   │         ├── columns: column1:22 column2:23
+                     │                                                                                                   │         ├── columns: column1:23 column2:24
                      │                                                                                                   │         └── tuple
-                     │                                                                                                   │              ├── variable: x:17
-                     │                                                                                                   │              └── variable: x:17
+                     │                                                                                                   │              ├── variable: x:18
+                     │                                                                                                   │              └── variable: x:18
                      │                                                                                                   └── project
-                     │                                                                                                        ├── columns: stmt_return_4:24!null
+                     │                                                                                                        ├── columns: stmt_return_4:25!null
                      │                                                                                                        ├── values
                      │                                                                                                        │    └── tuple
                      │                                                                                                        └── projections
-                     │                                                                                                             └── const: 0 [as=stmt_return_4:24]
+                     │                                                                                                             └── const: 0 [as=stmt_return_4:25]
                      └── const: 1
 
 # Case with an outer CTE.
@@ -7955,8 +7963,8 @@ project-set
                                                                        ├── true
                                                                        ├── when
                                                                        │    ├── le
-                                                                       │    │    ├── variable: i:10
-                                                                       │    │    └── variable: n:9
+                                                                       │    │    ├── placeholder: $2
+                                                                       │    │    └── placeholder: $1
                                                                        │    └── subquery
                                                                        │         ├── tail-call
                                                                        │         └── project
@@ -7986,7 +7994,7 @@ project-set
                                                                        │                                  │    │    └── tuple
                                                                        │                                  │    └── projections
                                                                        │                                  │         └── plus [as=i:17]
-                                                                       │                                  │              ├── variable: i:15
+                                                                       │                                  │              ├── placeholder: $2
                                                                        │                                  │              └── const: 1
                                                                        │                                  └── projections
                                                                        │                                       └── udf: stmt_if_4 [as=stmt_if_4:18]

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -810,11 +810,12 @@ func (b *Builder) buildTriggerFunction(
 		{name: triggerColOld, typ: tableTyp, class: tree.RoutineParamIn},
 	}, triggerFuncStaticParams...)
 	paramCols := make(opt.ColList, len(params))
-	for colOrd, param := range params {
-		paramColName := funcParamColName(param.name, colOrd)
-		col := b.synthesizeColumn(triggerFuncScope, paramColName, param.typ, nil /* expr */, nil /* scalar */)
-		col.setParamOrd(colOrd)
-		paramCols[colOrd] = col.id
+	for ord, param := range params {
+		paramColName := funcParamColName(param.name, ord)
+		col := b.synthesizeParameterColumn(
+			triggerFuncScope, paramColName, param.typ, ord, nil, /* scalar */
+		)
+		paramCols[ord] = col.id
 	}
 
 	// Initialize and cache the UDF definition before building the function body.

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -183,17 +183,13 @@ func (b *Builder) expandStarAndResolveType(
 // example, the query `SELECT (x + 1) AS "x_incr" FROM t` has a projection with
 // a synthesized column "x_incr".
 //
-// scope  The scope is passed in so it can be updated with the newly bound
-//
-//	variable.
-//
-// name   This is the name for the new column (e.g., if specified with
-//
-//	the AS keyword).
-//
-// typ    The type of the column.
-// expr   The expression this column refers to (if any).
-// scalar The scalar expression associated with this column (if any).
+//   - scope:  The scope is passed in so it can can be updated with the newly bound
+//     variable.
+//   - name: This is the name for the new column (e.g., if specified with
+//     the AS keyword).
+//   - typ: The type of the column.
+//   - expr: The expression this column refers to (if any).
+//   - scalar: The scalar expression associated with this column (if any).
 //
 // The new column is returned as a scopeColumn object.
 func (b *Builder) synthesizeColumn(
@@ -208,6 +204,24 @@ func (b *Builder) synthesizeColumn(
 		scalar: scalar,
 	})
 	return &scope.cols[len(scope.cols)-1]
+}
+
+// synthesizeParameterColumn synthesizes a column that represents a reference to
+// a routine parameter. ord is the 0-based parameter ordinal. This function
+// panics if the given ordinal is not in the range [0, maxFuncParams).
+func (b *Builder) synthesizeParameterColumn(
+	scope *scope, name scopeColumnName, typ *types.T, ord int, scalar opt.ScalarExpr,
+) *scopeColumn {
+	colID := b.factory.Metadata().AddColumn(name.MetadataName(), typ)
+	scope.cols = append(scope.cols, scopeColumn{
+		name:   name,
+		typ:    typ,
+		id:     colID,
+		scalar: scalar,
+	})
+	col := &scope.cols[len(scope.cols)-1]
+	col.setParamOrd(ord)
+	return col
 }
 
 // populateSynthesizedColumn is similar to synthesizeColumn, but it fills in

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -182,37 +182,10 @@ project
  │    │    │    ├── immutable
  │    │    │    ├── key: (192)
  │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
- │    │    │    ├── right-join (hash)
- │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:192!null
+ │    │    │    ├── left-join-apply
+ │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:192!null
  │    │    │    │    ├── immutable
  │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
- │    │    │    │    ├── union-all
- │    │    │    │    │    ├── columns: objoid:186!null description:189!null
- │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:177 crdb_internal.kv_catalog_comments.description:179
- │    │    │    │    │    ├── right columns: crdb_internal.kv_builtin_function_comments.oid:181 crdb_internal.kv_builtin_function_comments.description:182
- │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.description:179!null
- │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    └── select
- │    │    │    │    │    │         ├── columns: crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.description:179!null objsubid:185!null
- │    │    │    │    │    │         ├── immutable
- │    │    │    │    │    │         ├── fd: ()-->(185)
- │    │    │    │    │    │         ├── project
- │    │    │    │    │    │         │    ├── columns: objsubid:185!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.description:179!null
- │    │    │    │    │    │         │    ├── immutable
- │    │    │    │    │    │         │    ├── select
- │    │    │    │    │    │         │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
- │    │    │    │    │    │         │    │    ├── scan kv_catalog_comments
- │    │    │    │    │    │         │    │    │    └── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
- │    │    │    │    │    │         │    │    └── filters
- │    │    │    │    │    │         │    │         └── crdb_internal.kv_catalog_comments.classoid:176 != <vtable-oid> [outer=(176), constraints=(/176: (/NULL - /<vtable-oid>] [/<vtable-oid> - ]; tight)]
- │    │    │    │    │    │         │    └── projections
- │    │    │    │    │    │         │         └── crdb_internal.kv_catalog_comments.objsubid:178::INT8 [as=objsubid:185, outer=(178), immutable]
- │    │    │    │    │    │         └── filters
- │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
- │    │    │    │    │    └── scan kv_builtin_function_comments
- │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rownum:192!null
  │    │    │    │    │    ├── immutable
@@ -368,8 +341,50 @@ project
  │    │    │    │    │    └── projections
  │    │    │    │    │         └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
  │    │    │    │    │              └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
- │    │    │    │    └── filters
- │    │    │    │         └── objoid:186 = c.oid:1 [outer=(1,186), constraints=(/1: (/NULL - ]; /186: (/NULL - ]), fd=(1)==(186), (186)==(1)]
+ │    │    │    │    ├── union-all
+ │    │    │    │    │    ├── columns: description:189!null
+ │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.description:179
+ │    │    │    │    │    ├── right columns: crdb_internal.kv_builtin_function_comments.description:182
+ │    │    │    │    │    ├── outer: (1)
+ │    │    │    │    │    ├── immutable
+ │    │    │    │    │    ├── project
+ │    │    │    │    │    │    ├── columns: crdb_internal.kv_catalog_comments.description:179!null
+ │    │    │    │    │    │    ├── outer: (1)
+ │    │    │    │    │    │    ├── immutable
+ │    │    │    │    │    │    └── select
+ │    │    │    │    │    │         ├── columns: crdb_internal.kv_catalog_comments.description:179!null objsubid:185!null
+ │    │    │    │    │    │         ├── outer: (1)
+ │    │    │    │    │    │         ├── immutable
+ │    │    │    │    │    │         ├── fd: ()-->(185)
+ │    │    │    │    │    │         ├── project
+ │    │    │    │    │    │         │    ├── columns: objsubid:185!null crdb_internal.kv_catalog_comments.description:179!null
+ │    │    │    │    │    │         │    ├── outer: (1)
+ │    │    │    │    │    │         │    ├── immutable
+ │    │    │    │    │    │         │    ├── select
+ │    │    │    │    │    │         │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
+ │    │    │    │    │    │         │    │    ├── outer: (1)
+ │    │    │    │    │    │         │    │    ├── fd: ()-->(177)
+ │    │    │    │    │    │         │    │    ├── scan kv_catalog_comments
+ │    │    │    │    │    │         │    │    │    └── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
+ │    │    │    │    │    │         │    │    └── filters
+ │    │    │    │    │    │         │    │         ├── crdb_internal.kv_catalog_comments.classoid:176 != <vtable-oid> [outer=(176), constraints=(/176: (/NULL - /<vtable-oid>] [/<vtable-oid> - ]; tight)]
+ │    │    │    │    │    │         │    │         └── crdb_internal.kv_catalog_comments.objoid:177 = c.oid:1 [outer=(1,177), constraints=(/1: (/NULL - ]; /177: (/NULL - ]), fd=(1)==(177), (177)==(1)]
+ │    │    │    │    │    │         │    └── projections
+ │    │    │    │    │    │         │         └── crdb_internal.kv_catalog_comments.objsubid:178::INT8 [as=objsubid:185, outer=(178), immutable]
+ │    │    │    │    │    │         └── filters
+ │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── columns: crdb_internal.kv_builtin_function_comments.description:182!null
+ │    │    │    │    │         ├── outer: (1)
+ │    │    │    │    │         └── select
+ │    │    │    │    │              ├── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
+ │    │    │    │    │              ├── outer: (1)
+ │    │    │    │    │              ├── fd: ()-->(181)
+ │    │    │    │    │              ├── scan kv_builtin_function_comments
+ │    │    │    │    │              │    └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
+ │    │    │    │    │              └── filters
+ │    │    │    │    │                   └── crdb_internal.kv_builtin_function_comments.oid:181 = c.oid:1 [outer=(1,181), constraints=(/1: (/NULL - ]; /181: (/NULL - ]), fd=(1)==(181), (181)==(1)]
+ │    │    │    │    └── filters (true)
  │    │    │    └── aggregations
  │    │    │         ├── const-agg [as=c.oid:1, outer=(1)]
  │    │    │         │    └── c.oid:1

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -186,37 +186,10 @@ sort
       │    │    │    ├── immutable
       │    │    │    ├── key: (192)
       │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
-      │    │    │    ├── right-join (hash)
-      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:192!null
+      │    │    │    ├── left-join-apply
+      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:192!null
       │    │    │    │    ├── immutable
       │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
-      │    │    │    │    ├── union-all
-      │    │    │    │    │    ├── columns: objoid:186!null description:189!null
-      │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:177 crdb_internal.kv_catalog_comments.description:179
-      │    │    │    │    │    ├── right columns: crdb_internal.kv_builtin_function_comments.oid:181 crdb_internal.kv_builtin_function_comments.description:182
-      │    │    │    │    │    ├── immutable
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.description:179!null
-      │    │    │    │    │    │    ├── immutable
-      │    │    │    │    │    │    └── select
-      │    │    │    │    │    │         ├── columns: crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.description:179!null objsubid:185!null
-      │    │    │    │    │    │         ├── immutable
-      │    │    │    │    │    │         ├── fd: ()-->(185)
-      │    │    │    │    │    │         ├── project
-      │    │    │    │    │    │         │    ├── columns: objsubid:185!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.description:179!null
-      │    │    │    │    │    │         │    ├── immutable
-      │    │    │    │    │    │         │    ├── select
-      │    │    │    │    │    │         │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
-      │    │    │    │    │    │         │    │    ├── scan kv_catalog_comments
-      │    │    │    │    │    │         │    │    │    └── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
-      │    │    │    │    │    │         │    │    └── filters
-      │    │    │    │    │    │         │    │         └── crdb_internal.kv_catalog_comments.classoid:176 != <vtable-oid> [outer=(176), constraints=(/176: (/NULL - /<vtable-oid>] [/<vtable-oid> - ]; tight)]
-      │    │    │    │    │    │         │    └── projections
-      │    │    │    │    │    │         │         └── crdb_internal.kv_catalog_comments.objsubid:178::INT8 [as=objsubid:185, outer=(178), immutable]
-      │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
-      │    │    │    │    │    └── scan kv_builtin_function_comments
-      │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rownum:192!null
       │    │    │    │    │    ├── immutable
@@ -372,8 +345,50 @@ sort
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
       │    │    │    │    │              └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
-      │    │    │    │    └── filters
-      │    │    │    │         └── objoid:186 = c.oid:1 [outer=(1,186), constraints=(/1: (/NULL - ]; /186: (/NULL - ]), fd=(1)==(186), (186)==(1)]
+      │    │    │    │    ├── union-all
+      │    │    │    │    │    ├── columns: description:189!null
+      │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.description:179
+      │    │    │    │    │    ├── right columns: crdb_internal.kv_builtin_function_comments.description:182
+      │    │    │    │    │    ├── outer: (1)
+      │    │    │    │    │    ├── immutable
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: crdb_internal.kv_catalog_comments.description:179!null
+      │    │    │    │    │    │    ├── outer: (1)
+      │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    └── select
+      │    │    │    │    │    │         ├── columns: crdb_internal.kv_catalog_comments.description:179!null objsubid:185!null
+      │    │    │    │    │    │         ├── outer: (1)
+      │    │    │    │    │    │         ├── immutable
+      │    │    │    │    │    │         ├── fd: ()-->(185)
+      │    │    │    │    │    │         ├── project
+      │    │    │    │    │    │         │    ├── columns: objsubid:185!null crdb_internal.kv_catalog_comments.description:179!null
+      │    │    │    │    │    │         │    ├── outer: (1)
+      │    │    │    │    │    │         │    ├── immutable
+      │    │    │    │    │    │         │    ├── select
+      │    │    │    │    │    │         │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
+      │    │    │    │    │    │         │    │    ├── outer: (1)
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(177)
+      │    │    │    │    │    │         │    │    ├── scan kv_catalog_comments
+      │    │    │    │    │    │         │    │    │    └── columns: crdb_internal.kv_catalog_comments.classoid:176!null crdb_internal.kv_catalog_comments.objoid:177!null crdb_internal.kv_catalog_comments.objsubid:178!null crdb_internal.kv_catalog_comments.description:179!null
+      │    │    │    │    │    │         │    │    └── filters
+      │    │    │    │    │    │         │    │         ├── crdb_internal.kv_catalog_comments.classoid:176 != <vtable-oid> [outer=(176), constraints=(/176: (/NULL - /<vtable-oid>] [/<vtable-oid> - ]; tight)]
+      │    │    │    │    │    │         │    │         └── crdb_internal.kv_catalog_comments.objoid:177 = c.oid:1 [outer=(1,177), constraints=(/1: (/NULL - ]; /177: (/NULL - ]), fd=(1)==(177), (177)==(1)]
+      │    │    │    │    │    │         │    └── projections
+      │    │    │    │    │    │         │         └── crdb_internal.kv_catalog_comments.objsubid:178::INT8 [as=objsubid:185, outer=(178), immutable]
+      │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
+      │    │    │    │    │    └── project
+      │    │    │    │    │         ├── columns: crdb_internal.kv_builtin_function_comments.description:182!null
+      │    │    │    │    │         ├── outer: (1)
+      │    │    │    │    │         └── select
+      │    │    │    │    │              ├── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
+      │    │    │    │    │              ├── outer: (1)
+      │    │    │    │    │              ├── fd: ()-->(181)
+      │    │    │    │    │              ├── scan kv_builtin_function_comments
+      │    │    │    │    │              │    └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
+      │    │    │    │    │              └── filters
+      │    │    │    │    │                   └── crdb_internal.kv_builtin_function_comments.oid:181 = c.oid:1 [outer=(1,181), constraints=(/1: (/NULL - ]; /181: (/NULL - ]), fd=(1)==(181), (181)==(1)]
+      │    │    │    │    └── filters (true)
       │    │    │    └── aggregations
       │    │    │         ├── const-agg [as=c.oid:1, outer=(1)]
       │    │    │         │    └── c.oid:1

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -54,8 +54,8 @@ project
  │    │    │    ├── immutable
  │    │    │    ├── key: (134)
  │    │    │    ├── fd: (134)-->(3,8,26,35,89)
- │    │    │    ├── left-join (hash)
- │    │    │    │    ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null objoid:86 classoid:87 description:89 c.oid:91 relname:92 relnamespace:93 n.oid:128 nspname:129 rownum:134!null
+ │    │    │    ├── left-join-apply
+ │    │    │    │    ├── columns: t.oid:2!null t.typname:3!null t.typnamespace:4!null t.typtype:8 t.typbasetype:26 n.oid:34!null nspname:35!null classoid:87 description:89 c.oid:91 relname:92 relnamespace:93 n.oid:128 nspname:129 rownum:134!null
  │    │    │    │    ├── immutable
  │    │    │    │    ├── fd: (134)-->(2-4,8,26,34,35), (4)==(34), (34)==(4), (87)==(91), (91)==(87), (93)==(128), (128)==(93)
  │    │    │    │    ├── ordinality
@@ -76,39 +76,54 @@ project
  │    │    │    │    │         └── filters
  │    │    │    │    │              └── t.typnamespace:4 = n.oid:34 [outer=(4,34), constraints=(/4: (/NULL - ]; /34: (/NULL - ]), fd=(4)==(34), (34)==(4)]
  │    │    │    │    ├── inner-join (hash)
- │    │    │    │    │    ├── columns: objoid:86!null classoid:87!null description:89!null c.oid:91!null relname:92!null relnamespace:93!null n.oid:128!null nspname:129!null
+ │    │    │    │    │    ├── columns: classoid:87!null description:89!null c.oid:91!null relname:92!null relnamespace:93!null n.oid:128!null nspname:129!null
+ │    │    │    │    │    ├── outer: (2)
  │    │    │    │    │    ├── immutable
  │    │    │    │    │    ├── fd: ()-->(92,129), (87)==(91), (91)==(87), (93)==(128), (128)==(93)
  │    │    │    │    │    ├── union-all
- │    │    │    │    │    │    ├── columns: objoid:86!null classoid:87!null description:89!null
- │    │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:77 crdb_internal.kv_catalog_comments.classoid:76 crdb_internal.kv_catalog_comments.description:79
- │    │    │    │    │    │    ├── right columns: crdb_internal.kv_builtin_function_comments.oid:81 classoid:83 crdb_internal.kv_builtin_function_comments.description:82
+ │    │    │    │    │    │    ├── columns: classoid:87!null description:89!null
+ │    │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.classoid:76 crdb_internal.kv_catalog_comments.description:79
+ │    │    │    │    │    │    ├── right columns: classoid:83 crdb_internal.kv_builtin_function_comments.description:82
+ │    │    │    │    │    │    ├── outer: (2)
  │    │    │    │    │    │    ├── immutable
  │    │    │    │    │    │    ├── project
- │    │    │    │    │    │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.objoid:77!null crdb_internal.kv_catalog_comments.description:79!null
+ │    │    │    │    │    │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.description:79!null
+ │    │    │    │    │    │    │    ├── outer: (2)
  │    │    │    │    │    │    │    ├── immutable
  │    │    │    │    │    │    │    └── select
- │    │    │    │    │    │    │         ├── columns: crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.objoid:77!null crdb_internal.kv_catalog_comments.description:79!null objsubid:85!null
+ │    │    │    │    │    │    │         ├── columns: crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.description:79!null objsubid:85!null
+ │    │    │    │    │    │    │         ├── outer: (2)
  │    │    │    │    │    │    │         ├── immutable
  │    │    │    │    │    │    │         ├── fd: ()-->(85)
  │    │    │    │    │    │    │         ├── project
- │    │    │    │    │    │    │         │    ├── columns: objsubid:85!null crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.objoid:77!null crdb_internal.kv_catalog_comments.description:79!null
+ │    │    │    │    │    │    │         │    ├── columns: objsubid:85!null crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.description:79!null
+ │    │    │    │    │    │    │         │    ├── outer: (2)
  │    │    │    │    │    │    │         │    ├── immutable
  │    │    │    │    │    │    │         │    ├── select
  │    │    │    │    │    │    │         │    │    ├── columns: crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.objoid:77!null crdb_internal.kv_catalog_comments.objsubid:78!null crdb_internal.kv_catalog_comments.description:79!null
+ │    │    │    │    │    │    │         │    │    ├── outer: (2)
+ │    │    │    │    │    │    │         │    │    ├── fd: ()-->(77)
  │    │    │    │    │    │    │         │    │    ├── scan kv_catalog_comments
  │    │    │    │    │    │    │         │    │    │    └── columns: crdb_internal.kv_catalog_comments.classoid:76!null crdb_internal.kv_catalog_comments.objoid:77!null crdb_internal.kv_catalog_comments.objsubid:78!null crdb_internal.kv_catalog_comments.description:79!null
  │    │    │    │    │    │    │         │    │    └── filters
- │    │    │    │    │    │    │         │    │         └── crdb_internal.kv_catalog_comments.classoid:76 != <vtable-oid> [outer=(76), constraints=(/76: (/NULL - /<vtable-oid>] [/<vtable-oid> - ]; tight)]
+ │    │    │    │    │    │    │         │    │         ├── crdb_internal.kv_catalog_comments.classoid:76 != <vtable-oid> [outer=(76), constraints=(/76: (/NULL - /<vtable-oid>] [/<vtable-oid> - ]; tight)]
+ │    │    │    │    │    │    │         │    │         └── crdb_internal.kv_catalog_comments.objoid:77 = t.oid:2 [outer=(2,77), constraints=(/2: (/NULL - ]; /77: (/NULL - ]), fd=(2)==(77), (77)==(2)]
  │    │    │    │    │    │    │         │    └── projections
  │    │    │    │    │    │    │         │         └── crdb_internal.kv_catalog_comments.objsubid:78::INT8 [as=objsubid:85, outer=(78), immutable]
  │    │    │    │    │    │    │         └── filters
  │    │    │    │    │    │    │              └── objsubid:85 = 0 [outer=(85), constraints=(/85: [/0 - /0]; tight), fd=()-->(85)]
  │    │    │    │    │    │    └── project
- │    │    │    │    │    │         ├── columns: classoid:83!null crdb_internal.kv_builtin_function_comments.oid:81!null crdb_internal.kv_builtin_function_comments.description:82!null
+ │    │    │    │    │    │         ├── columns: classoid:83!null crdb_internal.kv_builtin_function_comments.description:82!null
+ │    │    │    │    │    │         ├── outer: (2)
  │    │    │    │    │    │         ├── fd: ()-->(83)
- │    │    │    │    │    │         ├── scan kv_builtin_function_comments
- │    │    │    │    │    │         │    └── columns: crdb_internal.kv_builtin_function_comments.oid:81!null crdb_internal.kv_builtin_function_comments.description:82!null
+ │    │    │    │    │    │         ├── select
+ │    │    │    │    │    │         │    ├── columns: crdb_internal.kv_builtin_function_comments.oid:81!null crdb_internal.kv_builtin_function_comments.description:82!null
+ │    │    │    │    │    │         │    ├── outer: (2)
+ │    │    │    │    │    │         │    ├── fd: ()-->(81)
+ │    │    │    │    │    │         │    ├── scan kv_builtin_function_comments
+ │    │    │    │    │    │         │    │    └── columns: crdb_internal.kv_builtin_function_comments.oid:81!null crdb_internal.kv_builtin_function_comments.description:82!null
+ │    │    │    │    │    │         │    └── filters
+ │    │    │    │    │    │         │         └── crdb_internal.kv_builtin_function_comments.oid:81 = t.oid:2 [outer=(2,81), constraints=(/2: (/NULL - ]; /81: (/NULL - ]), fd=(2)==(81), (81)==(2)]
  │    │    │    │    │    │         └── projections
  │    │    │    │    │    │              └── <vtable-oid> [as=classoid:83]
  │    │    │    │    │    ├── inner-join (hash)
@@ -132,8 +147,7 @@ project
  │    │    │    │    │    │         └── relnamespace:93 = n.oid:128 [outer=(93,128), constraints=(/93: (/NULL - ]; /128: (/NULL - ]), fd=(93)==(128), (128)==(93)]
  │    │    │    │    │    └── filters
  │    │    │    │    │         └── classoid:87 = c.oid:91 [outer=(87,91), constraints=(/87: (/NULL - ]; /91: (/NULL - ]), fd=(87)==(91), (91)==(87)]
- │    │    │    │    └── filters
- │    │    │    │         └── objoid:86 = t.oid:2 [outer=(2,86), constraints=(/2: (/NULL - ]; /86: (/NULL - ]), fd=(2)==(86), (86)==(2)]
+ │    │    │    │    └── filters (true)
  │    │    │    └── aggregations
  │    │    │         ├── const-agg [as=t.typname:3, outer=(3)]
  │    │    │         │    └── t.typname:3

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -799,6 +799,12 @@ func NewPlaceholder(name string) (*Placeholder, error) {
 	return &Placeholder{Idx: PlaceholderIdx(uval - 1)}, nil
 }
 
+// NewTypedPlaceholder allocates a Placeholder with the given 0-based index and
+// type.
+func NewTypedPlaceholder(idx PlaceholderIdx, typ *types.T) *Placeholder {
+	return &Placeholder{Idx: idx, typeAnnotation: typeAnnotation{typ: typ}}
+}
+
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(ctx *FmtCtx) {
 	if ctx.placeholderFormat != nil {

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -773,6 +773,10 @@ message LocalOnlySessionData {
   // OptimizerInlineAnyUnnestSubquery, when true, enables the InlineAnyProjectSet
   // normalization rule that inlines unnest subqueries in ANY comparisons.
   bool optimizer_inline_any_unnest_subquery = 198;
+  // OptimizerBuildRoutineParamsAsPlaceholders, when true, instructs the
+  // optimizer to build routine parameters as placeholders instead of outer
+  // columns.
+  bool optimizer_build_routine_params_as_placeholders = 199;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1115,6 +1115,10 @@ func (m *SessionDataMutator) SetUseImprovedRoutineDepsTriggersAndComputedCols(va
 	m.Data.UseImprovedRoutineDepsTriggersAndComputedCols = val
 }
 
+func (m *SessionDataMutator) SetOptimizerBuildRoutineParamsAsPlaceholders(val bool) {
+	m.Data.OptimizerBuildRoutineParamsAsPlaceholders = val
+}
+
 func (m *SessionDataMutator) SetDistSQLPreventPartitioningSoftLimitedScans(val bool) {
 	m.Data.DistSQLPreventPartitioningSoftLimitedScans = val
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4564,6 +4564,25 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_build_routine_params_as_placeholders`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_build_routine_params_as_placeholders`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_build_routine_params_as_placeholders", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerBuildRoutineParamsAsPlaceholders(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerBuildRoutineParamsAsPlaceholders,
+			), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### sql: add optimizer_build_routine_params_as_placeholders

The `optimizer_build_routine_params_as_placeholders` session setting has
been added. It currently has no effect on any behavior. It will be fully
implemented in a future commit.

Release note: None

#### opt: build routine parameter references as placeholders

Routine parameter references are now built as placeholder instead of
column variables. This more closely matches their behavior - within
a single execution of a routine, they have a constant value. It also
prevents poorly optimizing statments within routines. For example,
it prevents decorrelation rules from pulling filters with parameters
above joins, which can cause suboptimal plans.

This behavior can be reverted by disabling
`optimizer_build_routine_params_as_placeholders`.

Fixes #157840

Release note (performance improvement): The optimizer now produces
better query plans for statements within UDFs and stored procedures.
