### PR TITLE
bulkmerge: implement task distribution and loopback coordination

### DIFF
--- a/pkg/sql/bulkmerge/BUILD.bazel
+++ b/pkg/sql/bulkmerge/BUILD.bazel
@@ -25,6 +25,9 @@ go_library(
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/protoutil",
+        "//pkg/util/syncutil",
+        "//pkg/util/taskset",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -55,6 +58,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/bulkmerge/merge_test.go
+++ b/pkg/sql/bulkmerge/merge_test.go
@@ -7,46 +7,61 @@ package bulkmerge
 
 import (
 	"context"
+	"math/rand"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMergeProcessors(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
+func testMergeProcessors(
+	t *testing.T,
+	s serverutils.ApplicationLayerInterface,
+	expectedTaskCount, expectedTaskInstanceCount int,
+) {
 
-	// TODO(jeffswenson): start a three node instance to ensure each instances
-	// gets a processor.
 	ctx := context.Background()
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-
-	s := srv.ApplicationLayer()
 
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 
 	jobExecCtx, cleanup := sql.MakeJobExecContext(
 		ctx, "test", username.RootUserName(), &sql.MemoryMetrics{}, &execCfg,
 	)
+
+	// Wait for all nodes to be ready for DistSQL before planning.
+	// SetupAllNodesPlanning filters out unhealthy nodes, so if it returns the
+	// expected count, all nodes passed the NodeVitality.IsLive(DistSQL) check.
+	require.Eventually(t, func() bool {
+		_, sqlInstanceIDs, err := execCfg.DistSQLPlanner.SetupAllNodesPlanning(
+			ctx, jobExecCtx.ExtendedEvalContext(), &execCfg,
+		)
+		return err == nil && len(sqlInstanceIDs) >= expectedTaskInstanceCount
+	}, 30*time.Second, 100*time.Millisecond, "timed out waiting for %d nodes to be ready for DistSQL", expectedTaskInstanceCount)
 	defer cleanup()
 
-	plan, planCtx, err := newBulkMergePlan(ctx, jobExecCtx)
+	plan, planCtx, err := newBulkMergePlan(ctx, jobExecCtx, expectedTaskCount)
 	require.NoError(t, err)
 	defer plan.Release()
 
 	require.Equal(t, plan.GetResultTypes(), mergeCoordinatorOutputTypes)
 
-	var result string
+	var result execinfrapb.BulkMergeSpec_Output
 	rowWriter := sql.NewCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
-		result = string(*row[0].(*tree.DBytes))
+		require.NoError(t, protoutil.Unmarshal([]byte(*row[0].(*tree.DBytes)), &result))
 		return nil
 	})
 
@@ -72,7 +87,74 @@ func TestMergeProcessors(t *testing.T) {
 	)
 
 	require.NoError(t, rowWriter.Err())
-	// The output includes the routing key (e.g., "node1") from the SQL instance
-	// where the merge loopback processor runs.
-	require.Equal(t, result, "node1->merge->coordinator")
+
+	foundInstances := make(map[string]bool)
+	foundTasks := []int64{}
+	// ssts are expected to have the uri format nodelocal://<instance_id>/<job_id>/merger/<task_id>.sst
+	for _, sst := range result.SSTs {
+		parsed, err := url.Parse(sst.URI)
+		require.NoError(t, err)
+
+		filename := strings.Split(parsed.Path, "/")[3]
+
+		var taskID int64
+		taskID, err = strconv.ParseInt(strings.Split(filename, ".")[0], 10, 64)
+		require.NoError(t, err)
+		foundTasks = append(foundTasks, taskID)
+
+		foundInstances[parsed.Host] = true
+	}
+
+	slices.Sort(foundTasks)
+	require.Len(t, foundTasks, expectedTaskCount)
+	for _, taskID := range foundTasks {
+		require.GreaterOrEqual(t, taskID, int64(0))
+		require.Less(t, taskID, int64(expectedTaskCount))
+	}
+
+	require.Equalf(t, expectedTaskInstanceCount, len(foundInstances),
+		"expected %d instances but found instances: %v",
+		expectedTaskInstanceCount, foundInstances)
+}
+
+func TestDistributedMergeOneNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+
+	testMergeProcessors(t, srv.ApplicationLayer(), 5 /*taskCount*/, 1 /*instanceCount*/)
+}
+
+func TestDistributedMergeThreeNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	instanceCount := 3
+	taskCount := 100
+	tc := testcluster.StartTestCluster(t, instanceCount, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// Pick a random node to connect to
+	nodeIdx := rand.Intn(instanceCount)
+	testMergeProcessors(t, tc.Server(nodeIdx).ApplicationLayer(), taskCount, instanceCount)
+}
+
+func TestDistributedMergeMoreInstancesThanTasks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	instanceCount := 5
+	taskCount := 2 // Fewer tasks than instances
+	tc := testcluster.StartTestCluster(t, instanceCount, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// Pick a random node to connect to
+	nodeIdx := rand.Intn(instanceCount)
+	// Only 2 instances should actually process tasks since there are only 2 tasks
+	testMergeProcessors(t, tc.Server(nodeIdx).ApplicationLayer(), taskCount, 2)
 }


### PR DESCRIPTION
Previously, the bulkmerge processors had only a skeleton implementation. This change implements the core coordination logic:

1. Task Distribution: The merge coordinator now maintains a task set and distributes tasks across worker SQL instances using a loopback channel. As workers complete tasks, they are dynamically assigned new tasks until all tasks are processed.

2. Loopback Communication: Implements a loopback processor that receives task assignments from the coordinator and routes them back through the merge processors. Uses a flow-scoped channel map to enable communication between the coordinator and loopback processors.

3. Result Aggregation: The coordinator collects SST outputs from all processors and aggregates them into a final result proto.

4. Testing: Adds comprehensive tests for both single-node and multi-node scenarios, verifying that all tasks are processed and distributed across available instances.

The implementation uses protobuf marshaling for SST output and includes proper error handling throughout the pipeline.

Epic: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)