### PR TITLE
changefeedccl: stop db-level changefeed from failing on offline table

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -560,7 +560,7 @@ $$`)
 			defer e.Close()
 
 			ctx := context.Background()
-			decoder, err := cdcevent.NewEventDecoder(ctx, &execCfg, targets, false, false)
+			decoder, err := cdcevent.NewEventDecoder(ctx, &execCfg, targets, false, false, cdcevent.DecoderOptions{})
 			require.NoError(t, err)
 
 			for _, action := range tc.setupActions {

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -536,7 +536,7 @@ CREATE TABLE foo (
 			})
 			execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 			ctx := context.Background()
-			decoder, err := NewEventDecoder(ctx, &execCfg, targets, tc.includeVirtual, tc.keyOnly)
+			decoder, err := NewEventDecoder(ctx, &execCfg, targets, tc.includeVirtual, tc.keyOnly, DecoderOptions{})
 			require.NoError(t, err)
 			expectedEvents := len(tc.expectMainFamily) + len(tc.expectOnlyCFamily)
 			for i := 0; i < expectedEvents; i++ {
@@ -780,7 +780,7 @@ func TestEventColumnOrderingWithSchemaChanges(t *testing.T) {
 			})
 			execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 			ctx := context.Background()
-			decoder, err := NewEventDecoder(ctx, &execCfg, targets, tc.includeVirtual, false)
+			decoder, err := NewEventDecoder(ctx, &execCfg, targets, tc.includeVirtual, false, DecoderOptions{})
 			require.NoError(t, err)
 
 			expectedEvents := len(tc.expectMainFamily) + len(tc.expectECFamily)
@@ -1098,7 +1098,7 @@ CREATE TABLE foo (
 	})
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	ctx := context.Background()
-	decoder, err := NewEventDecoder(ctx, &execCfg, targets, false, false)
+	decoder, err := NewEventDecoder(ctx, &execCfg, targets, false, false, DecoderOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -238,6 +238,9 @@ func (c *rowFetcherCache) tableDescForKey(
 // is not being watched and does not need to be decoded.
 var ErrUnwatchedFamily = errors.New("watched table but unwatched family")
 
+// ErrTableOffline is a sentinel error that indicates the watched table is offline.
+var ErrTableOffline = errors.New("watched table is offline")
+
 // RowFetcherForColumnFamily returns row.Fetcher for the specified column family.
 // Returns ErrUnwatchedFamily error if family is not watched.
 func (c *rowFetcherCache) RowFetcherForColumnFamily(

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -568,7 +568,8 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		sf = schemafeed.DoNothingSchemaFeed
 	} else {
 		sf = schemafeed.New(ctx, cfg, schemaChange.EventClass, ca.targets,
-			initialHighWater, &ca.metrics.SchemaFeedMetrics, config.Opts.GetCanHandle())
+			initialHighWater, &ca.metrics.SchemaFeedMetrics, config.Opts.GetCanHandle(),
+			isDBLevelChangefeed(ca.spec.Feed))
 	}
 
 	monitoringCfg, err := makeKVFeedMonitoringCfg(ctx, ca.sliMetrics, opts, ca.FlowCtx.Cfg.Settings)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -781,7 +781,7 @@ func createChangefeedJobRecord(
 		_, tableToDatabaseLookup := buildTableToDatabaseAndSchemaLookup(tableAndParentDescs)
 		for _, desc := range tableNameToDescriptor {
 			if table, isTable := desc.(catalog.TableDescriptor); isTable {
-				if err := changefeedvalidators.ValidateTable(targets, table, tolerances); err != nil {
+				if err := changefeedvalidators.ValidateTable(targets, table, tolerances, false /* allowOfflineDescriptor */); err != nil {
 					return nil, changefeedbase.Targets{}, err
 				}
 				for _, warning := range changefeedvalidators.WarningsForTable(table, tolerances) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -13084,3 +13084,125 @@ func TestDatabaseLevelChangefeedWithInitialScanOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestDatabaseLevelChangefeedSkipOfflineTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			if _, err := w.Write([]byte("42,42\n")); err != nil {
+				t.Logf("failed to write: %s", err.Error())
+			}
+		}
+	}))
+	defer dataSrv.Close()
+
+	testSkipsOnOfflineTable := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE for_import (a INT PRIMARY KEY, b INT)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d`)
+		defer closeFeed(t, feed)
+		sqlDB.Exec(t, `INSERT INTO for_import VALUES (0, NULL)`)
+		assertPayloads(t, feed, []string{
+			`for_import: [0]->{"after": {"a": 0, "b": null}}`,
+		})
+		sqlDB.Exec(t, `IMPORT INTO for_import CSV DATA ($1)`, dataSrv.URL)
+		sqlDB.Exec(t, `INSERT INTO for_import VALUES (1, NULL)`)
+		assertPayloads(t, feed, []string{
+			`for_import: [1]->{"after": {"a": 1, "b": null}}`,
+		})
+	}
+	t.Run("skips on offline table", func(t *testing.T) {
+		cdcTest(t, testSkipsOnOfflineTable, feedTestEnterpriseSinks)
+	})
+
+	testSkipsOnOfflineTableWithDiff := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE for_import (a INT PRIMARY KEY, b INT)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d WITH diff`)
+		defer closeFeed(t, feed)
+		sqlDB.Exec(t, `IMPORT INTO for_import CSV DATA ($1)`, dataSrv.URL)
+		sqlDB.Exec(t, `UPDATE for_import set b = 2 WHERE a = 42`)
+		// The imported value is skipped, but shows up in the next diff.
+		assertPayloads(t, feed, []string{
+			`for_import: [42]->{"after": {"a": 42, "b": 2}, "before": {"a": 42, "b": 42}}`,
+		})
+		sqlDB.Exec(t, `UPDATE for_import set b = 3 WHERE a = 42`)
+		assertPayloads(t, feed, []string{
+			`for_import: [42]->{"after": {"a": 42, "b": 3}, "before": {"a": 42, "b": 2}}`,
+		})
+	}
+	t.Run("skips on offline table with diff", func(t *testing.T) {
+		cdcTest(t, testSkipsOnOfflineTableWithDiff, feedTestEnterpriseSinks)
+	})
+
+	testSkipsOnOfflineTableWithDiffBackfill := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE for_import (a INT PRIMARY KEY, b INT)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d WITH diff, schema_change_policy='backfill'`)
+		defer closeFeed(t, feed)
+		sqlDB.Exec(t, `IMPORT INTO for_import CSV DATA ($1)`, dataSrv.URL)
+		sqlDB.Exec(t, `ALTER TABLE for_import ADD COLUMN c INT DEFAULT 0`)
+		assertPayloads(t, feed, []string{
+			`for_import: [42]->{"after": {"a": 42, "b": 42, "c": 0}, "before": {"a": 42, "b": 42}}`,
+		})
+	}
+	t.Run("skips on offline table with diff backfill", func(t *testing.T) {
+		cdcTest(t, testSkipsOnOfflineTableWithDiffBackfill, feedTestEnterpriseSinks)
+	})
+
+	testAdvancesHWMOnOfflineTable := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest'`)
+
+		sqlDB.Exec(t, `CREATE TABLE for_import (a INT PRIMARY KEY, b INT)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d WITH resolved='100ms'`)
+		defer closeFeed(t, feed)
+		eFeed, ok := feed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok, "expected enterprise feed")
+		var tsStr string
+		sqlDB.QueryRow(t, `INSERT INTO for_import VALUES (0, NULL) RETURNING cluster_logical_timestamp()`).Scan(&tsStr)
+		ts := parseTimeToHLC(t, tsStr)
+		assertPayloads(t, feed, []string{
+			`for_import: [0]->{"after": {"a": 0, "b": null}}`,
+		})
+		require.NoError(t, eFeed.WaitForHighWaterMark(ts))
+
+		hwm, err := eFeed.HighWaterMark()
+		require.NoError(t, err)
+		require.True(t, ts.Less(hwm), "expected high-water > insert ts; got hwm=%s ts=%s", hwm, ts)
+
+		hwmBeforeImport := hwm
+
+		go func() {
+			sqlDB.ExpectErrWithRetry(t, `pause point`, `IMPORT INTO for_import CSV DATA ($1)`, `result is ambiguous`, dataSrv.URL)
+		}()
+		sqlDB.CheckQueryResultsRetry(t,
+			`SELECT count(*) FROM [SHOW JOBS] WHERE job_type='IMPORT' AND status='paused'`,
+			[][]string{{"1"}},
+		)
+
+		time.Sleep(2 * time.Second)
+		require.NoError(t, eFeed.WaitForHighWaterMark(hwmBeforeImport))
+		hwmDuringImport, err := eFeed.HighWaterMark()
+		require.NoError(t, err)
+		require.True(t, hwmBeforeImport.Less(hwmDuringImport), "expected high-water to advance during import; got hwm=%s hwmBeforeImport=%s", hwmDuringImport, hwmBeforeImport)
+
+		var state string
+		sqlDB.QueryRow(t, `
+			SELECT state
+			FROM crdb_internal.tables
+			WHERE database_name = 'd' AND schema_name = 'public' AND name = 'for_import'
+		`).Scan(&state)
+		require.Equal(t, "OFFLINE", state)
+	}
+	t.Run("advances HWM while table is offline", func(t *testing.T) {
+		cdcTest(t, testAdvancesHWMOnOfflineTable, feedTestForceSink("webhook"))
+	})
+
+	// TODO(158678): Add RESTORE subtest once db-level changefeeds support it.
+	// DB-level changefeeds do not yet add newly created tables to the
+	// changefeed when they are restored, and dropping an included table to
+	// restore it will fail the feed.
+}

--- a/pkg/ccl/changefeedccl/changefeedvalidators/table_validator.go
+++ b/pkg/ccl/changefeedccl/changefeedvalidators/table_validator.go
@@ -17,8 +17,9 @@ func ValidateTable(
 	targets changefeedbase.Targets,
 	tableDesc catalog.TableDescriptor,
 	canHandle changefeedbase.CanHandle,
+	allowOfflineDescriptor bool,
 ) error {
-	if err := validateTable(targets, tableDesc, canHandle); err != nil {
+	if err := validateTable(targets, tableDesc, canHandle, allowOfflineDescriptor); err != nil {
 		return changefeedbase.WithTerminalError(err)
 	}
 	return nil
@@ -28,6 +29,7 @@ func validateTable(
 	targets changefeedbase.Targets,
 	tableDesc catalog.TableDescriptor,
 	canHandle changefeedbase.CanHandle,
+	allowOfflineDescriptor bool,
 ) error {
 	// Technically, the only non-user table known not to work is system.jobs
 	// (which creates a cycle since the resolved timestamp high-water mark is
@@ -47,6 +49,9 @@ func validateTable(
 		return errors.Errorf(`CHANGEFEED cannot target sequences: %s`, tableDesc.GetName())
 	}
 	if tableDesc.Offline() {
+		if allowOfflineDescriptor {
+			return nil
+		}
 		return errors.Errorf("CHANGEFEED cannot target offline table: %s (offline reason: %q)", tableDesc.GetName(), tableDesc.GetOfflineReason())
 	}
 	found, err := targets.EachHavingTableID(tableDesc.GetID(), func(t changefeedbase.Target) error {

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -245,7 +245,7 @@ func newKVEventToRowConsumer(
 ) (_ *kvEventToRowConsumer, err error) {
 	includeVirtual := details.Opts.IncludeVirtual()
 	keyOnly := details.Opts.KeyOnly()
-	decoder, err := cdcevent.NewEventDecoder(ctx, cfg, details.Targets, includeVirtual, keyOnly)
+	decoder, err := cdcevent.NewEventDecoder(ctx, cfg, details.Targets, includeVirtual, keyOnly, cdcevent.DecoderOptions{SkipOffline: true})
 	if err != nil {
 		return nil, err
 	}
@@ -362,6 +362,15 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		// Column families are stored contiguously, so we'll get
 		// events for each one even if we're not watching them all.
 		if errors.Is(err, cdcevent.ErrUnwatchedFamily) {
+			// Release the event's allocation since we're not processing it.
+			a := ev.DetachAlloc()
+			a.Release(ctx)
+			return nil
+		}
+		if errors.Is(err, cdcevent.ErrTableOffline) {
+			// An event on an offline table should be silently dropped for db
+			// level changefeeds. Since the descriptor is offline, we can't
+			// safely decode the event.
 			// Release the event's allocation since we're not processing it.
 			a := ev.DetachAlloc()
 			a.Release(ctx)

--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -275,7 +275,7 @@ func makeRangefeedReaderAndDecoder(
 	})
 	sqlExecCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	ctx := context.Background()
-	decoder, err := cdcevent.NewEventDecoder(ctx, &sqlExecCfg, targets, false, false)
+	decoder, err := cdcevent.NewEventDecoder(ctx, &sqlExecCfg, targets, false, false, cdcevent.DecoderOptions{})
 	require.NoError(t, err)
 	return popRow, cleanup, decoder
 }

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -252,7 +252,7 @@ func TestFetchDescriptorVersionsCPULimiterPagination(t *testing.T) {
 		TestingAllEventFilter, targets, now, nil, changefeedbase.CanHandle{
 			MultipleColumnFamilies: true,
 			VirtualColumns:         true,
-		})
+		}, false)
 	scf := sf.(*schemaFeed)
 	desc, err := scf.fetchDescriptorVersions(ctx, beforeCreate, afterCreate)
 	require.NoError(t, err)
@@ -296,7 +296,7 @@ func TestSchemaFeedHandlesCascadeDatabaseDrop(t *testing.T) {
 		TestingAllEventFilter, targets, s.Clock().Now(), nil, changefeedbase.CanHandle{
 			MultipleColumnFamilies: true,
 			VirtualColumns:         true,
-		}).(*schemaFeed)
+		}, false).(*schemaFeed)
 
 	// initialize type dependencies in schema feed.
 	require.NoError(t, sf.primeInitialTableDescs(ctx))

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_datadriven_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_datadriven_test.go
@@ -118,7 +118,7 @@ func TestDataDriven(t *testing.T) {
 				f := schemafeed.New(ctx, cfg, schemafeed.TestingAllEventFilter, targets, now, nil, changefeedbase.CanHandle{
 					MultipleColumnFamilies: true,
 					VirtualColumns:         true,
-				})
+				}, false)
 				schemaFeeds[i] = f
 
 				go func() {

--- a/pkg/ccl/changefeedccl/tableset/watcher.go
+++ b/pkg/ccl/changefeedccl/tableset/watcher.go
@@ -172,7 +172,7 @@ func (w *Watcher) Start(ctx context.Context, initialTS hlc.Timestamp) (retErr er
 		StatementTimeName: changefeedbase.StatementTimeName(systemschema.NamespaceTable.GetName()),
 		Type:              jobspb.ChangefeedTargetSpecification_EACH_FAMILY,
 	})
-	dec, err := cdcevent.NewEventDecoder(ctx, w.execCfg, cfTargets, false, false)
+	dec, err := cdcevent.NewEventDecoder(ctx, w.execCfg, cfTargets, false, false, cdcevent.DecoderOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/crosscluster/logical/dead_letter_queue_test.go
@@ -442,7 +442,7 @@ func TestDLQJSONQuery(t *testing.T) {
 		FamilyName: "primary",
 	})
 
-	decoder, err := cdcevent.NewEventDecoder(ctx, &execCfg, targets, false, false)
+	decoder, err := cdcevent.NewEventDecoder(ctx, &execCfg, targets, false, false, cdcevent.DecoderOptions{})
 	require.NoError(t, err)
 
 	popRow, cleanup := cdctest.MakeRangeFeedValueReader(t, srv.ExecutorConfig(), tableDesc)

--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -113,7 +113,7 @@ func newCdcEventDecoder(
 		return nil, err
 	}
 
-	return cdcevent.NewEventDecoderWithCache(ctx, rfCache, false, false), nil
+	return cdcevent.NewEventDecoderWithCache(ctx, rfCache, false, false, cdcevent.DecoderOptions{}), nil
 }
 
 var originID1Options = &kvpb.WriteOptions{OriginID: 1}

--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -260,7 +260,7 @@ func makeSQLProcessorFromQuerier(
 
 	return &sqlRowProcessor{
 		querier:  querier,
-		decoder:  cdcevent.NewEventDecoderWithCache(ctx, rfCache, false, false),
+		decoder:  cdcevent.NewEventDecoderWithCache(ctx, rfCache, false, false, cdcevent.DecoderOptions{}),
 		settings: settings,
 		db:       db,
 		ie:       ie,


### PR DESCRIPTION
Previously, a changefeed would fail when one of its watched tables went into an offline state. A db-level changefeed should be able to run, emitting changes from other tables when one or more tables are in an offline state.

This patch skips events while a table is offline. The changefeed resumes emitting changes again once the table is public. The events while offline are not emitted once the table changes from offline to public.

Fixes: #155709
Epic: CRDB-1421

Release note: None