### PR TITLE
kvcoord: optimize txn write buffer for read-only txns

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -1162,6 +1162,15 @@ func (twb *txnWriteBuffer) mergeWithScanResp(
 			"with COL_BATCH_RESPONSE scan format")
 	}
 
+	if twb.buffer.Len() == 0 {
+		// If we haven't buffered any writes, then we can just return the server
+		// response unchanged.
+		// TODO(yuzefovich): we could take the optimization further by examining
+		// whether any buffered writes overlap with the Scan request and
+		// skipping the merge step if not.
+		return resp, nil
+	}
+
 	respIter := newScanRespIter(req, resp)
 	// First, calculate the size of the merged response. This then allows us to
 	// exactly pre-allocate the response slice when constructing the respMerger.
@@ -1184,6 +1193,15 @@ func (twb *txnWriteBuffer) mergeWithReverseScanResp(
 	if req.ScanFormat == kvpb.COL_BATCH_RESPONSE {
 		return nil, errors.AssertionFailedf("unexpectedly called mergeWithReverseScanResp on a " +
 			"ReverseScanRequest with COL_BATCH_RESPONSE scan format")
+	}
+
+	if twb.buffer.Len() == 0 {
+		// If we haven't buffered any writes, then we can just return the server
+		// response unchanged.
+		// TODO(yuzefovich): we could take the optimization further by examining
+		// whether any buffered writes overlap with the ReverseScan request and
+		// skipping the merge step if not.
+		return resp, nil
 	}
 
 	respIter := newReverseScanRespIter(req, resp)


### PR DESCRIPTION
In the txn write buffer we need to merge the ScanResponse coming from the server with any overlapping writes that we've buffered. This requires us to allocate `respMerger.batchResponses` which is the "staging" area of the merged response. However, if we don't have any overlapping buffered writes, then we simply copy the server response into that staging area. This commit adds an optimization to avoid this extra copy in a special but common case when the buffer is empty (i.e. we're in a read-only txn). We could extend the optimization further but that is left as a TODO.

Epic: None
Release note: None