### PR TITLE
build: update PGO profile to 20251204202750-818ff5108cdb1f16f69b3d915acdb4f669b848eb.pb.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -643,6 +643,6 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    sha256 = "7500eeeecba8edc9d25fd65b178568e7c543b50b3ef3ffc5e6e13af186ae2023",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250926213937-4c6b4ce4dd320a7aa835757ed60f295f6e7c692c.pb.gz",
+    sha256 = "5a23c5b33325d5fc3dfa4e67d872aa8371756f8e4f8f159509e8cc522c298cb2",
+    url = "https://storage.googleapis.com/cockroach-profiles/20251204202750-818ff5108cdb1f16f69b3d915acdb4f669b848eb.pb.gz",
 )


### PR DESCRIPTION
This PR updates the PGO (Profile-Guided Optimization) profile used for building CockroachDB.

The new profile was validated using tpcc-nowait benchmarks. Results comparing the old profile (before) vs new profile (after):

```
                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │            ops/sec             │   ops/sec    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          135.4 ± 3%    136.9 ± 4%       ~ (p=0.683 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         1.355k ± 3%   1.369k ± 4%       ~ (p=0.703 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       135.4 ± 3%    136.9 ± 4%       ~ (p=0.683 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          1.355k ± 3%   1.369k ± 4%       ~ (p=0.703 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        135.4 ± 3%    136.9 ± 4%       ~ (p=0.713 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            3.115k ± 3%   3.150k ± 4%       ~ (p=0.703 n=20)
geomean                                                                          492.1         497.6       +1.10%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/avg             │   ms/avg    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          67.55 ± 3%   67.20 ± 6%       ~ (p=0.693 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          108.4 ± 3%   106.1 ± 3%       ~ (p=0.457 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       14.45 ± 4%   14.40 ± 5%       ~ (p=0.416 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           29.70 ± 5%   30.90 ± 5%       ~ (p=0.176 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        19.65 ± 1%   19.55 ± 3%       ~ (p=0.804 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             64.20 ± 3%   63.50 ± 4%       ~ (p=0.693 n=20)
geomean                                                                          39.78        39.74       -0.11%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p50             │   ms/p50    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          63.95 ± 5%   62.90 ± 7%       ~ (p=0.582 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          104.9 ± 4%   102.8 ± 2%       ~ (p=0.611 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       9.400 ± 6%   9.400 ± 6%       ~ (p=0.104 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           26.20 ± 4%   27.30 ± 8%       ~ (p=0.163 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        15.20 ± 3%   15.45 ± 6%       ~ (p=0.734 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             50.30 ± 4%   50.30 ± 4%       ~ (p=0.426 n=20)
geomean                                                                          32.88        32.99       +0.34%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p95             │   ms/p95    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          113.2 ± 4%   113.2 ± 4%       ~ (p=0.622 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          192.9 ± 4%   184.5 ± 9%       ~ (p=0.269 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       41.90 ± 5%   41.90 ± 5%       ~ (p=0.621 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           60.80 ± 3%   60.80 ± 3%       ~ (p=0.960 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        48.20 ± 4%   46.10 ± 5%       ~ (p=0.338 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             163.6 ± 3%   159.4 ± 5%       ~ (p=0.102 n=20)
geomean                                                                          87.17        85.51       -1.90%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt   │
                                                           │             ms/p99             │   ms/p99    vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                          146.8 ± 3%   142.6 ± 6%       ~ (p=0.683 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                          234.9 ± 4%   226.5 ± 7%       ~ (p=0.211 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                       65.00 ± 3%   62.90 ± 7%       ~ (p=0.220 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                           88.10 ± 5%   86.00 ± 2%       ~ (p=0.957 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                        71.30 ± 6%   71.30 ± 0%       ~ (p=0.449 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                             213.9 ± 2%   209.7 ± 4%       ~ (p=0.210 n=20)
geomean                                                                          120.2        117.4       -2.34%

                                                           │ artifacts/benchstat_before.txt │   artifacts/benchstat_after.txt    │
                                                           │             ms/max             │   ms/max     vs base               │
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/delivery                         255.8 ±  5%   285.2 ± 12%       ~ (p=0.090 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/neworder                         402.7 ±  8%   402.7 ±  8%       ~ (p=0.700 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/orderstatus                      172.0 ± 12%   176.2 ± 10%       ~ (p=0.501 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/payment                          230.7 ±  5%   222.3 ±  9%       ~ (p=0.421 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/stocklevel                       192.9 ±  9%   192.9 ±  9%       ~ (p=0.781 n=20)
TPCC/tpcc-nowait/literal/w=1000/nodes=5/cpu=16/total                            402.7 ±  8%   402.7 ±  8%       ~ (p=0.700 n=20)
geomean                                                                         261.2         265.4        +1.61%
```

Epic: none
Release note: none