### PR TITLE
sst: fix warnings in .proto files

### DIFF
--- a/pkg/sql/bulksst/sst_info.proto
+++ b/pkg/sql/bulksst/sst_info.proto
@@ -11,14 +11,14 @@ import "gogoproto/gogo.proto";
 
 message SSTFileInfo {
     required string uri = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "URI"];;
-    required bytes start_key = 2 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
-    required bytes end_key = 3 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+    required bytes start_key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+    required bytes end_key = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
     required uint64 file_size = 4 [(gogoproto.nullable) = false];
     optional bytes row_sample = 5 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 }
 
 message SSTFiles {
     repeated SSTFileInfo sst = 1 [(gogoproto.customname) = "SST"];
-    repeated string row_samples = 2 [(gogoproto.nullable) = false];
+    repeated string row_samples = 2;
     required uint64 total_size = 3 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
This fixes the following warnings for fields recently added for the distributed merge work:
```
WARNING: field SSTFileInfo.StartKey is a non-nullable bytes type, nullable=false has no effect
WARNING: field SSTFileInfo.EndKey is a non-nullable bytes type, nullable=false has no effect
WARNING: field SSTFiles.RowSamples is a repeated non-nullable native type, nullable=false has no effect
```

Epic: CRDB-48845
Release notes: none