### PR TITLE
release-25.4: roachprod/roachtest: uniform storage capabilities

### DIFF
--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -136,8 +136,8 @@ func initCreateCmdFlags(createCmd *cobra.Command) {
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
-	createCmd.Flags().StringVar(&createVMOpts.SSDOpts.FileSystem,
-		"filesystem", vm.Ext4, "The underlying file system(ext4/zfs). ext4 is used by default.")
+	createCmd.Flags().StringVar((*string)(&createVMOpts.SSDOpts.FileSystem),
+		"filesystem", string(vm.Ext4), "The underlying file system(ext4/zfs/xfs/f2fs/btrfs). ext4 is used by default.")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
 		"local-ssd-no-ext4-barrier", true,
 		`Mount the local SSD with the "-o nobarrier" flag. Ignored if --local-ssd=false is specified.`)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1902,7 +1902,7 @@ func (c *clusterImpl) CreateSnapshot(
 func (c *clusterImpl) ApplySnapshots(ctx context.Context, snapshots []vm.VolumeSnapshot) error {
 	opts := vm.VolumeCreateOpts{
 		Size: c.spec.VolumeSize,
-		Type: c.spec.GCE.VolumeType, // TODO(irfansharif): This is only applicable to GCE. Change that.
+		Type: c.spec.VolumeType,
 		Labels: map[string]string{
 			vm.TagUsage: "roachtest",
 		},

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -516,10 +516,10 @@ var (
 		Usage: `Override use of local SSD`,
 	})
 
-	OverrideFilesystem string
+	OverrideFilesystem vm.Filesystem
 	_                  = registerRunFlag(&OverrideFilesystem, FlagInfo{
 		Name:  "filesystem",
-		Usage: `Override the underlying file system(ext4/zfs)`,
+		Usage: `Override the underlying file system(ext4/zfs/xfs/f2fs/btrfs)`,
 	})
 
 	OverrideNoExt4Barrier bool

--- a/pkg/cmd/roachtest/roachtestflags/manager.go
+++ b/pkg/cmd/roachtest/roachtestflags/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 )
@@ -74,6 +75,8 @@ func (m *manager) AddFlagsToCommand(cmd cmdID, cmdFlags *pflag.FlagSet) {
 			cmdFlags.StringToStringVarP(p, f.Name, f.Shorthand, *p, usage)
 		case *spec.Cloud:
 			cmdFlags.VarP(&cloudValue{val: p}, f.Name, f.Shorthand, usage)
+		case *vm.Filesystem:
+			cmdFlags.VarP(&filesystemValue{val: p}, f.Name, f.Shorthand, usage)
 		default:
 			panic(fmt.Sprintf("unsupported pointer type %T", p))
 		}
@@ -144,5 +147,28 @@ func (cv *cloudValue) Set(str string) error {
 		return errors.Errorf("invalid cloud %q", str)
 	}
 	*cv.val = val
+	return nil
+}
+
+type filesystemValue struct {
+	val *vm.Filesystem
+}
+
+var _ pflag.Value = (*filesystemValue)(nil)
+
+func (fv *filesystemValue) String() string {
+	return string(*fv.val)
+}
+
+func (fv *filesystemValue) Type() string {
+	return "string"
+}
+
+func (fv *filesystemValue) Set(str string) error {
+	val, err := vm.ParseFilesystemString(str)
+	if err != nil {
+		return err
+	}
+	*fv.val = val
 	return nil
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -25,13 +25,11 @@ import (
 type fileSystemType int
 
 const (
-	// Since ext4 is the default of 0, it isn't being
-	// used anywhere in the code. Therefore, it isn't
-	// added as a const here since it is unused, and
-	// leads to a lint error.
-
-	// Zfs file system.
-	Zfs fileSystemType = 1
+	Ext4 fileSystemType = iota
+	Zfs
+	Xfs
+	F2fs
+	Btrfs
 
 	// Extra labels added by roachtest
 	RoachtestBranch = "roachtest-branch"
@@ -204,6 +202,8 @@ type ClusterSpec struct {
 	SSDs                 int
 	RAID0                bool
 	VolumeSize           int
+	VolumeType           string
+	VolumeCount          int
 	LocalSSD             LocalSSDSetting
 	Geo                  bool
 	Lifetime             time.Duration
@@ -223,8 +223,6 @@ type ClusterSpec struct {
 	GCE struct {
 		MachineType    string
 		MinCPUPlatform string
-		VolumeType     string
-		VolumeCount    int // volume count is only supported for GCE. This can be moved up if we start supporting other clouds
 		Zones          string
 	} `cloud:"gce"`
 
@@ -241,13 +239,13 @@ type ClusterSpec struct {
 	// Azure-specific arguments. These values apply only on clusters instantiated on Azure.
 	Azure struct {
 		Zones string
+		// VolumeIOPS is the provisioned IOPS for ultra-disks.
+		VolumeIOPS int
 	} `cloud:"azure"`
 	// IBM-specific arguments. These values apply only on clusters instantiated on IBM.
 	IBM struct {
 		MachineType string
-		VolumeType  string
 		VolumeIOPS  int
-		VolumeCount int
 		Zones       string
 	} `cloud:"ibm"`
 }
@@ -317,11 +315,23 @@ func awsMachineSupportsSSD(machineType string) bool {
 }
 
 func getAWSOpts(
-	machineType string, volumeSize, ebsThroughput int, ebsIOPS int, localSSD bool, useSpotVMs bool,
+	machineType string,
+	volumeSize, volumeCount, ebsThroughput int,
+	volumeType string,
+	ebsIOPS int,
+	localSSD bool,
+	RAID0 bool,
+	useSpotVMs bool,
 ) vm.ProviderOpts {
 	opts := aws.DefaultProviderOpts()
 	if volumeSize != 0 {
 		opts.DefaultEBSVolume.Disk.VolumeSize = volumeSize
+	}
+	if volumeType != "" {
+		opts.DefaultEBSVolume.Disk.VolumeType = volumeType
+	}
+	if volumeCount != 0 {
+		opts.EBSVolumeCount = volumeCount
 	}
 	if ebsIOPS != 0 {
 		opts.DefaultEBSVolume.Disk.IOPs = ebsIOPS
@@ -334,6 +344,7 @@ func getAWSOpts(
 	} else {
 		opts.MachineType = machineType
 	}
+	opts.UseMultipleDisks = !RAID0
 	opts.UseSpot = useSpotVMs
 	return opts
 }
@@ -381,12 +392,29 @@ func getGCEOpts(
 	return opts
 }
 
-func getAzureOpts(machineType string, volumeSize int) vm.ProviderOpts {
+func getAzureOpts(
+	machineType string,
+	volumeSize int,
+	volumeType string,
+	volumeCount int,
+	volumeIOPS int,
+	RAID0 bool,
+) vm.ProviderOpts {
 	opts := azure.DefaultProviderOpts()
 	opts.MachineType = machineType
 	if volumeSize != 0 {
 		opts.NetworkDiskSize = int32(volumeSize)
 	}
+	if volumeType != "" {
+		opts.NetworkDiskType = volumeType
+	}
+	if volumeCount != 0 {
+		opts.NetworkDiskCount = volumeCount
+	}
+	if volumeIOPS != 0 {
+		opts.UltraDiskIOPS = int64(volumeIOPS)
+	}
+	opts.UseMultipleDisks = !RAID0
 	return opts
 }
 
@@ -396,7 +424,7 @@ func getIBMOpts(
 	volumeSize int,
 	volumeType string,
 	volumeIOPS int,
-	extraVolumeCount int,
+	volumeCount int,
 	RAID0 bool,
 ) vm.ProviderOpts {
 	opts := ibm.DefaultProviderOpts()
@@ -414,17 +442,10 @@ func getIBMOpts(
 	}
 
 	// We reuse the parameters of the default data volume for extra volumes.
-	opts.AttachedVolumes = make(ibm.IbmVolumeList, 0)
-	if extraVolumeCount > 0 {
-		for i := 0; i < extraVolumeCount; i++ {
-			opts.AttachedVolumes = append(opts.AttachedVolumes, &ibm.IbmVolume{
-				VolumeType: opts.DefaultVolume.VolumeType,
-				VolumeSize: opts.DefaultVolume.VolumeSize,
-				IOPS:       opts.DefaultVolume.IOPS,
-			})
-		}
-		opts.UseMultipleDisks = !RAID0
+	if volumeCount != 0 {
+		opts.AttachedVolumesCount = volumeCount
 	}
+	opts.UseMultipleDisks = !RAID0
 
 	return opts
 }
@@ -583,18 +604,25 @@ func (s *ClusterSpec) RoachprodOpts(
 		}
 	}
 
-	if s.FileSystem == Zfs {
-		if cloud != GCE && cloud != IBM {
-			return vm.CreateOpts{}, nil, nil, "", errors.Errorf(
-				"node creation with zfs file system not yet supported on %s", cloud,
-			)
+	switch s.FileSystem {
+	case Ext4:
+		// ext4 is the default, do nothing unless we randomly want to use zfs
+		if s.RandomlyUseZfs {
+			rng, _ := randutil.NewPseudoRand()
+			if rng.Float64() <= 0.2 {
+				createVMOpts.SSDOpts.FileSystem = vm.Zfs
+			}
 		}
+	case Zfs:
 		createVMOpts.SSDOpts.FileSystem = vm.Zfs
-	} else if s.RandomlyUseZfs && (cloud == GCE || cloud == IBM) {
-		rng, _ := randutil.NewPseudoRand()
-		if rng.Float64() <= 0.2 {
-			createVMOpts.SSDOpts.FileSystem = vm.Zfs
-		}
+	case Xfs:
+		createVMOpts.SSDOpts.FileSystem = vm.Xfs
+	case F2fs:
+		createVMOpts.SSDOpts.FileSystem = vm.F2fs
+	case Btrfs:
+		createVMOpts.SSDOpts.FileSystem = vm.Btrfs
+	default:
+		return vm.CreateOpts{}, nil, nil, "", errors.Errorf("unknown file system type: %v", s.FileSystem)
 	}
 
 	var workloadMachineType string
@@ -622,28 +650,34 @@ func (s *ClusterSpec) RoachprodOpts(
 	var workloadProviderOpts vm.ProviderOpts
 	switch cloud {
 	case AWS:
-		providerOpts = getAWSOpts(machineType, s.VolumeSize, s.AWS.VolumeThroughput, s.AWS.VolumeIOPS,
-			createVMOpts.SSDOpts.UseLocalSSD, s.UseSpotVMs)
-		workloadProviderOpts = getAWSOpts(workloadMachineType, s.VolumeSize, s.AWS.VolumeThroughput,
-			s.AWS.VolumeIOPS, createVMOpts.SSDOpts.UseLocalSSD, s.UseSpotVMs)
+		providerOpts = getAWSOpts(machineType, s.VolumeSize, s.VolumeCount, s.AWS.VolumeThroughput, s.VolumeType, s.AWS.VolumeIOPS,
+			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.UseSpotVMs)
+		workloadProviderOpts = getAWSOpts(workloadMachineType, s.VolumeSize, s.VolumeCount, s.AWS.VolumeThroughput, s.VolumeType, s.AWS.VolumeIOPS,
+			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.UseSpotVMs)
 	case GCE:
 		providerOpts = getGCEOpts(machineType, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.GCE.VolumeCount, s.UseSpotVMs,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.VolumeType,
+			s.VolumeCount, s.UseSpotVMs,
 		)
 		workloadProviderOpts = getGCEOpts(workloadMachineType, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.GCE.VolumeCount, s.UseSpotVMs,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.VolumeType,
+			s.VolumeCount, s.UseSpotVMs,
 		)
 	case Azure:
-		providerOpts = getAzureOpts(machineType, s.VolumeSize)
-		workloadProviderOpts = getAzureOpts(workloadMachineType, s.VolumeSize)
-	case IBM:
-		providerOpts = getIBMOpts(machineType, s.TerminateOnMigration, s.VolumeSize,
-			s.IBM.VolumeType, s.IBM.VolumeIOPS, s.IBM.VolumeCount, s.RAID0,
+		providerOpts = getAzureOpts(machineType,
+			s.VolumeSize, s.VolumeType, s.VolumeCount, s.Azure.VolumeIOPS, s.RAID0,
 		)
-		workloadProviderOpts = getIBMOpts(workloadMachineType, s.TerminateOnMigration, s.VolumeSize,
-			s.IBM.VolumeType, s.IBM.VolumeIOPS, s.IBM.VolumeCount, s.RAID0,
+		workloadProviderOpts = getAzureOpts(workloadMachineType,
+			s.VolumeSize, s.VolumeType, s.VolumeCount, s.Azure.VolumeIOPS, s.RAID0,
+		)
+	case IBM:
+		providerOpts = getIBMOpts(machineType, s.TerminateOnMigration,
+			s.VolumeSize, s.VolumeType, s.IBM.VolumeIOPS, s.VolumeCount, s.RAID0,
+		)
+		workloadProviderOpts = getIBMOpts(workloadMachineType, s.TerminateOnMigration,
+			s.VolumeSize, s.VolumeType, s.IBM.VolumeIOPS, s.VolumeCount, s.RAID0,
 		)
 	}
 

--- a/pkg/cmd/roachtest/spec/cluster_spec_test.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec_test.go
@@ -25,15 +25,22 @@ func TestClustersCompatible(t *testing.T) {
 	t.Run("spec has different GCE spec with cloud as GCE", func(t *testing.T) {
 		s1 := ClusterSpec{NodeCount: 5}
 		s2 := ClusterSpec{NodeCount: 5}
-		s1.GCE.VolumeType = "mock_volume1"
-		s2.GCE.VolumeType = "mock_volume2"
+		s1.VolumeType = "mock_volume1"
+		s2.VolumeType = "mock_volume2"
 		require.False(t, ClustersCompatible(s1, s2, GCE))
 	})
 	t.Run("spec has different GCE spec with cloud as AWS", func(t *testing.T) {
 		s1 := ClusterSpec{NodeCount: 5}
 		s2 := ClusterSpec{NodeCount: 5}
-		s1.GCE.VolumeType = "mock_volume1"
-		s2.GCE.VolumeType = "mock_volume2"
+		s1.VolumeType = "mock_volume1"
+		s2.VolumeType = "mock_volume2"
+		require.False(t, ClustersCompatible(s1, s2, AWS))
+	})
+	t.Run("spec has different spec with cloud as AWS", func(t *testing.T) {
+		s1 := ClusterSpec{NodeCount: 5}
+		s2 := ClusterSpec{NodeCount: 5}
+		s1.GCE.MinCPUPlatform = "mock_platform1"
+		s2.GCE.MinCPUPlatform = "mock_platform2"
 		require.True(t, ClustersCompatible(s1, s2, AWS))
 	})
 }

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -67,6 +67,20 @@ func VolumeSize(n int) Option {
 	}
 }
 
+// VolumeType sets the volume type.
+func VolumeType(volumeType string) Option {
+	return func(spec *ClusterSpec) {
+		spec.VolumeType = volumeType
+	}
+}
+
+// VolumeCount sets the volume count.
+func VolumeCount(volumeCount int) Option {
+	return func(spec *ClusterSpec) {
+		spec.VolumeCount = volumeCount
+	}
+}
+
 // SSD is a node option which requests nodes with the specified number of SSDs.
 func SSD(n int) Option {
 	return func(spec *ClusterSpec) {
@@ -238,20 +252,6 @@ func GCEMinCPUPlatform(platform string) Option {
 	}
 }
 
-// GCEVolumeType sets the volume type when the cluster is on GCE.
-func GCEVolumeType(volumeType string) Option {
-	return func(spec *ClusterSpec) {
-		spec.GCE.VolumeType = volumeType
-	}
-}
-
-// GCEVolumeCount sets the volume count when the cluster is on GCE.
-func GCEVolumeCount(volumeCount int) Option {
-	return func(spec *ClusterSpec) {
-		spec.GCE.VolumeCount = volumeCount
-	}
-}
-
 // GCEZones is a node option which requests Geo-distributed nodes; only applies
 // when the test runs on GCE.
 //
@@ -312,6 +312,14 @@ func AzureZones(zones string) Option {
 	}
 }
 
+// AzureVolumeIOPS sets the provisioned IOPS for ultra-disk volumes
+// when the cluster is on Azure.
+func AzureVolumeIOPS(iops int) Option {
+	return func(spec *ClusterSpec) {
+		spec.Azure.VolumeIOPS = iops
+	}
+}
+
 // IBMMachineType sets the machine (instance) type when the cluster is on IBM.
 func IBMMachineType(machineType string) Option {
 	return func(spec *ClusterSpec) {
@@ -319,24 +327,10 @@ func IBMMachineType(machineType string) Option {
 	}
 }
 
-// IBMVolumeType sets the volume type when the cluster is on IBM.
-func IBMVolumeType(volumeType string) Option {
-	return func(spec *ClusterSpec) {
-		spec.IBM.VolumeType = volumeType
-	}
-}
-
 // IBMVolumeIOPS sets the IOPS when the cluster is on IBM.
 func IBMVolumeIOPS(iops int) Option {
 	return func(spec *ClusterSpec) {
 		spec.IBM.VolumeIOPS = iops
-	}
-}
-
-// IBMVolumeCount sets the volume count when the cluster is on IBM.
-func IBMVolumeCount(count int) Option {
-	return func(spec *ClusterSpec) {
-		spec.IBM.VolumeCount = count
 	}
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2419,7 +2419,7 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 	// These params can be probabilistically set, so we pass them here to
 	// show what their actual values are in the posted issue.
 	if createOpts != nil {
-		clusterParams["fs"] = createOpts.SSDOpts.FileSystem
+		clusterParams["fs"] = string(createOpts.SSDOpts.FileSystem)
 		clusterParams["localSSD"] = fmt.Sprintf("%v", createOpts.SSDOpts.UseLocalSSD)
 	}
 

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -35,7 +35,7 @@ func registerDatabaseDrop(r registry.Registry) {
 		// node falls below 5% available capacity. 800GiB (7.2TiB) ought to be more
 		// than enough.
 		spec.VolumeSize(800),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
 	)

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -31,7 +31,7 @@ func registerIndexBackfill(r registry.Registry) {
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(500),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),
 	)

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_index_backfill.go
@@ -38,9 +38,9 @@ func registerMultiStoreIndexBackfill(r registry.Registry) {
 			spec.CPU(16),
 			spec.WorkloadNode(),
 			spec.WorkloadNodeCPU(16),
-			spec.GCEVolumeType("pd-ssd"),
+			spec.VolumeType("pd-ssd"),
 			spec.VolumeSize(200),
-			spec.GCEVolumeCount(4),
+			spec.VolumeCount(4),
 		),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule),

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -436,8 +436,8 @@ func registerDiskStalledWALFailoverWithProgress(r registry.Registry) {
 			spec.WorkloadNode(),
 			spec.ReuseNone(),
 			spec.DisableLocalSSD(),
-			spec.GCEVolumeCount(2),
-			spec.GCEVolumeType("pd-ssd"),
+			spec.VolumeCount(2),
+			spec.VolumeType("pd-ssd"),
 			spec.VolumeSize(100),
 			// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 			spec.Arch(spec.AllExceptFIPS),

--- a/pkg/cmd/roachtest/tests/invariant_check_detection.go
+++ b/pkg/cmd/roachtest/tests/invariant_check_detection.go
@@ -30,7 +30,7 @@ func registerInvariantCheckDetection(r registry.Registry) {
 			Name:             fmt.Sprintf("invariant-check-detection/failed=%t", failed),
 			Owner:            registry.OwnerTestEng,
 			Suites:           registry.ManualOnly,
-			Cluster:          r.MakeClusterSpec(1, spec.CPU(4), spec.ReuseNone(), spec.VolumeSize(100), spec.GCEVolumeType("pd-ssd")),
+			Cluster:          r.MakeClusterSpec(1, spec.CPU(4), spec.ReuseNone(), spec.VolumeSize(100), spec.VolumeType("pd-ssd")),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runInvariantCheckDetection(ctx, t, c, failed)
 			},

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -42,7 +42,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(800),
-		spec.GCEVolumeType("pd-ssd"),
+		spec.VolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 	}
 	testTimeout := 19 * time.Hour

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1032,14 +1032,20 @@ func Reformat(ctx context.Context, l *logger.Logger, clusterName string, fs stri
 	}
 
 	var fsCmd string
-	switch fs {
+	switch vm.Filesystem(fs) {
 	case vm.Zfs:
-		if err := install.Install(ctx, l, c, []string{vm.Zfs}); err != nil {
+		if err := install.Install(ctx, l, c, []string{string(vm.Zfs)}); err != nil {
 			return err
 		}
 		fsCmd = `sudo zpool create -f data1 -m /mnt/data1 /dev/sdb`
 	case vm.Ext4:
 		fsCmd = `sudo mkfs.ext4 -F /dev/sdb && sudo mount -o defaults /dev/sdb /mnt/data1`
+	case vm.Xfs:
+		fsCmd = `sudo mkfs.xfs -f /dev/sdb && sudo mount -o defaults /dev/sdb /mnt/data1`
+	case vm.F2fs:
+		fsCmd = `sudo mkfs.f2fs -f /dev/sdb && sudo mount -o defaults /dev/sdb /mnt/data1`
+	case vm.Btrfs:
+		fsCmd = `sudo mkfs.btrfs -f /dev/sdb && sudo mount -o defaults /dev/sdb /mnt/data1`
 	default:
 		return fmt.Errorf("unknown filesystem %q", fs)
 	}
@@ -1743,13 +1749,21 @@ func Create(
 	}
 
 	for _, o := range opts {
-		if o.CreateOpts.SSDOpts.FileSystem == vm.Zfs {
+		// Validate Filesystem option + check compatibility with providers.
+
+		fs, err := vm.ParseFileSystemOption(o.CreateOpts.SSDOpts.FileSystem)
+		if err != nil {
+			return err
+		}
+
+		if fs == vm.F2fs {
 			for _, provider := range o.CreateOpts.VMProviders {
-				// TODO(DarrylWong): support zfs on other providers, see: #123775.
-				// Once done, revisit all tests that set zfs to see if they can run on non GCE.
-				if !(provider == gce.ProviderName || provider == aws.ProviderName || provider == ibm.ProviderName) {
+				// TODO(golgeek): f2fs requires kernel 6+, which isn't available
+				// on IBM Cloud for Ubuntu 22.04 as of now. Remove this check when
+				// support is added.
+				if provider == ibm.ProviderName {
 					return fmt.Errorf(
-						"creating a node with --filesystem=zfs is currently not supported in %q", provider,
+						"creating a node with --filesystem=f2fs is currently not supported in %q", provider,
 					)
 				}
 			}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -141,7 +141,7 @@ type ebsDisk struct {
 // ebsVolume represents a mounted volume: name + ebsDisk
 type ebsVolume struct {
 	DeviceName string  `json:"DeviceName"`
-	Disk       ebsDisk `json:"Ebs"`
+	Disk       ebsDisk `json:"Ebs,omitempty"`
 }
 
 const ebsDefaultVolumeSizeGB = 500
@@ -239,6 +239,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		SSDMachineType:   defaultSSDMachineType,
 		RemoteUserName:   "ubuntu",
 		DefaultEBSVolume: defaultEBSVolumeValue,
+		EBSVolumeCount:   1,
 		CreateRateLimit:  2,
 		IAMProfile:       "roachprod-testing",
 	}
@@ -258,6 +259,10 @@ type ProviderOpts struct {
 	DefaultEBSVolume ebsVolume
 	EBSVolumes       ebsVolumeList
 	UseMultipleDisks bool
+
+	// EBSVolumeCount is the number of additional EBS volumes to attach.
+	// Only used if local-ssd=false, and is superseded by EBSVolumes.
+	EBSVolumeCount int
 
 	// IAMProfile designates the name of the instance profile to use for created
 	// EC2 instances if non-empty.
@@ -517,6 +522,9 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		o.DefaultEBSVolume.Disk.IOPs, "Number of IOPs to provision for supported disk types (io1, io2, gp3)")
 	flags.IntVar(&o.DefaultEBSVolume.Disk.Throughput, ProviderName+"-ebs-throughput",
 		o.DefaultEBSVolume.Disk.Throughput, "Additional throughput to provision, in MiB/s")
+
+	flags.IntVar(&o.EBSVolumeCount, ProviderName+"-ebs-volume-count", 1,
+		"Number of EBS volumes to create, only used if local-ssd=false and superseded by --aws-ebs-volume")
 
 	flags.VarP(&o.EBSVolumes, ProviderName+"-ebs-volume", "",
 		`Additional EBS disk to attached, repeated for extra disks; specified as JSON: {"VolumeType":"io2","VolumeSize":213,"Iops":321}`)
@@ -1604,21 +1612,6 @@ func genDeviceMapping(ebsVolumes ebsVolumeList, args []string) ([]string, error)
 func assignEBSVolumes(opts *vm.CreateOpts, providerOpts *ProviderOpts) ebsVolumeList {
 	// Make a local copy of providerOpts.EBSVolumes to prevent data races
 	ebsVolumes := providerOpts.EBSVolumes
-	// The local NVMe devices are automatically mapped.  Otherwise, we need to map an EBS data volume.
-	if !opts.SSDOpts.UseLocalSSD {
-		if len(ebsVolumes) == 0 && providerOpts.DefaultEBSVolume.Disk.VolumeType == "" {
-			providerOpts.DefaultEBSVolume.Disk.VolumeType = defaultEBSVolumeType
-			providerOpts.DefaultEBSVolume.Disk.DeleteOnTermination = true
-		}
-
-		if providerOpts.DefaultEBSVolume.Disk.VolumeType != "" {
-			// Add default volume to the list of volumes we'll setup.
-			v := ebsVolumes.newVolume()
-			v.Disk = providerOpts.DefaultEBSVolume.Disk
-			v.Disk.DeleteOnTermination = true
-			ebsVolumes = append(ebsVolumes, v)
-		}
-	}
 
 	osDiskVolume := &ebsVolume{
 		DeviceName: "/dev/sda1",
@@ -1628,7 +1621,29 @@ func assignEBSVolumes(opts *vm.CreateOpts, providerOpts *ProviderOpts) ebsVolume
 			DeleteOnTermination: true,
 		},
 	}
-	return append(ebsVolumes, osDiskVolume)
+
+	// If local SSD or boot disk only is requested, return that immediately.
+	// Local SSDs cannot be configured and will be automatically mapped by AWS
+	// depending on the instance type.
+	if opts.SSDOpts.UseLocalSSD {
+		return ebsVolumeList{osDiskVolume}
+	}
+
+	// aws-ebs-volume supersedes other volume settings, if none are provided,
+	// we build a list based on count and provided settings.
+	if len(ebsVolumes) == 0 {
+		for range providerOpts.EBSVolumeCount {
+			v := ebsVolumes.newVolume()
+			v.Disk = providerOpts.DefaultEBSVolume.Disk
+			v.Disk.DeleteOnTermination = true
+			ebsVolumes = append(ebsVolumes, v)
+		}
+	}
+
+	// Add the OS disk to the list of volumes to be created.
+	ebsVolumes = append(ebsVolumes, osDiskVolume)
+
+	return ebsVolumes
 }
 
 // Active is part of the vm.Provider interface.

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -29,39 +29,28 @@ import (
 const awsStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
-function setup_disks() {
-{{ if not .Zfs }}
-	mount_opts="defaults,nofail"
-	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
-{{ end }}
+{{ template "head_utils" . }}
+{{ template "apt_packages" . }}
 
-	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both EC2 NVMe Instance Storage and
-	# EBS, RAID'ing in this case can cause performance differences. So, to avoid this,
-	# EC2 NVMe Instance Storage are ignored.
+# Provider specific disk logic
+function detect_disks() {
+	# AWS-specific disk detection - returns list of available disks
+	# If both EC2 NVMe Instance Storage and EBS exist, prioritize EBS volumes to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
 	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
 	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
 	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
-	# Keep track of the Local SSDs and EBS volumes for RAID'ing
-	local_disks=()
-	ebs_volumes=()
-
-{{ if .Zfs }}
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-{{ end }}
+	local local_disks=()
+	local ebs_volumes=()
+	local disks=()
 
 	# On different machine types, the drives are either called nvme... or xvdd.
 	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
 		mounted="no"
-{{ if .Zfs }}
+{{ if eq .Filesystem "zfs" }}
 		# Check if the disk is already part of a zpool or mounted; skip if so.
 		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
 			mounted="yes"
@@ -78,79 +67,29 @@ function setup_disks() {
 			else
 				local_disks+=("${d}")
 			fi
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
 
 	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
-	disks=()
 	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
-	echo "Using only EBS disks: ${ebs_volumes[@]}"
+		echo "Using only EBS disks: ${ebs_volumes[@]}" >&2
 		disks=("${ebs_volumes[@]}")
 	else
-		echo "Using only local disks: ${local_disks[@]}"
+		echo "Using only local disks: ${local_disks[@]}" >&2
 		disks=("${local_disks[@]}")
 	fi
 
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-{{ if .Zfs }}
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-			mkfs.ext4 -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			tune2fs -m 0 ${disk}
-{{ end }}
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-{{ if .Zfs }}
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-		raiddisk="/dev/md0"
-		mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		tune2fs -m 0 ${raiddisk}
-{{ end }}
-		chmod 777 ${mountpoint}
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
 	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-{{ if .Zfs }}
-	zpool list
-{{ end }}
-
-	sudo touch {{ .DisksInitializedFile }}
 }
 
-{{ template "head_utils" . }}
-{{ template "apt_packages" . }}
-
-# Initialize disks.
-setup_disks
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 {{ template "ulimits" . }}
 {{ template "tcpdump" . }}
@@ -177,27 +116,28 @@ sudo touch {{ .OSInitializedFile }}
 func writeStartupScript(
 	name string,
 	extraMountOpts string,
-	fileSystem string,
+	fileSystem vm.Filesystem,
 	useMultiple bool,
 	enableFips bool,
 	remoteUser string,
 ) (string, error) {
+
+	// We define a local type in case we need to add more provider-specific params in
+	// the future.
 	type tmplParams struct {
 		vm.StartupArgs
-		ExtraMountOpts   string
-		UseMultipleDisks bool
 	}
 
 	args := tmplParams{
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithVMName(name),
 			vm.WithSharedUser(remoteUser),
-			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithFilesystem(fileSystem),
+			vm.WithExtraMountOpts(extraMountOpts),
+			vm.WithUseMultipleDisks(useMultiple),
 			vm.WithEnableFIPS(enableFips),
 			vm.WithChronyServers([]string{"169.254.169.123"}),
 		),
-		ExtraMountOpts:   extraMountOpts,
-		UseMultipleDisks: useMultiple,
 	}
 
 	tmpfile, err := os.CreateTemp("", "aws-startup-script")

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -4,103 +4,6 @@ echo
 #!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
-function setup_disks() {
-
-
-	use_multiple_disks=''
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both EC2 NVMe Instance Storage and
-	# EBS, RAID'ing in this case can cause performance differences. So, to avoid this,
-	# EC2 NVMe Instance Storage are ignored.
-	# Scenarios:
-	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
-	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
-	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
-	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
-	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
-	# Keep track of the Local SSDs and EBS volumes for RAID'ing
-	local_disks=()
-	ebs_volumes=()
-
-
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-
-
-	# On different machine types, the drives are either called nvme... or xvdd.
-	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
-		mounted="no"
-
-		# Check if the disk is already part of a zpool or mounted; skip if so.
-		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
-			mounted="yes"
-		fi
-
-		if [ "$mounted" == "no" ]; then
-			if udevadm info --query=property --name=${d} | grep "ID_MODEL=Amazon Elastic Block Store">/dev/null; then
-				ebs_volumes+=("${d}")
-			else
-				local_disks+=("${d}")
-			fi
-			echo "Disk ${d} not mounted, need to mount..."
-		else
-			echo "Disk ${d} already mounted, skipping..."
-		fi
-	done
-
-	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
-	disks=()
-	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
-	echo "Using only EBS disks: ${ebs_volumes[@]}"
-		disks=("${ebs_volumes[@]}")
-	else
-		echo "Using only local disks: ${local_disks[@]}"
-		disks=("${local_disks[@]}")
-	fi
-
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-		chmod 777 ${mountpoint}
-	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-
-	zpool list
-
-
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -112,6 +15,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -132,9 +37,198 @@ fi
 sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
+apt-get install -yq zfsutils-linux
 
-# Initialize disks.
-setup_disks
+
+
+# Provider specific disk logic
+function detect_disks() {
+	# AWS-specific disk detection - returns list of available disks
+	# If both EC2 NVMe Instance Storage and EBS exist, prioritize EBS volumes to avoid
+	# performance differences when RAID'ing mixed disk types.
+	# Scenarios:
+	#   (local SSD = 0, Network Disk - 1)  - no RAID'ing and mount network disk
+	#   (local SSD = 1, Network Disk - 0)  - no RAID'ing and mount local SSD
+	#   (local SSD >= 1, Network Disk = 1) - no RAID'ing and mount network disk
+	#   (local SSD > 1, Network Disk = 0)  - local SSDs selected for RAID'ing
+	#   (local SSD >= 0, Network Disk > 1) - network disks selected for RAID'ing
+	local local_disks=()
+	local ebs_volumes=()
+	local disks=()
+
+	# On different machine types, the drives are either called nvme... or xvdd.
+	for d in $(ls /dev/nvme?n1 /dev/xvdd); do
+		mounted="no"
+
+		# Check if the disk is already part of a zpool or mounted; skip if so.
+		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			if udevadm info --query=property --name=${d} | grep "ID_MODEL=Amazon Elastic Block Store">/dev/null; then
+				ebs_volumes+=("${d}")
+			else
+				local_disks+=("${d}")
+			fi
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# use only EBS volumes if available and ignore EC2 NVMe Instance Storage
+	if [ "${#ebs_volumes[@]}" -gt "0" ]; then
+		echo "Using only EBS disks: ${ebs_volumes[@]}" >&2
+		disks=("${ebs_volumes[@]}")
+	else
+		echo "Using only local disks: ${local_disks[@]}" >&2
+		disks=("${local_disks[@]}")
+	fi
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.zfs -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.zfs -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem='zfs'
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 
 
@@ -225,6 +319,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -288,16 +384,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":9100" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9100 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9100 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":9100" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -309,18 +437,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":9435" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9435 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9435 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":9435" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -917,19 +917,11 @@ func (p *Provider) createVM(
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithVMName(name),
 			vm.WithSharedUser(remoteUser),
+			vm.WithFilesystem(opts.SSDOpts.FileSystem),
+			vm.WithUseMultipleDisks(providerOpts.UseMultipleDisks),
 		),
-		DiskControllerNVMe: false,
-		AttachedDiskLun:    nil,
 	}
 	useNVMe := MachineSupportsNVMe(providerOpts.MachineType)
-	if useNVMe {
-		startupArgs.DiskControllerNVMe = true
-	}
-	if !opts.SSDOpts.UseLocalSSD && !useNVMe {
-		// We define lun42 explicitly in the data disk request below.
-		lun := 42
-		startupArgs.AttachedDiskLun = &lun
-	}
 
 	startupScript, err := evalStartupTemplate(startupArgs)
 	if err != nil {
@@ -1059,8 +1051,8 @@ func (p *Provider) createVM(
 	}
 
 	if !opts.SSDOpts.UseLocalSSD {
-		caching := compute.CachingTypesNone
 
+		caching := compute.CachingTypesNone
 		switch providerOpts.DiskCaching {
 		case "read-only":
 			caching = compute.CachingTypesReadOnly
@@ -1072,46 +1064,66 @@ func (p *Provider) createVM(
 			err = errors.Newf("unsupported caching behavior: %s", providerOpts.DiskCaching)
 			return compute.VirtualMachine{}, err
 		}
-		dataDisks := []compute.DataDisk{
-			{
-				DiskSizeGB: to.Int32Ptr(providerOpts.NetworkDiskSize),
-				Caching:    caching,
-				Lun:        to.Int32Ptr(42),
-			},
-		}
+		// Create multiple data disks with sequential LUNs starting after any
+		// reserved LUNs (e.g. the resource disk on 'd' sizes).
+		dataDisks := make([]compute.DataDisk, providerOpts.NetworkDiskCount)
+		for i := range providerOpts.NetworkDiskCount {
+			disk := compute.DataDisk{
+				CreateOption: compute.DiskCreateOptionTypesEmpty,
+				DiskSizeGB:   to.Int32Ptr(providerOpts.NetworkDiskSize),
+				Caching:      caching,
+				// LUNs start at 0, but we reserve LUN 0 for the potential resource disk
+				// that is automatically created on machine types with 'd' flag.
+				Lun: to.Int32Ptr(int32(i) + 1),
+			}
 
-		switch providerOpts.NetworkDiskType {
-		case "ultra-disk":
-			var ultraDisk compute.Disk
-			ultraDisk, err = p.createUltraDisk(l, ctx, group, name+"-ultra-disk", zone, providerOpts)
-			if err != nil {
+			switch providerOpts.NetworkDiskType {
+			case "ultra-disk":
+				// Create multiple ultra disks
+				var ultraDisk compute.Disk
+				ultraDisk, err = p.createUltraDisk(l, ctx, group, fmt.Sprintf("%s-ultra-disk-%d", name, i), zone, providerOpts)
+				if err != nil {
+					return compute.VirtualMachine{}, err
+				}
+
+				// UltraSSD specific disk configurations.
+				disk.CreateOption = compute.DiskCreateOptionTypesAttach
+				disk.Name = ultraDisk.Name
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesUltraSSDLRS,
+					ID:                 ultraDisk.ID,
+				}
+
+				// UltraSSDs must be enabled separately.
+				machine.AdditionalCapabilities = &compute.AdditionalCapabilities{
+					UltraSSDEnabled: to.BoolPtr(true),
+				}
+			case "standard-ssd":
+				// standard-ssd specific disk configurations.
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesStandardLRS,
+				}
+			case "premium-disk", "premium-ssd":
+				// premium-ssd-lrs specific disk configurations.
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesPremiumLRS,
+				}
+			case "premium-ssd-v2":
+				// premium-ssd-v2-lrs specific disk configurations.
+				disk.ManagedDisk = &compute.ManagedDiskParameters{
+					StorageAccountType: compute.StorageAccountTypesPremiumV2LRS,
+				}
+			default:
+				err = errors.Newf("unsupported network disk type: %s", providerOpts.NetworkDiskType)
 				return compute.VirtualMachine{}, err
 			}
-			// UltraSSD specific disk configurations.
-			dataDisks[0].CreateOption = compute.DiskCreateOptionTypesAttach
-			dataDisks[0].Name = ultraDisk.Name
-			dataDisks[0].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: compute.StorageAccountTypesUltraSSDLRS,
-				ID:                 ultraDisk.ID,
-			}
 
-			// UltraSSDs must be enabled separately.
-			machine.AdditionalCapabilities = &compute.AdditionalCapabilities{
-				UltraSSDEnabled: to.BoolPtr(true),
-			}
-		case "premium-disk":
-			// premium-disk specific disk configurations.
-			dataDisks[0].CreateOption = compute.DiskCreateOptionTypesEmpty
-			dataDisks[0].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: compute.StorageAccountTypesPremiumV2LRS,
-			}
-		default:
-			err = errors.Newf("unsupported network disk type: %s", providerOpts.NetworkDiskType)
-			return compute.VirtualMachine{}, err
+			dataDisks[i] = disk
+
 		}
-
 		machine.StorageProfile.DataDisks = &dataDisks
 	}
+
 	future, err := client.CreateOrUpdate(ctx, *group.Name, name, machine)
 	if err != nil {
 		return

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -19,13 +19,15 @@ type ProviderOpts struct {
 	// N.B. Azure splits up the region (location) and availability zone, but
 	// to keep things consistent with other providers, we treat zone to mean
 	// both and split it up later.
-	Zones           []string
-	MachineType     string
-	VnetName        string
-	NetworkDiskType string
-	NetworkDiskSize int32
-	UltraDiskIOPS   int64
-	DiskCaching     string
+	Zones            []string
+	MachineType      string
+	VnetName         string
+	NetworkDiskType  string
+	NetworkDiskSize  int32
+	NetworkDiskCount int
+	UltraDiskIOPS    int64
+	DiskCaching      string
+	UseMultipleDisks bool
 }
 
 // These default locations support availability zones. At the time of
@@ -40,13 +42,15 @@ var defaultZones = []string{
 // DefaultProviderOpts returns a new azure.ProviderOpts with default values set.
 func DefaultProviderOpts() *ProviderOpts {
 	return &ProviderOpts{
-		Zones:           nil,
-		MachineType:     string(armcompute.VirtualMachineSizeTypesStandardD4V3),
-		VnetName:        "common",
-		NetworkDiskType: "premium-disk",
-		NetworkDiskSize: 500,
-		UltraDiskIOPS:   5000,
-		DiskCaching:     "none",
+		Zones:            nil,
+		MachineType:      string(armcompute.VirtualMachineSizeTypesStandardD4V3),
+		VnetName:         "common",
+		NetworkDiskType:  "premium-ssd",
+		NetworkDiskSize:  500,
+		NetworkDiskCount: 1,
+		UltraDiskIOPS:    5000,
+		DiskCaching:      "none",
+		UseMultipleDisks: false,
 	}
 }
 
@@ -82,12 +86,17 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 			strings.Join(DefaultZones(true), ",")))
 	flags.StringVar(&o.VnetName, ProviderName+"-vnet-name", "common",
 		"The name of the VNet to use")
-	flags.StringVar(&o.NetworkDiskType, ProviderName+"-network-disk-type", "premium-disk",
-		"type of network disk [premium-disk, ultra-disk]. only used if local-ssd is false")
+	flags.StringVar(&o.NetworkDiskType, ProviderName+"-network-disk-type", "premium-ssd",
+		"type of network disk [standard-ssd, premium-ssd, premium-ssd-v2, ultra-disk]. only used if local-ssd is false")
 	flags.Int32Var(&o.NetworkDiskSize, ProviderName+"-volume-size", 500,
 		"Size in GB of network disk volume, only used if local-ssd=false")
+	flags.IntVar(&o.NetworkDiskCount, ProviderName+"-network-disk-count", 1,
+		"Number of network disks to attach, only used if local-ssd=false")
 	flags.Int64Var(&o.UltraDiskIOPS, ProviderName+"-ultra-disk-iops", 5000,
 		"Number of IOPS provisioned for ultra disk, only used if network-disk-type=ultra-disk")
 	flags.StringVar(&o.DiskCaching, ProviderName+"-disk-caching", "none",
 		"Disk caching behavior for attached storage.  Valid values are: none, read-only, read-write.  Not applicable to Ultra disks.")
+	flags.BoolVar(&o.UseMultipleDisks, ProviderName+"-enable-multiple-stores",
+		false, "Enable the use of multiple stores by creating one store directory per disk. "+
+			"Default is to raid0 stripe all disks or use ZFS (if --file-system=zfs).")
 }

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -5,34 +5,6 @@ echo
 
 # Script for setting up a Azure machine for roachprod use.
 
-function setup_disks() {
-	mount_opts="defaults"
-
-	devices=()
-
-
-	if (( ${#devices[@]} == 0 ));
-	then
-		# Use /mnt directly.
-		echo "No attached or NVME disks found, creating /mnt/data1"
-		mkdir -p /mnt/data1
-		chown ubuntu /mnt/data1
-		else
-		for d in "${!devices[@]}"; do
-			disk=${devices[$d]}
-			mount="/data$((d+1))"
-			sudo mkdir -p "${mount}"
-			sudo mkfs.ext4 -F "${disk}"
-			sudo mount -o "${mount_opts}" "${disk}" "${mount}"
-			echo "${disk} ${mount} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
-			ln -s "${mount}" "/mnt/$(basename $mount)"
-			tune2fs -m 0 ${disk}
-		done
-		chown ubuntu /data*
-	fi
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -44,6 +16,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -65,8 +39,187 @@ sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
 
-# Initialize disks.
-setup_disks
+
+# Provider specific disk logic
+function detect_disks() {
+	# Azure-specific disk detection - returns list of available disks
+	local local_or_network=()
+	local disks=()
+
+	# First, try to find NVMe disks (excluding boot disk nvme0n1)
+	if [ "$(ls /dev/disk/by-id/nvme-* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
+		if [ "${#local_or_network[@]}" -gt "0" ]; then
+			echo "Using NVMe disks: ${local_or_network[@]}" >&2
+		fi
+	fi
+
+	# If no NVMe disks found, try SCSI attached storage
+	if [ "${#local_or_network[@]}" -eq "0" ] && [ "$(ls /dev/disk/azure/scsi1/lun* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(ls /dev/disk/azure/scsi1/lun*))
+		echo "Using SCSI disks: ${local_or_network[@]}" >&2
+	fi
+
+	for l in ${local_or_network[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+
+		# Skip already mounted disks.
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs. -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs. -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem=''
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 # Disable Hyper-V Time Synchronization device
 # See https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-on-microsoft-azure#step-3-synchronize-clocks
@@ -164,6 +317,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -227,16 +382,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -248,18 +435,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -16,58 +16,71 @@ import (
 )
 
 // Startup script used to find/format/mount all local or attached disks.
-// Each disk is mounted as /data<disknum>, and, in addition, a symlink
-// created from /mnt/data<disknum> to the mount point.
+// Each disk is mounted at /mnt/data<disknum>.
 // azureStartupArgs specifies template arguments for the setup template.
+// We define a local type in case we need to add more provider-specific params in
+// the future.
 type azureStartupArgs struct {
 	vm.StartupArgs
-	AttachedDiskLun    *int // Use attached disk, with specified LUN; Use local ssd if nil.
-	DiskControllerNVMe bool // Interface data disk via NVMe
 }
 
 const azureStartupTemplate = `#!/bin/bash
 
 # Script for setting up a Azure machine for roachprod use.
 
-function setup_disks() {
-	mount_opts="defaults"
-
-	devices=()
-{{if .DiskControllerNVMe}}
-	# Setup nvme network storage, need to remove nvme OS disk from the device list.
-	devices=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
-{{else if .AttachedDiskLun}}
-	# Setup network attached storage
-	devices=("/dev/disk/azure/scsi1/lun{{.AttachedDiskLun}}")
-{{end}}
-
-	if (( ${#devices[@]} == 0 ));
-	then
-		# Use /mnt directly.
-		echo "No attached or NVME disks found, creating /mnt/data1"
-		mkdir -p /mnt/data1
-		chown {{.SharedUser}} /mnt/data1
-		else
-		for d in "${!devices[@]}"; do
-			disk=${devices[$d]}
-			mount="/data$((d+1))"
-			sudo mkdir -p "${mount}"
-			sudo mkfs.ext4 -F "${disk}"
-			sudo mount -o "${mount_opts}" "${disk}" "${mount}"
-			echo "${disk} ${mount} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
-			ln -s "${mount}" "/mnt/$(basename $mount)"
-			tune2fs -m 0 ${disk}
-		done
-		chown {{.SharedUser}} /data*
-	fi
-	sudo touch {{ .DisksInitializedFile }}
-}
-
 {{ template "head_utils" . }}
 {{ template "apt_packages" . }}
 
-# Initialize disks.
-setup_disks
+# Provider specific disk logic
+function detect_disks() {
+	# Azure-specific disk detection - returns list of available disks
+	local local_or_network=()
+	local disks=()
+
+	# First, try to find NVMe disks (excluding boot disk nvme0n1)
+	if [ "$(ls /dev/disk/by-id/nvme-* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(realpath -qe /dev/disk/by-id/nvme-* | grep -v "nvme0n1" | sort -u))
+		if [ "${#local_or_network[@]}" -gt "0" ]; then
+			echo "Using NVMe disks: ${local_or_network[@]}" >&2
+		fi
+	fi
+
+	# If no NVMe disks found, try SCSI attached storage
+	if [ "${#local_or_network[@]}" -eq "0" ] && [ "$(ls /dev/disk/azure/scsi1/lun* 2>/dev/null | wc -l)" -gt "0" ]; then
+		local_or_network=($(ls /dev/disk/azure/scsi1/lun*))
+		echo "Using SCSI disks: ${local_or_network[@]}" >&2
+	fi
+
+	for l in ${local_or_network[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+{{ if eq .Filesystem "zfs" }}
+		# Check if the disk is already part of a zpool or mounted; skip if so.
+		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+			mounted="yes"
+		fi
+{{ else }}
+		# Skip already mounted disks.
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+{{ end }}
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 # Disable Hyper-V Time Synchronization device
 # See https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-on-microsoft-azure#step-3-synchronize-clocks

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -53,6 +53,10 @@ const (
 	MaxConcurrentHosts    = 100
 )
 
+var (
+	armMachineTypes = []string{"a4x", "c4a-", "n4a", "t2a-"}
+)
+
 type VolumeType string
 
 const (
@@ -1241,7 +1245,95 @@ func newLimitedErrorGroup() *errgroup.Group {
 
 // useArmAMI returns true if the machine type is an arm64 machine type.
 func (o *ProviderOpts) useArmAMI() bool {
-	return strings.HasPrefix(strings.ToLower(o.MachineType), "t2a-")
+	for _, armType := range armMachineTypes {
+		if strings.HasPrefix(strings.ToLower(o.MachineType), armType) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *ProviderOpts) machineTypeSupportsLocalSSD() bool {
+	machineType := strings.ToLower(o.MachineType)
+
+	// A2 support local SSDs.
+	if strings.HasPrefix(machineType, "a2") {
+		return true
+	}
+
+	// A3 support local SSDs.
+	if strings.HasPrefix(machineType, "a3") {
+		return true
+	}
+
+	// A4, A4X support local SSDs.
+	if strings.HasPrefix(machineType, "a4") {
+		return true
+	}
+
+	// C2, C2D support local SSDs.
+	if strings.HasPrefix(machineType, "c2") {
+		return true
+	}
+
+	// C3, C4D support local SSDs only with the -lssd suffix.
+	if strings.HasPrefix(machineType, "c3") && strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	// C4, C4A, C4D support local SSDs only with the -lssd suffix.
+	if strings.HasPrefix(machineType, "c4") && strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	// G2 support local SSDs.
+	if strings.HasPrefix(machineType, "g2") {
+		return true
+	}
+
+	// G4 support local SSDs.
+	if strings.HasPrefix(machineType, "g4") {
+		return true
+	}
+
+	// H4D support local SSDs with suffix -lssd.
+	if strings.HasPrefix(machineType, "h4d-") && strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	// M1 partially support local SSDs.
+	if strings.HasPrefix(machineType, "m1") {
+		return true
+	}
+
+	// M3 support local SSDs.
+	if strings.HasPrefix(machineType, "m3") {
+		return true
+	}
+
+	// N1 support local SSDs.
+	if strings.HasPrefix(machineType, "n1") {
+		return true
+	}
+
+	// N2, N2D support local SSDs
+	if strings.HasPrefix(machineType, "n2") {
+		return true
+	}
+
+	// Z3 support local SSDs with suffix -(standard|high)ssd.
+	if strings.HasPrefix(machineType, "z3") {
+		return true
+	}
+
+	// E2 do not support local SSDs.
+	// H3 do not support local SSDs.
+	// M2, M4 do not support local SSDs.
+	// N4, N4A, N4D do not support local SSDs.
+	// T2A, T2D don't support local SSDs.
+
+	// We return false by default until we manually allowlist new machine types.
+	return false
 }
 
 // ConfigureClusterCleanupFlags is part of ProviderOpts. This implementation is a no-op.
@@ -1399,18 +1491,18 @@ func (p *Provider) computeInstanceArgs(
 	imageProject := defaultImageProject
 
 	if opts.Arch == string(vm.ArchARM64) && !providerOpts.useArmAMI() {
-		return nil, cleanUpFn, errors.Errorf("Requested arch is arm64, but machine type is %s. Do specify a t2a VM", providerOpts.MachineType)
+		return nil, cleanUpFn, errors.Errorf("Requested arch is arm64, but machine type is %s. Do specify an ARM64 VM", providerOpts.MachineType)
 	}
 
 	if providerOpts.useArmAMI() && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
 		return nil, cleanUpFn, errors.Errorf("machine type %s is arm64, but requested arch is %s", providerOpts.MachineType, opts.Arch)
 	}
-	if providerOpts.useArmAMI() && opts.SSDOpts.UseLocalSSD {
-		return nil, cleanUpFn, errors.New("local SSDs are not supported with T2A instances, use --local-ssd=false")
+	if opts.SSDOpts.UseLocalSSD && !providerOpts.machineTypeSupportsLocalSSD() {
+		return nil, cleanUpFn, errors.Errorf("local SSDs are not supported with %s instance types, use --local-ssd=false", providerOpts.MachineType)
 	}
 	if providerOpts.useArmAMI() {
 		if providerOpts.MinCPUPlatform != "" {
-			l.Printf("WARNING: --gce-min-cpu-platform is ignored for T2A instances")
+			l.Printf("WARNING: --gce-min-cpu-platform is ignored for ARM64 instances")
 			providerOpts.MinCPUPlatform = ""
 		}
 		// TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
@@ -1469,8 +1561,25 @@ func (p *Provider) computeInstanceArgs(
 	extraMountOpts := ""
 	// Dynamic args.
 	if opts.SSDOpts.UseLocalSSD {
-		if counts, err := AllowedLocalSSDCount(providerOpts.MachineType); err != nil {
+
+		counts, err := AllowedLocalSSDCount(providerOpts.MachineType)
+		if err != nil {
 			return nil, cleanUpFn, err
+		}
+
+		// If only one count is allowed, the VM will be automatically
+		// configured with that count of local SSDs.
+		if len(counts) == 1 {
+			// If only one count is allowed, the VM will be automatically
+			// configured with that count of local SSDs.
+			// In case the user specified a different count, warn it will be overriden.
+			if providerOpts.SSDCount != counts[0] {
+				l.Printf(
+					"WARNING: %[1]q only supports %[2]d local SSDs. Setting --gce-local-ssd-count to %[2]d",
+					providerOpts.MachineType,
+					counts[0],
+				)
+			}
 		} else {
 			// Make sure the minimum number of local SSDs is met.
 			minCount := counts[0]
@@ -1478,10 +1587,11 @@ func (p *Provider) computeInstanceArgs(
 				l.Printf("WARNING: SSD count must be at least %d for %q. Setting --gce-local-ssd-count to %d", minCount, providerOpts.MachineType, minCount)
 				providerOpts.SSDCount = minCount
 			}
+			for i := 0; i < providerOpts.SSDCount; i++ {
+				args = append(args, "--local-ssd", "interface=NVME")
+			}
 		}
-		for i := 0; i < providerOpts.SSDCount; i++ {
-			args = append(args, "--local-ssd", "interface=NVME")
-		}
+
 		// Add `discard` for Local SSDs on NVMe, as is advised in:
 		// https://cloud.google.com/compute/docs/disks/add-local-ssd
 		extraMountOpts = "discard"
@@ -2439,56 +2549,323 @@ func (p *Provider) ListLoadBalancers(_ *logger.Logger, vms vm.List) ([]vm.Servic
 	return addresses, nil
 }
 
+// parseMachineType parses a GCE machine type string into its components.
+// Returns family, specialization, number of CPUs, memory in MB, SSD option, error.
+// For example:
+// - Input: "n2-standard-4" -> Output: ("n2", "standard", 4, 0, "", nil)
+// - Input: "n2-custom-8-16384" -> Output: ("n2", "custom", 8, 16384, "", nil)
+// - Input: "c4d-standard-384-metal" -> Output: ("c4d", "standard", 384, 0, "", nil)
+// - Input: "c4a-standard-8-lssd" -> Output: ("c4a", "standard", 8, 0, "lssd", nil)
+// - Input: "c4-standard-288-lssd-metal" -> Output: ("c4", "standard", 288, 0, "lssd", nil)
+// The SSD option corresponds to the newest nomenclature for machine types
+// with Titanium SSDs support.
+func parseMachineType(
+	machineType string,
+) (family string, specialization string, numCPUs int, memMb int, ssdOption string, err error) {
+	// E.g., n2-standard-4, n2-custom-8-16384, c4d-standard-384-metal, c4a-standard-8-lssd, c4-standard-288-lssd-metal.
+	machineTypes := regexp.MustCompile(`^([a-z]+\d+[a-z]*)-(standard|highcpu|highmem|highgpu|ultragpu|edgegpu|custom)-(\d+)(?:-(\d+))?(.*)$`)
+	matches := machineTypes.FindStringSubmatch(machineType)
+
+	// Regexp captures the following informations:
+	// - matches[1]: machine family (n1, n2, h4d, ...)
+	// - matches[2]: machine type (standard|highcpu|highmem|custom)
+	// - matches[3]: number of CPUs
+	// - matches[4]: memory size in MB (only for custom types)
+	// - matches[5]: optional suffixes (e.g., "-lssd-metal", "-metal", "-lssd")
+
+	if len(matches) >= 3 {
+		family = matches[1]
+		specialization = matches[2]
+		numCPUs, err = strconv.Atoi(matches[3])
+		if err != nil {
+			return "", "", 0, 0, "", err
+		}
+		if specialization == "custom" {
+			if len(matches) >= 4 && matches[4] != "" {
+				memMb, err = strconv.Atoi(matches[4])
+				if err != nil {
+					return "", "", 0, 0, "", err
+				}
+			} else {
+				return "", "", 0, 0, "", fmt.Errorf("custom machine type %q missing memory size", machineType)
+			}
+		}
+		if len(matches) >= 6 && matches[5] != "" {
+			// Parse the suffixes (e.g., "-lssd-metal" -> ["lssd", "metal"])
+			suffixes := matches[5]
+			// Split by dashes and check each part
+			for _, suffix := range strings.Split(suffixes, "-") {
+				if suffix == "" {
+					continue
+				}
+				// Only return SSD options, ignore other suffixes like "metal"
+				switch suffix {
+				case "highssd", "standardlssd", "lssd":
+					ssdOption = suffix
+				}
+			}
+		}
+	}
+	return family, specialization, numCPUs, memMb, ssdOption, nil
+}
+
 // Given a machine type, return the allowed number (> 0) of local SSDs, sorted in ascending order.
 // N.B. Only n1, n2, n2d and c2 instances are supported since we don't typically use other instance types.
 // Consult https://cloud.google.com/compute/docs/disks/#local_ssd_machine_type_restrictions for other types of instances.
 func AllowedLocalSSDCount(machineType string) ([]int, error) {
-	// E.g., n2-standard-4, n2-custom-8-16384.
-	machineTypes := regexp.MustCompile(`^([cn])(\d+)(?:d)?-[a-z]+-(\d+)(?:-\d+)?$`)
-	matches := machineTypes.FindStringSubmatch(machineType)
 
-	if len(matches) >= 3 {
-		family := matches[1] + matches[2]
-		numCpus, err := strconv.Atoi(matches[3])
-		if err != nil {
-			return nil, err
+	family, _, numCPU, _, ssdOption, err := parseMachineType(machineType)
+	if err != nil {
+		return nil, err
+	}
+
+	switch family {
+	case "c3":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
 		}
-		if family == "n1" {
-			return []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 24}, nil
+		switch numCPU {
+		case 4:
+			return []int{1}, nil
+		case 8:
+			return []int{2}, nil
+		case 22:
+			return []int{4}, nil
+		case 44:
+			return []int{8}, nil
+		case 88:
+			return []int{16}, nil
+		case 176:
+			return []int{32}, nil
 		}
-		switch family {
-		case "n2":
-			if numCpus <= 10 {
-				return []int{1, 2, 4, 8, 16, 24}, nil
+
+	case "c3d":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 8, 16:
+			return []int{1}, nil
+		case 30:
+			return []int{2}, nil
+		case 60:
+			return []int{4}, nil
+		case 90:
+			return []int{8}, nil
+		case 180:
+			return []int{16}, nil
+		case 360:
+			return []int{32}, nil
+		}
+
+	case "c4":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 4, 8:
+			return []int{1}, nil
+		case 16:
+			return []int{2}, nil
+		case 24:
+			return []int{4}, nil
+		case 32:
+			return []int{5}, nil
+		case 48:
+			return []int{8}, nil
+		case 96:
+			return []int{16}, nil
+		case 144:
+			return []int{24}, nil
+		case 192:
+			return []int{32}, nil
+		case 288:
+			return []int{48}, nil
+		}
+
+	case "c4a":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 4:
+			return []int{1}, nil
+		case 8:
+			return []int{2}, nil
+		case 16:
+			return []int{4}, nil
+		case 32:
+			return []int{6}, nil
+		case 48:
+			return []int{10}, nil
+		case 64:
+			return []int{14}, nil
+		case 72:
+			return []int{16}, nil
+		}
+
+	case "c4d":
+		if ssdOption != "lssd" {
+			return nil, fmt.Errorf("unsupported local SSD option %q for machine type %q", ssdOption, machineType)
+		}
+		switch numCPU {
+		case 8, 16:
+			return []int{1}, nil
+		case 32:
+			return []int{2}, nil
+		case 48:
+			return []int{4}, nil
+		case 64:
+			return []int{6}, nil
+		case 96:
+			return []int{8}, nil
+		case 192:
+			return []int{16}, nil
+		case 384:
+			return []int{32}, nil
+		}
+
+	case "h4d":
+		return []int{10}, nil
+
+	case "z3":
+		switch numCPU {
+		case 8, 14:
+			return []int{1}, nil
+		case 16:
+			return []int{2}, nil
+		case 22:
+			switch ssdOption {
+			case "standardlssd":
+				return []int{2}, nil
+			case "highlssd":
+				return []int{3}, nil
 			}
-			if numCpus <= 20 {
-				return []int{2, 4, 8, 16, 24}, nil
+		case 32:
+			return []int{4}, nil
+		case 44:
+			switch ssdOption {
+			case "standardlssd":
+				return []int{3}, nil
+			case "highlssd":
+				return []int{6}, nil
 			}
-			if numCpus <= 40 {
-				return []int{4, 8, 16, 24}, nil
+		case 88:
+			switch ssdOption {
+			case "standardlssd":
+				return []int{6}, nil
+			case "highlssd":
+				return []int{12}, nil
 			}
-			if numCpus <= 80 {
-				return []int{8, 16, 24}, nil
-			}
-			if numCpus <= 128 {
-				return []int{16, 24}, nil
-			}
-		case "c2":
-			if numCpus <= 8 {
-				return []int{1, 2, 4, 8}, nil
-			}
-			if numCpus <= 16 {
-				return []int{2, 4, 8}, nil
-			}
-			if numCpus <= 30 {
-				return []int{4, 8}, nil
-			}
-			if numCpus <= 60 {
-				return []int{8}, nil
-			}
+		case 176, 192:
+			return []int{12}, nil
+
+		}
+
+	case "n1":
+		return []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 24}, nil
+
+	case "n2":
+		if numCPU <= 10 {
+			return []int{1, 2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 20 {
+			return []int{2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 40 {
+			return []int{4, 8, 16, 24}, nil
+		}
+		if numCPU <= 80 {
+			return []int{8, 16, 24}, nil
+		}
+		if numCPU <= 128 {
+			return []int{16, 24}, nil
+		}
+
+	case "n2d":
+		if numCPU <= 16 {
+			return []int{1, 2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 48 {
+			return []int{2, 4, 8, 16, 24}, nil
+		}
+		if numCPU <= 80 {
+			return []int{4, 8, 16, 24}, nil
+		}
+		if numCPU <= 224 {
+			return []int{8, 16, 24}, nil
+		}
+
+	case "c2":
+		if numCPU <= 8 {
+			return []int{1, 2, 4, 8}, nil
+		}
+		if numCPU <= 16 {
+			return []int{2, 4, 8}, nil
+		}
+		if numCPU <= 30 {
+			return []int{4, 8}, nil
+		}
+		if numCPU <= 60 {
+			return []int{8}, nil
+		}
+
+	case "c2d":
+		if numCPU <= 16 {
+			return []int{1, 2, 4, 8}, nil
+		}
+		if numCPU <= 32 {
+			return []int{2, 4, 8}, nil
+		}
+		if numCPU <= 56 {
+			return []int{4, 8}, nil
+		}
+		if numCPU <= 112 {
+			return []int{8}, nil
+		}
+
+	case "g2":
+		switch numCPU {
+		case 4, 8, 12, 16, 32:
+			return []int{1}, nil
+		case 24:
+			return []int{2}, nil
+		case 48:
+			return []int{4}, nil
+		case 96:
+			return []int{8}, nil
+		}
+
+	case "g4":
+		switch numCPU {
+		case 48:
+			return []int{4}, nil
+		case 96:
+			return []int{8}, nil
+		case 192:
+			return []int{16}, nil
+		case 384:
+			return []int{32}, nil
+		}
+
+	case "m1":
+		switch numCPU {
+		case 40:
+			return []int{1, 2, 3, 4, 5}, nil
+		case 80:
+			return []int{1, 2, 3, 4, 5, 6, 7, 8}, nil
+		}
+
+	case "m3":
+		switch numCPU {
+		case 32, 64:
+			return []int{4, 8}, nil
+		case 128:
+			return []int{8}, nil
 		}
 	}
-	return nil, fmt.Errorf("unsupported machine type: %q, matches: %v", machineType, matches)
+
+	return nil, fmt.Errorf("unsupported machine type: %q", machineType)
 }
 
 // N.B. neither boot disk nor additional persistent disks are assigned VM labels by default.

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -4,101 +4,6 @@ echo
 #!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-function setup_disks() {
-	first_setup=$1
-
-
-
-	use_multiple_disks=''
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
-	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
-	# Scenarios:
-	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
-	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
-	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
-	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
-	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	local_or_persistent=()
-	disks=()
-
-
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-
-
-	# N.B. we assume 0th disk is the boot disk.
-	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
-		local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
-		echo "Using only persistent disks: ${local_or_persistent[@]}"
-	else
-		local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
-		echo "Using only local disks: ${local_or_persistent[@]}"
-	fi
-
-	for l in ${local_or_persistent}; do
-		d=$(readlink -f $l)
-		mounted="no"
-
-		# Check if the disk is already part of a zpool or mounted; skip if so.
-		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
-			mounted="yes"
-		fi
-
-		if [ "$mounted" == "no" ]; then
-			disks+=("${d}")
-			echo "Disk ${d} not mounted, need to mount..."
-		else
-			echo "Disk ${d} already mounted, skipping..."
-		fi
-	done
-
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-
-		chmod 777 ${mountpoint}
-	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-
-	zpool list
-
-
-	mkdir -p /mnt/data1/cores
-	chmod a+w /mnt/data1/cores
-
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -110,6 +15,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -130,19 +37,196 @@ fi
 sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
+apt-get install -yq zfsutils-linux
+
+
 
 sudo -u ubuntu bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
 sudo -u ubuntu bash -c 'echo "dummy public key" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
 
+# Provider specific disk logic
+function detect_disks() {
+	# GCE-specific disk detection - returns list of available disks
+	# If both Local SSDs and Persistent disks exist, prioritize persistent disks to avoid
+	# performance differences when RAID'ing mixed disk types.
+	# Scenarios:
+	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
+	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
+	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
+	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
+	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
+	local local_or_persistent=()
+	local disks=()
+
+	# N.B. we assume 0th disk is the boot disk.
+	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
+		local_or_persistent=($(ls /dev/disk/by-id/google-persistent-disk-[1-9]))
+		echo "Using only persistent disks: ${local_or_persistent[@]}" >&2
+	else
+		local_or_persistent=($(ls /dev/disk/by-id/google-local-*))
+		echo "Using only local disks: ${local_or_persistent[@]}" >&2
+	fi
+
+	for l in ${local_or_persistent[@]}; do
+		d=$(readlink -f $l)
+		mounted="no"
+
+		# Check if the disk is already part of a zpool or mounted; skip if so.
+		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+			mounted="yes"
+		fi
+
+		if [ "$mounted" == "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs.zfs -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs.zfs -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint} zfs ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem='zfs'
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
 if [ -e /.roachprod-initialized ]; then
   echo "OS already initialized, only initializing disks."
   # Initialize disks, but don't write fstab entries again.
-  setup_disks false
+  setup_disks_wrapper false
   exit 0
 fi
 
 # Initialize disks and write fstab entries.
-setup_disks true
+setup_disks_wrapper true
+
 
 
 
@@ -233,6 +317,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -294,16 +380,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":9100" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9100 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9100 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9100 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":9100" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -315,18 +433,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":9435" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 9435 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 9435 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 9435 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":9435" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -25,48 +25,39 @@ import (
 const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-function setup_disks() {
-	first_setup=$1
+{{ template "head_utils" . }}
+{{ template "apt_packages" . }}
 
-{{ if not .Zfs }}
-	mount_opts="defaults,nofail"
-	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
-{{ end }}
+sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
+sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
 
-	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
-
-	mount_prefix="/mnt/data"
-
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
-	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
-	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
+# Provider specific disk logic
+function detect_disks() {
+	# GCE-specific disk detection - returns list of available disks
+	# If both Local SSDs and Persistent disks exist, prioritize persistent disks to avoid
+	# performance differences when RAID'ing mixed disk types.
 	# Scenarios:
 	#   (local SSD = 0, Persistent Disk - 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD = 1, Persistent Disk - 0) - no RAID'ing and local SSD mounted
 	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	local_or_persistent=()
-	disks=()
-
-{{ if .Zfs }}
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-{{ end }}
+	local local_or_persistent=()
+	local disks=()
 
 	# N.B. we assume 0th disk is the boot disk.
 	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
-		local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
-		echo "Using only persistent disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-persistent-disk-[1-9]))
+		echo "Using only persistent disks: ${local_or_persistent[@]}" >&2
 	else
-		local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
-		echo "Using only local disks: ${local_or_persistent[@]}"
+		local_or_persistent=($(ls /dev/disk/by-id/google-local-*))
+		echo "Using only local disks: ${local_or_persistent[@]}" >&2
 	fi
 
-	for l in ${local_or_persistent}; do
+	for l in ${local_or_persistent[@]}; do
 		d=$(readlink -f $l)
 		mounted="no"
-{{ if .Zfs }}
+{{ if eq .Filesystem "zfs" }}
 		# Check if the disk is already part of a zpool or mounted; skip if so.
 		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
 			mounted="yes"
@@ -79,86 +70,20 @@ function setup_disks() {
 {{ end }}
 		if [ "$mounted" == "no" ]; then
 			disks+=("${d}")
-			echo "Disk ${d} not mounted, need to mount..."
+			echo "Disk ${d} not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} already mounted, skipping..."
+			echo "Disk ${d} already mounted, skipping..." >&2
 		fi
 	done
 
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$((disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-{{ if .Zfs }}
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-			mkfs.ext4 -q -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			if [ "$first_setup" = "true" ]; then
-				echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			fi
-			tune2fs -m 0 ${disk}
-{{ end }}
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-{{ if .Zfs }}
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-		raiddisk="/dev/md0"
-		mdadm -q --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -q -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		if [ "$first_setup" = "true" ]; then
-			echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		fi
-		tune2fs -m 0 ${raiddisk}
-{{ end }}
-		chmod 777 ${mountpoint}
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
 	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-{{ if .Zfs }}
-	zpool list
-{{ end }}
-
-	mkdir -p /mnt/data1/cores
-	chmod a+w /mnt/data1/cores
-
-	sudo touch {{ .DisksInitializedFile }}
 }
 
-{{ template "head_utils" . }}
-{{ template "apt_packages" . }}
-
-sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
-sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
-
-if [ -e {{ .OSInitializedFile }} ]; then
-  echo "OS already initialized, only initializing disks."
-  # Initialize disks, but don't write fstab entries again.
-  setup_disks false
-  exit 0
-fi
-
-# Initialize disks and write fstab entries.
-setup_disks true
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 {{ template "ulimits" . }}
 {{ template "tcpdump" . }}
@@ -183,13 +108,18 @@ sudo touch {{ .OSInitializedFile }}
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool, enableCron bool,
+	extraMountOpts string,
+	fileSystem vm.Filesystem,
+	useMultiple bool,
+	enableFIPS bool,
+	enableCron bool,
 ) (string, error) {
+
+	// We define a local type in case we need to add more provider-specific params in
+	// the future.
 	type tmplParams struct {
 		vm.StartupArgs
-		ExtraMountOpts   string
-		UseMultipleDisks bool
-		PublicKey        string
+		PublicKey string
 	}
 
 	publicKey, err := config.SSHPublicKey()
@@ -201,13 +131,13 @@ func writeStartupScript(
 		StartupArgs: vm.DefaultStartupArgs(
 			vm.WithSharedUser(config.SharedUser),
 			vm.WithEnableCron(enableCron),
-			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithFilesystem(fileSystem),
 			vm.WithEnableFIPS(enableFIPS),
 			vm.WithChronyServers([]string{"metadata.google.internal"}),
+			vm.WithExtraMountOpts(extraMountOpts),
+			vm.WithUseMultipleDisks(useMultiple),
 		),
-		ExtraMountOpts:   extraMountOpts,
-		UseMultipleDisks: useMultiple,
-		PublicKey:        publicKey,
+		PublicKey: publicKey,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/ibm/helpers.go
+++ b/pkg/roachprod/vm/ibm/helpers.go
@@ -117,9 +117,9 @@ func (p *Provider) createInstance(
 			vm.WithVMName(opts.vmName),
 			vm.WithSharedUser(opts.providerOpts.RemoteUserName),
 			vm.WithChronyServers([]string{defaultNTPServer}),
-			vm.WithZfs(opts.vmOpts.SSDOpts.FileSystem == vm.Zfs),
+			vm.WithFilesystem(opts.vmOpts.SSDOpts.FileSystem),
+			vm.WithUseMultipleDisks(opts.providerOpts.UseMultipleDisks),
 		),
-		UseMultipleDisks: opts.providerOpts.UseMultipleDisks,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create startup script for instance %s", opts.vmName)
@@ -137,28 +137,34 @@ func (p *Provider) createInstance(
 
 	// Build the attached volumes information.
 	// Let's start with the default data disk.
-	attachedVolumes := volumeAttachments{
-		&volumeAttachment{
-			Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, 0),
-			ResourceGroupID:        p.config.roachprodResourceGroupID,
-			Capacity:               opts.providerOpts.DefaultVolume.VolumeSize,
-			IOPS:                   opts.providerOpts.DefaultVolume.IOPS,
-			Profile:                opts.providerOpts.DefaultVolume.VolumeType,
-			UserTags:               opts.tags,
-			DeleteOnInstanceDelete: true,
-		},
-	}
-	// Then we add any additional attached volumes.
-	for i, attachedVolume := range opts.providerOpts.AttachedVolumes {
-		attachedVolumes = append(attachedVolumes, &volumeAttachment{
-			Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, i+1),
-			ResourceGroupID:        p.config.roachprodResourceGroupID,
-			Capacity:               attachedVolume.VolumeSize,
-			IOPS:                   attachedVolume.IOPS,
-			Profile:                attachedVolume.VolumeType,
-			UserTags:               opts.tags,
-			DeleteOnInstanceDelete: true,
-		})
+	attachedVolumes := volumeAttachments{}
+
+	// If specific attached volumes are provided, use those.
+	// Otherwise, use the default volume configuration and create the specified count.
+	if len(opts.providerOpts.AttachedVolumes) != 0 {
+		for i, attachedVolume := range opts.providerOpts.AttachedVolumes {
+			attachedVolumes = append(attachedVolumes, &volumeAttachment{
+				Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, i),
+				ResourceGroupID:        p.config.roachprodResourceGroupID,
+				Capacity:               attachedVolume.VolumeSize,
+				IOPS:                   attachedVolume.IOPS,
+				Profile:                attachedVolume.VolumeType,
+				UserTags:               opts.tags,
+				DeleteOnInstanceDelete: true,
+			})
+		}
+	} else {
+		for i := range opts.providerOpts.AttachedVolumesCount {
+			attachedVolumes = append(attachedVolumes, &volumeAttachment{
+				Name:                   fmt.Sprintf("%s-data-%04d", opts.vmName, i),
+				ResourceGroupID:        p.config.roachprodResourceGroupID,
+				Capacity:               opts.providerOpts.DefaultVolume.VolumeSize,
+				IOPS:                   opts.providerOpts.DefaultVolume.IOPS,
+				Profile:                opts.providerOpts.DefaultVolume.VolumeType,
+				UserTags:               opts.tags,
+				DeleteOnInstanceDelete: true,
+			})
+		}
 	}
 
 	// Determine what happen in case of a host failure or maintenance.

--- a/pkg/roachprod/vm/ibm/helpers_test.go
+++ b/pkg/roachprod/vm/ibm/helpers_test.go
@@ -410,7 +410,7 @@ func TestCheckCreateOpts(t *testing.T) {
 			SSDOpts: struct {
 				UseLocalSSD   bool
 				NoExt4Barrier bool
-				FileSystem    string
+				FileSystem    vm.Filesystem
 			}{
 				UseLocalSSD: true,
 			},

--- a/pkg/roachprod/vm/ibm/provider_flags.go
+++ b/pkg/roachprod/vm/ibm/provider_flags.go
@@ -27,6 +27,10 @@ type ProviderOpts struct {
 	// DefaultVolume is the default data volume to be attached.
 	DefaultVolume IbmVolume
 
+	// AttachedVolumesCount is the number of additional volumes to be attached.
+	// This is superseded by the length of AttachedVolumes if that is non-empty.
+	AttachedVolumesCount int
+
 	// AttachedVolumes is a list of additional volumes to be attached.
 	AttachedVolumes IbmVolumeList
 
@@ -88,6 +92,7 @@ func DefaultProviderOpts() *ProviderOpts {
 		RemoteUserName:       defaultRemoteUser,
 		DefaultVolume:        IbmVolume{VolumeType: defaultVolumeType, VolumeSize: defaultVolumeSize},
 		AttachedVolumes:      IbmVolumeList{},
+		AttachedVolumesCount: 1,
 		TerminateOnMigration: false,
 	}
 }
@@ -121,6 +126,11 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		o.DefaultVolume.IOPS,
 		"Custom number of IOPS to provision for the default data volume",
 	)
+	flags.IntVar(&o.AttachedVolumesCount,
+		ProviderName+"-volume-count",
+		1,
+		"Number of additional volumes to attach, superseded by --"+ProviderName+"-attached-volume",
+	)
 
 	// Additional attached volumes
 	flags.VarP(
@@ -131,7 +141,7 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 Specified as JSON: '{ "VolumeType": "general-purpose", "VolumeSize": 1000, "IOPS": 15000 }'
 - VolumeType: 'general-purpose' (3 IOPS/GB), '5iops-tier' (5 IOPS/GB), '10iops-tier' (10 IOPS/GB), 'custom' (specify IOPS)
 - VolumeSize: Size in GB of the volume
-- IOPS: IOPS for the volume`,
+- IOPS: IOPS for the volume (if VolumeType is 'custom')`,
 	)
 
 	flags.StringSliceVar(

--- a/pkg/roachprod/vm/ibm/startup.go
+++ b/pkg/roachprod/vm/ibm/startup.go
@@ -16,35 +16,30 @@ import (
 // created from /mnt/data<disknum> to the mount point.
 
 // startupArgs specifies template arguments for the setup template.
+// We define a local type in case we need to add more provider-specific params in
+// the future.
 type startupArgs struct {
 	vm.StartupArgs
-	ExtraMountOpts   string
-	UseMultipleDisks bool
 }
 
 const startupTemplate = `#!/usr/bin/env bash
 
 # Script for setting up an IBM machine for roachprod use.
 
-function setup_disks() {
-	mount_prefix="/mnt/data"
-	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
+{{ template "head_utils" . }}
+{{ template "apt_packages" . }}
 
-{{ if not .Zfs }}
-	mount_opts="defaults,nofail"
-	{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
-{{ else }}
- 	apt-get update -q
-	apt-get install -yq zfsutils-linux
-{{ end }}
+# Provider specific disk logic
+function detect_disks() {
+	# IBM-specific disk detection - returns list of available disks
+	local disks=()
 
 	# List the attached data disks
-	disks=()
 	for d in $(find /dev/disk/by-id/ -type l -not -name *cloud-init* -not -name *part* -exec readlink -f {} \;); do
 		mounted="no"
 
 		# Check if the disk is already mounted; skip if so.
-{{ if .Zfs }}
+{{ if eq .Filesystem "zfs" }}
 		if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
 			mounted="yes"
 		fi
@@ -56,68 +51,20 @@ function setup_disks() {
 
 		if [ "$mounted" = "no" ]; then
 			disks+=("${d}")
-			echo "Disk ${d} is not mounted, mounting it"
+			echo "Disk ${d} is not mounted, need to mount..." >&2
 		else
-			echo "Disk ${d} is already mounted, skipping"
+			echo "Disk ${d} is already mounted, skipping..." >&2
 		fi
 	done
 
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$(( disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-{{ if .Zfs }}
-			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
-			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-			mkfs.ext4 -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			tune2fs -m 0 ${disk}
-{{ end }}
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-{{ if .Zfs }}
-		zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
-		# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
-{{ else }}
-		raiddisk="/dev/md0"
-		mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		tune2fs -m 0 ${raiddisk}
-{{ end }}
-		chmod 777 ${mountpoint}
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
 	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-{{ if .Zfs }}
-	zpool list
-{{ end }}
-	sudo touch {{ .DisksInitializedFile }}
 }
 
-{{ template "head_utils" . }}
-{{ template "apt_packages" . }}
-
-# Initialize disks.
-setup_disks
+# Common disk setup logic that calls the above detect_disks function
+{{ template "setup_disks_utils" . }}
 
 {{ template "ulimits" . }}
 {{ template "tcpdump" . }}

--- a/pkg/roachprod/vm/ibm/testdata/startup_script
+++ b/pkg/roachprod/vm/ibm/testdata/startup_script
@@ -5,78 +5,6 @@ echo
 
 # Script for setting up an IBM machine for roachprod use.
 
-function setup_disks() {
-	mount_prefix="/mnt/data"
-	use_multiple_disks=''
-
-
-	mount_opts="defaults,nofail"
-	
-
-
-	# List the attached data disks
-	disks=()
-	for d in $(find /dev/disk/by-id/ -type l -not -name *cloud-init* -not -name *part* -exec readlink -f {} \;); do
-		mounted="no"
-
-		# Check if the disk is already mounted; skip if so.
-
-		if mount | grep -q ${d}; then
-			mounted="yes"
-		fi
-
-
-		if [ "$mounted" = "no" ]; then
-			disks+=("${d}")
-			echo "Disk ${d} is not mounted, mounting it"
-		else
-			echo "Disk ${d} is already mounted, skipping"
-		fi
-	done
-
-	if [ "${#disks[@]}" -eq "0" ]; then
-		mountpoint="${mount_prefix}1"
-		echo "No disks mounted, creating ${mountpoint}"
-		mkdir -p ${mountpoint}
-		chmod 777 ${mountpoint}
-	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
-		disknum=1
-		for disk in "${disks[@]}"
-		do
-			mountpoint="${mount_prefix}${disknum}"
-			disknum=$(( disknum + 1 ))
-			echo "Mounting ${disk} at ${mountpoint}"
-			mkdir -p ${mountpoint}
-
-			mkfs.ext4 -F ${disk}
-			mount -o ${mount_opts} ${disk} ${mountpoint}
-			echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-			tune2fs -m 0 ${disk}
-
-			chmod 777 ${mountpoint}
-		done
-	else
-		mountpoint="${mount_prefix}1"
-		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
-		mkdir -p ${mountpoint}
-
-		raiddisk="/dev/md0"
-		mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
-		mkfs.ext4 -F ${raiddisk}
-		mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-		echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
-		tune2fs -m 0 ${raiddisk}
-
-		chmod 777 ${mountpoint}
-	fi
-
-	# Print the block device and FS usage output. This is useful for debugging.
-	lsblk
-	df -h
-
-	sudo touch /mnt/data1/.roachprod-initialized
-}
-
 
 
 # ensure any failure fails the entire script
@@ -88,6 +16,8 @@ exec &> >(tee -a /var/log/roachprod_startup.log)
 # Log the startup of the script with a timestamp
 echo "startup script starting: $(date -u)"
 
+# If disks are already initialized, exit early.
+# This happens upon VM restart if the disks are persistent.
 if [ -e /mnt/data1/.roachprod-initialized ]; then
 	echo "Already initialized, exiting."
 	exit 0
@@ -109,8 +39,174 @@ sudo apt-get update -q
 sudo apt-get install -qy --no-install-recommends mdadm
 
 
-# Initialize disks.
-setup_disks
+
+# Provider specific disk logic
+function detect_disks() {
+	# IBM-specific disk detection - returns list of available disks
+	local disks=()
+
+	# List the attached data disks
+	for d in $(find /dev/disk/by-id/ -type l -not -name *cloud-init* -not -name *part* -exec readlink -f {} \;); do
+		mounted="no"
+
+		# Check if the disk is already mounted; skip if so.
+
+		if mount | grep -q ${d}; then
+			mounted="yes"
+		fi
+
+
+		if [ "$mounted" = "no" ]; then
+			disks+=("${d}")
+			echo "Disk ${d} is not mounted, need to mount..." >&2
+		else
+			echo "Disk ${d} is already mounted, skipping..." >&2
+		fi
+	done
+
+	# Return disks array by printing each element (only if non-empty)
+	if [ "${#disks[@]}" -gt 0 ]; then
+		printf '%s\n' "${disks[@]}"
+	fi
+}
+
+# Common disk setup logic that calls the above detect_disks function
+
+
+# Common disk setup logic shared across all cloud providers.
+# This function formats, mounts, and configures disks (including RAID0/ZFS if needed).
+# Args:
+#   $1 = first_setup ("true" or "false") - controls whether to write fstab entries
+#   $2 = filesystem (e.g., "ext4", "zfs", "btrfs")
+#   $3 = mount_prefix (e.g., "/mnt/data")
+#   $4 = mount_opts (e.g., "defaults,nofail")
+#   $5 = use_multiple_disks ("true" or empty) - mount disks individually vs RAID0/ZFS
+#   $6+ = disk paths to setup
+# Usage: setup_disks "true" "ext4" "/mnt/data" "defaults,nofail" "" "${disks[@]}"
+function setup_disks() {
+	local first_setup=$1
+	local filesystem=$2
+	local mount_prefix=$3
+	local mount_opts=$4
+	local use_multiple_disks=$5
+	shift 5
+	local disks=("$@")
+
+	if [ "${#disks[@]}" -eq "0" ]; then
+		mountpoint="${mount_prefix}1"
+		echo "No disks mounted, creating ${mountpoint}"
+		mkdir -p ${mountpoint}
+		chmod 777 ${mountpoint}
+	elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
+		disknum=1
+		for disk in "${disks[@]}"
+		do
+			mountpoint="${mount_prefix}${disknum}"
+			disknum=$((disknum + 1 ))
+			echo "Mounting ${disk} at ${mountpoint}"
+			mkdir -p ${mountpoint}
+			if [ ${filesystem} == "zfs" ]; then
+				zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+				# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+			elif [ ${filesystem} == "btrfs" ]; then
+				mkfs.btrfs -f -L data${disknum} "${disk}"
+				mount -t btrfs -L data${disknum} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "LABEL=data${disknum} ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+				fi
+			else
+				mkfsForceOpt="-f"
+				if [ ${filesystem} == "ext4" ]; then
+					mkfsForceOpt="-F"
+				fi
+	
+				mkfs. -q ${mkfsForceOpt} ${disk}
+				mount -o ${mount_opts} ${disk} ${mountpoint}
+				if [ "$first_setup" = "true" ]; then
+					echo "${disk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+				fi
+			fi
+			chmod 777 ${mountpoint}
+		done
+	else
+		mountpoint="${mount_prefix}1"
+		echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
+		mkdir -p ${mountpoint}
+
+		if [ ${filesystem} == "zfs" ]; then
+			zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+			# NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+		elif [ ${filesystem} == "btrfs" ]; then
+			mkfs.btrfs -f -L data1 -d raid0 -m raid0 "${disks[@]}"
+			mount -t btrfs -L data1 ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "LABEL=data1 ${mountpoint} btrfs ${mount_opts} 0 0" | tee -a /etc/fstab
+			fi
+		else
+			mkfsForceOpt="-f"
+			if [ ${filesystem} == "ext4" ]; then
+				mkfsForceOpt="-F"
+			fi
+
+			raiddisk="/dev/md0"
+			mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
+			mkfs. -q ${mkfsForceOpt} ${raiddisk}
+			mount -o ${mount_opts} ${raiddisk} ${mountpoint}
+			if [ "$first_setup" = "true" ]; then
+				echo "${raiddisk} ${mountpoint}  ${mount_opts} 0 2" | tee -a /etc/fstab
+			fi
+
+			if [ ${filesystem} == "ext4" ]; then
+				tune2fs -m 0 ${raiddisk}
+			fi
+		fi
+
+		chmod 777 ${mountpoint}
+	fi
+
+	# Print the block device and FS usage output. This is useful for debugging.
+	lsblk
+	df -h
+	if [ ${filesystem} == "zfs" ]; then
+		zpool list
+	fi
+
+	sudo touch /mnt/data1/.roachprod-initialized
+}
+	
+function setup_disks_wrapper() {
+	first_setup=$1
+
+
+
+	# Define various parameters
+	mount_prefix="/mnt/data"
+	use_multiple_disks=''
+	filesystem=''
+
+	mount_opts="defaults,nofail"
+	if [ "${filesystem}" == "btrfs" ]; then
+		mount_opts="${mount_opts},noatime,noautodefrag"
+	fi
+	
+	# Detect disks
+	mapfile -t disks < <(detect_disks)
+
+	# Call shared setup logic
+	setup_disks "${first_setup}" "${filesystem}" "${mount_prefix}" "${mount_opts}" "${use_multiple_disks}" "${disks[@]}"
+}
+
+# Start the process of detecting disks to mount and configure them.
+if [ -e /.roachprod-initialized ]; then
+  echo "OS already initialized, only initializing disks."
+  # Initialize disks, but don't write fstab entries again.
+  setup_disks_wrapper false
+  exit 0
+fi
+
+# Initialize disks and write fstab entries.
+setup_disks_wrapper true
+
 
 
 
@@ -201,6 +297,8 @@ EOF
 
 cat <<'EOF' > /bin/gzip_core.sh
 #!/bin/sh
+mkdir -p /mnt/data1/cores
+chmod a+w /mnt/data1/cores
 exec /bin/gzip -f - > /mnt/data1/cores/core.$1.$2.$3.$4.gz
 EOF
 chmod +x /bin/gzip_core.sh
@@ -264,16 +362,48 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
+# Create iptables setup script for node_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/node_exporter && \
-	sudo systemd-run --unit node_exporter --same-dir \
-		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-node-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-node-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Prometheus Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=$(id -nu 1000)
+PermissionsStartOnly=true
+WorkingDirectory=${DEFAULT_USER_HOME}/node_exporter
+ExecStartPre=/usr/local/bin/setup-node-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/node_exporter/node_exporter \
+	--collector.systemd \
+	--collector.interrupts \
+	--collector.processes \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable node_exporter
+sudo systemctl start node_exporter
 
 
 
@@ -285,18 +415,46 @@ mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
 
+# Create iptables setup script for ebpf_exporter
 export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 0 -j DROP
-(
-	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
-	sudo systemd-run --unit ebpf_exporter --same-dir \
-		./ebpf_exporter \
-		--config.dir=examples \
-		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
-		--web.listen-address=":0" \
-		--web.telemetry-path="/metrics"
-)
+cat <<FIREWALL_EOF | sudo tee /usr/local/bin/setup-ebpf-exporter-firewall.sh
+#!/bin/bash
+# Remove existing rules for this port to avoid duplicates
+/usr/sbin/iptables -D INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT 2>/dev/null || true
+/usr/sbin/iptables -D INPUT -p tcp --dport 0 -j DROP 2>/dev/null || true
+# Add firewall rules
+/usr/sbin/iptables -A INPUT -p tcp -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} --dport 0 -j ACCEPT
+/usr/sbin/iptables -A INPUT -p tcp --dport 0 -j DROP
+FIREWALL_EOF
+sudo chmod +x /usr/local/bin/setup-ebpf-exporter-firewall.sh
+
+# Create systemd service file
+cat <<EOF | sudo tee /etc/systemd/system/ebpf_exporter.service
+[Unit]
+Description=Prometheus eBPF Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${DEFAULT_USER_HOME}/ebpf_exporter
+ExecStartPre=/usr/local/bin/setup-ebpf-exporter-firewall.sh
+ExecStart=${DEFAULT_USER_HOME}/ebpf_exporter/ebpf_exporter \
+	--config.dir=examples \
+	--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+	--web.listen-address=":0" \
+	--web.telemetry-path="/metrics"
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the service
+sudo systemctl daemon-reload
+sudo systemctl enable ebpf_exporter
+sudo systemctl start ebpf_exporter
 
 
 sudo touch /.roachprod-initialized

--- a/pkg/roachprod/vm/startup_args_overrides.go
+++ b/pkg/roachprod/vm/startup_args_overrides.go
@@ -85,19 +85,64 @@ func WithDisksInitializedFile(disksInitializedFile string) WithDisksInitializedF
 	return WithDisksInitializedFileOverride{DisksInitializedFile: disksInitializedFile}
 }
 
-// WithZfsOverride is an override for the Zfs field.
-type WithZfsOverride struct {
-	Zfs bool
+// WithFilesystemOverride is an override for the Filesystem field.
+type WithFilesystemOverride struct {
+	Filesystem Filesystem
 }
 
-// apply applies the Zfs override to the StartupArgs.
-func (o WithZfsOverride) apply(args *StartupArgs) {
-	args.Zfs = o.Zfs
+// apply applies the Filesystem override to the StartupArgs.
+func (o WithFilesystemOverride) apply(args *StartupArgs) {
+	args.Filesystem = o.Filesystem
 }
 
-// WithZfs overrides the Zfs field.
-func WithZfs(zfs bool) WithZfsOverride {
-	return WithZfsOverride{Zfs: zfs}
+// WithFilesystem overrides the Filesystem field.
+func WithFilesystem(filesystem Filesystem) WithFilesystemOverride {
+	return WithFilesystemOverride{Filesystem: filesystem}
+}
+
+// WithExtraMountOptsOverride is an override for the ExtraMountOpts field.
+type WithExtraMountOptsOverride struct {
+	ExtraMountOpts string
+}
+
+// apply applies the ExtraMountOpts override to the StartupArgs.
+func (o WithExtraMountOptsOverride) apply(args *StartupArgs) {
+	args.ExtraMountOpts = o.ExtraMountOpts
+}
+
+// WithExtraMountOpts overrides the ExtraMountOpts field.
+func WithExtraMountOpts(extraMountOpts string) WithExtraMountOptsOverride {
+	return WithExtraMountOptsOverride{ExtraMountOpts: extraMountOpts}
+}
+
+// WithBootDiskOnlyOverride is an override for the BootDiskOnly field.
+type WithBootDiskOnlyOverride struct {
+	BootDiskOnly bool
+}
+
+// apply applies the BootDiskOnly override to the StartupArgs.
+func (o WithBootDiskOnlyOverride) apply(args *StartupArgs) {
+	args.BootDiskOnly = o.BootDiskOnly
+}
+
+// WithBootDiskOnly overrides the BootDiskOnly field.
+func WithBootDiskOnly(bootDiskOnly bool) WithBootDiskOnlyOverride {
+	return WithBootDiskOnlyOverride{BootDiskOnly: bootDiskOnly}
+}
+
+// WithUseMultipleDisksOverride is an override for the UseMultipleDisks field.
+type WithUseMultipleDisksOverride struct {
+	UseMultipleDisks bool
+}
+
+// apply applies the UseMultipleDisks override to the StartupArgs.
+func (o WithUseMultipleDisksOverride) apply(args *StartupArgs) {
+	args.UseMultipleDisks = o.UseMultipleDisks
+}
+
+// WithUseMultipleDisks overrides the UseMultipleDisks field.
+func WithUseMultipleDisks(useMultipleDisks bool) WithUseMultipleDisksOverride {
+	return WithUseMultipleDisksOverride{UseMultipleDisks: useMultipleDisks}
 }
 
 // WithEnableFIPSOverride is an override for the EnableFIPS field.

--- a/pkg/roachprod/vm/startup_test.go
+++ b/pkg/roachprod/vm/startup_test.go
@@ -28,13 +28,13 @@ func TestGenericStartupArgs(t *testing.T) {
 		args := DefaultStartupArgs(WithOSInitializedFile("test"))
 		require.Equal(t, args.OSInitializedFile, "test")
 	})
-	t.Run("WithDiskInitializeFile", func(t *testing.T) {
+	t.Run("WithDisksInitializedFile", func(t *testing.T) {
 		args := DefaultStartupArgs(WithDisksInitializedFile("test"))
 		require.Equal(t, args.DisksInitializedFile, "test")
 	})
 	t.Run("WithZfs", func(t *testing.T) {
-		args := DefaultStartupArgs(WithZfs(true))
-		require.Equal(t, args.Zfs, true)
+		args := DefaultStartupArgs(WithFilesystem(Ext4))
+		require.Equal(t, args.Filesystem, Ext4)
 	})
 	t.Run("WithFIPS", func(t *testing.T) {
 		args := DefaultStartupArgs(WithEnableFIPS(true))

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -279,12 +279,35 @@ func (vl List) ProviderIDs() []string {
 	return ret
 }
 
+type Filesystem string
+
 const (
 	// Zfs refers to the zfs file system.
-	Zfs = "zfs"
+	Zfs Filesystem = "zfs"
 	// Ext4 refers to the ext4 file system.
-	Ext4 = "ext4"
+	Ext4 Filesystem = "ext4"
+	// Xfs refers to the xfs file system.
+	Xfs Filesystem = "xfs"
+	// F2fs refers to the f2fs file system.
+	F2fs Filesystem = "f2fs"
+	// Btrfs refers to the btrfs file system.
+	Btrfs Filesystem = "btrfs"
 )
+
+// ParseFilesystemString parses and validates a filesystem string.
+func ParseFilesystemString(s string) (Filesystem, error) {
+	return ParseFileSystemOption(Filesystem(s))
+}
+
+// ParseFileSystemOption parses and validates a Filesystem option.
+func ParseFileSystemOption(s Filesystem) (Filesystem, error) {
+	switch s {
+	case Zfs, Ext4, Xfs, F2fs, Btrfs:
+		return s, nil
+	default:
+		return "", errors.Newf("unsupported filesystem: %s", s)
+	}
+}
 
 // CreateOpts is the set of options when creating VMs.
 type CreateOpts struct {
@@ -301,7 +324,7 @@ type CreateOpts struct {
 		// mounting the SSD. Ignored if UseLocalSSD is not set.
 		NoExt4Barrier bool
 		// The file system to be used. This is set to "ext4" by default.
-		FileSystem string
+		FileSystem Filesystem
 	}
 	OsVolumeSize int
 }


### PR DESCRIPTION
Backport 2/2 commits from #156821.

/cc @cockroachdb/release

---

Until now, each cloud provider implementation had its own capabilities with regards to storage options. GCE was the only first class citizen with the most available options exposed in roachtest.

This patch attempts to bridge the feature parity gap between the cloud providers (up to what's exposed by each providers), bringing support for the following options in roachprod and roachtest:
- GCE:
  - local SSD
  - network disk size
  - network disk type (pd-standard, pd-ssd)
  - network disk count
  - RAID0 or multiple stores
- AWS:
  - local SSD
  - network disk size
  - network disk throughput
  - network disk IOPS
  - NEW: network disk type (gp2, gp3, io1, io2, st1, sc1, standard)
  - NEW: network disk count
  - NEW: RAID0 or multiple stores
- Azure:
  - local SSD
  - network disk size
  - NEW: network disk IOPS (ultra-disk only)
  - NEW: network disk type (standard-ssd, premium-ssd, premium-ssd-v2,
      ultra-disk)
  - NEW: network disk count
  - NEW: RAID0 or multiple stores
- IBM:
  - network disk size
  - network disk IOPS
  - network disk type (general-purpose, 5iops-tier, 10iops-tier, custom)
  - network disk count
  - RAID0 or multiple stores

This patch also splits the disk setup startup script snippets, with:
- a provider-specific way of detecting the attached disks
- a common logic to mount, format and aggregate the disks

This allows to offer the following filesystems across the board in roachprod (and roachtest):
- Ext4
- ZFS
- XFS
- F2FS (available for AWS, Azure and GCP, pending newer kernel for IBM)
- Btrfs

Epic: none
Closes: #123775
Informs: #146661, #113869
Release note: None

Release justification: Test only change
