### PR TITLE
workload/schemachanger: fix potential error for DETACHED flag in inspect

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3508,6 +3508,7 @@ func (og *operationGenerator) inspect(ctx context.Context, tx pgx.Tx) (*opStmt, 
 	}
 	if isDetachedUnsupported {
 		stmt.potentialExecErrors.add(pgcode.FeatureNotSupported)
+		stmt.potentialExecErrors.add(pgcode.Syntax)
 	}
 	// Always run DETACHED as this allows us to use INSPECT inside of a
 	// transaction. We have post-processing at the end of the run to verify


### PR DESCRIPTION
Previously, this was incorrectly expecting the pgcode FeatureNotSuported, when it should have been SyntaaxError.

Fixes: #158837
Release note: None