### PR TITLE
compose: allow unsafe internals in TestComposeCompare

### DIFF
--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     user: ${UID}:${GID}
     command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach1
+    environment:
+      - COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS=true
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
       - "${LIBGEOS_DIR_PATH}:/cockroach/lib"
@@ -16,6 +18,8 @@ services:
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
     image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     user: ${UID}:${GID}
+    environment:
+      - COCKROACH_OVERRIDE_ALLOW_UNSAFE_INTERNALS=true
     command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach2
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"


### PR DESCRIPTION
Previously, the test TestComposeCompare since access to unsafe internals is disabled by default, which is required by sqlsmith. To address this, this patch allows access to unsafe internals when starting the containers in this test.

Fixes: #158561
Release note: None