### PR TITLE
mmaprototype: add unit test to rebalance heterogeneous capacity stores

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
+        "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/syncutil",
@@ -33,6 +34,7 @@ go_library(
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_redact//interfaces",
+        "@com_github_dustin_go_humanize//:go-humanize",
     ],
 )
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -620,7 +620,7 @@ func sortTargetCandidateSetAndPick(
 				discardedCandsHadNoPendingChanges = false
 			}
 			log.KvDistribution.VEventf(ctx, 2,
-				"candiate store %v was discarded due to (nls=%t overloadDim=%t pending_thresh=%t): sls=%v", cand.StoreID,
+				"candidate store %v was discarded due to (nls=%t overloadDim=%t pending_thresh=%t): sls=%v", cand.StoreID,
 				candDiscardedByNLS, candDiscardedByOverloadDim, candDiscardedByPendingThreshold, cand.storeLoadSummary)
 			continue
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -36,6 +36,9 @@ const (
 	unknownReplicaID roachpb.ReplicaID = -1
 	// noReplicaID is used with a change that is removing a replica.
 	noReplicaID roachpb.ReplicaID = -2
+
+	nodeIDForLogging  = 0
+	storeIDForLogging = 0
 )
 
 type ReplicaType struct {
@@ -2425,7 +2428,6 @@ func computeLoadSummary(
 	var dimSummary [NumLoadDimensions]loadSummary
 	var worstDim LoadDimension
 	for i := range msl.load {
-		const nodeIDForLogging = 0
 		ls := loadSummaryForDimension(ctx, ss.StoreID, nodeIDForLogging, LoadDimension(i), ss.adjusted.load[i], ss.capacity[i],
 			msl.load[i], msl.util[i])
 		if ls > sls {
@@ -2438,7 +2440,6 @@ func computeLoadSummary(
 			highDiskSpaceUtil = highDiskSpaceUtilization(ss.adjusted.load[i], ss.capacity[i])
 		}
 	}
-	const storeIDForLogging = 0
 	nls := loadSummaryForDimension(ctx, storeIDForLogging, ns.NodeID, CPURate, ns.adjustedCPU, ns.CapacityCPU, mnl.loadCPU, mnl.utilCPU)
 	return storeLoadSummary{
 		worstDim:                   worstDim,

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -10,10 +10,13 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/redact"
+	"github.com/dustin/go-humanize"
 )
 
 // Misc helper classes for working with range, store and node load.
@@ -66,7 +69,40 @@ func (lv LoadVector) String() string {
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (lv LoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("[cpu:%d, write-bandwidth:%d, byte-size:%d]", lv[CPURate], lv[WriteBandwidth], lv[ByteSize])
+	formatVal := func(dim LoadDimension) redact.SafeString {
+		val := lv[dim]
+		if val == UnknownCapacity {
+			return "unknown"
+		}
+		switch dim {
+		case CPURate:
+			cpuDuration := time.Duration(val)
+			if cpuDuration < time.Microsecond {
+				// humanizeutil.Duration doesn't handle sub-microsecond durations
+				return redact.SafeString(cpuDuration.String())
+			}
+			return humanizeutil.Duration(cpuDuration)
+		case WriteBandwidth, ByteSize:
+			isNegative := false
+			if val < 0 {
+				val = -val
+				isNegative = true
+			}
+			bytesStr := humanize.Bytes(uint64(val))
+			if isNegative {
+				return redact.SafeString("-" + bytesStr)
+			}
+			return redact.SafeString(bytesStr)
+		default:
+			panic(fmt.Sprintf("unknown LoadDimension: %d", dim))
+		}
+	}
+	w.Printf(
+		"[cpu:%s/s, write-bandwidth:%s/s, byte-size:%s]",
+		formatVal(CPURate),
+		formatVal(WriteBandwidth),
+		formatVal(ByteSize),
+	)
 }
 
 func (lv *LoadVector) add(other LoadVector) {
@@ -502,6 +538,7 @@ func loadSummaryForDimension(
 	meanUtil float64,
 ) (summary loadSummary) {
 	summ := loadLow
+	reason := ""
 	if dim == WriteBandwidth && capacity == UnknownCapacity {
 		// Ignore smaller than 1MiB differences in write bandwidth. This 1MiB
 		// value is somewhat arbitrary, but is based on EBS gp3 having a default
@@ -556,13 +593,43 @@ func loadSummaryForDimension(
 	)
 	if fractionAbove > meanFractionSlow {
 		summ = overloadSlow
+		reason = "load is >10% above mean"
 	} else if fractionAbove < meanFractionLow {
 		summ = loadLow
+		reason = "load is >10% below mean"
 	} else if fractionAbove >= meanFractionNoChange {
 		summ = loadNoChange
+		reason = "load is within 5-10% of mean"
 	} else {
 		summ = loadNormal
+		reason = "load is within 5% of mean"
 	}
+
+	defer func() {
+		if !log.ExpensiveLogEnabled(ctx, 3) {
+			return
+		}
+
+		metrics := fmt.Sprintf("load=%d meanLoad=%d", load, meanLoad)
+		if capacity != UnknownCapacity {
+			metrics += fmt.Sprintf(" fractionUsed=%.2f%% meanUtil=%.2f%% capacity=%d", fractionUsed*100, meanUtil*100, capacity)
+		}
+
+		nodeIdStr := ""
+		if nodeID > nodeIDForLogging {
+			nodeIdStr = fmt.Sprintf("n%v", nodeID)
+		}
+
+		storeIdStr := ""
+		if storeID > storeIDForLogging {
+			storeIdStr = fmt.Sprintf("s%v", storeID)
+		}
+
+		log.KvDistribution.VEventf(ctx, 3,
+			"load summary for dim=%s (%s%s): %s, reason: %s [%s]",
+			dim, nodeIdStr, storeIdStr, summary, reason, metrics)
+	}()
+
 	if capacity != UnknownCapacity && meanUtil*1.1 < fractionUsed {
 		// Further tune the summary based on utilization.
 		//
@@ -571,19 +638,24 @@ func loadSummaryForDimension(
 		// overload due to heterogeneity, while we primarily still want to focus
 		// on balancing towards the mean usage.
 		if fractionUsed > 0.9 {
+			reason = "fractionUsed > 90%"
 			return min(summaryUpperBound, overloadUrgent)
 		}
 		// INVARIANT: fractionUsed <= 0.9
 		if fractionUsed > 0.75 {
 			if meanUtil*1.5 < fractionUsed {
+				reason = "fractionUsed > 75% and >1.5x meanUtil"
 				return min(summaryUpperBound, overloadUrgent)
 			}
+			reason = "fractionUsed > 75%"
 			return min(summaryUpperBound, overloadSlow)
 		}
 		// INVARIANT: fractionUsed <= 0.75
 		if meanUtil*1.75 < fractionUsed {
+			reason = "fractionUsed < 75% and >1.75x meanUtil"
 			return min(summaryUpperBound, overloadSlow)
 		}
+		reason = "fractionUsed < 75%"
 		return min(summaryUpperBound, max(summ, loadNoChange))
 	}
 	return min(summaryUpperBound, summ)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/multiple_ranges.txt
@@ -40,9 +40,9 @@ store-id=1
 # The top-k uses CPURate.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:40 B/s, byte-size:50 B] adjusted=[cpu:100ns/s, write-bandwidth:40 B/s, byte-size:50 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:45ns/s, write-bandwidth:40 B/s, byte-size:50 B] adjusted=[cpu:45ns/s, write-bandwidth:40 B/s, byte-size:50 B] node-reported-cpu=45 node-adjusted-cpu=45 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2
 
 
@@ -71,9 +71,9 @@ store-id=1
 # The top-2 ranges for store 2 are based on ByteSize.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:40 B/s, byte-size:50 B] adjusted=[cpu:100ns/s, write-bandwidth:40 B/s, byte-size:50 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:45ns/s, write-bandwidth:40 B/s, byte-size:50 B] adjusted=[cpu:45ns/s, write-bandwidth:40 B/s, byte-size:50 B] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r1 r2
 
 # StoreLeaseholderMsg not containing r1 and r4 since no longer the
@@ -94,17 +94,17 @@ store-id=1
 # but less than r3 in terms of ByteSize.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:100, write-bandwidth:40, byte-size:50] adjusted=[cpu:100, write-bandwidth:40, byte-size:50] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:40 B/s, byte-size:50 B] adjusted=[cpu:100ns/s, write-bandwidth:40 B/s, byte-size:50 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r2 r3
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:45, write-bandwidth:40, byte-size:50] adjusted=[cpu:45, write-bandwidth:40, byte-size:50] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:45ns/s, write-bandwidth:40 B/s, byte-size:50 B] adjusted=[cpu:45ns/s, write-bandwidth:40 B/s, byte-size:50 B] node-reported-cpu=45 node-adjusted-cpu=45 seq=2
   top-k-ranges (local-store-id=1) dim=ByteSize: r3 r2
 
 ranges
 ----
-range-id=2 local-store=1 load=[cpu:40, write-bandwidth:20, byte-size:5] raft-cpu=10
+range-id=2 local-store=1 load=[cpu:40ns/s, write-bandwidth:20 B/s, byte-size:5 B] raft-cpu=10
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
-range-id=3 local-store=1 load=[cpu:30, write-bandwidth:10, byte-size:10] raft-cpu=25
+range-id=3 local-store=1 load=[cpu:30ns/s, write-bandwidth:10 B/s, byte-size:10 B] raft-cpu=25
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 
@@ -123,8 +123,8 @@ store-id=1
 # The ranges reflect the latest state from the StoreLeaseholderMsg.
 ranges
 ----
-range-id=2 local-store=1 load=[cpu:40, write-bandwidth:20, byte-size:30] raft-cpu=10
+range-id=2 local-store=1 load=[cpu:40ns/s, write-bandwidth:20 B/s, byte-size:30 B] raft-cpu=10
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
-range-id=3 local-store=1 load=[cpu:30, write-bandwidth:10, byte-size:10] raft-cpu=25
+range-id=3 local-store=1 load=[cpu:30ns/s, write-bandwidth:10 B/s, byte-size:10 B] raft-cpu=25
   store-id=2 replica-id=5 type=VOTER_FULL
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica.txt
@@ -32,8 +32,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 store-leaseholder-msg 
 store-id=1
@@ -44,37 +44,37 @@ store-id=1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=2 replica-id=unknown type=VOTER_FULL leaseholder=true
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # Same store load from s1. Results in no change.
 store-load-msg
@@ -83,9 +83,9 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # Store leaseholder msg from s1 showing that s2 has a replica but not the lease.
 store-leaseholder-msg
@@ -100,10 +100,10 @@ store-id=1
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -121,10 +121,10 @@ store-id=1
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s enacted=5s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -134,8 +134,8 @@ ranges
 # The enacted changes are still adjusting the load.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=0 seq=4
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] node-reported-cpu=0 node-adjusted-cpu=88 seq=1
 
 # Store load msg from s2 showing updated load.
 store-load-msg
@@ -154,17 +154,17 @@ store-load-msg
 # adjusted load becomes negative.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:-75, write-bandwidth:-75, byte-size:-75] node-reported-cpu=5 node-adjusted-cpu=-75 seq=6
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=80 node-adjusted-cpu=168 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:-75ns/s, write-bandwidth:-75 B/s, byte-size:-75 B] node-reported-cpu=5 node-adjusted-cpu=-75 seq=6
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:168ns/s, write-bandwidth:168 B/s, byte-size:168 B] node-reported-cpu=80 node-adjusted-cpu=168 seq=3
 
 # The enacted changes are still adjusting the load.
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s enacted=5s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -187,5 +187,5 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=5 node-adjusted-cpu=5 seq=7
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] node-reported-cpu=5 node-adjusted-cpu=5 seq=7
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=4

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores.txt
@@ -35,8 +35,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
 
 # Store s1 has the single replica and lease for r1.
 store-leaseholder-msg 
@@ -48,25 +48,25 @@ store-id=1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 # The top-k uses CPURate, with r1 as the only range.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=0
 
 # Transfer the replica from s1 to s2. The lease will also be transferred.
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -74,15 +74,15 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # that the local-store representing the "range owner" is still s1.
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=2 replica-id=unknown type=VOTER_FULL leaseholder=true
 
 # The adjusted load is post transfer.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
 
 tick seconds=5
 ----
@@ -102,10 +102,10 @@ store-id=1
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -121,7 +121,7 @@ store-id=2
 # The local-store representing the "range owner" is now s2.
 ranges
 ----
-range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=2 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 
 # The addition of replica and lease on s2 is considered enacted. The removal
@@ -131,17 +131,17 @@ range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=35s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:88, write-bandwidth:88, byte-size:88] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=80 node-adjusted-cpu=88 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] node-reported-cpu=80 node-adjusted-cpu=88 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 tick seconds=5
@@ -152,10 +152,10 @@ t=10s
 reject-pending-changes change-ids=(1) expect-panic
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=35s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -169,8 +169,8 @@ store-load-msg
 # enactment time of change 1 (see lagForChangeReflectedInLoad).
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=168 seq=2
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:168, write-bandwidth:168, byte-size:168] node-reported-cpu=160 node-adjusted-cpu=168 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=160 node-adjusted-cpu=168 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:168ns/s, write-bandwidth:168 B/s, byte-size:168 B] node-reported-cpu=160 node-adjusted-cpu=168 seq=3
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 # Store load msg from s2 at time 16s, which is 11s after the enactment of
@@ -183,7 +183,7 @@ store-load-msg
 get-pending-changes
 ----
 pending(1)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=35s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -192,8 +192,8 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # change 1.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
 
 # Advance time, but not enough to GC change 2.
@@ -205,13 +205,13 @@ t=20s
 gc-pending-changes
 ----
 pending(1)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=35s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 ranges
 ----
-range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=2 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 
 # Store leaseholder msg from s2, showing that s1 is no longer a replica, so
@@ -226,15 +226,15 @@ store-id=2
 get-pending-changes
 ----
 pending(1)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=35s enacted=20s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=35s enacted=20s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 # Change 2 is still serving the purpose of adjusting the load on s1.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=160 node-adjusted-cpu=80 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=160 node-adjusted-cpu=80 seq=4
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Store load msg from s2, showing its new load.
@@ -244,8 +244,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=165 node-adjusted-cpu=85 seq=2
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=165 node-adjusted-cpu=85 seq=5
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=165 node-adjusted-cpu=85 seq=2
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] adjusted=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] node-reported-cpu=165 node-adjusted-cpu=85 seq=5
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 tick seconds=20
@@ -266,8 +266,8 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=3
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] node-reported-cpu=90 node-adjusted-cpu=90 seq=3
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] adjusted=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Transfer the replica from s2 back to s1. The lease will also be transferred.
@@ -275,18 +275,18 @@ make-pending-changes range-id=1
   rebalance-replica: remove-store-id=2 add-store-id=1
 ----
 pending(2)
-change-id=3 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=40s gc=5m40s
+change-id=3 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=40s gc=5m40s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=4 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=40s gc=5m40s
+change-id=4 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=40s gc=5m40s
   prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
 # Adjusted load shows the change.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=4
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:93ns/s, write-bandwidth:93 B/s, byte-size:93 B] node-reported-cpu=90 node-adjusted-cpu=98 seq=4
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] adjusted=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Enough time elapses to GC the changes.
@@ -306,8 +306,8 @@ pending(0)
 # Adjusted load no longer reflects the changes.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:85, write-bandwidth:85, byte-size:85] node-reported-cpu=90 node-adjusted-cpu=90 seq=7
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] node-reported-cpu=90 node-adjusted-cpu=90 seq=5
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] adjusted=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] node-reported-cpu=90 node-adjusted-cpu=90 seq=7
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Transfer the replica from s2 back to s1. The lease will also be transferred.
@@ -315,22 +315,22 @@ make-pending-changes range-id=1
   rebalance-replica: remove-store-id=2 add-store-id=1
 ----
 pending(2)
-change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m50s gc=10m50s
+change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=5m50s gc=10m50s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m50s gc=10m50s
+change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=5m50s gc=10m50s
   prev=(replica-id=2 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
 ranges
 ----
-range-id=1 local-store=2 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=2 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=unknown type=VOTER_FULL leaseholder=true
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=8
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:93ns/s, write-bandwidth:93 B/s, byte-size:93 B] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] adjusted=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] node-reported-cpu=90 node-adjusted-cpu=98 seq=8
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Store leaseholder msg from s1, showing that s1 is a replica and has the lease, so
@@ -348,16 +348,16 @@ store-id=1
 get-pending-changes
 ----
 pending(2)
-change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m50s gc=10m50s enacted=5m50s
+change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=5m50s gc=10m50s enacted=5m50s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m50s gc=6m20s
+change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=5m50s gc=6m20s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=3 type=VOTER_FULL leaseholder=true
 
 # store-id=2 still has top-k-ranges for local store s2 populated, since we
@@ -365,19 +365,19 @@ range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cp
 # is the leaseholder for r1.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:5, write-bandwidth:5, byte-size:5] adjusted=[cpu:93, write-bandwidth:93, byte-size:93] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] adjusted=[cpu:93ns/s, write-bandwidth:93 B/s, byte-size:93 B] node-reported-cpu=90 node-adjusted-cpu=98 seq=6
   top-k-ranges (local-store-id=1) dim=ByteSize: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:85, write-bandwidth:85, byte-size:85] adjusted=[cpu:5, write-bandwidth:5, byte-size:5] node-reported-cpu=90 node-adjusted-cpu=98 seq=8
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:85ns/s, write-bandwidth:85 B/s, byte-size:85 B] adjusted=[cpu:5ns/s, write-bandwidth:5 B/s, byte-size:5 B] node-reported-cpu=90 node-adjusted-cpu=98 seq=8
   top-k-ranges (local-store-id=2) dim=CPURate: r1
 
 # Change 6 is garbage collected since enough time has elapsed.
 gc-pending-changes
 ----
 pending(2)
-change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=5m50s gc=10m50s enacted=5m50s
+change-id=5 store-id=1 node-id=1 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=5m50s gc=10m50s enacted=5m50s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=5m50s gc=6m20s
+change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=5m50s gc=6m20s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -385,5 +385,5 @@ change-id=6 store-id=2 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth
 # invariant is still satisfied.
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=3 type=VOTER_FULL leaseholder=true

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_enacted_gc.txt
@@ -44,7 +44,7 @@ store-id=1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
+range-id=1 local-store=1 load=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] raft-cpu=1
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=3 replica-id=3 type=VOTER_FULL
 
@@ -53,10 +53,10 @@ make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -64,19 +64,19 @@ change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:
 # that the local-store representing the "range owner" is still s1.
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
+range-id=1 local-store=1 load=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] raft-cpu=1
   store-id=2 replica-id=unknown type=VOTER_FULL leaseholder=true
   store-id=3 replica-id=3 type=VOTER_FULL
 
 # The adjusted load is post transfer.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 tick seconds=5
 ----
@@ -98,16 +98,16 @@ store-id=2
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=35s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] start=0s gc=35s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 ranges
 ----
-range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+range-id=1 local-store=2 load=[cpu:3ns/s, write-bandwidth:3 B/s, byte-size:3 B] raft-cpu=2
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
   store-id=3 replica-id=3 type=VOTER_FULL
 
@@ -116,14 +116,14 @@ range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
 # no longer is the leaseholder for r1.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 tick seconds=35
 ----
@@ -132,10 +132,10 @@ t=40s
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=35s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] start=0s gc=35s
   prev=(replica-id=1 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -153,7 +153,7 @@ store-id=2
 
 ranges
 ----
-range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+range-id=1 local-store=2 load=[cpu:3ns/s, write-bandwidth:3 B/s, byte-size:3 B] raft-cpu=2
   store-id=1 replica-id=1 type=VOTER_FULL
   store-id=3 replica-id=3 type=VOTER_FULL
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
@@ -161,7 +161,7 @@ range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
 get-pending-changes
 ----
 pending(1)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
 
@@ -170,15 +170,15 @@ change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2
 # no longer is the leaseholder for r1.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 # Store leaseholder msg from s1, indicating no leases.
 store-leaseholder-msg
@@ -188,26 +188,26 @@ store-id=1
 # No top-k ranges for local store s1 anymore.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 # Make another pending change to transfer from s3 to s4.
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=3 add-store-id=4
 ----
 pending(3)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s gc=5m40s
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] start=40s gc=5m40s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:-3, byte-size:-3] start=40s gc=5m40s
+change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-3 B/s, byte-size:-3 B] start=40s gc=5m40s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -217,13 +217,13 @@ t=45s
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-3, byte-size:-3] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:-2ns/s, write-bandwidth:-3 B/s, byte-size:-3 B] node-reported-cpu=0 node-adjusted-cpu=-2 seq=1
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
 
 # Store leaseholder msg from s2, showing that s4 has the replica, and s3
 # replica has not been removed.
@@ -240,13 +240,13 @@ store-id=2
 get-pending-changes
 ----
 pending(3)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s gc=5m40s enacted=45s
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] start=40s gc=5m40s enacted=45s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:-3, byte-size:-3] start=40s gc=1m15s
+change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-3 B/s, byte-size:-3 B] start=40s gc=1m15s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -257,13 +257,13 @@ t=1m20s
 get-pending-changes
 ----
 pending(3)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s gc=5m40s enacted=45s
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] start=40s gc=5m40s enacted=45s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:-3, byte-size:-3] start=40s gc=1m15s
+change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-3 B/s, byte-size:-3 B] start=40s gc=1m15s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -271,16 +271,16 @@ change-id=4 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-2, write-bandwidth:
 gc-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s enacted=5s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s enacted=5s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2, write-bandwidth:3, byte-size:3] start=40s gc=5m40s enacted=45s
+change-id=3 store-id=4 node-id=4 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] start=40s gc=5m40s enacted=45s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
 
 ranges
 ----
-range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+range-id=1 local-store=2 load=[cpu:3ns/s, write-bandwidth:3 B/s, byte-size:3 B] raft-cpu=2
   store-id=1 replica-id=1 type=VOTER_FULL
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
   store-id=4 replica-id=4 type=VOTER_FULL
@@ -288,10 +288,10 @@ range-id=1 local-store=2 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=2
   top-k-ranges (local-store-id=2) dim=WriteBandwidth: r1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:3, byte-size:3] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=2
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:3 B/s, byte-size:3 B] node-reported-cpu=0 node-adjusted-cpu=2 seq=1
   top-k-ranges (local-store-id=2) dim=ByteSize: r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_fail_lease_transfer.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_replica_local_stores_fail_lease_transfer.txt
@@ -20,7 +20,7 @@ store-id=1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:2, write-bandwidth:2, byte-size:2] raft-cpu=1
+range-id=1 local-store=1 load=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] raft-cpu=1
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 # Transfer the replica from s1 to s2. The lease will also be transferred.
@@ -28,10 +28,10 @@ make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -50,17 +50,17 @@ store-id=1
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2, write-bandwidth:2, byte-size:2] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=1 range-id=1 load-delta=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] start=0s gc=5m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2, write-bandwidth:-2, byte-size:-2] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:-2, write-bandwidth:-2, byte-size:-2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
-store-id=2 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:2, write-bandwidth:2, byte-size:2] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:-2ns/s, write-bandwidth:-2 B/s, byte-size:-2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
+store-id=2 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:2ns/s, write-bandwidth:2 B/s, byte-size:2 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=1
 
 # Advance time enough that the pending changes are GC'd.
 tick seconds=330
@@ -79,6 +79,6 @@ pending(0)
 # indicating that s2 has a replica.
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:3, write-bandwidth:3, byte-size:3] raft-cpu=2
+range-id=1 local-store=1 load=[cpu:3ns/s, write-bandwidth:3 B/s, byte-size:3 B] raft-cpu=2
   store-id=2 replica-id=2 type=VOTER_FULL
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_capacity_mismatch.txt
@@ -1,0 +1,320 @@
+# Test scenario: Low capacity stores unable to take replicas from high capacity stores.
+#
+# This test demonstrates that stores with low capacities cannot accept replicas
+# from stores with higher capacities, even when they have lower absolute load.
+# The transfers fail due to the UTILIZATION override in loadSummaryForDimension(),
+# not because the target would have higher load relative to the mean.
+#
+# Modeled after allocbench/nodes=7/cpu=8/kv/r=95/access=skew/lbr=mmc
+
+set-store
+  store-id=1 node-id=1
+  store-id=2 node-id=2
+  store-id=3 node-id=3
+  store-id=4 node-id=4
+  store-id=5 node-id=5
+  store-id=6 node-id=6
+  store-id=7 node-id=7
+----
+node-id=1 locality-tiers=node=1
+  store-id=1 attrs=
+node-id=2 locality-tiers=node=2
+  store-id=2 attrs=
+node-id=3 locality-tiers=node=3
+  store-id=3 attrs=
+node-id=4 locality-tiers=node=4
+  store-id=4 attrs=
+node-id=5 locality-tiers=node=5
+  store-id=5 attrs=
+node-id=6 locality-tiers=node=6
+  store-id=6 attrs=
+node-id=7 locality-tiers=node=7
+  store-id=7 attrs=
+
+# High capacity stores (1000) with high load - these are overloaded
+store-load-msg
+  store-id=1 node-id=1 load=[900,0,0] capacity=[1000,-1,1000] secondary-load=0 load-time=0s
+  store-id=2 node-id=2 load=[900,0,0] capacity=[1000,-1,1000] secondary-load=0 load-time=0s
+  store-id=3 node-id=3 load=[900,0,0] capacity=[1000,-1,1000] secondary-load=0 load-time=0s
+----
+
+# Low capacity stores (500) with low absolute load but high relative utilization
+store-load-msg
+  store-id=4 node-id=4 load=[300,0,0] capacity=[500,500,500] secondary-load=0 load-time=0s
+  store-id=5 node-id=5 load=[280,0,0] capacity=[500,500,500] secondary-load=0 load-time=0s
+  store-id=6 node-id=6 load=[260,0,0] capacity=[500,500,500] secondary-load=0 load-time=0s
+  store-id=7 node-id=7 load=[250,0,0] capacity=[500,500,500] secondary-load=0 load-time=0s
+----
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=900 node-adjusted-cpu=900 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=900 node-adjusted-cpu=900 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=900 node-adjusted-cpu=900 seq=1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:300ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:300ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=300 node-adjusted-cpu=300 seq=1
+store-id=5 node-id=5 status=ok accepting all reported=[cpu:280ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:280ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=280 node-adjusted-cpu=280 seq=1
+store-id=6 node-id=6 status=ok accepting all reported=[cpu:260ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:260ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=260 node-adjusted-cpu=260 seq=1
+store-id=7 node-id=7 status=ok accepting all reported=[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=250 node-adjusted-cpu=250 seq=1
+
+# Set up ranges with replicas on high capacity stores (s1, s2, s3) that are overloaded
+# Each range contributes significant CPU load
+store-leaseholder-msg
+store-id=1
+  range-id=1 load=[200,0,0] raft-cpu=20
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+    store-id=3 replica-id=3 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+  range-id=2 load=[200,0,0] raft-cpu=20
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=2 replica-id=2 type=VOTER_FULL
+    store-id=4 replica-id=4 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+  range-id=3 load=[200,0,0] raft-cpu=20
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+    store-id=3 replica-id=3 type=VOTER_FULL
+    store-id=5 replica-id=5 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+  range-id=4 load=[200,0,0] raft-cpu=20
+    store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
+    store-id=3 replica-id=3 type=VOTER_FULL
+    store-id=6 replica-id=6 type=VOTER_FULL
+    config=num_replicas=3 constraints={} voter_constraints={}
+----
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=900 node-adjusted-cpu=900 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=900 node-adjusted-cpu=900 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r2 r1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=900 node-adjusted-cpu=900 seq=1
+  top-k-ranges (local-store-id=1) dim=CPURate: r3 r1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:300ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:300ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=300 node-adjusted-cpu=300 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r2
+store-id=5 node-id=5 status=ok accepting all reported=[cpu:280ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:280ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=280 node-adjusted-cpu=280 seq=1
+  top-k-ranges (local-store-id=1) dim=WriteBandwidth: r3
+store-id=6 node-id=6 status=ok accepting all reported=[cpu:260ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:260ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=260 node-adjusted-cpu=260 seq=1
+store-id=7 node-id=7 status=ok accepting all reported=[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=250 node-adjusted-cpu=250 seq=1
+
+# Try to rebalance from overloaded high capacity store to low capacity stores.
+#
+# Cluster means (from output below): cpu=541, capacity=714, utilization=75.8%
+#
+# Current utilization of stores:
+# - s1: 900/1000 = 90%
+# - s2: 900/1000 = 90%
+# - s3: 900/1000 = 90%
+# - s4: 300/500 = 60%
+# - s5: 280/500 = 56%
+# - s6: 260/500 = 52%
+# - s7: 250/500 = 50%
+#
+# Lease transfers add delta of 180 CPU (range load 200 minus raft-cpu 20).
+# Replica transfers add delta of 200 CPU (full range load since leaseholder moves too).
+#
+# Example: transferring r1 replica to s7 (from log lines 297-308):
+# - s7 current load: 250
+# - Delta: 200 (full range load including raft-cpu since leaseholder moves too)
+# - With 1.1x safety margin: 200 * 1.1 = 220 (see loadMultiplierForAddition)
+# - s7 load after transfer: 250 + 220 = 470
+# - s7 new utilization: 470/500 = 94%
+# - s1 load after transfer: 700
+#
+# KEY INSIGHT: The transfer fails due to UTILIZATION, not mean comparison.
+#
+# Mean comparison (fractionAbove = load/meanLoad - 1):
+#   s7 after transfer: 470/541 - 1 = -0.13 → would be "loadLow" (< -0.1 threshold)
+#
+# But utilization override kicks in (see loadSummaryForDimension):
+#   meanUtil*1.1 = 0.758*1.1 = 0.83 < fractionUsed (0.94)
+#   Since fractionUsed >= 0.9 → overloadUrgent
+#
+# So even though s7 (470 CPU) would have LOWER absolute load than s1 (700 CPU)
+# after the transfer, and lower load relative to the mean, the HIGH UTILIZATION
+# (94%) triggers the utilization override, making s7 overloadUrgent.
+rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=1.0
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:541ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:714ns/s, write-bandwidth:unknown/s, byte-size:714 B]) (nodes-cpu-load 541) (nodes-cpu-capacity 714)
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] evaluating s2: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-continued s2 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s2 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] evaluating s3: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-continued s3 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s3 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=300 meanLoad=541 fractionUsed=60.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=300 meanLoad=541 fractionUsed=60.00% meanUtil=75.80% capacity=500]
+[mmaid=1] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s5): loadLow, reason: load is >10% below mean [load=280 meanLoad=541 fractionUsed=56.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n5): loadLow, reason: load is >10% below mean [load=280 meanLoad=541 fractionUsed=56.00% meanUtil=75.80% capacity=500]
+[mmaid=1] evaluating s5: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s6): loadLow, reason: load is >10% below mean [load=260 meanLoad=541 fractionUsed=52.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n6): loadLow, reason: load is >10% below mean [load=260 meanLoad=541 fractionUsed=52.00% meanUtil=75.80% capacity=500]
+[mmaid=1] evaluating s6: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
+[mmaid=1] evaluating s7: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r3:[cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=693 fractionUsed=90.00% meanUtil=83.20% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=693 fractionUsed=90.00% meanUtil=83.20% capacity=1000]
+[mmaid=1] considering lease-transfer r3 from s1: candidates are [1 3 5]
+[mmaid=1] load summary for dim=CPURate (s3): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=693 fractionUsed=90.00% meanUtil=83.20% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=693 fractionUsed=90.00% meanUtil=83.20% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s5): loadLow, reason: load is >10% below mean [load=280 meanLoad=693 fractionUsed=56.00% meanUtil=83.20% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n5): loadLow, reason: load is >10% below mean [load=280 meanLoad=693 fractionUsed=56.00% meanUtil=83.20% capacity=500]
+[mmaid=1] candidate store 3 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s5(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s5
+[mmaid=1] load summary for dim=CPURate (s5): overloadUrgent, reason: fractionUsed > 90% [load=478 meanLoad=693 fractionUsed=95.60% meanUtil=83.20% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n5): overloadUrgent, reason: fractionUsed > 90% [load=478 meanLoad=693 fractionUsed=95.60% meanUtil=83.20% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=693 fractionUsed=72.00% meanUtil=83.20% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=693 fractionUsed=72.00% meanUtil=83.20% capacity=1000]
+[mmaid=1] cannot add load to n5s5: due to overloadUrgent
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] result(failed): cannot shed from s1 to s5 for r3: delta load [cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=700 fractionUsed=90.00% meanUtil=84.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=700 fractionUsed=90.00% meanUtil=84.00% capacity=1000]
+[mmaid=1] considering lease-transfer r2 from s1: candidates are [1 2 4]
+[mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=700 fractionUsed=90.00% meanUtil=84.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): overloadSlow, reason: load is >10% above mean [load=900 meanLoad=700 fractionUsed=90.00% meanUtil=84.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=300 meanLoad=700 fractionUsed=60.00% meanUtil=84.00% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=300 meanLoad=700 fractionUsed=60.00% meanUtil=84.00% capacity=500]
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=true pending_thresh=false): sls=(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
+[mmaid=1] load summary for dim=CPURate (s4): overloadUrgent, reason: fractionUsed > 90% [load=498 meanLoad=700 fractionUsed=99.60% meanUtil=84.00% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n4): overloadUrgent, reason: fractionUsed > 90% [load=498 meanLoad=700 fractionUsed=99.60% meanUtil=84.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=700 fractionUsed=72.00% meanUtil=84.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=720 meanLoad=700 fractionUsed=72.00% meanUtil=84.00% capacity=1000]
+[mmaid=1] cannot add load to n4s4: due to overloadUrgent
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=loadNormal worst=CPURate cpu=loadNormal writes=loadNormal bytes=loadNormal node=loadNormal high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] result(failed): cannot shed from s1 to s4 for r2: delta load [cpu:180ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=900 meanLoad=900 fractionUsed=90.00% meanUtil=90.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=900 meanLoad=900 fractionUsed=90.00% meanUtil=90.00% capacity=1000]
+[mmaid=1] considering lease-transfer r1 from s1: candidates are [1 2 3]
+[mmaid=1] result(failed): skipping r1 since store not overloaded relative to candidates
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=300 meanLoad=541 fractionUsed=60.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=300 meanLoad=541 fractionUsed=60.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s6): loadLow, reason: load is >10% below mean [load=260 meanLoad=541 fractionUsed=52.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n6): loadLow, reason: load is >10% below mean [load=260 meanLoad=541 fractionUsed=52.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n7): loadLow, reason: load is >10% below mean [load=250 meanLoad=541 fractionUsed=50.00% meanUtil=75.80% capacity=500]
+[mmaid=1] considering replica-transfer r3 from s1: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] discarding candidates with higher load than lowestLoadSet(loadNormal):  s2(SLS:overloadSlow, overloadedDimLoadSummary:overloadSlow), overloadedDim:CPURate
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s6(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s7(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s6
+[mmaid=1] load summary for dim=CPURate (s6): overloadUrgent, reason: fractionUsed > 90% [load=480 meanLoad=541 fractionUsed=96.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n6): overloadUrgent, reason: fractionUsed > 90% [load=480 meanLoad=541 fractionUsed=96.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] cannot add load to n6s6: due to overloadUrgent
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] result(failed): cannot shed from s1 to s6 for r3: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed > 75% [load=900 meanLoad=541 fractionUsed=90.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s5): loadLow, reason: load is >10% below mean [load=280 meanLoad=541 fractionUsed=56.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s5): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n5): loadLow, reason: load is >10% below mean [load=280 meanLoad=541 fractionUsed=56.00% meanUtil=75.80% capacity=500]
+[mmaid=1] considering replica-transfer r2 from s1: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] discarding candidates with higher load than lowestLoadSet(loadNormal):  s3(SLS:overloadSlow, overloadedDimLoadSummary:overloadSlow), overloadedDim:CPURate
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s5(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s6(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s7(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s6
+[mmaid=1] load summary for dim=CPURate (s6): overloadUrgent, reason: fractionUsed > 90% [load=480 meanLoad=541 fractionUsed=96.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s6): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n6): overloadUrgent, reason: fractionUsed > 90% [load=480 meanLoad=541 fractionUsed=96.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] cannot add load to n6s6: due to overloadUrgent
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] result(failed): cannot shed from s1 to s6 for r2: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] considering replica-transfer r1 from s1: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s5(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s6(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s7(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s7
+[mmaid=1] load summary for dim=CPURate (s7): overloadUrgent, reason: fractionUsed > 90% [load=470 meanLoad=541 fractionUsed=94.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=WriteBandwidth (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=ByteSize (s7): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=500]
+[mmaid=1] load summary for dim=CPURate (n7): overloadUrgent, reason: fractionUsed > 90% [load=470 meanLoad=541 fractionUsed=94.00% meanUtil=75.80% capacity=500]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: load is >10% above mean [load=700 meanLoad=541 fractionUsed=70.00% meanUtil=75.80% capacity=1000]
+[mmaid=1] cannot add load to n7s7: due to overloadUrgent
+[mmaid=1] [target_sls:(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))]
+[mmaid=1] result(failed): cannot shed from s1 to s7 for r1: delta load [cpu:200ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] start processing shedding store s2: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s2 with lease on local s1: r2:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] skipping remote store s2: in lease shedding grace period
+[mmaid=1] start processing shedding store s3: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:20ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] skipping remote store s3: in lease shedding grace period
+pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_frac_threshold.txt
@@ -8,36 +8,88 @@ ok
 rebalance-stores store-id=1 fraction-pending-decrease-threshold=0.4
 ----
 [mmaid=1] rebalanceStores begins
-[mmaid=1] cluster means: (stores-load [cpu:400, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] cluster means: (stores-load [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s2: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250, write-bandwidth:0, byte-size:0] r3:[cpu:250, write-bandwidth:0, byte-size:0] r2:[cpu:250, write-bandwidth:0, byte-size:0] r1:[cpu:250, write-bandwidth:0, byte-size:0]
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r3:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r4 from s1: candidates are [1 2 3]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s2
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
-[mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770, write-bandwidth:0, byte-size:0] target:[cpu:353, write-bandwidth:0, byte-size:0] (means: [cpu:400, write-bandwidth:0, byte-size:0]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
+[mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r3 from s1: candidates are [1 2 3]
-[mmaid=1] candiate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.53,0.00(false))
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.53,0.00(false))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s3
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
-[mmaid=1] result(success): shedding r3 lease from s1 to s3 [change:r3=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540, write-bandwidth:0, byte-size:0] target:[cpu:353, write-bandwidth:0, byte-size:0] (means: [cpu:400, write-bandwidth:0, byte-size:0]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
+[mmaid=1] result(success): shedding r3 lease from s1 to s3 [change:r3=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
 [mmaid=1] s1 has reached pending decrease threshold(0.46>=0.40) after 2 lease transfers
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 pending(4)
-change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=2 store-id=2 node-id=2 range-id=4 load-delta=[cpu:253, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=2 store-id=2 node-id=2 range-id=4 load-delta=[cpu:253ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=2 type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=1 node-id=1 range-id=3 load-delta=[cpu:-230, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=3 store-id=1 node-id=1 range-id=3 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=3 load-delta=[cpu:253, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=4 store-id=3 node-id=3 range-id=3 load-delta=[cpu:253ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=3 type=VOTER_FULL leaseholder=true)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_include.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_include.txt
@@ -27,9 +27,9 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:1000, write-bandwidth:0, byte-size:0] adjusted=[cpu:1000, write-bandwidth:0, byte-size:0] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:100, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:100, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
 
 store-leaseholder-msg
 store-id=1
@@ -58,9 +58,9 @@ store-id=1
 # n1's top-k-ranges reflect r3, r2, and r1.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:1000, write-bandwidth:0, byte-size:0] adjusted=[cpu:1000, write-bandwidth:0, byte-size:0] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r4 r3 r2 r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:100, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r4 r3 r2 r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:100, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r4 r3 r2 r1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_refusing_target.txt
@@ -46,23 +46,43 @@ ok refusing=leases
 rebalance-stores store-id=1
 ----
 [mmaid=1] rebalanceStores begins
-[mmaid=1] cluster means: (stores-load [cpu:700, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 700) (nodes-cpu-capacity 1000)
+[mmaid=1] cluster means: (stores-load [cpu:700ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 700) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=700 fractionUsed=10.00% meanUtil=70.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=700 fractionUsed=10.00% meanUtil=70.00% capacity=1000]
 [mmaid=1] evaluating s2: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
 [mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100, write-bandwidth:0, byte-size:0]
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
 [mmaid=1] skipping s2 for lease transfer: lease disposition refusing (health ok)
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=1000 meanLoad=1000 fractionUsed=100.00% meanUtil=100.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=1000 meanLoad=1000 fractionUsed=100.00% meanUtil=100.00% capacity=1000]
 [mmaid=1] considering lease-transfer r1 from s1: candidates are [1 3]
 [mmaid=1] result(failed): skipping r1 since store not overloaded relative to candidates
 [mmaid=1] attempting to shed replicas next
 [mmaid=1] excluding all stores on n1 due to overload/fd status
-[mmaid=1] considering replica-transfer r1 from s1: store load [cpu:1000, write-bandwidth:0, byte-size:0]
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=700 fractionUsed=100.00% meanUtil=70.00% capacity=1000]
+[mmaid=1] considering replica-transfer r1 from s1: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] result(failed): no candidates found for r1 after exclusions
 [mmaid=1] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] no top-K[CPURate] ranges found for s3 with lease on local s1

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_count.txt
@@ -8,36 +8,88 @@ ok
 rebalance-stores store-id=1 fraction-pending-decrease-threshold=1.0 max-lease-transfer-count=2
 ----
 [mmaid=1] rebalanceStores begins
-[mmaid=1] cluster means: (stores-load [cpu:400, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] cluster means: (stores-load [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s2: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250, write-bandwidth:0, byte-size:0] r3:[cpu:250, write-bandwidth:0, byte-size:0] r2:[cpu:250, write-bandwidth:0, byte-size:0] r1:[cpu:250, write-bandwidth:0, byte-size:0]
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r3:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r4 from s1: candidates are [1 2 3]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s2
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
-[mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770, write-bandwidth:0, byte-size:0] target:[cpu:353, write-bandwidth:0, byte-size:0] (means: [cpu:400, write-bandwidth:0, byte-size:0]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
+[mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r3 from s1: candidates are [1 2 3]
-[mmaid=1] candiate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.53,0.00(false))
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] candidate store 2 was discarded due to (nls=false overloadDim=false pending_thresh=true): sls=(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.53,0.00(false))
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s3
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
-[mmaid=1] result(success): shedding r3 lease from s1 to s3 [change:r3=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540, write-bandwidth:0, byte-size:0] target:[cpu:353, write-bandwidth:0, byte-size:0] (means: [cpu:400, write-bandwidth:0, byte-size:0]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
+[mmaid=1] result(success): shedding r3 lease from s1 to s3 [change:r3=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
 [mmaid=1] reached max lease transfer count 2, returning
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 pending(4)
-change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=2 store-id=2 node-id=2 range-id=4 load-delta=[cpu:253, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=2 store-id=2 node-id=2 range-id=4 load-delta=[cpu:253ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=2 type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=1 node-id=1 range-id=3 load-delta=[cpu:-230, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=3 store-id=1 node-id=1 range-id=3 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=3 load-delta=[cpu:253, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=4 store-id=3 node-id=3 range-id=3 load-delta=[cpu:253ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=3 type=VOTER_FULL leaseholder=true)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_lease_transfer_unbounded.txt
@@ -7,44 +7,136 @@ ok
 rebalance-stores store-id=1 fraction-pending-decrease-threshold=10.0 max-lease-transfer-count=999
 ----
 [mmaid=1] rebalanceStores begins
-[mmaid=1] cluster means: (stores-load [cpu:400, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] cluster means: (stores-load [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 400) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s1: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s1 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s2: node load loadLow, store load loadNormal, worst dim WriteBandwidth
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] evaluating s3: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=1] start processing shedding store s1: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250, write-bandwidth:0, byte-size:0] r3:[cpu:250, write-bandwidth:0, byte-size:0] r2:[cpu:250, write-bandwidth:0, byte-size:0] r1:[cpu:250, write-bandwidth:0, byte-size:0]
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r4:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r3:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:250ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] local store s1 is CPU overloaded (overloadUrgent >= overloadSlow), attempting lease transfers first
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=400 fractionUsed=100.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r4 from s1: candidates are [1 2 3]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s2
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n2s2: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
-[mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770, write-bandwidth:0, byte-size:0] target:[cpu:353, write-bandwidth:0, byte-size:0] (means: [cpu:400, write-bandwidth:0, byte-size:0]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
+[mmaid=1] result(success): shedding r4 lease from s1 to s2 [change:r4=[transfer_to=2 cids=1,2]] with resulting loads source:[cpu:770ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.23) (src:2.53,target:0.00))
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r3 from s1: candidates are [1 2 3]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s2
+[mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed < 75% [load=606 meanLoad=400 fractionUsed=60.60% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed < 75% [load=606 meanLoad=400 fractionUsed=60.60% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] cannot add load to n2s2: due to target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon)
 [mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=2.53,0.00(false)),src_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
-[mmaid=1] result(failed): cannot shed from s1 to s2 for r3: delta load [cpu:230, write-bandwidth:0, byte-size:0]
+[mmaid=1] result(failed): cannot shed from s1 to s2 for r3: delta load [cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=1] load summary for dim=CPURate (s1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=770 meanLoad=400 fractionUsed=77.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r2 from s1: candidates are [1 2 3]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=100 meanLoad=400 fractionUsed=10.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s3
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] can add load to n3s3: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.23(false))]
-[mmaid=1] result(success): shedding r2 lease from s1 to s3 [change:r2=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540, write-bandwidth:0, byte-size:0] target:[cpu:353, write-bandwidth:0, byte-size:0] (means: [cpu:400, write-bandwidth:0, byte-size:0]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
+[mmaid=1] result(success): shedding r2 lease from s1 to s3 [change:r2=[transfer_to=3 cids=3,4]] with resulting loads source:[cpu:540ns/s, write-bandwidth:0 B/s, byte-size:0 B] target:[cpu:353ns/s, write-bandwidth:0 B/s, byte-size:0 B] (means: [cpu:400ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (frac_pending: (src:0.00,target:0.46) (src:2.53,target:0.00))
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% [load=540 meanLoad=400 fractionUsed=54.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] considering lease-transfer r1 from s1: candidates are [1 2 3]
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): loadLow, reason: load is >10% below mean [load=353 meanLoad=400 fractionUsed=35.30% meanUtil=40.00% capacity=1000]
 [mmaid=1] sortTargetCandidateSetAndPick: candidates: s2(SLS:loadNormal, overloadedDimLoadSummary:loadLow) s3(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s2
+[mmaid=1] load summary for dim=CPURate (s2): overloadSlow, reason: fractionUsed < 75% [load=606 meanLoad=400 fractionUsed=60.60% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): overloadSlow, reason: fractionUsed < 75% [load=606 meanLoad=400 fractionUsed=60.60% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (s1): loadLow, reason: load is >10% below mean [load=310 meanLoad=400 fractionUsed=31.00% meanUtil=40.00% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): loadLow, reason: load is >10% below mean [load=310 meanLoad=400 fractionUsed=31.00% meanUtil=40.00% capacity=1000]
 [mmaid=1] cannot add load to n2s2: due to !overloadedDimPermitsChange,target_summary(overloadSlow)>=loadNoChange,targetSLS.frac_pending(2.53or0.00>=epsilon),target-store(overloadSlow)>src-store(loadNormal)
 [mmaid=1] [target_sls:(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=2.53,0.00(false)),src_sls:(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.46(false))]
-[mmaid=1] result(failed): cannot shed from s1 to s2 for r1: delta load [cpu:230, write-bandwidth:0, byte-size:0]
+[mmaid=1] result(failed): cannot shed from s1 to s2 for r1: delta load [cpu:230ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] skipping replica transfers for s1 to try more leases next time
 pending(4)
-change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=1 store-id=1 node-id=1 range-id=4 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=2 store-id=2 node-id=2 range-id=4 load-delta=[cpu:253, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=2 store-id=2 node-id=2 range-id=4 load-delta=[cpu:253ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=2 type=VOTER_FULL leaseholder=true)
-change-id=3 store-id=1 node-id=1 range-id=2 load-delta=[cpu:-230, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=3 store-id=1 node-id=1 range-id=2 load-delta=[cpu:-230ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=2 load-delta=[cpu:253, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=4 store-id=3 node-id=3 range-id=2 load-delta=[cpu:253ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=3 type=VOTER_FULL leaseholder=true)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_count.txt
@@ -7,25 +7,41 @@ ok
 rebalance-stores store-id=1 max-range-move-count=1 fraction-pending-decrease-threshold=1.0
 ----
 [mmaid=2] rebalanceStores begins
-[mmaid=2] cluster means: (stores-load [cpu:525, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
+[mmaid=2] cluster means: (stores-load [cpu:525ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
 [mmaid=2] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s2: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=2] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100, write-bandwidth:0, byte-size:0] r2:[cpu:100, write-bandwidth:0, byte-size:0] r1:[cpu:100, write-bandwidth:0, byte-size:0]
+[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next
 [mmaid=2] excluding all stores on n3 due to overload/fd status
-[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1000, write-bandwidth:0, byte-size:0]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
-[mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900, write-bandwidth:0, byte-size:0] target: [cpu:210, write-bandwidth:0, byte-size:0]
+[mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:210ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] reached max range move count 1; done shedding
 pending(2)
-change-id=1 store-id=4 node-id=4 range-id=3 load-delta=[cpu:110, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=1 store-id=4 node-id=4 range-id=3 load-delta=[cpu:110ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=2 store-id=3 node-id=3 range-id=3 load-delta=[cpu:-100, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=2 store-id=3 node-id=3 range-id=3 load-delta=[cpu:-100ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_frac_threshold.txt
@@ -7,25 +7,41 @@ ok
 rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=0.01
 ----
 [mmaid=2] rebalanceStores begins
-[mmaid=2] cluster means: (stores-load [cpu:525, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
+[mmaid=2] cluster means: (stores-load [cpu:525ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
 [mmaid=2] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s2: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=2] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100, write-bandwidth:0, byte-size:0] r2:[cpu:100, write-bandwidth:0, byte-size:0] r1:[cpu:100, write-bandwidth:0, byte-size:0]
+[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next
 [mmaid=2] excluding all stores on n3 due to overload/fd status
-[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1000, write-bandwidth:0, byte-size:0]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
-[mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900, write-bandwidth:0, byte-size:0] target: [cpu:210, write-bandwidth:0, byte-size:0]
+[mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:210ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] s3 has reached pending decrease threshold(0.10>=0.01) after rebalancing; done shedding
 pending(2)
-change-id=1 store-id=4 node-id=4 range-id=3 load-delta=[cpu:110, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=1 store-id=4 node-id=4 range-id=3 load-delta=[cpu:110ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=2 store-id=3 node-id=3 range-id=3 load-delta=[cpu:-100, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=2 store-id=3 node-id=3 range-id=3 load-delta=[cpu:-100ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_include.txt
@@ -25,10 +25,10 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:500, write-bandwidth:0, byte-size:0] adjusted=[cpu:500, write-bandwidth:0, byte-size:0] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:500, write-bandwidth:0, byte-size:0] adjusted=[cpu:500, write-bandwidth:0, byte-size:0] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:1000, write-bandwidth:0, byte-size:0] adjusted=[cpu:1000, write-bandwidth:0, byte-size:0] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:100, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
 
 store-leaseholder-msg
 store-id=1
@@ -52,12 +52,12 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:500, write-bandwidth:0, byte-size:0] adjusted=[cpu:500, write-bandwidth:0, byte-size:0] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:500, write-bandwidth:0, byte-size:0] adjusted=[cpu:500, write-bandwidth:0, byte-size:0] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r3 r2 r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:1000, write-bandwidth:0, byte-size:0] adjusted=[cpu:1000, write-bandwidth:0, byte-size:0] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=1000 node-adjusted-cpu=1000 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:100, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
 
 # On the first rebalance-stores invocation the lease shedding grace
 # period is active, and we don't move replicas.
@@ -65,15 +65,31 @@ store-id=4 node-id=4 status=ok accepting all reported=[cpu:100, write-bandwidth:
 rebalance-stores store-id=1
 ----
 [mmaid=1] rebalanceStores begins
-[mmaid=1] cluster means: (stores-load [cpu:525, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
+[mmaid=1] cluster means: (stores-load [cpu:525ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
+[mmaid=1] load summary for dim=CPURate (s1): loadNormal, reason: load is within 5% of mean [load=500 meanLoad=525 fractionUsed=50.00% meanUtil=52.50% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s1): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n1): loadNormal, reason: load is within 5% of mean [load=500 meanLoad=525 fractionUsed=50.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s2): loadNormal, reason: load is within 5% of mean [load=500 meanLoad=525 fractionUsed=50.00% meanUtil=52.50% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s2): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n2): loadNormal, reason: load is within 5% of mean [load=500 meanLoad=525 fractionUsed=50.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] evaluating s2: node load loadNormal, store load loadNormal, worst dim CPURate
+[mmaid=1] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=1] overload-continued s3 ((store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))) - within grace period
 [mmaid=1] store s3 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=1] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=1] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
 [mmaid=1] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=1] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=1] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100, write-bandwidth:0, byte-size:0] r2:[cpu:100, write-bandwidth:0, byte-size:0] r1:[cpu:100, write-bandwidth:0, byte-size:0]
+[mmaid=1] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=1] attempting to shed replicas next
 [mmaid=1] skipping remote store s3: in lease shedding grace period
 pending(0)

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/rebalance_stores_cpu_replica_unbounded.txt
@@ -10,53 +10,101 @@ ok
 rebalance-stores store-id=1 max-range-move-count=999 fraction-pending-decrease-threshold=10.0
 ----
 [mmaid=2] rebalanceStores begins
-[mmaid=2] cluster means: (stores-load [cpu:525, write-bandwidth:0, byte-size:0]) (stores-capacity [cpu:1000, write-bandwidth:1000, byte-size:1000]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
+[mmaid=2] cluster means: (stores-load [cpu:525ns/s, write-bandwidth:0 B/s, byte-size:0 B]) (stores-capacity [cpu:1µs/s, write-bandwidth:1.0 kB/s, byte-size:1.0 kB]) (nodes-cpu-load 525) (nodes-cpu-capacity 1000)
 [mmaid=2] evaluating s1: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s2: node load loadNormal, store load loadNormal, worst dim CPURate
 [mmaid=2] evaluating s3: node load overloadUrgent, store load overloadUrgent, worst dim CPURate
 [mmaid=2] store s3 was added to shedding store list
 [mmaid=2] evaluating s4: node load loadLow, store load loadNormal, worst dim WriteBandwidth
 [mmaid=2] start processing shedding store s3: cpu node load overloadUrgent, store load overloadUrgent, worst dim CPURate
-[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100, write-bandwidth:0, byte-size:0] r2:[cpu:100, write-bandwidth:0, byte-size:0] r1:[cpu:100, write-bandwidth:0, byte-size:0]
+[mmaid=2] top-K[CPURate] ranges for s3 with lease on local s1: r3:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r2:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] r1:[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] attempting to shed replicas next
 [mmaid=2] excluding all stores on n3 due to overload/fd status
-[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1000, write-bandwidth:0, byte-size:0]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 90% [load=1000 meanLoad=525 fractionUsed=100.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=100 meanLoad=525 fractionUsed=10.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] considering replica-transfer r3 from s3: store load [cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=0.00,0.00(true))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.00(true))]
-[mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900, write-bandwidth:0, byte-size:0] target: [cpu:210, write-bandwidth:0, byte-size:0]
-[mmaid=2] considering replica-transfer r2 from s3: store load [cpu:900, write-bandwidth:0, byte-size:0]
+[mmaid=2] result(success): rebalancing r3 from s3 to s4 [change: r3=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=1,2]] with resulting loads source: [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:210ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=900 meanLoad=525 fractionUsed=90.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=210 meanLoad=525 fractionUsed=21.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] considering replica-transfer r2 from s3: store load [cpu:900ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=320 meanLoad=525 fractionUsed=32.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=320 meanLoad=525 fractionUsed=32.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=1.10,0.00(false))] srcSLS[(store=overloadUrgent worst=CPURate cpu=overloadUrgent writes=loadNormal bytes=loadNormal node=overloadUrgent high_disk=false frac_pending=0.00,0.10(false))]
-[mmaid=2] result(success): rebalancing r2 from s3 to s4 [change: r2=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=3,4]] with resulting loads source: [cpu:800, write-bandwidth:0, byte-size:0] target: [cpu:320, write-bandwidth:0, byte-size:0]
-[mmaid=2] considering replica-transfer r1 from s3: store load [cpu:800, write-bandwidth:0, byte-size:0]
+[mmaid=2] result(success): rebalancing r2 from s3 to s4 [change: r2=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=3,4]] with resulting loads source: [cpu:800ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:320ns/s, write-bandwidth:0 B/s, byte-size:0 B]
+[mmaid=2] load summary for dim=CPURate (s3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadUrgent, reason: fractionUsed > 75% and >1.5x meanUtil [load=800 meanLoad=525 fractionUsed=80.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=320 meanLoad=525 fractionUsed=32.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=320 meanLoad=525 fractionUsed=32.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] considering replica-transfer r1 from s3: store load [cpu:800ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 [mmaid=2] sortTargetCandidateSetAndPick: candidates: s4(SLS:loadNormal, overloadedDimLoadSummary:loadLow), overloadedDim:CPURate, picked s4
+[mmaid=2] load summary for dim=CPURate (s4): loadLow, reason: load is >10% below mean [load=430 meanLoad=525 fractionUsed=43.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s4): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n4): loadLow, reason: load is >10% below mean [load=430 meanLoad=525 fractionUsed=43.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (s3): overloadSlow, reason: fractionUsed < 75% [load=700 meanLoad=525 fractionUsed=70.00% meanUtil=52.50% capacity=1000]
+[mmaid=2] load summary for dim=WriteBandwidth (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=ByteSize (s3): loadNormal, reason: load is within 5% of mean [load=0 meanLoad=0 fractionUsed=0.00% meanUtil=0.00% capacity=1000]
+[mmaid=2] load summary for dim=CPURate (n3): overloadSlow, reason: fractionUsed < 75% [load=700 meanLoad=525 fractionUsed=70.00% meanUtil=52.50% capacity=1000]
 [mmaid=2] can add load to n4s4: true targetSLS[(store=loadNormal worst=WriteBandwidth cpu=loadLow writes=loadNormal bytes=loadNormal node=loadLow high_disk=false frac_pending=2.20,0.00(false))] srcSLS[(store=overloadSlow worst=CPURate cpu=overloadSlow writes=loadNormal bytes=loadNormal node=overloadSlow high_disk=false frac_pending=0.00,0.20(false))]
-[mmaid=2] result(success): rebalancing r1 from s3 to s4 [change: r1=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=5,6]] with resulting loads source: [cpu:700, write-bandwidth:0, byte-size:0] target: [cpu:430, write-bandwidth:0, byte-size:0]
+[mmaid=2] result(success): rebalancing r1 from s3 to s4 [change: r1=[change_replicas=[{ADD_VOTER n4,s4} {REMOVE_VOTER n3,s3}] cids=5,6]] with resulting loads source: [cpu:700ns/s, write-bandwidth:0 B/s, byte-size:0 B] target: [cpu:430ns/s, write-bandwidth:0 B/s, byte-size:0 B]
 pending(6)
-change-id=1 store-id=4 node-id=4 range-id=3 load-delta=[cpu:110, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=1 store-id=4 node-id=4 range-id=3 load-delta=[cpu:110ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=2 store-id=3 node-id=3 range-id=3 load-delta=[cpu:-100, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=2 store-id=3 node-id=3 range-id=3 load-delta=[cpu:-100ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
-change-id=3 store-id=4 node-id=4 range-id=2 load-delta=[cpu:110, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=3 store-id=4 node-id=4 range-id=2 load-delta=[cpu:110ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=4 store-id=3 node-id=3 range-id=2 load-delta=[cpu:-100, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=4 store-id=3 node-id=3 range-id=2 load-delta=[cpu:-100ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
-change-id=5 store-id=4 node-id=4 range-id=1 load-delta=[cpu:110, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=5 store-id=4 node-id=4 range-id=1 load-delta=[cpu:110ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL)
-change-id=6 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-100, write-bandwidth:0, byte-size:0] start=5m0s gc=10m0s
+change-id=6 store-id=3 node-id=3 range-id=1 load-delta=[cpu:-100ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=5m0s gc=10m0s
   prev=(replica-id=3 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:500, write-bandwidth:0, byte-size:0] adjusted=[cpu:500, write-bandwidth:0, byte-size:0] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:500, write-bandwidth:0, byte-size:0] adjusted=[cpu:500, write-bandwidth:0, byte-size:0] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:500ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=500 node-adjusted-cpu=500 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r3 r2 r1
-store-id=3 node-id=3 status=ok accepting all reported=[cpu:1000, write-bandwidth:0, byte-size:0] adjusted=[cpu:700, write-bandwidth:0, byte-size:0] node-reported-cpu=1000 node-adjusted-cpu=700 seq=4
+store-id=3 node-id=3 status=ok accepting all reported=[cpu:1µs/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:700ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=1000 node-adjusted-cpu=700 seq=4
   top-k-ranges (local-store-id=1) dim=CPURate: r3 r2 r1
-store-id=4 node-id=4 status=ok accepting all reported=[cpu:100, write-bandwidth:0, byte-size:0] adjusted=[cpu:430, write-bandwidth:0, byte-size:0] node-reported-cpu=100 node-adjusted-cpu=430 seq=4
+store-id=4 node-id=4 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:430ns/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=100 node-adjusted-cpu=430 seq=4

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/remove_replica.txt
@@ -13,8 +13,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
 
 store-leaseholder-msg 
 store-id=1
@@ -26,14 +26,14 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 
@@ -41,7 +41,7 @@ make-pending-changes range-id=1
   remove-replica: remove-store-id=2
 ----
 pending(1)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:-20, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:-20ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -49,16 +49,16 @@ change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:-20, write-bandwidth
 # store 1 remaining.
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 # The load info for s2 should also reflect the load delta [-20,-80,-80] being
 # applied.
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
 
 store-leaseholder-msg
@@ -70,14 +70,14 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=20 node-adjusted-cpu=0 seq=2
 
 get-pending-changes
 ----
 pending(1)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:-20, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s enacted=0s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:-20ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s enacted=0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -87,9 +87,9 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=3
 
 get-pending-changes
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/removed_ranges.txt
@@ -19,17 +19,17 @@ store-id=1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
 
 make-pending-changes range-id=1
   rebalance-replica: remove-store-id=1 add-store-id=2
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 
@@ -47,10 +47,10 @@ store-id=1
 get-pending-changes
 ----
 pending(2)
-change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88, write-bandwidth:88, byte-size:88] start=0s gc=5m0s enacted=1s
+change-id=1 store-id=2 node-id=2 range-id=1 load-delta=[cpu:88ns/s, write-bandwidth:88 B/s, byte-size:88 B] start=0s gc=5m0s enacted=1s
   prev=(replica-id=none type=VOTER_FULL)
   next=(replica-id=unknown type=VOTER_FULL leaseholder=true)
-change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80, write-bandwidth:-80, byte-size:-80] start=0s gc=5m0s enacted=1s
+change-id=2 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-80ns/s, write-bandwidth:-80 B/s, byte-size:-80 B] start=0s gc=5m0s enacted=1s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=none type=VOTER_FULL)
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/store_status.txt
@@ -14,7 +14,7 @@ unhealthy shedding=leases,replicas
 
 get-load-info
 ----
-store-id=1 node-id=1 status=unhealthy shedding=leases,replicas reported=[cpu:0, write-bandwidth:0, byte-size:0] adjusted=[cpu:0, write-bandwidth:0, byte-size:0] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
+store-id=1 node-id=1 status=unhealthy shedding=leases,replicas reported=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] adjusted=[cpu:0s/s, write-bandwidth:0 B/s, byte-size:0 B] node-reported-cpu=0 node-adjusted-cpu=0 seq=0
 
 set-store-status store-id=1 health=ok replicas=ok leases=ok
 ----

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/transfer_lease.txt
@@ -17,8 +17,8 @@ store-load-msg
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
 
 store-leaseholder-msg 
 store-id=1
@@ -30,14 +30,14 @@ store-id=1
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=1
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=20 node-adjusted-cpu=20 seq=1
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 
@@ -46,23 +46,23 @@ make-pending-changes range-id=1
   transfer-lease: remove-store-id=1 add-store-id=2 
 ----
 pending(2)
-change-id=1 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-60, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=1 store-id=1 node-id=1 range-id=1 load-delta=[cpu:-60ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=1 type=VOTER_FULL leaseholder=true)
   next=(replica-id=1 type=VOTER_FULL)
-change-id=2 store-id=2 node-id=2 range-id=1 load-delta=[cpu:66, write-bandwidth:0, byte-size:0] start=0s gc=1m0s
+change-id=2 store-id=2 node-id=2 range-id=1 load-delta=[cpu:66ns/s, write-bandwidth:0 B/s, byte-size:0 B] start=0s gc=1m0s
   prev=(replica-id=2 type=VOTER_FULL)
   next=(replica-id=2 type=VOTER_FULL leaseholder=true)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=20 seq=2
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=20 seq=2
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:86, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=86 seq=2
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:86ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=20 node-adjusted-cpu=86 seq=2
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL
   store-id=2 replica-id=2 type=VOTER_FULL leaseholder=true
 
@@ -72,14 +72,14 @@ pending(0)
 
 get-load-info
 ----
-store-id=1 node-id=1 status=ok accepting all reported=[cpu:80, write-bandwidth:80, byte-size:80] adjusted=[cpu:80, write-bandwidth:80, byte-size:80] node-reported-cpu=80 node-adjusted-cpu=80 seq=3
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=80 node-adjusted-cpu=80 seq=3
   top-k-ranges (local-store-id=1) dim=CPURate: r1
-store-id=2 node-id=2 status=ok accepting all reported=[cpu:20, write-bandwidth:80, byte-size:80] adjusted=[cpu:20, write-bandwidth:80, byte-size:80] node-reported-cpu=20 node-adjusted-cpu=20 seq=3
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] adjusted=[cpu:20ns/s, write-bandwidth:80 B/s, byte-size:80 B] node-reported-cpu=20 node-adjusted-cpu=20 seq=3
   top-k-ranges (local-store-id=1) dim=WriteBandwidth: r1
 
 ranges
 ----
-range-id=1 local-store=1 load=[cpu:80, write-bandwidth:80, byte-size:80] raft-cpu=20
+range-id=1 local-store=1 load=[cpu:80ns/s, write-bandwidth:80 B/s, byte-size:80 B] raft-cpu=20
   store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
   store-id=2 replica-id=2 type=VOTER_FULL
 

--- a/pkg/kv/kvserver/mmaintegration/testdata/TestConvertReplicaChangeToMMA
+++ b/pkg/kv/kvserver/mmaintegration/testdata/TestConvertReplicaChangeToMMA
@@ -21,10 +21,10 @@ store-id=3 type=ADD_VOTER
 ----
 PendingRangeChange: range r1
  r1 type: RemoveReplica target store n1,s1 (replica-id=10 type=VOTER_FULL leaseholder=true)->(replica-id=none type=VOTER_FULL)
-  load: [cpu:-11, write-bandwidth:-100, byte-size:-1000]
+  load: [cpu:-11ns/s, write-bandwidth:-100 B/s, byte-size:-1.0 kB]
   secondary-load: [lease:-1, replica:0]
  r1 type: AddReplica target store n3,s3 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL leaseholder=true)
-  load: [cpu:12, write-bandwidth:110, byte-size:1100]
+  load: [cpu:12ns/s, write-bandwidth:110 B/s, byte-size:1.1 kB]
   secondary-load: [lease:1, replica:0]
 As kvpb.ReplicationChanges:
  [{ADD_VOTER n3,s3} {REMOVE_VOTER n1,s1}]
@@ -35,7 +35,7 @@ store-id=2 type=REMOVE_VOTER
 ----
 PendingRangeChange: range r1
  r1 type: RemoveReplica target store n2,s2 (replica-id=20 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
-  load: [cpu:-1, write-bandwidth:-100, byte-size:-1000]
+  load: [cpu:-1ns/s, write-bandwidth:-100 B/s, byte-size:-1.0 kB]
   secondary-load: [lease:0, replica:0]
 As kvpb.ReplicationChanges:
  [{REMOVE_VOTER n2,s2}]
@@ -47,10 +47,10 @@ store-id=3 type=ADD_VOTER
 ----
 PendingRangeChange: range r1
  r1 type: RemoveReplica target store n2,s2 (replica-id=20 type=VOTER_FULL)->(replica-id=none type=VOTER_FULL)
-  load: [cpu:-1, write-bandwidth:-100, byte-size:-1000]
+  load: [cpu:-1ns/s, write-bandwidth:-100 B/s, byte-size:-1.0 kB]
   secondary-load: [lease:0, replica:0]
  r1 type: AddReplica target store n3,s3 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
-  load: [cpu:1, write-bandwidth:110, byte-size:1100]
+  load: [cpu:1ns/s, write-bandwidth:110 B/s, byte-size:1.1 kB]
   secondary-load: [lease:0, replica:0]
 As kvpb.ReplicationChanges:
  [{REMOVE_VOTER n2,s2} {ADD_VOTER n3,s3}]
@@ -64,13 +64,13 @@ store-id=3 type=ADD_VOTER
 ----
 PendingRangeChange: range r1
  r1 type: RemoveReplica target store n1,s1 (replica-id=10 type=VOTER_FULL leaseholder=true)->(replica-id=none type=VOTER_FULL)
-  load: [cpu:-11, write-bandwidth:-100, byte-size:-1000]
+  load: [cpu:-11ns/s, write-bandwidth:-100 B/s, byte-size:-1.0 kB]
   secondary-load: [lease:-1, replica:0]
  r1 type: AddReplica target store n3,s3 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL)
-  load: [cpu:1, write-bandwidth:110, byte-size:1100]
+  load: [cpu:1ns/s, write-bandwidth:110 B/s, byte-size:1.1 kB]
   secondary-load: [lease:0, replica:0]
  r1 type: AddReplica target store n5,s5 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL leaseholder=true)
-  load: [cpu:12, write-bandwidth:110, byte-size:1100]
+  load: [cpu:12ns/s, write-bandwidth:110 B/s, byte-size:1.1 kB]
   secondary-load: [lease:1, replica:0]
 As kvpb.ReplicationChanges:
  [{ADD_VOTER n5,s5} {ADD_VOTER n3,s3} {REMOVE_VOTER n1,s1}]
@@ -113,10 +113,10 @@ store-id=3 type=ADD_VOTER
 ----
 PendingRangeChange: range r1
  r1 type: ChangeReplica target store n1,s1 (replica-id=10 type=VOTER_FULL leaseholder=true)->(replica-id=unknown type=NON_VOTER)
-  load: [cpu:-10, write-bandwidth:0, byte-size:0]
+  load: [cpu:-10ns/s, write-bandwidth:0 B/s, byte-size:0 B]
   secondary-load: [lease:-1, replica:0]
  r1 type: AddReplica target store n3,s3 (replica-id=none type=VOTER_FULL)->(replica-id=unknown type=VOTER_FULL leaseholder=true)
-  load: [cpu:12, write-bandwidth:110, byte-size:1100]
+  load: [cpu:12ns/s, write-bandwidth:110 B/s, byte-size:1.1 kB]
   secondary-load: [lease:1, replica:0]
 As kvpb.ReplicationChanges:
  [{ADD_VOTER n3,s3} {REMOVE_VOTER n1,s1} {ADD_NON_VOTER n1,s1}]


### PR DESCRIPTION
This adds a unit test to TestClusterState which performs rebalancing on a set of stores which have vastly different capacities, such that the stores with lower capacity are unable to accept replicas from stores with higher capacities.
Extra logging is also added to loadSummaryForDimension to help understand load summary calculations.

Informs #158203
Epic: CRDB-55052
Release note: None