### PR TITLE
logical: enable update swap optimization

### DIFF
--- a/pkg/crosscluster/logical/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sql_row_writer_test.go
@@ -33,7 +33,7 @@ func makeTestRow(t *testing.T, _ catalog.TableDescriptor, id int64, name string)
 }
 
 func newInternalSession(t *testing.T, s serverutils.ApplicationLayerInterface) isql.Session {
-	sd := tableHandlerSessionSettings(sql.NewInternalSessionData(context.Background(), s.ClusterSettings(), ""))
+	sd := tableHandlerSessionSettings(sql.NewInternalSessionData(context.Background(), s.ClusterSettings(), ""), s.ClusterSettings())
 	session, err := s.InternalDB().(isql.DB).Session(context.Background(), "test_session", isql.WithSessionData(sd))
 	require.NoError(t, err)
 	return session


### PR DESCRIPTION
This enables the update swap operator in LDR. Update swap was designed for LDR and its SQL statements are written assuming update swap exists. The randomized schema tests and conflict test give us high confidence that update swap is correct for LDR's use case.

Release note: none
Epic: CRDB-51533