### PR TITLE
release-25.4: sql: more routine dependency fixes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4256,6 +4256,327 @@ statement ok
 DELETE FROM xy WHERE true;
 
 # ==============================================================================
+# Test information_schema.triggers and pg_catalog.pg_trigger
+# ==============================================================================
+
+subtest trigger_introspection
+
+# Create test tables and trigger functions.
+statement ok
+CREATE TABLE test_triggers (
+    id INT PRIMARY KEY,
+    name TEXT,
+    value INT
+);
+
+statement ok
+CREATE TABLE audit_log (
+    id SERIAL PRIMARY KEY,
+    table_name TEXT,
+    operation TEXT,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+statement ok
+CREATE FUNCTION trigger_func1() RETURNS TRIGGER AS $$
+  BEGIN
+    INSERT INTO audit_log (table_name, operation)
+    VALUES (TG_TABLE_NAME, TG_OP);
+    RETURN NEW;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE FUNCTION trigger_func2() RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE 'Trigger fired';
+    RETURN NEW;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE TRIGGER after_insert_row
+AFTER INSERT ON test_triggers
+FOR EACH ROW
+EXECUTE FUNCTION trigger_func1();
+
+statement ok
+CREATE TRIGGER before_update_row
+BEFORE UPDATE ON test_triggers
+FOR EACH ROW
+WHEN ((NEW).value > 100)
+EXECUTE FUNCTION trigger_func2();
+
+statement ok
+CREATE TRIGGER after_delete_row
+AFTER DELETE ON test_triggers
+FOR EACH ROW
+EXECUTE FUNCTION trigger_func1();
+
+query TTTTTTITTTTT colnames
+SELECT
+    trigger_catalog,
+    trigger_schema,
+    trigger_name,
+    event_manipulation,
+    event_object_schema,
+    event_object_table,
+    action_order,
+    action_orientation,
+    action_timing,
+    action_reference_old_table,
+    action_reference_new_table,
+    created
+FROM information_schema.triggers
+WHERE event_object_table = 'test_triggers'
+ORDER BY trigger_name;
+----
+trigger_catalog  trigger_schema  trigger_name       event_manipulation  event_object_schema  event_object_table  action_order  action_orientation  action_timing  action_reference_old_table  action_reference_new_table  created
+test             public          after_delete_row   DELETE              public               test_triggers       NULL          ROW                 AFTER          NULL                        NULL                        NULL
+test             public          after_insert_row   INSERT              public               test_triggers       NULL          ROW                 AFTER          NULL                        NULL                        NULL
+test             public          before_update_row  UPDATE              public               test_triggers       NULL          ROW                 BEFORE         NULL                        NULL                        NULL
+
+# Test trigger with WHEN condition.
+query TTT colnames
+SELECT
+    trigger_name,
+    action_condition,
+    action_statement
+FROM information_schema.triggers
+WHERE trigger_name = 'before_update_row';
+----
+trigger_name       action_condition     action_statement
+before_update_row  ((new).value > 100)  EXECUTE FUNCTION trigger_func2()
+
+# Create trigger with transition tables.
+statement ok
+CREATE FUNCTION trigger_func3() RETURNS TRIGGER AS $$
+  BEGIN
+    RETURN NULL;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+# TODO(#126362, #135655): Enable tests for statement-level triggers when supported.
+statement error statement-level triggers are not yet supported
+CREATE TRIGGER after_update_transition
+AFTER UPDATE ON test_triggers
+REFERENCING OLD TABLE AS old_data NEW TABLE AS new_data
+FOR EACH STATEMENT
+EXECUTE FUNCTION trigger_func3();
+
+# TODO(#126362, #135655): Enable tests for statement-level triggers when supported.
+# The expected results are:
+# trigger_name             action_orientation  action_reference_old_table  action_reference_new_table  action_reference_old_row
+# after_update_transition  STATEMENT           old_data                    new_data                    NULL
+query TTTTT colnames
+SELECT
+    trigger_name,
+    action_orientation,
+    action_reference_old_table,
+    action_reference_new_table,
+    action_reference_old_row
+FROM information_schema.triggers
+WHERE trigger_name = 'after_update_transition';
+----
+trigger_name  action_orientation  action_reference_old_table  action_reference_new_table  action_reference_old_row
+
+# TODO(#126362, #135655): Populate tgoldtable and tgnewtable.
+# The expected results are:
+# tgname                   tgoldtable  tgnewtable
+# after_update_transition  old_data    new_data
+query TTT colnames
+SELECT tgname, tgoldtable, tgnewtable
+FROM pg_catalog.pg_trigger
+WHERE tgname = 'after_update_transition';
+----
+tgname  tgoldtable  tgnewtable
+
+# Test multiple event types (create a trigger for multiple events).
+statement ok
+CREATE TRIGGER multi_event_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON test_triggers
+FOR EACH ROW
+EXECUTE FUNCTION trigger_func1();
+
+# Each event should appear as a separate row.
+query TTT colnames
+SELECT
+    trigger_name,
+    event_manipulation,
+    action_timing
+FROM information_schema.triggers
+WHERE trigger_name = 'multi_event_trigger'
+ORDER BY event_manipulation;
+----
+trigger_name         event_manipulation  action_timing
+multi_event_trigger  DELETE              BEFORE
+multi_event_trigger  INSERT              BEFORE
+multi_event_trigger  UPDATE              BEFORE
+
+# Create a schema and add a trigger there.
+statement ok
+CREATE SCHEMA other_schema;
+
+statement ok
+CREATE TABLE other_schema.test_table (id INT PRIMARY KEY, data TEXT);
+
+statement ok
+CREATE TRIGGER other_schema_trigger
+AFTER INSERT ON other_schema.test_table
+FOR EACH ROW
+EXECUTE FUNCTION trigger_func1();
+
+query TI colnames
+SELECT
+    trigger_schema,
+    count(*) AS trigger_count
+FROM information_schema.triggers
+WHERE trigger_catalog = 'test'
+GROUP BY trigger_schema
+ORDER BY trigger_schema;
+----
+trigger_schema  trigger_count
+other_schema    1
+public          6
+
+# Create a trigger with arguments to test tgnargs and tgargs.
+statement ok
+CREATE TRIGGER trigger_with_args
+AFTER INSERT ON test_triggers
+FOR EACH ROW
+EXECUTE FUNCTION trigger_func1('arg1', 'arg2', 'test value with spaces');
+
+# Test pg_catalog.pg_trigger.
+query TIBITTT colnames
+SELECT
+    tgname,
+    tgtype,
+    tgfoid > 0 AS has_func_oid,
+    tgnargs,
+    tgenabled,
+    tgoldtable,
+    tgnewtable
+FROM pg_catalog.pg_trigger
+WHERE tgrelid = 'test_triggers'::regclass
+ORDER BY tgname;
+----
+tgname              tgtype  has_func_oid  tgnargs  tgenabled  tgoldtable  tgnewtable
+after_delete_row    9       true          0        A          NULL        NULL
+after_insert_row    5       true          0        A          NULL        NULL
+before_update_row   19      true          0        A          NULL        NULL
+multi_event_trigger 31      true          0        A          NULL        NULL
+trigger_with_args   5       true          3        A          NULL        NULL
+
+# Test INSTEAD OF triggers (not yet implemented)
+statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
+CREATE TRIGGER instead_of_trigger INSTEAD OF INSERT ON test_triggers
+FOR EACH ROW EXECUTE FUNCTION trigger_func1();
+
+statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
+CREATE TRIGGER instead_of_update_trigger INSTEAD OF UPDATE ON test_triggers
+FOR EACH ROW EXECUTE FUNCTION trigger_func1();
+
+statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
+CREATE TRIGGER instead_of_delete_trigger INSTEAD OF DELETE ON test_triggers
+FOR EACH ROW EXECUTE FUNCTION trigger_func1();
+
+# Test TRUNCATE triggers (not yet implemented)
+statement error statement-level triggers are not yet supported
+CREATE TRIGGER truncate_trigger AFTER TRUNCATE ON test_triggers
+FOR EACH STATEMENT EXECUTE FUNCTION trigger_func1();
+
+statement error statement-level triggers are not yet supported
+CREATE TRIGGER before_truncate_trigger BEFORE TRUNCATE ON test_triggers
+FOR EACH STATEMENT EXECUTE FUNCTION trigger_func1();
+
+# Test tgtype bitmap calculation
+# Bit 0: FOR EACH ROW (1) or FOR EACH STATEMENT (0)
+# Bit 1: BEFORE (2) or AFTER (0)
+# Bits 2-4: INSERT (4), DELETE (8), UPDATE (16)
+# TODO(#126363, #135657): Add tests for INSTEAD OF and TRUNCATE triggers here when supported.
+query TBBBBBBB colnames
+SELECT
+    tgname,
+    (tgtype::INT & 1) > 0 AS is_row_level,
+    (tgtype::INT & 2) > 0 AS is_before,
+    (tgtype::INT & 4) > 0 AS has_insert,
+    (tgtype::INT & 8) > 0 AS has_delete,
+    (tgtype::INT & 16) > 0 AS has_update,
+    (tgtype::INT & 32) > 0 AS has_instead,
+    (tgtype::INT & 64) > 0 AS has_truncate
+FROM pg_catalog.pg_trigger
+WHERE tgrelid = 'test_triggers'::regclass
+ORDER BY tgname;
+----
+tgname               is_row_level  is_before  has_insert  has_delete  has_update  has_instead  has_truncate
+after_delete_row     true          false      false       true        false       false        false
+after_insert_row     true          false      true        false       false       false        false
+before_update_row    true          true       false       false       true        false        false
+multi_event_trigger  true          true       true        true        true        false        false
+trigger_with_args    true          false      true        false       false       false        false
+
+# Check trigger arguments and column attributes.
+# TODO(#135656): Populate the tgattr column.
+query TITT colnames
+SELECT
+    tgname,
+    tgnargs,
+    encode(tgargs, 'escape') AS tgargs,
+    tgattr
+FROM pg_catalog.pg_trigger
+WHERE tgrelid = 'test_triggers'::regclass
+ORDER BY tgname;
+----
+tgname               tgnargs  tgargs                                      tgattr
+after_delete_row     0        ·                                           ·
+after_insert_row     0        ·                                           ·
+before_update_row    0        ·                                           ·
+multi_event_trigger  0        ·                                           ·
+trigger_with_args    3        arg1\000arg2\000test value with spaces\000  ·
+
+# Test trigger with WHEN condition.
+query TTT colnames
+SELECT
+    tgname,
+    tgqual,
+    tgattr
+FROM pg_catalog.pg_trigger
+WHERE tgrelid = 'test_triggers'::regclass AND tgqual IS NOT NULL;
+----
+tgname             tgqual               tgattr
+before_update_row  ((new).value > 100)  ·
+
+# Test cross-schema trigger.
+query TTT colnames
+SELECT
+    tgname,
+    tgrelid::regclass::text AS table_name,
+    tgfoid::regproc::text AS trigger_func_name
+FROM pg_catalog.pg_trigger
+WHERE tgrelid = 'other_schema.test_table'::regclass;
+----
+tgname                table_name  trigger_func_name
+other_schema_trigger  test_table  trigger_func1
+
+# Clean up
+statement ok
+DROP TABLE test_triggers CASCADE;
+
+statement ok
+DROP TABLE other_schema.test_table CASCADE;
+
+statement ok
+DROP SCHEMA other_schema;
+
+statement ok
+DROP TABLE audit_log CASCADE;
+
+statement ok
+DROP FUNCTION trigger_func1, trigger_func2, trigger_func3;
+
+subtest end
+
+# ==============================================================================
 # Regression tests.
 # ==============================================================================
 
@@ -4322,10 +4643,7 @@ SELECT id, a, b FROM tab_141810 ORDER BY id
 3  1     2
 4  NULL  NULL
 
-# ==============================================================================
-# Test case sensitivity of column names in triggers
-# ==============================================================================
-
+# Test case sensitivity of column names in triggers.
 subtest case_sensitivity
 
 # Setup: clean up any existing tables and functions
@@ -4766,328 +5084,6 @@ DROP SCHEMA sc1 CASCADE;
 
 subtest end
 
-# ==============================================================================
-# Test information_schema.triggers and pg_catalog.pg_trigger
-# ==============================================================================
-
-subtest trigger_introspection
-
-# Create test tables and trigger functions.
-statement ok
-CREATE TABLE test_triggers (
-    id INT PRIMARY KEY,
-    name TEXT,
-    value INT
-);
-
-statement ok
-CREATE TABLE audit_log (
-    id SERIAL PRIMARY KEY,
-    table_name TEXT,
-    operation TEXT,
-    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-statement ok
-CREATE FUNCTION trigger_func1() RETURNS TRIGGER AS $$
-  BEGIN
-    INSERT INTO audit_log (table_name, operation)
-    VALUES (TG_TABLE_NAME, TG_OP);
-    RETURN NEW;
-  END;
-$$ LANGUAGE PLpgSQL;
-
-statement ok
-CREATE FUNCTION trigger_func2() RETURNS TRIGGER AS $$
-  BEGIN
-    RAISE NOTICE 'Trigger fired';
-    RETURN NEW;
-  END;
-$$ LANGUAGE PLpgSQL;
-
-statement ok
-CREATE TRIGGER after_insert_row
-AFTER INSERT ON test_triggers
-FOR EACH ROW
-EXECUTE FUNCTION trigger_func1();
-
-statement ok
-CREATE TRIGGER before_update_row
-BEFORE UPDATE ON test_triggers
-FOR EACH ROW
-WHEN ((NEW).value > 100)
-EXECUTE FUNCTION trigger_func2();
-
-statement ok
-CREATE TRIGGER after_delete_row
-AFTER DELETE ON test_triggers
-FOR EACH ROW
-EXECUTE FUNCTION trigger_func1();
-
-query TTTTTTITTTTT colnames
-SELECT 
-    trigger_catalog,
-    trigger_schema,
-    trigger_name,
-    event_manipulation,
-    event_object_schema,
-    event_object_table,
-    action_order,
-    action_orientation,
-    action_timing,
-    action_reference_old_table,
-    action_reference_new_table,
-    created
-FROM information_schema.triggers
-WHERE event_object_table = 'test_triggers'
-ORDER BY trigger_name;
-----
-trigger_catalog  trigger_schema  trigger_name       event_manipulation  event_object_schema  event_object_table  action_order  action_orientation  action_timing  action_reference_old_table  action_reference_new_table  created
-test             public          after_delete_row   DELETE              public               test_triggers       NULL          ROW                 AFTER          NULL                        NULL                        NULL
-test             public          after_insert_row   INSERT              public               test_triggers       NULL          ROW                 AFTER          NULL                        NULL                        NULL
-test             public          before_update_row  UPDATE              public               test_triggers       NULL          ROW                 BEFORE         NULL                        NULL                        NULL
-
-# Test trigger with WHEN condition.
-query TTT colnames
-SELECT 
-    trigger_name,
-    action_condition,
-    action_statement
-FROM information_schema.triggers
-WHERE trigger_name = 'before_update_row';
-----
-trigger_name       action_condition     action_statement
-before_update_row  ((new).value > 100)  EXECUTE FUNCTION trigger_func2()
-
-# Create trigger with transition tables.
-statement ok
-CREATE FUNCTION trigger_func3() RETURNS TRIGGER AS $$
-  BEGIN
-    RETURN NULL;
-  END;
-$$ LANGUAGE PLpgSQL;
-
-# TODO(#126362, #135655): Enable tests for statement-level triggers when supported.
-statement error statement-level triggers are not yet supported
-CREATE TRIGGER after_update_transition
-AFTER UPDATE ON test_triggers
-REFERENCING OLD TABLE AS old_data NEW TABLE AS new_data
-FOR EACH STATEMENT
-EXECUTE FUNCTION trigger_func3();
-
-# TODO(#126362, #135655): Enable tests for statement-level triggers when supported.
-# The expected results are:
-# trigger_name             action_orientation  action_reference_old_table  action_reference_new_table  action_reference_old_row
-# after_update_transition  STATEMENT           old_data                    new_data                    NULL
-query TTTTT colnames
-SELECT
-    trigger_name,
-    action_orientation,
-    action_reference_old_table,
-    action_reference_new_table,
-    action_reference_old_row
-FROM information_schema.triggers
-WHERE trigger_name = 'after_update_transition';
-----
-trigger_name  action_orientation  action_reference_old_table  action_reference_new_table  action_reference_old_row
-
-# TODO(#126362, #135655): Populate tgoldtable and tgnewtable.
-# The expected results are:
-# tgname                   tgoldtable  tgnewtable
-# after_update_transition  old_data    new_data
-query TTT colnames
-SELECT tgname, tgoldtable, tgnewtable
-FROM pg_catalog.pg_trigger
-WHERE tgname = 'after_update_transition';
-----
-tgname  tgoldtable  tgnewtable
-
-# Test multiple event types (create a trigger for multiple events).
-statement ok
-CREATE TRIGGER multi_event_trigger
-BEFORE INSERT OR UPDATE OR DELETE ON test_triggers
-FOR EACH ROW
-EXECUTE FUNCTION trigger_func1();
-
-# Each event should appear as a separate row.
-query TTT colnames
-SELECT 
-    trigger_name,
-    event_manipulation,
-    action_timing
-FROM information_schema.triggers
-WHERE trigger_name = 'multi_event_trigger'
-ORDER BY event_manipulation;
-----
-trigger_name         event_manipulation  action_timing
-multi_event_trigger  DELETE              BEFORE
-multi_event_trigger  INSERT              BEFORE
-multi_event_trigger  UPDATE              BEFORE
-
-# Create a schema and add a trigger there.
-statement ok
-CREATE SCHEMA other_schema;
-
-statement ok
-CREATE TABLE other_schema.test_table (id INT PRIMARY KEY, data TEXT);
-
-statement ok
-CREATE TRIGGER other_schema_trigger
-AFTER INSERT ON other_schema.test_table
-FOR EACH ROW
-EXECUTE FUNCTION trigger_func1();
-
-query TI colnames
-SELECT 
-    trigger_schema,
-    count(*) AS trigger_count
-FROM information_schema.triggers
-WHERE trigger_catalog = 'test'
-GROUP BY trigger_schema
-ORDER BY trigger_schema;
-----
-trigger_schema  trigger_count
-other_schema    1
-public          7
-
-# Create a trigger with arguments to test tgnargs and tgargs.
-statement ok
-CREATE TRIGGER trigger_with_args
-AFTER INSERT ON test_triggers
-FOR EACH ROW
-EXECUTE FUNCTION trigger_func1('arg1', 'arg2', 'test value with spaces');
-
-# Test pg_catalog.pg_trigger.
-query TIBITTT colnames
-SELECT 
-    tgname,
-    tgtype,
-    tgfoid > 0 AS has_func_oid,
-    tgnargs,
-    tgenabled,
-    tgoldtable,
-    tgnewtable
-FROM pg_catalog.pg_trigger
-WHERE tgrelid = 'test_triggers'::regclass
-ORDER BY tgname;
-----
-tgname              tgtype  has_func_oid  tgnargs  tgenabled  tgoldtable  tgnewtable
-after_delete_row    9       true          0        A          NULL        NULL
-after_insert_row    5       true          0        A          NULL        NULL
-before_update_row   19      true          0        A          NULL        NULL
-multi_event_trigger 31      true          0        A          NULL        NULL
-trigger_with_args   5       true          3        A          NULL        NULL
-
-# Test INSTEAD OF triggers (not yet implemented)
-statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
-CREATE TRIGGER instead_of_trigger INSTEAD OF INSERT ON test_triggers
-FOR EACH ROW EXECUTE FUNCTION trigger_func1();
-
-statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
-CREATE TRIGGER instead_of_update_trigger INSTEAD OF UPDATE ON test_triggers
-FOR EACH ROW EXECUTE FUNCTION trigger_func1();
-
-statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
-CREATE TRIGGER instead_of_delete_trigger INSTEAD OF DELETE ON test_triggers
-FOR EACH ROW EXECUTE FUNCTION trigger_func1();
-
-# Test TRUNCATE triggers (not yet implemented)
-statement error statement-level triggers are not yet supported
-CREATE TRIGGER truncate_trigger AFTER TRUNCATE ON test_triggers
-FOR EACH STATEMENT EXECUTE FUNCTION trigger_func1();
-
-statement error statement-level triggers are not yet supported
-CREATE TRIGGER before_truncate_trigger BEFORE TRUNCATE ON test_triggers
-FOR EACH STATEMENT EXECUTE FUNCTION trigger_func1();
-
-# Test tgtype bitmap calculation
-# Bit 0: FOR EACH ROW (1) or FOR EACH STATEMENT (0)
-# Bit 1: BEFORE (2) or AFTER (0)
-# Bits 2-4: INSERT (4), DELETE (8), UPDATE (16)
-# TODO(#126363, #135657): Add tests for INSTEAD OF and TRUNCATE triggers here when supported.
-query TBBBBBBB colnames
-SELECT 
-    tgname,
-    (tgtype::INT & 1) > 0 AS is_row_level,
-    (tgtype::INT & 2) > 0 AS is_before,
-    (tgtype::INT & 4) > 0 AS has_insert,
-    (tgtype::INT & 8) > 0 AS has_delete,
-    (tgtype::INT & 16) > 0 AS has_update,
-    (tgtype::INT & 32) > 0 AS has_instead,
-    (tgtype::INT & 64) > 0 AS has_truncate
-FROM pg_catalog.pg_trigger
-WHERE tgrelid = 'test_triggers'::regclass
-ORDER BY tgname;
-----
-tgname               is_row_level  is_before  has_insert  has_delete  has_update  has_instead  has_truncate
-after_delete_row     true          false      false       true        false       false        false
-after_insert_row     true          false      true        false       false       false        false
-before_update_row    true          true       false       false       true        false        false
-multi_event_trigger  true          true       true        true        true        false        false
-trigger_with_args    true          false      true        false       false       false        false
-
-# Check trigger arguments and column attributes.
-# TODO(#135656): Populate the tgattr column.
-query TITT colnames
-SELECT 
-    tgname,
-    tgnargs,
-    encode(tgargs, 'escape') AS tgargs,
-    tgattr
-FROM pg_catalog.pg_trigger
-WHERE tgrelid = 'test_triggers'::regclass
-ORDER BY tgname;
-----
-tgname               tgnargs  tgargs                                      tgattr
-after_delete_row     0        ·                                           ·
-after_insert_row     0        ·                                           ·
-before_update_row    0        ·                                           ·
-multi_event_trigger  0        ·                                           ·
-trigger_with_args    3        arg1\000arg2\000test value with spaces\000  ·
-
-# Test trigger with WHEN condition.
-query TTT colnames
-SELECT 
-    tgname,
-    tgqual,
-    tgattr
-FROM pg_catalog.pg_trigger
-WHERE tgrelid = 'test_triggers'::regclass AND tgqual IS NOT NULL;
-----
-tgname             tgqual               tgattr
-before_update_row  ((new).value > 100)  ·
-
-# Test cross-schema trigger.
-query TTT colnames
-SELECT 
-    tgname,
-    tgrelid::regclass::text AS table_name,
-    tgfoid::regproc::text AS trigger_func_name
-FROM pg_catalog.pg_trigger
-WHERE tgrelid = 'other_schema.test_table'::regclass;
-----
-tgname                table_name  trigger_func_name
-other_schema_trigger  test_table  trigger_func1
-
-# Clean up
-statement ok
-DROP TABLE test_triggers CASCADE;
-
-statement ok
-DROP TABLE other_schema.test_table CASCADE;
-
-statement ok
-DROP SCHEMA other_schema;
-
-statement ok
-DROP TABLE audit_log CASCADE;
-
-statement ok
-DROP FUNCTION trigger_func1, trigger_func2, trigger_func3;
-
-subtest end
-
-
 # Previously, we had a bug where we did not properly look at references
 # in a trigger when cleaning up back references on sequences. See
 # issue #148103
@@ -5123,3 +5119,7 @@ statement ok
 DROP TRIGGER tr1 ON sc_tr_tbl;
 
 subtest end
+
+# ==============================================================================
+# End of regression tests. Add new features above the regression test section.
+# ==============================================================================

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -5120,6 +5120,67 @@ DROP TRIGGER tr1 ON sc_tr_tbl;
 
 subtest end
 
+# Regression test for unnecessary column dependencies added to a routine with a
+# mutation that involves a trigger.
+subtest regression_158154
+
+statement ok
+SET use_improved_routine_deps_triggers_and_computed_cols = true;
+
+statement ok
+CREATE TABLE xy_158154 (x INT, y INT);
+
+statement ok
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    SELECT x, y FROM xy_158154;
+    RAISE NOTICE '%: old: %, new: %', TG_OP, OLD, NEW;
+    RETURN COALESCE(NEW, OLD);
+  END
+$$;
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT ON xy_158154 FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE PROCEDURE p(blah INT) LANGUAGE SQL AS $$
+  INSERT INTO xy_158154 (x) VALUES (blah);
+$$;
+
+statement ok
+CALL p(100)
+
+statement error pgcode 2BP01 pq: cannot drop column "y" because trigger "foo" on table "xy_158154" depends on it
+ALTER TABLE xy_158154 DROP COLUMN y;
+
+statement ok
+DROP TRIGGER foo ON xy_158154;
+DROP FUNCTION g();
+
+# The procedure should not prevent the column drop.
+statement ok
+ALTER TABLE xy_158154 DROP COLUMN y;
+
+statement ok
+CALL p(200)
+
+query I rowsort
+SELECT * FROM xy_158154;
+----
+100
+200
+
+statement ok
+DROP PROCEDURE p
+
+statement ok
+DROP TABLE xy_158154
+
+statement ok
+RESET use_improved_routine_deps_triggers_and_computed_cols;
+
+subtest end
+
 # ==============================================================================
 # End of regression tests. Add new features above the regression test section.
 # ==============================================================================

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4547,6 +4547,10 @@ func (m *sessionDataMutator) SetOptimizerUseMaxFrequencySelectivity(val bool) {
 	m.data.OptimizerUseMaxFrequencySelectivity = val
 }
 
+func (m *sessionDataMutator) SetPreventUpdateSetColumnDrop(val bool) {
+	m.data.PreventUpdateSetColumnDrop = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4551,6 +4551,10 @@ func (m *sessionDataMutator) SetPreventUpdateSetColumnDrop(val bool) {
 	m.data.PreventUpdateSetColumnDrop = val
 }
 
+func (m *sessionDataMutator) SetUseImprovedRoutineDepsTriggersAndComputedCols(val bool) {
+	m.data.UseImprovedRoutineDepsTriggersAndComputedCols = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4289,6 +4289,7 @@ unconstrained_non_covering_index_scan_enabled                    off
 unsafe_allow_triggers_modifying_cascades                         off
 use_cputs_on_non_unique_indexes                                  off
 use_improved_routine_dependency_tracking                         on
+use_improved_routine_deps_triggers_and_computed_cols             off
 use_pre_25_2_variadic_builtins                                   off
 use_proc_txn_control_extended_protocol_fix                       on
 use_soft_limit_for_distribute_scan                               on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4238,6 +4238,7 @@ plan_cache_mode                                                  auto
 plpgsql_use_strict_into                                          off
 prefer_lookup_joins_for_fks                                      off
 prepared_statements_cache_size                                   0 B
+prevent_update_set_column_drop                                   off
 propagate_admission_header_to_leaf_transactions                  on
 propagate_input_ordering                                         off
 recursion_depth_limit                                            1000

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3193,6 +3193,7 @@ unsafe_allow_triggers_modifying_cascades                         off            
 use_cputs_on_non_unique_indexes                                  off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                                   on                  NULL      NULL        NULL        string
 use_improved_routine_dependency_tracking                         on                  NULL      NULL        NULL        string
+use_improved_routine_deps_triggers_and_computed_cols             off                 NULL      NULL        NULL        string
 use_pre_25_2_variadic_builtins                                   off                 NULL      NULL        NULL        string
 use_proc_txn_control_extended_protocol_fix                       on                  NULL      NULL        NULL        string
 use_soft_limit_for_distribute_scan                               on                  NULL      NULL        NULL        string
@@ -3442,6 +3443,7 @@ unsafe_allow_triggers_modifying_cascades                         off            
 use_cputs_on_non_unique_indexes                                  off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                                   on                  NULL  user     NULL      on                  on
 use_improved_routine_dependency_tracking                         on                  NULL  user     NULL      on                  on
+use_improved_routine_deps_triggers_and_computed_cols             off                 NULL  user     NULL      off                 off
 use_pre_25_2_variadic_builtins                                   off                 NULL  user     NULL      off                 off
 use_proc_txn_control_extended_protocol_fix                       on                  NULL  user     NULL      on                  on
 use_soft_limit_for_distribute_scan                               on                  NULL  user     NULL      on                  on
@@ -3683,6 +3685,7 @@ unsafe_allow_triggers_modifying_cascades                         NULL    NULL   
 use_cputs_on_non_unique_indexes                                  NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                                   NULL    NULL     NULL     NULL        NULL
 use_improved_routine_dependency_tracking                         NULL    NULL     NULL     NULL        NULL
+use_improved_routine_deps_triggers_and_computed_cols             NULL    NULL     NULL     NULL        NULL
 use_pre_25_2_variadic_builtins                                   NULL    NULL     NULL     NULL        NULL
 use_proc_txn_control_extended_protocol_fix                       NULL    NULL     NULL     NULL        NULL
 use_soft_limit_for_distribute_scan                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3140,6 +3140,7 @@ plan_cache_mode                                                  auto           
 plpgsql_use_strict_into                                          off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                                      off                 NULL      NULL        NULL        string
 prepared_statements_cache_size                                   0 B                 NULL      NULL        NULL        string
+prevent_update_set_column_drop                                   off                 NULL      NULL        NULL        string
 propagate_admission_header_to_leaf_transactions                  on                  NULL      NULL        NULL        string
 propagate_input_ordering                                         off                 NULL      NULL        NULL        string
 recursion_depth_limit                                            1000                NULL      NULL        NULL        string
@@ -3388,6 +3389,7 @@ plan_cache_mode                                                  auto           
 plpgsql_use_strict_into                                          off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                                      off                 NULL  user     NULL      off                 off
 prepared_statements_cache_size                                   0 B                 B     user     NULL      0 B                 0 B
+prevent_update_set_column_drop                                   off                 NULL  user     NULL      off                 off
 propagate_admission_header_to_leaf_transactions                  on                  NULL  user     NULL      on                  on
 propagate_input_ordering                                         off                 NULL  user     NULL      off                 off
 recursion_depth_limit                                            1000                NULL  user     NULL      1000                1000
@@ -3627,6 +3629,7 @@ plan_cache_mode                                                  NULL    NULL   
 plpgsql_use_strict_into                                          NULL    NULL     NULL     NULL        NULL
 prefer_lookup_joins_for_fks                                      NULL    NULL     NULL     NULL        NULL
 prepared_statements_cache_size                                   NULL    NULL     NULL     NULL        NULL
+prevent_update_set_column_drop                                   NULL    NULL     NULL     NULL        NULL
 propagate_admission_header_to_leaf_transactions                  NULL    NULL     NULL     NULL        NULL
 propagate_input_ordering                                         NULL    NULL     NULL     NULL        NULL
 recursion_depth_limit                                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -257,6 +257,7 @@ unsafe_allow_triggers_modifying_cascades                         off
 use_cputs_on_non_unique_indexes                                  off
 use_declarative_schema_changer                                   on
 use_improved_routine_dependency_tracking                         on
+use_improved_routine_deps_triggers_and_computed_cols             off
 use_pre_25_2_variadic_builtins                                   off
 use_proc_txn_control_extended_protocol_fix                       on
 use_soft_limit_for_distribute_scan                               on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -204,6 +204,7 @@ plan_cache_mode                                                  auto
 plpgsql_use_strict_into                                          off
 prefer_lookup_joins_for_fks                                      off
 prepared_statements_cache_size                                   0 B
+prevent_update_set_column_drop                                   off
 propagate_admission_header_to_leaf_transactions                  on
 propagate_input_ordering                                         off
 recursion_depth_limit                                            1000

--- a/pkg/sql/logictest/testdata/logic_test/udf_insert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_insert
@@ -235,8 +235,19 @@ SELECT f_drop(5,100,101);
 ----
 (5,100,101)
 
-statement error pgcode 2BP01 cannot drop column \"c\" because function \"f_drop\" depends on it
+statement error pgcode 2BP01 pq: cannot drop column "c" because function "f_drop" depends on it
 ALTER TABLE t_alter DROP COLUMN c;
+
+statement ok
+DROP FUNCTION f_drop;
+
+# Columns that aren't explicitly referenced by a routine can be dropped.
+statement ok
+ALTER TABLE t_alter DROP COLUMN c;
+ALTER TABLE t_alter DROP COLUMN b;
+
+statement error pgcode 2BP01 pq: cannot drop column "a" because function "f_int" depends on it
+ALTER TABLE t_alter DROP COLUMN a;
 
 query T
 SELECT f_record(6);

--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -386,3 +386,29 @@ statement error pgcode 2BP01 pq: cannot drop column "a" because function "f_upda
 ALTER TABLE table_drop DROP COLUMN a;
 
 subtest end
+
+# Prevent drop of column used in SET clause within a routine.
+subtest regression_158898
+
+statement ok
+SET prevent_update_set_column_drop = true;
+
+statement ok
+CREATE TABLE t158898 (col1 INT8 NOT NULL);
+
+statement ok
+CREATE OR REPLACE PROCEDURE p158898() LANGUAGE PLpgSQL AS $proc$
+  BEGIN UPDATE t158898 SET col1 = 1; END;
+$proc$;
+
+statement error pgcode 2BP01 pq: cannot drop column "col1" because function "p158898" depends on it
+ALTER TABLE t158898 DROP COLUMN col1;
+
+statement ok
+DROP PROCEDURE p158898;
+DROP TABLE t158898;
+
+statement ok
+RESET prevent_update_set_column_drop;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -412,3 +412,46 @@ statement ok
 RESET prevent_update_set_column_drop;
 
 subtest end
+
+# Allow drop of columns referenced only in computed column expressions.
+subtest regression_158154
+
+statement ok
+SET use_improved_routine_deps_triggers_and_computed_cols = true;
+
+statement ok
+CREATE TABLE t158154 (col1 INT8 NOT NULL, col2 TIMESTAMP NOT NULL, computed TIMESTAMP NOT NULL AS (col2) STORED);
+INSERT INTO t158154 (col1, col2) VALUES (1, '2024-01-01');
+
+statement ok
+CREATE OR REPLACE PROCEDURE p158154() LANGUAGE PLpgSQL AS $proc$
+  BEGIN UPDATE t158154 SET col1 = col1 + 1; END;
+$proc$;
+
+statement ok
+CALL p158154()
+
+query ITT
+SELECT * FROM t158154
+----
+2  2024-01-01 00:00:00 +0000 +0000  2024-01-01 00:00:00 +0000 +0000
+
+statement ok
+ALTER TABLE t158154 DROP COLUMN computed, DROP COLUMN col2;
+
+statement ok
+CALL p158154()
+
+query I
+SELECT * FROM t158154
+----
+3
+
+statement ok
+DROP PROCEDURE p158154;
+DROP TABLE t158154;
+
+statement ok
+RESET use_improved_routine_deps_triggers_and_computed_cols;
+
+subtest end

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -215,6 +215,7 @@ type Memo struct {
 	clampInequalitySelectivity                 bool
 	useMaxFrequencySelectivity                 bool
 	preventUpdateSetColumnDrop                 bool
+	useImprovedRoutineDepsTriggersComputedCols bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -330,6 +331,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		clampInequalitySelectivity:                 evalCtx.SessionData().OptimizerClampInequalitySelectivity,
 		useMaxFrequencySelectivity:                 evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity,
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
+		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -509,6 +511,7 @@ func (m *Memo) IsStale(
 		m.clampInequalitySelectivity != evalCtx.SessionData().OptimizerClampInequalitySelectivity ||
 		m.useMaxFrequencySelectivity != evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity ||
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
+		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -214,6 +214,7 @@ type Memo struct {
 	clampLowHistogramSelectivity               bool
 	clampInequalitySelectivity                 bool
 	useMaxFrequencySelectivity                 bool
+	preventUpdateSetColumnDrop                 bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -328,6 +329,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		clampLowHistogramSelectivity:               evalCtx.SessionData().OptimizerClampLowHistogramSelectivity,
 		clampInequalitySelectivity:                 evalCtx.SessionData().OptimizerClampInequalitySelectivity,
 		useMaxFrequencySelectivity:                 evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity,
+		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -506,6 +508,7 @@ func (m *Memo) IsStale(
 		m.clampLowHistogramSelectivity != evalCtx.SessionData().OptimizerClampLowHistogramSelectivity ||
 		m.clampInequalitySelectivity != evalCtx.SessionData().OptimizerClampInequalitySelectivity ||
 		m.useMaxFrequencySelectivity != evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity ||
+		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -611,6 +611,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerClampInequalitySelectivity = false
 	notStale()
 
+	// Stale prevent_update_set_column_drop.
+	evalCtx.SessionData().PreventUpdateSetColumnDrop = true
+	stale()
+	evalCtx.SessionData().PreventUpdateSetColumnDrop = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -617,6 +617,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().PreventUpdateSetColumnDrop = false
 	notStale()
 
+	// Stale use_improved_routine_deps_triggers_and_computed_cols.
+	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = true
+	stale()
+	evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -607,6 +607,27 @@ func (b *Builder) DisableUnsafeInternalCheck() func() {
 	}
 }
 
+// DisableSchemaDepTracking is used to disable dependency tracking for views and
+// routines, so that users don't have to face unnecessary restrictions during
+// schema changes.
+//
+// For example, we must prevent dropping a column that is referenced in the
+// WHERE clause or SET clause of an UPDATE statement. However, adding or
+// dropping columns that are synthesized with default or computed values is
+// perfectly safe, because those columns are determined from the table schema
+// rather than being user specified. If such a column is dropped, its value will
+// simply not be synthesized in mutation statements going forward.
+func (b *Builder) DisableSchemaDepTracking() func() {
+	if !b.trackSchemaDeps {
+		return func() {}
+	}
+	originalTrackSchemaDeps := b.trackSchemaDeps
+	b.trackSchemaDeps = false
+	return func() {
+		b.trackSchemaDeps = originalTrackSchemaDeps
+	}
+}
+
 // optTrackingTypeResolver is a wrapper around a TypeReferenceResolver that
 // remembers all of the resolved types in the provided Metadata.
 type optTrackingTypeResolver struct {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -398,7 +398,10 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		mb.buildUpsert(returning)
 	}
 
-	if b.trackSchemaDeps {
+	mb.trackTargetColDeps()
+
+	// Legacy path for resolving insert target column dependencies.
+	if b.trackSchemaDeps && !b.evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols {
 		dep := opt.SchemaDep{DataSource: tab}
 		// Track dependencies on insert columns.
 		for i := range mb.insertColIDs {

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -93,6 +93,8 @@ type mutationBuilder struct {
 	// explicit values in the insert statement, if b.trackSchemaDeps is true.
 	// It does not include columns that were explicitly given the value of
 	// DEFAULT, e.g., INSERT INTO t VALUES (1, DEFAULT).
+	// TODO(drewk): Remove this once we make the improved dependency tracking
+	// unconditional and use_improved_routine_dependency_tracking becomes a no-op.
 	implicitInsertCols opt.ColSet
 
 	// fetchColIDs lists the input column IDs storing values which are fetched
@@ -827,6 +829,14 @@ func (mb *mutationBuilder) addSynthesizedDefaultCols(
 func (mb *mutationBuilder) addSynthesizedComputedCols(
 	colIDs opt.OptionalColList, targetColList *opt.ColList, targetColSet *opt.ColSet, restrict bool,
 ) {
+	if mb.b.evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols {
+		// Avoid adding unnecessary dependencies on columns that are referenced by
+		// computed column expressions. We only need to track columns that were
+		// explicitly specified by the user, e.g. those in SET, WHERE or RETURNING
+		// clause, or the target columns of an INSERT.
+		defer mb.b.DisableSchemaDepTracking()()
+	}
+
 	// We will construct a new Project operator that will contain the newly
 	// synthesized column(s).
 	pb := makeProjectionBuilder(mb.b, mb.outScope)
@@ -945,6 +955,13 @@ func (mb *mutationBuilder) maybeAddRegionColLookup(op opt.Operator) {
 			return
 		}
 	}
+	if mb.b.evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols {
+		// It is not necessary to add transitive dependencies on the objects
+		// resolved below, since the schema changer already ensures that they are
+		// not dropped if "infer_rbr_region_col_using_constraint" is set.
+		defer mb.b.DisableSchemaDepTracking()()
+	}
+
 	// Resolve the referenced table.
 	refTabDescID := int64(lookupFK.ReferencedTableID())
 	refTab := mb.b.resolveTableRef(&tree.TableRef{TableID: refTabDescID}, privilege.SELECT)

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -31,12 +31,7 @@ func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta, scan
 	// depending on a table with a partial index predicate using an UDT will
 	// result in a type dependency being added between the view/function and the
 	// UDT.
-	if b.trackSchemaDeps {
-		b.trackSchemaDeps = false
-		defer func() {
-			b.trackSchemaDeps = true
-		}()
-	}
+	defer b.DisableSchemaDepTracking()()
 	tab := tabMeta.Table
 	numIndexes := tab.DeletableIndexCount()
 

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -38,6 +38,11 @@ import (
 func (mb *mutationBuilder) buildRowLevelBeforeTriggers(
 	eventType tree.TriggerEventType, cascade bool,
 ) bool {
+	if mb.b.evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols {
+		// Avoid adding transitive dependencies that are already tracked in the
+		// trigger object.
+		defer mb.b.DisableSchemaDepTracking()()
+	}
 	var eventsToMatch tree.TriggerEventTypeSet
 	eventsToMatch.Add(eventType)
 	triggers := cat.GetRowLevelTriggers(mb.tab, tree.TriggerActionTimeBefore, eventsToMatch)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -124,6 +124,8 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	}
 	mb.buildUpdate(returningExpr, cat.PolicyScopeUpdate, &exprColRefs)
 
+	mb.trackTargetColDeps()
+
 	return mb.outScope
 }
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -756,6 +756,11 @@ message LocalOnlySessionData {
   // referenced only as target columns in an UPDATE statement within a routine
   // are correctly tracked, preventing a drop that breaks the routine.
   bool prevent_update_set_column_drop = 195;
+  // UseImprovedRoutineDepsTriggersAndComputedCols, when true, enables improved
+  // dependency tracking for routines that perform mutations involving BEFORE
+  // triggers or computed columns. The fix applies at routine creation time and
+  // prevents unnecessary column dependencies from being recorded.
+  bool use_improved_routine_deps_triggers_and_computed_cols = 196;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -752,6 +752,10 @@ message LocalOnlySessionData {
   // OptimizerUseMaxFrequencySelectivity, when true, indicates that the
   // optimizer should use max frequency for selectivity estimation.
   bool optimizer_use_max_frequency_selectivity = 191;
+  // PreventUpdateSetColumnDrop, when true, enables a fix to ensure that columns
+  // referenced only as target columns in an UPDATE statement within a routine
+  // are correctly tracked, preventing a drop that breaks the routine.
+  bool prevent_update_set_column_drop = 195;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4455,6 +4455,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`prevent_update_set_column_drop`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`prevent_update_set_column_drop`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("prevent_update_set_column_drop", s)
+			if err != nil {
+				return err
+			}
+			m.SetPreventUpdateSetColumnDrop(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().PreventUpdateSetColumnDrop), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4472,6 +4472,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`use_improved_routine_deps_triggers_and_computed_cols`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`use_improved_routine_deps_triggers_and_computed_cols`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("use_improved_routine_deps_triggers_and_computed_cols", s)
+			if err != nil {
+				return err
+			}
+			m.SetUseImprovedRoutineDepsTriggersAndComputedCols(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 3/4 commits from #158935.

/cc @cockroachdb/release

---

#### sql: track SET columns in routine dependencies

Previously, we did not track dependencies on target columns in the SET clause
of an UPDATE statement while creating a routine. This meant that it was
possible to break a routine by dropping such a column if it wasn't referenced
elsewhere in the routine. This commit fixes the bug by adding target columns
that are explicitly referenced by an UPDATE statement to the routine
dependencies. The new behavior is gated behind the session variable
`prevent_update_set_column_drop`.

Fixes #158898

Release note (bug fix): Fixed a bug that allowed a column to be dropped from
its table despite being referenced by a routine. The bug could happen when the
column was only referenced as a target column in the SET clause of an UPDATE
statement within the routine. This fix only applies to newly-created routines.
In versions prior to v26.1, the fix must be enabled by setting the session
variable `prevent_update_set_column_drop`.

#### sql/logictest: rearrange trigger logic test

This commit pulls out some re-arranging of the `triggers` logic test
to avoid a confusing diff in the following commmit.

Epic: None
Release note: None

#### sql: avoid unnecessary column dependencies in routines

Previously, there were several cases where routines would add unnecessary
column dependencies:
* Columns referenced by a computed column expression would be added to
  the list of columns referenced by the routine.
* BEFORE triggers would confuse the logic used to distinguish explicit
  from implicit INSERT columns, because triggers change the column IDs
  to be inserted. This could cause the routine to add implicitly referenced
  columns to its dependencies.
* Dependencies from statements within a trigger would transitively apply
  to a routine that invoked trigger on a mutation.

This commit prevents newly-created routines from adding unnecessary
column dependencies in those cases, gated behind the session setting
`use_improved_routine_deps_triggers_and_computed_cols`.

Fixes #158154

Release note (bug fix): Fixed a bug that caused routines to prevent
dropping more columns than necessary, most notably columns referenced
by computed column expressions. The fix is gated behind the session
setting `use_improved_routine_deps_triggers_and_computed_cols`, which
is off by default prior to v26.1.

---

Release justification: fix requested by customer, default off