### PR TITLE
pkg/cli: enhance tsdump functionality to work with explicit static list of metrics

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1624,6 +1624,7 @@ func init() {
 	f.BoolVar(&debugTimeSeriesDumpOpts.disableDeltaProcessing, "disable-delta-processing", false, "disable delta calculation for counter metrics (enabled by default)")
 	f.Int64Var(&debugTimeSeriesDumpOpts.ddMetricInterval, "dd-metric-interval", debugTimeSeriesDumpOpts.ddMetricInterval, "interval in seconds for datadoginit format only (default 10). Regular datadog format uses actual intervals from tsdump.")
 	f.Lookup("dd-metric-interval").Hidden = true // this is for internal use only
+	f.StringVar(&debugTimeSeriesDumpOpts.metricsListFile, "metrics-list-file", "", "text file containing metric names or regex patterns to dump (one per line). Prefixes cr.node., cr.store., and cockroachdb. are automatically stripped if present. When specified, only matching metrics are dumped instead of all metrics.")
 
 	f = debugSendKVBatchCmd.Flags()
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,

--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -60,7 +60,8 @@ var debugTimeSeriesDumpOpts = struct {
 	noOfUploadWorkers      int
 	retryFailedRequests    bool
 	disableDeltaProcessing bool
-	ddMetricInterval       int64 // interval for datadoginit format only
+	ddMetricInterval       int64  // interval for datadoginit format only
+	metricsListFile        string // file containing explicit list of metrics to dump
 }{
 	format:                 tsDumpText,
 	from:                   timestampValue{},
@@ -199,9 +200,34 @@ will then convert it to the --format requested in the current invocation.
 
 			target, _ := addr.AddrWithDefaultLocalhost(serverCfg.AdvertiseAddr)
 			adminClient := conn.NewAdminClient()
-			names, err := serverpb.GetInternalTimeseriesNamesFromServer(ctx, adminClient)
+
+			var names []string
+			var filter []serverpb.MetricsFilterEntry
+			if debugTimeSeriesDumpOpts.metricsListFile != "" {
+				// Use explicit metrics list from file
+				filter, err = readMetricsListFile(debugTimeSeriesDumpOpts.metricsListFile)
+				if err != nil {
+					return err
+				}
+			}
+			var stats serverpb.FilterStats
+			names, stats, err = serverpb.GetInternalTimeseriesNamesFromServer(ctx, adminClient, filter)
 			if err != nil {
 				return err
+			}
+			if debugTimeSeriesDumpOpts.metricsListFile != "" {
+				// Print warnings for unmatched literal metric names
+				for _, literal := range stats.UnmatchedLiterals {
+					fmt.Fprintf(os.Stderr, "Warning: metric '%s' not found (check for typos or outdated metric names)\n", literal)
+				}
+				// Print regex match counts for user feedback
+				for pattern, count := range stats.RegexMatchCounts {
+					if count > 0 {
+						fmt.Fprintf(os.Stderr, "Pattern '%s' matched %d metrics\n", pattern, count)
+					} else {
+						fmt.Fprintf(os.Stderr, "Warning: pattern '%s' matched no metrics\n", pattern)
+					}
+				}
 			}
 			req := &tspb.DumpRequest{
 				StartNanos: time.Time(debugTimeSeriesDumpOpts.from).UnixNano(),
@@ -689,6 +715,81 @@ func (w defaultTSWriter) Emit(data *tspb.TimeSeriesData) error {
 		fmt.Fprintf(w.w, "%v %v\n", d.TimestampNanos, d.Value)
 	}
 	return nil
+}
+
+// regexMetaChars contains characters that indicate a line is a regex pattern
+// rather than a literal metric name. Metric names only contain alphanumeric
+// characters, dots, underscores, and hyphens.
+var regexMetaChars = regexp.MustCompile(`[*+?^$|()\[\]{}\\]`)
+
+// isRegexPattern returns true if the line contains regex metacharacters,
+// indicating it should be treated as a regex pattern rather than a literal name.
+func isRegexPattern(line string) bool {
+	return regexMetaChars.MatchString(line)
+}
+
+// readMetricsListFile reads a file containing metric names or regex patterns (one per line).
+// Lines starting with # are treated as comments and skipped. Inline comments
+// (text after #) are also stripped. Empty lines are skipped. If metric names
+// include cr.node., cr.store., or cockroachdb. prefixes, they are stripped.
+// Lines containing regex metacharacters (*+?^$|()[]{}\) are automatically
+// detected and treated as regex patterns.
+// Duplicate entries are removed. Returns entries without any prefix.
+func readMetricsListFile(filePath string) ([]serverpb.MetricsFilterEntry, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open metrics list file %s", filePath)
+	}
+	defer file.Close()
+
+	seen := make(map[string]struct{})
+	var entries []serverpb.MetricsFilterEntry
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		// Strip inline comments (anything after #)
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		// Auto-detect if this is a regex pattern based on metacharacters
+		isRegex := isRegexPattern(line)
+		if isRegex {
+			// Validate the regex - if invalid, warn and skip this line
+			if _, err := regexp.Compile(line); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: invalid regex pattern on line %d, skipping: %s (%v)\n", lineNum, line, err)
+				continue
+			}
+		} else {
+			// Strip common prefixes if present (cr.node., cr.store., cockroachdb.)
+			line = strings.TrimPrefix(line, "cr.node.")
+			line = strings.TrimPrefix(line, "cr.store.")
+			line = strings.TrimPrefix(line, "cockroachdb.")
+		}
+
+		// Skip duplicates
+		if _, exists := seen[line]; exists {
+			continue
+		}
+		seen[line] = struct{}{}
+		entries = append(entries, serverpb.MetricsFilterEntry{Value: line, IsRegex: isRegex})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error reading metrics list file %s", filePath)
+	}
+	if len(entries) == 0 {
+		return nil, errors.Newf("metrics list file %s contains no valid metric names or patterns", filePath)
+	}
+	return entries, nil
 }
 
 type tsDumpFormat int

--- a/pkg/server/server_import_ts_test.go
+++ b/pkg/server/server_import_ts_test.go
@@ -75,7 +75,7 @@ func TestServerWithTimeseriesImport(t *testing.T) {
 
 func dumpTSNonempty(t *testing.T, cc serverutils.RPCConn, dest string) (bytes int64) {
 	ac := cc.NewAdminClient()
-	names, err := serverpb.GetInternalTimeseriesNamesFromServer(context.Background(), ac)
+	names, _, err := serverpb.GetInternalTimeseriesNamesFromServer(context.Background(), ac, nil)
 	require.NoError(t, err)
 	c, err := cc.NewTimeSeriesClient().DumpRaw(context.Background(), &tspb.DumpRequest{
 		Names: names,

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -127,7 +127,12 @@ go_test(
     size = "medium",
     srcs = ["admin_test.go"],
     embed = [":serverpb"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//pkg/util/metric",
+        "@com_github_prometheus_client_model//go",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 disallowed_imports_test(

--- a/pkg/server/serverpb/admin_test.go
+++ b/pkg/server/serverpb/admin_test.go
@@ -6,9 +6,14 @@
 package serverpb
 
 import (
+	"context"
+	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestTableStatsResponseAdd verifies that TableStatsResponse.Add()
@@ -107,4 +112,255 @@ func TestTableStatsResponseAdd(t *testing.T) {
 		},
 	}, underTest.MissingNodes)
 
+}
+
+// mockAdminClient is a mock implementation of RPCAdminClient
+// that only implements AllMetricMetadata for testing purposes.
+type mockAdminClient struct {
+	RPCAdminClient // Embed the interface
+	metadata       map[string]metric.Metadata
+}
+
+// AllMetricMetadata returns the mocked metadata.
+func (m *mockAdminClient) AllMetricMetadata(
+	ctx context.Context, req *MetricMetadataRequest,
+) (*MetricMetadataResponse, error) {
+	return &MetricMetadataResponse{Metadata: m.metadata}, nil
+}
+
+// TestApplyMetricsFilter tests the applyMetricsFilter function which handles
+// filtering metrics by literal names and regex patterns.
+func TestApplyMetricsFilter(t *testing.T) {
+	counterType := io_prometheus_client.MetricType_COUNTER
+
+	metadata := map[string]metric.Metadata{
+		"sql.query.count":      {MetricType: counterType},
+		"sql.exec.count":       {MetricType: counterType},
+		"kv.range.count":       {MetricType: counterType},
+		"changefeed.running":   {MetricType: counterType},
+		"distsender.rpc.count": {MetricType: counterType},
+	}
+
+	testCases := []struct {
+		name                string
+		filter              []MetricsFilterEntry
+		expectedNames       []string
+		expectedMatchCounts map[string]int
+		expectedUnmatched   []string
+		expectError         bool
+		errorContains       string
+	}{
+		{
+			name: "literal entries",
+			filter: []MetricsFilterEntry{
+				{Value: "sql.query.count", IsRegex: false},
+				{Value: "kv.range.count", IsRegex: false},
+			},
+			expectedNames:       []string{"kv.range.count", "sql.query.count"},
+			expectedMatchCounts: map[string]int{},
+		},
+		{
+			name: "literal entry not found returns unmatched",
+			filter: []MetricsFilterEntry{
+				{Value: "sql.query.count", IsRegex: false},
+				{Value: "nonexistent.metric", IsRegex: false},
+			},
+			expectedNames:       []string{"sql.query.count"},
+			expectedMatchCounts: map[string]int{},
+			expectedUnmatched:   []string{"nonexistent.metric"},
+		},
+		{
+			name: "regex entry matches multiple",
+			filter: []MetricsFilterEntry{
+				{Value: `sql\..*`, IsRegex: true},
+			},
+			expectedNames:       []string{"sql.exec.count", "sql.query.count"},
+			expectedMatchCounts: map[string]int{`sql\..*`: 2},
+		},
+		{
+			name: "regex matches anywhere in string",
+			filter: []MetricsFilterEntry{
+				{Value: `count`, IsRegex: true},
+			},
+			expectedNames:       []string{"distsender.rpc.count", "kv.range.count", "sql.exec.count", "sql.query.count"},
+			expectedMatchCounts: map[string]int{`count`: 4},
+		},
+		{
+			name: "regex with no matches",
+			filter: []MetricsFilterEntry{
+				{Value: `nonexistent\..*`, IsRegex: true},
+			},
+			expectedNames:       []string{},
+			expectedMatchCounts: map[string]int{`nonexistent\..*`: 0},
+		},
+		{
+			name: "mixed literal and regex",
+			filter: []MetricsFilterEntry{
+				{Value: "changefeed.running", IsRegex: false},
+				{Value: `sql\..*`, IsRegex: true},
+			},
+			expectedNames:       []string{"changefeed.running", "sql.exec.count", "sql.query.count"},
+			expectedMatchCounts: map[string]int{`sql\..*`: 2},
+		},
+		{
+			name: "invalid regex returns error",
+			filter: []MetricsFilterEntry{
+				{Value: `[invalid`, IsRegex: true},
+			},
+			expectError:   true,
+			errorContains: "invalid regex pattern",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, stats, err := applyMetricsFilter(metadata, tc.filter)
+
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorContains)
+				return
+			}
+
+			require.NoError(t, err)
+			sort.Strings(result)
+			require.Equal(t, tc.expectedNames, result)
+
+			for pattern, expectedCount := range tc.expectedMatchCounts {
+				require.Equal(t, expectedCount, stats.RegexMatchCounts[pattern], "match count for pattern %s", pattern)
+			}
+
+			if tc.expectedUnmatched != nil {
+				require.Equal(t, tc.expectedUnmatched, stats.UnmatchedLiterals)
+			} else {
+				require.Empty(t, stats.UnmatchedLiterals)
+			}
+		})
+	}
+}
+
+// TestGetInternalTimeseriesNamesFromServer tests the full pipeline:
+// filtering -> histogram expansion -> prefix addition -> sorting.
+func TestGetInternalTimeseriesNamesFromServer(t *testing.T) {
+	counterType := io_prometheus_client.MetricType_COUNTER
+	gaugeType := io_prometheus_client.MetricType_GAUGE
+	histogramType := io_prometheus_client.MetricType_HISTOGRAM
+
+	mockMetadata := map[string]metric.Metadata{
+		"sql.query.count":      {MetricType: counterType},
+		"changefeed.running":   {MetricType: gaugeType},
+		"request.latency":      {MetricType: histogramType},
+		"distsender.rpc.count": {MetricType: counterType},
+	}
+
+	mockClient := &mockAdminClient{metadata: mockMetadata}
+	ctx := context.Background()
+
+	// Helper to build expected output with prefixes
+	buildExpected := func(baseNames ...string) []string {
+		var result []string
+		for _, prefix := range []string{"cr.node.", "cr.store."} {
+			for _, name := range baseNames {
+				result = append(result, prefix+name)
+			}
+		}
+		sort.Strings(result)
+		return result
+	}
+
+	// Helper to build expected histogram output
+	buildHistogramExpected := func(baseName string) []string {
+		var result []string
+		for _, prefix := range []string{"cr.node.", "cr.store."} {
+			for _, q := range metric.HistogramMetricComputers {
+				result = append(result, prefix+baseName+q.Suffix)
+			}
+		}
+		sort.Strings(result)
+		return result
+	}
+
+	// Build expected output for "all metrics" (nil/empty filter)
+	var allMetricsExpanded []string
+	for _, prefix := range []string{"cr.node.", "cr.store."} {
+		allMetricsExpanded = append(allMetricsExpanded, prefix+"sql.query.count")
+		allMetricsExpanded = append(allMetricsExpanded, prefix+"changefeed.running")
+		allMetricsExpanded = append(allMetricsExpanded, prefix+"distsender.rpc.count")
+		for _, q := range metric.HistogramMetricComputers {
+			allMetricsExpanded = append(allMetricsExpanded, prefix+"request.latency"+q.Suffix)
+		}
+	}
+	sort.Strings(allMetricsExpanded)
+
+	testCases := []struct {
+		name                string
+		filter              []MetricsFilterEntry
+		expectedNames       []string
+		expectedMatchCounts map[string]int
+		expectedUnmatched   []string
+	}{
+		{
+			name:          "nil filter returns all metrics",
+			filter:        nil,
+			expectedNames: allMetricsExpanded,
+		},
+		{
+			name:          "empty filter returns all metrics",
+			filter:        []MetricsFilterEntry{},
+			expectedNames: allMetricsExpanded,
+		},
+		{
+			name: "histogram expansion with all quantile suffixes",
+			filter: []MetricsFilterEntry{
+				{Value: "request.latency", IsRegex: false},
+			},
+			expectedNames: buildHistogramExpected("request.latency"),
+		},
+		{
+			name: "multiple non-histogram metrics gets both prefixes without expansion",
+			filter: []MetricsFilterEntry{
+				{Value: "sql.query.count", IsRegex: false},
+				{Value: "changefeed.running", IsRegex: false},
+			},
+			expectedNames: buildExpected("changefeed.running", "sql.query.count"),
+		},
+		{
+			name: "filter with regex returns match counts",
+			filter: []MetricsFilterEntry{
+				{Value: `.*count`, IsRegex: true},
+			},
+			expectedNames:       buildExpected("distsender.rpc.count", "sql.query.count"),
+			expectedMatchCounts: map[string]int{`.*count`: 2},
+		},
+		{
+			name: "unmatched literal returns in unmatchedLiterals",
+			filter: []MetricsFilterEntry{
+				{Value: "sql.query.count", IsRegex: false},
+				{Value: "nonexistent.metric", IsRegex: false},
+			},
+			expectedNames:     buildExpected("sql.query.count"),
+			expectedUnmatched: []string{"nonexistent.metric"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			names, stats, err := GetInternalTimeseriesNamesFromServer(ctx, mockClient, tc.filter)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedNames, names)
+
+			if tc.expectedMatchCounts != nil {
+				for pattern, expectedCount := range tc.expectedMatchCounts {
+					require.Equal(t, expectedCount, stats.RegexMatchCounts[pattern], "match count for pattern %s", pattern)
+				}
+			}
+
+			if tc.expectedUnmatched != nil {
+				require.Equal(t, tc.expectedUnmatched, stats.UnmatchedLiterals)
+			} else {
+				require.Empty(t, stats.UnmatchedLiterals)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This commit introduces the ability to specify a list of metrics to dump via 
a file using the `--metrics-list-file` flag in the `debug tsdump` command. 
The implementation includes:

- A new `metricsListFile` option in the `debugTimeSeriesDumpOpts` struct 
to hold the file path.
- Functions to read and parse the metrics list file, supporting both 
literal metric names and regex patterns.
- Logic to expand the specified metrics into their corresponding internal 
timeseries names, including handling of histogram metrics.

This enhancement allows users to selectively dump metrics, improving the 
flexibility and usability of the tsdump command.

Part of: CRDB-57350
Epic: CRDB-55082
Release note: none