### PR TITLE
opt: route descriptor lookups for AFTER triggers through cache

### DIFF
--- a/pkg/bench/rttanalysis/registry.go
+++ b/pkg/bench/rttanalysis/registry.go
@@ -24,6 +24,14 @@ import (
 // This structure facilitates a registry concept without needing to rename
 // existing benchmarks.
 //
+// All registered benchmark tests can be run with the command:
+//
+//	./dev test pkg/bench/rttanalysis -f TestBenchmarkExpectation
+//
+// A specific benchmark test can be run by adding its registered name as a suffix to the filter:
+//
+//	./dev test pkg/bench/rttanalysis -f TestBenchmarkExpectation/CreateRole
+//
 // The expectation is that there should be a single registry per package and
 // that tests are registered to it during initialization.
 type Registry struct {

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -119,7 +119,8 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_empty_database_Name
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 1,SystemDatabaseQueries/select_system.users_without_schema_Name
-1,TriggerResolution/insert_into_table_with_trigger
+1,TriggerResolution/insert_into_table_with_before_trigger
+4,TriggerResolution/insert_into_table_with_after_trigger
 18,Truncate/truncate_1_column_0_rows
 17,Truncate/truncate_1_column_1_row
 17,Truncate/truncate_1_column_2_rows

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -120,7 +120,7 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 1,SystemDatabaseQueries/select_system.users_without_schema_Name
 1,TriggerResolution/insert_into_table_with_before_trigger
-4,TriggerResolution/insert_into_table_with_after_trigger
+1,TriggerResolution/insert_into_table_with_after_trigger
 18,Truncate/truncate_1_column_0_rows
 17,Truncate/truncate_1_column_1_row
 17,Truncate/truncate_1_column_2_rows

--- a/pkg/bench/rttanalysis/trigger_resolution_test.go
+++ b/pkg/bench/rttanalysis/trigger_resolution_test.go
@@ -7,6 +7,12 @@ package rttanalysis
 
 import "testing"
 
+// BenchmarkTriggerResolution benchmarks the KV round-trips taken to
+// execute statements with triggers.
+//
+// This benchmark can be run with the command:
+//
+//	./dev test pkg/bench/rttanalysis -f TestBenchmarkExpectation/TriggerResolution
 func BenchmarkTriggerResolution(b *testing.B) {
 	reg.Run(b)
 }

--- a/pkg/bench/rttanalysis/trigger_resolution_test.go
+++ b/pkg/bench/rttanalysis/trigger_resolution_test.go
@@ -19,11 +19,19 @@ func BenchmarkTriggerResolution(b *testing.B) {
 func init() {
 	reg.Register("TriggerResolution", []RoundTripBenchTestCase{
 		{
-			Name: "insert into table with trigger",
+			Name: "insert into table with before trigger",
 			Setup: `
         CREATE TABLE trigger_table (a INT);
         CREATE FUNCTION trigger_fn() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
         CREATE TRIGGER tr BEFORE INSERT ON trigger_table FOR EACH ROW EXECUTE FUNCTION trigger_fn();`,
+			Stmt: `INSERT INTO trigger_table VALUES (100);`,
+		},
+		{
+			Name: "insert into table with after trigger",
+			Setup: `
+        CREATE TABLE trigger_table (a INT);
+        CREATE FUNCTION trigger_fn() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
+        CREATE TRIGGER tr AFTER INSERT ON trigger_table FOR EACH ROW EXECUTE FUNCTION trigger_fn();`,
 			Stmt: `INSERT INTO trigger_table VALUES (100);`,
 		},
 	})

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -660,11 +660,13 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 			tgLevel := tree.NewDString("ROW")
 			tgRelID := tree.NewDOid(oid.Oid(tb.mutatedTable.ID()))
 			tgTableName := tree.NewDString(string(tb.mutatedTable.Name()))
-			fqName, err := b.catalog.FullyQualifiedName(ctx, tb.mutatedTable)
+			schema, err := b.catalog.ResolveSchemaByID(
+				b.ctx, cat.Flags{}, cat.StableID(tb.mutatedTable.GetSchemaID()),
+			)
 			if err != nil {
 				panic(err)
 			}
-			tgTableSchema := tree.NewDString(fqName.Schema())
+			tgTableSchema := tree.NewDString(schema.Name().Schema())
 			var tgOp opt.ScalarExpr
 			switch tb.mutation {
 			case opt.InsertOp:

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -530,6 +530,12 @@ func (oc *optCatalog) UserHasGlobalPrivilegeOrRoleOption(
 }
 
 // FullyQualifiedName is part of the cat.Catalog interface.
+//
+// Note that:
+//   - this call may involve a database operation so it shouldn't be used in
+//     performance sensitive paths;
+//   - the fully qualified name of a data source object can change without the
+//     object itself changing (e.g. when a database is renamed).
 func (oc *optCatalog) FullyQualifiedName(
 	ctx context.Context, ds cat.DataSource,
 ) (cat.DataSourceName, error) {


### PR DESCRIPTION
#### bench/rttananlysis: document directions for running tests

These tests have a non-conventional construction that make it hard to
determine how they can be run. Each subset of tests is not a typical Go
function like `func TestAThing(t *testing.T) { ... }` that can be easily
searched for. A few comments have been added to explain how the tests
can be run.

Release note: None

#### bench/rttanalysis: add test case with an after trigger

Release note: None

#### opt: route descriptor lookups for AFTER triggers through cache

This commit applies the fix in #144217 for `BEFORE` triggers to `AFTER`
triggers. See that PR for more details.

Fixes #144211

Release note (performance improvement): After triggers now perform the
descriptor lookup for `TG_TABLE_SCHEMA` against a cache. This can
significantly reduce trigger planning latency.

#### opt: warn about performance of (*optCatalog).FullyQualifiedName

Release note: None
