### PR TITLE
ccl/multiregionccl: stabilize global_tables follower-read checks

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/global_tables
+++ b/pkg/ccl/multiregionccl/testdata/global_tables
@@ -32,7 +32,7 @@ SELECT * FROM db.global WHERE k = 2
 ----
 LEAD_FOR_GLOBAL_READS
 
-trace-sql idx=1
+trace-sql idx=1 retry
 SELECT * FROM db.global WHERE k = 1
 ----
 served locally: true
@@ -43,7 +43,7 @@ SELECT * FROM db.global WHERE k = 2
 ----
 LEAD_FOR_GLOBAL_READS
 
-trace-sql idx=2
+trace-sql idx=2 retry
 SELECT * FROM db.global WHERE k = 1
 ----
 served locally: true
@@ -54,7 +54,7 @@ SELECT * FROM db.global WHERE k = 2
 ----
 LEAD_FOR_GLOBAL_READS
 
-trace-sql idx=3
+trace-sql idx=3 retry
 SELECT * FROM db.global WHERE k = 1
 ----
 served locally: true
@@ -65,7 +65,7 @@ SELECT * FROM db.global WHERE k = 2
 ----
 LEAD_FOR_GLOBAL_READS
 
-trace-sql idx=4
+trace-sql idx=4 retry
 SELECT * FROM db.global WHERE k = 1
 ----
 served locally: true
@@ -95,7 +95,7 @@ SELECT * FROM db.global WHERE k = 2
 ----
 LEAD_FOR_GLOBAL_READS
 
-trace-sql idx=5
+trace-sql idx=5 retry
 SELECT * FROM db.global WHERE k = 1
 ----
 served locally: true


### PR DESCRIPTION
Follower read assertions in global_tables tests were flaky due to relying on AS OF SYSTEM TIME now(), where the local replica's closed timestamp hadn't yet advanced enough. This caused transactions to exceed their uncertainty window when closed timestamp hadn't been bumped recently.

The intent of the test is to ensure that queries run as of now can use follower reads. Since timing can interphere, this added retry logic to try the query again if the trace didn't match expectations.

Closes #152099
Release note: None
Epic: none