### PR TITLE
roachtest/decommission: deflake decommission/drains/dead

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1001,7 +1001,8 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster, 
 		decommNodeID = numNodes
 		decommNode   = c.Node(decommNodeID)
 	)
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+
+	c.Start(ctx, t.L(), withDecommissionVMod(option.DefaultStartOpts()), install.MakeClusterSettings(), c.All())
 
 	h := newDecommTestHelper(t, c)
 
@@ -1026,7 +1027,7 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster, 
 
 	// Decommission node 4 and poll its status during the decommission.
 	var (
-		maxAttempts = 50
+		maxAttempts = 125
 		retryOpts   = retry.Options{
 			InitialBackoff: time.Second,
 			MaxBackoff:     5 * time.Second,
@@ -1518,7 +1519,8 @@ func execCLIExt(
 // debugging failures.
 const decommissionVModuleStartOpts = `--vmodule=store_rebalancer=5,allocator=5,
   allocator_scorer=5,replicate_queue=5,replicate=6,split_queue=5,
-  replica_command=2,replica_raft=2,replica_proposal=2,replica_application_result=1`
+  replica_command=2,replica_raft=2,replica_proposal=2,replica_application_result=1,
+  replica_range_lease=3,raft=4,replica_raft_quiesce=3`
 
 func withDecommissionVMod(startOpts option.StartOpts) option.StartOpts {
 	startOpts.RoachprodOpts.ExtraArgs = append(


### PR DESCRIPTION
This commit does two things:

1) Runs decommission/drains tests with more verbosity using the vmodule settings.

2) Increases the time we wait for decommission to finish. This helps mitigate cases where the replicate queue fails to enqueue a range for some reason, and it takes ~5-10 minutes until it enqueues that range again. If that happened, the test could have failed waiting for 1 or more replicas to be removed out of the decommissioned node.

Fixes: #158482

Release note: None