### PR TITLE
builtins: add validation during crdb_internal.inject_hint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -727,3 +727,41 @@ RESET plan_cache_mode
 
 statement ok
 DEALLOCATE ALL
+
+# Test basic validation when calling crdb_internal.inject_hint.
+
+statement error could not parse statement fingerprint: at or near "foo": syntax error
+SELECT crdb_internal.inject_hint(
+  'foo',
+  'SELECT a FROM ab'
+)
+
+statement error could not parse hint donor statement: at or near "foo": syntax error
+SELECT crdb_internal.inject_hint(
+  'SELECT a FROM ab',
+  'foo'
+)
+
+statement error statement does not match hint donor statement: SELECT a FROM ab vs SELECT b FROM ab
+SELECT crdb_internal.inject_hint(
+  'SELECT a FROM ab',
+  'SELECT b FROM ab'
+)
+
+statement error hint injection donor statement AST node \$1 did not match AST node 5
+SELECT crdb_internal.inject_hint(
+  'SELECT a FROM ab WHERE b = 5',
+  'SELECT a FROM ab WHERE b = $1'
+)
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT a FROM ab WHERE b = 5',
+  'SELECT a FROM ab WHERE b = _'
+)
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT b FROM ab WHERE a = $1',
+  'SELECT b FROM ab WHERE a = _'
+)


### PR DESCRIPTION
Add some basic validation during `crdb_internal.inject_hint`. We now check that:

1. both statements parse as SQL
2. the donor statement matches the target statement when printed without constants or hints (via `HintInjectionDonor.Validate`)
3. a trial hint injection successfully rewrites the target statement as the donor statement

Notably we do *not* perform any semantic checks of the statements, so they might reference non-existent tables or indexes, etc.

Informs: #153633

Release note: None