### PR TITLE
azure: set default of cloudstorage.azure.try.timeout to 0

### DIFF
--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -55,7 +55,7 @@ var tryTimeout = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"cloudstorage.azure.try.timeout",
 	"the timeout for individual retry attempts in Azure operations",
-	60*time.Second)
+	0)
 
 var reuseSession = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -176,6 +176,9 @@ func TestAzureFaultInjection(t *testing.T) {
 	conf, err := cloud.ExternalStorageConfFromURI(uri, username.RootUserName())
 	require.NoError(t, err)
 
+	settings := cluster.MakeTestingClusterSettings()
+	tryTimeout.Override(context.Background(), &settings.SV, time.Minute)
+
 	args := cloud.EarlyBootExternalStorageContext{
 		IOConf:          base.ExternalIODirConfig{},
 		Settings:        cluster.MakeTestingClusterSettings(),

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -181,7 +181,6 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 				"kv.snapshot_rebalance.max_rate":                    "256 MiB",
 				"server.debug.default_vmodule":                      "s3_storage=2",
 				"cloudstorage.s3.client_retry_token_bucket.enabled": "false",
-				"cloudstorage.azure.try.timeout":                    "0s",
 			},
 		))
 }


### PR DESCRIPTION
This setting was previously set to 1m to deflake the TestAzureFaultInjection unit test, but unfortunately this also led to production backup flakes in the azure backup roachtest. Instead of reenabling this setting, we should to teach the resuming reader to time out hanging reads (reference issue #159098)

Epic: none

Release note: none