### PR TITLE
release-25.4: tests: avoid use of loopback dialer in Benchmark{Parallel,}Sysbench

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/kv/kvserver/concurrency",
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/rpc/nodedialer",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
Backport 1/1 commits from #155057 on behalf of @tbg.

----

When follow-the-workload is disabled (#153865), leases no longer reliably stay on n1. Since the workload clients are always created on n1, they were able to use the loopback dialer (which avoids going through the TCP layer by using inter-progress communication instead) prior to that change.
We want these benchmarks to be independent of lease placement, so we disable the loopback dialer. That this was not done initially is likely an oversight.

This commit will cause a a benchmark regression, but it is due to changing what is being benchmarked. The regression does not result in any production change.

Informs https://github.com/cockroachdb/cockroach/issues/153866.

Epic: CRDB-55052
^-- because this is required for #153865.

----

Release justification: test-only change.