### PR TITLE
ui: remove "oss" build cruft 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ help:
 .PHONY: build build%
 build:
 	./dev build $(TARGET)
-# Alias: buildshort -> build short; buildoss -> build oss; buildtests -> build tests etc.
+# Alias: buildshort -> build short; buildtests -> build tests etc.
 build%:
 	./dev build $(@:build%=%)
 

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=115
+DEV_VERSION=116
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -51,8 +51,8 @@ type UIDirectories struct {
 	e2eTests string
 	// eslintPlugin is the absolute path to ./pkg/ui/workspaces/eslint-plugin-crdb.
 	eslintPlugin string
-	// protoOss is the absolute path to ./pkg/ui/workspaces/db-console/src/js/.
-	protoOss string
+	// protoBase is the absolute path to ./pkg/ui/workspaces/db-console/src/js/.
+	protoBase string
 	// protoCcl is the absolute path to ./pkg/ui/workspaces/db-console/ccl/src/js/.
 	protoCcl string
 	// crdbJsProto is the absolute path to ./pkg/ui/workspaces/crdb-js-proto/.
@@ -73,7 +73,7 @@ func getUIDirs(d *dev) (*UIDirectories, error) {
 		dbConsole:     filepath.Join(workspace, "./pkg/ui/workspaces/db-console"),
 		e2eTests:      filepath.Join(workspace, "./pkg/ui/workspaces/e2e-tests"),
 		eslintPlugin:  filepath.Join(workspace, "./pkg/ui/workspaces/eslint-plugin-crdb"),
-		protoOss:      filepath.Join(workspace, "./pkg/ui/workspaces/db-console/src/js"),
+		protoBase:     filepath.Join(workspace, "./pkg/ui/workspaces/db-console/src/js"),
 		protoCcl:      filepath.Join(workspace, "./pkg/ui/workspaces/db-console/ccl/src/js"),
 		crdbApiClient: filepath.Join(workspace, "./pkg/ui/workspaces/crdb-api-client"),
 	}, nil
@@ -112,7 +112,7 @@ func (d *dev) assertNoLinkedNpmDeps(targets []buildTarget) error {
 	jsPkgRoots := []string{
 		uiDirs.root,
 		uiDirs.eslintPlugin,
-		uiDirs.protoOss,
+		uiDirs.protoBase,
 		uiDirs.protoCcl,
 		uiDirs.clusterUI,
 		uiDirs.dbConsole,
@@ -745,8 +745,8 @@ func arrangeFilesForWatchers(d *dev) error {
 
 	// Recreate protobuf client files that were previously copied out of the sandbox
 	for _, relPath := range protoFiles {
-		ossDst := filepath.Join(dbConsoleDst, relPath)
-		if err := d.os.CopyFile(filepath.Join(dbConsoleSrc, relPath), ossDst); err != nil {
+		baseDst := filepath.Join(dbConsoleDst, relPath)
+		if err := d.os.CopyFile(filepath.Join(dbConsoleSrc, relPath), baseDst); err != nil {
 			return err
 		}
 

--- a/pkg/ui/.gitignore
+++ b/pkg/ui/.gitignore
@@ -9,7 +9,6 @@ yarn.cluster-ui.installed
 yarn.protobuf.installed
 yarn-error.log
 assets.ccl.installed
-assets.oss.installed
 
 # Generated intermediates
 .cache-loader
@@ -21,8 +20,4 @@ dist_vendor/**
 !distccl/distccl.go
 !distccl/distccl_no_bazel.go
 !distccl/BUILD.bazel
-!distoss/assets/.gitkeep
-!distoss/distoss.go
-!distoss/distoss_no_bazel.go
-!distoss/BUILD.bazel
 *manifest.json

--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -90,18 +90,18 @@ bazel clean --expunge
 ```
 though be warned your next build will take a while.
 
-## CCL Build
+## Module Resolution
 
-In CCL builds, code in `pkg/ui/ccl/src` overrides code in `pkg/ui/src` at build
-time, via a Webpack import resolution rule. E.g. if a file imports
-`src/views/shared/components/licenseType`, it'll resolve to
-`pkg/ui/src/views/shared/components/licenseType` in an OSS build, and
-`pkg/ui/ccl/src/views/shared/components/licenseType` in a CCL build.
+Code in `pkg/ui/ccl/src` overrides code in `pkg/ui/src` at build time, via a
+Webpack import resolution rule. E.g. if a file imports
+`src/views/shared/components/licenseType`, it'll first look for the file in
+`pkg/ui/ccl/src/views/shared/components/licenseType`, then fall back to
+`pkg/ui/src/views/shared/components/licenseType`.
 
-CCL code can import OSS code by prefixing paths with `oss/`, e.g.
-`import "oss/src/myComponent"`. By convention, this is only done by a CCL file
-importing the OSS version of itself, e.g. to render the OSS version of itself
-when the trial period has expired.
+CCL code can import base code by prefixing paths with `oss/`, e.g.
+`import "oss/src/myComponent"`. By convention, this is done by a CCL file
+importing the base version of itself, e.g. to render the base version when
+the license doesn't support a particular feature.
 
 ## Running tests
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -6,9 +6,9 @@
 // Package ui embeds the assets for the web UI into the Cockroach binary.
 //
 // By default, it serves a stub web UI. Linking with distccl will replace the
-// stubs with the OSS UI or the CCL UI, respectively. The exported symbols in
-// this package are thus function pointers instead of functions so that they can
-// be mutated by init hooks.
+// stubs with the full UI. The exported symbols in this package are thus
+// function pointers instead of functions so that they can be mutated by init
+// hooks.
 package ui
 
 import (

--- a/pkg/ui/workspaces/db-console/.gitignore
+++ b/pkg/ui/workspaces/db-console/.gitignore
@@ -13,7 +13,6 @@ yarn-error.log
 .cache-loader
 dist*/**
 !distccl/distccl.go
-!distoss/distoss.go
 *manifest.json
 
 cypress/screenshots/*

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -30,8 +30,6 @@ WEBPACK_SRCS = [
     "webpack.config.js",
 ]
 
-WEBPACK_DATA_OSS = WEBPACK_DATA_COMMON
-
 WEBPACK_DATA_CCL = WEBPACK_DATA_COMMON + glob(["ccl/**"])
 
 # We want to perform only type-checking (with absolutely no files emitted).
@@ -97,63 +95,6 @@ webpack_bin.webpack_cli(
         "production",
         "--env",
         "output=./db-console-ccl",
-    ],
-    chdir = package_name(),
-    env = {
-        "NODE_OPTIONS": "--max-old-space-size=5000",
-    },
-    exec_properties = {
-        "Pool": "large",
-    },
-    visibility = ["//visibility:public"],
-)
-
-webpack_bin.webpack_cli(
-    name = "db-console-oss",
-    srcs = WEBPACK_SRCS + WEBPACK_DATA_OSS + [
-        ":node_modules",
-    ],
-    outs = [
-        "db-console-oss/assets/Inconsolata-Regular.woff",
-        "db-console-oss/assets/Inconsolata-Regular.woff2",
-        "db-console-oss/assets/Lato-Bold.woff",
-        "db-console-oss/assets/Lato-Bold.woff2",
-        "db-console-oss/assets/Lato-Light.woff",
-        "db-console-oss/assets/Lato-Light.woff2",
-        "db-console-oss/assets/Lato-Medium.woff",
-        "db-console-oss/assets/Lato-Medium.woff2",
-        "db-console-oss/assets/Lato-Regular.woff",
-        "db-console-oss/assets/Lato-Regular.woff2",
-        "db-console-oss/assets/RobotoMono-Bold.woff",
-        "db-console-oss/assets/RobotoMono-Bold.woff2",
-        "db-console-oss/assets/RobotoMono-Medium.woff",
-        "db-console-oss/assets/RobotoMono-Medium.woff2",
-        "db-console-oss/assets/RobotoMono-Regular.woff",
-        "db-console-oss/assets/RobotoMono-Regular.woff2",
-        "db-console-oss/assets/SFMono-Semibold.woff",
-        "db-console-oss/assets/SFMono-Semibold.woff2",
-        "db-console-oss/assets/SourceSansPro-Bold.woff",
-        "db-console-oss/assets/SourceSansPro-Bold.woff2",
-        "db-console-oss/assets/SourceSansPro-Regular.woff",
-        "db-console-oss/assets/SourceSansPro-Regular.woff2",
-        "db-console-oss/assets/SourceSansPro-SemiBold.woff",
-        "db-console-oss/assets/SourceSansPro-SemiBold.woff2",
-        "db-console-oss/assets/bundle.js",
-        "db-console-oss/assets/email_signup_bg.png",
-        "db-console-oss/assets/favicon.ico",
-        "db-console-oss/assets/heroBannerLp.png",
-        "db-console-oss/assets/login-background.png",
-        "db-console-oss/assets/not-found.svg",
-    ],
-    args = [
-        "--config",
-        "webpack.config.js",
-        "--env",
-        "dist=oss",
-        "--mode",
-        "production",
-        "--env",
-        "output=./db-console-oss",
     ],
     chdir = package_name(),
     env = {

--- a/pkg/ui/workspaces/db-console/webpack.config.js
+++ b/pkg/ui/workspaces/db-console/webpack.config.js
@@ -29,11 +29,8 @@ module.exports = (env, argv) => {
   env = env || {};
   const isBazelBuild = !!process.env.BAZEL_TARGET;
 
-  let localRoots = [path.resolve(__dirname)];
-  if (env.dist === "ccl") {
-    // CCL modules shadow OSS modules.
-    localRoots.unshift(path.resolve(__dirname, "ccl"));
-  }
+  // CCL modules shadow base modules.
+  let localRoots = [path.resolve(__dirname, "ccl"), path.resolve(__dirname)];
 
   let plugins = [
     new CopyWebpackPlugin({
@@ -79,7 +76,7 @@ module.exports = (env, argv) => {
     entry: [ "./src/index.tsx"],
     output: {
       filename: "bundle.js",
-      path: path.resolve(env.output || `../../dist${env.dist}`, "assets"),
+      path: path.resolve(env.output || "../../distccl", "assets"),
     },
     mode: argv.mode || "production",
 
@@ -259,7 +256,7 @@ module.exports = (env, argv) => {
 
     devServer: {
       static: {
-        directory: path.join(__dirname, `dist${env.dist}`),
+        directory: path.join(__dirname, "distccl"),
       },
       devMiddleware: {
         index: false,


### PR DESCRIPTION
This was automated by Claude.

Build Infrastructure:
1. pkg/ui/workspaces/db-console/BUILD.bazel - Removed WEBPACK_DATA_OSS variable and entire db-console-oss target
2. pkg/ui/workspaces/db-console/webpack.config.js - Simplified to always use CCL behavior (no more conditional on env.dist)

Gitignore cleanup:
3. pkg/ui/.gitignore - Removed assets.oss.installed and distoss/** exclusions
4. pkg/ui/workspaces/db-console/.gitignore - Removed distoss/distoss.go exclusion

Documentation:
5. pkg/ui/ui.go - Updated package comment to remove "OSS UI" reference
6. pkg/ui/README.md - Renamed "CCL Build" section to "Module Resolution" and updated text

Variable Renaming:
7. pkg/cmd/dev/ui.go - Renamed protoOss → protoBase and ossDst → baseDst

Makefile:
8. GNUmakefile - Removed buildoss from the comment alias example

Verification

- Go code compiles successfully (go build ./pkg/cmd/dev/...)
- ./dev ui --help works correctly
- webpack.config.js syntax is valid

Not Changed (preserved intentionally)

- LicenseType: "OSS" in redux state (license type enum, not build mode)
- oss/* path alias in tsconfig.json (import path prefix)
- OSSComponent/OSSProps naming (runtime license-based rendering)
- import from "oss/src/..." patterns (valid import paths)


Epic: None
Release note: None

----

Depends on 4 prior PRs for other build upgrades and cleanups: https://github.com/cockroachdb/cockroach/pull/158877, https://github.com/cockroachdb/cockroach/pull/158878, https://github.com/cockroachdb/cockroach/pull/158887, https://github.com/cockroachdb/cockroach/pull/158900