### PR TITLE
ui: fix double dispatch when metric time is selected

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
@@ -146,15 +146,9 @@ const TimeScaleDropdownWithSearchParams = (
     /* eslint react-hooks/exhaustive-deps: "off" */
   }, []);
 
-  // This will get triggered if the redux store updates the
-  // currentScale, we sync the query params to match.
-  useEffect(() => {
-    if (queryParamsRead) {
-      onTimeScaleChange(props.currentScale);
-    }
-  }, [props.currentScale]);
-
-  const onTimeScaleChange = (timeScale: TimeScale) => {
+  // Updates URL params to reflect the current time scale.
+  // Split from onTimeScaleChange to avoid double-dispatch issues.
+  const updateUrlParams = (timeScale: TimeScale) => {
     if (!timeScale.fixedWindowEnd) {
       const preset = findClosestTimeScale(
         defaultTimeScaleOptions,
@@ -185,7 +179,20 @@ const TimeScaleDropdownWithSearchParams = (
         search: urlParams.toString(),
       });
     }
+  };
 
+  // This will get triggered if the redux store updates the
+  // currentScale from an external source (e.g., MetricsTimeManager).
+  // We only sync the query params to match, without calling setTimeScale
+  // again to avoid a double-dispatch issue.
+  useEffect(() => {
+    if (queryParamsRead) {
+      updateUrlParams(props.currentScale);
+    }
+  }, [props.currentScale]);
+
+  const onTimeScaleChange = (timeScale: TimeScale) => {
+    updateUrlParams(timeScale);
     // Pushes changes to the session storage.
     props.setTimeScale(timeScale);
   };


### PR DESCRIPTION
Previously, when a new time window was selected in the time picker on the metrics page, we would dispatch a `ts/query` request twice because the first request would trigger a `useEffect` callback that triggered a second one. This was because of a desire to keep query params in the URL bar in sync with the time picker. We split up the query param update with the query param + redux update into two functions so that we can sync the params withou touching redux. This eliminates the double request cycle since redux is now updated once.

Resolves: #158507
Epic: None

Release note (bug fix): the DB Console no longer dispatches duplicate metric query requests when new time windows were selected on the metrics page.