### PR TITLE
sql/sem/tree: prevent schema_locked bypass with comma syntax

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -218,3 +218,45 @@ t_147993  CREATE TABLE public.t_147993 (
           ) WITH (schema_locked = true);
 
 subtest end
+
+# Regression test for #150484: schema_locked cannot be unset with the comma
+# syntax combined with other schema-changing operations. This prevents bypassing
+# the schema_locked protection by unsetting the lock and performing a schema
+# change in the same ALTER TABLE statement.
+subtest regression_150484
+
+statement ok
+CREATE TABLE t_150484 (n INT, m INT, FAMILY (n, m)) WITH (schema_locked=true);
+
+# Combining SET (schema_locked=false) with DROP COLUMN should fail.
+statement error pgcode 57000 pq: this schema change is disallowed because table "t_150484" is locked
+ALTER TABLE t_150484 SET (schema_locked=false), DROP COLUMN n;
+
+# Combining RESET (schema_locked) with ADD COLUMN should fail.
+statement error pgcode 57000 pq: this schema change is disallowed because table "t_150484" is locked
+ALTER TABLE t_150484 RESET (schema_locked), ADD COLUMN k INT;
+
+# Verify the table is still locked and unchanged.
+query TT
+SHOW CREATE TABLE t_150484
+----
+t_150484  CREATE TABLE public.t_150484 (
+            n INT8 NULL,
+            m INT8 NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT t_150484_pkey PRIMARY KEY (rowid ASC),
+            FAMILY fam_0_n_m_rowid (n, m, rowid)
+          ) WITH (schema_locked = true);
+
+# Confirm that SET (schema_locked=false) alone still works.
+statement ok
+ALTER TABLE t_150484 SET (schema_locked=false);
+
+# Now schema changes should work.
+statement ok
+ALTER TABLE t_150484 DROP COLUMN n;
+
+statement ok
+DROP TABLE t_150484;
+
+subtest end


### PR DESCRIPTION
Previously, the legacy schema changer allowed bypassing the schema_locked protection by combining `SET (schema_locked=false)` with other schema-changing commands in the same ALTER TABLE statement. For example:

```sql
ALTER TABLE t SET (schema_locked=false), DROP COLUMN n;
```

This would first unset schema_locked, then execute the DROP COLUMN on the now-unlocked table, effectively circumventing the protection.

The fix ensures `IsSetOrResetSchemaLocked()` returns `false` when the ALTER TABLE statement contains any commands other than storage parameter changes. This prevents schema_locked changes from being combined with other schema changes in the same statement.

Fixes: #150484

Release note (bug fix): Fixed a bug where the `schema_locked` table storage parameter could be bypassed by combining `SET (schema_locked=false)` with other schema changes in the same `ALTER TABLE` statement using comma syntax. Schema-locked tables now correctly reject such combined statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)