### PR TITLE
mmaprototype: dont redact store state logs

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 // rebalanceEnv tracks the state and outcomes of a rebalanceStores invocation.
@@ -265,7 +266,7 @@ func (re *rebalanceEnv) rebalanceStore(
 				_, _ = fmt.Fprintf(&b, " r%d:%v", rangeID, load)
 			}
 			log.KvDistribution.Infof(ctx, "top-K[%s] ranges for s%d with lease on local s%d:%s",
-				topKRanges.dim, store.StoreID, localStoreID, b.String())
+				topKRanges.dim, store.StoreID, localStoreID, redact.SafeString(b.String()))
 		} else {
 			log.KvDistribution.Infof(ctx, "no top-K[%s] ranges found for s%d with lease on local s%d",
 				topKRanges.dim, store.StoreID, localStoreID)

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -37,11 +37,11 @@ const (
 func (dim LoadDimension) SafeFormat(w redact.SafePrinter, _ rune) {
 	switch dim {
 	case CPURate:
-		w.Printf("CPURate")
+		w.SafeString("CPURate")
 	case WriteBandwidth:
-		w.Print("WriteBandwidth")
+		w.SafeString("WriteBandwidth")
 	case ByteSize:
-		w.Printf("ByteSize")
+		w.SafeString("ByteSize")
 	default:
 		panic("unknown LoadDimension")
 	}
@@ -53,6 +53,8 @@ func (dim LoadDimension) String() string {
 
 // LoadValue is the load on a resource.
 type LoadValue int64
+
+func (LoadValue) SafeValue() {}
 
 // LoadVector represents a vector of loads, with one element for each resource
 // dimension.
@@ -456,15 +458,15 @@ func (ls loadSummary) String() string {
 func (ls loadSummary) SafeFormat(w redact.SafePrinter, _ rune) {
 	switch ls {
 	case loadLow:
-		w.Print("loadLow")
+		w.SafeString("loadLow")
 	case loadNormal:
-		w.Print("loadNormal")
+		w.SafeString("loadNormal")
 	case loadNoChange:
-		w.Print("loadNoChange")
+		w.SafeString("loadNoChange")
 	case overloadSlow:
-		w.Print("overloadSlow")
+		w.SafeString("overloadSlow")
 	case overloadUrgent:
-		w.Print("overloadUrgent")
+		w.SafeString("overloadUrgent")
 	default:
 		panic("unknown loadSummary")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -926,7 +926,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			}
 			storeLoadMsg := mmaintegration.MakeStoreLoadMsg(storeDesc, origTimestampNanos)
 			mmaAlloc.SetStore(state.StoreAttrAndLocFromDesc(storeDesc))
-			mmaAlloc.ProcessStoreLoadMsg(context.TODO(), &storeLoadMsg)
+			mmaAlloc.ProcessStoreLoadMsg(ctx, &storeLoadMsg)
 		},
 	)
 

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -110,6 +110,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool": {
 						"storeStatus": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/mmaprototype": {
+						"LoadValue": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb": {
 						"SeqNum": {},
 					},


### PR DESCRIPTION
Many of the logs coming from the mmaprototype package were previously
redacted which is unnecessary since they don't contain any sensitive
information. This fixes some of the logs statements and SafeFormat
implementations to ensure logs like store usages and capacities are not
redacted.

Informs https://github.com/cockroachdb/cockroach/issues/158203
Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)
Release note: None