### PR TITLE
sql: add support for EXECUTE SCHEDULE statement

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -153,6 +153,7 @@ FILES = [
     "drop_trigger",
     "drop_type",
     "drop_view",
+    "execute_schedules_stmt",
     "execute_stmt",
     "experimental_audit",
     "explain_analyze_stmt",

--- a/docs/generated/sql/bnf/execute_schedules_stmt.bnf
+++ b/docs/generated/sql/bnf/execute_schedules_stmt.bnf
@@ -1,0 +1,3 @@
+execute_schedules_stmt ::=
+	'EXECUTE_SCHEDULE' 'SCHEDULE' a_expr
+	| 'EXECUTE_SCHEDULES' 'SCHEDULES' select_stmt

--- a/docs/generated/sql/bnf/preparable_stmt.bnf
+++ b/docs/generated/sql/bnf/preparable_stmt.bnf
@@ -8,6 +8,7 @@ preparable_stmt ::=
 	| drop_stmt
 	| explain_stmt
 	| import_stmt
+	| execute_schedules_stmt
 	| insert_stmt
 	| inspect_stmt
 	| pause_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -48,6 +48,7 @@ preparable_stmt ::=
 	| drop_stmt
 	| explain_stmt
 	| import_stmt
+	| execute_schedules_stmt
 	| insert_stmt
 	| inspect_stmt
 	| pause_stmt
@@ -242,6 +243,10 @@ explain_stmt ::=
 import_stmt ::=
 	'IMPORT' 'INTO' table_name '(' insert_column_list ')' import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
 	| 'IMPORT' 'INTO' table_name import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
+
+execute_schedules_stmt ::=
+	'EXECUTE_SCHEDULE' 'SCHEDULE' a_expr
+	| 'EXECUTE_SCHEDULES' 'SCHEDULES' select_stmt
 
 insert_stmt ::=
 	opt_with_clause 'INSERT' 'INTO' insert_target insert_rest returning_clause
@@ -746,6 +751,9 @@ opt_with_options ::=
 	'WITH' kv_option_list
 	| 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 
+
+a_expr ::=
+	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'SQRT' a_expr | 'CBRT' a_expr | qual_op a_expr | 'NOT' a_expr | 'NOT' a_expr | row 'OVERLAPS' row | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | 'AT' 'TIME' 'ZONE' a_expr | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'FIRST_CONTAINS' a_expr | 'CONTAINED_BY' a_expr | 'FIRST_CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'AND_AND' a_expr | 'AT_AT' a_expr | 'DISTANCE' a_expr | 'COS_DISTANCE' a_expr | 'NEG_INNER_PRODUCT' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | qual_op a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
 
 insert_target ::=
 	table_name_opt_idx
@@ -1880,9 +1888,6 @@ alter_virtual_cluster_service_stmt ::=
 backup_options_list ::=
 	( backup_options ) ( ( ',' backup_options ) )*
 
-a_expr ::=
-	( c_expr | '+' a_expr | '-' a_expr | '~' a_expr | 'SQRT' a_expr | 'CBRT' a_expr | qual_op a_expr | 'NOT' a_expr | 'NOT' a_expr | row 'OVERLAPS' row | 'DEFAULT' ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | 'COLLATE' collation_name | 'AT' 'TIME' 'ZONE' a_expr | '+' a_expr | '-' a_expr | '*' a_expr | '/' a_expr | 'FLOORDIV' a_expr | '%' a_expr | '^' a_expr | '#' a_expr | '&' a_expr | '|' a_expr | '<' a_expr | '>' a_expr | '?' a_expr | 'JSON_SOME_EXISTS' a_expr | 'JSON_ALL_EXISTS' a_expr | 'CONTAINS' a_expr | 'FIRST_CONTAINS' a_expr | 'CONTAINED_BY' a_expr | 'FIRST_CONTAINED_BY' a_expr | '=' a_expr | 'CONCAT' a_expr | 'LSHIFT' a_expr | 'RSHIFT' a_expr | 'FETCHVAL' a_expr | 'FETCHTEXT' a_expr | 'FETCHVAL_PATH' a_expr | 'FETCHTEXT_PATH' a_expr | 'REMOVE_PATH' a_expr | 'INET_CONTAINED_BY_OR_EQUALS' a_expr | 'AND_AND' a_expr | 'AT_AT' a_expr | 'DISTANCE' a_expr | 'COS_DISTANCE' a_expr | 'NEG_INNER_PRODUCT' a_expr | 'INET_CONTAINS_OR_EQUALS' a_expr | 'LESS_EQUALS' a_expr | 'GREATER_EQUALS' a_expr | 'NOT_EQUALS' a_expr | qual_op a_expr | 'AND' a_expr | 'OR' a_expr | 'LIKE' a_expr | 'LIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'LIKE' a_expr | 'NOT' 'LIKE' a_expr 'ESCAPE' a_expr | 'ILIKE' a_expr | 'ILIKE' a_expr 'ESCAPE' a_expr | 'NOT' 'ILIKE' a_expr | 'NOT' 'ILIKE' a_expr 'ESCAPE' a_expr | 'SIMILAR' 'TO' a_expr | 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr | 'NOT' 'SIMILAR' 'TO' a_expr 'ESCAPE' a_expr | '~' a_expr | 'NOT_REGMATCH' a_expr | 'REGIMATCH' a_expr | 'NOT_REGIMATCH' a_expr | 'IS' 'NAN' | 'IS' 'NOT' 'NAN' | 'IS' 'NULL' | 'ISNULL' | 'IS' 'NOT' 'NULL' | 'NOTNULL' | 'IS' 'TRUE' | 'IS' 'NOT' 'TRUE' | 'IS' 'FALSE' | 'IS' 'NOT' 'FALSE' | 'IS' 'UNKNOWN' | 'IS' 'NOT' 'UNKNOWN' | 'IS' 'DISTINCT' 'FROM' a_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' a_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' | 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'NOT' 'BETWEEN' opt_asymmetric b_expr 'AND' a_expr | 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'NOT' 'BETWEEN' 'SYMMETRIC' b_expr 'AND' a_expr | 'IN' in_expr | 'NOT' 'IN' in_expr | subquery_op sub_type a_expr ) )*
-
 for_schedules_clause ::=
 	'FOR' 'SCHEDULES' select_stmt
 	| 'FOR' 'SCHEDULE' a_expr
@@ -2074,6 +2079,53 @@ insert_column_item ::=
 
 kv_option_list ::=
 	( kv_option ) ( ( ',' kv_option ) )*
+
+c_expr ::=
+	d_expr
+	| d_expr array_subscripts
+	| case_expr
+	| 'EXISTS' select_with_parens
+
+qual_op ::=
+	'OPERATOR' '(' operator_op ')'
+
+row ::=
+	'ROW' '(' opt_expr_list ')'
+	| expr_tuple_unambiguous
+
+cast_target ::=
+	typename
+
+typename ::=
+	simple_typename opt_array_bounds
+	| simple_typename 'ARRAY'
+
+collation_name ::=
+	unrestricted_name
+
+opt_asymmetric ::=
+	'ASYMMETRIC'
+	| 
+
+b_expr ::=
+	( c_expr | '+' b_expr | '-' b_expr | '~' b_expr | qual_op b_expr ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | '+' b_expr | '-' b_expr | '*' b_expr | '/' b_expr | 'FLOORDIV' b_expr | '%' b_expr | '^' b_expr | '#' b_expr | '&' b_expr | '|' b_expr | '<' b_expr | '>' b_expr | '=' b_expr | 'CONCAT' b_expr | 'LSHIFT' b_expr | 'RSHIFT' b_expr | 'LESS_EQUALS' b_expr | 'GREATER_EQUALS' b_expr | 'NOT_EQUALS' b_expr | qual_op b_expr | 'IS' 'DISTINCT' 'FROM' b_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' b_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' ) )*
+
+in_expr ::=
+	select_with_parens
+	| expr_tuple1_ambiguous
+
+subquery_op ::=
+	all_op
+	| qual_op
+	| 'LIKE'
+	| 'NOT' 'LIKE'
+	| 'ILIKE'
+	| 'NOT' 'ILIKE'
+
+sub_type ::=
+	'ANY'
+	| 'SOME'
+	| 'ALL'
 
 opt_inspect_options_clause ::=
 	'WITH' 'OPTIONS' inspect_option_list
@@ -2310,10 +2362,6 @@ unrestricted_name ::=
 function_with_paramtypes ::=
 	db_object_name func_params
 	| db_object_name
-
-typename ::=
-	simple_typename opt_array_bounds
-	| simple_typename 'ARRAY'
 
 transaction_mode ::=
 	transaction_iso_level
@@ -2625,49 +2673,6 @@ backup_options ::=
 	| include_all_clusters '=' a_expr
 	| 'UPDATES_CLUSTER_MONITORING_METRICS'
 	| 'UPDATES_CLUSTER_MONITORING_METRICS' '=' a_expr
-
-c_expr ::=
-	d_expr
-	| d_expr array_subscripts
-	| case_expr
-	| 'EXISTS' select_with_parens
-
-qual_op ::=
-	'OPERATOR' '(' operator_op ')'
-
-row ::=
-	'ROW' '(' opt_expr_list ')'
-	| expr_tuple_unambiguous
-
-cast_target ::=
-	typename
-
-collation_name ::=
-	unrestricted_name
-
-opt_asymmetric ::=
-	'ASYMMETRIC'
-	| 
-
-b_expr ::=
-	( c_expr | '+' b_expr | '-' b_expr | '~' b_expr | qual_op b_expr ) ( ( 'TYPECAST' cast_target | 'TYPEANNOTATE' typename | '+' b_expr | '-' b_expr | '*' b_expr | '/' b_expr | 'FLOORDIV' b_expr | '%' b_expr | '^' b_expr | '#' b_expr | '&' b_expr | '|' b_expr | '<' b_expr | '>' b_expr | '=' b_expr | 'CONCAT' b_expr | 'LSHIFT' b_expr | 'RSHIFT' b_expr | 'LESS_EQUALS' b_expr | 'GREATER_EQUALS' b_expr | 'NOT_EQUALS' b_expr | qual_op b_expr | 'IS' 'DISTINCT' 'FROM' b_expr | 'IS' 'NOT' 'DISTINCT' 'FROM' b_expr | 'IS' 'OF' '(' type_list ')' | 'IS' 'NOT' 'OF' '(' type_list ')' ) )*
-
-in_expr ::=
-	select_with_parens
-	| expr_tuple1_ambiguous
-
-subquery_op ::=
-	all_op
-	| qual_op
-	| 'LIKE'
-	| 'NOT' 'LIKE'
-	| 'ILIKE'
-	| 'NOT' 'ILIKE'
-
-sub_type ::=
-	'ANY'
-	| 'SOME'
-	| 'ALL'
 
 opt_template_clause ::=
 	'TEMPLATE' opt_equal non_reserved_word_or_sconst
@@ -2999,6 +3004,81 @@ kv_option ::=
 	| 'SCONST' '=' string_or_placeholder
 	| 'SCONST'
 
+array_subscripts ::=
+	( array_subscript ) ( ( array_subscript ) )*
+
+case_expr ::=
+	'CASE' case_arg when_clause_list case_default 'END'
+
+operator_op ::=
+	all_op
+
+opt_expr_list ::=
+	expr_list
+	| 
+
+expr_tuple_unambiguous ::=
+	'(' ')'
+	| '(' tuple1_unambiguous_values ')'
+
+simple_typename ::=
+	general_type_name
+	| '@' iconst32
+	| complex_type_name
+	| const_typename
+	| interval_type
+
+opt_array_bounds ::=
+	'[' ']'
+	| 
+
+expr_tuple1_ambiguous ::=
+	'(' ')'
+	| '(' tuple1_ambiguous_values ')'
+
+all_op ::=
+	'+'
+	| '-'
+	| '*'
+	| '/'
+	| '%'
+	| '^'
+	| '<'
+	| '>'
+	| '='
+	| 'LESS_EQUALS'
+	| 'GREATER_EQUALS'
+	| 'NOT_EQUALS'
+	| '?'
+	| '&'
+	| '|'
+	| '#'
+	| 'FLOORDIV'
+	| 'CONTAINS'
+	| 'FIRST_CONTAINS'
+	| 'CONTAINED_BY'
+	| 'FIRST_CONTAINED_BY'
+	| 'LSHIFT'
+	| 'RSHIFT'
+	| 'CONCAT'
+	| 'FETCHVAL'
+	| 'FETCHTEXT'
+	| 'FETCHVAL_PATH'
+	| 'FETCHTEXT_PATH'
+	| 'JSON_SOME_EXISTS'
+	| 'JSON_ALL_EXISTS'
+	| 'NOT_REGMATCH'
+	| 'REGIMATCH'
+	| 'NOT_REGIMATCH'
+	| 'AND_AND'
+	| 'AT_AT'
+	| 'DISTANCE'
+	| 'COS_DISTANCE'
+	| 'NEG_INNER_PRODUCT'
+	| '~'
+	| 'SQRT'
+	| 'CBRT'
+
 inspect_option_list ::=
 	( inspect_option ) ( ( ',' inspect_option ) )*
 
@@ -3200,17 +3280,6 @@ func_params ::=
 	'(' func_params_list ')'
 	| '(' ')'
 
-simple_typename ::=
-	general_type_name
-	| '@' iconst32
-	| complex_type_name
-	| const_typename
-	| interval_type
-
-opt_array_bounds ::=
-	'[' ']'
-	| 
-
 transaction_iso_level ::=
 	'ISOLATION' 'LEVEL' iso_level
 
@@ -3401,70 +3470,6 @@ array_expr ::=
 include_all_clusters ::=
 	'INCLUDE_ALL_VIRTUAL_CLUSTERS'
 
-array_subscripts ::=
-	( array_subscript ) ( ( array_subscript ) )*
-
-case_expr ::=
-	'CASE' case_arg when_clause_list case_default 'END'
-
-operator_op ::=
-	all_op
-
-opt_expr_list ::=
-	expr_list
-	| 
-
-expr_tuple_unambiguous ::=
-	'(' ')'
-	| '(' tuple1_unambiguous_values ')'
-
-expr_tuple1_ambiguous ::=
-	'(' ')'
-	| '(' tuple1_ambiguous_values ')'
-
-all_op ::=
-	'+'
-	| '-'
-	| '*'
-	| '/'
-	| '%'
-	| '^'
-	| '<'
-	| '>'
-	| '='
-	| 'LESS_EQUALS'
-	| 'GREATER_EQUALS'
-	| 'NOT_EQUALS'
-	| '?'
-	| '&'
-	| '|'
-	| '#'
-	| 'FLOORDIV'
-	| 'CONTAINS'
-	| 'FIRST_CONTAINS'
-	| 'CONTAINED_BY'
-	| 'FIRST_CONTAINED_BY'
-	| 'LSHIFT'
-	| 'RSHIFT'
-	| 'CONCAT'
-	| 'FETCHVAL'
-	| 'FETCHTEXT'
-	| 'FETCHVAL_PATH'
-	| 'FETCHTEXT_PATH'
-	| 'JSON_SOME_EXISTS'
-	| 'JSON_ALL_EXISTS'
-	| 'NOT_REGMATCH'
-	| 'REGIMATCH'
-	| 'NOT_REGIMATCH'
-	| 'AND_AND'
-	| 'AT_AT'
-	| 'DISTANCE'
-	| 'COS_DISTANCE'
-	| 'NEG_INNER_PRODUCT'
-	| '~'
-	| 'SQRT'
-	| 'CBRT'
-
 opt_equal ::=
 	'='
 	| 
@@ -3646,6 +3651,52 @@ only_signed_fconst ::=
 db_object_name_list ::=
 	( db_object_name ) ( ( ',' db_object_name ) )*
 
+array_subscript ::=
+	'[' a_expr ']'
+	| '[' opt_slice_bound ':' opt_slice_bound ']'
+
+case_arg ::=
+	a_expr
+	| 
+
+when_clause_list ::=
+	( when_clause ) ( ( when_clause ) )*
+
+case_default ::=
+	'ELSE' a_expr
+	| 
+
+tuple1_unambiguous_values ::=
+	a_expr ','
+	| a_expr ',' expr_list
+
+general_type_name ::=
+	type_function_name_no_crdb_extra
+
+complex_type_name ::=
+	general_type_name '.' unrestricted_name
+	| general_type_name '.' unrestricted_name '.' unrestricted_name
+
+const_typename ::=
+	numeric
+	| bit_without_length
+	| bit_with_length
+	| character_without_length
+	| character_with_length
+	| const_datetime
+	| const_geo
+	| const_vector
+
+interval_type ::=
+	'INTERVAL'
+	| 'INTERVAL' interval_qualifier
+	| 'INTERVAL' '(' iconst32 ')'
+
+tuple1_ambiguous_values ::=
+	a_expr
+	| a_expr ','
+	| a_expr ',' expr_list
+
 inspect_option ::=
 	'INDEX' 'ALL'
 	| 'INDEX' '(' table_index_name_list ')'
@@ -3746,28 +3797,6 @@ type_func_name_no_crdb_extra_keyword ::=
 
 func_params_list ::=
 	( routine_param ) ( ( ',' routine_param ) )*
-
-general_type_name ::=
-	type_function_name_no_crdb_extra
-
-complex_type_name ::=
-	general_type_name '.' unrestricted_name
-	| general_type_name '.' unrestricted_name '.' unrestricted_name
-
-const_typename ::=
-	numeric
-	| bit_without_length
-	| bit_with_length
-	| character_without_length
-	| character_with_length
-	| const_datetime
-	| const_geo
-	| const_vector
-
-interval_type ::=
-	'INTERVAL'
-	| 'INTERVAL' interval_qualifier
-	| 'INTERVAL' '(' iconst32 ')'
 
 iso_level ::=
 	'READ' 'UNCOMMITTED'
@@ -3930,30 +3959,6 @@ func_expr_common_subexpr ::=
 
 array_expr_list ::=
 	( array_expr ) ( ( ',' array_expr ) )*
-
-array_subscript ::=
-	'[' a_expr ']'
-	| '[' opt_slice_bound ':' opt_slice_bound ']'
-
-case_arg ::=
-	a_expr
-	| 
-
-when_clause_list ::=
-	( when_clause ) ( ( when_clause ) )*
-
-case_default ::=
-	'ELSE' a_expr
-	| 
-
-tuple1_unambiguous_values ::=
-	a_expr ','
-	| a_expr ',' expr_list
-
-tuple1_ambiguous_values ::=
-	a_expr
-	| a_expr ','
-	| a_expr ',' expr_list
 
 func_expr_windowless ::=
 	func_application
@@ -4675,34 +4680,12 @@ opt_nulls_order ::=
 	| 'NULLS' 'LAST'
 	| 
 
-group_by_list ::=
-	( group_by_item ) ( ( ',' group_by_item ) )*
+opt_slice_bound ::=
+	a_expr
+	| 
 
-window_definition_list ::=
-	( window_definition ) ( ( ',' window_definition ) )*
-
-for_locking_strength ::=
-	'FOR' 'UPDATE'
-	| 'FOR' 'NO' 'KEY' 'UPDATE'
-	| 'FOR' 'SHARE'
-	| 'FOR' 'KEY' 'SHARE'
-
-opt_locked_rels ::=
-	'OF' table_name_list
-
-opt_nowait_or_skip ::=
-	'SKIP' 'LOCKED'
-	| 'NOWAIT'
-
-wildcard_pattern ::=
-	name '.' '*'
-
-routine_param ::=
-	routine_param_class param_name routine_param_type
-	| param_name routine_param_class routine_param_type
-	| param_name routine_param_type
-	| routine_param_class routine_param_type
-	| routine_param_type
+when_clause ::=
+	'WHEN' a_expr 'THEN' a_expr
 
 type_function_name_no_crdb_extra ::=
 	'identifier'
@@ -4775,6 +4758,35 @@ interval_qualifier ::=
 	| 'HOUR' 'TO' 'MINUTE'
 	| 'HOUR' 'TO' interval_second
 	| 'MINUTE' 'TO' interval_second
+
+group_by_list ::=
+	( group_by_item ) ( ( ',' group_by_item ) )*
+
+window_definition_list ::=
+	( window_definition ) ( ( ',' window_definition ) )*
+
+for_locking_strength ::=
+	'FOR' 'UPDATE'
+	| 'FOR' 'NO' 'KEY' 'UPDATE'
+	| 'FOR' 'SHARE'
+	| 'FOR' 'KEY' 'SHARE'
+
+opt_locked_rels ::=
+	'OF' table_name_list
+
+opt_nowait_or_skip ::=
+	'SKIP' 'LOCKED'
+	| 'NOWAIT'
+
+wildcard_pattern ::=
+	name '.' '*'
+
+routine_param ::=
+	routine_param_class param_name routine_param_type
+	| param_name routine_param_class routine_param_type
+	| param_name routine_param_type
+	| routine_param_class routine_param_type
+	| routine_param_type
 
 opt_column ::=
 	'COLUMN'
@@ -4888,13 +4900,6 @@ special_function ::=
 	| 'GREATEST' '(' expr_list ')'
 	| 'LEAST' '(' expr_list ')'
 
-opt_slice_bound ::=
-	a_expr
-	| 
-
-when_clause ::=
-	'WHEN' a_expr 'THEN' a_expr
-
 opt_class ::=
 	name
 	| 
@@ -4963,18 +4968,6 @@ rowsfrom_item ::=
 col_def_list ::=
 	( col_def ) ( ( ',' col_def ) )*
 
-group_by_item ::=
-	a_expr
-
-window_definition ::=
-	window_name 'AS' window_specification
-
-routine_param_class ::=
-	'IN'
-	| 'OUT'
-	| 'INOUT'
-	| 'IN' 'OUT'
-
 opt_float ::=
 	'(' 'ICONST' ')'
 	| 
@@ -5036,6 +5029,18 @@ geo_shape_type ::=
 interval_second ::=
 	'SECOND'
 	| 'SECOND' '(' iconst32 ')'
+
+group_by_item ::=
+	a_expr
+
+window_definition ::=
+	window_name 'AS' window_specification
+
+routine_param_class ::=
+	'IN'
+	| 'OUT'
+	| 'INOUT'
+	| 'IN' 'OUT'
 
 col_qual_list ::=
 	(  ) ( ( col_qualification ) )*

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -153,6 +153,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:drop_trigger.bnf",
     "//docs/generated/sql/bnf:drop_type.bnf",
     "//docs/generated/sql/bnf:drop_view.bnf",
+    "//docs/generated/sql/bnf:execute_schedules_stmt.bnf",
     "//docs/generated/sql/bnf:execute_stmt.bnf",
     "//docs/generated/sql/bnf:experimental_audit.bnf",
     "//docs/generated/sql/bnf:explain_analyze_stmt.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -154,6 +154,7 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:drop_type.html",
     "//docs/generated/sql/bnf:drop_view.html",
     "//docs/generated/sql/bnf:execute.html",
+    "//docs/generated/sql/bnf:execute_schedules.html",
     "//docs/generated/sql/bnf:experimental_audit.html",
     "//docs/generated/sql/bnf:explain.html",
     "//docs/generated/sql/bnf:explain_analyze.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -163,6 +163,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:drop_trigger.bnf",
     "//docs/generated/sql/bnf:drop_type.bnf",
     "//docs/generated/sql/bnf:drop_view.bnf",
+    "//docs/generated/sql/bnf:execute_schedules_stmt.bnf",
     "//docs/generated/sql/bnf:execute_stmt.bnf",
     "//docs/generated/sql/bnf:experimental_audit.bnf",
     "//docs/generated/sql/bnf:explain_analyze_stmt.bnf",

--- a/pkg/sql/lexbase/predicates.go
+++ b/pkg/sql/lexbase/predicates.go
@@ -49,6 +49,7 @@ var lookaheadKeywords = []string{
 	"tenant",
 	"set",
 	"for",
+	"execute",
 }
 
 // reservedOrLookaheadKeywords are the reserved keywords plus those keywords for

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1756,3 +1756,79 @@ ALTER TABLE tbl_to_add_ttl SET (ttl_expiration_expression = 'expire_at')
 NOTICE: Columns within table tbl_to_add_ttl are referenced as foreign keys. This will make TTL deletion jobs more expensive as dependent rows in other tables will need to be updated as well. To improve performance of the TTL job, consider reducing the value of ttl_delete_batch_size.
 
 subtest end
+
+subtest execute_schedule
+
+statement ok
+CREATE TABLE tbl_execute_schedule (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMPTZ NOT NULL DEFAULT now() - '1 day'
+) WITH (ttl_expiration_expression = 'expire_at', ttl_job_cron = '@daily')
+
+statement ok
+CREATE TABLE tbl_execute_schedule_2 (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMPTZ NOT NULL DEFAULT now() - '1 day'
+) WITH (ttl_expiration_expression = 'expire_at', ttl_job_cron = '@daily')
+
+# Get the schedule IDs.
+let $schedule_id_1
+SELECT id FROM [SHOW SCHEDULES] WHERE label LIKE '%tbl_execute_schedule%' ORDER BY id LIMIT 1
+
+let $schedule_id_2
+SELECT id FROM [SHOW SCHEDULES] WHERE label LIKE '%tbl_execute_schedule_2%'
+
+# Verify both schedules exist.
+query I
+SELECT count(*) FROM [SHOW SCHEDULES] WHERE label LIKE '%tbl_execute_schedule%'
+----
+2
+
+# Verify the schedules are initially set to run in the future (@daily means tomorrow).
+query I
+SELECT count(*) FROM [SHOW SCHEDULES] WHERE label LIKE '%tbl_execute_schedule%' AND next_run > now()
+----
+2
+
+# Verify EXECUTE SCHEDULE syntax works with a schedule ID and updates next_run to the past.
+statement ok
+EXECUTE SCHEDULE $schedule_id_1
+
+# Verify that next_run was updated to now (or past) for schedule 1.
+# This proves EXECUTE SCHEDULE changed next_run from the future to the past.
+query B
+SELECT next_run <= now() FROM [SHOW SCHEDULES] WHERE id = $schedule_id_1
+----
+true
+
+# Verify EXECUTE SCHEDULES syntax works with a SELECT statement returning one schedule.
+statement ok
+EXECUTE SCHEDULES SELECT $schedule_id_2
+
+# Verify that next_run was updated for schedule 2.
+query B
+SELECT next_run <= now() FROM [SHOW SCHEDULES] WHERE id = $schedule_id_2
+----
+true
+
+# Verify EXECUTE SCHEDULES works with multiple schedules.
+statement ok
+EXECUTE SCHEDULES (SELECT id FROM [SHOW SCHEDULES] WHERE label LIKE '%tbl_execute_schedule%')
+
+# Verify both schedules have next_run <= now().
+query I
+SELECT count(*) FROM [SHOW SCHEDULES] WHERE label LIKE '%tbl_execute_schedule%' AND next_run <= now()
+----
+2
+
+# Paused schedules should not be runnable.
+statement ok
+PAUSE SCHEDULE $schedule_id_1
+
+statement error cannot execute a paused schedule; use RESUME SCHEDULE instead
+EXECUTE SCHEDULE $schedule_id_1
+
+statement ok
+RESUME SCHEDULE $schedule_id_1
+
+subtest end

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -349,6 +349,9 @@ func TestContextualHelp(t *testing.T) {
 		{`RESUME SCHEDULES ??`, `RESUME SCHEDULES`},
 		{`RESUME ALL ??`, `RESUME ALL JOBS`},
 
+		{`EXECUTE SCHEDULE ??`, `EXECUTE SCHEDULES`},
+		{`EXECUTE SCHEDULES ??`, `EXECUTE SCHEDULES`},
+
 		{`REVOKE ALL ??`, `REVOKE`},
 		{`REVOKE ALL ON foo FROM ??`, `REVOKE`},
 		{`REVOKE ALL ON foo FROM bar ??`, `REVOKE`},

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -211,7 +211,7 @@ func (l *lexer) Lex(lval *sqlSymType) int {
 			}
 		}
 
-	case NOT, WITH, AS, GENERATED, NULLS, RESET, ROLE, USER, ON, TENANT, CLUSTER, SET, CREATE, FOR:
+	case NOT, WITH, AS, GENERATED, NULLS, RESET, ROLE, USER, ON, TENANT, CLUSTER, SET, CREATE, FOR, EXECUTE:
 		nextToken := sqlSymType{}
 		if l.lastPos+1 < len(l.tokens) {
 			nextToken = l.tokens[l.lastPos+1]
@@ -326,6 +326,13 @@ func (l *lexer) Lex(lval *sqlSymType) int {
 				lval.id = FOR_TABLE
 			case JOB:
 				lval.id = FOR_JOB
+			}
+		case EXECUTE:
+			switch nextToken.id {
+			case SCHEDULE:
+				lval.id = EXECUTE_SCHEDULE
+			case SCHEDULES:
+				lval.id = EXECUTE_SCHEDULES
 			}
 		}
 	}

--- a/pkg/sql/parser/testdata/control_job
+++ b/pkg/sql/parser/testdata/control_job
@@ -629,3 +629,84 @@ DETAIL: source SQL:
 PAUSE ALL JOBS
               ^
 HINT: try \h PAUSE ALL JOBS
+
+parse
+EXECUTE SCHEDULES SELECT a
+----
+EXECUTE SCHEDULES SELECT a
+EXECUTE SCHEDULES SELECT (a) -- fully parenthesized
+EXECUTE SCHEDULES SELECT a -- literals removed
+EXECUTE SCHEDULES SELECT _ -- identifiers removed
+
+parse
+EXECUTE SCHEDULES SELECT 123
+----
+EXECUTE SCHEDULES SELECT 123
+EXECUTE SCHEDULES SELECT (123) -- fully parenthesized
+EXECUTE SCHEDULES SELECT _ -- literals removed
+EXECUTE SCHEDULES SELECT 123 -- identifiers removed
+
+error
+EXECUTE SCHEDULE SELECT 123
+----
+at or near "select": syntax error
+DETAIL: source SQL:
+EXECUTE SCHEDULE SELECT 123
+                 ^
+HINT: try \h EXECUTE SCHEDULES
+
+parse
+EXECUTE SCHEDULE (SELECT 123)
+----
+EXECUTE SCHEDULES VALUES ((SELECT 123)) -- normalized!
+EXECUTE SCHEDULES VALUES (((SELECT (123)))) -- fully parenthesized
+EXECUTE SCHEDULES VALUES ((SELECT _)) -- literals removed
+EXECUTE SCHEDULES VALUES ((SELECT 123)) -- identifiers removed
+
+parse
+EXPLAIN EXECUTE SCHEDULES SELECT a
+----
+EXPLAIN EXECUTE SCHEDULES SELECT a
+EXPLAIN EXECUTE SCHEDULES SELECT (a) -- fully parenthesized
+EXPLAIN EXECUTE SCHEDULES SELECT a -- literals removed
+EXPLAIN EXECUTE SCHEDULES SELECT _ -- identifiers removed
+
+parse
+EXECUTE SCHEDULE a
+----
+EXECUTE SCHEDULES VALUES (a) -- normalized!
+EXECUTE SCHEDULES VALUES ((a)) -- fully parenthesized
+EXECUTE SCHEDULES VALUES (a) -- literals removed
+EXECUTE SCHEDULES VALUES (_) -- identifiers removed
+
+parse
+EXECUTE SCHEDULE 123
+----
+EXECUTE SCHEDULES VALUES (123) -- normalized!
+EXECUTE SCHEDULES VALUES ((123)) -- fully parenthesized
+EXECUTE SCHEDULES VALUES (_) -- literals removed
+EXECUTE SCHEDULES VALUES (123) -- identifiers removed
+
+parse
+EXPLAIN EXECUTE SCHEDULE a
+----
+EXPLAIN EXECUTE SCHEDULES VALUES (a) -- normalized!
+EXPLAIN EXECUTE SCHEDULES VALUES ((a)) -- fully parenthesized
+EXPLAIN EXECUTE SCHEDULES VALUES (a) -- literals removed
+EXPLAIN EXECUTE SCHEDULES VALUES (_) -- identifiers removed
+
+parse
+EXECUTE SCHEDULES (SELECT schedule_id FROM system.scheduled_jobs WHERE label = 'my_schedule')
+----
+EXECUTE SCHEDULES (SELECT schedule_id FROM system.scheduled_jobs WHERE label = 'my_schedule')
+EXECUTE SCHEDULES (SELECT (schedule_id) FROM system.scheduled_jobs WHERE ((label) = ('my_schedule'))) -- fully parenthesized
+EXECUTE SCHEDULES (SELECT schedule_id FROM system.scheduled_jobs WHERE label = '_') -- literals removed
+EXECUTE SCHEDULES (SELECT _ FROM _._ WHERE _ = 'my_schedule') -- identifiers removed
+
+parse
+EXPLAIN EXECUTE SCHEDULES (SELECT schedule_id FROM system.scheduled_jobs WHERE label = 'my_schedule')
+----
+EXPLAIN EXECUTE SCHEDULES (SELECT schedule_id FROM system.scheduled_jobs WHERE label = 'my_schedule')
+EXPLAIN EXECUTE SCHEDULES (SELECT (schedule_id) FROM system.scheduled_jobs WHERE ((label) = ('my_schedule'))) -- fully parenthesized
+EXPLAIN EXECUTE SCHEDULES (SELECT schedule_id FROM system.scheduled_jobs WHERE label = '_') -- literals removed
+EXPLAIN EXECUTE SCHEDULES (SELECT _ FROM _._ WHERE _ = 'my_schedule') -- identifiers removed

--- a/pkg/sql/sem/tree/run_control.go
+++ b/pkg/sql/sem/tree/run_control.go
@@ -92,6 +92,7 @@ const (
 	PauseSchedule ScheduleCommand = iota
 	ResumeSchedule
 	DropSchedule
+	ExecuteSchedule
 )
 
 func (c ScheduleCommand) String() string {
@@ -102,6 +103,8 @@ func (c ScheduleCommand) String() string {
 		return "RESUME"
 	case DropSchedule:
 		return "DROP"
+	case ExecuteSchedule:
+		return "EXECUTE"
 	default:
 		panic("unhandled schedule command")
 	}


### PR DESCRIPTION
Add a new SQL statement 'EXECUTE SCHEDULE <schedule_id>' to execute a scheduled job immediately. This reuses the existing logic from ALTER BACKUP SCHEDULE ... EXECUTE IMMEDIATELY, but generalizes it to support any scheduled job.

This functionality is particularly useful for TTL jobs, allowing users to trigger them on demand.

The <schedule_id> can be a literal or a subquery (e.g., from SHOW SCHEDULES). If multiple are provided, you must use EXECUTE SCHEDULES.

To avoid having two methods of executing a scheduled backup, if EXECUTE SCHEDULE is run against a backup schedule it will fail. The failure will have a hint to use ALTER BACKUP SCHEDULE.

Resolves: #146723
Epic: none
Release note (sql change): Added support for EXECUTE SCHEDULE <schedule_id> to allow immediate execution of a scheduled job. This does not apply to ALTER BACKUP SCHEDULE; attempting to execute a backup schedule will result in an error.