### PR TITLE
ui, sql: Record AC Wait time in statement and transaction statistics

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3342,6 +3342,7 @@ Fields in this struct should be updated in sync with apps_stats.proto.
 | `MaxDiskUsage` | MaxDiskUsage collects the maximum temporary disk usage that occurred. This is set in cases where a query had to spill to disk, e.g. when performing a large sort where not all of the tuples fit in memory. | no |
 | `CPUSQLNanos` | CPUSQLNanos collects the CPU time spent executing SQL operations in nanoseconds. Currently, it is only collected for statements without mutations that have a vectorized plan. | no |
 | `MVCCIteratorStats` | Internal storage iteration statistics. | yes |
+| `AdmissionWaitTime` | AdmissionWaitTime is the cumulative time spent in admission control queues. | no |
 
 
 

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -254,6 +254,7 @@ func (s *ExecStats) Add(other ExecStats) {
 	s.NetworkMessages.Add(other.NetworkMessages, execStatCollectionCount, other.Count)
 	s.MaxDiskUsage.Add(other.MaxDiskUsage, execStatCollectionCount, other.Count)
 	s.CPUSQLNanos.Add(other.CPUSQLNanos, execStatCollectionCount, other.Count)
+	s.AdmissionWaitTime.Add(other.AdmissionWaitTime, execStatCollectionCount, other.Count)
 
 	s.MVCCIteratorStats.StepCount.Add(other.MVCCIteratorStats.StepCount, execStatCollectionCount, other.Count)
 	s.MVCCIteratorStats.StepCountInternal.Add(other.MVCCIteratorStats.StepCountInternal, execStatCollectionCount, other.Count)

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -366,6 +366,9 @@ message ExecStats {
   optional MVCCIteratorStats mvcc_iterator_stats = 8 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "MVCCIteratorStats"];
 
+  // AdmissionWaitTime is the cumulative time spent in admission control queues.
+  optional NumericStat admission_wait_time = 9 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields
   // here!
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -136,6 +136,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "mean": {{.Float}},
            "sqDiff": {{.Float}}
          },
+         "admissionWaitTime": {
+           "mean": {{.Float}},
+           "sqDiff": {{.Float}}
+         },
          "mvccIteratorStats": {
            "stepCount": {
              "mean": {{.Float}},
@@ -324,6 +328,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "mean": {{.Float}},
            "sqDiff": {{.Float}}
          },
+         "admissionWaitTime": {
+           "mean": {{.Float}},
+           "sqDiff": {{.Float}}
+         },
          "mvccIteratorStats": {
            "stepCount": {
              "mean": {{.Float}},
@@ -495,6 +503,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
       "sqDiff": {{.Float}}
     },
     "cpuSQLNanos": {
+      "mean": {{.Float}},
+      "sqDiff": {{.Float}}
+    },
+    "admissionWaitTime": {
       "mean": {{.Float}},
       "sqDiff": {{.Float}}
     },

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -370,6 +370,7 @@ func (e *execStats) jsonFields() jsonFields {
 		{"maxDiskUsage", (*numericStats)(&e.MaxDiskUsage)},
 		{"cpuSQLNanos", (*numericStats)(&e.CPUSQLNanos)},
 		{"mvccIteratorStats", (*iteratorStats)(&e.MVCCIteratorStats)},
+		{"admissionWaitTime", (*numericStats)(&e.AdmissionWaitTime)},
 	}
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -382,6 +382,7 @@ func (s *stmtStats) recordExecStatsLocked(stats execstats.QueryLevelStats) {
 	s.mu.data.ExecStats.NetworkMessages.Record(count, float64(stats.DistSQLNetworkMessages))
 	s.mu.data.ExecStats.MaxDiskUsage.Record(count, float64(stats.MaxDiskUsage))
 	s.mu.data.ExecStats.CPUSQLNanos.Record(count, float64(stats.SQLCPUTime.Nanoseconds()))
+	s.mu.data.ExecStats.AdmissionWaitTime.Record(count, float64(stats.AdmissionWaitTime.Nanoseconds()))
 
 	s.mu.data.ExecStats.MVCCIteratorStats.StepCount.Record(count, float64(stats.MvccSteps))
 	s.mu.data.ExecStats.MVCCIteratorStats.StepCountInternal.Record(count, float64(stats.MvccStepsInternal))

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -248,6 +248,7 @@ func (s *Container) RecordTransaction(ctx context.Context, value *sqlstats.Recor
 		stats.mu.data.ExecStats.NetworkMessages.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.DistSQLNetworkMessages))
 		stats.mu.data.ExecStats.MaxDiskUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxDiskUsage))
 		stats.mu.data.ExecStats.CPUSQLNanos.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.SQLCPUTime.Nanoseconds()))
+		stats.mu.data.ExecStats.AdmissionWaitTime.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.AdmissionWaitTime.Nanoseconds()))
 
 		stats.mu.data.ExecStats.MVCCIteratorStats.StepCount.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MvccSteps))
 		stats.mu.data.ExecStats.MVCCIteratorStats.StepCountInternal.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MvccStepsInternal))

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -180,6 +180,7 @@ type ExecStats = {
   networkBytes: NumericStat;
   networkMsgs: NumericStat;
   cpuSQLNanos: NumericStat;
+  admissionWaitTime: NumericStat;
 };
 
 type StatementStatistics = {
@@ -224,6 +225,8 @@ export function convertStatementRawFormatToAggregatedStatistics(
         network_bytes: s.statistics.execution_statistics.networkBytes,
         network_messages: s.statistics.execution_statistics.networkMsgs,
         cpu_sql_nanos: s.statistics.execution_statistics.cpuSQLNanos,
+        admission_wait_time:
+          s.statistics.execution_statistics.admissionWaitTime,
       },
       bytes_read: s.statistics.statistics.bytesRead,
       count: s.statistics.statistics.cnt,

--- a/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.tsx
@@ -52,6 +52,13 @@ const cpuBars = [
   ),
 ];
 
+const admissionWaitTimeBars = [
+  bar(
+    "admission-wait-time",
+    (d: StatementStatistics) => d.stats.exec_stats.admission_wait_time?.mean,
+  ),
+];
+
 const maxMemUsageBars = [
   bar(
     "max-mem-usage",
@@ -86,6 +93,14 @@ const contentionStdDev = bar(cx("contention-dev"), (d: StatementStatistics) =>
 );
 const cpuStdDev = bar(cx("cpu-dev"), (d: StatementStatistics) =>
   stdDevLong(d.stats.exec_stats.cpu_sql_nanos, d.stats.exec_stats.count),
+);
+const admissionWaitTimeStdDev = bar(
+  cx("admission-wait-time-dev"),
+  (d: StatementStatistics) =>
+    stdDevLong(
+      d.stats.exec_stats.admission_wait_time,
+      d.stats.exec_stats.count,
+    ),
 );
 const maxMemUsageStdDev = bar(
   cx("max-mem-usage-dev"),
@@ -122,6 +137,12 @@ export const cpuBarChart = barChartFactory(
   cpuBars,
   v => Duration(v),
   cpuStdDev,
+);
+export const admissionWaitTimeBarChart = barChartFactory(
+  "grey",
+  admissionWaitTimeBars,
+  v => Duration(v),
+  admissionWaitTimeStdDev,
 );
 export const maxMemUsageBarChart = barChartFactory(
   "grey",

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -838,6 +838,13 @@ export class StatementDetails extends React.Component<
                   )}
                 />
                 <SummaryCardItem
+                  label="Admission Wait Time"
+                  value={formatNumberForDisplay(
+                    stats?.exec_stats?.admission_wait_time?.mean,
+                    Duration,
+                  )}
+                />
+                <SummaryCardItem
                   label="Client Wait Time"
                   value={formatNumberForDisplay(stats?.idle_lat.mean, duration)}
                 />

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -13,6 +13,7 @@ import {
   latencyBarChart,
   contentionBarChart,
   cpuBarChart,
+  admissionWaitTimeBarChart,
   maxMemUsageBarChart,
   networkBytesBarChart,
   retryBarChart,
@@ -152,6 +153,10 @@ export function makeStatementsColumns(
     sampledExecStatsBarChartOptions,
   );
   const cpuBar = cpuBarChart(statements, sampledExecStatsBarChartOptions);
+  const admissionWaitTimeBar = admissionWaitTimeBarChart(
+    statements,
+    sampledExecStatsBarChartOptions,
+  );
   const maxMemUsageBar = maxMemUsageBarChart(
     statements,
     sampledExecStatsBarChartOptions,
@@ -230,6 +235,14 @@ export function makeStatementsColumns(
       cell: cpuBar,
       sort: (stmt: AggregateStatistics) =>
         FixLong(Number(stmt.stats.exec_stats.cpu_sql_nanos?.mean)),
+    },
+    {
+      name: "admissionWaitTime",
+      title: statisticsTableTitles.admissionWaitTime(statType),
+      cell: admissionWaitTimeBar,
+      className: cx("statements-table__col-admission-wait-time"),
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.exec_stats.admission_wait_time?.mean)),
     },
     {
       name: "latencyMin",

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -22,6 +22,7 @@ import {
 // Single place for column names. Used in table columns and in columns selector.
 export const statisticsColumnLabels = {
   actions: "Actions",
+  admissionWaitTime: "Admission Wait Time",
   applicationName: "Application Name",
   bytesRead: "Bytes Read",
   clientAddress: "Client IP Address",
@@ -681,6 +682,26 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("cpu")}
+      </Tooltip>
+    );
+  },
+  admissionWaitTime: (_: StatisticType) => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <>
+            <p>
+              Average time spent waiting in admission control queues within the
+              specified time interval. The gray bar indicates mean admission
+              wait time. The blue bar indicates one standard deviation from the
+              mean.
+            </p>
+          </>
+        }
+      >
+        {getLabel("admissionWaitTime")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
@@ -75,6 +75,21 @@ const cpuStdDev = bar(cx("cpu-dev"), (d: Transaction) =>
     d.stats_data.stats.exec_stats.count,
   ),
 );
+const admissionWaitTimeBar = [
+  bar(
+    "admission-wait-time",
+    (d: TransactionInfo) =>
+      d.stats_data.stats.exec_stats.admission_wait_time?.mean,
+  ),
+];
+const admissionWaitTimeStdDev = bar(
+  cx("admission-wait-time-dev"),
+  (d: Transaction) =>
+    stdDevLong(
+      d.stats_data.stats.exec_stats.admission_wait_time,
+      d.stats_data.stats.exec_stats.count,
+    ),
+);
 const maxMemUsageBar = [
   bar("max-mem-usage", (d: TransactionInfo) =>
     longToInt(d.stats_data.stats.exec_stats.max_mem_usage?.mean),
@@ -137,6 +152,12 @@ export const transactionsCPUBarChart = barChartFactory(
   cpuBar,
   v => Duration(v),
   cpuStdDev,
+);
+export const transactionsAdmissionWaitTimeBarChart = barChartFactory(
+  "grey",
+  admissionWaitTimeBar,
+  v => Duration(v),
+  admissionWaitTimeStdDev,
 );
 export const transactionsMaxMemUsageBarChart = barChartFactory(
   "grey",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -40,6 +40,7 @@ import {
   transactionsServiceLatencyBarChart,
   transactionsContentionBarChart,
   transactionsCPUBarChart,
+  transactionsAdmissionWaitTimeBarChart,
   transactionsMaxMemUsageBarChart,
   transactionsNetworkBytesBarChart,
   transactionsRetryBarChart,
@@ -128,6 +129,10 @@ export function makeTransactionsColumns(
     sampledExecStatsBarChartOptions,
   );
   const cpuBar = transactionsCPUBarChart(
+    transactions,
+    sampledExecStatsBarChartOptions,
+  );
+  const admissionWaitTimeBar = transactionsAdmissionWaitTimeBarChart(
     transactions,
     sampledExecStatsBarChartOptions,
   );
@@ -238,6 +243,16 @@ export function makeTransactionsColumns(
       className: cx("statements-table__col-cpu"),
       sort: (item: TransactionInfo) =>
         FixLong(Number(item.stats_data.stats.exec_stats.cpu_sql_nanos?.mean)),
+    },
+    {
+      name: "admissionWaitTime",
+      title: statisticsTableTitles.admissionWaitTime(statType),
+      cell: admissionWaitTimeBar,
+      className: cx("statements-table__col-admission-wait-time"),
+      sort: (item: TransactionInfo) =>
+        FixLong(
+          Number(item.stats_data.stats.exec_stats.admission_wait_time?.mean),
+        ),
     },
     {
       name: "maxMemUsage",

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -153,6 +153,12 @@ export function addExecStats(a: ExecStats, b: ExecStats): ExecStats {
       countA,
       countB,
     ),
+    admission_wait_time: addMaybeUnsetNumericStat(
+      a.admission_wait_time,
+      b.admission_wait_time,
+      countA,
+      countB,
+    ),
   };
 }
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4624,6 +4624,13 @@ func (m *SampledExecStats) AppendJSONFields(printComma bool, b redact.Redactable
 	printComma, b = m.MVCCIteratorStats.AppendJSONFields(false, b)
 	b = append(b, '}')
 
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"AdmissionWaitTime\":"...)
+	b = strconv.AppendInt(b, int64(m.AdmissionWaitTime), 10)
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -539,6 +539,9 @@ message SampledExecStats {
 
   // Internal storage iteration statistics.
   MVCCIteratorStats mvcc_iterator_stats = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "MVCCIteratorStats"];
+
+  // AdmissionWaitTime is the cumulative time spent in admission control queues.
+  int64 admission_wait_time = 8 [(gogoproto.jsontag) = ",includeempty"];
 }
 
 // Internal storage iteration statistics for a single execution.


### PR DESCRIPTION
This commit starts recording the newly added admissionWaitTime field from execstats.queryLevelStats and exposes it in the UI.

Fixes: https://cockroachlabs.atlassian.net/browse/CRDB-57266 Release note (ui change): Admission Control wait time is now recorded to statement_statistics and transaction_statistics and is displayed in the SQL Activity page.