### PR TITLE
admission: improve filler & allocator tests, etc.

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2025 The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
@@ -123,6 +123,9 @@ func (f *cpuTimeTokenFiller) start() {
 			select {
 			case t := <-ticker.Ch():
 				var remainingTicks int64
+				// Note that time-measuring operations such as t.Sub use monotonic
+				// time. Thus, elapsedSinceIntervalStart should always be >= 0.
+				// https://pkg.go.dev/time#hdr-Monotonic_Clocks
 				elapsedSinceIntervalStart := t.Sub(intervalStart)
 				if elapsedSinceIntervalStart >= time.Second {
 					// INVARIANT: During each interval, allocateTokens(1) must be

--- a/pkg/util/admission/cpu_time_token_filler_test.go
+++ b/pkg/util/admission/cpu_time_token_filler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2025 The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
@@ -25,6 +25,11 @@ import (
 func TestCPUTimeTokenFiller(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	if time.Second%timePerTick != 0 || timePerTick > time.Second {
+		t.Errorf("timePerTick=%v must be < 1s & must divide 1s evenly", timePerTick)
+		return
+	}
 
 	// Fixed time for reproducibility.
 	unixNanos := int64(1758938600000000000) // 2025-09-24T14:30:00Z
@@ -141,10 +146,10 @@ func TestCPUTimeTokenAllocator(t *testing.T) {
 	}
 
 	model := &testModel{buf: &buf}
-	model.rates[testTier0][canBurst] = 5
-	model.rates[testTier0][noBurst] = 4
-	model.rates[testTier1][canBurst] = 3
-	model.rates[testTier1][noBurst] = 2
+	model.rates[testTier0][canBurst] = 5000
+	model.rates[testTier0][noBurst] = 4000
+	model.rates[testTier1][canBurst] = 3000
+	model.rates[testTier1][noBurst] = 2000
 	allocator := cpuTimeTokenAllocator{
 		granter:  granter,
 		settings: cluster.MakeClusterSettings(),

--- a/pkg/util/admission/cpu_time_token_granter.go
+++ b/pkg/util/admission/cpu_time_token_granter.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2025 The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.

--- a/pkg/util/admission/cpu_time_token_granter_test.go
+++ b/pkg/util/admission/cpu_time_token_granter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2025 The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
@@ -164,7 +164,14 @@ func TestCPUTimeTokenGranter(t *testing.T) {
 			bucketCapacity[testTier1][canBurst] = 10
 			bucketCapacity[testTier1][noBurst] = 1
 			granter.refill(delta, bucketCapacity)
-			fmt.Fprintf(&buf, "refill(%v %v)\n", delta, bucketCapacity)
+			fmt.Fprint(&buf, "refill(\n")
+			for tier := int(numResourceTiers - 1); tier >= 0; tier-- {
+				for qual := int(numBurstQualifications - 1); qual >= 0; qual-- {
+					fmt.Fprintf(&buf, "\ttier%d %s -> delta: %v, cap: %v\n",
+						tier, burstQualification(qual).String(), delta[tier][qual], bucketCapacity[tier][qual])
+				}
+			}
+			fmt.Fprint(&buf, ")\n")
 			return flushAndReset(false /* init */)
 
 		case "reset-tokens-used":

--- a/pkg/util/admission/testdata/cpu_time_token_allocator
+++ b/pkg/util/admission/testdata/cpu_time_token_allocator
@@ -1,9 +1,14 @@
-# First call to resetInterval should add refillRates to all buckets.
-# We want the buckets to start full, and cpuTimeTokenFiller calls
-# resetInterval on startup. The target CPU utilizations are passed as
-# an argument to fit, and they are a function of cluster settings, plus
-# some simple logic in resetInterval. Here, the  default values for the
-# target CPU utilizations are shown.
+# The first call to resetInterval should add refillRates to all
+# buckets. We want the buckets to start full, and cpuTimeTokenFiller calls
+# resetInterval on startup. The refill rates are below for reference:
+#
+#        canBurst noBurst
+# tier0  5000     4000
+# tier1  3000     2000
+#
+# The target CPU utilizations are passed as an argument to fit, and they
+# are a function of cluster settings, plus some simple logic in resetInterval.
+# Here, the default values for the target CPU utilizations are shown.
 resetInterval
 ----
 fit(
@@ -13,63 +18,8 @@ fit(
 	tier0 canBurst -> 100%
 )
 cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
-
-clear
-----
-cpuTTG canBurst noBurst
-tier0  0        0
-tier1  0        0
-
-allocate remaining=5
-----
-cpuTTG canBurst noBurst
-tier0  1        1
-tier1  1        1
-
-allocate remaining=4
-----
-cpuTTG canBurst noBurst
-tier0  2        2
-tier1  2        2
-
-allocate remaining=3
-----
-cpuTTG canBurst noBurst
-tier0  3        3
-tier1  3        2
-
-allocate remaining=2
-----
-cpuTTG canBurst noBurst
-tier0  4        4
-tier1  3        2
-
-allocate remaining=1
-----
-cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
-
-resetInterval
-----
-fit(
-	tier1 noBurst -> 80%
-	tier1 canBurst -> 85%
-	tier0 noBurst -> 95%
-	tier0 canBurst -> 100%
-)
-cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
-
-# No more tokens added due to bucket capacities being hit.
-allocate remaining=5
-----
-cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
+tier0  5000     4000
+tier1  3000     2000
 
 # clear simulates tokens being taken due to admitted work.
 clear
@@ -78,13 +28,50 @@ cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
 
-# In the interval, one call to allocateTokens made already,
-# so we do not expect the full rates to end up in the buckets.
+# Over an interval (between calls to resetInterval), the refill rate should
+# be added to each bucket. Again, here are the refill rates:
+#
+#        canBurst noBurst
+# tier0  5000     4000
+# tier1  3000     2000
+#
+# The rates should be added as smoothly as possible over the 5 tick (
+# interval (see allocate remaining=5 calls below). So each call to
+# allocate should add refill rate / 5 tokens. So the amount that each call
+# to allocate should add is below:
+#
+#        canBurst noBurst
+# tier0  1000     800
+# tier1  600      400
+allocate remaining=5
+----
+cpuTTG canBurst noBurst
+tier0  1000     800
+tier1  600      400
+
+allocate remaining=4
+----
+cpuTTG canBurst noBurst
+tier0  2000     1600
+tier1  1200     800
+
+allocate remaining=3
+----
+cpuTTG canBurst noBurst
+tier0  3000     2400
+tier1  1800     1200
+
+allocate remaining=2
+----
+cpuTTG canBurst noBurst
+tier0  4000     3200
+tier1  2400     1600
+
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
-tier0  4        3
-tier1  2        1
+tier0  5000     4000
+tier1  3000     2000
 
 resetInterval
 ----
@@ -95,8 +82,62 @@ fit(
 	tier0 canBurst -> 100%
 )
 cpuTTG canBurst noBurst
-tier0  4        3
-tier1  2        1
+tier0  5000     4000
+tier1  3000     2000
+
+# resetInterval has been called, so a new interval has started.
+# So in theory more tokens can be added. But in this case the
+# buckets are already full. The max capacity for each bucket is
+# one second worth of tokens at the current refill rate. So no
+# tokens will be added on this call to allocate.
+allocate remaining=5
+----
+cpuTTG canBurst noBurst
+tier0  5000     4000
+tier1  3000     2000
+
+clear
+----
+cpuTTG canBurst noBurst
+tier0  0        0
+tier1  0        0
+
+# In the interval, one call to allocateTokens was made already.
+# So we do not expect the full rates to end up in the buckets.
+# We expect the full rates - one tick worth of tokens to end up
+# in the bucket instead.
+#
+#        canBurst noBurst
+# tier0  5000-1000     4000-800
+# tier1  3000-600     2000-400
+#
+# Which yields:
+#
+#        canBurst noBurst
+# tier0  4000     3200
+# tier1  2400     1600
+#
+# Note that all remaining tokens were added in a single call to
+# allocate, which simulates three ticks being dropped (allocate
+# remaining=4, allocate remaining=3, & allocate remaining=2). See
+# the comment about dropped ticks above cpuTimeTokenFiller for more.
+allocate remaining=1
+----
+cpuTTG canBurst noBurst
+tier0  4000     3200
+tier1  2400     1600
+
+resetInterval
+----
+fit(
+	tier1 noBurst -> 80%
+	tier1 canBurst -> 85%
+	tier0 noBurst -> 95%
+	tier0 canBurst -> 100%
+)
+cpuTTG canBurst noBurst
+tier0  4000     3200
+tier1  2400     1600
 
 clear
 ----
@@ -105,12 +146,13 @@ tier0  0        0
 tier1  0        0
 
 # In this interval, no call to allocateTokens so far, so we do
-# expect the full rates to end up in the bucket.
+# expect the full rates to end up in the bucket, again in a single
+# call to allocate.
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
+tier0  5000     4000
+tier1  3000     2000
 
 resetInterval
 ----
@@ -121,8 +163,8 @@ fit(
 	tier0 canBurst -> 100%
 )
 cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
+tier0  5000     4000
+tier1  3000     2000
 
 clear
 ----
@@ -130,17 +172,19 @@ cpuTTG canBurst noBurst
 tier0  0        0
 tier1  0        0
 
+# In this interval, two ticks, so half of the tokens should be added
+# on the first call to allocate, and the other half on the second call.
 allocate remaining=2
 ----
 cpuTTG canBurst noBurst
-tier0  3        2
-tier1  2        1
+tier0  2500     2000
+tier1  1500     1000
 
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
-tier0  5        4
-tier1  3        2
+tier0  5000     4000
+tier1  3000     2000
 
 # These final cases test how cpuTimeTokenAllocator handles changes to
 # refillRates. See the comment above deltaRefillRates for a full explanation
@@ -157,8 +201,8 @@ fit(
 	tier0 canBurst -> 100%
 )
 cpuTTG canBurst noBurst
-tier0  6        5
-tier1  4        3
+tier0  5001     4001
+tier1  3001     2001
 
 clear
 ----
@@ -171,8 +215,8 @@ tier1  0        0
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
-tier0  6        5
-tier1  4        3
+tier0  5001     4001
+tier1  3001     2001
 
 # Another test of a change to refillRates. If we decrease refillRates by two
 # (on all buckets), we expect two tokens to be removed from all buckets, as
@@ -186,8 +230,8 @@ fit(
 	tier0 canBurst -> 100%
 )
 cpuTTG canBurst noBurst
-tier0  4        3
-tier1  2        1
+tier0  4999     3999
+tier1  2999     1999
 
 clear
 ----
@@ -200,8 +244,8 @@ tier1  0        0
 allocate remaining=1
 ----
 cpuTTG canBurst noBurst
-tier0  4        3
-tier1  2        1
+tier0  4999     3999
+tier1  2999     1999
 
 clear
 ----

--- a/pkg/util/admission/testdata/cpu_time_token_filler
+++ b/pkg/util/admission/testdata/cpu_time_token_filler
@@ -3,9 +3,20 @@ init
 resetInterval()
 elapsed: 0s
 
-# Let 2s pass, 200ms at a time. Expect a call to allocateTokens
-# per 200ms advance (since advance uses AdvanceInOneTick). Expect
-# a reset every 1s.
+# cpuTimeTokenFiller ticks time & calls cpuTimeTokenAllocator, with some smart
+# logic to handle delayed or dropped ticks, as is discussed in the docs above
+# cpuTimeTokenFiller. So this test ticks simulated time, and then goldens out
+# the calls to the allocator.
+#
+# Let 2s pass, 200ms at a time. Expect a call to allocateTokens per 200ms
+# advance. Expect a reset every 1s. timePerTick is set to 1ms, so if 200ms
+# has passed then (1000ms - 200ms) / 1ms = 800ms / 1ms = 800 ticks are left.
+# So the ticker should call allocateTokens(800) in this case.
+#
+# Note that AdvanceInOneTick is used in these test cases. So this test case
+# is dropping 199 / 200 ticks (timePerTick = 1ms). This tests the drop tick
+# logic, but the primary reason we do it here is to make the test readable.
+# 1000 ticks would be a lot to golden out.
 advance dur=200ms
 ----
 allocateTokens(800)
@@ -26,6 +37,20 @@ advance dur=200ms
 allocateTokens(200)
 elapsed: 800ms
 
+# cpuTimeTokenFiller splits time into 1s intervals. An invariant of the filler
+# is to call allocateTokens(1) every interval. (This is implemented by making
+# the call once 1s passes, unless it was already made during a previous tick.)
+# This invariant is important, as it lets cpuTimeTokenAllocator ensure that it
+# has added refill rates tokens to all the buckets every 1s, as is required to
+# meet the high level requirements of CPU time token AC.
+#
+# After this call to advance, the interval is over. So below we see the call
+# to allocateTokens(1) & then we see that resetInterval is called, to signal
+# the start of a new interval. As part of that interval, allocateToken(100)
+# is called too. (Note that it is because we are simulating dropped ticks (as
+# per the earlier comment) that two calls to allocateTokens are needed during
+# a single tick. In the typical case, by the time the interval ends,
+# allocateTokens(1) would *already* be called.
 advance dur=200ms
 ----
 allocateTokens(1)
@@ -33,6 +58,9 @@ resetInterval()
 allocateTokens(1000)
 elapsed: 1s
 
+# Test another 1s interval with 5 200ms-separated ticks (so there are dropped
+# ticks in between). This is the same as the first case, but we want to check
+# we get the same behavior after a call to resetInterval.
 advance dur=200ms
 ----
 allocateTokens(800)
@@ -60,8 +88,8 @@ resetInterval()
 allocateTokens(1000)
 elapsed: 2s
 
-# Let 1s pass in one tick. Expect allocateTokens(1) to be called.
-# Expect a reset.
+# Let 1s pass in a single tick (so 999 dropped ticks). Expect
+# allocateTokens(1) to be called. Expect a reset.
 advance dur=1000ms
 ----
 allocateTokens(1)
@@ -69,7 +97,7 @@ resetInterval()
 allocateTokens(1000)
 elapsed: 3s
 
-# Let 1s pass in a different tick interval than every 200ms.
+# Let 1s pass with different tick intervals than once every 200ms.
 advance dur=400ms
 ----
 allocateTokens(600)
@@ -92,6 +120,58 @@ resetInterval()
 allocateTokens(1000)
 elapsed: 4s
 
+# Let interval pass with a bunch of "crooked" numbers that one might
+# get from a production clock.
+advance dur=195ms3ns
+----
+allocateTokens(805)
+elapsed: 4.195000003s
+
+advance dur=205ms2ns
+----
+allocateTokens(600)
+elapsed: 4.400000005s
+
+advance dur=205ms10ns
+----
+allocateTokens(395)
+elapsed: 4.605000015s
+
+advance dur=199ms9ns
+----
+allocateTokens(196)
+elapsed: 4.804000024s
+
+# After this call to advance, the 1s interval is over-shot. As expected,
+# allocateTokens(1) is called, and then the interval ends, and a new
+# one starts. Note though that the filler makes no attempt to correct the
+# 54ms error. That is, the new interval starts at t=5.054s, not at second
+# boundary. Thus the token bucket may be under-filled. We are okay with
+# this behavior: If ticks are delayed, the CPU must be overloaded, so
+# handing out a few less tokens is acceptable.
+advance dur=250ms
+----
+allocateTokens(1)
+resetInterval()
+allocateTokens(1000)
+elapsed: 5.054000024s
+
+# Let 3ms pass 1ms at a time using the production tick interval of 1ms.
+advance dur=1ms
+----
+allocateTokens(999)
+elapsed: 5.055000024s
+
+advance dur=1ms
+----
+allocateTokens(998)
+elapsed: 5.056000024s
+
+advance dur=1ms
+----
+allocateTokens(997)
+elapsed: 5.057000024s
+
 stop
 ----
-elapsed: 4s
+elapsed: 5.057000024s

--- a/pkg/util/admission/testdata/cpu_time_token_granter
+++ b/pkg/util/admission/testdata/cpu_time_token_granter
@@ -263,9 +263,8 @@ reset-tokens-used
 reset-tokens-used-in-interval() returned -1
 
 # Test refill, which is the interface cpuTimeTokenFiller uses to add tokens to
-# the buckets. The final allocation of tokens in the buckets is a result of
-# the toAdd argument to refill, the bucket capacities in certain cases capping how
-# tokens should be added, and one queued request being granted admission.
+# the buckets. Note that there is a single tier1 non-burstable request waiting
+# for admission.
 init tier1waiter=1
 ----
 cpuTTG canBurst noBurst
@@ -274,10 +273,24 @@ tier1  0        0
 tier0requester: waitingRequests: false, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 0
 tier1requester: waitingRequests: true, returnValueFromHasWaitingRequests: noBurst, returnValueFromGranted: 1
 
+# The arguments to refill are hard-coded in the test code, but they are also
+# shown in the below output. The corresponding entry in delta is added to every
+# bucket, subject to a max capacity of the corresponding entry in cap. Note as
+# per the call init above, there is one tier1 non-burstable request waiting for
+# admission. Due to the call to refill, it is granted admission, as can be seen
+# in the output below. So one token is deducted from all buckets, post the deltas
+# being added to the buckets. For example, tier0 canBurst was 0, then 3 is added
+# to it subject to a cap of 10 (so cap is applied), then 1 token is deducted, so
+# the final state of the bucket is 3-1 = 2.
 refill
 ----
 kvtier1: granted in chain 0, and returning 1
-refill([[5 4] [3 1]] [[4 3] [10 1]])
+refill(
+	tier1 noBurst -> delta: 1, cap: 1
+	tier1 canBurst -> delta: 3, cap: 10
+	tier0 noBurst -> delta: 4, cap: 3
+	tier0 canBurst -> delta: 5, cap: 4
+)
 cpuTTG canBurst noBurst
 tier0  3        2
 tier1  2        0


### PR DESCRIPTION
**admission: improve filler & allocator tests, etc.**

This commits addresses feedback given by tbg@ after merge of https://github.com/cockroachdb/cockroach/pull/155476. Specifically, this commit improves the tests of the cpuTimeTokenFiller & the cpuTimeTokenAllocator. This commit especially improves the comments, to make the tests more understandable to new engineers.

Release note: None.

Part of: https://github.com/cockroachdb/cockroach/issues/154470