### PR TITLE
cloud/azure: default enable caching SDK clients

### DIFF
--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -60,7 +60,7 @@ var reuseSession = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"cloudstorage.azure.session_reuse.enabled",
 	"persist the last opened azure client and re-use it when opening a new client with the same argument (some settings may take 2mins to take effect)",
-	false,
+	true,
 )
 
 // A note on Azure authentication:


### PR DESCRIPTION
This mirrors the default in s3 client handling.

Release note: none.
Epic: none.