### PR TITLE
release-25.2: sqlstats: don't buffer stmt stats if setting is disabled 

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -587,6 +587,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 
 		for _, txn := range simulatedTxns {
 			// Collect stats for the simulated transaction.
+			statsCollector.StartTransaction()
 			txnFingerprintIDHash := util.MakeFNV64()
 			for _, fingerprint := range txn.stmtFingerprints {
 				stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(fingerprint, false, "defaultdb")


### PR DESCRIPTION
Previously, if `sql.metrics.statement_details.enabled` cluster setting is set to `false`, we would still keep on buffering the stmt stats until the txn ends, only to simply discard whatever we have buffered. This commit makes it so that when the txn begins, we check the cluster setting to see whether buffering stmt stats makes sense.

Note that the insights ingester already is disabled whenever either the stmt details or the txn details setting is disabled, and on 25.4 we've refactored the logic so that sql stats share the ingestion pipeline with insights. This commit bring 25.2 closer to that state but also allows us to mitigate pathological memory usage with extremely large txns (those that execute 100k+ statements).

There could be more cleanup done around this, but this is the most targetted fix I could think of.

Epic: None
Release note: None
Release justification: low-risk stability improvement.