### PR TITLE
kvnemesis: correctly verify the span config of the system range

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -843,7 +843,9 @@ func setAndVerifyZoneConfigs(
 							Key:    desc.StartKey.AsRawKey(),
 							EndKey: desc.EndKey.AsRawKey(),
 						}
-						if replicaSpan.Overlaps(dataSpan) || desc.RangeID <= 3 {
+						// Ranges 1-4 are the ranges we constrained above
+						// (1: meta1, 2: meta2, 3: liveness, 4: system).
+						if replicaSpan.Overlaps(dataSpan) || desc.RangeID <= 4 {
 							overlappingReplicas = append(overlappingReplicas, replica)
 						}
 						return true // continue


### PR DESCRIPTION
Previously, kvnemesis verified the correct span config for some critical ranges: meta (r1), liveness (r2) and system (r3). However, as of 8844739, meta1 and meta2 start off as separate ranges, pushing the system range to r4. It's important for this range to be replicated correctly in kvnemesis to ensure it's available in the presence of network partitions. Unavailability of the system range can result in splits not able to allocate new range IDs.

This commit bumps up the max range ID used for span config verification from 3 to 4.

Informs: #158366

Release note: None