### PR TITLE
release-25.4.1-rc: roachtest: get more tags when fetching latest

### DIFF
--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -188,7 +188,7 @@ func repeatGitCloneE(
 func repeatGetLatestTag(
 	ctx context.Context, t test.Test, user string, repo string, releaseRegex *regexp.Regexp,
 ) (string, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/tags", user, repo)
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/tags?per_page=100", user, repo)
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	type Tag struct {
 		Name string


### PR DESCRIPTION
Backport 1/1 commits from #158362 on behalf of @bghal.

----

The GitHub API's tags endpoint returns 30 tags by default; there isn't
an explicit ordering. The tests had been erroring as none of the
returned django tabs were matches.
This change fetches the maximum of 100 tags to increase the likelihood
of finding matching tags and getting the latest.
Correctness would require fetching all the pages.

Fixes: #158186
Fixes: #158185
Fixes: #158233
Fixes: #158234
Fixes: #158177

Epic: none

Release note: None


----

Release justification: test only change