### PR TITLE
workflow: retire macos-13 (amd64) from bincheck CI

### DIFF
--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -15,12 +15,6 @@ jobs:
     - uses: actions/checkout@v3
     - run: cd build/release/bincheck && ./test-linux ${{ github.ref_name }} ${{ github.sha }}
 
-  darwin-amd64:
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v3
-    - run: cd build/release/bincheck && ./test-macos-amd64 ${{ github.ref_name }} ${{ github.sha }}
-
   darwin-arm64:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.

Epic: none Release note: none