### PR TITLE
sql/rowexec: fix data race in indexBackfiller

### DIFF
--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -316,7 +316,8 @@ func (ib *indexBackfiller) makeIndexBackfillSink(ctx context.Context) (indexBack
 	if ib.spec.UseDistributedMergeSink {
 		// TODO(158378): We need to fully implement all stages of the distributed
 		// merge flow for index backfill.
-		return newSSTIndexBackfillSink(ctx, ib.flowCtx, ib.spec, ib.processorID)
+		return newSSTIndexBackfillSink(
+			ctx, ib.flowCtx, ib.spec.DistributedMergeFilePrefix, ib.spec.WriteAsOf, ib.processorID)
 	}
 
 	minBufferSize := backfillerBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)


### PR DESCRIPTION
This fixes a data race in the indexBackfiller. The race occurred because newSSTIndexBackfillSink was receiving the entire BackfillerSpec struct by value. Passing a struct by value requires copying all its fields, which races with concurrent writes to spec.ChunkSize.

The fix passes only the two required fields (DistributedMergeFilePrefix and WriteAsOf) as individual parameters instead of passing the entire spec struct.

Fixes #158582.
Fixes #158588
Fixes #158587
Fixes #158586 
Fixes #158585 
Fixes #158584 
Fixes #158583
Epic: CRDB-48845
Release note: None