### PR TITLE
roachprod: add GCE hyperdisk-balanced support and misc improvements

### DIFF
--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -190,13 +190,16 @@ var localClusterRegex = regexp.MustCompile(`^local(|-[a-zA-Z0-9\-]+)$`)
 // establishing a remote session.
 // See https://github.com/openssh/openssh-portable/blob/86bdd385/ssh_config.5#L1123-L1130
 var DefaultPubKeyNames = []string{
+	// google_compute_engine is listed first because it's typically not
+	// passphrase-protected, avoiding passphrase prompts when connecting to GCE
+	// VMs if the ssh-agent is slow to respond.
+	"google_compute_engine",
 	"id_rsa",
 	"id_ecdsa",
 	"id_ecdsa_sk",
 	"id_ed25519",
 	"id_ed25519_sk",
 	"id_dsa",
-	"google_compute_engine",
 }
 
 // SSHPublicKeyPath returns the path to the default public key expected by

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -166,8 +166,8 @@ func (d *ebsDisk) Set(s string) error {
 	case "gp2":
 		// Nothing -- size checked above.
 	case "gp3":
-		if d.IOPs > 16000 {
-			return errors.AssertionFailedf("Iops required for gp3 disk: [3000, 16000]")
+		if d.IOPs > 80000 {
+			return errors.AssertionFailedf("Iops required for gp3 disk: [3000, 80000]")
 		}
 		if d.IOPs == 0 {
 			// 3000 is a base IOPs for gp3.
@@ -1378,7 +1378,8 @@ func (p *Provider) runInstance(
 	}
 	imageID := withFlagOverride(az.Region.AMI_X86_64, &providerOpts.ImageAMI)
 	useArmAMI := strings.Index(machineType, "6g.") == 1 || strings.Index(machineType, "6gd.") == 1 ||
-		strings.Index(machineType, "7g.") == 1 || strings.Index(machineType, "7gd.") == 1
+		strings.Index(machineType, "7g.") == 1 || strings.Index(machineType, "7gd.") == 1 ||
+		strings.Index(machineType, "8g.") == 1 || strings.Index(machineType, "8gd.") == 1
 	if useArmAMI && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
 		return nil, errors.Errorf("machine type %s is arm64, but requested arch is %s", machineType, opts.Arch)
 	}


### PR DESCRIPTION
Add support for GCE hyperdisk-balanced disk type with new flags:
- --gce-pd-volume-provisioned-iops: Required for hyperdisk-balanced,
  optional for pd-extreme
- --gce-pd-volume-provisioned-throughput: Required for hyperdisk-balanced

Additional improvements:
- Move google_compute_engine to front of SSH key list to avoid
  passphrase prompts when connecting to GCE VMs (the key is typically
  not passphrase-protected)
- Increase AWS gp3 max IOPS validation from 16000 to 80000
- Add AWS m8g/m8gd ARM instance type detection

Release note: None
Epic: None
