### PR TITLE
cli, security: add `--allow-debug-user` flag to enable debug user

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -966,6 +966,22 @@ access to that client.
 `,
 	}
 
+	AllowDebugUser = FlagInfo{
+		Name: "allow-debug-user",
+		Description: `
+When set, allows authentication attempts by clients presenting certificates
+with "debuguser" as one of the principals (CommonName or SubjectAlternativeName).
+This applies to both SQL client connections and RPC connections. By default,
+the debuguser is not allowed to authenticate. Authentication attempts by debuguser
+will be rejected with an error unless this flag is explicitly set.
+<PRE>
+
+</PRE>
+Note: This flag is intended for debugging and troubleshooting purposes. The
+debuguser should only be enabled when necessary and disabled when not in use.
+`,
+	}
+
 	TLSCipherSuites = FlagInfo{
 		Name: "tls-cipher-suites",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -489,6 +489,7 @@ var startCtx struct {
 	serverNodeCertDN       string
 	serverTLSCipherSuites  []string
 	disallowRootLogin      bool
+	allowDebugUser         bool
 
 	// The TLS auto-handshake parameters.
 	initToken             string
@@ -545,6 +546,7 @@ func setStartContextDefaults() {
 	startCtx.serverRootCertDN = ""
 	startCtx.serverNodeCertDN = ""
 	startCtx.disallowRootLogin = false
+	startCtx.allowDebugUser = false
 	startCtx.serverListenAddr = ""
 	startCtx.unencryptedLocalhostHTTP = false
 	startCtx.tempDir = ""

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -571,6 +571,13 @@ func init() {
 		cliflagcfg.BoolFlag(f, &startCtx.disallowRootLogin, cliflags.DisallowRootLogin)
 		_ = f.MarkHidden(cliflags.DisallowRootLogin.Name)
 
+		// We add the allow debug user flag for enabling the debuguser from rpc
+		// and sql access for debugging and troubleshooting purposes. We currently
+		// mark it as hidden since the flag behavior is experimental and subject to
+		// change. By default, debuguser is not allowed to authenticate.
+		cliflagcfg.BoolFlag(f, &startCtx.allowDebugUser, cliflags.AllowDebugUser)
+		_ = f.MarkHidden(cliflags.AllowDebugUser.Name)
+
 		// TLS Cipher Suites configured
 		cliflagcfg.StringSliceFlag(f, &startCtx.serverTLSCipherSuites, cliflags.TLSCipherSuites)
 
@@ -1161,6 +1168,7 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		return err
 	}
 	security.SetDisallowRootLogin(startCtx.disallowRootLogin)
+	security.SetAllowDebugUser(startCtx.allowDebugUser)
 	// Currently we don't handle the case where we are setting the --insecure flag
 	// as well as providing the --tls-cipher-suites, we should probably error out
 	// if both are set, issue: #144935.
@@ -1171,6 +1179,7 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 	serverCfg.Insecure = startCtx.serverInsecure
 	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
 	serverCfg.DisallowRootLogin = startCtx.disallowRootLogin
+	serverCfg.AllowDebugUser = startCtx.allowDebugUser
 
 	fs := cliflagcfg.FlagSetForCmd(cmd)
 

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -393,94 +393,113 @@ func TestAuthenticationHook(t *testing.T) {
 		isSubjectRoleOptionOrDNSet bool
 		subjectRequired            bool
 		disallowRootLogin          bool
+		allowDebugUser             bool
 		expectedErr                string
 	}{
 		// Insecure mode, empty username.
-		{true, "", username.EmptyRole, "", "", true, false, false, roachpb.SystemTenantID, false, false, false, `user is missing`},
+		{true, "", username.EmptyRole, "", "", true, false, false, roachpb.SystemTenantID, false, false, false, false, `user is missing`},
 		// Insecure mode, non-empty username.
-		{true, "", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, `user "foo" is not allowed`},
+		{true, "", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, false, `user "foo" is not allowed`},
 		// Secure mode, no TLS state.
-		{false, "", username.EmptyRole, "", "", false, false, false, roachpb.SystemTenantID, false, false, false, `no client certificates in request`},
+		{false, "", username.EmptyRole, "", "", false, false, false, roachpb.SystemTenantID, false, false, false, false, `no client certificates in request`},
 		// Secure mode, bad user.
 		{false, "(CN=foo)", username.NodeUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, false, `certificate authentication failed for user "node"`},
+			false, false, false, false, `certificate authentication failed for user "node"`},
 		// Secure mode, node user.
-		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, false, ``},
+		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, false, false, ``},
 		// Secure mode, node cert and unrelated user.
 		{false, "(CN=node)", fooUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, false, `certificate authentication failed for user "foo"`},
+			false, false, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, root user.
 		{false, "(CN=root)", username.NodeUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, false, `certificate authentication failed for user "node"`},
+			false, false, false, false, `certificate authentication failed for user "node"`},
 		// Secure mode, tenant cert, foo user.
 		{false, "(OU=Tenants,CN=foo)", fooUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, false, `using tenant client certificate as user certificate is not allowed`},
+			false, false, false, false, `using tenant client certificate as user certificate is not allowed`},
 		// Secure mode, multiple cert principals.
-		{false, "(CN=foo)dns:bar", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, `user "foo" is not allowed`},
-		{false, "(CN=foo)dns:bar", barUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, `user "bar" is not allowed`},
+		{false, "(CN=foo)dns:bar", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, false, `user "foo" is not allowed`},
+		{false, "(CN=foo)dns:bar", barUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, false, `user "bar" is not allowed`},
 		// Secure mode, principal map.
-		{false, "(CN=foo)dns:bar", blahUser, "", "foo:blah", true, true, false, roachpb.SystemTenantID, false, false, false, `user "blah" is not allowed`},
-		{false, "(CN=foo)dns:bar", blahUser, "", "bar:blah", true, true, false, roachpb.SystemTenantID, false, false, false, `user "blah" is not allowed`},
+		{false, "(CN=foo)dns:bar", blahUser, "", "foo:blah", true, true, false, roachpb.SystemTenantID, false, false, false, false, `user "blah" is not allowed`},
+		{false, "(CN=foo)dns:bar", blahUser, "", "bar:blah", true, true, false, roachpb.SystemTenantID, false, false, false, false, `user "blah" is not allowed`},
 		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, "", "", true, true, false, roachpb.MustMakeTenantID(123),
-			false, false, false, `user "foo" is not allowed`},
+			false, false, false, false, `user "foo" is not allowed`},
 		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, "", "", true, false, false, roachpb.SystemTenantID,
-			false, false, false, `certificate authentication failed for user "foo"`},
+			false, false, false, false, `certificate authentication failed for user "foo"`},
 		{false, "(CN=foo)", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			false, false, false, `user "foo" is not allowed`},
+			false, false, false, false, `user "foo" is not allowed`},
 		{false, "(CN=foo)uri:crdb://tenant/1/user/foo", fooUser, "", "", true, false, false, roachpb.MustMakeTenantID(123),
-			false, false, false, `certificate authentication failed for user "foo"`},
+			false, false, false, false, `certificate authentication failed for user "foo"`},
 		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", blahUser, "", "", true, false, false, roachpb.MustMakeTenantID(123),
-			false, false, false, `certificate authentication failed for user "blah"`},
+			false, false, false, false, `certificate authentication failed for user "blah"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option not set.
 		{false, "(" + subjectDNString + ")", fooUser, "", "", true, true, false, roachpb.MustMakeTenantID(123),
-			false, false, false, `user "foo" is not allowed`},
+			false, false, false, false, `user "foo" is not allowed`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set matching TLS cert subject.
 		{false, "(" + subjectDNString + ")", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `user "foo" is not allowed`},
+			true, false, false, false, `user "foo" is not allowed`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN empty.
 		{false, "(CN=foo)", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `certificate authentication failed for user "foo"`},
+			true, false, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN mismatches on OU field.
 		{false, "(" + fieldMismatchSubjectDNString + ")", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `certificate authentication failed for user "foo"`},
+			true, false, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN subset of role subject DN.
 		{false, "(" + subsetSubjectDNString + ")", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `certificate authentication failed for user "foo"`},
+			true, false, false, false, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set mismatching TLS cert subject only on CN(required for
 		// matching) having DNS as foo.
 		{false, "(" + fieldMismatchOnlyOnCommonNameString + ")dns:foo", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `certificate authentication failed for user "foo"`},
+			true, false, false, false, `certificate authentication failed for user "foo"`},
 		{false, "(" + rootDNString + ")", username.RootUser, rootDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `user "root" is not allowed`},
+			true, false, false, false, `user "root" is not allowed`},
 		{false, "(" + nodeDNString + ")", username.NodeUser, nodeDNString, "", true, true, true, roachpb.MustMakeTenantID(123),
-			true, false, false, ""},
+			true, false, false, false, ""},
 		// tls cert dn matching root dn set, where CN != root
 		{false, "(" + subjectDNString + ")", username.RootUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, false, false, `user "root" is not allowed`},
+			true, false, false, false, `user "root" is not allowed`},
 		{false, "(" + subjectDNString + ")", fooUser, "", "", true, false, false, roachpb.MustMakeTenantID(123),
-			false, true, false, `user "foo" does not have a distinguished name set which subject_required cluster setting mandates`},
+			false, true, false, false, `user "foo" does not have a distinguished name set which subject_required cluster setting mandates`},
 		{false, "(" + subjectDNString + ")", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
-			true, true, false, `user "foo" is not allowed`},
+			true, true, false, false, `user "foo" is not allowed`},
 
 		// Test cases for disallow root login functionality
 		// Root user with disallow root login disabled - should succeed
-		{false, "(CN=root)", username.RootUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, ``},
+		{false, "(CN=root)", username.RootUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, false, ``},
 		// Root user with disallow root login enabled - should fail
-		{false, "(CN=root)", username.RootUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, true, `certificate authentication failed for user "root"`},
+		{false, "(CN=root)", username.RootUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, true, false, `certificate authentication failed for user "root"`},
 		// Non-root user with disallow root login enabled - should succeed
-		{false, "(CN=foo)", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, true, `user "foo" is not allowed`},
+		{false, "(CN=foo)", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, true, false, `user "foo" is not allowed`},
 		// Node user with disallow root login enabled - should succeed
-		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, true, ``},
+		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, true, false, ``},
 		// Root user with tenant-scoped certificate and disallow root login enabled - should fail
-		{false, "(CN=root)uri:crdb://tenant/123/user/root", username.RootUser, "", "", true, false, false, roachpb.MustMakeTenantID(123), false, false, true, `certificate authentication failed for user "root"`},
+		{false, "(CN=root)uri:crdb://tenant/123/user/root", username.RootUser, "", "", true, false, false, roachpb.MustMakeTenantID(123), false, false, true, false, `certificate authentication failed for user "root"`},
 		// Root user with DNS SAN and disallow root login enabled - should fail
-		{false, "(CN=root)dns:root", username.RootUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, true, `certificate authentication failed for user "root"`},
+		{false, "(CN=root)dns:root", username.RootUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, true, false, `certificate authentication failed for user "root"`},
+
+		// Test cases for allow debug user functionality
+		// Debug user with allow debug user disabled (default) - should fail
+		{false, "(CN=debug_user)", username.DebugUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, false, false, `certificate authentication failed for user "debug_user"`},
+		// Debug user with allow debug user enabled - should succeed
+		{false, "(CN=debug_user)", username.DebugUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, true, `user "debug_user" is not allowed`},
+		// Non-debug user with allow debug user enabled - should succeed (no impact)
+		{false, "(CN=foo)", fooUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, true, `user "foo" is not allowed`},
+		// Node user with allow debug user enabled - should succeed (no impact)
+		{false, "(CN=node)", username.NodeUser, "", "", true, true, true, roachpb.SystemTenantID, false, false, false, true, ``},
+		// Debug user with tenant-scoped certificate and allow debug user disabled - should fail
+		{false, "(CN=debug_user)uri:crdb://tenant/123/user/debug_user", username.DebugUser, "", "", true, false, false, roachpb.MustMakeTenantID(123), false, false, false, false, `certificate authentication failed for user "debug_user"`},
+		// Debug user with tenant-scoped certificate and allow debug user enabled - should succeed
+		{false, "(CN=debug_user)uri:crdb://tenant/123/user/debug_user", username.DebugUser, "", "", true, true, false, roachpb.MustMakeTenantID(123), false, false, false, true, `user "debug_user" is not allowed`},
+		// Debug user with DNS SAN and allow debug user disabled - should fail
+		{false, "(CN=debug_user)dns:debug_user", username.DebugUser, "", "", true, false, false, roachpb.SystemTenantID, false, false, false, false, `certificate authentication failed for user "debug_user"`},
+		// Debug user with DNS SAN and allow debug user enabled - should succeed
+		{false, "(CN=debug_user)dns:debug_user", username.DebugUser, "", "", true, true, false, roachpb.SystemTenantID, false, false, false, true, `user "debug_user" is not allowed`},
 	}
 
 	ctx := context.Background()
@@ -491,14 +510,16 @@ func TestAuthenticationHook(t *testing.T) {
 				security.UnsetRootSubject()
 				security.UnsetNodeSubject()
 				security.SetDisallowRootLogin(false)
+				security.SetAllowDebugUser(false)
 			}()
 			err := security.SetCertPrincipalMap(strings.Split(tc.principalMap, ","))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// Set the global flag for disallowing root login
+			// Set the global flags for disallowing root login and allowing debug user
 			security.SetDisallowRootLogin(tc.disallowRootLogin)
+			security.SetAllowDebugUser(tc.allowDebugUser)
 
 			var roleSubject *ldap.DN
 			if tc.isSubjectRoleOptionOrDNSet {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -217,6 +217,13 @@ type BaseConfig struct {
 	// and RPC connections.
 	DisallowRootLogin bool
 
+	// AllowDebugUser when set, allows authentication attempts by clients
+	// presenting certificates with "debuguser" as one of the principals
+	// (CommonName or SubjectAlternativeName). This applies to both SQL client
+	// connections and RPC connections. By default, debuguser is not allowed to
+	// authenticate.
+	AllowDebugUser bool
+
 	// ReadyFn is called when the server has started listening on its
 	// sockets.
 	//


### PR DESCRIPTION
 We introduce an `--allow-debug-user` flag which now enables the debug_user
 from access to both sql and rpc apis.

fixes: None
Epic CRDB-49035

 Release Note(security change): We are adding a new flag
 `--allow-debug-user` to the cockroach start command to explicitly allow
 enabling the debug_user to log into the system. This flag is currently
 experimental and is disabled by default. When not set, authentication
 attempts by `debug_user` will be rejected with an error: 
`"certificate authentication failed for user "debug_user""` for SQL connections
 and `"failed to perform RPC, as debug_user login is not allowed"` for RPC
 connections.

 This flag is intended for debugging and troubleshooting purposes and should
 only be enabled when necessary for diagnostic operations. The debug_user
 should be disabled when not actively in use.

 Note: Certificates must include "debug_user" as one of the principals
 (CommonName or SubjectAlternativeName) for this functionality. The flag
 controls whether such certificates are accepted for both SQL client
 connections and RPC connections.