### PR TITLE
cli: set database user name in debug.zip and tsdump generation

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/ts"
@@ -191,6 +192,11 @@ will then convert it to the --format requested in the current invocation.
 		if convertFile == "" {
 			// To enable conversion without a running cluster, we want to skip
 			// connecting to the server when converting an existing tsdump.
+			if cliCtx.clientOpts.User != username.RootUser {
+				// Error is ignored because PurposeValidation does not return errors.
+				serverCfg.User, _ = username.MakeSQLUsernameFromUserInput(cliCtx.clientOpts.User, username.PurposeValidation)
+			}
+
 			conn, finish, err := newClientConn(ctx, serverCfg)
 			if err != nil {
 				return err

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -229,6 +230,11 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 	// We later print a deprecation warning at the end of the zip operation for visibility.
 	if zipCtx.redactLogs {
 		zipCtx.redact = true
+	}
+
+	if cliCtx.clientOpts.User != username.RootUser {
+		// Error is ignored because PurposeValidation does not return errors.
+		serverCfg.User, _ = username.MakeSQLUsernameFromUserInput(cliCtx.clientOpts.User, username.PurposeValidation)
 	}
 
 	var tenants []*serverpb.Tenant

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -942,6 +942,63 @@ test/generate_series(1,15000) as t(x).4.json.err.txt
 	assert.Equal(t, expected, fileList.String())
 }
 
+// TestZipNonRootUser verifies that debug zip works with non-root users.
+func TestZipNonRootUser(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+	skip.UnderRace(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := s.SQLConn(t, serverutils.DBName("system"))
+	defer sqlDB.Close()
+
+	// Create a test user with ADMIN privileges
+	_, err := sqlDB.Exec(`CREATE USER testuser`)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`GRANT ADMIN TO testuser`)
+	require.NoError(t, err)
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	// Test with non-root user
+	c := TestCLI{
+		t:        t,
+		Server:   s,
+		Insecure: true,
+	}
+
+	zipName := filepath.Join(dir, "test.zip")
+	out, err := c.RunWithCapture(fmt.Sprintf(
+		"debug zip --user=testuser --concurrency=1 --cpu-profile-duration=0s --validate-zip-file=false %s",
+		zipName,
+	))
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+
+	// Verify the zip file was created
+	_, err = os.Stat(zipName)
+	require.NoError(t, err)
+
+	// Test that root user still works (regression test)
+	zipNameRoot := filepath.Join(dir, "test_root.zip")
+	out, err = c.RunWithCapture(fmt.Sprintf(
+		"debug zip --concurrency=1 --cpu-profile-duration=0s --validate-zip-file=false %s",
+		zipNameRoot,
+	))
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+
+	// Verify the zip file was created
+	_, err = os.Stat(zipNameRoot)
+	require.NoError(t, err)
+}
+
 // This checks that SQL retry errors are properly handled.
 func TestZipFallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Previously, debug.zip and tsdump generation relies on the root user. Both tsdump and debug.zip generation have dependency on root user during sql and rpc connection initialisation. We have introduced a flag `--disallow-root-login` to restrict root user access as part of PR 155216. This patch updates debug.zip and tsdump generation flows to rely on username which is passed through `--user` and `--url` flags. This change is backward compatible as the default value for the username is root in both debug.zip and tsdump flows.

Epic: CRDB-49078
 Part of: CRDB-57580
Release note (cli change): We can use the user defined database user in debug.zip and tsdump generation flows. The database user name can be passed through `--url` and `--user` flags. Both flows have hard dependency on root user as of now. This change is backward compatible as default value is root in both flows. It is part of long term initiative where we want to restrict root user access.