### PR TITLE
storepool: consider StoreLiveness status when determining suspect stores 

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -2741,7 +2741,7 @@ func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	stopper, g, _, storePool, nl := storepool.CreateTestStorePool(ctx, st,
+	stopper, g, _, storePool, nl, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDeadOff, true, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_LIVE)
@@ -3131,7 +3131,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	stopper, g, _, storePool, nl := storepool.CreateTestStorePool(ctx, st,
+	stopper, g, _, storePool, nl, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDeadOff, true, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_LIVE)
@@ -3200,7 +3200,7 @@ func TestAllocatorShouldTransferSuspected(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	stopper, g, clock, storePool, nl := storepool.CreateTestStorePool(ctx, st,
+	stopper, g, clock, storePool, nl, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDeadOff, true, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_LIVE)
@@ -6316,7 +6316,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	stopper, g, _, storePool, _ := storepool.CreateTestStorePool(ctx, st,
+	stopper, g, _, storePool, _, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDeadOff, true, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_LIVE)
@@ -8462,7 +8462,7 @@ func TestAllocatorComputeActionDynamicNumReplicas(t *testing.T) {
 	var numNodes int
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	stopper, _, _, sp, _ := storepool.CreateTestStorePool(ctx, st,
+	stopper, _, _, sp, _, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDeadOff, false, /* deterministic */
 		func() int { return numNodes },
 		livenesspb.NodeLivenessStatus_LIVE)
@@ -9519,7 +9519,8 @@ func exampleRebalancing(
 			return nodes
 		},
 		storepool.NewMockNodeLiveness(livenesspb.NodeLivenessStatus_LIVE).NodeLivenessFunc,
-		/* deterministic */ true,
+		storepool.NewMockStoreLiveness().StoreLivenessFunc,
+		true, /* deterministic */
 	)
 	alloc := MakeAllocator(st, MakeAllocatorSync(sp, st), true /* deterministic */, func(id roachpb.NodeID) (time.Duration, bool) {
 		return 0, false

--- a/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
@@ -43,7 +43,7 @@ func CreateTestAllocatorWithKnobs(
 	allocSyncKnobs *mmaintegration.TestingKnobs,
 ) (*stop.Stopper, *gossip.Gossip, *storepool.StorePool, Allocator, *timeutil.ManualTime) {
 	st := cluster.MakeTestingClusterSettings()
-	stopper, g, manual, storePool, _ := storepool.CreateTestStorePool(ctx, st,
+	stopper, g, manual, storePool, _, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDeadOff, deterministic,
 		func() int { return numNodes },
 		livenesspb.NodeLivenessStatus_LIVE)

--- a/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
         "//pkg/kv/kvserver/allocator/load",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
+        "//pkg/kv/kvserver/storeliveness",
+        "//pkg/kv/kvserver/storeliveness/storelivenesspb",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -93,21 +93,21 @@ func (o *OverrideStorePool) String() string {
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (o *OverrideStorePool) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Print(o.sp.statusString(o.overrideNodeLivenessFn))
+	w.Print(o.sp.statusString(o.overrideNodeLivenessFn, o.sp.StoreLivenessFn))
 }
 
 // IsStoreReadyForRoutineReplicaTransfer implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) IsStoreReadyForRoutineReplicaTransfer(
 	ctx context.Context, targetStoreID roachpb.StoreID,
 ) bool {
-	return o.sp.isStoreReadyForRoutineReplicaTransferInternal(ctx, targetStoreID, o.overrideNodeLivenessFn)
+	return o.sp.isStoreReadyForRoutineReplicaTransferInternal(ctx, targetStoreID, o.overrideNodeLivenessFn, o.sp.StoreLivenessFn)
 }
 
 // DecommissioningReplicas implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) DecommissioningReplicas(
 	repls []roachpb.ReplicaDescriptor,
 ) []roachpb.ReplicaDescriptor {
-	return o.sp.decommissioningReplicasWithLiveness(repls, o.overrideNodeLivenessFn)
+	return o.sp.decommissioningReplicasWithLiveness(repls, o.overrideNodeLivenessFn, o.sp.StoreLivenessFn)
 }
 
 // GetStoreList implements the AllocatorStorePool interface.
@@ -119,14 +119,14 @@ func (o *OverrideStorePool) GetStoreList(
 		storeIDs = append(storeIDs, storeID)
 		return true
 	})
-	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, o.sp.StoreLivenessFn, filter)
 }
 
 // GetStoreListFromIDs implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) GetStoreListFromIDs(
 	storeIDs roachpb.StoreIDSlice, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, o.sp.StoreLivenessFn, filter)
 }
 
 // GetStoreListForTargets implements the AllocatorStorePool interface.
@@ -138,14 +138,14 @@ func (o *OverrideStorePool) GetStoreListForTargets(
 		storeIDs = append(storeIDs, tgt.StoreID)
 	}
 
-	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, o.sp.StoreLivenessFn, filter)
 }
 
 // LiveAndDeadReplicas implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) LiveAndDeadReplicas(
 	repls []roachpb.ReplicaDescriptor, includeSuspectAndDrainingStores bool,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
-	return o.sp.liveAndDeadReplicasWithLiveness(repls, o.overrideNodeLivenessFn, includeSuspectAndDrainingStores)
+	return o.sp.liveAndDeadReplicasWithLiveness(repls, o.overrideNodeLivenessFn, o.sp.StoreLivenessFn, includeSuspectAndDrainingStores)
 }
 
 // ClusterNodeCount implements the AllocatorStorePool interface.

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -29,7 +29,7 @@ func TestOverrideStorePoolStatusString(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	const nodeCount = 5
 
-	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
+	stopper, g, _, testStorePool, mnl, _ := CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
@@ -111,7 +111,7 @@ func TestOverrideStorePoolDecommissioningReplicas(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	const nodeCount = 5
 
-	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
+	stopper, g, _, testStorePool, mnl, _ := CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
@@ -228,7 +228,7 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 	const nodeCount = 8
 
 	// We're going to manually mark stores dead in this test.
-	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
+	stopper, g, _, testStorePool, mnl, _ := CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/load"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -55,6 +57,25 @@ type NodeLivenessFunc func(nid roachpb.NodeID) livenesspb.NodeLivenessStatus
 func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLivenessFunc {
 	return func(nodeID roachpb.NodeID) livenesspb.NodeLivenessStatus {
 		return nodeLiveness.GetNodeVitalityFromCache(nodeID).LivenessStatus()
+	}
+}
+
+// StoreLivenessFunc accepts a nodeID and storeID, and returns whether the store
+// is considered unreachable in StoreLiveness or not. If the store is considered
+// unreachable, true is returned. On the other hand, if the store is considered
+// live, or if no attempt was made by the store to get support, false is
+// returned.
+//
+// Additonally, the timestamp at which the store last had its support withdrawn
+// is also returned. The only case where this may be empty is if the store has
+// never had its support withdrawn.
+type StoreLivenessFunc func(nid roachpb.NodeID, sid roachpb.StoreID) (isUnreachable bool, _ hlc.ClockTimestamp)
+
+// MakeStoreLivenessFunc returns a StoreLivenessFunc.
+func MakeStoreLivenessFunc(storeLiveness *storeliveness.NodeContainer) StoreLivenessFunc {
+	return func(nid roachpb.NodeID, sid roachpb.StoreID) (bool, hlc.ClockTimestamp) {
+		state, withdrawnTS := storeLiveness.SupportState(slpb.StoreIdent{NodeID: nid, StoreID: sid})
+		return state == storeliveness.StateNotSupporting, withdrawnTS
 	}
 }
 
@@ -145,6 +166,7 @@ func (sd *StoreDetailMu) status(
 	now hlc.Timestamp,
 	deadThreshold time.Duration,
 	nl NodeLivenessFunc,
+	sl StoreLivenessFunc,
 	suspectDuration time.Duration,
 ) StoreStatus {
 	sd.RLock() // all exist paths will RUnlock() the lock.
@@ -220,6 +242,12 @@ func (sd *StoreDetailMu) status(
 		return updateLastUnavailableAndReturnStatusRLocked(now, StoreStatusDraining)
 	}
 
+	// Also check whether the store is considered unreachable in StoreLiveness.
+	isUnreachable, supportWithdrawnTS := sl(sd.Desc.Node.NodeID, sd.Desc.StoreID)
+	if isUnreachable {
+		return returnStatusRLocked(StoreStatusDead)
+	}
+
 	// A store is throttled if it has missed receiving snapshots recently.
 	if sd.ThrottledUntil.After(now) {
 		return returnStatusRLocked(StoreStatusThrottled)
@@ -229,6 +257,12 @@ func (sd *StoreDetailMu) status(
 	// looking at the time it was last unavailable making sure we have not seen any
 	// failures for a period of time defined by StoreSuspectDuration.
 	if sd.LastUnavailable.AddDuration(suspectDuration).After(now) {
+		return returnStatusRLocked(StoreStatusSuspect)
+	}
+
+	// Also check whether the store is considered suspect by virtue of its
+	// withdrawal timestamp in the StoreLiveness fabric.
+	if !supportWithdrawnTS.IsEmpty() && supportWithdrawnTS.ToTimestamp().AddDuration(suspectDuration).After(now) {
 		return returnStatusRLocked(StoreStatusSuspect)
 	}
 
@@ -363,12 +397,13 @@ type StorePool struct {
 	log.AmbientContext
 	st *cluster.Settings
 
-	clock          *hlc.Clock
-	gossip         *gossip.Gossip
-	nodeCountFn    NodeCountFunc
-	NodeLivenessFn NodeLivenessFunc
-	startTime      hlc.Timestamp
-	deterministic  bool
+	clock           *hlc.Clock
+	gossip          *gossip.Gossip
+	nodeCountFn     NodeCountFunc
+	NodeLivenessFn  NodeLivenessFunc
+	StoreLivenessFn StoreLivenessFunc
+	startTime       hlc.Timestamp
+	deterministic   bool
 
 	// We use separate mutexes for storeDetails and nodeLocalities because the
 	// nodeLocalities map is used in the critical code path of Replica.Send()
@@ -408,17 +443,19 @@ func NewStorePool(
 	clock *hlc.Clock,
 	nodeCountFn NodeCountFunc,
 	nodeLivenessFn NodeLivenessFunc,
+	storeLivenessFn StoreLivenessFunc,
 	deterministic bool,
 ) *StorePool {
 	sp := &StorePool{
-		AmbientContext: ambient,
-		st:             st,
-		clock:          clock,
-		gossip:         g,
-		nodeCountFn:    nodeCountFn,
-		NodeLivenessFn: nodeLivenessFn,
-		startTime:      clock.Now(),
-		deterministic:  deterministic,
+		AmbientContext:  ambient,
+		st:              st,
+		clock:           clock,
+		gossip:          g,
+		nodeCountFn:     nodeCountFn,
+		NodeLivenessFn:  nodeLivenessFn,
+		StoreLivenessFn: storeLivenessFn,
+		startTime:       clock.Now(),
+		deterministic:   deterministic,
 	}
 	sp.localitiesMu.nodeLocalities = make(map[roachpb.NodeID]localityWithString)
 	sp.changeMu.onChange = []CapacityChangeFn{}
@@ -438,10 +475,12 @@ func (sp *StorePool) String() string {
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (sp *StorePool) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Print(sp.statusString(sp.NodeLivenessFn))
+	w.Print(sp.statusString(sp.NodeLivenessFn, sp.StoreLivenessFn))
 }
 
-func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
+func (sp *StorePool) statusString(
+	nl NodeLivenessFunc, sl StoreLivenessFunc,
+) redact.RedactableString {
 	ids := make(roachpb.StoreIDSlice, sp.getStoreDetailsCount())
 	sp.Details.StoreDetails.Range(func(id roachpb.StoreID, _ *StoreDetailMu) bool {
 		ids = append(ids, id)
@@ -461,7 +500,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
 			continue
 		}
 		buf.Print(id)
-		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
+		status := detail.status(now, timeUntilNodeDead, nl, sl, timeAfterNodeSuspect)
 		if status != StoreStatusAvailable {
 			buf.Printf(" (status=%s)", status)
 		}
@@ -722,7 +761,9 @@ func (sp *StorePool) GetStoreStatuses() map[roachpb.StoreID]StoreStatus {
 
 	result := make(map[roachpb.StoreID]StoreStatus)
 	sp.Details.StoreDetails.Range(func(storeID roachpb.StoreID, sd *StoreDetailMu) bool {
-		result[storeID] = sd.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
+		result[storeID] = sd.status(
+			now, timeUntilNodeDead, sp.NodeLivenessFn, sp.StoreLivenessFn, timeAfterNodeSuspect,
+		)
 		return true
 	})
 	return result
@@ -764,13 +805,13 @@ func (sp *StorePool) GetStoreDescriptor(storeID roachpb.StoreID) (roachpb.StoreD
 func (sp *StorePool) DecommissioningReplicas(
 	repls []roachpb.ReplicaDescriptor,
 ) (decommissioningReplicas []roachpb.ReplicaDescriptor) {
-	return sp.decommissioningReplicasWithLiveness(repls, sp.NodeLivenessFn)
+	return sp.decommissioningReplicasWithLiveness(repls, sp.NodeLivenessFn, sp.StoreLivenessFn)
 }
 
 // decommissioningReplicasWithLiveness filters out replicas on decommissioning node/store
 // from the provided repls and returns them in a slice, using the provided NodeLivenessFunc.
 func (sp *StorePool) decommissioningReplicasWithLiveness(
-	repls []roachpb.ReplicaDescriptor, nl NodeLivenessFunc,
+	repls []roachpb.ReplicaDescriptor, nl NodeLivenessFunc, sl StoreLivenessFunc,
 ) (decommissioningReplicas []roachpb.ReplicaDescriptor) {
 	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
@@ -780,7 +821,7 @@ func (sp *StorePool) decommissioningReplicasWithLiveness(
 
 	for _, repl := range repls {
 		detail := sp.GetStoreDetail(repl.StoreID)
-		switch detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect) {
+		switch detail.status(now, timeUntilNodeDead, nl, sl, timeAfterNodeSuspect) {
 		case StoreStatusDecommissioning:
 			decommissioningReplicas = append(decommissioningReplicas, repl)
 		}
@@ -837,7 +878,7 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 // liveness or deadness at the moment) or an error if the store is not found in
 // the pool.
 func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
-	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn)
+	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn, sp.StoreLivenessFn)
 	if err != nil {
 		return false, err
 	}
@@ -847,7 +888,7 @@ func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 // IsDraining returns true if the given store's status is `StoreStatusDraining`
 // or an error if the store is not found in the pool.
 func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
-	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn)
+	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn, sp.StoreLivenessFn)
 	if err != nil {
 		return false, err
 	}
@@ -857,7 +898,7 @@ func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
 // IsLive returns true if the node is considered alive by the store pool or an error
 // if the store is not found in the pool.
 func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {
-	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn)
+	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn, sp.StoreLivenessFn)
 	if err != nil {
 		return false, err
 	}
@@ -869,7 +910,7 @@ func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {
 // follower reads. A healthy store does not imply that replicas can be moved to
 // this store.
 func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
-	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn)
+	status, err := sp.storeStatus(storeID, sp.NodeLivenessFn, sp.StoreLivenessFn)
 	if err != nil {
 		return false
 	}
@@ -882,7 +923,7 @@ func (sp *StorePool) IsStoreHealthy(storeID roachpb.StoreID) bool {
 }
 
 func (sp *StorePool) storeStatus(
-	storeID roachpb.StoreID, nl NodeLivenessFunc,
+	storeID roachpb.StoreID, nl NodeLivenessFunc, sl StoreLivenessFunc,
 ) (StoreStatus, error) {
 	sd, ok := sp.Details.StoreDetails.Load(storeID)
 	if !ok {
@@ -893,7 +934,7 @@ func (sp *StorePool) storeStatus(
 	now := sp.clock.Now()
 	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
-	return sd.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect), nil
+	return sd.status(now, timeUntilNodeDead, nl, sl, timeAfterNodeSuspect), nil
 }
 
 // LiveAndDeadReplicas divides the provided repls slice into two slices: the
@@ -911,7 +952,7 @@ func (sp *StorePool) storeStatus(
 func (sp *StorePool) LiveAndDeadReplicas(
 	repls []roachpb.ReplicaDescriptor, includeSuspectAndDrainingStores bool,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
-	return sp.liveAndDeadReplicasWithLiveness(repls, sp.NodeLivenessFn, includeSuspectAndDrainingStores)
+	return sp.liveAndDeadReplicasWithLiveness(repls, sp.NodeLivenessFn, sp.StoreLivenessFn, includeSuspectAndDrainingStores)
 }
 
 // liveAndDeadReplicasWithLiveness divides the provided repls slice into two slices: the
@@ -919,7 +960,10 @@ func (sp *StorePool) LiveAndDeadReplicas(
 // provided NodeLivenessFunc.
 // See comment on StorePool.LiveAndDeadReplicas(..).
 func (sp *StorePool) liveAndDeadReplicasWithLiveness(
-	repls []roachpb.ReplicaDescriptor, nl NodeLivenessFunc, includeSuspectAndDrainingStores bool,
+	repls []roachpb.ReplicaDescriptor,
+	nl NodeLivenessFunc,
+	sl StoreLivenessFunc,
+	includeSuspectAndDrainingStores bool,
 ) (liveReplicas, deadReplicas []roachpb.ReplicaDescriptor) {
 	now := sp.clock.Now()
 	timeUntilNodeDead := liveness.TimeUntilNodeDead.Get(&sp.st.SV)
@@ -928,7 +972,7 @@ func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 	for _, repl := range repls {
 		detail := sp.GetStoreDetail(repl.StoreID)
 		// Mark replica as dead if store is dead.
-		status := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect)
+		status := detail.status(now, timeUntilNodeDead, nl, sl, timeAfterNodeSuspect)
 		switch status {
 		case StoreStatusDead:
 			deadReplicas = append(deadReplicas, repl)
@@ -1180,7 +1224,7 @@ func (sp *StorePool) GetStoreList(filter StoreFilter) (StoreList, int, Throttled
 		storeIDs = append(storeIDs, storeID)
 		return true
 	})
-	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, filter)
+	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, sp.StoreLivenessFn, filter)
 }
 
 // GetStoreListFromIDs is the same function as GetStoreList but only returns stores
@@ -1188,7 +1232,7 @@ func (sp *StorePool) GetStoreList(filter StoreFilter) (StoreList, int, Throttled
 func (sp *StorePool) GetStoreListFromIDs(
 	storeIDs roachpb.StoreIDSlice, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, filter)
+	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, sp.StoreLivenessFn, filter)
 }
 
 // GetStoreListForTargets is the same as GetStoreList, but only returns stores
@@ -1202,13 +1246,13 @@ func (sp *StorePool) GetStoreListForTargets(
 		storeIDs = append(storeIDs, tgt.StoreID)
 	}
 
-	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, filter)
+	return sp.getStoreListFromIDs(storeIDs, sp.NodeLivenessFn, sp.StoreLivenessFn, filter)
 }
 
 // getStoreListFromIDs is the same as GetStoreListFromIDs, but takes a
 // NodeLivenessFunc as an argument.
 func (sp *StorePool) getStoreListFromIDs(
-	storeIDs roachpb.StoreIDSlice, nl NodeLivenessFunc, filter StoreFilter,
+	storeIDs roachpb.StoreIDSlice, nl NodeLivenessFunc, sl StoreLivenessFunc, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
 	if sp.deterministic {
 		sort.Sort(storeIDs)
@@ -1230,7 +1274,7 @@ func (sp *StorePool) getStoreListFromIDs(
 			// Do nothing; this store is not in the StorePool.
 			continue
 		}
-		switch s := detail.status(now, timeUntilNodeDead, nl, timeAfterNodeSuspect); s {
+		switch s := detail.status(now, timeUntilNodeDead, nl, sl, timeAfterNodeSuspect); s {
 		case StoreStatusThrottled:
 			aliveStoreCount++
 			detail.RLock()
@@ -1404,13 +1448,13 @@ func (sp *StorePool) IsStoreReadyForRoutineReplicaTransfer(
 	if sp.OverrideIsStoreReadyForRoutineReplicaTransferFn != nil {
 		return sp.OverrideIsStoreReadyForRoutineReplicaTransferFn(ctx, targetStoreID)
 	}
-	return sp.isStoreReadyForRoutineReplicaTransferInternal(ctx, targetStoreID, sp.NodeLivenessFn)
+	return sp.isStoreReadyForRoutineReplicaTransferInternal(ctx, targetStoreID, sp.NodeLivenessFn, sp.StoreLivenessFn)
 }
 
 func (sp *StorePool) isStoreReadyForRoutineReplicaTransferInternal(
-	ctx context.Context, targetStoreID roachpb.StoreID, nl NodeLivenessFunc,
+	ctx context.Context, targetStoreID roachpb.StoreID, nl NodeLivenessFunc, sl StoreLivenessFunc,
 ) bool {
-	status, err := sp.storeStatus(targetStoreID, nl)
+	status, err := sp.storeStatus(targetStoreID, nl, sl)
 	if err != nil {
 		return false
 	}

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -61,7 +61,7 @@ func testingResetLoad(s State, rangeID RangeID) {
 func NewStorePool(
 	nodeCountFn storepool.NodeCountFunc,
 	nodeLivenessFn storepool.NodeLivenessFunc,
-	hlc *hlc.Clock,
+	clock *hlc.Clock,
 	st *cluster.Settings,
 ) *storepool.StorePool {
 	stopper := stop.NewStopper()
@@ -75,10 +75,13 @@ func NewStorePool(
 		ambientCtx,
 		st,
 		g,
-		hlc,
+		clock,
 		nodeCountFn,
 		nodeLivenessFn,
-		/* deterministic */ true,
+		// TODO(kv-distribution): consider adding tests which mock
+		// StoreLivenessFn.
+		storepool.NewMockStoreLiveness().StoreLivenessFunc,
+		true, /* deterministic */
 	)
 	return sp
 }

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6256,7 +6256,7 @@ func TestStoreMetricsOnIncomingOutgoingMsg(t *testing.T) {
 	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 123)))
 	cfg := kvserver.TestStoreConfig(clock)
 	var stopper *stop.Stopper
-	stopper, _, _, cfg.StorePool, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
+	stopper, _, _, cfg.StorePool, _, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 1 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -313,6 +313,7 @@ func NewTestStorePool(cfg StoreConfig) *storepool.StorePool {
 		func(roachpb.NodeID) livenesspb.NodeLivenessStatus {
 			return livenesspb.NodeLivenessStatus_LIVE
 		},
+		storepool.NewMockStoreLiveness().StoreLivenessFunc,
 		/* deterministic */ false,
 	)
 }

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -39,7 +39,7 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 	ctx := context.Background()
 	// We're going to manually mark stores dead in this test.
 	st := cluster.MakeTestingClusterSettings()
-	stopper, g, _, sp, _ := storepool.CreateTestStorePool(ctx, st,
+	stopper, g, _, sp, _, _ := storepool.CreateTestStorePool(ctx, st,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
@@ -231,7 +231,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 123)))
 	cfg := TestStoreConfig(clock)
 	var stopper *stop.Stopper
-	stopper, _, _, cfg.StorePool, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
+	stopper, _, _, cfg.StorePool, _, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 10 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -146,7 +146,7 @@ func TestRaftCrossLocalityMetrics(t *testing.T) {
 	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 123)))
 	cfg := TestStoreConfig(clock)
 	var stopper *stop.Stopper
-	stopper, _, _, cfg.StorePool, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
+	stopper, _, _, cfg.StorePool, _, _ = storepool.CreateTestStorePool(ctx, cfg.Settings,
 		liveness.TestTimeUntilNodeDead, false, /* deterministic */
 		func() int { return 0 }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -243,7 +243,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		cfg.Clock,
 		nodeCountFn,
 		storepool.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
-		/* deterministic */ false,
+		storepool.MakeStoreLivenessFunc(cfg.StoreLiveness),
+		false, /* deterministic */
 	)
 	cfg.MMAllocator = mmaprototype.NewAllocatorState(timeutil.DefaultTimeSource{},
 		rand.New(rand.NewSource(timeutil.Now().UnixNano())))


### PR DESCRIPTION
First 4 commits from https://github.com/cockroachdb/cockroach/pull/158629; only the last one is relevant for this PR. Feel free to hold off on reviewing until the thing merges.

----

This patch treats stores from which we recently (within the suspect
duration) withdrew support in StoreLiveness as suspect. Doing so
ensures we don't transfer leases to such stores, as shown by the
changes to TestLeaseTransferAfterStoreLivenessSupportWithdrawn.

Closes https://github.com/cockroachdb/cockroach/issues/158513

Release note: None