### PR TITLE
drtprod/scripts: run tpcc continuously to avoid w_ytd overflow

### DIFF
--- a/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
@@ -65,9 +65,12 @@ while true; do
     ./cockroach workload init tpcc \
         --warehouses=3000 \
         --secure \
-  --concurrency 4 \
+        --concurrency 4 \
         --db cct_tpcc_drop \
-        \$PG_URL_N1 | tee "\$INIT_LOG"
+        "$PG_URL_N1" | tee "\$INIT_LOG"
+    if [ \$? -eq 0 ]; then
+        rm "\$INIT_LOG"
+    fi
     echo ">> Dropping cct_tpcc_drop_old if it exists"
     ./cockroach sql --url "${PG_URL_N1}" -e "DROP DATABASE cct_tpcc_drop_old CASCADE;"
     sleep 5
@@ -77,12 +80,15 @@ while true; do
         --active-warehouses 1000 \
         --db cct_tpcc_drop \
         --secure \
-  --prometheus-port 2113 \
+        --prometheus-port 2113 \
         --ramp 5m \
         --display-every 5s \
         --duration 60m \
-  --tolerate-errors \
-   "\${PGURLS_ARR[@]}" | tee "\$RUN_LOG"
+        --tolerate-errors \
+        "\${PGURLS_ARR[@]}" | tee "\$RUN_LOG"
+    if [ \$? -eq 0 ]; then
+        rm "\$RUN_LOG"
+    fi
 
     echo ">> Renaming to cct_tpcc_drop_old"
     ./cockroach sql --url "${PG_URL_N1}" -e "ALTER DATABASE cct_tpcc_drop RENAME TO cct_tpcc_drop_old;"

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
@@ -140,21 +140,14 @@ if [ -z "\$PGURLS" ]; then
     fi
 fi
 read -r -a PGURLS_ARR <<< "\$PGURLS"
-j=0
-while true; do
-    echo ">> Starting tpcc workload"
-    ((j++))
-    LOG=./tpcc_\$j.txt
-    ./cockroach workload run tpcc $@ \
-        $partition_args \
-        --tolerate-errors \
-        --families \
-         \${PGURLS_ARR[@]}  | tee \$LOG
-    if [ \$? -eq 0 ]; then
-        rm "\$LOG"
-    fi
-    sleep 1
-done
+echo ">> Starting tpcc workload"
+LOG=./tpcc_log.txt
+./cockroach workload run tpcc $@ \
+    $partition_args \
+    --tolerate-errors \
+    --families \
+    --duration 0 \
+    \${PGURLS_ARR[@]} 2>&1 | tee \$LOG
 EOF
 
   # Upload the script to the workload cluster


### PR DESCRIPTION
After running TPCC for extended periods (e.g., a week), the workload fails with "DECIMAL(12,2) overflow" errors because the accumulated w_ytd balance grows indefinitely and exceeds 10^10.

Setting `--duration 0` in `generate_tpcc_run.sh` to run the workload continuously instead of restarting in a loop. This allows the workload's built-in long-duration mode to periodically reset w_ytd values, preventing overflow.

Also clean up log files after successful runs in generate_tpcc_drop.sh.

Epic: none

Release note: None