### PR TITLE
rttanalysis: use SetupEx/ResetEx for multi-database benchmark

### DIFF
--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -946,8 +946,8 @@ ORDER BY
 		{
 			Name: `liquibase migrations on multiple dbs`,
 			// 15 databases, each with 40 tables.
-			Setup: liquibaseSetup,
-			Reset: liquibaseReset,
+			SetupEx: liquibaseSetup,
+			ResetEx: liquibaseReset,
 			Stmt: `SELECT
   NULL AS table_cat,
   n.nspname AS table_schem,
@@ -1067,16 +1067,18 @@ func buildNTypes(n int) string {
 	return b.String()
 }
 
-func buildNDatabasesWithMTables(amtDbs int, amtTbls int) (string, string) {
-	b := strings.Builder{}
-	reset := strings.Builder{}
+func buildNDatabasesWithMTables(amtDbs int, amtTbls int) ([]string, []string) {
+	setupEx := make([]string, amtDbs)
+	resetEx := make([]string, amtDbs)
 	tbls := buildNTables(amtTbls)
 	for i := 0; i < amtDbs; i++ {
 		db := fmt.Sprintf("d%d", i)
+		b := strings.Builder{}
 		b.WriteString(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s;\n", db))
-		reset.WriteString(fmt.Sprintf("DROP DATABASE %s;\n", db))
 		b.WriteString(fmt.Sprintf("USE %s;\n", db))
 		b.WriteString(tbls)
+		setupEx[i] = b.String()
+		resetEx[i] = fmt.Sprintf("DROP DATABASE %s", db)
 	}
-	return b.String(), reset.String()
+	return setupEx, resetEx
 }


### PR DESCRIPTION
Update buildNDatabasesWithMTables to return slices for SetupEx and ResetEx, with each database having its own element. This should make it less likely to encounter txn retry errors during cleanup.

Fixes: #156226

Release note: None