### PR TITLE
backup: disable reading from backup index by default

### DIFF
--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -37,7 +37,7 @@ var (
 		settings.ApplicationLevel,
 		"backup.index.read.enabled",
 		"if true, the backup index will be read when reading from a backup collection",
-		metamorphic.ConstantWithTestBool("backup.index.read.enabled", true),
+		metamorphic.ConstantWithTestBool("backup.index.read.enabled", false),
 	)
 )
 


### PR DESCRIPTION
Epic: CRDB-57536

Release note: None