### PR TITLE
kvserver: lower slow latch request threshold to 2s for nodeliveness rng

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -554,6 +554,10 @@ type latchManager interface {
 
 	// Metrics returns information about the state of the latchManager.
 	Metrics() LatchMetrics
+
+	// OnRangeDescUpdated informs the latchManager that its range's descriptor has been
+	// updated.
+	OnRangeDescUpdated(desc *roachpb.RangeDescriptor)
 }
 
 // latchGuard is a handle to a set of acquired key latches.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -654,6 +654,7 @@ func (m *managerImpl) GetDependents(txnID uuid.UUID) []uuid.UUID {
 // OnRangeDescUpdated implements the RangeStateListener interface.
 func (m *managerImpl) OnRangeDescUpdated(desc *roachpb.RangeDescriptor) {
 	m.twq.OnRangeDescUpdated(desc)
+	m.lm.OnRangeDescUpdated(desc)
 }
 
 var allKeysSpan = roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey}

--- a/pkg/kv/kvserver/concurrency/latch_manager.go
+++ b/pkg/kv/kvserver/concurrency/latch_manager.go
@@ -8,11 +8,17 @@ package concurrency
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
+
+// Node liveness heartbeats time out at 3s, so log slow latch acquisitions
+// sooner than 3s to help diagnose potential heartbeat failures.
+const slowLatchRequestThresholdSecondsOverride = 2
 
 // latchManagerImpl implements the latchManager interface.
 type latchManagerImpl struct {
@@ -66,4 +72,12 @@ func (m *latchManagerImpl) Release(ctx context.Context, lg latchGuard) {
 
 func (m *latchManagerImpl) Metrics() LatchMetrics {
 	return m.m.Metrics()
+}
+
+func (m *latchManagerImpl) OnRangeDescUpdated(desc *roachpb.RangeDescriptor) {
+	if keys.NodeLivenessSpan.Overlaps(desc.KeySpan().AsRawSpanWithNoLocals()) {
+		m.m.SetSlowLatchRequestThresholdOverride(slowLatchRequestThresholdSecondsOverride)
+	} else {
+		m.m.SetSlowLatchRequestThresholdOverride(0)
+	}
 }

--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -8,6 +8,7 @@ package spanlatch
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -70,6 +71,11 @@ type Manager struct {
 
 	// clock is used to provide predictable timestamps for testing.
 	clock *hlc.Clock
+
+	// slowLatchRequestThresholdOverride, when set to a nonzero value smaller
+	// than kv.concurrency.slow_latch_request_duration, overrides that setting
+	// as the threshold in seconds for considering a latch request to be slow.
+	slowLatchRequestThresholdOverride atomic.Int64
 }
 
 // scopedManager is a latch manager scoped to either local or global keys.
@@ -712,10 +718,24 @@ func (m *Manager) longLatchHoldThreshold() time.Duration {
 
 // slowLatchRequestThreshold returns the threshold for logging slow latch requests.
 func (m *Manager) slowLatchRequestThreshold() time.Duration {
-	if m.settings == nil {
-		return math.MaxInt64 // disable
+	threshold := time.Duration(math.MaxInt64)
+	if m.settings != nil {
+		threshold = SlowLatchRequestThreshold.Get(&m.settings.SV)
 	}
-	return SlowLatchRequestThreshold.Get(&m.settings.SV)
+
+	thresholdOverride := time.Duration(m.slowLatchRequestThresholdOverride.Load()) * time.Second
+	if thresholdOverride != 0 && thresholdOverride < threshold {
+		threshold = thresholdOverride
+	}
+
+	return threshold
+}
+
+// SetSlowLatchRequestThresholdOverride sets an override for the slow latch
+// request threshold. The override only applies if non-zero and smaller than the
+// cluster setting kv.concurrency.slow_latch_request_duration.
+func (m *Manager) SetSlowLatchRequestThresholdOverride(thresholdSeconds int64) {
+	m.slowLatchRequestThresholdOverride.Store(thresholdSeconds)
 }
 
 // Metrics holds information about the state of a Manager.


### PR DESCRIPTION
The default value of SlowLatchRequestThreshold is 5s, but since liveness heartbeats timeout after 3 seconds, its preferable to lower the threshold for the liveness range. This ensures that there will be logging/metrics for slow latch requests on this range before the request times out.

Fixes https://github.com/cockroachdb/cockroach/issues/154271
Release note: None
Epic: None
Part of: [CRDB-54843](https://cockroachlabs.atlassian.net/browse/CRDB-54843)