### PR TITLE
execinfrapb: fix protobuf warning

### DIFF
--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -591,9 +591,9 @@ message BulkMergeSpec {
 	message SST {
 		optional string uri = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "URI"];
 		// start_key is the first key in the SST.
-		optional bytes start_key = 2 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+		optional bytes start_key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 		// end_key is the last key in the SST.
-		optional bytes end_key = 3 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+		optional bytes end_key = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 	}
 
 	// ssts is the list of input SSTs to merge.


### PR DESCRIPTION
Fix "is a non-nullable bytes type, nullable=false has no effect" warning in recently added protobuf.

Epic: None
Release note: None