### PR TITLE
roachtest: allow unsafe restore for tpcdsvec and sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -36,13 +36,13 @@ func registerSQLSmith(r registry.Registry) {
 		"tpch-sf1": func(r *rand.Rand) []string {
 			return []string{`
 RESTORE TABLE tpch.* FROM LATEST IN 'gs://cockroach-fixtures-us-east1/workload/tpch/scalefactor=1/backup_25_3?AUTH=implicit'
-WITH into_db = 'defaultdb';
+WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 `}
 		},
 		"tpcc": func(r *rand.Rand) []string {
 			return []string{`
 RESTORE TABLE tpcc.* FROM LATEST IN 'gs://cockroach-fixtures-us-east1/workload/tpcc/version=25.3,fks=true,seed=1,warehouses=1?AUTH=implicit'
-WITH into_db = 'defaultdb';
+WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 `}
 		},
 	}

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -66,8 +66,9 @@ func registerTPCDSVec(r registry.Registry) {
 			t.Fatal(err)
 		}
 		t.Status("restoring TPCDS dataset for Scale Factor 1")
-		if _, err := clusterConn.Exec(
-			`RESTORE DATABASE tpcds FROM LATEST IN 'gs://cockroach-fixtures-us-east1/workload/tpcds/scalefactor=1/backup_25_3?AUTH=implicit';`,
+		if _, err := clusterConn.Exec(`
+RESTORE DATABASE tpcds FROM LATEST IN 'gs://cockroach-fixtures-us-east1/workload/tpcds/scalefactor=1/backup_25_3?AUTH=implicit'
+WITH unsafe_restore_incompatible_version;`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Fixes: #158747
Fixes: #158749
Fixes: #158750
Fixes: #158751
Fixes: #158755
Fixes: #158756
Fixes: #158761

Release note: None