### PR TITLE
release-25.4: roachtest: send more schema change flakes to foundations

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -51,7 +51,7 @@ func handleSchemaChangeWorkloadError(err error) error {
 	// crash.
 	if err != nil {
 		flattenedErr := errors.FlattenDetails(err)
-		if strings.Contains(flattenedErr, "UNEXPECTED ERROR") || strings.Contains(flattenedErr, "UNEXPECTED COMMIT ERROR") {
+		if strings.Contains(flattenedErr, "workload run error: ***") || strings.Contains(flattenedErr, "UNEXPECTED ERROR") || strings.Contains(flattenedErr, "UNEXPECTED COMMIT ERROR") {
 			return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "schema change workload failed"))
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #158637 on behalf of @msbutler.

----

Epic: none

Release note: none

----

Release justification: