### PR TITLE
catalog: fix remaining issues for logictest with leased descriptors

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1289,6 +1289,7 @@ func (tc *Collection) aggregateAllLayers(
 	flags := defaultUnleasedFlags()
 	if getAllOptions.allowLeased {
 		flags.layerFilters.withoutLeased = false
+		flags.layerFilters.withAdding = true
 	}
 	if getAllOptions.withMetadata {
 		flags.layerFilters.withMetadata = true

--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -465,6 +465,8 @@ type layerFilters struct {
 	// This is always acquired for descriptors from storage, and may need an extra
 	// round trip.
 	withMetadata bool
+	// withAdding specifies that adding descriptors can be safely included.
+	withAdding bool
 }
 
 type descFilters struct {

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,4 +1,4 @@
-# LogicTest: !local-prepared
+# LogicTest: !local-prepared default-configs 3node-tenant local-leased-descriptors
 statement ok
 SET CLUSTER SETTING sql.cross_db_fks.enabled = TRUE
 

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,4 +1,4 @@
-# LogicTest: !local-prepared
+# LogicTest: !local-prepared default-configs 3node-tenant local-leased-descriptors
 # knob-opt: allow-unsafe
 
 subtest lost_table_data

--- a/pkg/sql/logictest/tests/local-leased-descriptors/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-leased-descriptors/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 12,
+    shard_count = 13,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/local-leased-descriptors/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-leased-descriptors/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 13,
+    shard_count = 14,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/local-leased-descriptors/generated_test.go
+++ b/pkg/sql/logictest/tests/local-leased-descriptors/generated_test.go
@@ -87,6 +87,13 @@ func TestLogic_crdb_internal(
 	runLogicTest(t, "crdb_internal")
 }
 
+func TestLogic_fk(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "fk")
+}
+
 func TestLogic_pg_catalog(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-leased-descriptors/generated_test.go
+++ b/pkg/sql/logictest/tests/local-leased-descriptors/generated_test.go
@@ -101,6 +101,13 @@ func TestLogic_privileges_comments(
 	runLogicTest(t, "privileges_comments")
 }
 
+func TestLogic_schema_repair(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "schema_repair")
+}
+
 func TestLogic_show_create(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Currently on logictest there are two failures that prevent enabling leased descriptors by default:

- [x] GetAll does not support adding descriptors with leased descriptors, which can lead to errors invoking pg_catalog / information_schema functions. These are normally skipped by the existing KV calls, and we should have similar behavior. This is observed in the fk logictest.
- [x] schema_repair can fail because our leased descriptor mode is emitting update keys for offline / dropped descriptors. This can prevent the timestamp from moving forward in this mode, and we need to wait for a range feed checkpoint.


This patch addresses both issues, getting us closer to enabling this config by default

Fixes: #159002
Release note: None


