### PR TITLE
mma: cleanup and populate counter metrics

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -169,6 +169,38 @@ func (a *allocatorState) ProcessStoreLoadMsg(ctx context.Context, msg *StoreLoad
 func (a *allocatorState) AdjustPendingChangeDisposition(change ExternalRangeChange, success bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	metrics := a.ensureMetricsForLocalStoreLocked(change.localStoreID)
+	isLeaseTransfer := change.IsPureTransferLease()
+	switch change.origin {
+	case OriginExternal:
+		if isLeaseTransfer {
+			if success {
+				metrics.ExternalLeaseChangeSuccess.Inc(1)
+			} else {
+				metrics.ExternalLeaseChangeFailure.Inc(1)
+			}
+		} else {
+			if success {
+				metrics.ExternalReplicaChangeSuccess.Inc(1)
+			} else {
+				metrics.ExternalReplicaChangeFailure.Inc(1)
+			}
+		}
+	case originMMARebalance:
+		if isLeaseTransfer {
+			if success {
+				metrics.RebalanceLeaseChangeSuccess.Inc(1)
+			} else {
+				metrics.RebalanceLeaseChangeFailure.Inc(1)
+			}
+		} else {
+			if success {
+				metrics.RebalanceReplicaChangeSuccess.Inc(1)
+			} else {
+				metrics.RebalanceReplicaChangeFailure.Inc(1)
+			}
+		}
+	}
 	_, ok := a.cs.ranges[change.RangeID]
 	if !ok {
 		// Range no longer exists. This can happen if the StoreLeaseholderMsg
@@ -218,15 +250,15 @@ func (a *allocatorState) RegisterExternalChange(
 	defer a.mu.Unlock()
 	counterMetrics := a.ensureMetricsForLocalStoreLocked(localStoreID)
 	if err := a.cs.preCheckOnApplyReplicaChanges(change); err != nil {
-		counterMetrics.ExternalFailedToRegister.Inc(1)
+		counterMetrics.ExternalRegisterFailure.Inc(1)
 		log.KvDistribution.Infof(context.Background(),
 			"did not register external changes: due to %v", err)
 		return ExternalRangeChange{}, false
 	} else {
-		counterMetrics.ExternaRegisterSuccess.Inc(1)
+		counterMetrics.ExternalRegisterSuccess.Inc(1)
 	}
 	a.cs.addPendingRangeChange(change)
-	return MakeExternalRangeChange(change), true
+	return MakeExternalRangeChange(OriginExternal, localStoreID, change), true
 }
 
 // ComputeChanges implements the Allocator interface.

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -548,7 +548,8 @@ func (re *rebalanceEnv) rebalanceReplicas(
 				replicaChanges, rangeID))
 		}
 		re.addPendingRangeChange(rangeChange)
-		re.changes = append(re.changes, MakeExternalRangeChange(rangeChange))
+		re.changes = append(re.changes,
+			MakeExternalRangeChange(originMMARebalance, localStoreID, rangeChange))
 		re.rangeMoveCount++
 		log.KvDistribution.VEventf(ctx, 2,
 			"result(success): rebalancing r%v from s%v to s%v [change: %v] with resulting loads source: %v target: %v",
@@ -722,7 +723,8 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			panic(errors.Wrapf(err, "pre-check failed for lease transfer %v", leaseChange))
 		}
 		re.addPendingRangeChange(leaseChange)
-		re.changes = append(re.changes, MakeExternalRangeChange(leaseChange))
+		re.changes = append(re.changes,
+			MakeExternalRangeChange(originMMARebalance, store.StoreID, leaseChange))
 		log.KvDistribution.Infof(ctx,
 			"result(success): shedding r%v lease from s%v to s%v [change:%v] with "+
 				"resulting loads source:%v target:%v (means: %v) (frac_pending: (src:%.2f,target:%.2f) (src:%.2f,target:%.2f))",

--- a/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/range_change.go
@@ -20,6 +20,9 @@ import (
 // It is a partial external representation of a set of changes that are
 // internally modeled using a slice of *pendingReplicaChanges.
 type ExternalRangeChange struct {
+	origin       ChangeOrigin
+	localStoreID roachpb.StoreID
+
 	roachpb.RangeID
 	Changes []ExternalReplicaChange
 }
@@ -48,7 +51,9 @@ type ExternalReplicaChange struct {
 	ChangeType ReplicaChangeType
 }
 
-func MakeExternalRangeChange(change PendingRangeChange) ExternalRangeChange {
+func MakeExternalRangeChange(
+	origin ChangeOrigin, localStoreID roachpb.StoreID, change PendingRangeChange,
+) ExternalRangeChange {
 	changes := make([]ExternalReplicaChange, len(change.pendingReplicaChanges))
 	for i, rc := range change.pendingReplicaChanges {
 		changeType := rc.replicaChangeType()
@@ -64,8 +69,10 @@ func MakeExternalRangeChange(change PendingRangeChange) ExternalRangeChange {
 		}
 	}
 	return ExternalRangeChange{
-		RangeID: change.RangeID,
-		Changes: changes,
+		origin:       origin,
+		localStoreID: localStoreID,
+		RangeID:      change.RangeID,
+		Changes:      changes,
 	}
 }
 

--- a/pkg/kv/kvserver/mmaintegration/mma_conversion_test.go
+++ b/pkg/kv/kvserver/mmaintegration/mma_conversion_test.go
@@ -114,7 +114,8 @@ func TestConvertReplicaChangeToMMA(t *testing.T) {
 					mmaChanges.SortForTesting()
 					var b strings.Builder
 					fmt.Fprintf(&b, "PendingRangeChange: %s", mmaChanges.StringForTesting())
-					externalChange := mmaprototype.MakeExternalRangeChange(mmaChanges)
+					externalChange := mmaprototype.MakeExternalRangeChange(
+						mmaprototype.OriginExternal, 1 /* arbitrary local store */, mmaChanges)
 					if externalChange.IsChangeReplicas() {
 						fmt.Fprintf(&b, "As kvpb.ReplicationChanges:\n %v\n", externalChange.ReplicationChanges())
 					} else if externalChange.IsPureTransferLease() {

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -52,6 +52,8 @@ const (
 	LabelName            = "name"
 	LabelType            = "type"
 	LabelLevel           = "level"
+	LabelOrigin          = "origin"
+	LabelResult          = "result"
 )
 
 type LabelConfig uint64


### PR DESCRIPTION
These metrics use static labels representing origin={external,rebalance},
type={replica,lease}, result={success,failure}.

Epic: [CRDB-55052](https://cockroachlabs.atlassian.net/browse/CRDB-55052)

Release note: None