### PR TITLE
roachprod/cli: add disk-stall chaos command with cgroup support

### DIFF
--- a/pkg/cmd/roachprod/cli/BUILD.bazel
+++ b/pkg/cmd/roachprod/cli/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bash_completion.go",
         "chaos.go",
+        "chaos_disk.go",
         "chaos_network.go",
         "commands.go",
         "flags.go",

--- a/pkg/cmd/roachprod/cli/chaos.go
+++ b/pkg/cmd/roachprod/cli/chaos.go
@@ -121,6 +121,7 @@ Default: all`)
 	// Add subcommands
 	chaosCmd.AddCommand(cr.buildChaosNetworkPartitionCmd())
 	chaosCmd.AddCommand(cr.buildChaosNetworkLatencyCmd())
+	chaosCmd.AddCommand(cr.buildChaosDiskStallCmd())
 
 	return chaosCmd
 }

--- a/pkg/cmd/roachprod/cli/chaos.go
+++ b/pkg/cmd/roachprod/cli/chaos.go
@@ -38,6 +38,8 @@ const (
 	StageRecover FailureStage = "recover"
 	// StageCleanup runs only the cleanup phase
 	StageCleanup FailureStage = "cleanup"
+	// StageInjectRecover runs inject, waits, then recovers (without setup/cleanup)
+	StageInjectRecover FailureStage = "inject-recover"
 )
 
 // ValidStages returns all valid lifecycle stage values for a failure
@@ -48,6 +50,7 @@ func ValidStages() []string {
 		string(StageInject),
 		string(StageRecover),
 		string(StageCleanup),
+		string(StageInjectRecover),
 	}
 }
 
@@ -113,6 +116,7 @@ Global flags control the duration and cleanup behavior of all chaos commands.
   - inject: runs only the inject phase (activates the failure)
   - recover: runs only the recover phase (removes the failure)
   - cleanup: runs only the cleanup phase (removes failure dependencies)
+  - inject-recover: runs inject, waits for --wait-before-cleanup or --run-forever, then recovers
 Default: all`)
 	chaosCmd.PersistentFlags().BoolVar(&verbose,
 		"verbose", false,
@@ -230,6 +234,8 @@ func runFailureLifecycle(
 		return runRecoverStage(ctx, failer, args)
 	case StageCleanup:
 		return runCleanupStage(ctx, failer, args)
+	case StageInjectRecover:
+		return runInjectRecoverStage(ctx, failer, args, opts)
 	case StageAll:
 		return runFullLifecycle(ctx, failer, args, opts)
 	default:
@@ -300,6 +306,29 @@ func runCleanupStage(
 	return nil
 }
 
+// runInjectRecoverStage runs inject, waits for the configured duration or interrupt,
+// then recovers. This is useful when setup has already been run separately and cleanup
+// will be run separately afterward.
+func runInjectRecoverStage(
+	ctx context.Context, failer *failures.Failer, args failures.FailureArgs, opts GlobalChaosOpts,
+) error {
+	// Inject phase
+	if err := runInjectStage(ctx, failer, args); err != nil {
+		return err
+	}
+
+	// Wait phase
+	waitForDurationOrInterrupt(opts)
+
+	// Recover phase
+	if err := runRecoverStage(ctx, failer, args); err != nil {
+		return err
+	}
+
+	config.Logger.Printf("Inject-recover stage completed successfully")
+	return nil
+}
+
 // runFullLifecycle executes the complete failure lifecycle:
 // Setup → Inject → Wait → Recover → Cleanup
 func runFullLifecycle(
@@ -327,19 +356,7 @@ func runFullLifecycle(
 	}
 
 	// Wait phase
-	if opts.RunForever {
-		config.Logger.Printf("Failure injected. Waiting for interrupt (Ctrl+C)...")
-		<-waitForInterrupt()
-		config.Logger.Printf("Interrupt received. Beginning recovery...")
-	} else {
-		config.Logger.Printf("Failure injected. Waiting %s before recovery...", opts.WaitBeforeCleanup)
-		select {
-		case <-time.After(opts.WaitBeforeCleanup):
-			config.Logger.Printf("Wait period complete. Beginning recovery...")
-		case <-waitForInterrupt():
-			config.Logger.Printf("Interrupt received. Beginning recovery...")
-		}
-	}
+	waitForDurationOrInterrupt(opts)
 
 	// Recover phase
 	if err := runRecoverStage(ctx, failer, args); err != nil {
@@ -354,6 +371,24 @@ func runFullLifecycle(
 	cleanupDone = true
 	config.Logger.Printf("Failure lifecycle completed successfully")
 	return nil
+}
+
+// waitForDurationOrInterrupt waits for the configured duration or until an interrupt signal
+// is received, whichever comes first. If RunForever is set, it waits indefinitely until interrupted.
+func waitForDurationOrInterrupt(opts GlobalChaosOpts) {
+	if opts.RunForever {
+		config.Logger.Printf("Failure injected. Waiting for interrupt (Ctrl+C)...")
+		<-waitForInterrupt()
+		config.Logger.Printf("Interrupt received. Beginning recovery...")
+	} else {
+		config.Logger.Printf("Failure injected. Waiting %s before recovery...", opts.WaitBeforeCleanup)
+		select {
+		case <-time.After(opts.WaitBeforeCleanup):
+			config.Logger.Printf("Wait period complete. Beginning recovery...")
+		case <-waitForInterrupt():
+			config.Logger.Printf("Interrupt received. Beginning recovery...")
+		}
+	}
 }
 
 // waitForInterrupt returns a channel that receives a signal when SIGINT or SIGTERM is received

--- a/pkg/cmd/roachprod/cli/chaos_disk.go
+++ b/pkg/cmd/roachprod/cli/chaos_disk.go
@@ -20,27 +20,33 @@ func (cr *commandRegistry) buildChaosDiskStallCmd() *cobra.Command {
 	var nodes []int32
 	var stallType string
 	var restartNodes bool
-	var cycle bool
+	var cycle, skipFailurePropagation bool
 	var cycleStallDuration, cycleUnstallDuration time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "disk-stall <cluster>",
 		Short: "Injects disk stalls to test storage resilience",
-		Long: `Injects disk stalls using cgroup to throttle disk I/O.
+		Long: `Injects disk stalls to test storage resilience.
 
-Disk stall type:
-  cgroup: Uses cgroups v2 to throttle disk I/O operations
+Disk stall types:
+  cgroup:  Uses cgroups v2 to throttle disk I/O operations.
+           Supports partial throttling and selective stalling
+           (reads only, writes only, or including logs).
 
-By default, cgroup stalls write operations completely. This simulates scenarios where
-the disk becomes slow or unresponsive, allowing you to test how CockroachDB handles
-degraded storage performance.
+  dmsetup: Uses device-mapper linear target with suspend/resume.
+           Completely freezes All disk I/O (reads and writes).
+           Requires node restart during setup to disable filesystem journaling.
+           More closely simulates a hardware disk failure.
 
-The stall can be temporary (default 5 minutes) or you can use --run-forever to keep
-it active until manually stopped with Ctrl+C.
+By default, stalls are maintained for 5 minutes. Use --run-forever to keep
+the stall active until manually stopped with Ctrl+C.
 
 Examples:
-  # Stall disk I/O on nodes 1,2,3 for 5 minutes (default)
+  # Stall disk writes on nodes 1,2,3 using cgroup
   roachprod chaos disk-stall mycluster --type cgroup --nodes 1,2,3
+
+  # Completely freeze disk I/O using dmsetup (simulates hardware failure)
+  roachprod chaos disk-stall mycluster --type dmsetup --nodes 1,2
 
   # Cycle stalling on/off with custom durations
   roachprod chaos disk-stall mycluster --type cgroup --nodes 1 \
@@ -52,8 +58,8 @@ Examples:
   # Stall for 15 minutes before recovery
   roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --wait-before-cleanup 15m
 
-	# Stall for 30s before recovery on an insecure cluster
-	roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --wait-before-cleanup 30s --insecure
+  # dmsetup stall on an insecure cluster
+  roachprod chaos disk-stall mycluster --type dmsetup --nodes 1 --wait-before-cleanup 30s --insecure
 `,
 		Args: cobra.ExactArgs(1),
 		Run: Wrap(func(cmd *cobra.Command, args []string) error {
@@ -74,21 +80,38 @@ Examples:
 				// - StallLogs (default: false)
 				// - Throughput (default: 0 = full stall, can be 2+ for throttling)
 				failureArgs = failures.DiskStallArgs{
-					StallReads:           false,
-					StallWrites:          true,
-					StallLogs:            false,
-					Throughput:           0, // Full stall
-					RestartNodes:         restartNodes,
-					Nodes:                nodeList,
-					Cycle:                cycle,
-					CycleStallDuration:   cycleStallDuration,
-					CycleUnstallDuration: cycleUnstallDuration,
+					StallReads:             false,
+					StallWrites:            true,
+					StallLogs:              false,
+					Throughput:             0, // Full stall
+					RestartNodes:           restartNodes,
+					Nodes:                  nodeList,
+					Cycle:                  cycle,
+					CycleStallDuration:     cycleStallDuration,
+					CycleUnstallDuration:   cycleUnstallDuration,
+					SkipFailurePropagation: true,
 				}
 				config.Logger.Printf("Stalling disk I/O on nodes %s using cgroup",
 					formatNodeList(nodeList))
 
+			case "dmsetup":
+				failureName = failures.DmsetupDiskStallName
+				// Dmsetup freezes all I/O completely - no granular control like cgroup.
+				// It suspends the device-mapper target, blocking all reads and writes.
+				failureArgs = failures.DiskStallArgs{
+					StallWrites:            true, // Always true for dmsetup (stalls everything)
+					RestartNodes:           restartNodes,
+					Nodes:                  nodeList,
+					Cycle:                  cycle,
+					CycleStallDuration:     cycleStallDuration,
+					CycleUnstallDuration:   cycleUnstallDuration,
+					SkipFailurePropagation: skipFailurePropagation,
+				}
+				config.Logger.Printf("Stalling disk I/O on nodes %s using dmsetup device-mapper",
+					formatNodeList(nodeList))
+
 			default:
-				return errors.Newf("--type must be 'cgroup', got: %s", stallType)
+				return errors.Newf("--type must be 'cgroup' or 'dmsetup', got: %s", stallType)
 			}
 
 			opts, err := getGlobalChaosOpts()
@@ -119,7 +142,7 @@ Examples:
 	cmd.Flags().Int32SliceVarP(&nodes, "nodes", "n", nil,
 		"nodes on which to inject the disk stall")
 	cmd.Flags().StringVar(&stallType, "type", "",
-		"disk staller type: cgroup (uses cgroups v2 to throttle I/O)")
+		"disk staller type: cgroup (throttles I/O via cgroups v2) or dmsetup (freezes I/O via device-mapper)")
 	cmd.Flags().BoolVar(&restartNodes, "restart-nodes", true,
 		"allow the failure mode to restart nodes as needed")
 	cmd.Flags().BoolVar(&cycle, "cycle", false,
@@ -128,6 +151,8 @@ Examples:
 		"duration of each stall cycle")
 	cmd.Flags().DurationVar(&cycleUnstallDuration, "cycle-unstall-duration", 5*time.Second,
 		"duration of each unstall cycle")
+	cmd.Flags().BoolVar(&skipFailurePropagation, "skip-failure-propagation", true,
+		"skip waiting for node unavailability after inject")
 
 	_ = cmd.MarkFlagRequired("nodes")
 	_ = cmd.MarkFlagRequired("type")

--- a/pkg/cmd/roachprod/cli/chaos_disk.go
+++ b/pkg/cmd/roachprod/cli/chaos_disk.go
@@ -1,0 +1,137 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// buildChaosDiskStallCmd creates the disk-stall chaos command
+func (cr *commandRegistry) buildChaosDiskStallCmd() *cobra.Command {
+	var nodes []int32
+	var stallType string
+	var restartNodes bool
+	var cycle bool
+	var cycleStallDuration, cycleUnstallDuration time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "disk-stall <cluster>",
+		Short: "Injects disk stalls to test storage resilience",
+		Long: `Injects disk stalls using cgroup to throttle disk I/O.
+
+Disk stall type:
+  cgroup: Uses cgroups v2 to throttle disk I/O operations
+
+By default, cgroup stalls write operations completely. This simulates scenarios where
+the disk becomes slow or unresponsive, allowing you to test how CockroachDB handles
+degraded storage performance.
+
+The stall can be temporary (default 5 minutes) or you can use --run-forever to keep
+it active until manually stopped with Ctrl+C.
+
+Examples:
+  # Stall disk I/O on nodes 1,2,3 for 5 minutes (default)
+  roachprod chaos disk-stall mycluster --type cgroup --nodes 1,2,3
+
+  # Cycle stalling on/off with custom durations
+  roachprod chaos disk-stall mycluster --type cgroup --nodes 1 \
+    --cycle --cycle-stall-duration 10s --cycle-unstall-duration 5s
+
+  # Stall until manually interrupted
+  roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --run-forever
+
+  # Stall for 15 minutes before recovery
+  roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --wait-before-cleanup 15m
+
+	# Stall for 30s before recovery on an insecure cluster
+	roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --wait-before-cleanup 30s --insecure
+`,
+		Args: cobra.ExactArgs(1),
+		Run: Wrap(func(cmd *cobra.Command, args []string) error {
+			clusterName := args[0]
+			nodeList := parseInt32SliceToNodes(nodes)
+
+			// Validate type
+			var failureName string
+			var failureArgs failures.DiskStallArgs
+
+			switch stallType {
+			case "cgroup":
+				failureName = failures.CgroupsDiskStallName
+				// Cgroup defaults: stall writes completely
+				// These can be exposed as flags in the future:
+				// - StallReads (default: false)
+				// - StallWrites (default: true)
+				// - StallLogs (default: false)
+				// - Throughput (default: 0 = full stall, can be 2+ for throttling)
+				failureArgs = failures.DiskStallArgs{
+					StallReads:           false,
+					StallWrites:          true,
+					StallLogs:            false,
+					Throughput:           0, // Full stall
+					RestartNodes:         restartNodes,
+					Nodes:                nodeList,
+					Cycle:                cycle,
+					CycleStallDuration:   cycleStallDuration,
+					CycleUnstallDuration: cycleUnstallDuration,
+				}
+				config.Logger.Printf("Stalling disk I/O on nodes %s using cgroup",
+					formatNodeList(nodeList))
+
+			default:
+				return errors.Newf("--type must be 'cgroup', got: %s", stallType)
+			}
+
+			opts, err := getGlobalChaosOpts()
+			if err != nil {
+				return err
+			}
+
+			// Create failer from registry
+			failer, err := createFailer(
+				clusterName,
+				failureName,
+				opts,
+				getClusterOptions()...,
+			)
+			if err != nil {
+				return err
+			}
+
+			return runFailureLifecycle(
+				context.Background(),
+				failer,
+				failureArgs,
+				opts,
+			)
+		}),
+	}
+
+	cmd.Flags().Int32SliceVarP(&nodes, "nodes", "n", nil,
+		"nodes on which to inject the disk stall")
+	cmd.Flags().StringVar(&stallType, "type", "",
+		"disk staller type: cgroup (uses cgroups v2 to throttle I/O)")
+	cmd.Flags().BoolVar(&restartNodes, "restart-nodes", true,
+		"allow the failure mode to restart nodes as needed")
+	cmd.Flags().BoolVar(&cycle, "cycle", false,
+		"repeatedly stall and unstall the disk until recovery")
+	cmd.Flags().DurationVar(&cycleStallDuration, "cycle-stall-duration", 5*time.Second,
+		"duration of each stall cycle")
+	cmd.Flags().DurationVar(&cycleUnstallDuration, "cycle-unstall-duration", 5*time.Second,
+		"duration of each unstall cycle")
+
+	_ = cmd.MarkFlagRequired("nodes")
+	_ = cmd.MarkFlagRequired("type")
+	initFlagInsecureForCmd(cmd)
+
+	return cmd
+}

--- a/pkg/roachprod/failureinjection/failures/disk_stall.go
+++ b/pkg/roachprod/failureinjection/failures/disk_stall.go
@@ -70,6 +70,10 @@ type DiskStallArgs struct {
 	Cycle                bool
 	CycleStallDuration   time.Duration
 	CycleUnstallDuration time.Duration
+	// If true, WaitForFailureToPropagate becomes a no-op. This is useful for:
+	// - Multi-store clusters with WAL failover enabled, where the cluster continues
+	//   operating normally during a disk stall on a single store.
+	SkipFailurePropagation bool
 }
 
 func (s *CGroupDiskStaller) Description() string {
@@ -294,6 +298,9 @@ func (s *CGroupDiskStaller) WaitForFailureToPropagate(
 	if args.(DiskStallArgs).Cycle {
 		l.Printf("Stall cycle is enabled, skipping WaitForFailureToPropagate")
 		return nil
+	} else if args.(DiskStallArgs).SkipFailurePropagation {
+		l.Printf("SkipFailurePropagation set true, skipping WaitForFailureToPropagate")
+		return nil
 	}
 
 	diskStallArgs := args.(DiskStallArgs)
@@ -408,6 +415,9 @@ const (
 	DmsetupDiskStallName = "dmsetup-disk-stall"
 	dmsetupStallCmd      = "sudo dmsetup suspend --noflush --nolockfs data1"
 	dmsetupUnstallCmd    = "sudo dmsetup resume data1"
+	// dmsetupStateFile stores the original disk device name so cleanup can find it
+	// even when running as a separate stage after setup has modified the mount.
+	dmsetupStateFile = "/tmp/dmsetup-disk-stall-device"
 )
 
 type DmsetupDiskStaller struct {
@@ -436,6 +446,38 @@ func (s *DmsetupDiskStaller) Description() string {
 	return "dmsetup disk staller"
 }
 
+// getStoredDeviceName reads the device name from the state file saved during setup.
+// This allows cleanup to find the original device even when running as a separate stage.
+func (s *DmsetupDiskStaller) getStoredDeviceName(
+	ctx context.Context, l *logger.Logger,
+) (string, error) {
+	res, err := s.RunWithDetails(ctx, l, s.c.Nodes[:1], fmt.Sprintf("cat %s 2>/dev/null", dmsetupStateFile))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read stored device name")
+	}
+	dev := strings.TrimSpace(res.Stdout)
+	if dev == "" {
+		return "", errors.New("no stored device name found; run setup stage first")
+	}
+	return dev, nil
+}
+
+// getOrStoreDeviceName gets the disk device name, storing it to the state file if not already stored.
+// This is used during setup to persist the device name for later stages.
+func (s *DmsetupDiskStaller) getOrStoreDeviceName(
+	ctx context.Context, l *logger.Logger,
+) (string, error) {
+	dev, err := s.DiskDeviceName(ctx, l)
+	if err != nil {
+		return "", err
+	}
+	// Save the device name for later use by cleanup when running stages independently.
+	if err = s.Run(ctx, l, s.c.Nodes, fmt.Sprintf("echo '%s' > %s", dev, dmsetupStateFile)); err != nil {
+		return "", errors.Wrap(err, "failed to save device name to state file")
+	}
+	return dev, nil
+}
+
 func (s *DmsetupDiskStaller) Setup(ctx context.Context, l *logger.Logger, args FailureArgs) error {
 	diskStallArgs := args.(DiskStallArgs)
 	var err error
@@ -450,7 +492,8 @@ func (s *DmsetupDiskStaller) Setup(ctx context.Context, l *logger.Logger, args F
 		}
 	}
 
-	dev, err := s.DiskDeviceName(ctx, l)
+	// Get the device name and store it for later stages (cleanup).
+	dev, err := s.getOrStoreDeviceName(ctx, l)
 	if err != nil {
 		return err
 	}
@@ -558,9 +601,15 @@ func (s *DmsetupDiskStaller) Cleanup(
 		}
 	}
 
-	dev, err := s.DiskDeviceName(ctx, l)
+	// Try to get the device name from the state file first (for independent stage runs),
+	// fall back to live lookup (for full lifecycle runs where mount is still intact).
+	dev, err := s.getStoredDeviceName(ctx, l)
 	if err != nil {
-		return err
+		l.Printf("Could not read stored device name, trying live lookup: %v", err)
+		dev, err = s.DiskDeviceName(ctx, l)
+		if err != nil {
+			return errors.Wrap(err, "failed to determine disk device")
+		}
 	}
 
 	if err := s.Run(ctx, l, s.c.Nodes, `sudo dmsetup resume data1`); err != nil {
@@ -575,7 +624,8 @@ func (s *DmsetupDiskStaller) Cleanup(
 	if err := s.Run(ctx, l, s.c.Nodes, `sudo tune2fs -O has_journal `+dev); err != nil {
 		return err
 	}
-	if err := s.Run(ctx, l, s.c.Nodes, `sudo mount /mnt/data1`); err != nil {
+	// Mount the original device back to /mnt/data1.
+	if err := s.Run(ctx, l, s.c.Nodes, fmt.Sprintf("sudo mount %s /mnt/data1", dev)); err != nil {
 		return err
 	}
 	// Reinstall snapd.
@@ -593,6 +643,9 @@ func (s *DmsetupDiskStaller) Cleanup(
 		return err
 	}
 
+	// Clean up the state file.
+	_ = s.Run(ctx, l, s.c.Nodes, fmt.Sprintf("rm -f %s", dmsetupStateFile))
+
 	if diskStallArgs.RestartNodes {
 		if err := s.StartCluster(ctx, l); err != nil {
 			return err
@@ -606,6 +659,9 @@ func (s *DmsetupDiskStaller) WaitForFailureToPropagate(
 ) error {
 	if args.(DiskStallArgs).Cycle {
 		l.Printf("Stall cycle is enabled, skipping WaitForFailureToPropagate")
+		return nil
+	} else if args.(DiskStallArgs).SkipFailurePropagation {
+		l.Printf("SkipFailurePropagation set true, skipping WaitForFailureToPropagate")
 		return nil
 	}
 	nodes := args.(DiskStallArgs).Nodes


### PR DESCRIPTION
Previously, roachprod chaos commands only supported network failures (partitions and latency). There was no CLI support for injecting disk stalls to test CockroachDB's storage resilience.

This commit adds a new `roachprod chaos disk-stall` command that integrates with the existing failure injection library to inject disk I/O stalls using cgroups v2.

Example usage:
```shell
roachprod chaos disk-stall mycluster --type cgroup --nodes 1,2,3

roachprod chaos disk-stall mycluster --type cgroup --nodes 1 --insecure

#using dmsetup
roachprod chaos disk-stall mycluster --type dmsetup --nodes 1 --insecure
```

Epic: none

Release note: None