### PR TITLE
storage: bump mvcc_history_minimum_size

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -554,7 +554,8 @@ var (
 		"the minimum size of a value that will be separated into a blob file given the value is "+
 			"likely not the latest version of a key",
 		int64(metamorphic.ConstantWithTestRange("storage.value_separation.mvcc_history_minimum_size",
-			32 /* 32 bytes (default) */, 25 /* 25 bytes (minimum) */, 512 /* 512 bytes (maximum) */)),
+			1<<10, /* 1 KiB (default) */
+			25 /* 25 bytes (minimum) */, 1<<20 /* 1 MiB (maximum) */)),
 		settings.IntWithMinimum(1),
 	)
 )


### PR DESCRIPTION
Set a less aggressive minimum size threshold for
`mvcc_history_minimum_size`. Benchmarking with the kv50 workload demonstrated that we cannot realize the benefits of aggressively separating mvcc history just yet.

Epic: none

Release note: None