### PR TITLE
roachtest: randomize volume type and XFS

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec_test.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec_test.go
@@ -44,3 +44,24 @@ func TestClustersCompatible(t *testing.T) {
 		require.True(t, ClustersCompatible(s1, s2, AWS))
 	})
 }
+
+func TestClustersRetainClearedInfo(t *testing.T) {
+	// Adding a test in case we switch the ClustersCompatible signature to take
+	// pointers to ClusterSpec in the future.
+	t.Run("original structs are not modified", func(t *testing.T) {
+		s1 := ClusterSpec{
+			NodeCount:              5,
+			ExposedMetamorphicInfo: map[string]string{"VolumeType": "io2"},
+		}
+		s2 := ClusterSpec{
+			NodeCount:              5,
+			ExposedMetamorphicInfo: map[string]string{"VolumeType": "gp3"},
+		}
+
+		ClustersCompatible(s1, s2, GCE)
+
+		// Original data should still be there
+		require.Equal(t, "io2", s1.ExposedMetamorphicInfo["VolumeType"])
+		require.Equal(t, "gp3", s2.ExposedMetamorphicInfo["VolumeType"])
+	})
+}

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -209,6 +209,21 @@ func DisableLocalSSD() Option {
 	}
 }
 
+// RandomizeVolumeType is an Option which randomly picks the volume type
+// to be used. Unless SSD is forced, the volume type is picked randomly
+// between the available types for a provider:
+// - GCE: pd-ssd, local-ssd
+// - AWS: gp3, io2, local-ssd
+// - Azure: premium-ssd, premium-ssd-v2, ultra-disk, local-ssd
+// - IBM: 10iops-tier
+// Note: this option has no effect if VolumeType is explicitly set
+// or PreferLocalSSD/DisableLocalSSD is used.
+func RandomizeVolumeType() Option {
+	return func(spec *ClusterSpec) {
+		spec.RandomizeVolumeType = true
+	}
+}
+
 // TerminateOnMigration ensures VM is terminated in case GCE triggers a live migration.
 func TerminateOnMigration() Option {
 	return func(spec *ClusterSpec) {
@@ -240,10 +255,18 @@ func SetFileSystem(fs fileSystemType) Option {
 // RandomlyUseZfs is an Option which randomly picks
 // the file system to be used, and sets it to zfs,
 // about 20% of the time.
-// Zfs is only picked if the cloud is gce.
 func RandomlyUseZfs() Option {
 	return func(spec *ClusterSpec) {
 		spec.RandomlyUseZfs = true
+	}
+}
+
+// RandomlyUseXfs is an Option which randomly picks
+// the file system to be used, and sets it to xfs,
+// about 20% of the time.
+func RandomlyUseXfs() Option {
+	return func(spec *ClusterSpec) {
+		spec.RandomlyUseXfs = true
 	}
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -459,15 +459,15 @@ func (r *testRunner) Run(
 		// We should also check against the spec of the cluster, but we don't
 		// currently have a way of doing that; we're relying on the fact that attaching to the cluster
 		// will fail if the cluster is incompatible.
-		spec := tests[0].Cluster
-		spec.Lifetime = 0
+		spec1 := tests[0].Cluster
+		spec1.Lifetime = 0
 		for i := 1; i < len(tests); i++ {
 			spec2 := tests[i].Cluster
 			spec2.Lifetime = 0
-			if spec != spec2 {
+			if !spec.ClustersCompatible(spec1, spec2, roachtestflags.Cloud) {
 				return errors.Errorf("cluster specified but found tests "+
 					"with incompatible specs: %s (%s) - %s (%s)",
-					tests[0].Name, spec, tests[i].Name, spec2,
+					tests[0].Name, spec1, tests[i].Name, spec2,
 				)
 			}
 		}
@@ -2596,6 +2596,11 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 		"ssd":                    fmt.Sprintf("%d", spec.Cluster.SSDs),
 		"runtimeAssertionsBuild": fmt.Sprintf("%t", roachtestutil.UsingRuntimeAssertions(t)),
 		"coverageBuild":          fmt.Sprintf("%t", t.goCoverEnabled),
+	}
+
+	// Include cluster spec metamorphic test parameters.
+	for k, v := range spec.Cluster.GetMetamorphicInfo() {
+		clusterParams[k] = v
 	}
 
 	// These params can be probabilistically set, so we pass them here to

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -42,8 +42,16 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		// TODO(aaditya): change to weekly once the test stabilizes.
 		Suites: registry.Suites(registry.Nightly),
 		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
-		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone(), spec.Arch(spec.AllExceptFIPS)),
-		Leases:  registry.MetamorphicLeases,
+		Cluster: r.MakeClusterSpec(
+			2,
+			spec.CPU(8),
+			spec.WorkloadNode(),
+			spec.ReuseNone(),
+			spec.Arch(spec.AllExceptFIPS),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
+		Leases: registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount != 2 {
 				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -40,8 +40,14 @@ func registerElasticIO(r registry.Registry) {
 		Suites: registry.Suites(registry.Nightly),
 		// Tags:      registry.Tags(`weekly`),
 		// Second node is solely for Prometheus.
-		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
-		Leases:  registry.MetamorphicLeases,
+		Cluster: r.MakeClusterSpec(
+			2,
+			spec.CPU(8),
+			spec.WorkloadNode(),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
+		Leases: registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() {
 				t.Skip("IO overload test is not meant to run locally")

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -40,7 +40,13 @@ func registerIntentResolutionOverload(r registry.Registry) {
 		// TODO(sumeer): Reduce to weekly after working well.
 		// Tags:      registry.Tags(`weekly`),
 		// Second node is solely for Prometheus.
-		Cluster:          r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
+		Cluster: r.MakeClusterSpec(
+			2,
+			spec.CPU(8),
+			spec.WorkloadNode(),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -47,6 +47,8 @@ func registerSnapshotOverloadIO(r registry.Registry) {
 				spec.VolumeSize(cfg.volumeSize),
 				spec.ReuseNone(),
 				spec.DisableLocalSSD(),
+				spec.RandomizeVolumeType(),
+				spec.RandomlyUseXfs(),
 				// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 				spec.Arch(spec.AllExceptFIPS),
 			),

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -343,7 +343,16 @@ func registerKV(r registry.Registry) {
 		if opts.nodes > 3 {
 			workloadNodeCPUs = opts.cpus
 		}
-		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(workloadNodeCPUs), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
+		cSpec := r.MakeClusterSpec(
+			opts.nodes+1,
+			spec.CPU(opts.cpus),
+			spec.WorkloadNode(),
+			spec.WorkloadNodeCPU(workloadNodeCPUs),
+			spec.SSD(opts.ssds),
+			spec.RAID0(opts.raid0),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		)
 
 		var clouds registry.CloudSet
 		tags := make(map[string]struct{})
@@ -389,10 +398,15 @@ func registerKV(r registry.Registry) {
 func registerKVContention(r registry.Registry) {
 	const nodes = 4
 	r.Add(registry.TestSpec{
-		Name:             fmt.Sprintf("kv/contention/nodes=%d", nodes),
-		Owner:            registry.OwnerKV,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(nodes+1, spec.WorkloadNode()),
+		Name:      fmt.Sprintf("kv/contention/nodes=%d", nodes),
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: r.MakeClusterSpec(
+			nodes+1,
+			spec.WorkloadNode(),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -524,9 +538,14 @@ func registerKVLongRunningTxn(r registry.Registry) {
 
 func registerKVGracefulDraining(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "kv/gracefuldraining",
-		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(7, spec.WorkloadNode()),
+		Name:  "kv/gracefuldraining",
+		Owner: registry.OwnerKV,
+		Cluster: r.MakeClusterSpec(
+			7,
+			spec.WorkloadNode(),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -773,7 +792,12 @@ func registerKVSplits(r registry.Registry) {
 			Name:    name,
 			Owner:   registry.OwnerKV,
 			Timeout: item.timeout,
-			Cluster: r.MakeClusterSpec(4, spec.WorkloadNode()),
+			Cluster: r.MakeClusterSpec(
+				4,
+				spec.WorkloadNode(),
+				spec.RandomizeVolumeType(),
+				spec.RandomlyUseXfs(),
+			),
 			// These tests are carefully tuned to succeed up to certain number of
 			// splits; they are flaky in slower environments.
 			CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
@@ -841,9 +865,16 @@ func registerKVScalability(r registry.Registry) {
 		for _, p := range []int{0, 95} {
 			p := p
 			r.Add(registry.TestSpec{
-				Name:             fmt.Sprintf("kv%d/scale/nodes=6", p),
-				Owner:            registry.OwnerKV,
-				Cluster:          r.MakeClusterSpec(7, spec.CPU(8), spec.WorkloadNode(), spec.WorkloadNodeCPU(8)),
+				Name:  fmt.Sprintf("kv%d/scale/nodes=6", p),
+				Owner: registry.OwnerKV,
+				Cluster: r.MakeClusterSpec(
+					7,
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.RandomizeVolumeType(),
+					spec.RandomlyUseXfs(),
+				),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 				Leases:           registry.MetamorphicLeases,
@@ -976,9 +1007,16 @@ func registerKVRangeLookups(r registry.Registry) {
 			panic("unexpected")
 		}
 		r.Add(registry.TestSpec{
-			Name:             fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
-			Owner:            registry.OwnerKV,
-			Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
+			Name:  fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
+			Owner: registry.OwnerKV,
+			Cluster: r.MakeClusterSpec(
+				nodes+1,
+				spec.CPU(cpus),
+				spec.WorkloadNode(),
+				spec.WorkloadNodeCPU(cpus),
+				spec.RandomizeVolumeType(),
+				spec.RandomlyUseXfs(),
+			),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
@@ -1003,8 +1041,16 @@ func registerKVRestartImpact(r registry.Registry) {
 		Suites:           registry.Suites(registry.Weekly),
 		Owner:            registry.OwnerAdmissionControl,
 		Timeout:          4 * time.Hour,
-		Cluster:          r.MakeClusterSpec(13, spec.CPU(8), spec.WorkloadNode(), spec.WorkloadNodeCPU(8), spec.DisableLocalSSD()),
-		Leases:           registry.MetamorphicLeases,
+		Cluster: r.MakeClusterSpec(
+			13,
+			spec.CPU(8),
+			spec.WorkloadNode(),
+			spec.WorkloadNodeCPU(8),
+			spec.DisableLocalSSD(),
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
+		Leases: registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := len(c.CRDBNodes())
 			startOpts := option.NewStartOpts(option.NoBackupSchedule)

--- a/pkg/cmd/roachtest/tests/kv_rangefeed.go
+++ b/pkg/cmd/roachtest/tests/kv_rangefeed.go
@@ -480,7 +480,14 @@ func registerKVRangefeed(r registry.Registry) {
 			Name:      testName,
 			Owner:     registry.OwnerKV,
 			Benchmark: true,
-			Cluster:   r.MakeClusterSpec(4, spec.CPU(8), spec.WorkloadNode(), spec.WorkloadNodeCPU(4)),
+			Cluster: r.MakeClusterSpec(
+				4,
+				spec.CPU(8),
+				spec.WorkloadNode(),
+				spec.WorkloadNodeCPU(4),
+				spec.RandomizeVolumeType(),
+				spec.RandomlyUseXfs(),
+			),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKVRangefeed(ctx, t, c, opts)
 			},

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -63,7 +63,13 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 	if b.NumShards > 0 {
 		nameParts = append(nameParts, fmt.Sprintf("shards=%d", b.NumShards))
 	}
-	opts := []spec.Option{spec.CPU(b.CPUs), spec.WorkloadNode(), spec.WorkloadNodeCPU(b.CPUs)}
+	opts := []spec.Option{
+		spec.CPU(b.CPUs),
+		spec.WorkloadNode(),
+		spec.WorkloadNodeCPU(b.CPUs),
+		spec.RandomizeVolumeType(),
+		spec.RandomlyUseXfs(),
+	}
 	switch b.KeyDistribution {
 	case sequential:
 		nameParts = append(nameParts, "sequential")

--- a/pkg/cmd/roachtest/tests/large_kv.go
+++ b/pkg/cmd/roachtest/tests/large_kv.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -23,9 +24,13 @@ import (
 
 func registerLargeKV(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "storage/large_kv",
-		Owner:            registry.OwnerStorage,
-		Cluster:          r.MakeClusterSpec(1),
+		Name:  "storage/large_kv",
+		Owner: registry.OwnerStorage,
+		Cluster: r.MakeClusterSpec(
+			1,
+			spec.RandomizeVolumeType(),
+			spec.RandomlyUseXfs(),
+		),
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.Suites(registry.Roachtest),
 		Timeout:          60 * time.Minute,

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1357,7 +1357,8 @@ func (p *Provider) runInstance(
 	extraMountOpts := ""
 	// Dynamic args.
 	if opts.SSDOpts.UseLocalSSD {
-		if opts.SSDOpts.NoExt4Barrier {
+		// Disable ext4 barriers if specified and using ext4.
+		if opts.SSDOpts.NoExt4Barrier && opts.SSDOpts.FileSystem == vm.Ext4 {
 			extraMountOpts = "nobarrier"
 		}
 	}
@@ -1597,6 +1598,56 @@ func getSpotInstanceRequestId(
 	return spotInstanceRequestId, nil
 }
 
+// calculateProvisionedIOPS calculates the appropriate IOPS for io1/io2 volumes
+// based on volume size, respecting AWS constraints.
+//
+// AWS enforces maximum IOPS-to-size ratios:
+// - io1: 50 IOPS/GB (max 64,000 IOPS)
+// - io2: 500 IOPS/GB for standard, 1000 IOPS/GB for Block Express (max 256,000 IOPS)
+//
+// We use 10 IOPS/GB as a baseline to match Azure's ultra-disk default ratio,
+// with a minimum of 3,000 IOPS (matching gp3 baseline), but we must respect
+// AWS's IOPS-to-size ratio constraints.
+func calculateProvisionedIOPS(volumeType string, volumeSize int) int {
+	if volumeType != "io1" && volumeType != "io2" {
+		return 0
+	}
+
+	// Calculate baseline: 10 IOPS/GB
+	iops := volumeSize * 10
+
+	// Determine AWS constraints for this volume type
+	var maxIOPSPerGB int
+	var absoluteMaxIOPS int
+	switch volumeType {
+	case "io1":
+		maxIOPSPerGB = 50
+		absoluteMaxIOPS = 64000
+	case "io2":
+		// As of April 2025, all io2 volumes are Block Express with 1000 IOPS/GB.
+		// We use the more conservative 500 IOPS/GB for compatibility.
+		maxIOPSPerGB = 500
+		absoluteMaxIOPS = 64000 // Use 64k for compatibility; Block Express supports 256k
+	}
+
+	// Apply constraint-aware minimum
+	if iops < 3000 {
+		// Set a minimum of 3,000 IOPS (matching gp3 baseline)
+		iops = 3000
+
+		// But if that exceeds the maximum allowed IOPS for this volume size,
+		// set to the maximum allowed instead.
+		maxAllowedIOPS := volumeSize * maxIOPSPerGB
+		if iops > maxAllowedIOPS {
+			iops = maxAllowedIOPS
+		}
+	} else if iops > absoluteMaxIOPS {
+		iops = absoluteMaxIOPS
+	}
+
+	return iops
+}
+
 func genDeviceMapping(ebsVolumes ebsVolumeList, args []string) ([]string, error) {
 	mapping, err := json.Marshal(ebsVolumes)
 	if err != nil {
@@ -1644,6 +1695,13 @@ func assignEBSVolumes(opts *vm.CreateOpts, providerOpts *ProviderOpts) ebsVolume
 			v := ebsVolumes.newVolume()
 			v.Disk = providerOpts.DefaultEBSVolume.Disk
 			v.Disk.DeleteOnTermination = true
+
+			// io2/io1 volumes require IOPS to be specified. If not already set,
+			// calculate based on volume size using AWS-compliant logic.
+			if v.Disk.IOPs == 0 {
+				v.Disk.IOPs = calculateProvisionedIOPS(v.Disk.VolumeType, v.Disk.VolumeSize)
+			}
+
 			ebsVolumes = append(ebsVolumes, v)
 		}
 	}

--- a/pkg/roachprod/vm/aws/support_test.go
+++ b/pkg/roachprod/vm/aws/support_test.go
@@ -26,3 +26,103 @@ func TestWriteStartupScriptTemplate(t *testing.T) {
 
 	echotest.Require(t, string(f), datapathutils.TestDataPath(t, "startup_script"))
 }
+
+// TestIOPSCalculation tests that IOPS are calculated correctly for io1/io2 volumes,
+// respecting AWS's maximum IOPS-to-size ratio constraints.
+func TestIOPSCalculation(t *testing.T) {
+	testCases := []struct {
+		name         string
+		volumeType   string
+		volumeSize   int
+		expectedIOPS int
+		description  string
+	}{
+		// io1 volume tests (50 IOPS/GB max)
+		{
+			name:         "io1_50gb_should_cap_at_2500",
+			volumeType:   "io1",
+			volumeSize:   50,
+			expectedIOPS: 2500, // 50 GB * 50 IOPS/GB = 2,500 (not 3,000)
+			description:  "50GB io1 volume should cap at 2,500 IOPS, not apply 3,000 minimum",
+		},
+		{
+			name:         "io1_30gb_should_cap_at_1500",
+			volumeType:   "io1",
+			volumeSize:   30,
+			expectedIOPS: 1500, // 30 GB * 50 IOPS/GB = 1,500 (not 3,000)
+			description:  "30GB io1 volume should cap at 1,500 IOPS",
+		},
+		{
+			name:         "io1_59gb_should_cap_at_2950",
+			volumeType:   "io1",
+			volumeSize:   59,
+			expectedIOPS: 2950, // 59 GB * 50 IOPS/GB = 2,950 (not 3,000)
+			description:  "59GB io1 volume should cap at 2,950 IOPS",
+		},
+		{
+			name:         "io1_60gb_should_use_3000_minimum",
+			volumeType:   "io1",
+			volumeSize:   60,
+			expectedIOPS: 3000, // 60 GB * 50 IOPS/GB = 3,000 (minimum applies)
+			description:  "60GB io1 volume should use 3,000 IOPS minimum",
+		},
+		{
+			name:         "io1_100gb_uses_calculated_1000_iops",
+			volumeType:   "io1",
+			volumeSize:   100,
+			expectedIOPS: 3000, // 100 GB * 10 IOPS/GB = 1,000, but minimum is 3,000
+			description:  "100GB io1 volume uses 3,000 IOPS minimum (calculated 1,000 < 3,000)",
+		},
+		{
+			name:         "io1_500gb_uses_5000_iops",
+			volumeType:   "io1",
+			volumeSize:   500,
+			expectedIOPS: 5000, // 500 GB * 10 IOPS/GB = 5,000
+			description:  "500GB io1 volume uses calculated 5,000 IOPS",
+		},
+		{
+			name:         "io1_max_size_caps_at_64000",
+			volumeType:   "io1",
+			volumeSize:   10000,
+			expectedIOPS: 64000, // 10,000 GB * 10 IOPS/GB = 100,000, but max is 64,000
+			description:  "Large io1 volume should cap at 64,000 IOPS",
+		},
+
+		// io2 volume tests (500 IOPS/GB max for standard, using conservative limit)
+		{
+			name:         "io2_5gb_should_cap_at_2500",
+			volumeType:   "io2",
+			volumeSize:   5,
+			expectedIOPS: 2500, // 5 GB * 500 IOPS/GB = 2,500 (not 3,000)
+			description:  "5GB io2 volume should cap at 2,500 IOPS",
+		},
+		{
+			name:         "io2_6gb_should_use_3000_minimum",
+			volumeType:   "io2",
+			volumeSize:   6,
+			expectedIOPS: 3000, // 6 GB * 500 IOPS/GB = 3,000 (minimum applies)
+			description:  "6GB io2 volume should use 3,000 IOPS minimum",
+		},
+		{
+			name:         "io2_500gb_uses_5000_iops",
+			volumeType:   "io2",
+			volumeSize:   500,
+			expectedIOPS: 5000, // 500 GB * 10 IOPS/GB = 5,000
+			description:  "500GB io2 volume uses calculated 5,000 IOPS",
+		},
+		{
+			name:         "io2_max_size_caps_at_64000",
+			volumeType:   "io2",
+			volumeSize:   10000,
+			expectedIOPS: 64000, // 10,000 GB * 10 IOPS/GB = 100,000, but max is 64,000
+			description:  "Large io2 volume should cap at 64,000 IOPS",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iops := calculateProvisionedIOPS(tc.volumeType, tc.volumeSize)
+			require.Equal(t, tc.expectedIOPS, iops, tc.description)
+		})
+	}
+}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1609,7 +1609,9 @@ func (p *Provider) computeInstanceArgs(
 			// Add `discard` for Local SSDs on NVMe, as is advised in:
 			// https://cloud.google.com/compute/docs/disks/add-local-ssd
 			extraMountOpts = "discard"
-			if opts.SSDOpts.NoExt4Barrier {
+
+			// Disable ext4 barriers if specified and using ext4.
+			if opts.SSDOpts.NoExt4Barrier && opts.SSDOpts.FileSystem == vm.Ext4 {
 				extraMountOpts = fmt.Sprintf("%s,nobarrier", extraMountOpts)
 			}
 		} else {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -388,7 +388,7 @@ type CreateOpts struct {
 	SSDOpts        struct {
 		UseLocalSSD bool
 		// NoExt4Barrier, if set, makes the "-o nobarrier" flag be used when
-		// mounting the SSD. Ignored if UseLocalSSD is not set.
+		// mounting the SSD. Ignored if UseLocalSSD is not set or filesystem is not ext4.
 		NoExt4Barrier bool
 		// The file system to be used. This is set to "ext4" by default.
 		FileSystem Filesystem


### PR DESCRIPTION
Prior to this patch, tests had three possiblities for volume types:
1. Specify `PreferLocalSSD()` `DisableLocalSSD()` options.
2. Force a specific volume type via `VolumeType()` (volume type being provider specific, this was only possible for tests that target a single provider).
3. Rely on the default behavior for `PreferLocalSSD()` and use the default volume type in roachprod for the provider in case local SSD was not selected.

The way `PreferLocalSSD()` was implemented meant that most of the tests were actually running on local SSDs (when available on the machine type), leading to a gap in the testing strategy with regards to volume types.

This patch brings the new ClusterSpec option `RandomizeVolumeType()`. In case volume type is not forced and neither `PreferLocalSSD()` or `DisableLocalSSD()` are specified, specifying `RandomizeVolumeType()` will take precendence over the `--local-ssd` argument and will randomly select a volume type from those available in the targeted provider:
- AWS: gp3, io2, local SSD
- GCE: pd-ssd, local SSD
- Azure: premium-ssd, premium-ssd-v2, ultra-disk, local SSD
- IBM: 10iops-tier

Note: volume type randomization gives the same weight to all options.

This patch also introduces a random chance of provisioning XFS as a filesystem via the option `RandomlyUseXfs()`.
The option is built in the same way as `RandomlyUseZfs()`, granting a 20% chance of XFS if present.
If both `RandomlyUseZfs()` and `RandomlyUseXfs()` are used, they both get a 20% chance, leaving 60% chance for the default ext4.

All/most of the KV tests, and a few admission-control are switched to volume type/filesystem randomization as requested in [this issue](https://github.com/cockroachdb/cockroach/issues/146661). 

Epic: none
Fixes: 146661
Release note: None