### PR TITLE
build: remove reference to nonexistent `local-mixed-25.3` directory

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
@@ -81,7 +81,7 @@ if [ $exit_status = 0 ]; then
 fi
 
 # Generate a corpus for all mixed version variants
-for config in local-mixed-25.3 local-mixed-25.4; do
+for config in local-mixed-25.4; do
   $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
       //pkg/sql/logictest/tests/$config/... \
       --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed \


### PR DESCRIPTION
Closes #158741.

Release note: none
Epic: none