### PR TITLE
release-25.3: workload/schemachange: add UndefinedObject error for CITEXT in mixed-version tests

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1326,6 +1326,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 		{code: pgcode.FeatureNotSupported, condition: hasVectorType},
 		{code: pgcode.Syntax, condition: hasCitextType},
 		{code: pgcode.FeatureNotSupported, condition: hasCitextType},
+		{code: pgcode.UndefinedObject, condition: hasCitextType},
 	})
 	opStmt.sql = tree.Serialize(stmt)
 	return opStmt, nil


### PR DESCRIPTION
Previously, the schemachange workload could fail unexpectedly in mixed-version tests when CREATE TABLE statements with CITEXT columns were executed on nodes that didn't yet support the CITEXT type (introduced in v25.3). This caused the test to fail with "type 'citext' does not exist" (error code 42704, UndefinedObject).

This commit adds the UndefinedObject error code to the list of potential errors when CITEXT columns are present in CREATE TABLE statements, allowing the workload to properly handle this compatibility issue during mixed-version cluster upgrades.

Fixes: #156993
Fixes: https://github.com/cockroachdb/cockroach/issues/158492

Release note: None
Release justification: test only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)