### PR TITLE
ts: update the recording of changefeed child metrics

### DIFF
--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//pkg/util/log/logmetrics",
         "//pkg/util/log/severity",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/syncutil",
         "//pkg/util/system",
         "@com_github_cockroachdb_crlib//crtime",

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"math"
 	"os"
@@ -190,6 +191,11 @@ type MetricsRecorder struct {
 	// round-trip) that requires a mutex to be safe for concurrent usage. We
 	// therefore give it its own mutex to avoid blocking other methods.
 	writeSummaryMu syncutil.Mutex
+
+	// childMetricNameCache caches the encoded names for child metrics to avoid
+	// rebuilding them on every recording. Uses syncutil.Map for lock-free reads.
+	// Stores full cache entries to detect hash collisions.
+	childMetricNameCache syncutil.Map[uint64, cacheEntry]
 }
 
 // NewMetricsRecorder initializes a new MetricsRecorder object that uses the
@@ -463,20 +469,22 @@ func (mr *MetricsRecorder) GetTimeSeriesData(childMetrics bool) []tspb.TimeSerie
 
 		// Record child metrics from app registry for system tenant only.
 		recorder := registryRecorder{
-			registry:       mr.mu.appRegistry,
-			format:         nodeTimeSeriesPrefix,
-			source:         mr.mu.desc.NodeID.String(),
-			timestampNanos: now.UnixNano(),
+			registry:             mr.mu.appRegistry,
+			format:               nodeTimeSeriesPrefix,
+			source:               mr.mu.desc.NodeID.String(),
+			timestampNanos:       now.UnixNano(),
+			childMetricNameCache: &mr.childMetricNameCache,
 		}
 		recorder.recordChangefeedChildMetrics(&data)
 
 		// Record child metrics from app-level registries for secondary tenants
 		for tenantID, r := range mr.mu.tenantRegistries {
 			tenantRecorder := registryRecorder{
-				registry:       r,
-				format:         nodeTimeSeriesPrefix,
-				source:         tsutil.MakeTenantSource(mr.mu.desc.NodeID.String(), tenantID.String()),
-				timestampNanos: now.UnixNano(),
+				registry:             r,
+				format:               nodeTimeSeriesPrefix,
+				source:               tsutil.MakeTenantSource(mr.mu.desc.NodeID.String(), tenantID.String()),
+				timestampNanos:       now.UnixNano(),
+				childMetricNameCache: &mr.childMetricNameCache,
 			}
 			tenantRecorder.recordChangefeedChildMetrics(&data)
 		}
@@ -800,6 +808,9 @@ type registryRecorder struct {
 	format         string
 	source         string
 	timestampNanos int64
+	// childMetricNameCache is an optional cache for encoded child metric names.
+	// If nil, no caching will be performed.
+	childMetricNameCache *syncutil.Map[uint64, cacheEntry]
 }
 
 // allowedChangefeedMetrics is the list of changefeed metrics that should have
@@ -949,6 +960,61 @@ func (rr registryRecorder) recordChild(
 	})
 }
 
+func hashLabels(labels []*prometheusgo.LabelPair) uint64 {
+	h := fnv.New64a()
+	for _, label := range labels {
+		h.Write([]byte(label.GetName()))
+		h.Write([]byte(label.GetValue()))
+	}
+	return h.Sum64()
+}
+
+// cacheEntry holds a cached metric name along with the labels that produced it,
+// used for verification when hash collisions occur.
+type cacheEntry struct {
+	labels []*prometheusgo.LabelPair
+	name   string
+}
+
+// labelsEqual returns true if two label slices are equal.
+func labelsEqual(a, b []*prometheusgo.LabelPair) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].GetName() != b[i].GetName() || a[i].GetValue() != b[i].GetValue() {
+			return false
+		}
+	}
+	return true
+}
+
+// getOrComputeMetricName looks up the encoded metric name in the cache,
+// or computes it using the provided computeFn if not found.
+// Verifies labels on cache hit to detect hash collisions.
+func getOrComputeMetricName(
+	cache *syncutil.Map[uint64, cacheEntry],
+	labels []*prometheusgo.LabelPair,
+	computeFn func() string,
+) string {
+	if cache == nil {
+		return computeFn()
+	}
+	labelHash := hashLabels(labels)
+	if cached, ok := cache.Load(labelHash); ok {
+		if labelsEqual(cached.labels, labels) {
+			return cached.name
+		}
+		// Hash collision detected - proceed to compute
+	}
+	name := computeFn()
+	cache.Store(labelHash, &cacheEntry{
+		labels: labels,
+		name:   name,
+	})
+	return name
+}
+
 // recordChangefeedChildMetrics iterates through changefeed metrics in the registry and processes child metrics
 // for those that have TsdbRecordLabeled set to true in their metadata.
 // Records up to 1024 child metrics per metric to prevent unbounded memory usage and performance issues.
@@ -968,19 +1034,6 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 		metadata := iterable.GetMetadata()
 		if !metadata.GetTsdbRecordLabeled() {
 			return // Skip this metric if child collection is not enabled
-		}
-
-		recordMetric := func(name string, value float64) {
-			*dest = append(*dest, tspb.TimeSeriesData{
-				Name:   fmt.Sprintf(rr.format, name),
-				Source: rr.source,
-				Datapoints: []tspb.TimeSeriesDatapoint{
-					{
-						TimestampNanos: rr.timestampNanos,
-						Value:          value,
-					},
-				},
-			})
 		}
 
 		// Handle AggHistogram - use direct child access for per-child snapshots
@@ -1006,31 +1059,34 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 					}
 				}
 
-				// Get per-child snapshots
-				cumulativeSnapshot := child.CumulativeSnapshot()
-				windowedSnapshot := child.WindowedSnapshot()
-
-				// Check if we got valid snapshots by checking the sample count
-				// Empty snapshots will have count=0, which is safe to record but may not be meaningful
-				// This check ensures we handle cases where the histogram isn't properly initialized
-				cumulativeCount, _ := cumulativeSnapshot.Total()
-				windowedCount, _ := windowedSnapshot.Total()
-				if cumulativeCount < 0 || windowedCount < 0 {
-					// Skip malformed snapshots to avoid recording bad data
-					return
-				}
-
-				baseName := metadata.Name + metric.EncodeLabeledName(&prometheusgo.Metric{Label: childLabels})
-
+				// Check cache for encoded name
+				baseName := getOrComputeMetricName(rr.childMetricNameCache, childLabels, func() string {
+					return metadata.Name + metric.EncodeLabeledName(&prometheusgo.Metric{Label: childLabels})
+				})
 				// Record all histogram computed metrics using child-specific snapshots
 				for _, c := range metric.HistogramMetricComputers {
-					var value float64
+					var snapshot metric.HistogramSnapshot
 					if c.IsSummaryMetric {
-						value = c.ComputedMetric(windowedSnapshot)
+						snapshot = child.WindowedSnapshot()
 					} else {
-						value = c.ComputedMetric(cumulativeSnapshot)
+						snapshot = child.CumulativeSnapshot()
 					}
-					recordMetric(baseName+c.Suffix, value)
+					count, _ := snapshot.Total()
+					if count < 0 {
+						continue // Skip malformed snapshots
+					}
+					value := c.ComputedMetric(snapshot)
+					metricName := baseName + c.Suffix
+					*dest = append(*dest, tspb.TimeSeriesData{
+						Name:   fmt.Sprintf(rr.format, metricName),
+						Source: rr.source,
+						Datapoints: []tspb.TimeSeriesDatapoint{
+							{
+								TimestampNanos: rr.timestampNanos,
+								Value:          value,
+							},
+						},
+					})
 				}
 				childMetricsCount++
 			})
@@ -1063,7 +1119,22 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 			} else {
 				return
 			}
-			recordMetric(prom.GetName(false /* useStaticLabels */)+metric.EncodeLabeledName(childMetric), value)
+
+			// Check cache for encoded name
+			metricName := getOrComputeMetricName(rr.childMetricNameCache, childMetric.Label, func() string {
+				return prom.GetName(false /* useStaticLabels */) + metric.EncodeLabeledName(childMetric)
+			})
+
+			*dest = append(*dest, tspb.TimeSeriesData{
+				Name:   fmt.Sprintf(rr.format, metricName),
+				Source: rr.source,
+				Datapoints: []tspb.TimeSeriesDatapoint{
+					{
+						TimestampNanos: rr.timestampNanos,
+						Value:          value,
+					},
+				},
+			})
 			childMetricsCount++
 		}
 		promIter.Each(m.Label, processChildMetric)

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -1227,6 +1227,7 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 				},
 				Duration:     10 * time.Second,
 				BucketConfig: metric.IOLatencyBuckets,
+				Mode:         metric.HistogramModePrometheus,
 			},
 			"scope",
 		)

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -293,6 +293,28 @@ func TestMetricsRecorderLabels(t *testing.T) {
 	child4 := aggGauge.AddChild("yours", "paused")
 	child4.Update(0)
 
+	aggHistogram := aggmetric.NewHistogram(
+		metric.HistogramOptions{
+			Metadata: metric.Metadata{
+				Name:     "changefeed.stage.downstream_client_send.latency",
+				Category: metric.Metadata_CHANGEFEEDS,
+			},
+			Duration:     10 * time.Second,
+			BucketConfig: metric.IOLatencyBuckets,
+			Mode:         metric.HistogramModePrometheus,
+		},
+		"scope",
+	)
+	appReg.AddMetric(aggHistogram)
+	// Add child histogram metrics
+	child5 := aggHistogram.AddChild("default")
+	child5.RecordValue(100)
+	child5.RecordValue(200)
+	child6 := aggHistogram.AddChild("user")
+	child6.RecordValue(300)
+	child6.RecordValue(400)
+	child6.RecordValue(500)
+
 	// Enable the cluster setting for child metrics storage
 	ChildMetricsStorageEnabled.Override(context.Background(), &st.SV, true)
 
@@ -333,6 +355,34 @@ func TestMetricsRecorderLabels(t *testing.T) {
 			labelMatchers:  []string{"db=\"yours\"", "status__=\"paused\""},
 			expectedSource: "7",
 			expectedValue:  0,
+		},
+		{
+			name:           "histogram default -count",
+			metricPrefix:   "cr.node.changefeed.stage.downstream_client_send.latency",
+			labelMatchers:  []string{"scope=\"default\"", "-count"},
+			expectedSource: "7",
+			expectedValue:  2,
+		},
+		{
+			name:           "histogram user -count",
+			metricPrefix:   "cr.node.changefeed.stage.downstream_client_send.latency",
+			labelMatchers:  []string{"scope=\"user\"", "-count"},
+			expectedSource: "7",
+			expectedValue:  3,
+		},
+		{
+			name:           "histogram default -avg",
+			metricPrefix:   "cr.node.changefeed.stage.downstream_client_send.latency",
+			labelMatchers:  []string{"scope=\"default\"", "-avg"},
+			expectedSource: "7",
+			expectedValue:  150,
+		},
+		{
+			name:           "histogram user -avg",
+			metricPrefix:   "cr.node.changefeed.stage.downstream_client_send.latency",
+			labelMatchers:  []string{"scope=\"user\"", "-avg"},
+			expectedSource: "7",
+			expectedValue:  400,
 		},
 	}
 
@@ -1147,7 +1197,7 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 		require.Contains(t, metricName, "changefeed.aggregator_progress{feed_name=\"my-feed!\", job_id=\"test@123\"}")
 	})
 
-	t.Run("counter and gauge support", func(t *testing.T) {
+	t.Run("counter, gauge, histogram support", func(t *testing.T) {
 		reg := metric.NewRegistry()
 
 		// Test with gauge
@@ -1168,6 +1218,24 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 		counterChild := counter.AddChild("counter")
 		counterChild.Inc(50)
 
+		// Test with histogram
+		histogram := aggmetric.NewHistogram(
+			metric.HistogramOptions{
+				Metadata: metric.Metadata{
+					Name:     "changefeed.emitted_batch_sizes",
+					Category: metric.Metadata_CHANGEFEEDS,
+				},
+				Duration:     10 * time.Second,
+				BucketConfig: metric.IOLatencyBuckets,
+			},
+			"scope",
+		)
+		reg.AddMetric(histogram)
+		histChild := histogram.AddChild("default")
+		histChild.RecordValue(100)
+		histChild.RecordValue(200)
+		histChild.RecordValue(300)
+
 		recorder := registryRecorder{
 			registry:       reg,
 			format:         nodeTimeSeriesPrefix,
@@ -1178,7 +1246,7 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 		var dest []tspb.TimeSeriesData
 		recorder.recordChangefeedChildMetrics(&dest)
 
-		require.Len(t, dest, 2)
+		require.Len(t, dest, 13) // 1 gauge + 1 counter + 11 histogram metrics
 
 		// Find gauge and counter data points
 		var gaugeValue, counterValue float64
@@ -1192,6 +1260,20 @@ func TestRecordChangefeedChildMetrics(t *testing.T) {
 
 		require.Equal(t, float64(100), gaugeValue)
 		require.Equal(t, float64(50), counterValue)
+
+		// Verify that histogram suffixes are present
+		foundSuffixes := make(map[string]bool)
+		expectedSuffixes := []string{"-count", "-sum", "-p50", "-p75", "-p90", "-p99", "-p99.9", "-p99.99", "-p99.999", "-max", "-avg"}
+
+		for _, data := range dest {
+			for _, suffix := range expectedSuffixes {
+				if strings.Contains(data.Name, suffix) {
+					foundSuffixes[suffix] = true
+				}
+			}
+		}
+
+		require.Equal(t, len(expectedSuffixes), len(foundSuffixes), "Expected to find histogram metric suffixes")
 	})
 }
 


### PR DESCRIPTION
ts: record histogram child metrics

When child metrics collection was performed, it only picked up gauges and counters.
This commit adds the ability to record histograms as well.
This was done through exposing child histograms snapshots which were previously not accessible.

Epic: CRDB-55079
Release: None

--

ts: memoize child metric name transformation

Curently the child metric name transformations are being performed every polling cycle.
The memoization will ensure every subsequent poll does not need to allocate memory and cpu to transform the names.

Epic: CRDB-55079
Release: None
