### PR TITLE
ci: ensure we correctly report owners for generated tests

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -262,6 +262,11 @@ jobs:
       - run: ./build/github/prepare-summarize-build.sh
       - name: run tests
         run: ./build/github/unit-tests.sh
+      - name: generate code
+        if: failure()
+        # NB: To correctly report test owners, we'll have to make sure all Go
+        # code is generated and hoisted into the workspace (#107885).
+        run: ./build/github/generate-go-code.sh
       - name: upload test results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/github/generate-go-code.sh
+++ b/build/github/generate-go-code.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euo pipefail
+
+ENGFLOW_ARGS="--config crosslinux --jobs 50 $(./build/github/engflow-args.sh) --remote_download_minimal"
+
+bazel run //pkg/gen:code $ENGFLOW_ARGS

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -61,6 +61,18 @@ type XMLMessage struct {
 	Contents string     `xml:",chardata"`
 }
 
+// AnyFailures returns true iff there are any errors/failures in the test.xml.
+func AnyFailures(suites TestSuites) bool {
+	for _, suite := range suites.Suites {
+		for _, testCase := range suite.TestCases {
+			if testCase.Failure != nil || testCase.Error != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // OutputOfBinaryRule returns the path of the binary produced by the
 // given build target, relative to bazel-bin. That is,
 //

--- a/pkg/build/util/util_test.go
+++ b/pkg/build/util/util_test.go
@@ -13,6 +13,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAnyFailures(t *testing.T) {
+	xml1 := `<testsuites>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestMergeXml" timestamp="2025-12-02T20:59:24.432Z">
+		<testcase classname="util" name="TestMergeXml" time="0.000"></testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestMungeTestXML" timestamp="2025-12-02T20:59:24.433Z">
+		<testcase classname="util" name="TestMungeTestXML" time="0.000"></testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestOutputOfBinaryRule" timestamp="2025-12-02T20:59:24.432Z">
+		<testcase classname="util" name="TestOutputOfBinaryRule" time="0.000"></testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestOutputsOfGenrule" timestamp="2025-12-02T20:59:24.432Z">
+		<testcase classname="util" name="TestOutputsOfGenrule" time="0.000"></testcase>
+	</testsuite>
+</testsuites>`
+	xml2 := `<testsuites>
+	<testsuite errors="0" failures="1" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestAnyFailures" timestamp="2025-12-02T21:01:33.393Z">
+		<testcase classname="util" name="TestAnyFailures" time="0.000">
+			<failure message="Failed" type="">=== RUN   TestAnyFailures&#xA;    util_test.go:33: &#xA;        &#x9;Error Trace:&#x9;pkg/build/util/util_test.go:33&#xA;        &#x9;Error:      &#x9;An error is expected but got nil.&#xA;        &#x9;Test:       &#x9;TestAnyFailures&#xA;--- FAIL: TestAnyFailures (0.00s)&#xA;</failure>
+		</testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestMergeXml" timestamp="2025-12-02T21:01:33.393Z">
+		<testcase classname="util" name="TestMergeXml" time="0.000"></testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestMungeTestXML" timestamp="2025-12-02T21:01:33.393Z">
+		<testcase classname="util" name="TestMungeTestXML" time="0.000"></testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestOutputOfBinaryRule" timestamp="2025-12-02T21:01:33.393Z">
+		<testcase classname="util" name="TestOutputOfBinaryRule" time="0.000"></testcase>
+	</testsuite>
+	<testsuite errors="0" failures="0" skipped="0" tests="1" time="0.000" name="github.com/cockroachdb/cockroach/pkg/build/util.TestOutputsOfGenrule" timestamp="2025-12-02T21:01:33.393Z">
+		<testcase classname="util" name="TestOutputsOfGenrule" time="0.000"></testcase>
+	</testsuite>
+</testsuites>`
+
+	var suite1, suite2 TestSuites
+	require.NoError(t, xml.Unmarshal([]byte(xml1), &suite1))
+	require.False(t, AnyFailures(suite1))
+	require.NoError(t, xml.Unmarshal([]byte(xml2), &suite2))
+	require.True(t, AnyFailures(suite2))
+}
+
 func TestOutputOfBinaryRule(t *testing.T) {
 	require.Equal(t, OutputOfBinaryRule("//pkg/cmd/cockroach-short", false),
 		"pkg/cmd/cockroach-short/cockroach-short_/cockroach-short")

--- a/pkg/internal/codeowners/codeowners.go
+++ b/pkg/internal/codeowners/codeowners.go
@@ -169,19 +169,8 @@ func (co *CodeOwners) GetTestOwner(
 			panic("test-eng team could not be found in TEAMS.yaml")
 		}
 
-		// Workaround for #107885.
-		if strings.Contains(packageName, "backup") {
-			dr := co.GetTeamForAlias("cockroachdb/disaster-recovery")
-			if dr.Name() == "" {
-				panic("disaster-recovery team could not be found in TEAMS.yaml")
-			}
-
-			_logs = append(_logs, fmt.Sprintf("assigning %s.%s to 'disaster-recovery' due to #107885", packageName, testName))
-			_teams = []team.Team{dr}
-		} else {
-			_logs = append(_logs, fmt.Sprintf("assigning %s.%s to 'test-eng' as catch-all", packageName, testName))
-			_teams = []team.Team{testEng}
-		}
+		_logs = append(_logs, fmt.Sprintf("assigning %s.%s to 'test-eng' as catch-all", packageName, testName))
+		_teams = []team.Team{testEng}
 	}
 	return
 }


### PR DESCRIPTION
To do so, generate code before any time where we would be filing issues
to test owners.

Closes: #107885
Release note: none
Epic: CRDB-36213
