### PR TITLE
jobs: hold claim on failed job for one adoption cycle

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -3317,3 +3317,66 @@ func TestLoadJobProgress(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []float32{7.1}, p.GetDetails().(*jobspb.Progress_Import).Import.ReadProgress)
 }
+
+func TestAdoptionDelayAfterJobFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer jobs.ResetConstructors()()
+
+	ctx := context.Background()
+	adoptionCompleted := make(chan struct{})
+	// We disable the adoption loop to prevent adoption attempts from laying a
+	// claim on a failed job before we can verify the behavior.
+	knobs := jobs.NewTestingKnobsWithIntervals(time.Hour, time.Hour, time.Hour, time.Hour)
+
+	var testJobID jobspb.JobID
+	knobs.AfterJobStateMachine = func(id jobspb.JobID) {
+		if id != testJobID {
+			return
+		}
+		close(adoptionCompleted)
+	}
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: knobs,
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	cleanup := jobs.TestingRegisterConstructor(
+		jobspb.TypeRestore,
+		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+			return jobstest.FakeResumer{
+				OnResume: func(ctx context.Context) error {
+					return errors.New("job failed")
+				},
+				FailOrCancel: func(ctx context.Context) error {
+					return errors.New("job fast-failed reverting")
+				},
+			}
+		},
+		jobs.UsesTenantCostControl,
+	)
+	defer cleanup()
+
+	registry := s.JobRegistry().(*jobs.Registry)
+	rec := jobs.Record{
+		Details:  jobspb.RestoreDetails{},
+		Progress: jobspb.RestoreProgress{},
+		Username: username.TestUserName(),
+	}
+
+	testJobID = registry.MakeJobID()
+	_, err := registry.CreateAdoptableJobWithTxn(ctx, rec, testJobID, nil /* txn */)
+	require.NoError(t, err)
+	registry.TestingNudgeAdoptionQueue()
+
+	<-adoptionCompleted
+	var claimID gosql.NullInt64
+	err = db.QueryRow(
+		"SELECT claim_instance_id FROM system.jobs WHERE id = $1", testJobID,
+	).Scan(&claimID)
+	require.NoError(t, err)
+	require.True(t, claimID.Valid, "expected job to still have a claim_instance_id after failure")
+}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -1040,7 +1041,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 		defer cancel()
 
 		cancelLoopTask(ctx)
-		lc := makeLoopController(r.settings, cancelIntervalSetting, r.knobs.IntervalOverrides.Cancel)
+		lc := makeLoopController(r, cancelIntervalSetting, r.knobs.IntervalOverrides.Cancel)
 		defer lc.cleanup()
 		for {
 			select {
@@ -1071,7 +1072,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		lc := makeLoopController(r.settings, gcIntervalSetting, r.knobs.IntervalOverrides.Gc)
+		lc := makeLoopController(r, gcIntervalSetting, r.knobs.IntervalOverrides.Gc)
 		defer lc.cleanup()
 
 		// Retention duration of terminal job records.
@@ -1109,7 +1110,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
-		lc := makeLoopController(r.settings, adoptIntervalSetting, r.knobs.IntervalOverrides.Adopt)
+		lc := makeLoopController(r, adoptIntervalSetting, r.knobs.IntervalOverrides.Adopt)
 		defer lc.cleanup()
 		for {
 			select {
@@ -2080,4 +2081,16 @@ func (r *Registry) IsIngesting(jobID catpb.JobID) bool {
 	defer r.mu.Unlock()
 	_, ok := r.mu.ingestingJobs[jobID]
 	return ok
+}
+
+// GetLoopInterval fetches the loop interval for a specific setting, applying
+// any overrides and scaling as necessary.
+func (r *Registry) GetLoopInterval(
+	s *settings.DurationSetting, overrideKnob *time.Duration,
+) time.Duration {
+	if overrideKnob != nil {
+		return *overrideKnob
+	}
+	interval := s.Get(&r.settings.SV)
+	return time.Duration(intervalBaseSetting.Get(&r.settings.SV) * float64(interval))
 }

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -119,6 +119,9 @@ type TestingIntervalOverrides struct {
 
 	// WaitForJobsMaxDelay
 	WaitForJobsMaxDelay *time.Duration
+
+	// ClaimTTLOnFailure overrides the ClaimTTLOnFailureSetting cluster setting.
+	ClaimTTLOnFailure *time.Duration
 }
 
 const defaultShortInterval = 10 * time.Millisecond
@@ -146,6 +149,7 @@ func NewTestingKnobsWithIntervals(
 			Cancel:            &cancel,
 			RetryInitialDelay: &initialDelay,
 			RetryMaxDelay:     &maxDelay,
+			ClaimTTLOnFailure: &adopt,
 		},
 	}
 }

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -109,7 +109,11 @@ func TestImportData(t *testing.T) {
 
 	skip.UnderRace(t, "takes >1min under race")
 
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/inspect/inspect_resumer_test.go
+++ b/pkg/sql/inspect/inspect_resumer_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -192,6 +193,7 @@ func TestInspectJobProtectedTimestamp(t *testing.T) {
 							return nil
 						},
 					},
+					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				},
 			})
 			defer s.Stopper().Stop(ctx)


### PR DESCRIPTION
This commit teaches the job system to hold the claim on failed jobs for one adoption cycle before releasing the claim. This alleviates hot loops where a fast-failing job can be picked up repeatedly by different nodes within an adoption cycle.

Fixes: #158597

Release note: None