### PR TITLE
release-25.4: storage/metamorphic: increase min bound of target file size

### DIFF
--- a/pkg/storage/metamorphic/options.go
+++ b/pkg/storage/metamorphic/options.go
@@ -114,7 +114,7 @@ func randomOptions() *pebble.Options {
 	opts.Levels[0].BlockSize = 1 << rngIntRange(rng, 1, 20)
 	opts.Levels[0].BlockSizeThreshold = int(rngIntRange(rng, 50, 100))
 	opts.Levels[0].IndexBlockSize = opts.Levels[0].BlockSize
-	opts.TargetFileSizes[0] = 1 << rngIntRange(rng, 1, 20)
+	opts.TargetFileSizes[0] = int64(max(1<<rngIntRange(rng, 9, 20), 570))
 	for i := 1; i < len(opts.Levels); i++ {
 		opts.Levels[i] = opts.Levels[i-1]
 		opts.TargetFileSizes[i] = opts.TargetFileSizes[i-1] * 2


### PR DESCRIPTION
/cc @cockroachdb/release 

Release justification: test-only fix!

When the target file size is less than an empty table writer, we try to split the table as soon as possible (and emit just a small piece of a span in many cases). These many tiny tables slow down the tests a lot, to the point of timing out certain operations.

This change sets the minimum target file size in the metamorphic tests to 570 as the estimated size of an empty column writer is 565.

Epic: none
Fixes: #156842

Release note: None