### PR TITLE
ci: skip AI review for draft PRs

### DIFF
--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -8,7 +8,7 @@ jobs:
   claude-code-pr-review:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: "!startsWith(github.base_ref, 'release-') && !contains(github.event.pull_request.labels.*.name, 'O-No-AI-Review') && github.event.pull_request.merged == false"
+    if: "!startsWith(github.base_ref, 'release-') && !contains(github.event.pull_request.labels.*.name, 'O-No-AI-Review') && !github.event.pull_request.merged && !github.event.pull_request.draft"
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Skip Claude Code PR Review workflow for draft PRs
- Draft PRs are work-in-progress and not ready for review, so running AI review wastes resources
- The workflow will still trigger when a PR is marked ready for review via the `ready_for_review` event

Release note: None
Epic: None

🤖 Generated with [Claude Code](https://claude.ai/code)