### PR TITLE
schemachanger: disable distributed merge for unique index creation in DSC

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
     name = "backfill_test",
     srcs = [
         "backfill_test.go",
+        "distributed_merge_mode_test.go",
         "index_backfiller_cols_test.go",
         "main_test.go",
         "mvcc_index_merger_test.go",
@@ -88,6 +89,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/execinfra",
+        "//pkg/sql/parser",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/backfill/distributed_merge_mode.go
+++ b/pkg/sql/backfill/distributed_merge_mode.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
 
@@ -118,4 +119,53 @@ func DetermineDistributedMergeMode(
 		return jobspb.IndexBackfillDistributedMergeMode_Enabled, nil
 	}
 	return jobspb.IndexBackfillDistributedMergeMode_Disabled, nil
+}
+
+// StatementAllowsDistributedMerge reports whether this statement may use the
+// distributed merge pipeline. This only checks statement-level eligibility. It
+// does not decide whether the statement actually runs an index backfill.
+//
+// TODO(156934): everything is allowed except statements that create new unique
+// indexes. Unique index creation is blocked until the distributed merge path
+// supports enforcing uniqueness.
+func StatementAllowsDistributedMerge(stmt tree.Statement) bool {
+	switch s := stmt.(type) {
+	case *tree.CreateIndex:
+		if s.Unique {
+			return false
+		}
+	case *tree.AlterTable:
+		for _, cmd := range s.Cmds {
+			if alterTableCmdIntroducesUniqueness(cmd) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// alterTableCmdIntroducesUniqueness reports whether this command adds a new
+// uniqueness requirement.
+func alterTableCmdIntroducesUniqueness(cmd tree.AlterTableCmd) bool {
+	switch c := cmd.(type) {
+	case *tree.AlterTableAddColumn:
+		col := c.ColumnDef
+		if col == nil {
+			return false
+		}
+		if col.PrimaryKey.IsPrimaryKey {
+			return true
+		}
+		if col.Unique.IsUnique && !col.Unique.WithoutIndex {
+			return true
+		}
+	case *tree.AlterTableAddConstraint:
+		if u, ok := c.ConstraintDef.(*tree.UniqueConstraintTableDef); ok {
+			return !u.WithoutIndex
+		}
+	case *tree.AlterTableAlterPrimaryKey:
+		// Primary keys are unique and always backed by an index.
+		return true
+	}
+	return false
 }

--- a/pkg/sql/backfill/distributed_merge_mode_test.go
+++ b/pkg/sql/backfill/distributed_merge_mode_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backfill
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatementAllowsDistributedMerge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name   string
+		stmt   string
+		expect bool
+	}{
+		{
+			name:   "non-unique create index",
+			stmt:   "CREATE INDEX idx ON t(a)",
+			expect: true,
+		},
+		{
+			name:   "create unique index",
+			stmt:   "CREATE UNIQUE INDEX idx ON t(a)",
+			expect: false,
+		},
+		{
+			name:   "alter table add unique constraint",
+			stmt:   "ALTER TABLE t ADD CONSTRAINT c UNIQUE (a)",
+			expect: false,
+		},
+		{
+			name:   "alter table add unique without index",
+			stmt:   "ALTER TABLE t ADD CONSTRAINT c UNIQUE WITHOUT INDEX (a)",
+			expect: true,
+		},
+		{
+			name:   "alter table alter primary key",
+			stmt:   "ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a)",
+			expect: false,
+		},
+		{
+			name:   "alter table add column with unique",
+			stmt:   "ALTER TABLE t ADD COLUMN b INT UNIQUE",
+			expect: false,
+		},
+		{
+			name:   "alter table add column with primary key",
+			stmt:   "ALTER TABLE t ADD COLUMN b INT PRIMARY KEY",
+			expect: false,
+		},
+		{
+			name:   "alter table add column without unique",
+			stmt:   "ALTER TABLE t ADD COLUMN b INT",
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parser.ParseOne(tc.stmt)
+			require.NoError(t, err)
+			actual := StatementAllowsDistributedMerge(parsed.AST)
+			require.Equal(t, tc.expect, actual)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -732,19 +732,6 @@ onlyif config local-mixed-25.4
 statement error pq: .*distributed merge requires cluster version 26.*
 CREATE INDEX dist_merge_idx_idx ON dist_merge_idx (b)
 
-# Try an operation that is implemented in the declarative schema changer.
-#
-# TODO(158378): Declarative schema change don't yet implement the full flow for
-# distributed merge. So, we end up with a similar situation as above where we
-# get to validation and notice no rows were ingested.
-skipif config local-mixed-25.4
-statement error pgcode 23505 pq: .*duplicate key value violates unique constraint.*
-ALTER TABLE dist_merge_idx ALTER PRIMARY KEY USING COLUMNS (b)
-
-onlyif config local-mixed-25.4
-statement error pq: .*distributed merge requires cluster version 26.*
-ALTER TABLE dist_merge_idx ALTER PRIMARY KEY USING COLUMNS (b)
-
 statement ok
 SET CLUSTER SETTING bulkio.index_backfill.distributed_merge.mode = 'disabled'
 

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -15,10 +15,12 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/security/username",
         "//pkg/settings/cluster",
+        "//pkg/sql/backfill",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/catprivilege",

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",
-        "//pkg/sql/backfill",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -30,7 +30,6 @@ type deferredState struct {
 	indexesToSplitAndScatter     []indexesToSplitAndScatter
 	ttlScheduleMetadataUpdates   []ttlScheduleMetadataUpdate
 	gcJobs
-	distributedMergeMode jobspb.IndexBackfillDistributedMergeMode
 }
 
 type databaseRoleSettingToDelete struct {
@@ -100,6 +99,7 @@ func (s *deferredState) AddNewSchemaChangerJob(
 	auth scpb.Authorization,
 	descriptorIDs catalog.DescriptorIDSet,
 	runningStatus redact.RedactableString,
+	distributedMergeMode jobspb.IndexBackfillDistributedMergeMode,
 ) error {
 	if s.schemaChangerJob != nil {
 		return errors.AssertionFailedf("cannot create more than one new schema change job")
@@ -111,7 +111,7 @@ func (s *deferredState) AddNewSchemaChangerJob(
 		auth,
 		descriptorIDs,
 		runningStatus,
-		s.distributedMergeMode,
+		distributedMergeMode,
 	)
 	return nil
 }

--- a/pkg/sql/schemachanger/scexec/exec_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_mutation.go
@@ -8,7 +8,6 @@ package scexec
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/scmutationexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/errors"
@@ -39,13 +38,6 @@ func executeMutationOps(
 	}
 	// Execute deferred ops last.
 	nvs := deferredState{}
-	mode, err := backfill.DetermineDistributedMergeMode(
-		ctx, deps.ClusterSettings(), backfill.DistributedMergeConsumerDeclarative,
-	)
-	if err != nil {
-		return err
-	}
-	nvs.distributedMergeMode = mode
 	nv := scmutationexec.NewDeferredVisitor(&nvs)
 	for _, op := range ops {
 		if dop, ok := op.(scop.DeferredMutationOp); ok {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -133,6 +133,7 @@ type DeferredMutationStateUpdater interface {
 		auth scpb.Authorization,
 		descriptorIDs catalog.DescriptorIDSet,
 		runningStatus redact.RedactableString,
+		distributedMergeMode jobspb.IndexBackfillDistributedMergeMode,
 	) error
 
 	// UpdateSchemaChangerJob will update the progress and payload of the

--- a/pkg/sql/schemachanger/scexec/scmutationexec/schema_change_job.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/schema_change_job.go
@@ -31,6 +31,7 @@ func (d *deferredVisitor) CreateSchemaChangerJob(
 		job.Authorization,
 		catalog.MakeDescriptorIDSet(job.DescriptorIDs...),
 		job.RunningStatus,
+		job.DistributedMergeMode,
 	)
 }
 

--- a/pkg/sql/schemachanger/scop/deferred_mutation.go
+++ b/pkg/sql/schemachanger/scop/deferred_mutation.go
@@ -68,8 +68,9 @@ type CreateSchemaChangerJob struct {
 
 	// NonCancelable maps to the job's property, but in the schema changer can
 	// be thought of as !Revertible.
-	NonCancelable bool
-	RunningStatus redact.RedactableString
+	NonCancelable        bool
+	RunningStatus        redact.RedactableString
+	DistributedMergeMode jobspb.IndexBackfillDistributedMergeMode
 }
 
 // RemoveDatabaseRoleSettings is used to delete a role setting for a database.

--- a/pkg/sql/schemachanger/scpb/state.go
+++ b/pkg/sql/schemachanger/scpb/state.go
@@ -15,6 +15,21 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// DistributedMergeMode captures whether distributed merge is enabled for index
+// backfills planned by the declarative schema changer. The zero value indicates
+// the mode has not been evaluated yet.
+type DistributedMergeMode int32
+
+const (
+	// DistributedMergeModeUnset indicates the mode has not been computed.
+	DistributedMergeModeUnset DistributedMergeMode = iota
+	// DistributedMergeModeDisabled indicates distributed merge should not be
+	// used.
+	DistributedMergeModeDisabled
+	// DistributedMergeModeEnabled indicates distributed merge should be used.
+	DistributedMergeModeEnabled
+)
+
 // CurrentState is a TargetState decorated with the current status of the
 // elements in the target state.
 type CurrentState struct {
@@ -40,6 +55,12 @@ type CurrentState struct {
 	// NonCancelable property of the job; if a schema change is no longer
 	// Revertible, the job must be NonCancelable.
 	Revertible bool
+
+	// DistributedMergeMode captures the planned distributed merge configuration
+	// for any index backfills associated with this state. It is populated during
+	// planning and plumbed through to job creation; it is not reconstructed from
+	// descriptor state for existing jobs.
+	DistributedMergeMode DistributedMergeMode
 }
 
 // ByteSize returns an estimated memory allocation for a schema change state `s`.
@@ -58,6 +79,7 @@ func (s CurrentState) ByteSize() (ret int64) {
 	ret += int64(s.TargetState.Authorization.Size())
 	ret += int64(cap(s.Initial)+cap(s.Current)) * int64(unsafe.Sizeof(Status(0)))
 	ret += int64(unsafe.Sizeof(false))
+	ret += int64(unsafe.Sizeof(DistributedMergeMode(0)))
 	return ret
 }
 
@@ -72,11 +94,12 @@ func (s CurrentState) WithCurrentStatuses(current []Status) CurrentState {
 // DeepCopy returns a deep copy of the receiver.
 func (s CurrentState) DeepCopy() CurrentState {
 	return CurrentState{
-		TargetState: *protoutil.Clone(&s.TargetState).(*TargetState),
-		Initial:     append(make([]Status, 0, len(s.Initial)), s.Initial...),
-		Current:     append(make([]Status, 0, len(s.Current)), s.Current...),
-		InRollback:  s.InRollback,
-		Revertible:  s.Revertible,
+		TargetState:          *protoutil.Clone(&s.TargetState).(*TargetState),
+		Initial:              append(make([]Status, 0, len(s.Initial)), s.Initial...),
+		Current:              append(make([]Status, 0, len(s.Current)), s.Current...),
+		InRollback:           s.InRollback,
+		Revertible:           s.Revertible,
+		DistributedMergeMode: s.DistributedMergeMode,
 	}
 }
 


### PR DESCRIPTION
The distributed merge pipeline does not yet plan to support uniqueness enforcement during index backfills. To avoid issues when non-unique support is added, this change adds statement level filtering that disables distributed merge when creating unique indexes (CREATE UNIQUE INDEX, ALTER TABLE ADD CONSTRAINT UNIQUE, or ALTER PRIMARY KEY).

This filtering currently only applies to the declarative schema changer. The decision is made during DSC planning and stored in CurrentState, then plumbed through to job creation. Non-unique index creation will continue to use distributed merge when the cluster setting enables it.

Informs: #158378
Epic: CRDB-48845
Release note: none