### PR TITLE
mmaprototype: add more tests for err in TestNormalizedVoterAllRelatio…

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedSpanConfig/Basic
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedSpanConfig/Basic
@@ -554,7 +554,9 @@ after:
    +region=c:2
    +region=a:1
 
-# A voter constraint is promoted to a replica constraint.
+# A voter constraint that is missing from the replica constraints is promoted
+# to a replica constraint during normalization, since voters are a subset of
+# all replicas.
 normalize num-replicas=5 num-voters=3
 constraint num-replicas=1 +region=a +zone=a1
 constraint num-replicas=1 +region=a +zone=a3
@@ -584,7 +586,6 @@ after:
    +region=a,+zone=a1:1
    +region=a,+zone=a2:1
    :1
-err=intersecting conjunctions in constraints and voter constraints
 
 # Unable to promote one of the voter constraints that is missing in the
 # replica constraints, since the replica constraints are already full. An

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedSpanConfig/Basic
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedSpanConfig/Basic
@@ -363,7 +363,6 @@ after:
    +region=b,+zone=b1:1
    +region=a,-zone=a1:1
    :1
-err=intersecting conjunctions in constraints and voter constraints
 
 # Multi-region with under-specified voter-constraint. In this case the
 # under-specification is not the unconstrained set, but the conjunction

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedVoterAllRelationships
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedVoterAllRelationships
@@ -34,7 +34,7 @@ table:
 	emptyConstraintIndex: -1
 	emptyVoterConstraintIndex: -1
 	relationships:
-	[idx=0][voter=+zone=us-west-b,+region=us-west:3] [all=+zone=us-west-a,+region=us-west:3] rel=possiblyIntersecting
+	[idx=0][voter=+zone=us-west-b,+region=us-west:3] [all=+zone=us-west-a,+region=us-west:3] rel=nonIntersecting
 
 # Test with equal voter and all constraints.
 normalized-voter-all-rels num-replicas=3 num-voters=3
@@ -235,7 +235,7 @@ input:
  constraints:
    +region=us-west
    +region=us-east:2
-normalization error: invalid mix of constraints
+normalization error: cannot have zero-replica constraints mixed with non-zero-replica constraints
 
 # Test with multiple relationships.
 normalized-voter-all-rels num-replicas=8 num-voters=5

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedVoterAllRelationships
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedVoterAllRelationships
@@ -13,7 +13,8 @@ table:
 	emptyVoterConstraintIndex: -1
 	relationships:
 
-# Test with intersecting voter and all constraints.
+# Test non-intersecting: same region but different zones (same type, same key,
+# different values).
 normalized-voter-all-rels num-replicas=3 num-voters=3
 constraint +zone=us-west-a +region=us-west 
 voter-constraint +zone=us-west-b +region=us-west 
@@ -127,6 +128,81 @@ table:
 	emptyVoterConstraintIndex: -1
 	relationships:
 	[idx=0][voter=+region=us-east:3] [all=+region=us-west:5] rel=nonIntersecting
+
+# Test with non-intersecting constraints (same type, different key, different
+# values).
+normalized-voter-all-rels num-replicas=5 num-voters=3
+constraint +region=us-west 
+voter-constraint +dc=dc-1
+----
+input:
+ num-replicas=5 num-voters=3
+ constraints:
+   +region=us-west
+ voter-constraints:
+   +dc=dc-1
+normalized:
+ num-replicas=5 num-voters=3
+ constraints:
+   +region=us-west:5
+ voter-constraints:
+   +dc=dc-1:3
+table:
+	emptyConstraintIndex: -1
+	emptyVoterConstraintIndex: -1
+	relationships:
+	[idx=0][voter=+dc=dc-1:3] [all=+region=us-west:5] rel=nonIntersecting
+
+# Test non-intersecting: same type, same key, different values. During the
+# sorted walk, all-replica constraint has smaller zone value (us-west-a <
+# us-west-b), so the differing value is encountered from all-replica constraints
+# first.
+normalized-voter-all-rels num-replicas=5 num-voters=3
+constraint +region=us-west +zone=us-west-a
+voter-constraint +region=us-west +zone=us-west-b
+----
+input:
+ num-replicas=5 num-voters=3
+ constraints:
+   +region=us-west,+zone=us-west-a
+ voter-constraints:
+   +region=us-west,+zone=us-west-b
+normalized:
+ num-replicas=5 num-voters=3
+ constraints:
+   +zone=us-west-a,+region=us-west:5
+ voter-constraints:
+   +zone=us-west-b,+region=us-west:3
+table:
+	emptyConstraintIndex: -1
+	emptyVoterConstraintIndex: -1
+	relationships:
+	[idx=0][voter=+zone=us-west-b,+region=us-west:3] [all=+zone=us-west-a,+region=us-west:5] rel=nonIntersecting
+
+# Test non-intersecting: same type, same key, different values. During the
+# sorted walk, voter constraint has smaller zone value (us-west-a < us-west-b),
+# so the differing value is encountered from voter constraints first.
+normalized-voter-all-rels num-replicas=5 num-voters=3
+constraint +region=us-west +zone=us-west-b
+voter-constraint +region=us-west +zone=us-west-a
+----
+input:
+ num-replicas=5 num-voters=3
+ constraints:
+   +region=us-west,+zone=us-west-b
+ voter-constraints:
+   +region=us-west,+zone=us-west-a
+normalized:
+ num-replicas=5 num-voters=3
+ constraints:
+   +zone=us-west-b,+region=us-west:5
+ voter-constraints:
+   +zone=us-west-a,+region=us-west:3
+table:
+	emptyConstraintIndex: -1
+	emptyVoterConstraintIndex: -1
+	relationships:
+	[idx=0][voter=+zone=us-west-a,+region=us-west:3] [all=+zone=us-west-b,+region=us-west:5] rel=nonIntersecting
 
 # Test error case: multiple empty voter constraints (via normalization adding
 # empty constraint).

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedVoterAllRelationships
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/TestNormalizedVoterAllRelationships
@@ -128,7 +128,8 @@ table:
 	relationships:
 	[idx=0][voter=+region=us-east:3] [all=+region=us-west:5] rel=nonIntersecting
 
-# Test error case: multiple empty voter constraints.
+# Test error case: multiple empty voter constraints (via normalization adding
+# empty constraint).
 normalized-voter-all-rels num-replicas=5 num-voters=3
 voter-constraint num-replicas=1
 ----
@@ -159,7 +160,8 @@ input:
    +region=us-west:2
 normalization error: constraint replicas add up to more than configured replicas
 
-# Test error case: multiple empty constraints.
+# Test error case: multiple empty constraints (via normalization adding empty
+# constraint).
 normalized-voter-all-rels num-replicas=8 num-voters=5
 constraint num-replicas=2
 voter-constraint num-replicas=1 +region=us-west
@@ -183,6 +185,57 @@ table:
 	emptyVoterConstraintIndex: -1
 	relationships:
 	err: multiple empty constraints: {2 []} and {6 []}
+
+# Test error case: multiple explicit empty constraints.
+normalized-voter-all-rels num-replicas=5 num-voters=3
+constraint num-replicas=2
+constraint num-replicas=3
+voter-constraint num-replicas=1 +region=us-west
+----
+input:
+ num-replicas=5 num-voters=3
+ constraints:
+   :2
+   :3
+ voter-constraints:
+   +region=us-west:1
+normalized:
+ num-replicas=5 num-voters=3
+ constraints:
+   :2
+   :3
+ voter-constraints:
+   +region=us-west:1
+   :2
+table:
+	emptyConstraintIndex: -1
+	emptyVoterConstraintIndex: -1
+	relationships:
+	err: multiple empty constraints: {2 []} and {3 []}
+
+# Test error case: voter constraint replicas add up to more than configured voters.
+normalized-voter-all-rels num-replicas=5 num-voters=1
+voter-constraint num-replicas=2 +region=us-west
+----
+input:
+ num-replicas=5 num-voters=1
+ voter-constraints:
+   +region=us-west:2
+normalization error: constraint replicas add up to more than configured replicas
+
+# Test error case: invalid mix of constraints (NumReplicas=0 and NumReplicas>0 together).
+# A constraint without num-replicas= defaults to 0 (applies to all), mixed with one that
+# specifies num-replicas>0 is invalid.
+normalized-voter-all-rels num-replicas=5 num-voters=3
+constraint +region=us-west
+constraint num-replicas=2 +region=us-east
+----
+input:
+ num-replicas=5 num-voters=3
+ constraints:
+   +region=us-west
+   +region=us-east:2
+normalization error: invalid mix of constraints
 
 # Test with multiple relationships.
 normalized-voter-all-rels num-replicas=8 num-voters=5


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: add more tests for err in TestNormalizedVoterAllRelationships**


---
**mmaprototype: improve comment on relationship**


---
**mma: additional case for non-intersecting conjunctions**

A=[+region=a, +zone=a1], B=[+region=a, +zone=a2] is now classified as
non-intersecting. This fixes an existing todo.

---
**mmaprototype: fix conjNonIntersecting**

Previously, we started returning conjNonIntersecting when we encounter
same type, same key, different values. However, the fix only returned
early if the differing value is encountered from cc. This commit changed
it so that we also check and return early for b.

---
**mmaprototype: add test cases for conjNonIntersecting**


