### PR TITLE
sql: extend SST writer support to legacy schema changer backfill

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -930,6 +930,10 @@ message KeyVisualizerProgress {}
 
 message ResumeSpanList {
   repeated roachpb.Span resume_spans = 1 [(gogoproto.nullable) = false];
+  repeated IndexBackfillSSTManifest sst_manifests = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "SSTManifests"
+  ];
 }
 
 enum Status {

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "distributed_merge_mode.go",
         "index_backfiller_cols.go",
         "mvcc_index_merger.go",
+        "sst_manifest.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/backfill",
     visibility = ["//visibility:public"],

--- a/pkg/sql/backfill/sst_manifest.go
+++ b/pkg/sql/backfill/sst_manifest.go
@@ -1,0 +1,164 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backfill
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// SSTManifestBuffer accumulates SST metadata emitted during an index backfill
+// map stage. Callers may append new manifests and snapshot the buffer when
+// persisting checkpoints so they avoid copying slices manually throughout the
+// ingestion pipeline.
+type SSTManifestBuffer struct {
+	syncutil.Mutex
+	manifests []jobspb.IndexBackfillSSTManifest
+	dirty     bool
+}
+
+// NewSSTManifestBuffer constructs a buffer initialized with the provided
+// manifests.
+func NewSSTManifestBuffer(initial []jobspb.IndexBackfillSSTManifest) *SSTManifestBuffer {
+	buf := &SSTManifestBuffer{}
+	buf.manifests = append(buf.manifests, initial...)
+	if len(initial) > 0 {
+		buf.dirty = true
+	}
+	return buf
+}
+
+func (b *SSTManifestBuffer) snapshotLocked() []jobspb.IndexBackfillSSTManifest {
+	return append([]jobspb.IndexBackfillSSTManifest(nil), b.manifests...)
+}
+
+// Snapshot returns a copy of the buffered manifests.
+func (b *SSTManifestBuffer) Snapshot() []jobspb.IndexBackfillSSTManifest {
+	b.Lock()
+	defer b.Unlock()
+	return b.snapshotLocked()
+}
+
+// Append adds the provided manifests to the buffer and returns the updated
+// snapshot.
+func (b *SSTManifestBuffer) Append(
+	newManifests []jobspb.IndexBackfillSSTManifest,
+) []jobspb.IndexBackfillSSTManifest {
+	if len(newManifests) == 0 {
+		return b.Snapshot()
+	}
+	b.Lock()
+	defer b.Unlock()
+	b.manifests = append(b.manifests, newManifests...)
+	b.dirty = true
+	return b.snapshotLocked()
+}
+
+// Dirty reports whether the buffer has accumulated manifests that have not been
+// snapshotted since the last call to SnapshotAndMarkClean.
+func (b *SSTManifestBuffer) Dirty() bool {
+	if b == nil {
+		return false
+	}
+	b.Lock()
+	defer b.Unlock()
+	return b.dirty
+}
+
+// SnapshotAndMarkClean returns a copy of the buffered manifests and clears the
+// dirty flag. Callers should invoke this once they have persisted the snapshot.
+func (b *SSTManifestBuffer) SnapshotAndMarkClean() []jobspb.IndexBackfillSSTManifest {
+	if b == nil {
+		return nil
+	}
+	b.Lock()
+	defer b.Unlock()
+	b.dirty = false
+	return b.snapshotLocked()
+}
+
+// StripTenantPrefixFromSSTManifests normalizes SST manifest metadata by
+// removing tenant prefixes before persisting it in job state. This matches the
+// CompletedSpans handling and keeps job progress tenant-agnostic.
+func StripTenantPrefixFromSSTManifests(
+	codec keys.SQLCodec, manifests []jobspb.IndexBackfillSSTManifest,
+) ([]jobspb.IndexBackfillSSTManifest, error) {
+	ret := make([]jobspb.IndexBackfillSSTManifest, len(manifests))
+	for i, out := range manifests {
+		ret[i].URI = out.URI
+		ret[i].FileSize = out.FileSize
+		if out.WriteTimestamp != nil {
+			ts := *out.WriteTimestamp
+			ret[i].WriteTimestamp = &ts
+		}
+		if out.Span != nil {
+			stripped, err := stripTenantPrefixFromSpans(codec, *out.Span)
+			if err != nil {
+				return nil, err
+			}
+			ret[i].Span = &stripped
+		}
+		if len(out.RowSample) > 0 {
+			key, err := codec.StripTenantPrefix(out.RowSample)
+			if err != nil {
+				return nil, err
+			}
+			ret[i].RowSample = append(roachpb.Key(nil), key...)
+		}
+	}
+	return ret, nil
+}
+
+// AddTenantPrefixToSSTManifests rehydrates manifests with the executing
+// processor's tenant prefix so they can be used against the local keyspace.
+func AddTenantPrefixToSSTManifests(
+	codec keys.SQLCodec, manifests []jobspb.IndexBackfillSSTManifest,
+) []jobspb.IndexBackfillSSTManifest {
+	ret := make([]jobspb.IndexBackfillSSTManifest, len(manifests))
+	for i, out := range manifests {
+		ret[i].URI = out.URI
+		ret[i].FileSize = out.FileSize
+		if out.WriteTimestamp != nil {
+			ts := *out.WriteTimestamp
+			ret[i].WriteTimestamp = &ts
+		}
+		if out.Span != nil {
+			sp := addTenantPrefixToSpan(codec, *out.Span)
+			ret[i].Span = &sp
+		}
+		if len(out.RowSample) > 0 {
+			prefixed := make(roachpb.Key, 0, len(codec.TenantPrefix())+len(out.RowSample))
+			prefixed = append(prefixed, codec.TenantPrefix()...)
+			prefixed = append(prefixed, out.RowSample...)
+			ret[i].RowSample = prefixed
+		}
+	}
+	return ret
+}
+
+func stripTenantPrefixFromSpans(codec keys.SQLCodec, span roachpb.Span) (roachpb.Span, error) {
+	var err error
+	var out roachpb.Span
+	if out.Key, err = codec.StripTenantPrefix(span.Key); err != nil {
+		return roachpb.Span{}, err
+	}
+	if out.EndKey, err = codec.StripTenantPrefix(span.EndKey); err != nil {
+		return roachpb.Span{}, err
+	}
+	return out, nil
+}
+
+func addTenantPrefixToSpan(codec keys.SQLCodec, span roachpb.Span) roachpb.Span {
+	prefix := codec.TenantPrefix()
+	prefix = prefix[:len(prefix):len(prefix)]
+	out := roachpb.Span{
+		Key:    append(prefix, span.Key...),
+		EndKey: append(prefix, span.EndKey...),
+	}
+	return out
+}

--- a/pkg/sql/rowexec/backfiller_test.go
+++ b/pkg/sql/rowexec/backfiller_test.go
@@ -7,6 +7,7 @@ package rowexec_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -49,7 +50,7 @@ func TestingWriteResumeSpan(
 	ctx, traceSpan := tracing.ChildSpan(ctx, "checkpoint")
 	defer traceSpan.Finish()
 
-	resumeSpans, job, mutationIdx, err := rowexec.GetResumeSpans(
+	resumeSpans, manifests, job, mutationIdx, err := rowexec.GetResumeSpansAndSSTManifests(
 		ctx, jobsRegistry, txn, codec, col, id, mutationID, filter,
 	)
 	if err != nil {
@@ -57,7 +58,7 @@ func TestingWriteResumeSpan(
 	}
 
 	resumeSpans = roachpb.SubtractSpans(resumeSpans, finished)
-	return rowexec.SetResumeSpansInJob(ctx, resumeSpans, mutationIdx, txn, job)
+	return rowexec.SetResumeSpansAndSSTManifestsInJob(ctx, &codec, resumeSpans, manifests, mutationIdx, txn, job)
 }
 
 func TestWriteResumeSpan(t *testing.T) {
@@ -231,5 +232,96 @@ func TestWriteResumeSpan(t *testing.T) {
 		if !e.EqualValue(got[i]) {
 			t.Fatalf("expected = %+v, got = %+v", e, got[i])
 		}
+	}
+}
+
+func TestResumeSpanSSTManifestRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				SchemaChangeJobNoOp: func() bool {
+					// Disable schema change execution. This way all mutations never leave the descriptor.
+					return true
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+	sqlRunner.Exec(t, `SET create_table_with_schema_locked=false`)
+	sqlRunner.Exec(t, `SET use_declarative_schema_changer='off'`)
+	sqlRunner.Exec(t, `CREATE DATABASE t;`)
+	sqlRunner.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY, v INT);`)
+	sqlRunner.Exec(t, `CREATE UNIQUE INDEX vidx ON t.test (v);`)
+
+	registry := s.JobRegistry().(*jobs.Registry)
+	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
+		kvDB, s.Codec(), "t", "test")
+
+	// Pick up the index we created above. Note: there is a schema change knob
+	// that no-ops the schema change leaving the mutation in place.
+	require.Equal(t, 2, len(tableDesc.AllMutations()))
+	mutationID := tableDesc.AllMutations()[0].MutationID()
+
+	// The job is marked as completed since we made it a no-op. But since we want
+	// to update the job progress, lets change it back to running.
+	require.Equal(t, 1, len(tableDesc.MutationJobs))
+	jobID := tableDesc.MutationJobs[0].JobID
+	require.NotZero(t, jobID)
+	sqlRunner.Exec(t, fmt.Sprintf("UPDATE system.jobs SET status = 'running' WHERE id = %d", jobID))
+
+	var expected jobspb.IndexBackfillSSTManifest
+	ts := s.Clock().Now()
+	expected.URI = "nodelocal://1/index-backfill/test"
+	prefix := s.Codec().TenantPrefix()
+	prefix = prefix[:len(prefix):len(prefix)]
+	makeKey := func(s string) roachpb.Key {
+		key := make(roachpb.Key, 0, len(prefix)+len(s))
+		key = append(key, prefix...)
+		key = append(key, s...)
+		return key
+	}
+	span := roachpb.Span{
+		Key:    makeKey("sst-start"),
+		EndKey: makeKey("sst-end"),
+	}
+	expected.Span = &span
+	expected.FileSize = 12345
+	expected.RowSample = makeKey("sample")
+	expected.WriteTimestamp = &ts
+
+	if err := sqltestutils.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		spans, _, job, mutationIdx, err := rowexec.GetResumeSpansAndSSTManifests(
+			ctx, registry, txn, s.Codec(), col, tableDesc.ID, mutationID, backfill.IndexMutationFilter,
+		)
+		if err != nil {
+			return err
+		}
+		codec := s.Codec()
+		return rowexec.SetResumeSpansAndSSTManifestsInJob(
+			ctx, &codec, spans, []jobspb.IndexBackfillSSTManifest{expected}, mutationIdx, txn, job,
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sqltestutils.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
+		_, manifests, _, _, err := rowexec.GetResumeSpansAndSSTManifests(
+			ctx, registry, txn, s.Codec(), col, tableDesc.ID, mutationID, backfill.IndexMutationFilter,
+		)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, []jobspb.IndexBackfillSSTManifest{expected}, manifests)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/sql/schemachanger/scexec/backfiller/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/backfiller/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/sql/backfill",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/schemachanger/scexec",
         "//pkg/testutils",

--- a/pkg/sql/schemachanger/scexec/backfiller/progress_test.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/progress_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/stretchr/testify/require"
 )
@@ -31,13 +32,13 @@ func TestSSTManifestTenantPrefixConversion(t *testing.T) {
 		WriteTimestamp: &ts,
 	}}
 
-	stripped, err := stripTenantPrefixFromSSTManifests(tenantCodec, input)
+	stripped, err := backfill.StripTenantPrefixFromSSTManifests(tenantCodec, input)
 	require.NoError(t, err)
 	require.Len(t, stripped, 1)
 	require.False(t, bytes.HasPrefix(stripped[0].Span.Key, tenantCodec.TenantPrefix()))
 	require.False(t, bytes.HasPrefix(stripped[0].Span.EndKey, tenantCodec.TenantPrefix()))
 	require.False(t, bytes.HasPrefix(stripped[0].RowSample, tenantCodec.TenantPrefix()))
 
-	withPrefix := addTenantPrefixToSSTManifests(tenantCodec, stripped)
+	withPrefix := backfill.AddTenantPrefixToSSTManifests(tenantCodec, stripped)
 	require.Equal(t, input, withPrefix)
 }


### PR DESCRIPTION
Previously, SST writer support during index backfill with distributed merge was only available in the declarative schema changer (added in #158456). This commit extends the same logic to the legacy schema changer. To avoid duplication, shared logic was extracted into a helper function reused by both.

Informs #158378
Epic: CRDB-48845

Release note: none