### PR TITLE
release-25.3: roachtest/activerecord: bump rails version to 8.1

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -27,8 +27,8 @@ var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\
 
 // WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
 // This is used by docs automation to produce a list of supported versions for ORM's.
-var supportedRailsVersion = "8.0.1"
-var activerecordAdapterVersion = "v8.0.1"
+var supportedRailsVersion = "8.1.0"
+var activerecordAdapterVersion = "v8.1.0"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 
@@ -172,7 +172,18 @@ func registerActiveRecord(r registry.Registry) {
 
 		t.Status("running activerecord test suite")
 
+		// Enable autocommit before DDL by default within the test suite.
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
+			`cd /mnt/data1/activerecord-cockroachdb-adapter/ && `+
+				`sudo sed -i 's/autocommit_before_ddl: false/autocommit_before_ddl: true/g' test/config.yml`,
+		)
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
+		// Proceed for any other (command) errors
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
+			t.Fatal(err)
+		}
+
+		result, err = c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			fmt.Sprintf(
 				`cd /mnt/data1/activerecord-cockroachdb-adapter/ && `+
 					`sudo RAILS_VERSION=%s RUBYOPT="-W0" TESTOPTS="-v" bundle exec rake test`, supportedRailsVersion),

--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -36,6 +36,7 @@ var activeRecordIgnoreList = blocklist{
 	`AssociationCallbacksTest#test_has_many_callbacks_for_destroy_on_parent`:                                                                                   "flaky",
 	`BasicsTest#test_default_values_are_deeply_dupped`:                                                                                                         "flaky",
 	`CascadedEagerLoadingTest#test_eager_association_loading_with_cascaded_three_levels_by_ping_pong`:                                                          "flaky",
+	`CockroachDBReferentialIntegrityTest#test_should_reraise_invalid_foreign_key_exception_and_show_warning`:                                                   "affected by autocommit_before_ddl",
 	`CockroachDB::AdapterForeignKeyTest#test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false`:                                  "flaky",
 	`CockroachDB::AdapterForeignKeyTest#test_foreign_key_violations_on_delete_are_translated_to_specific_exception`:                                            "flaky",
 	`CockroachDB::AdapterForeignKeyTest#test_foreign_key_violations_on_insert_are_translated_to_specific_exception`:                                            "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #158776 on behalf of @fqazi.

----

Previously, we were testing an older Rails versions against CRDB. Now that the new 8.1 version is avaialble, we can bump the version up, which will remove some flakes. As a part of this change we will also enable autocommit_before_ddl within the test suite.

Fixes: #157123

Release note: None

----

Release justification: test only change