### PR TITLE
release-25.4: workload: fix tpcc unsafe_internals_accessed logs

### DIFF
--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -426,7 +426,8 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, time.Duration
 						fmt.Sprintf(`
 						UPDATE stock
 						SET
-							s_quantity = CASE (s_i_id, s_w_id) %[1]s ELSE crdb_internal.force_error('', 'unknown case') END,
+ 						  -- force error in ELSE case with a divide by zero error
+							s_quantity = CASE (s_i_id, s_w_id) %[1]s ELSE (1/0)::INT END,
 							s_ytd = CASE (s_i_id, s_w_id) %[2]s END,
 							s_order_cnt = CASE (s_i_id, s_w_id) %[3]s END,
 							s_remote_cnt = CASE (s_i_id, s_w_id) %[4]s END


### PR DESCRIPTION
Backport 1/1 commits from #155632.

/cc @cockroachdb/release

---

The tpcc workload started generating a lot of unsafe_internals_accessed logs due to the use of `crdb_internal.force_error`.

This PR fixes this by replacing the usage of `crdb_internal.force_error` with `(1/0)::INT` which provides the same functionality of forcing an error without using an internal built in.

Epic: None
Release note: None

Release justification: Improves noisiness in testing clusters, change to non-production code.
