### PR TITLE
release-25.2: codeowners: include gitignore'd files in test file lookup

### DIFF
--- a/pkg/internal/codeowners/codeowners.go
+++ b/pkg/internal/codeowners/codeowners.go
@@ -208,7 +208,7 @@ func getFile(packageName, testName string) (res string, logs []string, err error
 			return
 		}
 		cmd := exec.Command(`/bin/bash`, `-c`,
-			fmt.Sprintf(`cd "$(git rev-parse --show-toplevel)" && git grep -n 'func %s(' '%s/*_test.go'`,
+			fmt.Sprintf(`cd "$(git rev-parse --show-toplevel)" && git grep --no-index -n 'func %s(' '%s/*_test.go'`,
 				testName, packageName))
 		// This command returns output such as:
 		// ../ccl/storageccl/export_test.go:31:func TestExportCmd(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #159081 on behalf of @rickystewart.

----

Release note: none
Epic: none

----

Release justification: Non-production code changes