### PR TITLE
tracing: introduce cluster settings for span/trace structured byte limits

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -716,7 +716,7 @@ func (sp *Span) reset(
 				goroutineID:  goroutineID,
 				recording: recordingState{
 					logs:             makeSizeLimitedBuffer[*tracingpb.LogRecord](maxLogBytesPerSpan, nil /* scratch */),
-					structured:       makeSizeLimitedBuffer[*tracingpb.StructuredRecord](maxStructuredBytesPerSpan, h.structuredEventsAlloc[:]),
+					structured:       makeSizeLimitedBuffer[*tracingpb.StructuredRecord](sp.i.tracer.MaxStructuredBytesPerSpan(), h.structuredEventsAlloc[:]),
 					childrenMetadata: h.childrenMetadataAlloc,
 					finishedChildren: MakeTrace(tracingpb.RecordedSpan{}),
 				},


### PR DESCRIPTION
This commit introduces two cluster settings that allow us to configure the
previous constants maxStructuredBytesPerTrace, and maxStructuredBytesPerSpan.

Fixes: https://github.com/cockroachdb/cockroach/issues/87539
Release note: None