### PR TITLE
sql/logictest: add infrastructure for distributed merge index backfill testing

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1857,6 +1857,19 @@ func (t *logicTest) newCluster(
 				t.Fatal(err)
 			}
 		}
+
+		if cfg.UseDistributedMergeIndexBackfill {
+			mode := "declarative"
+			if cfg.DisableDeclarativeSchemaChanger {
+				mode = "legacy"
+			}
+			if _, err := conn.Exec(
+				fmt.Sprintf("SET CLUSTER SETTING bulkio.index_backfill.distributed_merge.mode = '%s'", mode),
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+
 		// We disable the automatic stats collection in order to have
 		// deterministic tests.
 		//

--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -98,6 +98,9 @@ type TestClusterConfig struct {
 	// EnableLeasedDescriptorSupport enables leased descriptors for pg_catalog /
 	// crdb_internal and locked leasing behavior.
 	EnableLeasedDescriptorSupport bool
+	// UseDistributedMergeIndexBackfill enables the use of distributed
+	// merge when index backfills are preformed.
+	UseDistributedMergeIndexBackfill bool
 }
 
 // TenantMode is the type of the UseSecondaryTenant field in TestClusterConfig.
@@ -529,6 +532,20 @@ var LogicTestConfigs = []TestClusterConfig{
 		BootstrapVersion:         clusterversion.V25_4,
 		NumNodes:                 3,
 	},
+	{
+		Name:                             "local-dist-merge-backfill-declarative-schema-changer",
+		NumNodes:                         1,
+		OverrideDistSQLMode:              "on",
+		UseDistributedMergeIndexBackfill: true,
+	},
+	{
+		Name:                             "local-dist-merge-backfill-legacy-schema-changer",
+		NumNodes:                         1,
+		OverrideDistSQLMode:              "on",
+		UseDistributedMergeIndexBackfill: true,
+		DisableDeclarativeSchemaChanger:  true,
+		DisableSchemaLockedByDefault:     true,
+	},
 }
 
 // ConfigIdx is an index in the above slice.
@@ -654,6 +671,12 @@ var DefaultConfigSets = map[string]ConfigSet{
 	// Special alias for configs where schema locked is disabled.
 	"schema-locked-disabled": makeConfigSet(
 		"local-legacy-schema-changer",
+	),
+
+	// Alias for configs that uses distributed merge pipeline for index backfills.
+	"dist-merge-index-backfill": makeConfigSet(
+		"local-dist-merge-backfill-declarative-schema-changer",
+		"local-dist-merge-backfill-legacy-schema-changer",
 	),
 }
 


### PR DESCRIPTION
Before this change, there was no way to configure logictests to use distributed merge for index backfills during schema changes.

This change adds the infrastructure to support testing index backfills using the distributed merge pipeline. It introduces a new UseDistributedMergeIndexBackfill field in TestClusterConfig and a corresponding cluster setting that can be configured per test. A new test configuration "local-dist-merge-backfill-declarative-schema-changer" is added along with a "dist-merge-index-backfill" config set alias.

No tests currently use this new configuration because the end-to-end distributed merge pipeline for index backfills is not yet implemented. Once the pipeline is complete, this infrastructure will allow us to validate index backfill operations using distributed merge by running existing logictests under the new configuration.

Informs #158378

Epic: CRDB-48845
Release note: none