### PR TITLE
drtprod: changes for 300 node provisioning

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_remote_300.yaml
+++ b/pkg/cmd/drtprod/configs/drt_remote_300.yaml
@@ -1,0 +1,28 @@
+# YAML for creating and configuring the drt monitor cluster. This is used for remotre deployment
+environment:
+  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
+  ROACHPROD_DNS: drt.crdb.io
+  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
+  ROACHPROD_GCE_DNS_ZONE: drt
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
+  MONITOR_CLUSTER: <yaml file name>-monitor # this is overwritten with the yaml file name
+
+targets:
+  - target_name: $MONITOR_CLUSTER
+    steps:
+      - command: create
+        continue_on_failure: true
+        args:
+          - $MONITOR_CLUSTER
+        flags:
+          clouds: gce
+          gce-zones: "us-central1-a"
+          nodes: 1
+          gce-machine-type: n2-standard-64
+          username: drt
+          lifetime: 72k
+          gce-image: "ubuntu-2204-jammy-v20240319"
+      - command: sync
+        flags:
+          clouds: gce
+      - script: pkg/cmd/drtprod/scripts/add_dd_api_key_to_bash.sh

--- a/pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
+++ b/pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
@@ -8,9 +8,19 @@ if [ -z "${CLUSTER}" ]; then
   exit 1
 fi
 
-drtprod ssh "$CLUSTER" -- "sudo apt-get purge -y snapd"
-drtprod ssh "$CLUSTER" -- "sudo umount -f /mnt/data1"
-drtprod ssh "$CLUSTER" -- "sudo dmsetup remove_all"
-drtprod ssh "$CLUSTER" -- "sudo tune2fs -O ^has_journal /dev/nvme0n1"
-drtprod ssh "$CLUSTER" -- 'echo "0 $(sudo blockdev --getsz /dev/nvme0n1) linear /dev/nvme0n1 0" | sudo dmsetup create data1'
-drtprod ssh "$CLUSTER" -- "sudo mount /dev/mapper/data1 /mnt/data1"
+# Create and upload the setup script to the remote cluster
+roachprod ssh "$CLUSTER" -- "tee setup_dmsetup.sh > /dev/null << 'EOF'
+#!/bin/bash
+
+DEVICE=\$(df -kh | grep \"/data1\" | cut -d\" \" -f1)
+
+sudo apt-get purge -y snapd
+sudo umount -f /mnt/data1
+sudo dmsetup remove_all
+sudo tune2fs -O ^has_journal \${DEVICE}
+echo \"0 \$(sudo blockdev --getsz \"\${DEVICE}\") linear \"\${DEVICE}\" 0\" | sudo dmsetup create data1
+sudo mount /dev/mapper/data1 /mnt/data1
+EOF"
+
+# Make the script executable and run it
+roachprod ssh "$CLUSTER" -- "chmod +x setup_dmsetup.sh && ./setup_dmsetup.sh"


### PR DESCRIPTION
For provisioning a 300 node cluster we use a remote node. That node needs memory for executing the gcloud commands. So, a new drt_remote_300.yaml file is created. Also, the dmsetup was failing as the script was hard-coded for local ssd. This PR changes that logic to read the device by running "df -k" and getting the device name for /data1.

Release: None
Epic: None