### PR TITLE
sql/pgwire: fix precision loss in binary decimal decoding

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/decimal
+++ b/pkg/sql/pgwire/testdata/pgtest/decimal
@@ -81,3 +81,23 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"binary":"00010001000000000001"},{"binary":"00010001000000000001"},{"binary":"0001000100000000000a"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# ResultFormatCodes [1] = FormatBinary
+# [0, 2, 0, 0, 0, 0, 0, 5, 0, 1, 8fc] = binary 1.23000
+# [0, 2, 0, 0, 0, 0, 0, a, 0, 1, 8fc] = binary 1.2300000000
+# [0, 1, 0, 0, 0, 0, 0, a, 0, 1] = binary 1.0000000000
+send
+Parse {"Name": "s3", "Query": "SELECT $1::decimal, $2::decimal, $3::decimal"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "s3", "ParameterFormatCodes": [1], "Parameters": [{"binary":"0002000000000005000108fc"}, {"binary":"000200000000000a000108fc"}, {"binary": "000100000000000a0001"}]}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1.23000"},{"text":"1.2300000000"},{"text":"1.0000000000"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Decimal decoding implementation was ignoring trailing zeros after the decimal point that were implicitly added by the dscale value, resulting precision losses. For example, 1.23000 could be decoded as 1.23. This commit fixes it by adding missing zeros.

Release note: None
Epic: CRDB-57092
Fixes: #158093