### PR TITLE
sql/parser: support array types in composite type definitions

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3513,7 +3513,7 @@ enum_val_list ::=
 	( 'SCONST' ) ( ( ',' 'SCONST' ) )*
 
 composite_type_list ::=
-	( name simple_typename ) ( ( ',' name simple_typename ) )*
+	( name typename ) ( ( ',' name typename ) )*
 
 routine_param_with_default_list ::=
 	( routine_param_with_default ) ( ( ',' routine_param_with_default ) )*

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -163,7 +163,7 @@ statement error pgcode 0A000 pq: cannot accept a value of type trigger
 CREATE TYPE udt AS (x INT, y TRIGGER, z TEXT);
 
 # Trigger array UDT field.
-statement error pgcode 42601 pq: at or near "\[": syntax error
+statement error pgcode 42704 pq: at or near ",": syntax error: type trigger\[\] does not exist
 CREATE TYPE udt AS (x INT, y TRIGGER[], z TEXT);
 
 # ==============================================================================

--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -54,6 +54,43 @@ NULL   NULL  NULL
 statement error cannot drop type \"t\" because other objects .* still depend on it
 DROP TYPE t
 
+# Test array types within composite type definitions.
+statement ok
+CREATE TYPE arr_composite AS (a INT[], b TEXT[])
+
+query TTTT
+SELECT database_name, schema_name, descriptor_name, create_statement
+FROM crdb_internal.create_type_statements WHERE descriptor_name = 'arr_composite'
+----
+test  public  arr_composite  CREATE TYPE public.arr_composite AS (a INT8[], b STRING[])
+
+statement ok
+CREATE TABLE arr_composite_tab (x arr_composite)
+
+statement ok
+INSERT INTO arr_composite_tab VALUES ((ARRAY[1, 2, 3], ARRAY['a', 'b']))
+
+statement ok
+INSERT INTO arr_composite_tab VALUES (ROW(ARRAY[4, 5], ARRAY['c', 'd', 'e']))
+
+query T rowsort
+SELECT * FROM arr_composite_tab
+----
+("{1,2,3}","{a,b}")
+("{4,5}","{c,d,e}")
+
+query TT rowsort
+SELECT (x).a, (x).b FROM arr_composite_tab
+----
+{1,2,3}  {a,b}
+{4,5}    {c,d,e}
+
+statement ok
+DROP TABLE arr_composite_tab
+
+statement ok
+DROP TYPE arr_composite
+
 # Test arrays of composite types.
 statement disable-cf-mutator ok
 CREATE TABLE atyp(a t[])

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -12631,7 +12631,7 @@ opt_composite_type_list:
   }
 
 composite_type_list:
-  name simple_typename
+  name typename
   {
     $$.val = []tree.CompositeTypeElem{
         tree.CompositeTypeElem{
@@ -12640,7 +12640,7 @@ composite_type_list:
         },
     }
   }
-| composite_type_list ',' name simple_typename
+| composite_type_list ',' name typename
   {
     $$.val = append($1.compositeTypeList(),
         tree.CompositeTypeElem{

--- a/pkg/sql/parser/testdata/create_type
+++ b/pkg/sql/parser/testdata/create_type
@@ -77,3 +77,27 @@ CREATE TYPE foo AS (a "What A wild Thing To Call A Type", b "🌟 ")
 CREATE TYPE foo AS (a "What A wild Thing To Call A Type", b "🌟 ") -- fully parenthesized
 CREATE TYPE foo AS (a "What A wild Thing To Call A Type", b "🌟 ") -- literals removed
 CREATE TYPE _ AS (_ _, _ _) -- identifiers removed
+
+parse
+CREATE TYPE foo AS (a INT[])
+----
+CREATE TYPE foo AS (a INT8[]) -- normalized!
+CREATE TYPE foo AS (a INT8[]) -- fully parenthesized
+CREATE TYPE foo AS (a INT8[]) -- literals removed
+CREATE TYPE _ AS (_ INT8[]) -- identifiers removed
+
+parse
+CREATE TYPE foo AS (a INT ARRAY)
+----
+CREATE TYPE foo AS (a INT8[]) -- normalized!
+CREATE TYPE foo AS (a INT8[]) -- fully parenthesized
+CREATE TYPE foo AS (a INT8[]) -- literals removed
+CREATE TYPE _ AS (_ INT8[]) -- identifiers removed
+
+parse
+CREATE TYPE foo AS (a INT[], b TEXT[])
+----
+CREATE TYPE foo AS (a INT8[], b STRING[]) -- normalized!
+CREATE TYPE foo AS (a INT8[], b STRING[]) -- fully parenthesized
+CREATE TYPE foo AS (a INT8[], b STRING[]) -- literals removed
+CREATE TYPE _ AS (_ INT8[], _ STRING[]) -- identifiers removed


### PR DESCRIPTION
Previously, CREATE TYPE with composite type syntax did not allow array
types in the field definitions. For example, `CREATE TYPE t AS (a int[])`
would fail with a syntax error because the grammar rule used
`simple_typename` which doesn't include array modifiers.

This commit changes the `composite_type_list` grammar rule to use
`typename` instead of `simple_typename`, which properly handles both
`int[]` bracket syntax and `int array` keyword syntax.

Fixes: #109597

Release note (sql change): CREATE TYPE with composite type syntax now
supports array types in field definitions. For example,
`CREATE TYPE t AS (a INT[])` and `CREATE TYPE t AS (a INT ARRAY)` now
work correctly, matching PostgreSQL behavior.