### PR TITLE
drtprod: 300 node scale workload parameters

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale_300.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_300.yaml
@@ -183,6 +183,5 @@ targets:
           workers: 266666
           conns: 100
           active-workers: 100
-          duration: 12h
           ramp: 1h
           wait: 0

--- a/pkg/cmd/drtprod/configs/drt_scale_300.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_300.yaml
@@ -181,8 +181,8 @@ targets:
           warehouses:  $WAREHOUSES
           active-warehouses: 266666
           workers: 266666
-          conns: 1000
-          active-workers: 1000
+          conns: 100
+          active-workers: 100
           duration: 12h
           ramp: 1h
           wait: 0


### PR DESCRIPTION
Small updates to the workload parameters.
- With 1000 connections and active workers the cluster became overloaded. Change to 100.
- We don't need to pass duration as the script already sets it to 0 (which is what we want).

Epic: None
Release note: None