### PR TITLE
release-24.3: backup: skip TestBackupExportRequestTimeout under deadlock

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7622,6 +7622,8 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDeadlock(t)
+
 	allowRequest := make(chan struct{})
 	defer close(allowRequest)
 


### PR DESCRIPTION
Backport 1/1 commits from #154980.

/cc @cockroachdb/release

---

Informs #154840

Release note: none
