### PR TITLE
asim: improve ability to specify store liveness and node membership

### DIFF
--- a/pkg/kv/kvserver/asim/event/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/event/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/history",
         "//pkg/kv/kvserver/asim/state",
-        "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/asim/event/event.go
+++ b/pkg/kv/kvserver/asim/event/event.go
@@ -16,7 +16,7 @@ import (
 
 // Event outlines the necessary behaviours that event structs must implement.
 // Some key implementations of the interface includes assertionEvent,
-// SetSpanConfigEvent, AddNodeEvent, SetNodeLivenessEvent,
+// SetSpanConfigEvent, AddNodeEvent, SetNodeStatusEvent,
 // SetCapacityOverrideEvent.
 type Event interface {
 	// Func returns a closure associated with event which could be an assertion

--- a/pkg/kv/kvserver/asim/state/liveness.go
+++ b/pkg/kv/kvserver/asim/state/liveness.go
@@ -14,83 +14,126 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-// MockNodeLiveness is responsible for tracking the liveness status of nodes
-// without the need for real heartbeating. Instead, this mock implementation
-// manages the statuses of all nodes by manually updating and accessing the
-// internal map. It implements the NodeVitalityInterface to enable the
-// SpanConfigConformance reporter to call it. Thus, we only expect calls to the
-// ScanNodeVitalityFromCache function.
-type MockNodeLiveness struct {
-	clock     *hlc.Clock
-	statusMap map[NodeID]livenesspb.NodeLivenessStatus
+// LivenessState represents the liveness of a store.
+// They are ordered from best (healthy) to worst.
+type LivenessState byte
+
+const (
+	// LivenessLive means the store is alive and healthy.
+	LivenessLive LivenessState = iota
+	// LivenessUnavailable means the store is recently down but not yet marked dead.
+	LivenessUnavailable
+	// LivenessDead means the store has been down long enough to be considered dead.
+	LivenessDead
+)
+
+// StoreStatus represents the status of a store in the simulation. For MMA,
+// liveness is tracked per-store and to support this, asim does as well.
+// Whenever we simulate the single-metric allocator, it sees a node as live if
+// all of its stores are live, i.e. we make the assumption that an unhealthy
+// store would also render the node unhealthy (to sma). This should generally
+// hold in practice (for example, liveness heartbeats synchronously write to all
+// engines).
+type StoreStatus struct {
+	Liveness LivenessState
 }
 
-var _ livenesspb.NodeVitalityInterface = &MockNodeLiveness{}
-
-func (m MockNodeLiveness) GetNodeVitalityFromCache(roachpb.NodeID) livenesspb.NodeVitality {
-	panic("GetNodeVitalityFromCache is not expected to be called on MockNodeLiveness")
+// NodeStatus represents the status of a node in the simulation. This holds
+// signals that are genuinely per-node: membership and draining.
+type NodeStatus struct {
+	Membership livenesspb.MembershipStatus
+	Draining   bool
 }
 
-func (m MockNodeLiveness) ScanNodeVitalityFromKV(
+// StatusTracker is responsible for tracking the liveness status of stores
+// and the membership/draining status of nodes without real heartbeating.
+// It implements the NodeVitalityInterface to enable the SpanConfigConformance
+// reporter to call it.
+//
+// Liveness is tracked per-store (for MMA). When SMA needs node-level liveness,
+// it is aggregated from the stores: the node takes the "worst" liveness state
+// of any of its stores.
+type StatusTracker struct {
+	clock          *hlc.Clock
+	storeStatusMap map[StoreID]StoreStatus
+	nodeStatusMap  map[NodeID]NodeStatus
+	// storeToNode maps each store to its node for aggregation.
+	storeToNode map[StoreID]NodeID
+}
+
+var _ livenesspb.NodeVitalityInterface = &StatusTracker{}
+
+// registerStore registers a new store with its node mapping and initializes it as live.
+func (st *StatusTracker) registerStore(storeID StoreID, nodeID NodeID) {
+	st.storeStatusMap[storeID] = StoreStatus{Liveness: LivenessLive}
+	st.storeToNode[storeID] = nodeID
+}
+
+func (st StatusTracker) GetNodeVitalityFromCache(roachpb.NodeID) livenesspb.NodeVitality {
+	panic("GetNodeVitalityFromCache is not expected to be called on StatusTracker")
+}
+
+func (st StatusTracker) ScanNodeVitalityFromKV(
 	context.Context,
 ) (livenesspb.NodeVitalityMap, error) {
-	panic("ScanNodeVitalityFromKV is not expected to be called on MockNodeLiveness")
+	panic("ScanNodeVitalityFromKV is not expected to be called on StatusTracker")
 }
 
-// convertNodeStatusToNodeVitality constructs a node vitality in a manner that
-// respects all node liveness status properties. The node vitality record for
-// nodes in different states are set as follows:
-// timeUntilNodeDead = time.Minute
-// - unknown: invalid NodeVitality
-// - live, decommissioning: expirationWallTime = MaxTimeStamp - timeUntilNodeDead
-// - unavailable: expirationWallTime = now - time.Second
-// - dead, decommissioned: expirationWallTime = 0
+// worstLivenessForStoresOnNode returns the "worst" liveness state across all
+// stores on a node. The ordering is: Dead is worse than Unavailable is worse
+// than Live.
+func (st StatusTracker) worstLivenessForStoresOnNode(nodeID NodeID) LivenessState {
+	worst := LivenessLive
+	for storeID, ss := range st.storeStatusMap {
+		if st.storeToNode[storeID] == nodeID {
+			worst = max(worst, ss.Liveness)
+		}
+	}
+	return worst
+}
+
+// convertToNodeVitality constructs a NodeVitality for a node by combining
+// store-level liveness (aggregated) with node-level membership and draining.
 //
-// Explanation: refer to liveness.LivenessStatus for an overview of the states a
-// liveness record goes through.
+// This is used by the old allocator (SMA) which operates on nodes. MMA uses
+// store-level liveness directly and doesn't need NodeVitality.
 //
-// - live, decommissioning: set liveness expiration to be in the
-// future(MaxTimestamp) and minus timeUntilNodeDead to avoid overflow in
-// liveness status check tExp+timeUntilNodeDead.
-// - unavailable: set liveness expiration to be just recently expired. This
-// needs to be within now - timeUntilNodeDead <= expirationWallTime < now so
-// that the status is not dead nor alive.
-// - dead, decommissioned: set liveness expiration to be in the
-// past(MinTimestamp).
-func convertNodeStatusToNodeVitality(
-	nid roachpb.NodeID, status livenesspb.NodeLivenessStatus, now hlc.Timestamp,
+// The liveness affects the expiration timestamp:
+//   - live: expiration far in the future (node passes isAlive checks)
+//   - unavailable: expiration just recently passed (node is unavailable but not dead)
+//   - dead: expiration far in the past (node fails isAlive checks)
+//
+// timeUntilNodeDead is set to 1 minute.
+func (st StatusTracker) convertToNodeVitality(
+	nodeID NodeID, now hlc.Timestamp,
 ) livenesspb.NodeVitality {
 	const timeUntilNodeDead = time.Minute
 	var liveTs = hlc.MaxTimestamp.AddDuration(-timeUntilNodeDead).ToLegacyTimestamp()
-	var deadTs = hlc.MinTimestamp.ToLegacyTimestamp()
 	var unavailableTs = now.AddDuration(-time.Second).ToLegacyTimestamp()
+	var deadTs = hlc.MinTimestamp.ToLegacyTimestamp()
+
+	ns := st.nodeStatusMap[nodeID]
+	liveness := st.worstLivenessForStoresOnNode(nodeID)
+
+	nid := roachpb.NodeID(nodeID)
 	l := livenesspb.Liveness{
 		NodeID:     nid,
-		Draining:   false,
 		Epoch:      1,
-		Membership: livenesspb.MembershipStatus_ACTIVE,
+		Membership: ns.Membership,
+		Draining:   ns.Draining,
 	}
-	switch status {
-	case livenesspb.NodeLivenessStatus_UNKNOWN:
-		return livenesspb.NodeVitality{}
-	case livenesspb.NodeLivenessStatus_DEAD:
-		l.Expiration = deadTs
-	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
+
+	switch liveness {
+	case LivenessLive:
+		l.Expiration = liveTs
+	case LivenessUnavailable:
 		l.Expiration = unavailableTs
-	case livenesspb.NodeLivenessStatus_LIVE:
-		l.Expiration = liveTs
-	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
-		l.Expiration = liveTs
-		l.Membership = livenesspb.MembershipStatus_DECOMMISSIONING
-	case livenesspb.NodeLivenessStatus_DECOMMISSIONED:
+	case LivenessDead:
 		l.Expiration = deadTs
-		l.Membership = livenesspb.MembershipStatus_DECOMMISSIONED
-	case livenesspb.NodeLivenessStatus_DRAINING:
-		l.Expiration = liveTs
-		l.Draining = true
 	}
+
 	ncs := livenesspb.NewNodeConnectionStatus(nid, nil)
-	ncs.SetIsConnected(true)
+	ncs.SetIsConnected(liveness == LivenessLive)
 	entry := l.CreateNodeVitality(
 		now,               /* now */
 		hlc.Timestamp{},   /* descUpdateTime */
@@ -102,12 +145,12 @@ func convertNodeStatusToNodeVitality(
 	return entry
 }
 
-func (m MockNodeLiveness) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
+func (st StatusTracker) ScanNodeVitalityFromCache() livenesspb.NodeVitalityMap {
 	isLiveMap := livenesspb.NodeVitalityMap{}
-	for nodeID, status := range m.statusMap {
+	now := st.clock.Now()
+	for nodeID := range st.nodeStatusMap {
 		nid := roachpb.NodeID(nodeID)
-		now := m.clock.Now()
-		isLiveMap[nid] = convertNodeStatusToNodeVitality(nid, status, now)
+		isLiveMap[nid] = st.convertToNodeVitality(nodeID, now)
 	}
 	return isLiveMap
 }

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/mmaintegration"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -163,11 +162,21 @@ type State interface {
 	// NextReplicasFn returns a function, that when called will return the current
 	// replicas that exist on the store.
 	NextReplicasFn(StoreID) func() []Replica
-	// SetNodeLiveness sets the liveness status of the node with ID NodeID to be
-	// the status given.
-	SetNodeLiveness(NodeID, livenesspb.NodeLivenessStatus)
+	// SetStoreStatus sets the liveness for a store directly.
+	SetStoreStatus(storeID StoreID, status StoreStatus)
+	// StoreStatus returns the liveness status for a store.
+	StoreStatus(StoreID) StoreStatus
+	// SetNodeStatus sets the membership and draining signals for a node.
+	SetNodeStatus(nodeID NodeID, status NodeStatus)
+	// NodeStatus returns the membership and draining signals for a node.
+	NodeStatus(NodeID) NodeStatus
+	// SetAllStoresLiveness sets the liveness for all stores on a node at once.
+	// This is useful for DSL commands that operate at the node level.
+	SetAllStoresLiveness(nodeID NodeID, liveness LivenessState)
 	// NodeLivenessFn returns a function, that when called will return the
 	// liveness of the Node with ID NodeID.
+	// This is used by the store pool, which is used only by the single-metric
+	// allocator (not mma).
 	// TODO(kvoli): Find a better home for this method, required by the
 	// storepool.
 	NodeLivenessFn() storepool.NodeLivenessFunc

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/decommission_conformance.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/decommission_conformance.txt
@@ -20,7 +20,7 @@ set_span_config delay=5m
 [0,10000): num_replicas=3 constraints={'+region=a':1,'+region=b':1,'+region=c':1}
 ----
 
-set_liveness node=4 liveness=decommissioning delay=5m
+set_status node=4 membership=decommissioning delay=5m
 ----
 
 assertion type=conformance under=0 over=0 unavailable=0 violating=0

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/downreplicate_recently_down_node_issue152604.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/downreplicate_recently_down_node_issue152604.txt
@@ -14,14 +14,13 @@ gen_cluster nodes=5
 gen_ranges ranges=100 repl_factor=5 min_key=1 max_key=10000
 ----
 
-# Mark n4 and n5 as NodeLivenessStatus_UNAVAILABLE, which is the status
-# stores have when down but not down for long enough to be marked as dead.
-# The range doesn't lose quorum as a result of this, since three replicas
-# are still around.
-set_liveness node=4 liveness=unavailable
+# Mark n4 and n5 as unavailable, which is the status stores have when down
+# but not down for long enough to be marked as dead. The range doesn't lose
+# quorum as a result of this, since three replicas are still around.
+set_status node=4 liveness=unavailable
 ----
 
-set_liveness node=5 liveness=unavailable
+set_status node=5 liveness=unavailable
 ----
 
 # Trigger down-replication to three replicas.

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/liveness.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/sma/liveness.txt
@@ -17,12 +17,12 @@ gen_ranges ranges=700
 
 # n7 is dead and remains dead forever. It will still have its initial (3000)
 # replicas.
-set_liveness node=7 liveness=dead
+set_status node=7 liveness=dead
 ----
 
 # n6 becomes decommissioning after 3 minutes and remains decommissioning
 # thereafter.
-set_liveness node=6 liveness=decommissioning delay=3m
+set_status node=6 membership=decommissioning delay=3m
 ----
 
 # The number of replicas on the dead and decommissioning stores should be 0,


### PR DESCRIPTION
When determining which stores/nodes are fit for being considered as sources and/or targets, we have to consider the two dimensions of liveness (is the process likely running?) and membership/operator intent (is this store decommissioning or draining?).

The current asim model models health as a LivenessStatus, which is a single flat enum value. However, both the single-metric and multi-metric allocators in production can draw from a richer tapestry of signals. For example, #155734 sees the single-metric allocator make poor rebalancing decisions that hinge on the fact that it can consider a node "decommissioning" in one place but "unavailable" in another. We couldn't reproduce that particular issue in asim because the liveness status would "force" the single-metric allocator to consistently observe either of the two values - something that can be different in production code.

Independently but relatedly, we are also working on adding liveness/status responsivity to the multi-metric allocator (#156776). We are careful to avoid some of the poor behaviors of the single-metric allocator, but similarly, we want to be able to exercise both decommissioning live and decommissioning dead nodes, not to mention that mma will reason about liveness at a store level.

All of this suggested a reworking of how asim models liveness and operator intent. In fact, I ended up in this refactor after having implemented the health/status "plumbing" for the multi metric allocator and realizing that we'd need to make changes such as the ones presented here to meaningfully simulation test mma in the presence of interesting liveness/status combinations.

The re-working ended up being fairly intense, but I really like where it gets us. We no longer model liveness using a LivenessStatus enum value. Instead, we have asim-attached types StoreStatus and NodeStatus that cleanly track liveness (for a store) and membership/draining status (which are node-level concepts today) and the DSL commands reflect this - we can set individual stores as live/dead, we can set nodes as decommissioning, et cetera.

The single-metric allocator now receives signals that closely match what it would in production. It is now possible to specify a situation in which a store is decommissioning but also recently became non-live (which is what was required to simulate #155734). These signals originate in our clean new structs, from which we can (without bending over backwards) construct "NodeVitality" objects, which is what is required.

As a reminder, the multi-metric allocator doesn't react to health signals at all yet, so it hasn't been hooked up to anything. This will be done in a separate PR that also adds logic to mma that puts these signals to use.

Informs #156776.

Epic: CRDB-55052