### PR TITLE
sql/ttl: use AOST timestamp when computing query bounds

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/ctxgroup",
-        "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",


### PR DESCRIPTION
Previously, when computing query bounds from spans in the TTL job
processor, we used the current timestamp for the KV Scan/ReverseScan
operations. This could cause contention with foreground traffic.

This change updates the TTL processor to use the same AOST (As Of
System Time) timestamp for computing query bounds that is already
used for the SELECT queries. This aligns the bounds computation with
the historical time at which the TTL job operates, reducing load on
the system and improving overall efficiency.


Existing TTL tests pass (`TestRowLevelTTLJobRandomEntries`, `TestRowLevelTTLJobMultipleNodes`, etc.).

Resolves: #155871
Epic: CRDB-55074

🤖 Generated with [Claude Code](https://claude.com/claude-code)