### PR TITLE
release-25.3: sql: TestExplainGist ignore DROP COLUMN flakes

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -210,6 +210,17 @@ func TestExplainGist(t *testing.T) {
 						return
 					}
 				}
+				// Check for declarative schema changer errors.
+				for _, stmtAndError := range []struct {
+					stmt string
+					err  string
+				}{
+					{"DROP COLUMN", "ALTER TABLE: unable to make progress"}, // #152841
+				} {
+					if strings.Contains(err.Error(), stmtAndError.err) && strings.Contains(stmt, stmtAndError.stmt) {
+						return
+					}
+				}
 				t.Log(stmts.String())
 				t.Fatalf("%v:\n%s;", err, stmt)
 			}


### PR DESCRIPTION
Previously, the test TestExplainGist could flake if we ran a DROP COLUMN on a column referenced by a stored expression. This was due to a bug in our schema changer rules. Since the rule change it self is not safe to backport, we are going to limit flakes by ignore this error in TestExplainGist.

Fixes: #139328

Release note: None
Release justification: test only change