### PR TITLE
sql: prevent rare fatal with parallel checks

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1036,6 +1036,11 @@ type PlanningCtx struct {
 	// based on other "regular" factors).
 	flowConcurrency distsql.ConcurrencyKind
 
+	// parallelCheckMainGoroutine, if set, indicates that this plan is part of
+	// parallel checks and is run on the main goroutine (i.e. the one that
+	// executed the main plan of the query).
+	parallelCheckMainGoroutine bool
+
 	// onFlowCleanup contains non-nil functions that will be called after the
 	// local flow finished running and is being cleaned up. It allows us to
 	// release the resources that are acquired during the physical planning and


### PR DESCRIPTION
We just saw a test failure where a node crashed because of `fatal error: concurrent map writes`. This happened during the flow setup of parallel checks and is traced back to using the same `descs.Collection` across multiple goroutines that might modify it concurrently. This patch ensures that only the "main" goroutine of parallel checks is using the planner's collection while forcing all other goroutines to create a separate one. I was unable to reproduce this problem in a unit test, but I still decided to include the test changes.

Given that we've only seen it once in a test setup, I chose to not include the release note.

Fixes: #158239.
Release note: None