### PR TITLE
workload/schemachanger: add potential error for DETACHED flag in inspect

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3501,7 +3501,14 @@ func (og *operationGenerator) inspect(ctx context.Context, tx pgx.Tx) (*opStmt, 
 	stmt.potentialExecErrors.addAll(codesWithConditions{
 		{pgcode.FeatureNotSupported, asof != ""},
 	})
-
+	// Detached flag was added in 26.1, so we expect errors till the user upgrades.
+	isDetachedUnsupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.V26_1.Version())
+	if err != nil {
+		return nil, err
+	}
+	if isDetachedUnsupported {
+		stmt.potentialExecErrors.add(pgcode.FeatureNotSupported)
+	}
 	// Always run DETACHED as this allows us to use INSPECT inside of a
 	// transaction. We have post-processing at the end of the run to verify
 	// INSPECT didn't find any issues.


### PR DESCRIPTION
Previously, when running in a mixed version state the detached flag for INSPECT may not have been supported, specifically if we ran it against an older release. This patch adds a version gate to add a potential error when the DETACHED flag is specified on INSPECT on 25.4.

Fixes: #158326

Release note: None