### PR TITLE
release-25.3: sqlccl: ignore another known error in TestExplainGist

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -202,6 +202,7 @@ func TestExplainGist(t *testing.T) {
 					"expected equivalence dependants to be its closure",                  // #119045
 					"type check failed while initializing stat",                          // #125620
 					"argument expression has type RECORD, need type USER DEFINED RECORD", // #139910
+					"invalid datum type given: RECORD, expected RECORD",                  // #140773
 					"not in index", // #148405
 				} {
 					if strings.Contains(err.Error(), knownErr) {


### PR DESCRIPTION
Backport 1/1 commits from #158210 on behalf of @yuzefovich.

----

Informs: #140773
Epic: None
Release note: None

----

Release justification: test-only change.