### PR TITLE
tablemetadatacache: shorten gc operation

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -153,14 +153,10 @@ func (u *tableMetadataUpdater) pruneCache(ctx context.Context) (removed int, err
 			nil, // txn
 			sessiondata.NodeUserWithBulkLowPriSessionDataOverride, `
 DELETE FROM system.table_metadata
-WHERE table_id IN (
-  SELECT table_id
-  FROM system.table_metadata
-  WHERE table_id NOT IN (
-    SELECT id FROM system.namespace
-  )
-  LIMIT $1
+WHERE table_id NOT IN (
+  SELECT id FROM system.descriptor
 )
+LIMIT $1
 RETURNING table_id`, pruneBatchSize)
 
 		if err != nil {


### PR DESCRIPTION
Previously, we used the system.namespace table in a doubly nested query to find old table_metadata rows to cleanup. It's been surfaced that this operation can be simplified, and optimized, by leveraging a negative join on the `system.descriptor` table's primary key, and by using only a singly nested query. This should make table metadata gc operations much faster on clusters with many deleted tables.

Fixes: #158488
Release note: none