### PR TITLE
roachtest: remove clearrange zfs test

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -37,24 +37,6 @@ func registerClearRange(r registry.Registry) {
 			},
 		})
 	}
-	// Using a separate clearrange test on zfs instead of randomly
-	// using the same test, cause the Timeout might be different,
-	// and may need to be tweaked.
-	r.Add(registry.TestSpec{
-		Name:  `clearrange/zfs/checks=true`,
-		Owner: registry.OwnerStorage,
-		// 5h for import, 120 for the test. The import should take closer
-		// to <3:30h but it varies.
-		Timeout:           5*time.Hour + 120*time.Minute,
-		Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
-		CompatibleClouds:  registry.OnlyGCE,
-		Suites:            registry.Suites(registry.Nightly),
-		EncryptionSupport: registry.EncryptionMetamorphic,
-		Leases:            registry.MetamorphicLeases,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runClearRange(ctx, t, c, true /* checks */)
-		},
-	})
 }
 
 func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressiveChecks bool) {


### PR DESCRIPTION
ZFS is not officially supported. I'm skeptical this variant provides any useful coverage. There continues to be a ycsb variant that runs on ZFS.

Epic: none
Release note: none