### PR TITLE
release: fix teamcity-support.sh to not fail when FIPS line is missing

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -76,7 +76,7 @@ verify_docker_image(){
   build_type=$(grep "^Build Type:" <<< "$output" | cut -d: -f2 | sed 's/ //g')
   sha=$(grep "^Build Commit ID:" <<< "$output" | cut -d: -f2 | sed 's/ //g')
   build_tag=$(grep "^Build Tag:" <<< "$output" | cut -d: -f2 | sed 's/ //g')
-  fips_enabled=$(grep '^FIPS enabled:\s*true' <<< "$output")
+  fips_enabled=$(grep '^FIPS enabled:\s*true' <<< "$output" || true)
 
   # Build Type should always be "release"
   if [ "$build_type" != "release" ]; then


### PR DESCRIPTION
With `set -o pipefail`, if the `grep` command does not find a matching line for `FIPS enabled: true`, it exits with a non-zero status, causing the entire script to fail. This change adds `|| true` to the end of the `grep` command, ensuring that even if no matching line is found, the command will still exit with a zero status, allowing the script to continue executing without errors.

Epic: none
Release note: none