### PR TITLE
kvnemesis: treat pg replica unavailable as an unavailable error

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -114,7 +114,8 @@ func exceptConditionFailed(err error) bool {
 }
 
 func exceptReplicaUnavailable(err error) bool {
-	return errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil))
+	return errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil)) ||
+		strings.Contains(err.Error(), "replica unavailable")
 }
 
 func exceptContextCanceled(err error) bool {


### PR DESCRIPTION
This commit expands the condition where we expect a replica unavailable to include pg replica unavailable errors. This will apply to SQL requests that hit things like the leaderless watcher due to a known unavailability

Fixes: #158683

Release note: None