### PR TITLE
roachprod/vm: fix JSON serialization of VM.Errors field

### DIFF
--- a/pkg/cmd/roachprod/cli/BUILD.bazel
+++ b/pkg/cmd/roachprod/cli/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/roachprodutil",
         "//pkg/roachprod/ssh",
-        "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/envutil",

--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/roachprodutil"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -547,15 +546,15 @@ hosts file.
 				if listDetails {
 					collated := filteredCloud.BadInstanceErrors()
 
-					// Sort by Error() value for stable output
-					var errors ui.ErrorsByError
-					for err := range collated {
-						errors = append(errors, err)
+					// Sort by error message for stable output
+					var errMsgs []string
+					for msg := range collated {
+						errMsgs = append(errMsgs, msg)
 					}
-					sort.Sort(errors)
+					sort.Strings(errMsgs)
 
-					for _, e := range errors {
-						fmt.Printf("%s: %s\n", e, collated[e].Names())
+					for _, msg := range errMsgs {
+						fmt.Printf("%s: %s\n", msg, collated[msg].Names())
 					}
 				}
 			}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1141,20 +1141,20 @@ func (in *DescribeInstancesOutputInstance) toVM(
 	// Convert the tag map into a more useful representation
 	tagMap := in.Tags.MakeMap()
 
-	var errs []error
+	var errs []vm.VMError
 	createdAt, err := time.Parse(time.RFC3339, in.LaunchTime)
 	if err != nil {
-		errs = append(errs, vm.ErrNoExpiration)
+		errs = append(errs, vm.NewVMError(vm.ErrNoExpiration))
 	}
 
 	var lifetime time.Duration
 	if lifeText, ok := tagMap[vm.TagLifetime]; ok {
 		lifetime, err = time.ParseDuration(lifeText)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, vm.NewVMError(err))
 		}
 	} else {
-		errs = append(errs, vm.ErrNoExpiration)
+		errs = append(errs, vm.NewVMError(vm.ErrNoExpiration))
 	}
 
 	var nonBootableVolumes []vm.Volume
@@ -1165,11 +1165,11 @@ func (in *DescribeInstancesOutputInstance) toVM(
 				if vol, ok := volumes[bdm.Disk.VolumeID]; ok {
 					nonBootableVolumes = append(nonBootableVolumes, vol)
 				} else {
-					errs = append(errs, errors.Newf(
+					errs = append(errs, vm.NewVMError(errors.Newf(
 						"Attempted to add volume %s however it is not in the attached volumes for instance %s",
 						bdm.Disk.VolumeID,
 						in.InstanceID,
-					))
+					)))
 				}
 			}
 		}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -604,19 +604,19 @@ func (p *Provider) computeVirtualMachineToVM(cvm compute.VirtualMachine) (*vm.VM
 	}
 
 	if createdPtr := cvm.Tags[vm.TagCreated]; createdPtr == nil {
-		m.Errors = append(m.Errors, vm.ErrNoExpiration)
+		m.Errors = append(m.Errors, vm.NewVMError(vm.ErrNoExpiration))
 	} else if parsed, err := time.Parse(time.RFC3339, *createdPtr); err == nil {
 		m.CreatedAt = parsed
 	} else {
-		m.Errors = append(m.Errors, vm.ErrNoExpiration)
+		m.Errors = append(m.Errors, vm.NewVMError(vm.ErrNoExpiration))
 	}
 
 	if lifetimePtr := cvm.Tags[vm.TagLifetime]; lifetimePtr == nil {
-		m.Errors = append(m.Errors, vm.ErrNoExpiration)
+		m.Errors = append(m.Errors, vm.NewVMError(vm.ErrNoExpiration))
 	} else if parsed, err := time.ParseDuration(*lifetimePtr); err == nil {
 		m.Lifetime = parsed
 	} else {
-		m.Errors = append(m.Errors, vm.ErrNoExpiration)
+		m.Errors = append(m.Errors, vm.NewVMError(vm.ErrNoExpiration))
 	}
 
 	// The network info needs a separate request.
@@ -625,7 +625,7 @@ func (p *Provider) computeVirtualMachineToVM(cvm compute.VirtualMachine) (*vm.VM
 		return nil, err
 	}
 	if err := p.fillNetworkDetails(context.Background(), m, nicID); errors.Is(err, vm.ErrBadNetwork) {
-		m.Errors = append(m.Errors, err)
+		m.Errors = append(m.Errors, vm.NewVMError(err))
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/vm/ibm/ibm_extended_types.go
+++ b/pkg/roachprod/vm/ibm/ibm_extended_types.go
@@ -548,7 +548,7 @@ func (i *instance) toVM() vm.VM {
 
 	if i == nil || i.instance == nil {
 		return vm.VM{
-			Errors: []error{errors.New("instance is nil")},
+			Errors: []vm.VMError{vm.NewVMError(errors.New("instance is nil"))},
 		}
 	}
 
@@ -556,37 +556,37 @@ func (i *instance) toVM() vm.VM {
 		err := i.load()
 		if err != nil {
 			return vm.VM{
-				Errors: []error{errors.Wrap(err, "failed to load instance")},
+				Errors: []vm.VMError{vm.NewVMError(errors.Wrap(err, "failed to load instance"))},
 			}
 		}
 	}
 
-	var vmErrors []error
+	var vmErrors []vm.VMError
 
 	vpcID := ""
 	region, err := i.provider.zoneToRegion(*i.instance.Zone.Name)
 	if err != nil {
-		vmErrors = append(vmErrors, errors.Wrap(err, "unable to get region"))
+		vmErrors = append(vmErrors, vm.NewVMError(errors.Wrap(err, "unable to get region")))
 	} else {
 		vpcID = i.provider.config.regions[region].vpcID
 	}
 
 	// Check if the instance is in a valid state.
 	if core.StringNilMapper(i.instance.Status) == "failed" {
-		vmErrors = append(vmErrors, errors.New("instance is in failed state"))
+		vmErrors = append(vmErrors, vm.NewVMError(errors.New("instance is in failed state")))
 	}
 
 	// Gather tags
 	tags, err := i.getTagsAsMap()
 	if err != nil {
-		vmErrors = append(vmErrors, errors.Wrap(err, "unable to get tags"))
+		vmErrors = append(vmErrors, vm.NewVMError(errors.Wrap(err, "unable to get tags")))
 	}
 
 	var lifetime time.Duration
 	if lifeText, ok := tags[vm.TagLifetime]; ok {
 		lifetime, err = time.ParseDuration(lifeText)
 		if err != nil {
-			vmErrors = append(vmErrors, errors.Wrap(err, "unable to compute lifetime"))
+			vmErrors = append(vmErrors, vm.NewVMError(errors.Wrap(err, "unable to compute lifetime")))
 		}
 	} else {
 		// Missing lifetime tag, use the default lifetime.
@@ -598,7 +598,7 @@ func (i *instance) toVM() vm.VM {
 	privateIP := i.getPrivateIPAddress()
 	publicIP, err := i.getPublicIPAddress()
 	if err != nil {
-		vmErrors = append(vmErrors, errors.Wrap(err, "unable to get public IP"))
+		vmErrors = append(vmErrors, vm.NewVMError(errors.Wrap(err, "unable to get public IP")))
 	}
 
 	nonBootAttachedVolumes := []vm.Volume{}


### PR DESCRIPTION
The VM.Errors field was typed as []error, but Go's encoding/json cannot
unmarshal into an error interface type because it doesn't know what
concrete type to create. This caused roachprod list to fail when loading
cached cluster info containing VMs with errors:

  json: cannot unmarshal object into Go struct field
  VM.vms.errors of type error

This change introduces a VMError wrapper type that:
- Implements the error interface
- Implements json.Marshaler to serialize as a JSON string (error message)
- Implements json.Unmarshaler to handle both the new format (strings) and
  legacy format (empty objects from broken serialization)
- Implements Unwrap() so errors.Is/As still work

All cloud providers (AWS, Azure, GCE, IBM) are updated to use the new
VMError type via NewVMError(). The BadInstanceErrors() function now
returns map[string]vm.List (grouped by error message string) instead of
map[error]vm.List since serialization loses pointer identity.

Release note: None
Epic: None

Co-authored-by: Claude <noreply@anthropic.com>
