### PR TITLE
cloud/azure: include env vars in client cache check

### DIFF
--- a/pkg/cloud/azure/azure_file_credential.go
+++ b/pkg/cloud/azure/azure_file_credential.go
@@ -62,6 +62,10 @@ func NewAzureFileCredential(
 	return c, nil
 }
 
+func credFileEnv() string {
+	return envutil.EnvOrDefaultString("COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE", "")
+}
+
 // NewDefaultAzureCredentialWithFile creates a credential chain that's simply
 // a FileCredential prepended to the chain in DefaultAzureCredential.
 func NewDefaultAzureCredentialWithFile(
@@ -74,7 +78,7 @@ func NewDefaultAzureCredentialWithFile(
 	var credentials []azcore.TokenCredential
 	var credErrors []string
 
-	credentialFileName := envutil.EnvOrDefaultString("COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE", "")
+	credentialFileName := credFileEnv()
 	fileCredentials, err := NewAzureFileCredential(credentialFileName, &FileCredentialOptions{ClientOptions: options.ClientOptions, testingKnobs: options.testingKnobs})
 	if err != nil {
 		credErrors = append(credErrors, errors.Wrap(err, "file credential").Error())

--- a/pkg/cloud/azure/azure_file_credentials_test.go
+++ b/pkg/cloud/azure/azure_file_credentials_test.go
@@ -211,8 +211,7 @@ func TestAzureFileCredential(t *testing.T) {
 
 		t.Run("invalid-on-reload", func(t *testing.T) {
 			credFile := path.Join(tmpDir, "reload-on-error-invalid-on-reload")
-			cleanup := envutil.TestSetEnv(t, "COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE", credFile)
-			defer cleanup()
+			defer envutil.TestSetEnv(t, "COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE", credFile)()
 
 			require.NoError(t, writeAzureCredentialsFile(credFile, cfg.tenantID, cfg.clientID, cfg.clientSecret))
 


### PR DESCRIPTION
The tests of the azure client expect changes in environment variables to be reflected in subsequent uses of the client. However, the client was being cached without considering the env vars -- as they typically do not change during a process' lifetime outside of tests, violating the assumptions of these tests. Now the env var values are factored into the cache key.

Release note: none.
Epic: none.