### PR TITLE
roachtest: deflake network/authentication/nodes=4

### DIFF
--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -135,10 +135,12 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 			if timeutil.Since(tStart) > 30*time.Second {
 				t.L().Printf("still waiting for leases to move")
 				// The leases have not moved yet, so display some progress.
-				dumpRangesCmd := roachtestutil.NewCommand("./cockroach sql -e 'TABLE crdb_internal.ranges'").
+				dumpRangesCmd := roachtestutil.NewCommand(
+					"./cockroach sql -e 'SET allow_unsafe_internals=true; TABLE crdb_internal.ranges'").
 					Flag("certs-dir", certsDir).
 					Flag("port", "{pgport:1}").
 					String()
+
 				t.L().Printf("SQL: %s", dumpRangesCmd)
 				err = c.RunE(ctx, option.WithNodes(c.Node(1)), dumpRangesCmd)
 				require.NoError(t, err)


### PR DESCRIPTION
Recently (#158085) we stopped allowing acess to crdb_internal by default. Roachtests usually set a session variable to override that: https://github.com/cockroachdb/cockroach/blob/0eb1ca14aafbe71de1cfd0a7f200b8df50702e94/pkg/cmd/roachtest/cluster.go#L2986 However, this specific test runs a one-off command using CLI: "./cockroach sql -e".

This commit sets that session var for this command.

Fixes: #158550

Release note: None