### PR TITLE
release-26.1: sql/delegate: show changefeed jobs remove database column

### DIFF
--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -61,7 +61,7 @@ func (d *fakeResumer) CollectProfile(context.Context, interface{}) error {
 func TestShowChangefeedJobsDatabaseLevel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
+	skip.WithIssue(t, 159108, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)

--- a/pkg/sql/delegate/show_changefeed_jobs.go
+++ b/pkg/sql/delegate/show_changefeed_jobs.go
@@ -73,13 +73,6 @@ targets AS (
     id,
     names
   FROM table_targets
-),
-database as (
-  SELECT
-    sd.id, 
-    name
-  FROM spec_details sd
-  INNER JOIN crdb_internal.databases d ON sd.descriptor_id::int = d.id
 )
 SELECT
   job_id,
@@ -100,13 +93,11 @@ SELECT
   ) AS sink_uri,
   targets.names AS full_table_names,
   changefeed_details->'opts'->>'topics' AS topics,
-  COALESCE(changefeed_details->'opts'->>'format','json') AS format,
-  database.name AS database_name
+  COALESCE(changefeed_details->'opts'->>'format','json') AS format
 FROM
   crdb_internal.jobs
   INNER JOIN targets ON job_id = targets.id
   INNER JOIN payload ON job_id = payload.id
-  LEFT JOIN database ON job_id = database.id
 `
 	)
 	var whereClause, innerWhereClause, orderbyClause string


### PR DESCRIPTION
Previously, to support db-level changefeeds, a new column, database, was added to the results of SHOW CHANGEFEED JOBS, both for table-level and db-level changefeeds. However, as db-level changefeeds are disabled, this database column is not necessary to have just for table-level changefeeds.

This patch removes the database column from SHOW CHANGEFEED JOBS.

Fixes: #159105
Epic: CRDB-1421

Release note (sql change): A new column, database, was being added to SHOW CHANGEFEED JOBS as part of 26.1. This patch reverts adding that column for 26.1.

Release justification: Removes feature for unreleased db-level changefeeds