### PR TITLE
release-25.2: roachtest: deflake asyncpg test

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
@@ -86,4 +86,5 @@ var asyncpgIgnoreList = blocklist{
 	`test_copy.TestCopyTo.test_copy_to_table_timeout`:                            "flaky; see #119291 and https://github.com/MagicStack/asyncpg/issues/240",
 	`test_execute.TestExecuteMany.test_executemany_server_failure_during_writes`: "flaky",
 	`test_listeners.TestListeners.test_dangling_listener_warns`:                  "flaky",
+	`test_timeout.TestTimeout.test_timeout_05`:                                   "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #159077 on behalf of @spilchen.

----

This deflakes the 'test_timeout.TestTimeout.test_timeout_05' test, which we have seen fail occasionally. Since it deals with timing, we are going to mark it as flaky.

Closes #159030
Epic: none
Release note: none

----

Release justification: test only change