### PR TITLE
storeliveness: remove stale TODO

### DIFF
--- a/pkg/kv/kvserver/storeliveness/transport.go
+++ b/pkg/kv/kvserver/storeliveness/transport.go
@@ -48,12 +48,8 @@ const (
 	connClass = rpcbase.SystemClass
 )
 
-// TODO(dodeca12): Currently this complexity allows the fallback to immediate
-// heartbeat sends. Once the smearing has been battle-tested, remove this and
-// default to using the smeared heartbeat sends approach (no more fallback).
-//
-// HeartbeatSmearingEnabled controls whether heartbeat sends are distributed over
-// time to avoid spiking the number of runnable goroutines. When enabled,
+// HeartbeatSmearingEnabled controls whether heartbeat sends are distributed
+// over time to avoid spiking the number of runnable goroutines. When enabled,
 // heartbeats are paced by the transport's smearing sender goroutine across
 // HeartbeatSmearingRefreshInterval. When disabled, heartbeats are sent
 // immediately upon enqueueing, bypassing the smearing mechanism.


### PR DESCRIPTION
No longer applies as the cluster setting is on by default.

Epic: none

Release note: None