### PR TITLE
util/ioctx: add RandomAccessReader for cloud storage

### DIFF
--- a/pkg/util/ioctx/BUILD.bazel
+++ b/pkg/util/ioctx/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ioctx",
-    srcs = ["reader.go"],
+    srcs = [
+        "random_access_reader.go",
+        "reader.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/ioctx",
     visibility = ["//visibility:public"],
     deps = ["@com_github_cockroachdb_errors//:errors"],
@@ -11,7 +14,10 @@ go_library(
 go_test(
     name = "ioctx_test",
     size = "small",
-    srcs = ["reader_test.go"],
+    srcs = [
+        "random_access_reader_test.go",
+        "reader_test.go",
+    ],
     embed = [":ioctx"],
     deps = [
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/ioctx/random_access_reader.go
+++ b/pkg/util/ioctx/random_access_reader.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ioctx
+
+import (
+	"context"
+	"io"
+
+	"github.com/cockroachdb/errors"
+)
+
+// OpenerAtFunc is a factory function that opens a reader at a specific offset.
+// endHint can be used to optimize the read if the end position is known.
+type OpenerAtFunc func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error)
+
+// randomAccessReader wraps any cloud storage reader and adds ReadAt/Seek support
+// using a factory function that can open readers at specific offsets.
+//
+// This provides random access capabilities without requiring the cloud storage
+// implementation itself to support seeking. Each ReadAt call opens a new reader
+// at the requested offset.
+//
+// Thread Safety:
+//   - ReadAt: Safe for concurrent calls. Each call opens its own reader.
+//   - Read/Seek: NOT safe for concurrent calls. Should only be used from a single goroutine.
+type randomAccessReader struct {
+	ctx    context.Context
+	size   int64
+	openAt OpenerAtFunc
+
+	// Current sequential reader (for Read operations)
+	current ReadCloserCtx
+	pos     int64
+}
+
+var _ io.ReaderAt = &randomAccessReader{}
+var _ io.ReadSeekCloser = &randomAccessReader{}
+
+// NewRandomAccessReader creates a reader that supports ReadAt and Seek
+// by using the provided opener function to create readers at specific offsets.
+//
+// Parameters:
+//   - ctx: Context for operations
+//   - size: Total size of the file
+//   - openAt: Factory function that opens a reader at a given offset
+func NewRandomAccessReader(
+	ctx context.Context, size int64, openAt OpenerAtFunc,
+) *randomAccessReader {
+	return &randomAccessReader{
+		ctx:    ctx,
+		size:   size,
+		openAt: openAt,
+	}
+}
+
+// Read implements io.Reader using sequential access
+func (r *randomAccessReader) Read(p []byte) (int, error) {
+	if r.current == nil {
+		// Open reader at current position
+		opened, err := r.openAt(r.ctx, r.pos, r.size)
+		if err != nil {
+			return 0, err
+		}
+		r.current = opened
+	}
+
+	n, err := r.current.Read(r.ctx, p)
+	r.pos += int64(n)
+	return n, err
+}
+
+// ReadAt implements io.ReaderAt - safe for concurrent calls.
+// Each call opens a new reader at the requested offset, so multiple
+// goroutines can call ReadAt simultaneously.
+//
+// Note: This opens a new connection (HTTP request) for every ReadAt call.
+// For cloud storage, this means each random access read results in a new
+// range request to the storage service.
+func (r *randomAccessReader) ReadAt(p []byte, off int64) (int, error) {
+	if off >= r.size {
+		return 0, io.EOF
+	}
+
+	// Open a new reader at the requested offset
+	reader, err := r.openAt(r.ctx, off, off+int64(len(p)))
+	if err != nil {
+		return 0, err
+	}
+	defer reader.Close(r.ctx)
+
+	// Read exactly len(p) bytes or until EOF
+	return io.ReadFull(ReaderCtxAdapter(r.ctx, reader), p)
+}
+
+// Seek implements io.Seeker
+func (r *randomAccessReader) Seek(offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = r.pos + offset
+	case io.SeekEnd:
+		newPos = r.size + offset
+	default:
+		return 0, errors.Newf("invalid whence: %d", whence)
+	}
+
+	if newPos < 0 {
+		return 0, errors.New("negative position")
+	}
+
+	// Close current reader if position changed
+	if r.current != nil && newPos != r.pos {
+		r.current.Close(r.ctx)
+		r.current = nil
+	}
+
+	r.pos = newPos
+	return newPos, nil
+}
+
+// Close closes any open reader
+func (r *randomAccessReader) Close() error {
+	if r.current != nil {
+		return r.current.Close(r.ctx)
+	}
+	return nil
+}

--- a/pkg/util/ioctx/random_access_reader_test.go
+++ b/pkg/util/ioctx/random_access_reader_test.go
@@ -1,0 +1,296 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ioctx
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// mockReadCloser implements ReadCloserCtx for testing
+type mockReadCloser struct {
+	data   string
+	offset int64
+	pos    int64
+}
+
+func newMockReadCloser(data string, offset int64) *mockReadCloser {
+	return &mockReadCloser{
+		data:   data,
+		offset: offset,
+		pos:    offset,
+	}
+}
+
+func (m *mockReadCloser) Read(ctx context.Context, p []byte) (int, error) {
+	if m.pos >= int64(len(m.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[m.pos:])
+	m.pos += int64(n)
+	return n, nil
+}
+
+func (m *mockReadCloser) Close(ctx context.Context) error {
+	return nil
+}
+
+// TestRandomAccessReaderReadAt tests the ReadAt implementation
+func TestRandomAccessReaderReadAt(t *testing.T) {
+	ctx := context.Background()
+	testData := "0123456789abcdefghijklmnopqrstuvwxyz"
+
+	// Create opener function that simulates cloud storage offset reads
+	openAt := func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error) {
+		if offset >= int64(len(testData)) {
+			return nil, io.EOF
+		}
+		return newMockReadCloser(testData, offset), nil
+	}
+
+	reader := NewRandomAccessReader(ctx, int64(len(testData)), openAt)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	t.Run("read-at-beginning", func(t *testing.T) {
+		p := make([]byte, 5)
+		n, err := reader.ReadAt(p, 0)
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		require.Equal(t, "01234", string(p))
+	})
+
+	t.Run("read-at-middle", func(t *testing.T) {
+		p := make([]byte, 5)
+		n, err := reader.ReadAt(p, 10)
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		require.Equal(t, "abcde", string(p))
+	})
+
+	t.Run("read-at-end", func(t *testing.T) {
+		p := make([]byte, 5)
+		n, err := reader.ReadAt(p, int64(len(testData))-5)
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		require.Equal(t, "vwxyz", string(p))
+	})
+
+	t.Run("read-past-end", func(t *testing.T) {
+		p := make([]byte, 5)
+		_, err := reader.ReadAt(p, int64(len(testData)))
+		require.Equal(t, io.EOF, err)
+	})
+
+	t.Run("read-partial-at-end", func(t *testing.T) {
+		// Request 10 bytes but only 3 available
+		p := make([]byte, 10)
+		n, err := reader.ReadAt(p, int64(len(testData))-3)
+		// io.ReadFull returns ErrUnexpectedEOF when it can't fill the buffer
+		require.Equal(t, io.ErrUnexpectedEOF, err)
+		require.Equal(t, 3, n)
+		require.Equal(t, "xyz", string(p[:n]))
+	})
+
+	t.Run("concurrent-reads", func(t *testing.T) {
+		// ReadAt should be safe for concurrent calls
+		done := make(chan bool, 2)
+
+		go func() {
+			p := make([]byte, 5)
+			n, err := reader.ReadAt(p, 0)
+			require.NoError(t, err)
+			require.Equal(t, 5, n)
+			require.Equal(t, "01234", string(p))
+			done <- true
+		}()
+
+		go func() {
+			p := make([]byte, 5)
+			n, err := reader.ReadAt(p, 10)
+			require.NoError(t, err)
+			require.Equal(t, 5, n)
+			require.Equal(t, "abcde", string(p))
+			done <- true
+		}()
+
+		<-done
+		<-done
+	})
+}
+
+// TestRandomAccessReaderSeek tests the Seek implementation
+func TestRandomAccessReaderSeek(t *testing.T) {
+	ctx := context.Background()
+	testData := "0123456789"
+
+	openAt := func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error) {
+		if offset >= int64(len(testData)) {
+			return nil, io.EOF
+		}
+		return newMockReadCloser(testData, offset), nil
+	}
+
+	reader := NewRandomAccessReader(ctx, int64(len(testData)), openAt)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	t.Run("seek-start", func(t *testing.T) {
+		pos, err := reader.Seek(5, io.SeekStart)
+		require.NoError(t, err)
+		require.Equal(t, int64(5), pos)
+	})
+
+	t.Run("seek-current", func(t *testing.T) {
+		// Position is 5 from previous test
+		pos, err := reader.Seek(2, io.SeekCurrent)
+		require.NoError(t, err)
+		require.Equal(t, int64(7), pos)
+	})
+
+	t.Run("seek-end", func(t *testing.T) {
+		pos, err := reader.Seek(-3, io.SeekEnd)
+		require.NoError(t, err)
+		require.Equal(t, int64(7), pos)
+	})
+
+	t.Run("seek-negative", func(t *testing.T) {
+		_, err := reader.Seek(-1, io.SeekStart)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "negative position")
+	})
+
+	t.Run("seek-invalid-whence", func(t *testing.T) {
+		_, err := reader.Seek(0, 999)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid whence")
+	})
+}
+
+// TestRandomAccessReaderRead tests sequential Read operations
+func TestRandomAccessReaderRead(t *testing.T) {
+	ctx := context.Background()
+	testData := "0123456789"
+
+	openAt := func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error) {
+		if offset >= int64(len(testData)) {
+			return nil, io.EOF
+		}
+		return newMockReadCloser(testData, offset), nil
+	}
+
+	reader := NewRandomAccessReader(ctx, int64(len(testData)), openAt)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	t.Run("sequential-reads", func(t *testing.T) {
+		p := make([]byte, 3)
+
+		// First read
+		n, err := reader.Read(p)
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.Equal(t, "012", string(p))
+
+		// Second read
+		n, err = reader.Read(p)
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.Equal(t, "345", string(p))
+
+		// Third read
+		n, err = reader.Read(p)
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.Equal(t, "678", string(p))
+	})
+}
+
+// TestRandomAccessReaderSeekThenRead tests Seek followed by Read
+func TestRandomAccessReaderSeekThenRead(t *testing.T) {
+	ctx := context.Background()
+	testData := "0123456789"
+
+	openAt := func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error) {
+		if offset >= int64(len(testData)) {
+			return nil, io.EOF
+		}
+		return newMockReadCloser(testData, offset), nil
+	}
+
+	reader := NewRandomAccessReader(ctx, int64(len(testData)), openAt)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	// Seek to position 5
+	pos, err := reader.Seek(5, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), pos)
+
+	// Read from that position
+	p := make([]byte, 3)
+	n, err := reader.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "567", string(p))
+}
+
+// TestRandomAccessReaderOpenerError tests error handling from opener function
+func TestRandomAccessReaderOpenerError(t *testing.T) {
+	ctx := context.Background()
+
+	expectedErr := errors.New("storage unavailable")
+	openAt := func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error) {
+		return nil, expectedErr
+	}
+
+	reader := NewRandomAccessReader(ctx, 100, openAt)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	t.Run("readat-opener-error", func(t *testing.T) {
+		p := make([]byte, 5)
+		_, err := reader.ReadAt(p, 0)
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("read-opener-error", func(t *testing.T) {
+		p := make([]byte, 5)
+		_, err := reader.Read(p)
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+	})
+}
+
+// TestRandomAccessReaderEmptyFile tests reading from an empty file
+func TestRandomAccessReaderEmptyFile(t *testing.T) {
+	ctx := context.Background()
+
+	openAt := func(ctx context.Context, offset int64, endHint int64) (ReadCloserCtx, error) {
+		return newMockReadCloser("", offset), nil
+	}
+
+	reader := NewRandomAccessReader(ctx, 0, openAt)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	t.Run("readat-empty", func(t *testing.T) {
+		p := make([]byte, 5)
+		_, err := reader.ReadAt(p, 0)
+		require.Equal(t, io.EOF, err)
+	})
+}


### PR DESCRIPTION
Add a general-purpose wrapper that provides ReadAt/Seek support for any cloud storage reader using an opener factory function pattern.

This enables random access (required by formats like Parquet) without requiring the cloud storage implementation itself to natively support ReadAt/Seek. Instead, it opens new readers at specific offsets for each ReadAt call.

Key features:
- Thread-safe ReadAt: Each call opens a new connection, allowing concurrent reads from different offsets
- Seek support: Tracks position logically without seeking underlying readers
- Generic: Works with any ReadCloserCtx via OpenerAtFunc factory

Release note: None

Epic: CRDB-23802