### PR TITLE
sql/hints: handle multiple hint injections for a fingerprint

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -121,7 +121,13 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		}
 
 		if len(params.p.stmt.Hints) > 0 {
-			ob.AddStmtHintCount(uint64(len(params.p.stmt.Hints)))
+			var hintCount uint64
+			for _, hint := range params.p.stmt.Hints {
+				if hint.Enabled && hint.Err == nil {
+					hintCount += 1
+				}
+			}
+			ob.AddStmtHintCount(hintCount)
 		}
 
 		if e.options.Flags[tree.ExplainFlagJSON] {

--- a/pkg/sql/hints/hint_cache.go
+++ b/pkg/sql/hints/hint_cache.go
@@ -404,6 +404,9 @@ func (c *StatementHintsCache) GetGeneration() int64 {
 // fingerprint, along with the unique ID of each hint (for invalidating cached
 // plans). It returns nil if the statement has no hints, or there was an error
 // retrieving them.
+//
+// Hints are returned in order of creation time (descending) with the most
+// recent hints first.
 func (c *StatementHintsCache) MaybeGetStatementHints(
 	ctx context.Context, statementFingerprint string, fingerprintFlags tree.FmtFlags,
 ) (hints []Hint, ids []int64) {
@@ -511,7 +514,8 @@ type cacheEntry struct {
 
 	// hints, fingerprints, and ids have the same length. fingerprints[i] is the
 	// statement fingerprint to which hints[i] applies, while ids[i] uniquely
-	// identifies a hint in the system table. They are kept in order of id.
+	// identifies a hint in the system table. They are kept in order of creation
+	// time (descending), meaning the most recent hints are first.
 	//
 	// We track the hint ID for invalidating cached query plans after a hint is
 	// added or removed. We track the fingerprint to resolve hash collisions. Note

--- a/pkg/sql/hints/hint_cache_test.go
+++ b/pkg/sql/hints/hint_cache_test.go
@@ -557,12 +557,12 @@ func requireHintsCount(
 	checkIDOrder(t, ids)
 }
 
-// checkIDOrder verifies that the row IDs are in ascending order.
+// checkIDOrder verifies that the row IDs are in descending order.
 func checkIDOrder(t *testing.T, ids []int64) {
 	t.Helper()
 	for i := 1; i < len(ids); i++ {
-		if ids[i] <= ids[i-1] {
-			t.Fatalf("expected IDs to be in ascending order, got %v", ids)
+		if ids[i] >= ids[i-1] {
+			t.Fatalf("expected IDs to be in descending order, got %v", ids)
 		}
 	}
 }

--- a/pkg/sql/hints/hint_table_test.go
+++ b/pkg/sql/hints/hint_table_test.go
@@ -48,6 +48,8 @@ func TestHintTableOperations(t *testing.T) {
 	var hint1, hint2 hints.Hint
 	hint1.SetValue(&hintpb.InjectHints{DonorSQL: "SELECT a FROM t@t_b_idx WHERE b = $1"})
 	hint2.SetValue(&hintpb.InjectHints{DonorSQL: "SELECT c FROM t@{NO_FULL_SCAN} WHERE d = $2"})
+	hint1.Enabled = true
+	hint2.Enabled = true
 	var err error
 	donorStmt1, err := parserutils.ParseOne(hint1.InjectHints.DonorSQL)
 	require.NoError(t, err)
@@ -118,7 +120,7 @@ func TestHintTableOperations(t *testing.T) {
 	require.Len(t, hintsFromDB, 2)
 	require.Equal(t, fingerprint1, fingerprints[0])
 	require.Equal(t, fingerprint1, fingerprints[1])
-	require.Less(t, hintIDs[0], hintIDs[1])
+	require.Greater(t, hintIDs[0], hintIDs[1])
 
 	// Insert hint for different fingerprint.
 	var insertedHintID3 int64

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -433,7 +433,12 @@ func (ih *instrumentationHelper) Setup(
 	ih.implicitTxn = implicitTxn
 	ih.txnPriority = txnPriority
 	ih.txnBufferedWritesEnabled = p.txn.BufferedWritesEnabled()
-	ih.stmtHintsCount = uint64(len(stmt.Hints))
+	ih.stmtHintsCount = 0
+	for _, hint := range stmt.Hints {
+		if hint.Enabled && hint.Err == nil {
+			ih.stmtHintsCount += 1
+		}
+	}
 	ih.retryCount = uint64(retryCount)
 	ih.codec = cfg.Codec
 	ih.origCtx = ctx

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -765,3 +765,181 @@ SELECT crdb_internal.inject_hint(
   'SELECT b FROM ab WHERE a = $1',
   'SELECT b FROM ab WHERE a = _'
 )
+
+# If there are multiple hint injections for the same fingerprint, we should
+# always pick the newest one.
+
+onlyif config local
+query T
+EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: xy@xy_pkey
+│ equality: (b) = (x)
+│ equality cols are key
+│
+└── • scan
+      missing stats
+      table: abc@abc_pkey
+      spans: [/10 - /10]
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
+  'SELECT y FROM abc INNER HASH JOIN xy ON x = b WHERE a = _'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+onlyif config local
+query T
+EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+distribution: local
+vectorized: true
+statement hints count: 1
+·
+• hash join
+│ equality: (b) = (x)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: abc@abc_pkey
+│     spans: [/10 - /10]
+│
+└── • scan
+      missing stats
+      table: xy@xy_pkey
+      spans: FULL SCAN
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
+  'SELECT y FROM abc@abc_b_idx JOIN xy ON x = b WHERE a = _'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+onlyif config local
+query T
+EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+distribution: local
+vectorized: true
+statement hints count: 1
+·
+• lookup join
+│ table: xy@xy_pkey
+│ equality: (b) = (x)
+│ equality cols are key
+│
+└── • filter
+    │ filter: a = 10
+    │
+    └── • scan
+          missing stats
+          table: abc@abc_b_idx
+          spans: FULL SCAN
+
+# Even if the newest hint injection doesn't work for some reason, we should
+# still only consider that newest hint injection.
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
+  'SELECT y FROM abc JOIN xy@xy_z_idx ON x = b WHERE a = _'
+)
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+statement ok
+SET tracing = on
+
+statement ok
+SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+
+statement ok
+SET tracing = off
+
+query T
+SELECT regexp_replace(split_part(message, ': SELECT', 1), E'\\d+', 'x')
+FROM [SHOW TRACE FOR SESSION]
+WHERE message LIKE '%injected hints%'
+----
+injected hints from external statement hint x
+trying planning with injected hints
+planning with injected hints failed with: index "xy_z_idx" not found
+falling back to planning without injected hints
+
+onlyif config local
+query T
+EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+distribution: local
+vectorized: true
+statement hints count: 1
+·
+• lookup join
+│ table: xy@xy_pkey
+│ equality: (b) = (x)
+│ equality cols are key
+│
+└── • scan
+      missing stats
+      table: abc@abc_pkey
+      spans: [/10 - /10]
+
+# If there are multiple hint injections for the same fingerprint added in the
+# same transaction, we should pick the last one added.
+
+statement ok
+BEGIN
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
+  'SELECT y FROM abc JOIN xy@xy_y_idx ON x = b WHERE a = _'
+)
+
+statement ok
+SELECT crdb_internal.inject_hint(
+  'SELECT y FROM abc JOIN xy ON x = b WHERE a = _',
+  'SELECT y FROM abc INNER MERGE JOIN xy ON x = b WHERE a = _'
+)
+
+statement ok
+COMMIT
+
+statement ok
+SELECT crdb_internal.await_statement_hints_cache()
+
+onlyif config local
+query T
+EXPLAIN SELECT y FROM abc JOIN xy ON x = b WHERE a = 10
+----
+distribution: local
+vectorized: true
+statement hints count: 1
+·
+• merge join
+│ equality: (b) = (x)
+│ left cols are key
+│ right cols are key
+│
+├── • scan
+│     missing stats
+│     table: abc@abc_pkey
+│     spans: [/10 - /10]
+│
+└── • scan
+      missing stats
+      table: xy@xy_pkey
+      spans: FULL SCAN

--- a/pkg/sql/prep/metadata.go
+++ b/pkg/sql/prep/metadata.go
@@ -43,11 +43,11 @@ type Metadata struct {
 
 	// Hints are any external statement hints from the system.statement_hints
 	// table that could apply to this statement, based on the statement
-	// fingerprint.
+	// fingerprint. Hints are ordered with the most recent first.
 	Hints []hints.Hint
 
 	// HintIDs are the IDs of any external statement hints, which are used for
-	// invalidation of cached plans.
+	// invalidation of cached plans. The order matches Hints.
 	HintIDs []int64
 
 	// HintsGeneration is the generation of the hints cache at the time the


### PR DESCRIPTION
Make a couple of changes to better define behavior with multiple hint injections for a single statement fingerprint.

1. Order hints by created_at time descending, so newest is first.
2. Keep track of whether hints are enabled, and whether they saw an error when decoding.
3. Disable all hint injection hints that are not the newest.

Informs: #153633

Release note: None