### PR TITLE
roachtest: don't assert range tombstones are present

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -430,7 +430,7 @@ func (bo replicateBulkOps) runDriver(
 			}
 		}
 	}
-	runBackupMVCCRangeTombstones(workloadCtx, t, c, mvccRangeTombstoneConfig{
+	runBackupImportRollback(workloadCtx, t, c, importRollbackConfig{
 		skipBackupRestore: true,
 		skipClusterSetup:  true,
 		short:             bo.short,


### PR DESCRIPTION
Previously, we would run multiple import rollbacks and assert range tombstones are present. As of #137924 we no longer use range tombstones as part of an import rollback. They are now mostly used by schema changes which have their own test coverage.

Release note: none
Fixes: #159035
Fixes: #159036
Fixes: #159037