### PR TITLE
sql/importer: add format-specific file reader creation

### DIFF
--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -145,6 +145,67 @@ func runImport(
 	}
 }
 
+// makeFileReader creates a fileReader for the given format, applying
+// decompression for formats that need it (CSV, Avro, etc.) or providing
+// seekable access for formats that require it (Parquet).
+func makeFileReader(
+	ctx context.Context,
+	format roachpb.IOFileFormat,
+	raw ioctx.ReadCloserCtx,
+	dataFile string,
+	dataFileSize int64,
+	storage cloud.ExternalStorage,
+) (*fileReader, io.Closer, error) {
+	var readCloser io.ReadCloser
+	var randomReader ioctx.ReaderAtSeekerCloser
+	var counter *byteCounter
+
+	switch format.Format {
+	case roachpb.IOFileFormat_Parquet:
+		// Parquet needs seekable, uncompressed access
+		// (compression is handled internally by Parquet)
+		if storage == nil {
+			// This shouldn't really happen, makeExternalStorage would have returned an error.
+			return nil, nil, errors.AssertionFailedf("storage must be non-nil for Parquet format")
+		}
+		// This works with any cloud storage that supports offset reads.
+		openAt := func(ctx context.Context, offset int64, endHint int64) (ioctx.ReadCloserCtx, error) {
+			opts := cloud.ReadOptions{
+				Offset: offset,
+			}
+			// Set LengthHint if endHint is provided and valid.
+			if endHint > offset {
+				opts.LengthHint = endHint - offset
+			}
+			r, _, err := storage.ReadFile(ctx, "", opts)
+			return r, err
+		}
+		randomReader = ioctx.NewRandomAccessReader(ctx, dataFileSize, openAt)
+		readCloser = randomReader
+		// counter = nil, since it is not very useful for random access files;
+		// we track progress on the rows read within a parquet file.
+	default:
+		// Default sequential access.
+		source := ioctx.ReaderCtxAdapter(ctx, raw)
+		counter = &byteCounter{r: source}
+		// Apply decompression wrapper
+		decompressed, err := decompressingReader(counter, dataFile, format.Compression)
+		if err != nil {
+			return nil, nil, err
+		}
+		readCloser = decompressed
+		// randomReader = nil, it is not used for sequential access.
+	}
+
+	return &fileReader{
+		Reader:   readCloser,
+		ReaderAt: randomReader, // nil for sequential access.
+		Seeker:   randomReader, // nil for sequential access.
+		counter:  counter,      // nil for parquet.
+		total:    dataFileSize,
+	}, readCloser, nil
+}
+
 // readInputFiles reads each of the passed dataFiles using the passed func. The
 // key part of dataFiles is the unique index of the data file among all files in
 // the IMPORT. progressFn, if not nil, is periodically invoked with a percentage
@@ -236,19 +297,18 @@ func readInputFiles(
 				return err
 			}
 			defer es.Close()
+
 			raw, _, err := es.ReadFile(ctx, "", cloud.ReadOptions{NoFileSize: true})
 			if err != nil {
 				return err
 			}
 			defer raw.Close(ctx)
-
-			src := &fileReader{total: fileSizes[dataFileIndex], counter: byteCounter{r: ioctx.ReaderCtxAdapter(ctx, raw)}}
-			decompressed, err := decompressingReader(&src.counter, dataFile, format.Compression)
+			// Create fileReader with format-specific handling
+			src, closer, err := makeFileReader(ctx, format, raw, dataFile, fileSizes[dataFileIndex], es)
 			if err != nil {
 				return err
 			}
-			defer decompressed.Close()
-			src.Reader = decompressed
+			defer closer.Close()
 
 			var rejected chan string
 			if (format.Format == roachpb.IOFileFormat_CSV && format.SaveRejected) ||
@@ -373,14 +433,28 @@ func (b *byteCounter) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// fileReader wraps cloud storage readers to provide io.Reader, io.ReaderAt, and io.Seeker
+// interfaces along with progress tracking.
+//
+// Thread Safety:
+// The fileReader provides different thread safety guarantees for different methods:
+//   - ReadAt: Safe for concurrent calls. Multiple goroutines can call ReadAt simultaneously.
+//     This may be used by formats like Parquet that read different file sections in parallel.
+//   - Read/Seek: NOT safe for concurrent calls. Should only be used from a single goroutine.
+//
+// Usage patterns:
+// - Sequential formats (CSV, Avro, etc.): Single goroutine uses Read/Seek
+// - Random-access formats (Parquet): Multiple goroutines could call ReadAt; Seek only during initialization
 type fileReader struct {
 	io.Reader
+	io.ReaderAt
+	io.Seeker
 	total   int64
-	counter byteCounter
+	counter *byteCounter
 }
 
 func (f fileReader) ReadFraction() float32 {
-	if f.total == 0 {
+	if f.total == 0 || f.counter == nil {
 		return 0.0
 	}
 	return float32(f.counter.n) / float32(f.total)
@@ -396,6 +470,8 @@ type inputConverter interface {
 func formatHasNamedColumns(format roachpb.IOFileFormat_FileFormat) bool {
 	switch format {
 	case roachpb.IOFileFormat_Avro:
+		return true
+	case roachpb.IOFileFormat_Parquet:
 		return true
 	}
 	return false

--- a/pkg/sql/importer/read_import_base_test.go
+++ b/pkg/sql/importer/read_import_base_test.go
@@ -7,16 +7,23 @@ package importer
 
 import (
 	"context"
+	"io"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -194,4 +201,249 @@ func TestParallelImportProducerHandlesCancellation(t *testing.T) {
 					&importFileContext{}, &nilDataProducer{}, &nilDataConsumer{}))
 			return nil
 		}))
+}
+
+// mockSeekableReader is a mock that implements ReadCloserCtx, ReaderAtCtx, and SeekerCtx
+// for testing makeFileReader with Parquet format
+type mockSeekableReader struct {
+	data   []byte
+	pos    int64
+	closed bool
+}
+
+func newMockSeekableReader(data string) *mockSeekableReader {
+	return &mockSeekableReader{
+		data: []byte(data),
+	}
+}
+
+func (m *mockSeekableReader) Read(ctx context.Context, p []byte) (int, error) {
+	if m.pos >= int64(len(m.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[m.pos:])
+	m.pos += int64(n)
+	return n, nil
+}
+
+func (m *mockSeekableReader) Close(ctx context.Context) error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockSeekableReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	if off >= int64(len(m.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (m *mockSeekableReader) Seek(ctx context.Context, offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = m.pos + offset
+	case io.SeekEnd:
+		newPos = int64(len(m.data)) + offset
+	default:
+		return 0, errors.Newf("invalid whence: %d", whence)
+	}
+
+	if newPos < 0 {
+		return 0, errors.New("negative position")
+	}
+
+	m.pos = newPos
+	return newPos, nil
+}
+
+// mockNonSeekableReader implements ReadCloserCtx but NOT SeekerCtx
+type mockNonSeekableReader struct {
+	data   []byte
+	pos    int64
+	closed bool
+}
+
+func newMockNonSeekableReader(data string) *mockNonSeekableReader {
+	return &mockNonSeekableReader{
+		data: []byte(data),
+	}
+}
+
+func (m *mockNonSeekableReader) Read(ctx context.Context, p []byte) (int, error) {
+	if m.pos >= int64(len(m.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[m.pos:])
+	m.pos += int64(n)
+	return n, nil
+}
+
+func (m *mockNonSeekableReader) Close(ctx context.Context) error {
+	m.closed = true
+	return nil
+}
+
+// mockExternalStorage is a minimal mock implementation of cloud.ExternalStorage
+// for testing file reader creation.
+type mockExternalStorage struct {
+	data []byte
+}
+
+func newMockExternalStorage(data string) *mockExternalStorage {
+	return &mockExternalStorage{
+		data: []byte(data),
+	}
+}
+
+func (m *mockExternalStorage) ReadFile(
+	ctx context.Context, basename string, opts cloud.ReadOptions,
+) (ioctx.ReadCloserCtx, int64, error) {
+	// Create a reader starting at the specified offset
+	start := opts.Offset
+	if start >= int64(len(m.data)) {
+		return nil, 0, io.EOF
+	}
+
+	// If LengthHint is set, limit the data to that length
+	end := int64(len(m.data))
+	if opts.LengthHint > 0 && start+opts.LengthHint < end {
+		end = start + opts.LengthHint
+	}
+
+	return newMockSeekableReader(string(m.data[start:end])), int64(len(m.data)), nil
+}
+
+func (m *mockExternalStorage) Close() error                  { return nil }
+func (m *mockExternalStorage) Conf() cloudpb.ExternalStorage { return cloudpb.ExternalStorage{} }
+func (m *mockExternalStorage) ExternalIOConf() base.ExternalIODirConfig {
+	return base.ExternalIODirConfig{}
+}
+func (m *mockExternalStorage) RequiresExternalIOAccounting() bool { return false }
+func (m *mockExternalStorage) Settings() *cluster.Settings        { return nil }
+func (m *mockExternalStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	return nil, errors.New("not implemented")
+}
+func (m *mockExternalStorage) List(
+	ctx context.Context, prefix, delimiter string, fn cloud.ListingFn,
+) error {
+	return errors.New("not implemented")
+}
+func (m *mockExternalStorage) Delete(ctx context.Context, basename string) error {
+	return errors.New("not implemented")
+}
+func (m *mockExternalStorage) Size(ctx context.Context, basename string) (int64, error) {
+	return int64(len(m.data)), nil
+}
+
+func TestMakeFileReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	testData := "test data for file reader"
+
+	t.Run("parquet-with-seekable-reader", func(t *testing.T) {
+		mockStorage := newMockExternalStorage(testData)
+		mockReader := newMockSeekableReader(testData)
+		format := roachpb.IOFileFormat{
+			Format: roachpb.IOFileFormat_Parquet,
+		}
+
+		reader, closer, err := makeFileReader(ctx, format, mockReader, "test.parquet", int64(len(testData)), mockStorage)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NotNil(t, closer)
+
+		// Verify fileReader has all required interfaces
+		require.NotNil(t, reader.Reader)
+		require.NotNil(t, reader.ReaderAt)
+		require.NotNil(t, reader.Seeker)
+		require.Equal(t, int64(len(testData)), reader.total)
+
+		// Clean up
+		err = closer.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("parquet-with-non-seekable-reader", func(t *testing.T) {
+		// Even with non-seekable readers from storage, Parquet should work
+		// because we wrap them with RandomAccessReader
+		mockStorage := newMockExternalStorage(testData)
+		mockReader := newMockNonSeekableReader(testData)
+		format := roachpb.IOFileFormat{
+			Format: roachpb.IOFileFormat_Parquet,
+		}
+
+		reader, closer, err := makeFileReader(ctx, format, mockReader, "test.parquet", int64(len(testData)), mockStorage)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NotNil(t, closer)
+
+		// Verify fileReader has all required interfaces (wrapper provides them)
+		require.NotNil(t, reader.Reader)
+		require.NotNil(t, reader.ReaderAt)
+		require.NotNil(t, reader.Seeker)
+		require.Equal(t, int64(len(testData)), reader.total)
+
+		// Clean up
+		err = closer.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("csv-format", func(t *testing.T) {
+		// CSV doesn't need seeking, so use a non-seekable reader factory
+		mockStorage := newMockExternalStorage(testData)
+		mockReader := newMockNonSeekableReader(testData)
+		format := roachpb.IOFileFormat{
+			Format:      roachpb.IOFileFormat_CSV,
+			Compression: roachpb.IOFileFormat_None,
+		}
+
+		reader, closer, err := makeFileReader(ctx, format, mockReader, "test.csv", int64(len(testData)), mockStorage)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NotNil(t, closer)
+
+		// Verify fileReader for CSV
+		require.NotNil(t, reader.Reader)
+		require.Nil(t, reader.ReaderAt) // CSV doesn't need ReaderAt
+		require.Nil(t, reader.Seeker)   // CSV doesn't need Seeker
+		require.Equal(t, int64(len(testData)), reader.total)
+
+		// Clean up
+		err = closer.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("avro-format", func(t *testing.T) {
+		// Avro doesn't need seeking, so use a non-seekable reader factory
+		mockStorage := newMockExternalStorage(testData)
+		mockReader := newMockNonSeekableReader(testData)
+		format := roachpb.IOFileFormat{
+			Format:      roachpb.IOFileFormat_Avro,
+			Compression: roachpb.IOFileFormat_None,
+		}
+
+		reader, closer, err := makeFileReader(ctx, format, mockReader, "test.avro", int64(len(testData)), mockStorage)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NotNil(t, closer)
+
+		// Verify fileReader for Avro
+		require.NotNil(t, reader.Reader)
+		require.Nil(t, reader.ReaderAt)
+		require.Nil(t, reader.Seeker)
+		require.Equal(t, int64(len(testData)), reader.total)
+
+		// Clean up
+		err = closer.Close()
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
This commit refactors file reading in the import infrastructure to support different file format requirements. Specifically, it adds support for formats that require random access (like Parquet) while maintaining existing support for sequential formats (CSV, Avro, etc.).

Changes:
- Added makeFileReader() to create format-specific file readers
- Updated fileReader struct to include io.ReaderAt and io.Seeker interfaces
- Parquet format gets seekable, uncompressed access (compression is handled internally by Parquet library)
- Other formats continue to use decompression wrappers
- Added thread safety documentation for concurrent vs sequential access
- Added formatHasNamedColumns() support for Parquet
- Comprehensive tests for makeFileReader with different formats

The fileReader now provides:
- io.Reader for sequential reading (CSV, Avro, etc.)
- io.ReaderAt for random access (Parquet)
- io.Seeker for repositioning (Parquet)
- Progress tracking via ReadFraction()

Thread safety:
- ReadAt is safe for concurrent calls (used by Parquet for parallel column reading)
- Read/Seek are not safe for concurrent calls (used by sequential formats)

This infrastructure enables efficient Parquet import without buffering entire files to disk, leveraging cloud storage range request capabilities.

Release note: none

Epic: CRDB-23802