### PR TITLE
bulkmerge: skip tests under `race`

### DIFF
--- a/pkg/sql/bulkmerge/BUILD.bazel
+++ b/pkg/sql/bulkmerge/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/bulkmerge/merge_test.go
+++ b/pkg/sql/bulkmerge/merge_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -132,6 +133,8 @@ func TestDistributedMergeThreeNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t)
+
 	ctx := context.Background()
 	instanceCount := 3
 	taskCount := 100
@@ -146,6 +149,8 @@ func TestDistributedMergeThreeNodes(t *testing.T) {
 func TestDistributedMergeMoreInstancesThanTasks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	instanceCount := 5


### PR DESCRIPTION
These are prone to OOM'ing under `race`.

Release note: none
Epic: none