### PR TITLE
release-25.3: roachtest: deflake activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -43,6 +43,7 @@ var activeRecordIgnoreList = blocklist{
 	`CockroachDB::AdapterForeignKeyTest#test_foreign_key_violations_on_insert_are_translated_to_specific_exception`:                                            "flaky",
 	`CockroachDB::FixturesTest#test_create_fixtures`:                                                                                                           "flaky",
 	`CockroachDB::FixturesTest#test_create_symbol_fixtures`:                                                                                                    "flaky",
+	`DumpSchemasTest#test_schema_dump_with_dump_schemas_all`:                                                                                                   "flaky",
 	`FixtureWithSetModelClassPrevailsOverNamingConventionTest#test_model_class_in_fixture_file_is_respected`:                                                   "flaky",
 	`HasManyAssociationsTest#test_collection_association_with_private_kernel_method`:                                                                           "flaky",
 	`HasManyAssociationsTest#test_delete_all_association_with_primary_key_deletes_correct_records`:                                                             "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #159074.

/cc @cockroachdb/release

---

The 'DumpSchemasTest#test_schema_dump_with_dump_schemas_all' fails consistently ever since we recently updated the activerecord adapter. Adding this test as a known flake to get the testsuite clean.

Closes #158942
Epic: none
Release note: none

Release justification: test only fix