### PR TITLE
jobs: avoid skipping incremental backups

### DIFF
--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -538,10 +538,6 @@ func TestJobSchedulerRetriesFailed(t *testing.T) {
 
 	daemon := newJobScheduler(h.cfg, h.env, metric.NewRegistry())
 
-	schedule := h.newScheduledJobForExecutor("schedule", executorName, nil)
-	schedules := ScheduledJobDB(h.cfg.DB)
-	require.NoError(t, schedules.Create(ctx, schedule))
-
 	startTime := h.env.Now()
 	execTime := startTime.Add(time.Hour).Add(time.Second)
 
@@ -556,6 +552,10 @@ func TestJobSchedulerRetriesFailed(t *testing.T) {
 		{jobspb.ScheduleDetails_RETRY_SCHED, cron.Next(execTime).Round(time.Microsecond)},
 	} {
 		t.Run(tc.onError.String(), func(t *testing.T) {
+			schedule := h.newScheduledJobForExecutor("schedule", executorName, nil)
+			schedules := ScheduledJobDB(h.cfg.DB)
+			require.NoError(t, schedules.Create(ctx, schedule))
+
 			h.env.SetTime(startTime)
 			schedule.SetScheduleDetails(jobstest.AddDummyScheduleDetails(jobspb.ScheduleDetails{OnError: tc.onError}))
 			require.NoError(t, schedule.SetScheduleAndNextRun("@hourly"))

--- a/pkg/jobs/scheduled_job.go
+++ b/pkg/jobs/scheduled_job.go
@@ -174,6 +174,9 @@ func (j *ScheduledJob) ExecutionArgs() *jobspb.ExecutionArguments {
 // SetScheduleAndNextRun updates periodicity of this schedule, and updates this schedules
 // next run time.
 func (j *ScheduledJob) SetScheduleAndNextRun(scheduleExpr string) error {
+	if j.rec.ScheduleExpr == scheduleExpr {
+		return nil
+	}
 	j.rec.ScheduleExpr = scheduleExpr
 	j.markDirty("schedule_expr")
 	return j.ScheduleNextRun()

--- a/pkg/jobs/scheduled_job_test.go
+++ b/pkg/jobs/scheduled_job_test.go
@@ -74,6 +74,24 @@ func TestSetsSchedule(t *testing.T) {
 	require.True(t, loaded.NextRun().Equal(expectedNextRun))
 }
 
+func TestSetScheduleNoop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	h, cleanup := newTestHelper(t)
+	defer cleanup()
+
+	j := h.newScheduledJob(t, "test_job", "test sql")
+
+	require.NoError(t, j.SetScheduleAndNextRun("*/5 * * * *"))
+	initial := j.rec.NextRun
+	require.False(t, initial.IsZero())
+
+	h.env.SetTime(initial.Add(time.Minute * 5))
+
+	require.NoError(t, j.SetScheduleAndNextRun("*/5 * * * *"))
+	require.Equal(t, initial, j.rec.NextRun)
+}
+
 func TestCreateOneOffJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
if SetScheduleAndNextRun is called after NextRun it will skip the job execution, now it only updates NextRun if the schedule changes.

Release note (bug fix): Fixed a bug where issuing a noop schedule modification could skip the next incremental backup

Fixes: #158296