### PR TITLE
sql: port 5 builtin functions to information_schema

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3349,6 +3349,10 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="current_user"></a><code>current_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="information_schema.crdb_reset_index_usage_stats"></a><code>information_schema.crdb_reset_index_usage_stats() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to clear the collected index usage statistics.</p>
+</span></td><td>Volatile</td></tr>
+<tr><td><a name="information_schema.crdb_reset_sql_stats"></a><code>information_schema.crdb_reset_sql_stats() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to clear the collected SQL statistics.</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="session_user"></a><code>session_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the session user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="to_regclass"></a><code>to_regclass(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual relation name to its OID</p>

--- a/pkg/ccl/logictestccl/testdata/logic_test/builtins
+++ b/pkg/ccl/logictestccl/testdata/logic_test/builtins
@@ -88,7 +88,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
 query cache hit
 
 statement ok
-SELECT crdb_internal.clear_query_plan_cache();
+SELECT information_schema.crdb_clear_query_plan_cache();
 
 statement ok
 SET TRACING = "on", cluster;
@@ -201,7 +201,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%reading statis
 ----
 
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 SET TRACING = "on", cluster;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
@@ -60,7 +60,7 @@ ANALYZE great_grandparent;
 
 # Clear the stat cache so that the new statistic is guaranteed to be used.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 # Only the scan in the main query is parallelized when we don't have stats on
 # the descendant tables.
@@ -74,7 +74,7 @@ ANALYZE grandparent;
 
 # Clear the stat cache so that the new statistic is guaranteed to be used.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 # Now we also should parallelize lookup join into the grandparent table.
 query I
@@ -87,7 +87,7 @@ ANALYZE parent;
 
 # Clear the stat cache so that the new statistic is guaranteed to be used.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 # Now we also should parallelize lookup join into the parent table.
 query I
@@ -100,7 +100,7 @@ ANALYZE child;
 
 # Clear the stat cache so that the new statistic is guaranteed to be used.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 # Finally, all three lookup joins as well as the scan in the main query should
 # be parallelized.
@@ -306,7 +306,7 @@ ALTER TABLE grandparent INJECT STATISTICS '[
 
 # Clear the stat cache so that the new statistic is guaranteed to be used.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 query I
 SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
@@ -351,7 +351,7 @@ ALTER TABLE grandparent INJECT STATISTICS '[
 
 # Clear the stat cache so that the new statistic is guaranteed to be used.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 query I
 SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -616,8 +616,8 @@ func testResetSQLStatsRPCForTenant(
 		t.Run(fmt.Sprintf("flushed=%t", flushed), func(t *testing.T) {
 			// Clears the SQL Stats at the end of each test via builtin.
 			defer func() {
-				testTenantConn.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
-				controlCluster.TenantConn(serverccl.RandomServer).Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+				testTenantConn.Exec(t, "SELECT information_schema.crdb_reset_sql_stats()")
+				controlCluster.TenantConn(serverccl.RandomServer).Exec(t, "SELECT information_schema.crdb_reset_sql_stats()")
 			}()
 
 			for _, stmt := range stmts {
@@ -704,7 +704,7 @@ func testResetIndexUsageStatsRPCForTenant(
 			resetFn: func(helper serverccl.TenantTestHelper) {
 				// Reset index usage stats using SQL shell built-in.
 				testingCluster := helper.TestCluster()
-				testingCluster.TenantConn(0).Exec(t, "SELECT crdb_internal.reset_index_usage_stats()")
+				testingCluster.TenantConn(0).Exec(t, "SELECT information_schema.crdb_reset_index_usage_stats()")
 			},
 		},
 		{

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -676,6 +676,7 @@ var functions = func() *functionsMu {
 			"crdb_internal.create_join_token",
 			"crdb_internal.reset_multi_region_zone_configs_for_database",
 			"crdb_internal.reset_index_usage_stats",
+			"information_schema.crdb_reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",
 			"crdb_internal.replication_stream_progress",
 			"crdb_internal.complete_replication_stream",
@@ -683,6 +684,7 @@ var functions = func() *functionsMu {
 			"crdb_internal.request_statement_bundle",
 			"crdb_internal.set_compaction_concurrency",
 			"crdb_internal.reset_sql_stats",
+			"information_schema.crdb_reset_sql_stats",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -1303,6 +1303,19 @@ func TestUnprivilegedUserResetIndexUsageStats(t *testing.T) {
 	)
 
 	require.Contains(t, err.Error(), "user non_admin_user does not have REPAIRCLUSTER system privilege")
+
+	// Test that information_schema.crdb_reset_index_usage_stats has the same behavior
+	_, err = ie.ExecEx(
+		ctx,
+		"test-reset-index-usage-stats-information-schema-as-non-admin-user",
+		nil, /* txn */
+		sessiondata.InternalExecutorOverride{
+			User: username.MakeSQLUsernameFromPreNormalizedString("non_admin_user"),
+		},
+		"SELECT information_schema.crdb_reset_index_usage_stats()",
+	)
+
+	require.Contains(t, err.Error(), "user non_admin_user does not have REPAIRCLUSTER system privilege")
 }
 
 // TestCombinedStatementUsesCorrectSourceTable tests that requests read from

--- a/pkg/sql/logictest/testdata/logic_test/canary_stats
+++ b/pkg/sql/logictest/testdata/logic_test/canary_stats
@@ -172,7 +172,7 @@ statement ok
 DEALLOCATE ALL;
 
 statement ok
-SELECT crdb_internal.clear_query_plan_cache();
+SELECT information_schema.crdb_clear_query_plan_cache();
 
 statement ok
 SET TRACING = "on", cluster;

--- a/pkg/sql/logictest/testdata/logic_test/constrained_stats
+++ b/pkg/sql/logictest/testdata/logic_test/constrained_stats
@@ -34,7 +34,7 @@ CREATE STATISTICS full_stat FROM products;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 # Test stats collections with WHERE expressions
 statement ok
@@ -159,7 +159,7 @@ CREATE STATISTICS products_full FROM products;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS stat_discount ON discount_price FROM products WHERE discount_price > 30
@@ -222,7 +222,7 @@ CREATE STATISTICS fullstat FROM partial_indexes;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 # Filter implies the partial index predicate, so it can be used.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_crdb_internal
@@ -39,7 +39,7 @@ start_key           end_key       replicas  lease_holder
 …/1/9               <after:/Max>  {5}       5
 
 
-# As of #69273, crdb_internal.reset_sql_stats()'s behavior changes from in-memory
+# As of #69273, reset_sql_stats()'s behavior changes from in-memory
 # only to truncating system table. Hence, we create a small table here to
 # to ensure that this test doesn't run for a very long time.
 statement ok
@@ -49,7 +49,7 @@ statement ok
 INSERT INTO smalldata VALUES (1), (2), (3)
 
 query II
-SELECT a, count(*) AS cnt FROM smalldata GROUP BY a HAVING crdb_internal.reset_sql_stats() ORDER BY a
+SELECT a, count(*) AS cnt FROM smalldata GROUP BY a HAVING information_schema.crdb_reset_sql_stats() ORDER BY a
 ----
 1 1
 2 1

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2456,7 +2456,7 @@ INSERT INTO xy VALUES (-1, 9), (-2, 8), (5, 15), (6, 16)
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS abcd_a_partial ON a FROM abcd USING EXTREMES;
@@ -2576,7 +2576,7 @@ INSERT INTO a_null VALUES (NULL), (NULL), (NULL);
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS a_null_stat_partial ON a FROM a_null USING EXTREMES;
@@ -2614,7 +2614,7 @@ INSERT INTO d_desc VALUES (0, 0), (5, 50);
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS sdp ON a FROM d_desc USING EXTREMES;
@@ -2648,7 +2648,7 @@ CREATE STATISTICS sdn ON a FROM d_desc;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS sdnp ON a FROM d_desc USING EXTREMES;
@@ -2704,7 +2704,7 @@ INSERT INTO s VALUES ('a'), ('b'), ('f');
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS s_partial ON s FROM s USING EXTREMES;
@@ -2731,7 +2731,7 @@ CREATE STATISTICS j_full ON j FROM j;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement error pq: table j does not contain a non-partial forward index with j as a prefix column
 CREATE STATISTICS j_partial ON j FROM j USING EXTREMES;
@@ -2766,7 +2766,7 @@ CREATE STATISTICS only_null_stat ON a FROM only_null;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement error pq: the latest full statistic histogram for column a has only NULL values
 EXPLAIN ANALYZE CREATE STATISTICS only_null_partial ON a FROM only_null USING EXTREMES;
@@ -3071,7 +3071,7 @@ INSERT INTO t68254 (a, b, c) VALUES (5, '5', '{"foo": {"bar": {"baz": 5}}}')
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS j6 ON d FROM t68254 USING EXTREMES
@@ -3143,7 +3143,7 @@ INSERT INTO int_outer_buckets SELECT generate_series(-10, -1) UNION ALL SELECT g
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS int_outer_buckets_partial ON a FROM int_outer_buckets USING EXTREMES;
@@ -3172,7 +3172,7 @@ CREATE STATISTICS int_outer_buckets_full ON a FROM int_outer_buckets;
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS int_outer_buckets_partial ON a FROM int_outer_buckets USING EXTREMES;
@@ -3219,7 +3219,7 @@ INSERT INTO timestamp_outer_buckets VALUES
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS timestamp_outer_buckets_partial ON a FROM timestamp_outer_buckets USING EXTREMES;
@@ -3295,7 +3295,7 @@ INSERT INTO timestamp_outer_buckets VALUES ('2024-06-28 01:00:00');
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS timestamp_outer_buckets_partial ON a FROM timestamp_outer_buckets USING EXTREMES;
@@ -3325,7 +3325,7 @@ CREATE STATISTICS bool_table_full ON a FROM bool_table
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement error pgcode 0A000 creating partial statistics at extremes on bool and enum columns is disabled
 CREATE STATISTICS bool_table_partial ON a FROM bool_table USING EXTREMES;
@@ -3342,7 +3342,7 @@ CREATE STATISTICS enum_table_full ON a FROM enum_table
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement error pgcode 0A000 creating partial statistics at extremes on bool and enum columns is disabled
 CREATE STATISTICS enum_table_full ON a FROM enum_table USING EXTREMES
@@ -3628,7 +3628,7 @@ INSERT INTO pstat_allindex VALUES
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 CREATE STATISTICS pstat_allindex_partial FROM pstat_allindex USING EXTREMES;

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -2140,7 +2140,7 @@ ANALYZE t151995;
 # Clear the stat cache so that the new statistic is guaranteed to be used (which
 # are needed for the inverted join to be picked).
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement error geos error: IllegalArgumentException: BufferOp::getResultGeometry distance must be a finite value
 SELECT *

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -149,7 +149,7 @@ WHERE feature_name = 'sql.session.statement-hints'
 5
 
 statement ok
-SELECT crdb_internal.clear_statement_hints_cache()
+SELECT information_schema.crdb_clear_statement_hints_cache()
 
 statement ok
 SELECT * FROM xy WHERE x > y

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -122,7 +122,7 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzsllFvo0YQx9_7K
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 query T
 EXPLAIN (DISTSQL) CREATE STATISTICS s1_constrained ON a FROM data WHERE a > 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1271,7 +1271,7 @@ ALTER TABLE ka INJECT STATISTICS '[
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 INSERT INTO ka VALUES (10000, 9999), (10001, 10000), (9999, NULL)
@@ -1346,7 +1346,7 @@ ALTER TABLE ka INJECT STATISTICS '[
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 INSERT INTO ka VALUES (10003, 10002), (10004, NULL)
@@ -1384,7 +1384,7 @@ CREATE STATISTICS ka_fullstat ON a FROM ka
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 statement ok
 INSERT INTO ka VALUES (10, 10)
@@ -1395,7 +1395,7 @@ CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
 # Now clear the stats cache so that the query below is guaranteed to pick up the
 # new stats (partial and merged).
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 query T
 EXPLAIN SELECT * FROM ka WHERE a > 5
@@ -1464,7 +1464,7 @@ ka_partialstat  {a}
 
 # Ensure that the system table is read on the next query.
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 query T
 EXPLAIN SELECT * FROM ka WHERE a = 10
@@ -1585,7 +1585,7 @@ WHERE stat->>'name' = '__merged__';
 # Now clear the stats cache so that the query below is guaranteed to pick up the
 # new stats (partial and merged).
 statement ok
-SELECT crdb_internal.clear_table_stats_cache();
+SELECT information_schema.crdb_clear_table_stats_cache();
 
 query T
 EXPLAIN (OPT, VERBOSE) SELECT * FROM m WHERE b < 35

--- a/pkg/sql/pgwire/testdata/pgtest/procedure
+++ b/pkg/sql/pgwire/testdata/pgtest/procedure
@@ -67,11 +67,11 @@ until
 ReadyForQuery
 ----
 {"Type":"RowDescription","Fields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func379","UnknownFields":null}
 {"Type":"RowDescription","Fields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func379","UnknownFields":null}
 {"Type":"RowDescription","Fields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func379","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -87,10 +87,10 @@ ReadyForQuery
 ----
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"foo","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func379","UnknownFields":null}
 {"Type":"RowDescription","Fields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"bar","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func379","UnknownFields":null}
 {"Type":"RowDescription","Fields":null}
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func381","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"baz","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"builtins.go","Line":0,"Routine":"func379","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CALL"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2864,6 +2864,11 @@ var builtinOidsArray = []string{
 	2909: `crdb_internal.clear_statement_hints_cache() -> void`,
 	2910: `crdb_internal.await_statement_hints_cache() -> void`,
 	2911: `information_schema.crdb_datums_to_bytes(any...) -> bytes`,
+	2912: `information_schema.crdb_reset_index_usage_stats() -> bool`,
+	2913: `information_schema.crdb_reset_sql_stats() -> bool`,
+	2914: `information_schema.crdb_clear_query_plan_cache() -> void`,
+	2915: `information_schema.crdb_clear_table_stats_cache() -> void`,
+	2916: `information_schema.crdb_clear_statement_hints_cache() -> void`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -610,7 +610,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	require.NotEmpty(t, metadata.StmtFingerprintIDs)
 
 	// Do the same but testing transferTopStats.
-	db.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+	db.Exec(t, "SELECT information_schema.crdb_reset_sql_stats()")
 	db.Exec(t, "SELECT 1")
 
 	sqlstatstestutil.WaitForTransactionEntriesAtLeast(t, obsConn, 1)

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -295,7 +295,7 @@ func TestFailedInsights(t *testing.T) {
 	rootConn.Exec(t, "SET SESSION application_name=$1", appName)
 
 	testutils.RunTrueAndFalse(t, "with_redaction", func(t *testing.T, testRedacted bool) {
-		rootConn.Exec(t, `select crdb_internal.reset_sql_stats()`)
+		rootConn.Exec(t, `select information_schema.crdb_reset_sql_stats()`)
 		conn := s.SQLConn(t)
 		if testRedacted {
 			conn = s.SQLConn(t, serverutils.User("testuser"))

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -273,7 +273,7 @@ func TestStmtStatsEnable(t *testing.T) {
 
 	sqlConn := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
-	sqlConn.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+	sqlConn.Exec(t, "SELECT information_schema.crdb_reset_sql_stats()")
 
 	appName := "TestStmtStatsEnable"
 	sqlConn.Exec(t, "SET application_name = $1", appName)

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -701,7 +701,7 @@ func TestUnprivilegedUserReset(t *testing.T) {
 		sessiondata.InternalExecutorOverride{
 			User: username.MakeSQLUsernameFromPreNormalizedString("non_admin_user"),
 		},
-		"SELECT crdb_internal.reset_sql_stats()",
+		"SELECT information_schema.crdb_reset_sql_stats()",
 	)
 
 	require.Contains(t, err.Error(), "user non_admin_user does not have REPAIRCLUSTER system privilege")

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -93,7 +93,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 
 	// Clear the stat cache to ensure that upcoming partial stat collections see
 	// the latest full statistic.
-	sqlRun.Exec(t, `SELECT crdb_internal.clear_table_stats_cache();`)
+	sqlRun.Exec(t, `SELECT information_schema.crdb_clear_table_stats_cache();`)
 
 	// Try to refresh again. With rowsAffected=0, the probability of a refresh
 	// is 0, so refreshing will not succeed.

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -744,7 +744,7 @@ func TestTelemetryLoggingInternalEnabled(t *testing.T) {
 	// Since TRUNCATE is not a DML stmt, both should certainly get logged.
 	stubTime := timeutil.FromUnixMicros(int64(1e6))
 	st.SetTime(stubTime)
-	db.Exec(t, `SELECT crdb_internal.reset_sql_stats();`)
+	db.Exec(t, `SELECT information_schema.crdb_reset_sql_stats();`)
 
 	expectedQueries := []string{
 		`TRUNCATE TABLE system.public.statement_statistics`,
@@ -758,7 +758,7 @@ func TestTelemetryLoggingInternalEnabled(t *testing.T) {
 	}
 
 	for _, e := range entries {
-		if strings.Contains(e.Message, "SELECT crdb_internal.reset_sql_stats") {
+		if strings.Contains(e.Message, "SELECT information_schema.crdb_reset_sql_stats") {
 			t.Errorf("unexpected query log: %s", e.Message)
 		}
 	}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -438,6 +438,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					// arguments.
 					continue
 				case "crdb_internal.reset_sql_stats",
+					"information_schema.crdb_reset_sql_stats",
 					"crdb_internal.check_consistency",
 					"crdb_internal.request_statement_bundle",
 					"crdb_internal.reset_activity_tables",


### PR DESCRIPTION
As part of the stable SQL API effort, expose the following builtin functions in information_schema to complement the existing crdb_internal versions:

- crdb_internal.reset_index_usage_stats → information_schema.crdb_reset_index_usage_stats
- crdb_internal.reset_sql_stats → information_schema.crdb_reset_sql_stats
- crdb_internal.clear_query_plan_cache → information_schema.crdb_clear_query_plan_cache
- crdb_internal.clear_table_stats_cache → information_schema.crdb_clear_table_stats_cache
- crdb_internal.clear_statement_hints_cache → information_schema.crdb_clear_statement_hints_cache

The implementations are shared between both schemas to ensure identical behavior. All existing test usages throughout the codebase have been updated to use the information_schema versions to demonstrate the new functions work correctly.

This follows the pattern established in PR #156963 which ported index_usage_statistics and datums_to_bytes to information_schema.

Epic: None

Release note (sql change): Added information_schema versions of 5 builtin functions: crdb_reset_index_usage_stats, crdb_reset_sql_stats, crdb_clear_query_plan_cache, crdb_clear_table_stats_cache, and
crdb_clear_statement_hints_cache. These complement the existing crdb_internal versions as part of the stable SQL API effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)