### PR TITLE
backup: write index full subdirs in reverse chronological order

### DIFF
--- a/pkg/backup/backupbase/constants.go
+++ b/pkg/backup/backupbase/constants.go
@@ -63,11 +63,7 @@ const (
 
 	// BackupIndexDirectoryName is the path from the root of the backup collection
 	// to the directory containing the index files for the backup collection.
-	BackupIndexDirectoryPath = "index/"
-
-	// BackupIndexFlattenedSubdir is the format used for the top-level
-	// subdirectories within the index directory.
-	BackupIndexFlattenedSubdir = "2006-01-02-150405.00"
+	BackupIndexDirectoryPath = backupMetadataDirectory + "/index/"
 
 	// BackupIndexFilenameTimestampFormat is the format used for the human
 	// readable start and end times in the index file names.

--- a/pkg/backup/backupinfo/BUILD.bazel
+++ b/pkg/backup/backupinfo/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "//pkg/backup/backupbase",
         "//pkg/backup/backuppb",
         "//pkg/backup/backuptestutils",
+        "//pkg/backup/backuputils",
         "//pkg/base",
         "//pkg/blobs",
         "//pkg/ccl",

--- a/pkg/backup/backuputils/utils.go
+++ b/pkg/backup/backuputils/utils.go
@@ -111,6 +111,19 @@ func EncodeDescendingTS(ts time.Time) string {
 	return hex.EncodeToString(buffer)
 }
 
+// DecodeDescendingTS decodes a time.Time encoded with EncodeDescendingTS.
+func DecodeDescendingTS(encoded string) (time.Time, error) {
+	buffer, err := hex.DecodeString(encoded)
+	if err != nil {
+		return time.Time{}, err
+	}
+	_, tsMillis, err := encoding.DecodeUvarintDescending(buffer)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMilli(int64(tsMillis)), nil
+}
+
 // AbsoluteBackupPathInCollectionURI returns the absolute path of a backup
 // assuming the root is the collection URI. Backup URI represents the URI that
 // points to the directory containing the backup manifest of the backup. Since


### PR DESCRIPTION
Pre-requisite work outlined in the faster `SHOW BACKUP` [design doc](https://docs.google.com/document/d/1_HepOulhmHcKvBrc0o7fSTJ9RXF8wkKG72W0Qgtfca8).

Epic: CRDB-57536

Closes: #158891

Release note: None