### PR TITLE
clusterversion: update M3 M4 runbooks

### DIFF
--- a/pkg/clusterversion/CLAUDE.md
+++ b/pkg/clusterversion/CLAUDE.md
@@ -12,7 +12,9 @@ This document provides an overview of the quarterly release preparation tasks wi
 - [M.1: Bump Current Version](runbooks/M1_bump_current_version.md) - Advance master to next development version
 - [M.2: Enable Mixed-Cluster Logic Tests](runbooks/M2_enable_mixed_cluster_logic_tests.md) - Add bootstrap data and test configs
 - [M.3: Enable Upgrade Tests](runbooks/M3_enable_upgrade_tests.md) - Generate fixtures and enable roachtests
+  - [M.3 Quick Reference](runbooks/M3_enable_upgrade_tests_QUICK.md) - Streamlined checklist version
 - [M.4: Bump MinSupported Version](runbooks/M4_bump_minsupported_version.md) - Remove support for oldest version
+  - [M.4 Quick Reference](runbooks/M4_bump_minsupported_version_QUICK.md) - Streamlined checklist version
 
 ## For Claude Code AI
 
@@ -21,17 +23,25 @@ This document provides an overview of the quarterly release preparation tasks wi
 When the user asks you to perform a release task (e.g., "perform M.1", "do the M.2 task", "help with R.1"):
 
 1. **Read the appropriate runbook** from the `runbooks/` directory using the Read tool
+   - **Prefer QUICK versions when available** (e.g., `M4_bump_minsupported_version_QUICK.md`)
+   - Quick versions are streamlined checklists optimized for execution
+   - Full versions have detailed explanations and troubleshooting
 2. **Follow the runbook exactly** - it contains step-by-step instructions, expected files, and common errors
 3. **Use the TodoWrite tool** to track your progress through the runbook steps
 4. **Ask clarifying questions** if the runbook is unclear or doesn't match the current codebase state
+5. **Reference the full runbook** when you encounter errors or need deeper explanation
 
 **Adding new runbooks:**
 
 1. **Create a new file** in `pkg/clusterversion/runbooks/` following the naming pattern: `{R|M}N_descriptive_name.md`
-2. **Update this file** to add the new runbook to the Quick Navigation section
-3. **Update `pkg/clusterversion/README.md`** with a "Claude Prompt" section that references the new runbook
-4. **Follow the existing structure:** Use consistent header levels (# for title, ## for major sections, ### for subsections)
-5. **Include these sections:** Overview, Prerequisites, Step-by-Step Checklist, Expected Files Modified, Validation/Verification, Common Errors, Quick Reference Commands
+2. **Consider creating a QUICK version** for complex tasks (e.g., `{R|M}N_descriptive_name_QUICK.md`)
+   - Quick versions should be action-oriented checklists
+   - Use tables, bullet points, and minimal prose
+   - Focus on WHAT to do, not WHY
+3. **Update this file** to add the new runbook to the Quick Navigation section
+4. **Update `pkg/clusterversion/README.md`** with a "Claude Prompt" section that references the new runbook
+5. **Follow the existing structure:** Use consistent header levels (# for title, ## for major sections, ### for subsections)
+6. **Include these sections:** Overview, Prerequisites, Step-by-Step Checklist, Expected Files Modified, Validation/Verification, Common Errors, Quick Reference Commands
 
 ## Runbook Structure Guidelines
 

--- a/pkg/clusterversion/runbooks/M3_enable_upgrade_tests.md
+++ b/pkg/clusterversion/runbooks/M3_enable_upgrade_tests.md
@@ -2,6 +2,10 @@
 
 This section provides step-by-step instructions for the M.3 task: "Enable upgrade tests" on the master branch after the first RC is published. This task enables roachtest upgrade tests with the newly released version.
 
+**📋 Quick Reference:** For a streamlined checklist-style guide, see [`M3_enable_upgrade_tests_QUICK.md`](M3_enable_upgrade_tests_QUICK.md). This document provides detailed explanations and troubleshooting.
+
+---
+
 ### Overview
 
 **When to perform:** After the first RC (e.g., v25.4.0-rc.1) is published and available on the releases page.

--- a/pkg/clusterversion/runbooks/M3_enable_upgrade_tests_QUICK.md
+++ b/pkg/clusterversion/runbooks/M3_enable_upgrade_tests_QUICK.md
@@ -1,0 +1,490 @@
+# M.3: Enable Upgrade Tests - Quick Reference
+
+**Full details:** See `M3_enable_upgrade_tests.md`
+
+## Overview
+
+Enable upgrade tests after the first RC is published using a **2-PR approach** (recommended).
+
+**Critical:** Fixtures MUST be generated on **gceworker** (amd64), NOT Mac.
+
+**Reference PRs:**
+- Fixtures: #150712
+- Code: #152080
+
+---
+
+## Prerequisites Checklist
+
+- [ ] First RC published (e.g., v25.4.0-rc.1) - verify at cockroachlabs.com/docs/releases
+- [ ] M.1 and M.2 completed (V25_4 constant exists, bootstrap data added)
+- [ ] Access to gceworker (or can create one)
+- [ ] Know exact RC version number
+
+---
+
+## PR 1: Fixtures (~6 files)
+
+### Step 1: Update Releases File (on Mac)
+
+```bash
+git checkout master
+git pull origin master
+git checkout -b enable-upgrade-tests-25.4-fixtures
+
+# Build and run release tool
+bazel build //pkg/cmd/release:release
+_bazel/bin/pkg/cmd/release/release_/release update-releases-file
+```
+
+**Files updated:**
+- `pkg/testutils/release/cockroach_releases.yaml` - Adds RC version
+- `pkg/sql/logictest/REPOSITORIES.bzl` - Adds RC binaries with checksums
+
+### ⚠️ CRITICAL: Verify REPOSITORIES.bzl
+
+The tool may **incorrectly remove** older version binaries still needed by active testserver configs.
+
+```bash
+# Check active testserver configs
+grep "cockroach-go-testserver-" pkg/sql/logictest/logictestbase/logictestbase.go | grep "Name:"
+
+# Verify REPOSITORIES.bzl has binaries for ALL active versions
+grep -E "^\s+\(\"25\.[0-9]" pkg/sql/logictest/REPOSITORIES.bzl
+```
+
+**If a version is missing:**
+```bash
+# Get old config
+git show HEAD^:pkg/sql/logictest/REPOSITORIES.bzl | grep -A 4 "25.X.Y"
+
+# Manually restore to REPOSITORIES.bzl
+```
+
+**Pattern:** Keep N-2, N-1, and N release binaries until their testserver configs are removed.
+
+### Commit
+
+```bash
+git add pkg/testutils/release/cockroach_releases.yaml pkg/sql/logictest/REPOSITORIES.bzl
+git commit -m "master: Update pkg/testutils/release/cockroach_releases.yaml
+
+Updates releases file with v25.4.0-rc.1 RC and adds RC binaries to REPOSITORIES.bzl.
+
+Part of M.3 fixtures preparation.
+
+Release note: None
+Epic: None"
+```
+
+---
+
+### Step 2: Generate Fixtures on gceworker
+
+#### 2.1: Setup gceworker (First Time)
+
+**⚠️ MUST run update-firewall BEFORE create, or connection will fail!**
+
+```bash
+# On Mac - set zone (optional)
+export CLOUDSDK_COMPUTE_ZONE=us-west1-a  # Or us-east1-b
+
+# Update firewall FIRST
+./scripts/gceworker.sh update-firewall
+
+# Create gceworker (takes 5-10 min)
+./scripts/gceworker.sh create
+
+# SSH to gceworker
+./scripts/gceworker.sh start
+```
+
+**Zones:**
+- `us-west1-a` (Oregon - West Coast)
+- `us-east1-b` (South Carolina - East Coast)
+
+#### 2.2: Clone Repo on gceworker
+
+**On gceworker terminal:**
+
+```bash
+mkdir -p ~/go/src/github.com/cockroachdb
+cd ~/go/src/github.com/cockroachdb
+git clone git@github.com:<your-username>/cockroach.git
+cd cockroach
+
+# Add upstream and fetch tags
+git remote add upstream https://github.com/cockroachdb/cockroach.git
+git fetch upstream --tags
+
+# Checkout RC tag
+git checkout v25.4.0-rc.1
+
+# Set environment
+export FIXTURE_VERSION=v25.4.0-rc.1
+export COCKROACH_DEV_LICENSE="<your-license>"
+
+# Verify
+echo $COCKROACH_DEV_LICENSE
+```
+
+#### 2.3: Build Binaries
+
+```bash
+# Configure (first time only)
+./dev doctor
+# Press Enter for "dev" config
+# Type "n" for lintonbuild
+
+# Build
+./dev build cockroach short //c-deps:libgeos roachprod workload roachtest
+
+# Clean up previous clusters (error "does not exist" is OK)
+./bin/roachprod destroy local
+```
+
+#### 2.4: Generate Fixtures
+
+```bash
+./bin/roachtest run generate-fixtures --local --debug \
+  --cockroach ./cockroach --suite fixtures
+```
+
+**Expected:** Test FAILS intentionally and prints move commands.
+
+#### 2.5: Move Fixtures
+
+```bash
+# Copy command from test output and run it:
+for i in 1 2 3 4; do
+  mkdir -p pkg/cmd/roachtest/fixtures/${i} && \
+  mv artifacts/generate-fixtures/run_1/logs/${i}.unredacted/checkpoint-*.tgz \
+    pkg/cmd/roachtest/fixtures/${i}/
+done
+
+# Verify
+ls -lh pkg/cmd/roachtest/fixtures/*/checkpoint-v25.4.tgz
+```
+
+**Expected:** 4 files, each ~3-5 MB.
+
+---
+
+### Step 3: Copy Fixtures to Mac
+
+**On Mac terminal:**
+
+```bash
+# Create tmp directory
+mkdir -p /tmp/fixtures-25.4
+
+# Copy from gceworker (adjust username/zone)
+scp -r gceworker-<yourname>.us-west1-a.cockroach-workers:~/go/src/github.com/cockroachdb/cockroach/pkg/cmd/roachtest/fixtures /tmp/fixtures-25.4/
+
+# Navigate to local repo
+cd ~/go/src/github.com/cockroachdb/cockroach
+git checkout enable-upgrade-tests-25.4-fixtures
+
+# Copy fixtures
+for i in 1 2 3 4; do
+  cp /tmp/fixtures-25.4/fixtures/${i}/checkpoint-v25.4.tgz pkg/cmd/roachtest/fixtures/${i}/
+done
+
+# Verify
+ls -lh pkg/cmd/roachtest/fixtures/*/checkpoint-v25.4.tgz
+```
+
+---
+
+### Step 4: Commit and Push Fixtures PR
+
+```bash
+git add pkg/cmd/roachtest/fixtures/*/checkpoint-v25.4.tgz
+git status  # Verify
+
+git commit -m "roachtest: add 25.4 fixtures
+
+Adds roachtest fixtures for v25.4.0-rc.1 to enable upgrade testing.
+
+Fixtures generated on gceworker by running:
+  ./bin/roachtest run generate-fixtures --local --debug \\
+    --cockroach ./cockroach --suite fixtures
+
+Part of M.3 \"Enable upgrade tests\" checklist.
+
+Release note: None
+Epic: None
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# Push to fork
+git push -u celiala enable-upgrade-tests-25.4-fixtures
+
+# Create PR
+gh pr create --repo cockroachdb/cockroach \
+  --title "master: Update releases file and add 25.4 fixtures" \
+  --body "Part of M.3: Enable upgrade tests for 25.4.
+
+This PR:
+- Updates releases file with v25.4.0-rc.1
+- Updates REPOSITORIES.bzl with RC binaries
+- Adds roachtest fixtures for v25.4.0-rc.1
+
+Fixtures generated on gceworker using amd64 architecture.
+
+Epic: None"
+```
+
+**Wait for this PR to merge before proceeding to PR 2.**
+
+---
+
+## PR 2: Code Changes (~9 files)
+
+### Step 1: Create Branch
+
+```bash
+git checkout master
+git pull origin master
+git checkout -b enable-upgrade-tests-25.4-code
+```
+
+---
+
+### Step 2: Update PreviousRelease Constant
+
+**File:** `pkg/clusterversion/cockroach_versions.go` (line ~332)
+
+```go
+// Before
+const PreviousRelease Key = V25_3
+
+// After
+const PreviousRelease Key = V25_4
+```
+
+---
+
+### Step 3: Add cockroach-go-testserver-25.4 Config
+
+**File:** `pkg/sql/logictest/logictestbase/logictestbase.go`
+
+**Add config** (after 25.3 config, line ~560):
+
+```go
+{
+	// This config runs tests using a 25.4 predecessor binary, testing upgrade
+	// compatibility.
+	Name:                        "cockroach-go-testserver-25.4",
+	NumNodes:                    1,
+	OverrideDistSQLMode:         "off",
+	UseCockroachGoTestserver:    true,
+	CockroachGoTestserverVersion: "v25.4.0",
+	DeclarativeCorpusCollection: true,
+},
+```
+
+**Add to set** (line ~615):
+
+```go
+"cockroach-go-testserver-configs": makeConfigSet(
+	"cockroach-go-testserver-25.2",
+	"cockroach-go-testserver-25.3",
+	"cockroach-go-testserver-25.4",  // Add this
+),
+```
+
+---
+
+### Step 4: Update BUILD.bazel Visibility
+
+**File:** `pkg/sql/logictest/BUILD.bazel` (line ~160)
+
+```bazel
+cockroach_predecessor_version(
+    name = "cockroach_predecessor_version",
+    visibility = [
+        "//pkg/ccl/logictestccl:__subpackages__",
+        "//pkg/sql/logictest/tests/cockroach-go-testserver-25.2:__pkg__",
+        "//pkg/sql/logictest/tests/cockroach-go-testserver-25.3:__pkg__",
+        "//pkg/sql/logictest/tests/cockroach-go-testserver-25.4:__pkg__",  # Add
+        "//pkg/sql/sqlitelogictest:__subpackages__",
+    ],
+)
+```
+
+---
+
+### Step 5: Verify supportsSkipUpgradeTo
+
+**File:** `pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go` (line ~850)
+
+```go
+func supportsSkipUpgradeTo(v *version.Version) bool {
+	return v.Major() == 25 && v.Minor() == 4 && v.Patch() == 0 && v.PreRelease() == ""
+}
+```
+
+**Check:** If Minor() == 4 covers 25.4, no changes needed. Otherwise, update condition.
+
+---
+
+### Step 6: Generate Bazel Files
+
+```bash
+./dev gen bazel
+```
+
+**Generates:**
+- `pkg/sql/logictest/tests/cockroach-go-testserver-25.4/BUILD.bazel`
+- `pkg/sql/logictest/tests/cockroach-go-testserver-25.4/generated_test.go`
+- Updates to various BUILD.bazel files
+
+---
+
+### Step 7: Commit and Push Code PR
+
+```bash
+git add -A
+git status  # Verify
+
+git commit -m "clusterversion: bump PreviousRelease to V25_4
+
+Updates PreviousRelease constant from V25_3 to V25_4 and adds the
+cockroach-go-testserver-25.4 logictest configuration to enable
+upgrade tests for version 25.4.
+
+Changes:
+- Updated PreviousRelease constant
+- Added cockroach-go-testserver-25.4 test configuration
+- Generated test files for new config
+- Updated BUILD.bazel files via ./dev gen bazel
+
+The supportsSkipUpgradeTo logic already handles 25.4 correctly.
+
+Part of M.3 \"Enable upgrade tests\" checklist.
+
+Release note: None
+Epic: None
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# Push to fork
+git push -u celiala enable-upgrade-tests-25.4-code
+
+# Create PR
+gh pr create --repo cockroachdb/cockroach \
+  --title "clusterversion: bump PreviousRelease to V25_4" \
+  --body "Part of M.3: Enable upgrade tests for 25.4.
+
+This PR:
+- Updates PreviousRelease constant to V25_4
+- Adds cockroach-go-testserver-25.4 logictest configuration
+- Generates test files for the new configuration
+
+Depends on fixtures PR being merged first.
+
+Epic: None"
+```
+
+---
+
+## Expected Files
+
+### PR 1 (Fixtures): ~6 files
+1. `pkg/testutils/release/cockroach_releases.yaml`
+2. `pkg/sql/logictest/REPOSITORIES.bzl`
+3-6. `pkg/cmd/roachtest/fixtures/{1,2,3,4}/checkpoint-v25.4.tgz`
+
+### PR 2 (Code): ~9 files
+1. `pkg/clusterversion/cockroach_versions.go`
+2. `pkg/sql/logictest/logictestbase/logictestbase.go`
+3. `pkg/sql/logictest/BUILD.bazel`
+4. `pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go` (verify only)
+5. `pkg/sql/logictest/tests/cockroach-go-testserver-25.4/BUILD.bazel` (generated)
+6. `pkg/sql/logictest/tests/cockroach-go-testserver-25.4/generated_test.go` (generated)
+7-9. Various BUILD.bazel updates from `./dev gen bazel`
+
+---
+
+## Validation
+
+### Fixtures PR
+
+```bash
+# Verify fixture sizes
+ls -lh pkg/cmd/roachtest/fixtures/*/checkpoint-v25.4.tgz
+
+# Verify releases file updated
+grep -A 2 '"25.4":' pkg/testutils/release/cockroach_releases.yaml
+
+# Verify REPOSITORIES.bzl has RC binaries
+grep "25.4.0-rc.1" pkg/sql/logictest/REPOSITORIES.bzl
+```
+
+### Code PR
+
+```bash
+# Verify PreviousRelease updated
+grep "const PreviousRelease" pkg/clusterversion/cockroach_versions.go
+
+# Verify testserver config added
+grep "cockroach-go-testserver-25.4" pkg/sql/logictest/logictestbase/logictestbase.go
+
+# Build succeeds
+./dev build short
+```
+
+---
+
+## Critical Warnings
+
+| Warning | Impact | Prevention |
+|---------|--------|------------|
+| ⚠️ **Fixtures on Mac** | Wrong architecture, tests fail | MUST use gceworker (amd64) |
+| ⚠️ **REPOSITORIES.bzl verification** | Nightly builds break | Manually verify ALL active testserver versions present |
+| ⚠️ **gceworker firewall** | Can't connect to gceworker | MUST run `update-firewall` BEFORE `create` |
+| ⚠️ **Session disconnect** | Lose environment vars | Re-export FIXTURE_VERSION and COCKROACH_DEV_LICENSE |
+
+---
+
+## Quick Troubleshooting
+
+### gceworker Issues
+
+| Error | Fix |
+|-------|-----|
+| SSH connection fails (exit 255) | `./scripts/gceworker.sh start` (retry) or destroy & recreate |
+| "bazel: command not found" | Run `./dev doctor` to install |
+| "COCKROACH_DEV_LICENSE not set" | `export COCKROACH_DEV_LICENSE="<license>"` |
+
+### Fixture Generation
+
+| Error | Fix |
+|-------|-----|
+| "license required" | Verify: `echo $COCKROACH_DEV_LICENSE` |
+| "roachprod cluster exists" | `./bin/roachprod destroy local` |
+| Fixtures 0 bytes or >10MB | Compare with previous version sizes, regenerate if needed |
+
+### REPOSITORIES.bzl
+
+| Error | Fix |
+|-------|-----|
+| Tool removed needed version | `git show HEAD^:pkg/sql/logictest/REPOSITORIES.bzl | grep -A 4 "X.Y.Z"` then restore manually |
+| Nightly build fails "missing binary" | Verify all active testserver versions in REPOSITORIES.bzl |
+
+---
+
+## Alternative: Single PR Approach
+
+If you prefer one combined PR (not recommended):
+
+1. Do all steps from PR1 and PR2 on a single branch
+2. Commit everything together (~15 files)
+3. Example: #141765
+
+**Recommendation:** Stick with 2-PR approach for easier review.

--- a/pkg/clusterversion/runbooks/M4_bump_minsupported_version_QUICK.md
+++ b/pkg/clusterversion/runbooks/M4_bump_minsupported_version_QUICK.md
@@ -1,0 +1,384 @@
+# M.4: Bump MinSupported - Quick Reference
+
+**Full details:** See `M4_bump_minsupported_version.md`
+
+## Overview
+
+Two PRs to bump MinSupported (e.g., from V25_2 → V25_3 → V25_4), each following this 5-commit pattern.
+
+**Reference PRs:**
+- 25.2→25.3: #157767
+- 25.3→25.4: #158225
+
+---
+
+## Prerequisites Checklist
+
+- [ ] Final release published (e.g., v25.2.0)
+- [ ] Working on `master` branch
+- [ ] Know versions: FROM (e.g., 25.2) and TO (e.g., 25.3)
+
+---
+
+## Commit 1: Bump MinSupported Constant
+
+### Critical Files (⚠️ BUILD BREAKS IF MISSED)
+
+| File | Action | Line |
+|------|--------|------|
+| `pkg/clusterversion/cockroach_versions.go` | `const MinSupported Key = V25_3` | ~362 |
+| `pkg/storage/pebble.go` | Update `MinimumSupportedFormatVersion` | ~2518 |
+
+**For pebble.go:** Check `pebbleFormatVersionMap` at line ~2510, use the pebble format for new MinSupported version.
+
+### Find Files to Update
+
+```bash
+git grep -l "MinSupported" pkg/ | grep -v "_test.go"
+git grep "V25_2" pkg/ | grep -v testdata
+```
+
+### Common Files
+
+- `pkg/crosscluster/logical/logical_replication_writer_processor.go`
+- `pkg/crosscluster/physical/alter_replication_job.go`
+- `pkg/kv/kvserver/closedts/policyrefresher/policy_refresher.go`
+- `pkg/kv/kvserver/closedts/sidetransport/sender.go`
+- `pkg/kv/kvserver/obsolete_code_test.go`
+- `pkg/sql/backfill/mvcc_index_merger.go`
+- `pkg/sql/catalog/funcdesc/helpers.go`
+- `pkg/sql/conn_executor.go`
+- `pkg/sql/create_index.go`
+- `pkg/sql/create_table.go`
+- `pkg/sql/distsql_running.go`
+
+**⚠️ DO NOT modify:** `pkg/sql/execversion/version.go` (owned by SQL Queries team)
+
+### Commit
+
+```bash
+git add pkg/clusterversion/cockroach_versions.go pkg/storage/pebble.go <other-files>
+git commit -m "clusterversion, storage: bump MinSupported from v25.2 to v25.3
+
+Part of the quarterly M.4 \"Bump MinSupported\" task.
+
+This commit updates the MinSupported constant from V25_2 to V25_3.
+After this change, clusters running v25.2 can no longer connect to master.
+
+Release note: None"
+```
+
+### Verify
+
+```bash
+./dev test pkg/storage -f TestMinimumSupportedFormatVersion -v
+```
+
+---
+
+## Commit 2: Remove Schema Changer Rules
+
+### Actions
+
+```bash
+rm -rf pkg/sql/schemachanger/scplan/internal/rules/release_25_2/
+```
+
+Edit `pkg/sql/schemachanger/scplan/plan.go`:
+- Remove import for `release_25_2`
+- Remove from `rulesForReleases` array (line ~158)
+
+Edit `pkg/sql/schemachanger/scplan/BUILD.bazel`:
+- Remove dependency
+
+### Commit
+
+```bash
+git add -A
+git commit -m "schemachanger: remove release_25_2 schema changer rules
+
+Part of the quarterly M.4 \"Bump MinSupported\" task.
+
+After bumping MinSupported from v25.2 to v25.3, the frozen schema
+changer rules for release 25.2 are no longer needed.
+
+Release note: None"
+```
+
+---
+
+## Commit 3: Remove Bootstrap Data
+
+### Actions
+
+```bash
+rm pkg/sql/catalog/bootstrap/data/25_2_system.keys
+rm pkg/sql/catalog/bootstrap/data/25_2_system.sha256
+rm pkg/sql/catalog/bootstrap/data/25_2_tenant.keys
+rm pkg/sql/catalog/bootstrap/data/25_2_tenant.sha256
+```
+
+Edit `pkg/sql/catalog/bootstrap/initial_values.go`:
+- Remove V25_2 entry from `initialValuesFactoryByKey` map (line ~66)
+- Remove `go:embed` variables (lines ~147-157)
+
+Edit `pkg/sql/catalog/bootstrap/BUILD.bazel`:
+- Remove embedsrcs entries
+
+### Commit
+
+```bash
+git add -A
+git commit -m "bootstrap: remove 25.2 bootstrap data
+
+Part of the quarterly M.4 \"Bump MinSupported\" task.
+
+This commit removes the bootstrap data for v25.2, which is now below
+the minimum supported version.
+
+Release note: None"
+```
+
+---
+
+## Commit 4: Update Mixed Version Tests
+
+### Files to Update
+
+```bash
+ls pkg/sql/logictest/testdata/logic_test/mixed_version_*
+```
+
+Typical files:
+- `mixed_version_char`
+- `mixed_version_citext`
+- `mixed_version_ltree`
+- `mixed_version_partial_stats`
+
+**Note:** Some of these files may not exist in newer versions. Only update files that exist.
+
+### Action
+
+Update LogicTest headers:
+
+```diff
+-# LogicTest: cockroach-go-testserver-25.2
++# LogicTest: cockroach-go-testserver-25.3
+```
+
+Or for multi-config files:
+
+```diff
+-# LogicTest: cockroach-go-testserver-25.2 cockroach-go-testserver-25.3
++# LogicTest: cockroach-go-testserver-25.3
+```
+
+### Commit
+
+```bash
+git add pkg/sql/logictest/testdata/logic_test/mixed_version_*
+git commit -m "logictest: update mixed_version tests to use 25.3 testserver
+
+Part of the quarterly M.4 \"Bump MinSupported\" task.
+
+Updates LogicTest headers for mixed-version tests to test against v25.3
+instead of v25.2.
+
+Release note: None"
+```
+
+---
+
+## Commit 5: Remove Local-Mixed Test Configuration
+
+### Critical Files (⚠️ BREAKS NIGHTLY IF MISSED)
+
+| File | Action |
+|------|--------|
+| `pkg/sql/logictest/logictestbase/logictestbase.go` | Remove config definition and set entries |
+| `build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh` | ⚠️ Update `for config in` loop |
+| Test directories | Delete `local-mixed-25.2/` |
+| Logic test files | Remove skipif/onlyif refs |
+
+### Step 1: Update logictestbase.go
+
+Remove config definition (lines ~501-515):
+```go
+// REMOVE:
+{
+    Name:                        "local-mixed-25.2",
+    NumNodes:                    1,
+    OverrideDistSQLMode:         "off",
+    BootstrapVersion:            clusterversion.TODO_Delete_V25_2,
+    DisableUpgrade:              true,
+    DeclarativeCorpusCollection: true,
+    DisableSchemaLockedByDefault: true,
+},
+```
+
+Remove from sets (lines ~660, ~684):
+```go
+"default-configs": makeConfigSet(
+    "local-mixed-25.2",  // REMOVE THIS LINE
+)
+
+"schema-locked-disabled": makeConfigSet(
+    "local-mixed-25.2",  // REMOVE THIS LINE
+)
+```
+
+### Step 2: Update Nightly Build Script (⚠️ CRITICAL)
+
+Edit `build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh` (line ~84):
+
+```diff
+-for config in local-mixed-25.2 local-mixed-25.3; do
++for config in local-mixed-25.3; do
+```
+
+**This broke the nightly in PR #158225!** Don't forget this file.
+
+### Step 3: Delete Test Directories
+
+```bash
+rm -rf pkg/ccl/logictestccl/tests/local-mixed-25.2/
+rm -rf pkg/sql/logictest/tests/local-mixed-25.2/
+rm -rf pkg/sql/sqlitelogictest/tests/local-mixed-25.2/
+```
+
+### Step 4: Update Logic Test Files
+
+```bash
+# Remove from dedicated directive lines
+find pkg/sql/logictest/testdata/logic_test/ \
+     pkg/ccl/logictestccl/testdata/logic_test/ \
+     -type f -exec grep -l "local-mixed-25\.2" {} \; | while read file; do
+  sed -i '' \
+    -e '/^# LogicTest:/s/ !*local-mixed-25\.2//g' \
+    -e '/^skipif config local-mixed-25\.2$/d' \
+    -e '/^onlyif config local-mixed-25\.2$/d' \
+    "$file"
+done
+
+# Remove from multi-config lines
+find pkg/sql/logictest/testdata/logic_test/ \
+     pkg/ccl/logictestccl/testdata/logic_test/ \
+     -type f -exec grep -l "local-mixed-25\.2" {} \; | while read file; do
+  sed -i '' \
+    -e '/^onlyif config/s/ local-mixed-25\.2//g' \
+    -e '/^skipif config/s/ local-mixed-25\.2//g' \
+    "$file"
+done
+
+# Remove empty LogicTest directives (if any)
+sed -i '' '/^# LogicTest:$/d' pkg/sql/logictest/testdata/logic_test/* \
+          pkg/ccl/logictestccl/testdata/logic_test/* 2>/dev/null || true
+```
+
+**⚠️ IMPORTANT:** After sed, manually check files with `onlyif` directives - you may need to remove guarded statements. See full runbook for details.
+
+### Step 5: Regenerate Bazel
+
+```bash
+./dev gen bazel
+```
+
+### Commit
+
+```bash
+git add -A
+git commit -m "logictest: remove local-mixed-25.2 test configuration
+
+Part of the quarterly M.4 \"Bump MinSupported\" task.
+
+After bumping MinSupported from v25.2 to v25.3, the local-mixed-25.2
+test configuration is no longer needed.
+
+Changes:
+- Removed local-mixed-25.2 config from logictestbase.go
+- Updated nightly build script (sqllogic_corpus_nightly_impl.sh)
+- Deleted test directories
+- Removed skipif/onlyif references from test files
+- Regenerated Bazel BUILD files
+
+Release note: None"
+```
+
+---
+
+## Validation
+
+### Run Tests
+
+```bash
+./dev test pkg/clusterversion pkg/storage
+```
+
+### Build
+
+```bash
+./dev build short
+```
+
+### Check Commits
+
+```bash
+git log --oneline HEAD~5..HEAD
+```
+
+Expected:
+1. Bump MinSupported from v25.2 to v25.3
+2. Remove release_25_2 schema changer rules
+3. Remove 25.2 bootstrap data
+4. Update mixed_version tests to use 25.3 testserver
+5. Remove local-mixed-25.2 test configuration
+
+### Compare with Reference PR
+
+```bash
+# Get files from reference PR
+gh pr view 157767 --json files --jq '.files[].path' | sort > /tmp/ref_files.txt
+
+# Get your files
+git diff --name-only master | sort > /tmp/current_files.txt
+
+# Compare
+echo "=== Only in current ==="
+comm -13 /tmp/ref_files.txt /tmp/current_files.txt
+
+echo "=== Only in reference ==="
+comm -23 /tmp/ref_files.txt /tmp/current_files.txt
+```
+
+Justify differences (version-specific files are expected to differ).
+
+---
+
+## Critical Files Checklist
+
+Before creating PR, verify these files were updated:
+
+- [ ] `pkg/storage/pebble.go` - MinimumSupportedFormatVersion
+- [ ] `build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh` - nightly loop
+- [ ] All three test directory types deleted (ccl, logictest, sqlitelogictest)
+- [ ] `./dev gen bazel` ran successfully
+
+---
+
+## Expected File Count
+
+~70-80 files changed across 5 commits with ~5,000-6,000 deletions.
+
+---
+
+## Quick Troubleshooting
+
+| Error | Quick Fix |
+|-------|-----------|
+| `TestMinimumSupportedFormatVersion` fails | Check `pkg/storage/pebble.go` MinimumSupportedFormatVersion matches pebbleFormatVersionMap |
+| Nightly build fails "nonexistent local-mixed" | Update `sqllogic_corpus_nightly_impl.sh` |
+| `panic: unknown config name` | Logic test files still reference old config - run sed commands again |
+| `empty LogicTest directive` | Remove with `sed -i '' '/^# LogicTest:$/d' <file>` |
+| Duplicate statement errors | Manually review files with `onlyif` - see full runbook |
+
+**Full troubleshooting:** See main runbook section "Common Errors and Solutions"


### PR DESCRIPTION
This PR:
- adds a note to update `sqllogic_corpus_nightly_impl.sh` which was 
  - correctly done for 25.3 bump (#157767), 
  - but missed for 25.4 bump (#158225)
- adds a "quick reference" version for M3 and M4 runbooks, to mitigate bot confusion.

Improvements related to: 
- https://github.com/cockroachdb/cockroach/pull/158817
- https://github.com/cockroachdb/cockroach/issues/158741

Release note: None
Epic: None