### PR TITLE
release-25.2: roachprod/roachtest: uniform storage capabilities

### DIFF
--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -128,8 +128,8 @@ func initCreateCmdFlags(createCmd *cobra.Command) {
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
-	createCmd.Flags().StringVar(&createVMOpts.SSDOpts.FileSystem,
-		"filesystem", vm.Ext4, "The underlying file system(ext4/zfs). ext4 is used by default.")
+	createCmd.Flags().StringVar((*string)(&createVMOpts.SSDOpts.FileSystem),
+		"filesystem", string(vm.Ext4), "The underlying file system(ext4/zfs/xfs/f2fs/btrfs). ext4 is used by default.")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
 		"local-ssd-no-ext4-barrier", true,
 		`Mount the local SSD with the "-o nobarrier" flag. Ignored if --local-ssd=false is specified.`)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1868,7 +1868,7 @@ func (c *clusterImpl) CreateSnapshot(
 func (c *clusterImpl) ApplySnapshots(ctx context.Context, snapshots []vm.VolumeSnapshot) error {
 	opts := vm.VolumeCreateOpts{
 		Size: c.spec.VolumeSize,
-		Type: c.spec.GCE.VolumeType, // TODO(irfansharif): This is only applicable to GCE. Change that.
+		Type: c.spec.VolumeType,
 		Labels: map[string]string{
 			vm.TagUsage: "roachtest",
 		},

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -507,10 +507,10 @@ var (
 		Usage: `Override use of local SSD`,
 	})
 
-	OverrideFilesystem string
+	OverrideFilesystem vm.Filesystem
 	_                  = registerRunFlag(&OverrideFilesystem, FlagInfo{
 		Name:  "filesystem",
-		Usage: `Override the underlying file system(ext4/zfs)`,
+		Usage: `Override the underlying file system(ext4/zfs/xfs/f2fs/btrfs)`,
 	})
 
 	OverrideNoExt4Barrier bool

--- a/pkg/cmd/roachtest/roachtestflags/manager.go
+++ b/pkg/cmd/roachtest/roachtestflags/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 )
@@ -74,6 +75,8 @@ func (m *manager) AddFlagsToCommand(cmd cmdID, cmdFlags *pflag.FlagSet) {
 			cmdFlags.StringToStringVarP(p, f.Name, f.Shorthand, *p, usage)
 		case *spec.Cloud:
 			cmdFlags.VarP(&cloudValue{val: p}, f.Name, f.Shorthand, usage)
+		case *vm.Filesystem:
+			cmdFlags.VarP(&filesystemValue{val: p}, f.Name, f.Shorthand, usage)
 		default:
 			panic(fmt.Sprintf("unsupported pointer type %T", p))
 		}
@@ -144,5 +147,28 @@ func (cv *cloudValue) Set(str string) error {
 		return errors.Errorf("invalid cloud %q", str)
 	}
 	*cv.val = val
+	return nil
+}
+
+type filesystemValue struct {
+	val *vm.Filesystem
+}
+
+var _ pflag.Value = (*filesystemValue)(nil)
+
+func (fv *filesystemValue) String() string {
+	return string(*fv.val)
+}
+
+func (fv *filesystemValue) Type() string {
+	return "string"
+}
+
+func (fv *filesystemValue) Set(str string) error {
+	val, err := vm.ParseFilesystemString(str)
+	if err != nil {
+		return err
+	}
+	*fv.val = val
 	return nil
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec_test.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec_test.go
@@ -25,15 +25,22 @@ func TestClustersCompatible(t *testing.T) {
 	t.Run("spec has different GCE spec with cloud as GCE", func(t *testing.T) {
 		s1 := ClusterSpec{NodeCount: 5}
 		s2 := ClusterSpec{NodeCount: 5}
-		s1.GCE.VolumeType = "mock_volume1"
-		s2.GCE.VolumeType = "mock_volume2"
+		s1.VolumeType = "mock_volume1"
+		s2.VolumeType = "mock_volume2"
 		require.False(t, ClustersCompatible(s1, s2, GCE))
 	})
 	t.Run("spec has different GCE spec with cloud as AWS", func(t *testing.T) {
 		s1 := ClusterSpec{NodeCount: 5}
 		s2 := ClusterSpec{NodeCount: 5}
-		s1.GCE.VolumeType = "mock_volume1"
-		s2.GCE.VolumeType = "mock_volume2"
+		s1.VolumeType = "mock_volume1"
+		s2.VolumeType = "mock_volume2"
+		require.False(t, ClustersCompatible(s1, s2, AWS))
+	})
+	t.Run("spec has different spec with cloud as AWS", func(t *testing.T) {
+		s1 := ClusterSpec{NodeCount: 5}
+		s2 := ClusterSpec{NodeCount: 5}
+		s1.GCE.MinCPUPlatform = "mock_platform1"
+		s2.GCE.MinCPUPlatform = "mock_platform2"
 		require.True(t, ClustersCompatible(s1, s2, AWS))
 	})
 }

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -71,6 +71,20 @@ func VolumeSize(n int) Option {
 	}
 }
 
+// VolumeType sets the volume type.
+func VolumeType(volumeType string) Option {
+	return func(spec *ClusterSpec) {
+		spec.VolumeType = volumeType
+	}
+}
+
+// VolumeCount sets the volume count.
+func VolumeCount(volumeCount int) Option {
+	return func(spec *ClusterSpec) {
+		spec.VolumeCount = volumeCount
+	}
+}
+
 // SSD is a node option which requests nodes with the specified number of SSDs.
 func SSD(n int) Option {
 	return func(spec *ClusterSpec) {
@@ -242,13 +256,6 @@ func GCEMinCPUPlatform(platform string) Option {
 	}
 }
 
-// GCEVolumeType sets the volume type when the cluster is on GCE.
-func GCEVolumeType(volumeType string) Option {
-	return func(spec *ClusterSpec) {
-		spec.GCE.VolumeType = volumeType
-	}
-}
-
 // GCEZones is a node option which requests Geo-distributed nodes; only applies
 // when the test runs on GCE.
 //
@@ -275,6 +282,14 @@ func AWSVolumeThroughput(throughput int) Option {
 	}
 }
 
+// AWSVolumeIOPS sets the provisioned IOPS for EBS volumes when the cluster is
+// on AWS.
+func AWSVolumeIOPS(iops int) Option {
+	return func(spec *ClusterSpec) {
+		spec.AWS.VolumeIOPS = iops
+	}
+}
+
 // AWSZones is a node option which requests Geo-distributed nodes; only applies
 // when the test runs on AWS.
 //
@@ -298,5 +313,13 @@ func AWSZones(zones string) Option {
 func AzureZones(zones string) Option {
 	return func(spec *ClusterSpec) {
 		spec.Azure.Zones = zones
+	}
+}
+
+// AzureVolumeIOPS sets the provisioned IOPS for ultra-disk volumes
+// when the cluster is on Azure.
+func AzureVolumeIOPS(iops int) Option {
+	return func(spec *ClusterSpec) {
+		spec.Azure.VolumeIOPS = iops
 	}
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2200,7 +2200,7 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 	// These params can be probabilistically set, so we pass them here to
 	// show what their actual values are in the posted issue.
 	if createOpts != nil {
-		clusterParams["fs"] = createOpts.SSDOpts.FileSystem
+		clusterParams["fs"] = string(createOpts.SSDOpts.FileSystem)
 		clusterParams["localSSD"] = fmt.Sprintf("%v", createOpts.SSDOpts.UseLocalSSD)
 	}
 

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -35,7 +35,7 @@ func registerDatabaseDrop(r registry.Registry) {
 		// node falls below 5% available capacity. 800GiB (7.2TiB) ought to be more
 		// than enough.
 		spec.VolumeSize(800),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
 	)

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -31,7 +31,7 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(500),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
 	)

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -42,7 +42,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(800),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 	}
 	testTimeout := 19 * time.Hour

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -141,7 +141,7 @@ type ebsDisk struct {
 // ebsVolume represents a mounted volume: name + ebsDisk
 type ebsVolume struct {
 	DeviceName string  `json:"DeviceName"`
-	Disk       ebsDisk `json:"Ebs"`
+	Disk       ebsDisk `json:"Ebs,omitempty"`
 }
 
 const ebsDefaultVolumeSizeGB = 500
@@ -239,6 +239,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		SSDMachineType:   defaultSSDMachineType,
 		RemoteUserName:   "ubuntu",
 		DefaultEBSVolume: defaultEBSVolumeValue,
+		EBSVolumeCount:   1,
 		CreateRateLimit:  2,
 		IAMProfile:       "roachprod-testing",
 	}
@@ -258,6 +259,10 @@ type ProviderOpts struct {
 	DefaultEBSVolume ebsVolume
 	EBSVolumes       ebsVolumeList
 	UseMultipleDisks bool
+
+	// EBSVolumeCount is the number of additional EBS volumes to attach.
+	// Only used if local-ssd=false, and is superseded by EBSVolumes.
+	EBSVolumeCount int
 
 	// IAMProfile designates the name of the instance profile to use for created
 	// EC2 instances if non-empty.
@@ -511,6 +516,9 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		o.DefaultEBSVolume.Disk.IOPs, "Number of IOPs to provision for supported disk types (io1, io2, gp3)")
 	flags.IntVar(&o.DefaultEBSVolume.Disk.Throughput, ProviderName+"-ebs-throughput",
 		o.DefaultEBSVolume.Disk.Throughput, "Additional throughput to provision, in MiB/s")
+
+	flags.IntVar(&o.EBSVolumeCount, ProviderName+"-ebs-volume-count", 1,
+		"Number of EBS volumes to create, only used if local-ssd=false and superseded by --aws-ebs-volume")
 
 	flags.VarP(&o.EBSVolumes, ProviderName+"-ebs-volume", "",
 		`Additional EBS disk to attached, repeated for extra disks; specified as JSON: {"VolumeType":"io2","VolumeSize":213,"Iops":321}`)
@@ -1595,21 +1603,6 @@ func genDeviceMapping(ebsVolumes ebsVolumeList, args []string) ([]string, error)
 func assignEBSVolumes(opts *vm.CreateOpts, providerOpts *ProviderOpts) ebsVolumeList {
 	// Make a local copy of providerOpts.EBSVolumes to prevent data races
 	ebsVolumes := providerOpts.EBSVolumes
-	// The local NVMe devices are automatically mapped.  Otherwise, we need to map an EBS data volume.
-	if !opts.SSDOpts.UseLocalSSD {
-		if len(ebsVolumes) == 0 && providerOpts.DefaultEBSVolume.Disk.VolumeType == "" {
-			providerOpts.DefaultEBSVolume.Disk.VolumeType = defaultEBSVolumeType
-			providerOpts.DefaultEBSVolume.Disk.DeleteOnTermination = true
-		}
-
-		if providerOpts.DefaultEBSVolume.Disk.VolumeType != "" {
-			// Add default volume to the list of volumes we'll setup.
-			v := ebsVolumes.newVolume()
-			v.Disk = providerOpts.DefaultEBSVolume.Disk
-			v.Disk.DeleteOnTermination = true
-			ebsVolumes = append(ebsVolumes, v)
-		}
-	}
 
 	osDiskVolume := &ebsVolume{
 		DeviceName: "/dev/sda1",
@@ -1619,7 +1612,29 @@ func assignEBSVolumes(opts *vm.CreateOpts, providerOpts *ProviderOpts) ebsVolume
 			DeleteOnTermination: true,
 		},
 	}
-	return append(ebsVolumes, osDiskVolume)
+
+	// If local SSD or boot disk only is requested, return that immediately.
+	// Local SSDs cannot be configured and will be automatically mapped by AWS
+	// depending on the instance type.
+	if opts.SSDOpts.UseLocalSSD {
+		return ebsVolumeList{osDiskVolume}
+	}
+
+	// aws-ebs-volume supersedes other volume settings, if none are provided,
+	// we build a list based on count and provided settings.
+	if len(ebsVolumes) == 0 {
+		for range providerOpts.EBSVolumeCount {
+			v := ebsVolumes.newVolume()
+			v.Disk = providerOpts.DefaultEBSVolume.Disk
+			v.Disk.DeleteOnTermination = true
+			ebsVolumes = append(ebsVolumes, v)
+		}
+	}
+
+	// Add the OS disk to the list of volumes to be created.
+	ebsVolumes = append(ebsVolumes, osDiskVolume)
+
+	return ebsVolumes
 }
 
 // Active is part of the vm.Provider interface.

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -29,39 +29,28 @@ import (
 const awsStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
-function setup_disks() {
-{{ if not .Zfs }}
-	mount_opts="defaults,nofail"
-	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
-{{ end }}
+{{ template "head_utils" . }}
+{{ template "apt_packages" . }}
 
-	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both EC2 NVMe Instance Storage and
-	# EBS, RAID'ing in this case can cause performance differences. So, to avoid this,
-	# EC2 NVMe Instance Storage are ignored.
+# Provider specific disk logic
+function detect_disks() {
+	# AWS-specific disk detection - returns list of available disks
+	# If both EC2 NVMe Instance Storage and EBS exist, prioritize EBS volumes to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
 	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
 	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
 	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
-	# Keep track of the Local SSDs and EBS volumes for RAID'ing
-	local_disks=()
-	ebs_volumes=()
-
-{{ if .Zfs }}
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-{{ end }}
+	local local_disks=()
+	local ebs_volumes=()
+	local disks=()
 
 	# On different machine types, the drives are either called nvme... or xvdd.
 	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
 		mounted="no"
-{{ if .Zfs }}
+{{ if eq .Filesystem "zfs" }}
 		# Check if the disk is already part of a zpool or mounted; skip if so.
 		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
 			mounted="yes"
@@ -78,79 +67,29 @@ function setup_disks() {
 			else
 				local_disks+=("${d}")
 			fi
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
 
 	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
-	disks=()
 	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
-	echo "Using only EBS disks: ${ebs_volumes[@]}"
+		echo "Using only EBS disks: ${ebs_volumes[@]}" >&2
 		disks=("${ebs_volumes[@]}")
 	else
-		echo "Using only local disks: ${local_disks[@]}"
+		echo "Using only local disks: ${local_disks[@]}" >&2
 		disks=("${local_disks[@]}")
 	fi
 
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-{{ if .Zfs }}
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-			mkfs.ext4 -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			tune2fs -m 0 ${disk}
-{{ end }}
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-{{ if .Zfs }}
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-		raiddisk="/dev/md0"
-		mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		tune2fs -m 0 ${raiddisk}
-{{ end }}
-		chmod 777 ${mountpoint}
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
 	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-{{ if .Zfs }}
-	zpool list
-{{ end }}
-
-	sudo touch {{ .DisksInitializedFile }}
 }
 
-{{ template "head_utils" . }}
-{{ template "apt_packages" . }}
-
-# Initialize disks.
-setup_disks
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 {{ template "ulimits" . }}
 {{ template "tcpdump" . }}
@@ -177,27 +116,28 @@ sudo touch {{ .OSInitializedFile }}
 func writeStartupScript(
 	name string,
 	extraMountOpts string,
-	fileSystem string,
+	fileSystem vm.Filesystem,
 	useMultiple bool,
 	enableFips bool,
 	remoteUser string,
 ) (string, error) {
+
+	// We define a local type in case we need to add more provider-specific params in
+	// the future.
 	type tmplParams struct {
 		vm.StartupArgs
-		ExtraMountOpts   string
-		UseMultipleDisks bool
 	}
 
 	args := tmplParams{
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithVMName(name),
 			vm.WithSharedUser(remoteUser),
-			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithFilesystem(fileSystem),
+			vm.WithExtraMountOpts(extraMountOpts),
+			vm.WithUseMultipleDisks(useMultiple),
 			vm.WithEnableFIPS(enableFips),
 			vm.WithChronyServers([]string{"169.254.169.123"}),
 		),
-		ExtraMountOpts:   extraMountOpts,
-		UseMultipleDisks: useMultiple,
 	}
 
 	tmpfile, err := os.CreateTemp("", "aws-startup-script")

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -4,31 +4,47 @@ echo
 #!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
-function setup_disks() {
 
 
-	use_multiple_disks=''
+# ensure any failure fails the entire script
+set -eux
 
-	mount_prefix="/mnt/data"
+# Redirect output to stdout/err and a log file
+exec &> >(tee -a /var/log/roachprod_startup.log)
 
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both EC2 NVMe Instance Storage and
-	# EBS, RAID'ing in this case can cause performance differences. So, to avoid this,
-	# EC2 NVMe Instance Storage are ignored.
+# Log the startup of the script with a timestamp
+echo "startup script starting: $(date -u)"
+
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
+if [ -e /mnt/data1/.roachprod-initialized ]; then
+	echo "Already initialized, exiting."
+	exit 0
+fi
+
+
+
+sudo apt-get update -q
+sudo apt-get install -qy --no-install-recommends mdadm
+
+apt-get install -yq zfsutils-linux
+
+
+
+# Provider specific disk logic
+function detect_disks() {
+	# AWS-specific disk detection - returns list of available disks
+	# If both EC2 NVMe Instance Storage and EBS exist, prioritize EBS volumes to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
 	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
 	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
 	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
-	# Keep track of the Local SSDs and EBS volumes for RAID'ing
-	local_disks=()
-	ebs_volumes=()
-
-
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-
+	local local_disks=()
+	local ebs_volumes=()
+	local disks=()
 
 	# On different machine types, the drives are either called nvme... or xvdd.
 	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
@@ -45,21 +61,48 @@ function setup_disks() {
 			else
 				local_disks+=("${d}")
 			fi
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
 
 	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
-	disks=()
 	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
-	echo "Using only EBS disks: ${ebs_volumes[@]}"
+		echo "Using only EBS disks: ${ebs_volumes[@]}" >&2
 		disks=("${ebs_volumes[@]}")
 	else
-		echo "Using only local disks: ${local_disks[@]}"
+		echo "Using only local disks: ${local_disks[@]}" >&2
 		disks=("${local_disks[@]}")
 	fi
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
 
 	if [ "${#disks[@]}" -eq "0" ]; then
 		mountpoint="${mount_prefix}1"
@@ -74,10 +117,27 @@ function setup_disks() {
 			disknum=$((disknum + 1 ))
 			echo "Mounting ${disk} at ${mountpoint}"
 			mkdir -p ${mountpoint}
-
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.zfs -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
 			chmod 777 ${mountpoint}
 		done
 	else
@@ -85,8 +145,33 @@ function setup_disks() {
 		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
 		mkdir -p ${mountpoint}
 
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.zfs -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
 
 		chmod 777 ${mountpoint}
 	fi
@@ -94,37 +179,44 @@ function setup_disks() {
 	# Print the block device and FS usage output. This is useful for debugging.
 	lsblk
 	df -h
-
-	zpool list
-
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
 
 	sudo touch /mnt/data1/.roachprod-initialized
 }
+	
+function setup_disks_wrapper() {
+	first_setup=$1
 
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem='zfs'
 
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
 
-# ensure any failure fails the entire script
-set -eux
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
 
-# Redirect output to stdout/err and a log file
-exec &> >(tee -a /var/log/roachprod_startup.log)
-
-# Log the startup of the script with a timestamp
-echo "startup script starting: $(date -u)"
-
-if [ -e /mnt/data1/.roachprod-initialized ]; then
-	echo "Already initialized, exiting."
-	exit 0
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
 fi
 
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
 
-
-sudo apt-get update -q
-sudo apt-get install -qy --no-install-recommends mdadm
-
-
-# Initialize disks.
-setup_disks
 
 
 
@@ -220,6 +312,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -282,16 +376,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":9100" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9100 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9100 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":9100" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -303,18 +429,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":9435" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9435 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9435 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":9435" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -817,19 +817,11 @@ func (p *Provider) createVM(
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithVMName(name),
 			vm.WithSharedUser(remoteUser),
+			vm.WithFilesystem(opts.SSDOpts.FileSystem),
+			vm.WithUseMultipleDisks(providerOpts.UseMultipleDisks),
 		),
-		DiskControllerNVMe: false,
-		AttachedDiskLun:    nil,
 	}
 	useNVMe := MachineSupportsNVMe(providerOpts.MachineType)
-	if useNVMe {
-		startupArgs.DiskControllerNVMe = true
-	}
-	if !opts.SSDOpts.UseLocalSSD && !useNVMe {
-		// We define lun42 explicitly in the data disk request below.
-		lun := 42
-		startupArgs.AttachedDiskLun = &lun
-	}
 
 	startupScript, err := evalStartupTemplate(startupArgs)
 	if err != nil {
@@ -948,8 +940,8 @@ func (p *Provider) createVM(
 	}
 
 	if !opts.SSDOpts.UseLocalSSD {
-		caching := compute.CachingTypesNone
 
+		caching := compute.CachingTypesNone
 		switch providerOpts.DiskCaching {
 		case "read-only":
 			caching = compute.CachingTypesReadOnly
@@ -961,46 +953,66 @@ func (p *Provider) createVM(
 			err = errors.Newf("unsupported caching behavior: %s", providerOpts.DiskCaching)
 			return compute.VirtualMachine{}, err
 		}
-		dataDisks := []compute.DataDisk{
-			{
-				DiskSizeGB: to.Int32Ptr(providerOpts.NetworkDiskSize),
-				Caching:    caching,
-				Lun:        to.Int32Ptr(42),
-			},
-		}
+		// Create multiple data disks with sequential LUNs starting after any
+		// reserved LUNs (e.g. the resource disk on 'd' sizes).
+		dataDisks := make([]compute.DataDisk, providerOpts.NetworkDiskCount)
+		for i := range providerOpts.NetworkDiskCount {
+			disk := compute.DataDisk{
+				CreateOption: compute.DiskCreateOptionTypesEmpty,
+				DiskSizeGB:   to.Int32Ptr(providerOpts.NetworkDiskSize),
+				Caching:      caching,
+				// LUNs start at 0, but we reserve LUN 0 for the potential resource disk
+				// that is automatically created on machine types with 'd' flag.
+				Lun: to.Int32Ptr(int32(i) + 1),
+			}
 
-		switch providerOpts.NetworkDiskType {
-		case "ultra-disk":
-			var ultraDisk compute.Disk
-			ultraDisk, err = p.createUltraDisk(l, ctx, group, name+"-ultra-disk", zone, providerOpts)
-			if err != nil {
+			switch providerOpts.NetworkDiskType {
+			case "ultra-disk":
+				// Create multiple ultra disks
+				var ultraDisk compute.Disk
+				ultraDisk, err = p.createUltraDisk(l, ctx, group, fmt.Sprintf("%s-ultra-disk-%d", name, i), zone, providerOpts)
+				if err != nil {
+					return compute.VirtualMachine{}, err
+				}
+
+				// UltraSSD specific disk configurations.
+				disk.CreateOption = compute.DiskCreateOptionTypesAttach
+				disk.Name = ultraDisk.Name
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesUltraSSDLRS,
+					ID:                 ultraDisk.ID,
+				}
+
+				// UltraSSDs must be enabled separately.
+				machine.AdditionalCapabilities = &compute.AdditionalCapabilities{
+					UltraSSDEnabled: to.BoolPtr(true),
+				}
+			case "standard-ssd":
+				// standard-ssd specific disk configurations.
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesStandardLRS,
+				}
+			case "premium-disk", "premium-ssd":
+				// premium-ssd-lrs specific disk configurations.
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesPremiumLRS,
+				}
+			case "premium-ssd-v2":
+				// premium-ssd-v2-lrs specific disk configurations.
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesPremiumV2LRS,
+				}
+			default:
+				err = errors.Newf("unsupported network disk type: %s", providerOpts.NetworkDiskType)
 				return compute.VirtualMachine{}, err
 			}
-			// UltraSSD specific disk configurations.
-			dataDisks[0].CreateOption = compute.DiskCreateOptionTypesAttach
-			dataDisks[0].Name = ultraDisk.Name
-			dataDisks[0].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: compute.StorageAccountTypesUltraSSDLRS,
-				ID:                 ultraDisk.ID,
-			}
 
-			// UltraSSDs must be enabled separately.
-			machine.AdditionalCapabilities = &compute.AdditionalCapabilities{
-				UltraSSDEnabled: to.BoolPtr(true),
-			}
-		case "premium-disk":
-			// premium-disk specific disk configurations.
-			dataDisks[0].CreateOption = compute.DiskCreateOptionTypesEmpty
-			dataDisks[0].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: compute.StorageAccountTypesPremiumV2LRS,
-			}
-		default:
-			err = errors.Newf("unsupported network disk type: %s", providerOpts.NetworkDiskType)
-			return compute.VirtualMachine{}, err
+			dataDisks[i] = disk
+
 		}
-
 		machine.StorageProfile.DataDisks = &dataDisks
 	}
+
 	future, err := client.CreateOrUpdate(ctx, *group.Name, name, machine)
 	if err != nil {
 		return

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -19,13 +19,15 @@ type ProviderOpts struct {
 	// N.B. Azure splits up the region (location) and availability zone, but
 	// to keep things consistent with other providers, we treat zone to mean
 	// both and split it up later.
-	Zones           []string
-	MachineType     string
-	VnetName        string
-	NetworkDiskType string
-	NetworkDiskSize int32
-	UltraDiskIOPS   int64
-	DiskCaching     string
+	Zones            []string
+	MachineType      string
+	VnetName         string
+	NetworkDiskType  string
+	NetworkDiskSize  int32
+	NetworkDiskCount int
+	UltraDiskIOPS    int64
+	DiskCaching      string
+	UseMultipleDisks bool
 }
 
 // These default locations support availability zones. At the time of
@@ -40,13 +42,15 @@ var DefaultZones = []string{
 // DefaultProviderOpts returns a new azure.ProviderOpts with default values set.
 func DefaultProviderOpts() *ProviderOpts {
 	return &ProviderOpts{
-		Zones:           nil,
-		MachineType:     string(armcompute.VirtualMachineSizeTypesStandardD4V3),
-		VnetName:        "common",
-		NetworkDiskType: "premium-disk",
-		NetworkDiskSize: 500,
-		UltraDiskIOPS:   5000,
-		DiskCaching:     "none",
+		Zones:            nil,
+		MachineType:      string(armcompute.VirtualMachineSizeTypesStandardD4V3),
+		VnetName:         "common",
+		NetworkDiskType:  "premium-ssd",
+		NetworkDiskSize:  500,
+		NetworkDiskCount: 1,
+		UltraDiskIOPS:    5000,
+		DiskCaching:      "none",
+		UseMultipleDisks: false,
 	}
 }
 
@@ -82,12 +86,17 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 			strings.Join(DefaultZones, ",")))
 	flags.StringVar(&o.VnetName, ProviderName+"-vnet-name", "common",
 		"The name of the VNet to use")
-	flags.StringVar(&o.NetworkDiskType, ProviderName+"-network-disk-type", "premium-disk",
-		"type of network disk [premium-disk, ultra-disk]. only used if local-ssd is false")
+	flags.StringVar(&o.NetworkDiskType, ProviderName+"-network-disk-type", "premium-ssd",
+		"type of network disk [standard-ssd, premium-ssd, premium-ssd-v2, ultra-disk]. only used if local-ssd is false")
 	flags.Int32Var(&o.NetworkDiskSize, ProviderName+"-volume-size", 500,
 		"Size in GB of network disk volume, only used if local-ssd=false")
+	flags.IntVar(&o.NetworkDiskCount, ProviderName+"-network-disk-count", 1,
+		"Number of network disks to attach, only used if local-ssd=false")
 	flags.Int64Var(&o.UltraDiskIOPS, ProviderName+"-ultra-disk-iops", 5000,
 		"Number of IOPS provisioned for ultra disk, only used if network-disk-type=ultra-disk")
 	flags.StringVar(&o.DiskCaching, ProviderName+"-disk-caching", "none",
 		"Disk caching behavior for attached storage.  Valid values are: none, read-only, read-write.  Not applicable to Ultra disks.")
+	flags.BoolVar(&o.UseMultipleDisks, ProviderName+"-enable-multiple-stores",
+		false, "Enable the use of multiple stores by creating one store directory per disk. "+
+			"Default is to raid0 stripe all disks or use ZFS (if --file-system=zfs).")
 }

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -5,34 +5,6 @@ echo
 
 # Script for setting up a Azure machine for roachprod use.
 
-function setup_disks() {
-	mount_opts="defaults"
-
-	devices=()
-
-
-	if (( ${#devices[@]} == 0 ));
-	then
-		# Use /mnt directly.
-		echo "No attached or NVME disks found, creating /mnt/data1"
-		mkdir -p /mnt/data1
-		chown ubuntu /mnt/data1
-		else
-		for d in "${!devices[@]}"; do
-			disk=${devices[$d]}
-			mount="/data$((d+1))"
-			sudo mkdir -p "${mount}"
-			sudo mkfs.ext4 -F "${disk}"
-			sudo mount -o "${mount_opts}" "${disk}" "${mount}"
-			echo "${disk} ${mount} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
-			ln -s "${mount}" "/mnt/$(basename $mount)"
-			tune2fs -m 0 ${disk}
-		done
-		chown ubuntu /data*
-	fi
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -44,6 +16,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -55,8 +29,185 @@ sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
 
-# Initialize disks.
-setup_disks
+
+# Provider specific disk logic
+function detect_disks() {
+	# Azure-specific disk detection - returns list of available disks
+	local local_or_network=()
+	local disks=()
+
+	# First, try to find NVMe disks (excluding boot disk nvme0n1)
+	if [ "$(ls /dev/disk/by-id/nvme-* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
+		if [ "${#local_or_network[@]}" -gt "0" ]; then
+			echo "Using NVMe disks: ${local_or_network[@]}" >&2
+		fi
+	fi
+
+	# If no NVMe disks found, try SCSI attached storage
+	if [ "${#local_or_network[@]}" -eq "0" ] && [ "$(ls /dev/disk/azure/scsi1/lun* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(ls /dev/disk/azure/scsi1/lun*))
+		echo "Using SCSI disks: ${local_or_network[@]}" >&2
+	fi
+
+	for l in ${local_or_network[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+
+		# Skip already mounted disks.
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs. -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs. -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem=''
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 # Disable Hyper-V Time Synchronization device
 # See https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-on-microsoft-azure#step-3-synchronize-clocks
@@ -159,6 +310,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -221,16 +374,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -242,18 +427,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -16,58 +16,71 @@ import (
 )
 
 // Startup script used to find/format/mount all local or attached disks.
-// Each disk is mounted as /data<disknum>, and, in addition, a symlink
-// created from /mnt/data<disknum> to the mount point.
+// Each disk is mounted at /mnt/data<disknum>.
 // azureStartupArgs specifies template arguments for the setup template.
+// We define a local type in case we need to add more provider-specific params in
+// the future.
 type azureStartupArgs struct {
 	vm.StartupArgs
-	AttachedDiskLun    *int // Use attached disk, with specified LUN; Use local ssd if nil.
-	DiskControllerNVMe bool // Interface data disk via NVMe
 }
 
 const azureStartupTemplate = `#!/bin/bash
 
 # Script for setting up a Azure machine for roachprod use.
 
-function setup_disks() {
-	mount_opts="defaults"
-
-	devices=()
-{{if .DiskControllerNVMe}}
-	# Setup nvme network storage, need to remove nvme OS disk from the device list.
-	devices=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
-{{else if .AttachedDiskLun}}
-	# Setup network attached storage
-	devices=("/dev/disk/azure/scsi1/lun{{.AttachedDiskLun}}")
-{{end}}
-
-	if (( ${#devices[@]} == 0 ));
-	then
-		# Use /mnt directly.
-		echo "No attached or NVME disks found, creating /mnt/data1"
-		mkdir -p /mnt/data1
-		chown {{.SharedUser}} /mnt/data1
-		else
-		for d in "${!devices[@]}"; do
-			disk=${devices[$d]}
-			mount="/data$((d+1))"
-			sudo mkdir -p "${mount}"
-			sudo mkfs.ext4 -F "${disk}"
-			sudo mount -o "${mount_opts}" "${disk}" "${mount}"
-			echo "${disk} ${mount} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
-			ln -s "${mount}" "/mnt/$(basename $mount)"
-			tune2fs -m 0 ${disk}
-		done
-		chown {{.SharedUser}} /data*
-	fi
-	sudo touch {{ .DisksInitializedFile }}
-}
-
 {{ template "head_utils" . }}
 {{ template "apt_packages" . }}
 
-# Initialize disks.
-setup_disks
+# Provider specific disk logic
+function detect_disks() {
+	# Azure-specific disk detection - returns list of available disks
+	local local_or_network=()
+	local disks=()
+
+	# First, try to find NVMe disks (excluding boot disk nvme0n1)
+	if [ "$(ls /dev/disk/by-id/nvme-* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
+		if [ "${#local_or_network[@]}" -gt "0" ]; then
+			echo "Using NVMe disks: ${local_or_network[@]}" >&2
+		fi
+	fi
+
+	# If no NVMe disks found, try SCSI attached storage
+	if [ "${#local_or_network[@]}" -eq "0" ] && [ "$(ls /dev/disk/azure/scsi1/lun* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(ls /dev/disk/azure/scsi1/lun*))
+		echo "Using SCSI disks: ${local_or_network[@]}" >&2
+	fi
+
+	for l in ${local_or_network[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+{{ if eq .Filesystem "zfs" }}
+		# Check if the disk is already part of a zpool or mounted; skip if so.
+		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+			mounted="yes"
+		fi
+{{ else }}
+		# Skip already mounted disks.
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+{{ end }}
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 # Disable Hyper-V Time Synchronization device
 # See https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-on-microsoft-azure#step-3-synchronize-clocks

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -47,6 +47,10 @@ const (
 	MaxConcurrentVMOps  = 16
 )
 
+var (
+	armMachineTypes = []string{"a4x", "c4a-", "n4a", "t2a-"}
+)
+
 type VolumeType string
 
 const (
@@ -1192,7 +1196,95 @@ func (p *Provider) ConfigureProviderFlags(flags *pflag.FlagSet, opt vm.MultipleP
 
 // useArmAMI returns true if the machine type is an arm64 machine type.
 func (o *ProviderOpts) useArmAMI() bool {
-	return strings.HasPrefix(strings.ToLower(o.MachineType), "t2a-")
+	for _, armType := range armMachineTypes {
+		if strings.HasPrefix(strings.ToLower(o.MachineType), armType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *ProviderOpts) machineTypeSupportsLocalSSD() bool {
+	machineType := strings.ToLower(o.MachineType)
+
+	// A2 support local SSDs.
+	if strings.HasPrefix(machineType, "a2") {
+		return true
+	}
+
+	// A3 support local SSDs.
+	if strings.HasPrefix(machineType, "a3") {
+		return true
+	}
+
+	// A4, A4X support local SSDs.
+	if strings.HasPrefix(machineType, "a4") {
+		return true
+	}
+
+	// C2, C2D support local SSDs.
+	if strings.HasPrefix(machineType, "c2") {
+		return true
+	}
+
+	// C3, C4D support local SSDs only with the -lssd suffix.
+	if strings.HasPrefix(machineType, "c3") && strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	// C4, C4A, C4D support local SSDs only with the -lssd suffix.
+	if strings.HasPrefix(machineType, "c4") && strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	// G2 support local SSDs.
+	if strings.HasPrefix(machineType, "g2") {
+		return true
+	}
+
+	// G4 support local SSDs.
+	if strings.HasPrefix(machineType, "g4") {
+		return true
+	}
+
+	// H4D support local SSDs with suffix -lssd.
+	if strings.HasPrefix(machineType, "h4d-") && strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	// M1 partially support local SSDs.
+	if strings.HasPrefix(machineType, "m1") {
+		return true
+	}
+
+	// M3 support local SSDs.
+	if strings.HasPrefix(machineType, "m3") {
+		return true
+	}
+
+	// N1 support local SSDs.
+	if strings.HasPrefix(machineType, "n1") {
+		return true
+	}
+
+	// N2, N2D support local SSDs
+	if strings.HasPrefix(machineType, "n2") {
+		return true
+	}
+
+	// Z3 support local SSDs with suffix -(standard|high)ssd.
+	if strings.HasPrefix(machineType, "z3") {
+		return true
+	}
+
+	// E2 do not support local SSDs.
+	// H3 do not support local SSDs.
+	// M2, M4 do not support local SSDs.
+	// N4, N4A, N4D do not support local SSDs.
+	// T2A, T2D don't support local SSDs.
+
+	// We return false by default until we manually allowlist new machine types.
+	return false
 }
 
 // ConfigureClusterCleanupFlags is part of ProviderOpts. This implementation is a no-op.
@@ -1355,18 +1447,18 @@ func (p *Provider) computeInstanceArgs(
 	imageProject := defaultImageProject
 
 	if opts.Arch == string(vm.ArchARM64) && !providerOpts.useArmAMI() {
-		return nil, cleanUpFn, errors.Errorf("Requested arch is arm64, but machine type is %s. Do specify a t2a VM", providerOpts.MachineType)
+		return nil, cleanUpFn, errors.Errorf("Requested arch is arm64, but machine type is %s. Do specify an ARM64 VM", providerOpts.MachineType)
 	}
 
 	if providerOpts.useArmAMI() && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
 		return nil, cleanUpFn, errors.Errorf("machine type %s is arm64, but requested arch is %s", providerOpts.MachineType, opts.Arch)
 	}
-	if providerOpts.useArmAMI() && opts.SSDOpts.UseLocalSSD {
-		return nil, cleanUpFn, errors.New("local SSDs are not supported with T2A instances, use --local-ssd=false")
+	if opts.SSDOpts.UseLocalSSD && !providerOpts.machineTypeSupportsLocalSSD() {
+		return nil, cleanUpFn, errors.Errorf("local SSDs are not supported with %s instance types, use --local-ssd=false", providerOpts.MachineType)
 	}
 	if providerOpts.useArmAMI() {
 		if providerOpts.MinCPUPlatform != "" {
-			l.Printf("WARNING: --gce-min-cpu-platform is ignored for T2A instances")
+			l.Printf("WARNING: --gce-min-cpu-platform is ignored for ARM64 instances")
 			providerOpts.MinCPUPlatform = ""
 		}
 		// TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
@@ -1419,8 +1511,25 @@ func (p *Provider) computeInstanceArgs(
 	extraMountOpts := ""
 	// Dynamic args.
 	if opts.SSDOpts.UseLocalSSD {
-		if counts, err := AllowedLocalSSDCount(providerOpts.MachineType); err != nil {
+
+		counts, err := AllowedLocalSSDCount(providerOpts.MachineType)
+		if err != nil {
 			return nil, cleanUpFn, err
+		}
+
+		// If only one count is allowed, the VM will be automatically
+		// configured with that count of local SSDs.
+		if len(counts) == 1 {
+			// If only one count is allowed, the VM will be automatically
+			// configured with that count of local SSDs.
+			// In case the user specified a different count, warn it will be overriden.
+			if providerOpts.SSDCount != counts[0] {
+				l.Printf(
+					"WARNING: %[1]q only supports %[2]d local SSDs. Setting --gce-local-ssd-count to %[2]d",
+					providerOpts.MachineType,
+					counts[0],
+				)
+			}
 		} else {
 			// Make sure the minimum number of local SSDs is met.
 			minCount := counts[0]
@@ -1428,10 +1537,11 @@ func (p *Provider) computeInstanceArgs(
 				l.Printf("WARNING: SSD count must be at least %d for %q. Setting --gce-local-ssd-count to %d", minCount, providerOpts.MachineType, minCount)
 				providerOpts.SSDCount = minCount
 			}
+			for i := 0; i < providerOpts.SSDCount; i++ {
+				args = append(args, "--local-ssd", "interface=NVME")
+			}
 		}
-		for i := 0; i < providerOpts.SSDCount; i++ {
-			args = append(args, "--local-ssd", "interface=NVME")
-		}
+
 		// Add `discard` for Local SSDs on NVMe, as is advised in:
 		// https://cloud.google.com/compute/docs/disks/add-local-ssd
 		extraMountOpts = "discard"
@@ -2370,56 +2480,323 @@ func (p *Provider) ListLoadBalancers(_ *logger.Logger, vms vm.List) ([]vm.Servic
 	return addresses, nil
 }
 
+// parseMachineType parses a GCE machine type string into its components.
+// Returns family, specialization, number of CPUs, memory in MB, SSD option, error.
+// For example:
+// - Input: "n2-standard-4" -> Output: ("n2", "standard", 4, 0, "", nil)
+// - Input: "n2-custom-8-16384" -> Output: ("n2", "custom", 8, 16384, "", nil)
+// - Input: "c4d-standard-384-metal" -> Output: ("c4d", "standard", 384, 0, "", nil)
+// - Input: "c4a-standard-8-lssd" -> Output: ("c4a", "standard", 8, 0, "lssd", nil)
+// - Input: "c4-standard-288-lssd-metal" -> Output: ("c4", "standard", 288, 0, "lssd", nil)
+// The SSD option corresponds to the newest nomenclature for machine types
+// with Titanium SSDs support.
+func parseMachineType(
+	machineType string,
+) (family string, specialization string, numCPUs int, memMb int, ssdOption string, err error) {
+	// E.g., n2-standard-4, n2-custom-8-16384, c4d-standard-384-metal, c4a-standard-8-lssd, c4-standard-288-lssd-metal.
+	machineTypes := regexp.MustCompile(`^([a-z]+\d+[a-z]*)-(standard|highcpu|highmem|highgpu|ultragpu|edgegpu|custom)-(\d+)(?:-(\d+))?(.*)$`)
+	matches := machineTypes.FindStringSubmatch(machineType)
+
+	// Regexp captures the following informations:
+	// - matches[1]: machine family (n1, n2, h4d, ...)
+	// - matches[2]: machine type (standard|highcpu|highmem|custom)
+	// - matches[3]: number of CPUs
+	// - matches[4]: memory size in MB (only for custom types)
+	// - matches[5]: optional suffixes (e.g., "-lssd-metal", "-metal", "-lssd")
+
+	if len(matches) >= 3 {
+		family = matches[1]
+		specialization = matches[2]
+		numCPUs, err = strconv.Atoi(matches[3])
+		if err != nil {
+			return "", "", 0, 0, "", err
+		}
+		if specialization == "custom" {
+			if len(matches) >= 4 && matches[4] != "" {
+				memMb, err = strconv.Atoi(matches[4])
+				if err != nil {
+					return "", "", 0, 0, "", err
+				}
+			} else {
+				return "", "", 0, 0, "", fmt.Errorf("custom machine type %q missing memory size", machineType)
+			}
+		}
+		if len(matches) >= 6 && matches[5] != "" {
+			// Parse the suffixes (e.g., "-lssd-metal" -> ["lssd", "metal"])
+			suffixes := matches[5]
+			// Split by dashes and check each part
+			for _, suffix := range strings.Split(suffixes, "-") {
+				if suffix == "" {
+					continue
+				}
+				// Only return SSD options, ignore other suffixes like "metal"
+				switch suffix {
+				case "highssd", "standardlssd", "lssd":
+					ssdOption = suffix
+				}
+			}
+		}
+	}
+	return family, specialization, numCPUs, memMb, ssdOption, nil
+}
+
 // Given a machine type, return the allowed number (> 0) of local SSDs, sorted in ascending order.
 // N.B. Only n1, n2, n2d and c2 instances are supported since we don't typically use other instance types.
 // Consult https://cloud.google.com/compute/docs/disks/#local_ssd_machine_type_restrictions for other types of instances.
 func AllowedLocalSSDCount(machineType string) ([]int, error) {
-	// E.g., n2-standard-4, n2-custom-8-16384.
-	machineTypes := regexp.MustCompile(`^([cn])(\d+)(?:d)?-[a-z]+-(\d+)(?:-\d+)?$`)
-	matches := machineTypes.FindStringSubmatch(machineType)
 
-	if len(matches) >= 3 {
-		family := matches[1] + matches[2]
-		numCpus, err := strconv.Atoi(matches[3])
-		if err != nil {
-			return nil, err
+	family, _, numCPU, _, ssdOption, err := parseMachineType(machineType)
+	if err != nil {
+		return nil, err
+	}
+
+	switch family {
+	case "c3":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
 		}
-		if family == "n1" {
-			return []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 24}, nil
+		switch numCPU {
+		case 4:
+			return []int{1}, nil
+		case 8:
+			return []int{2}, nil
+		case 22:
+			return []int{4}, nil
+		case 44:
+			return []int{8}, nil
+		case 88:
+			return []int{16}, nil
+		case 176:
+			return []int{32}, nil
 		}
-		switch family {
-		case "n2":
-			if numCpus <= 10 {
-				return []int{1, 2, 4, 8, 16, 24}, nil
+
+	case "c3d":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 8, 16:
+			return []int{1}, nil
+		case 30:
+			return []int{2}, nil
+		case 60:
+			return []int{4}, nil
+		case 90:
+			return []int{8}, nil
+		case 180:
+			return []int{16}, nil
+		case 360:
+			return []int{32}, nil
+		}
+
+	case "c4":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 4, 8:
+			return []int{1}, nil
+		case 16:
+			return []int{2}, nil
+		case 24:
+			return []int{4}, nil
+		case 32:
+			return []int{5}, nil
+		case 48:
+			return []int{8}, nil
+		case 96:
+			return []int{16}, nil
+		case 144:
+			return []int{24}, nil
+		case 192:
+			return []int{32}, nil
+		case 288:
+			return []int{48}, nil
+		}
+
+	case "c4a":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 4:
+			return []int{1}, nil
+		case 8:
+			return []int{2}, nil
+		case 16:
+			return []int{4}, nil
+		case 32:
+			return []int{6}, nil
+		case 48:
+			return []int{10}, nil
+		case 64:
+			return []int{14}, nil
+		case 72:
+			return []int{16}, nil
+		}
+
+	case "c4d":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 8, 16:
+			return []int{1}, nil
+		case 32:
+			return []int{2}, nil
+		case 48:
+			return []int{4}, nil
+		case 64:
+			return []int{6}, nil
+		case 96:
+			return []int{8}, nil
+		case 192:
+			return []int{16}, nil
+		case 384:
+			return []int{32}, nil
+		}
+
+	case "h4d":
+		return []int{10}, nil
+
+	case "z3":
+		switch numCPU {
+		case 8, 14:
+			return []int{1}, nil
+		case 16:
+			return []int{2}, nil
+		case 22:
+			switch ssdOption {
+			case "standardlssd":
+				return []int{2}, nil
+			case "highlssd":
+				return []int{3}, nil
 			}
-			if numCpus <= 20 {
-				return []int{2, 4, 8, 16, 24}, nil
+		case 32:
+			return []int{4}, nil
+		case 44:
+			switch ssdOption {
+			case "standardlssd":
+				return []int{3}, nil
+			case "highlssd":
+				return []int{6}, nil
 			}
-			if numCpus <= 40 {
-				return []int{4, 8, 16, 24}, nil
+		case 88:
+			switch ssdOption {
+			case "standardlssd":
+				return []int{6}, nil
+			case "highlssd":
+				return []int{12}, nil
 			}
-			if numCpus <= 80 {
-				return []int{8, 16, 24}, nil
-			}
-			if numCpus <= 128 {
-				return []int{16, 24}, nil
-			}
-		case "c2":
-			if numCpus <= 8 {
-				return []int{1, 2, 4, 8}, nil
-			}
-			if numCpus <= 16 {
-				return []int{2, 4, 8}, nil
-			}
-			if numCpus <= 30 {
-				return []int{4, 8}, nil
-			}
-			if numCpus <= 60 {
-				return []int{8}, nil
-			}
+		case 176, 192:
+			return []int{12}, nil
+
+		}
+
+	case "n1":
+		return []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 24}, nil
+
+	case "n2":
+		if numCPU <= 10 {
+			return []int{1, 2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 20 {
+			return []int{2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 40 {
+			return []int{4, 8, 16, 24}, nil
+		}
+		if numCPU <= 80 {
+			return []int{8, 16, 24}, nil
+		}
+		if numCPU <= 128 {
+			return []int{16, 24}, nil
+		}
+
+	case "n2d":
+		if numCPU <= 16 {
+			return []int{1, 2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 48 {
+			return []int{2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 80 {
+			return []int{4, 8, 16, 24}, nil
+		}
+		if numCPU <= 224 {
+			return []int{8, 16, 24}, nil
+		}
+
+	case "c2":
+		if numCPU <= 8 {
+			return []int{1, 2, 4, 8}, nil
+		}
+		if numCPU <= 16 {
+			return []int{2, 4, 8}, nil
+		}
+		if numCPU <= 30 {
+			return []int{4, 8}, nil
+		}
+		if numCPU <= 60 {
+			return []int{8}, nil
+		}
+
+	case "c2d":
+		if numCPU <= 16 {
+			return []int{1, 2, 4, 8}, nil
+		}
+		if numCPU <= 32 {
+			return []int{2, 4, 8}, nil
+		}
+		if numCPU <= 56 {
+			return []int{4, 8}, nil
+		}
+		if numCPU <= 112 {
+			return []int{8}, nil
+		}
+
+	case "g2":
+		switch numCPU {
+		case 4, 8, 12, 16, 32:
+			return []int{1}, nil
+		case 24:
+			return []int{2}, nil
+		case 48:
+			return []int{4}, nil
+		case 96:
+			return []int{8}, nil
+		}
+
+	case "g4":
+		switch numCPU {
+		case 48:
+			return []int{4}, nil
+		case 96:
+			return []int{8}, nil
+		case 192:
+			return []int{16}, nil
+		case 384:
+			return []int{32}, nil
+		}
+
+	case "m1":
+		switch numCPU {
+		case 40:
+			return []int{1, 2, 3, 4, 5}, nil
+		case 80:
+			return []int{1, 2, 3, 4, 5, 6, 7, 8}, nil
+		}
+
+	case "m3":
+		switch numCPU {
+		case 32, 64:
+			return []int{4, 8}, nil
+		case 128:
+			return []int{8}, nil
 		}
 	}
-	return nil, fmt.Errorf("unsupported machine type: %q, matches: %v", machineType, matches)
+
+	return nil, fmt.Errorf("unsupported machine type: %q", machineType)
 }
 
 // N.B. neither boot disk nor additional persistent disks are assigned VM labels by default.

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -4,42 +4,60 @@ echo
 #!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-function setup_disks() {
-	first_setup=$1
+
+
+# ensure any failure fails the entire script
+set -eux
+
+# Redirect output to stdout/err and a log file
+exec &> >(tee -a /var/log/roachprod_startup.log)
+
+# Log the startup of the script with a timestamp
+echo "startup script starting: $(date -u)"
+
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
+if [ -e /mnt/data1/.roachprod-initialized ]; then
+	echo "Already initialized, exiting."
+	exit 0
+fi
 
 
 
-	use_multiple_disks=''
+sudo apt-get update -q
+sudo apt-get install -qy --no-install-recommends mdadm
 
-	mount_prefix="/mnt/data"
+apt-get install -yq zfsutils-linux
 
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
-	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
+
+
+sudo -u ubuntu bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
+sudo -u ubuntu bash -c 'echo "dummy public key" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
+
+# Provider specific disk logic
+function detect_disks() {
+	# GCE-specific disk detection - returns list of available disks
+	# If both Local SSDs and Persistent disks exist, prioritize persistent disks to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
 	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	local_or_persistent=()
-	disks=()
-
-
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-
+	local local_or_persistent=()
+	local disks=()
 
 	# N.B. we assume 0th disk is the boot disk.
 	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
-		local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
-		echo "Using only persistent disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-persistent-disk-[1-9]))
+		echo "Using only persistent disks: ${local_or_persistent[@]}" >&2
 	else
-		local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
-		echo "Using only local disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-local-*))
+		echo "Using only local disks: ${local_or_persistent[@]}" >&2
 	fi
 
-	for l in ${local_or_persistent}; do
+	for l in ${local_or_persistent[@]}; do
 		d=$(readlink -f $l)
 		mounted="no"
 
@@ -50,11 +68,39 @@ function setup_disks() {
 
 		if [ "$mounted" == "no" ]; then
 			disks+=("${d}")
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
 
 	if [ "${#disks[@]}" -eq "0" ]; then
 		mountpoint="${mount_prefix}1"
@@ -69,10 +115,27 @@ function setup_disks() {
 			disknum=$((disknum + 1 ))
 			echo "Mounting ${disk} at ${mountpoint}"
 			mkdir -p ${mountpoint}
-
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.zfs -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
 			chmod 777 ${mountpoint}
 		done
 	else
@@ -80,8 +143,33 @@ function setup_disks() {
 		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
 		mkdir -p ${mountpoint}
 
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.zfs -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
 
 		chmod 777 ${mountpoint}
 	fi
@@ -89,50 +177,44 @@ function setup_disks() {
 	# Print the block device and FS usage output. This is useful for debugging.
 	lsblk
 	df -h
-
-	zpool list
-
-
-	mkdir -p /mnt/data1/cores
-	chmod a+w /mnt/data1/cores
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
 
 	sudo touch /mnt/data1/.roachprod-initialized
 }
+	
+function setup_disks_wrapper() {
+	first_setup=$1
 
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem='zfs'
 
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
 
-# ensure any failure fails the entire script
-set -eux
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
 
-# Redirect output to stdout/err and a log file
-exec &> >(tee -a /var/log/roachprod_startup.log)
-
-# Log the startup of the script with a timestamp
-echo "startup script starting: $(date -u)"
-
-if [ -e /mnt/data1/.roachprod-initialized ]; then
-	echo "Already initialized, exiting."
-	exit 0
-fi
-
-
-
-sudo apt-get update -q
-sudo apt-get install -qy --no-install-recommends mdadm
-
-
-sudo -u ubuntu bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
-sudo -u ubuntu bash -c 'echo "dummy public key" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
-
+# Start the process of detecting disks to mount and configure them.
 if [ -e /.roachprod-initialized ]; then
   echo "OS already initialized, only initializing disks."
   # Initialize disks, but don't write fstab entries again.
-  setup_disks false
+  setup_disks_wrapper false
   exit 0
 fi
 
 # Initialize disks and write fstab entries.
-setup_disks true
+setup_disks_wrapper true
+
 
 
 
@@ -228,6 +310,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -288,16 +372,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":9100" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9100 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9100 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":9100" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -309,18 +425,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":9435" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9435 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9435 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":9435" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -25,48 +25,39 @@ import (
 const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-function setup_disks() {
-	first_setup=$1
+{{ template "head_utils" . }}
+{{ template "apt_packages" . }}
 
-{{ if not .Zfs }}
-	mount_opts="defaults,nofail"
-	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
-{{ end }}
+sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
+sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
 
-	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
-	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
+# Provider specific disk logic
+function detect_disks() {
+	# GCE-specific disk detection - returns list of available disks
+	# If both Local SSDs and Persistent disks exist, prioritize persistent disks to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
 	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	local_or_persistent=()
-	disks=()
-
-{{ if .Zfs }}
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-{{ end }}
+	local local_or_persistent=()
+	local disks=()
 
 	# N.B. we assume 0th disk is the boot disk.
 	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
-		local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
-		echo "Using only persistent disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-persistent-disk-[1-9]))
+		echo "Using only persistent disks: ${local_or_persistent[@]}" >&2
 	else
-		local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
-		echo "Using only local disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-local-*))
+		echo "Using only local disks: ${local_or_persistent[@]}" >&2
 	fi
 
-	for l in ${local_or_persistent}; do
+	for l in ${local_or_persistent[@]}; do
 		d=$(readlink -f $l)
 		mounted="no"
-{{ if .Zfs }}
+{{ if eq .Filesystem "zfs" }}
 		# Check if the disk is already part of a zpool or mounted; skip if so.
 		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
 			mounted="yes"
@@ -79,86 +70,20 @@ function setup_disks() {
 {{ end }}
 		if [ "$mounted" == "no" ]; then
 			disks+=("${d}")
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
 
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-{{ if .Zfs }}
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-			mkfs.ext4 -q -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			if [ "$first_setup" = "true" ]; then
-				echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			fi
-			tune2fs -m 0 ${disk}
-{{ end }}
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-{{ if .Zfs }}
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-		raiddisk="/dev/md0"
-		mdadm -q --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -q -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		if [ "$first_setup" = "true" ]; then
-			echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		fi
-		tune2fs -m 0 ${raiddisk}
-{{ end }}
-		chmod 777 ${mountpoint}
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
 	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-{{ if .Zfs }}
-	zpool list
-{{ end }}
-
-	mkdir -p /mnt/data1/cores
-	chmod a+w /mnt/data1/cores
-
-	sudo touch {{ .DisksInitializedFile }}
 }
 
-{{ template "head_utils" . }}
-{{ template "apt_packages" . }}
-
-sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
-sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
-
-if [ -e {{ .OSInitializedFile }} ]; then
-  echo "OS already initialized, only initializing disks."
-  # Initialize disks, but don't write fstab entries again.
-  setup_disks false
-  exit 0
-fi
-
-# Initialize disks and write fstab entries.
-setup_disks true
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 {{ template "ulimits" . }}
 {{ template "tcpdump" . }}
@@ -183,13 +108,18 @@ sudo touch {{ .OSInitializedFile }}
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool, enableCron bool,
+	extraMountOpts string,
+	fileSystem vm.Filesystem,
+	useMultiple bool,
+	enableFIPS bool,
+	enableCron bool,
 ) (string, error) {
+
+	// We define a local type in case we need to add more provider-specific params in
+	// the future.
 	type tmplParams struct {
 		vm.StartupArgs
-		ExtraMountOpts   string
-		UseMultipleDisks bool
-		PublicKey        string
+		PublicKey string
 	}
 
 	publicKey, err := config.SSHPublicKey()
@@ -201,13 +131,13 @@ func writeStartupScript(
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithSharedUser(config.SharedUser),
 			vm.WithEnableCron(enableCron),
-			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithFilesystem(fileSystem),
 			vm.WithEnableFIPS(enableFIPS),
 			vm.WithChronyServers([]string{"metadata.google.internal"}),
+			vm.WithExtraMountOpts(extraMountOpts),
+			vm.WithUseMultipleDisks(useMultiple),
 		),
-		ExtraMountOpts:   extraMountOpts,
-		UseMultipleDisks: useMultiple,
-		PublicKey:        publicKey,
+		PublicKey: publicKey,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -55,17 +55,19 @@ const (
 )
 
 type StartupArgs struct {
-	VMName               string   // Name of the VM
-	SharedUser           string   // The name of the shared user
-	StartupLogs          string   // File to redirect startup script output logs
-	OSInitializedFile    string   // File to touch when OS is initialized
-	DisksInitializedFile string   // File to touch when disks are initialized
-	Zfs                  bool     // Use ZFS instead of ext4
-	EnableFIPS           bool     // Enable FIPS mode
-	EnableCron           bool     // Enable cron service
-	ChronyServers        []string // List of NTP servers to use
-	NodeExporterPort     int      // Port that NodeExporter listens on
-	EbpfExporterPort     int      // Port that EbpfExporter listens on
+	VMName               string     // Name of the VM
+	SharedUser           string     // The name of the shared user
+	StartupLogs          string     // File to redirect startup script output logs
+	OSInitializedFile    string     // File to touch when OS is initialized
+	DisksInitializedFile string     // File to touch when disks are initialized
+	UseMultipleDisks     bool       // Whether to use multiple disks
+	ExtraMountOpts       string     // Extra mount options for disks (if filesystem is not ZFS)
+	Filesystem           Filesystem // Filesystem to use for disks: ext4, zfs, xfs
+	EnableFIPS           bool       // Enable FIPS mode
+	EnableCron           bool       // Enable cron service
+	ChronyServers        []string   // List of NTP servers to use
+	NodeExporterPort     int        // Port that NodeExporter listens on
+	EbpfExporterPort     int        // Port that EbpfExporter listens on
 }
 
 func DefaultStartupArgs(overrides ...IArgOverride) StartupArgs {
@@ -99,6 +101,7 @@ var (
 		"fips_utils":            startupScriptFIPS,
 		"head_utils":            startupScriptHead,
 		"hostname_utils":        startupScriptHostname,
+		"setup_disks_utils":     startupScriptMountDisks,
 		"node_exporter":         startupScriptNodeExporter,
 		"ebpf_exporter":         startupScriptEbpfExporter,
 		"keepalives":            startupScriptKeepalives,
@@ -111,7 +114,16 @@ var (
 
 const startupScriptAptPackages = `
 sudo apt-get update -q
-sudo apt-get install -qy --no-install-recommends mdadm`
+sudo apt-get install -qy --no-install-recommends mdadm
+{{ if eq .Filesystem "zfs" }}
+apt-get install -yq zfsutils-linux
+{{ else if eq .Filesystem "f2fs" }}
+apt-get install -yq f2fs-tools linux-modules-extra-$(uname -r)
+{{ else if eq .Filesystem "btrfs" }}
+apt-get install -yq btrfs-progs
+{{ else if eq .Filesystem "xfs" }}
+apt-get install -yq xfsprogs
+{{ end }}`
 
 const startupScriptChrony = `
 sudo apt-get install -qy chrony
@@ -152,6 +164,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -194,6 +208,8 @@ exec &> >(tee -a {{ .StartupLogs }})
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e {{ .DisksInitializedFile }} ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -230,16 +246,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport {{.NodeExporterPort}} -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport {{.NodeExporterPort}} -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":{{.NodeExporterPort}}" \
-		--web.telemetry-path="` + NodeExporterMetricsPath + `"
-)`
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport {{.NodeExporterPort}} -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport {{.NodeExporterPort}} -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport {{.NodeExporterPort}} -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport {{.NodeExporterPort}} -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":{{.NodeExporterPort}}" \
+	--web.telemetry-path="` + NodeExporterMetricsPath + `"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter`
 
 const startupScriptEbpfExporter = `
 # Add and start ebpf_exporter, only authorize scrapping from internal network.
@@ -250,18 +298,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport {{.EbpfExporterPort}} -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport {{.EbpfExporterPort}} -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":{{.EbpfExporterPort}}" \
-		--web.telemetry-path="` + EbpfExporterMetricsPath + `"
-)`
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport {{.EbpfExporterPort}} -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport {{.EbpfExporterPort}} -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport {{.EbpfExporterPort}} -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport {{.EbpfExporterPort}} -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":{{.EbpfExporterPort}}" \
+	--web.telemetry-path="` + EbpfExporterMetricsPath + `"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter`
 
 const startupScriptSSH = `
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
@@ -316,6 +392,139 @@ const startupScriptUlimits = `
 # root and non-root users. Load generators running a lot of concurrent
 # workers bump into this often.
 sudo sh -c 'echo "root - nofile 1048576\n* - nofile 1048576" > /etc/security/limits.d/10-roachprod-nofiles.conf'`
+
+const startupScriptMountDisks = `
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.{{ .Filesystem }} -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} {{ .Filesystem }} ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.{{ .Filesystem }} -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} {{ .Filesystem }} ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch {{ .DisksInitializedFile }}
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks='{{ if .UseMultipleDisks }}true{{ end }}'
+	filesystem='{{ .Filesystem }}'
+
+	mount_opts="defaults,nofail{{- if .ExtraMountOpts -}},{{- .ExtraMountOpts -}}{{- end -}}"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e {{ .OSInitializedFile }} ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true`
 
 func GenerateStartupScript(w io.Writer, cloudSpecificTemplate string, args any) error {
 	t := template.New("start")

--- a/pkg/roachprod/vm/startup_args_overrides.go
+++ b/pkg/roachprod/vm/startup_args_overrides.go
@@ -85,19 +85,49 @@ func WithDisksInitializedFile(disksInitializedFile string) WithDisksInitializedF
 	return WithDisksInitializedFileOverride{DisksInitializedFile: disksInitializedFile}
 }
 
-// WithZfsOverride is an override for the Zfs field.
-type WithZfsOverride struct {
-	Zfs bool
+// WithFilesystemOverride is an override for the Filesystem field.
+type WithFilesystemOverride struct {
+	Filesystem Filesystem
 }
 
-// apply applies the Zfs override to the StartupArgs.
-func (o WithZfsOverride) apply(args *StartupArgs) {
-	args.Zfs = o.Zfs
+// apply applies the Filesystem override to the StartupArgs.
+func (o WithFilesystemOverride) apply(args *StartupArgs) {
+	args.Filesystem = o.Filesystem
 }
 
-// WithZfs overrides the Zfs field.
-func WithZfs(zfs bool) WithZfsOverride {
-	return WithZfsOverride{Zfs: zfs}
+// WithFilesystem overrides the Filesystem field.
+func WithFilesystem(filesystem Filesystem) WithFilesystemOverride {
+	return WithFilesystemOverride{Filesystem: filesystem}
+}
+
+// WithExtraMountOptsOverride is an override for the ExtraMountOpts field.
+type WithExtraMountOptsOverride struct {
+	ExtraMountOpts string
+}
+
+// apply applies the ExtraMountOpts override to the StartupArgs.
+func (o WithExtraMountOptsOverride) apply(args *StartupArgs) {
+	args.ExtraMountOpts = o.ExtraMountOpts
+}
+
+// WithExtraMountOpts overrides the ExtraMountOpts field.
+func WithExtraMountOpts(extraMountOpts string) WithExtraMountOptsOverride {
+	return WithExtraMountOptsOverride{ExtraMountOpts: extraMountOpts}
+}
+
+// WithUseMultipleDisksOverride is an override for the UseMultipleDisks field.
+type WithUseMultipleDisksOverride struct {
+	UseMultipleDisks bool
+}
+
+// apply applies the UseMultipleDisks override to the StartupArgs.
+func (o WithUseMultipleDisksOverride) apply(args *StartupArgs) {
+	args.UseMultipleDisks = o.UseMultipleDisks
+}
+
+// WithUseMultipleDisks overrides the UseMultipleDisks field.
+func WithUseMultipleDisks(useMultipleDisks bool) WithUseMultipleDisksOverride {
+	return WithUseMultipleDisksOverride{UseMultipleDisks: useMultipleDisks}
 }
 
 // WithEnableFIPSOverride is an override for the EnableFIPS field.

--- a/pkg/roachprod/vm/startup_test.go
+++ b/pkg/roachprod/vm/startup_test.go
@@ -28,13 +28,13 @@ func TestGenericStartupArgs(t *testing.T) {
 		args := DefaultStartupArgs(WithOSInitializedFile("test"))
 		require.Equal(t, args.OSInitializedFile, "test")
 	})
-	t.Run("WithDiskInitializeFile", func(t *testing.T) {
+	t.Run("WithDisksInitializedFile", func(t *testing.T) {
 		args := DefaultStartupArgs(WithDisksInitializedFile("test"))
 		require.Equal(t, args.DisksInitializedFile, "test")
 	})
 	t.Run("WithZfs", func(t *testing.T) {
-		args := DefaultStartupArgs(WithZfs(true))
-		require.Equal(t, args.Zfs, true)
+		args := DefaultStartupArgs(WithFilesystem(Ext4))
+		require.Equal(t, args.Filesystem, Ext4)
 	})
 	t.Run("WithFIPS", func(t *testing.T) {
 		args := DefaultStartupArgs(WithEnableFIPS(true))

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -273,12 +273,35 @@ func (vl List) ProviderIDs() []string {
 	return ret
 }
 
+type Filesystem string
+
 const (
 	// Zfs refers to the zfs file system.
-	Zfs = "zfs"
+	Zfs Filesystem = "zfs"
 	// Ext4 refers to the ext4 file system.
-	Ext4 = "ext4"
+	Ext4 Filesystem = "ext4"
+	// Xfs refers to the xfs file system.
+	Xfs Filesystem = "xfs"
+	// F2fs refers to the f2fs file system.
+	F2fs Filesystem = "f2fs"
+	// Btrfs refers to the btrfs file system.
+	Btrfs Filesystem = "btrfs"
 )
+
+// ParseFilesystemString parses and validates a filesystem string.
+func ParseFilesystemString(s string) (Filesystem, error) {
+	return ParseFileSystemOption(Filesystem(s))
+}
+
+// ParseFileSystemOption parses and validates a Filesystem option.
+func ParseFileSystemOption(s Filesystem) (Filesystem, error) {
+	switch s {
+	case Zfs, Ext4, Xfs, F2fs, Btrfs:
+		return s, nil
+	default:
+		return "", errors.Newf("unsupported filesystem: %s", s)
+	}
+}
 
 // CreateOpts is the set of options when creating VMs.
 type CreateOpts struct {
@@ -295,7 +318,7 @@ type CreateOpts struct {
 		// mounting the SSD. Ignored if UseLocalSSD is not set.
 		NoExt4Barrier bool
 		// The file system to be used. This is set to "ext4" by default.
-		FileSystem string
+		FileSystem Filesystem
 	}
 	OsVolumeSize int
 }


### PR DESCRIPTION
Backport 2/2 commits from #156821.

/cc @cockroachdb/release

---

Until now, each cloud provider implementation had its own capabilities with regards to storage options. GCE was the only first class citizen with the most available options exposed in roachtest.

This patch attempts to bridge the feature parity gap between the cloud providers (up to what's exposed by each providers), bringing support for the following options in roachprod and roachtest:
- GCE:
  - local SSD
  - network disk size
  - network disk type (pd-standard, pd-ssd)
  - network disk count
  - RAID0 or multiple stores
- AWS:
  - local SSD
  - network disk size
  - network disk throughput
  - network disk IOPS
  - NEW: network disk type (gp2, gp3, io1, io2, st1, sc1, standard)
  - NEW: network disk count
  - NEW: RAID0 or multiple stores
- Azure:
  - local SSD
  - network disk size
  - NEW: network disk IOPS (ultra-disk only)
  - NEW: network disk type (standard-ssd, premium-ssd, premium-ssd-v2,
      ultra-disk)
  - NEW: network disk count
  - NEW: RAID0 or multiple stores
- IBM:
  - network disk size
  - network disk IOPS
  - network disk type (general-purpose, 5iops-tier, 10iops-tier, custom)
  - network disk count
  - RAID0 or multiple stores

This patch also splits the disk setup startup script snippets, with:
- a provider-specific way of detecting the attached disks
- a common logic to mount, format and aggregate the disks

This allows to offer the following filesystems across the board in roachprod (and roachtest):
- Ext4
- ZFS
- XFS
- F2FS (available for AWS, Azure and GCP, pending newer kernel for IBM)
- Btrfs

Epic: none
Closes: #123775
Informs: #146661, #113869
Release note: None

Release justification: Test only change
