### PR TITLE
backup: populate session data for schema change jobs

### DIFF
--- a/pkg/backup/restore_schema_change_creation.go
+++ b/pkg/backup/restore_schema_change_creation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	descpb "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -195,6 +196,9 @@ func createSchemaChangeJobsFromMutations(
 				spanList[i] = jobspb.ResumeSpanList{ResumeSpans: []roachpb.Span{tableDesc.PrimaryIndexSpan(codec)}}
 			}
 		}
+		// Populate session data for schema changes that require it.
+		sd := sql.NewInternalSessionData(ctx, jr.ClusterSettings(), "schema-change-restore")
+		sd.UserProto = username.EncodeProto()
 		jobRecord := jobs.Record{
 			// We indicate that this schema change was triggered by a RESTORE since
 			// the job description may not have all the information to fully describe
@@ -206,6 +210,7 @@ func createSchemaChangeJobsFromMutations(
 				DescID:          tableDesc.ID,
 				TableMutationID: mutationID,
 				ResumeSpanList:  spanList,
+				SessionData:     &sd.SessionData,
 				// The version distinction for database jobs doesn't matter for a schema
 				// change on a single table.
 				FormatVersion: jobspb.DatabaseJobFormatVersion,

--- a/pkg/backup/testdata/backup-restore/materialized_view
+++ b/pkg/backup/testdata/backup-restore/materialized_view
@@ -8,6 +8,7 @@ CREATE DATABASE testdb;
 USE testdb;
 CREATE TABLE testdb.t (a int primary key, b int);
 CREATE MATERIALIZED VIEW testdb.mv AS SELECT a, b FROM testdb.t;
+CREATE MATERIALIZED VIEW testdb.mv2 AS SELECT a, b FROM testdb.t;
 INSERT INTO testdb.t (a, b) VALUES (1, 2);
 ----
 
@@ -22,6 +23,18 @@ INSERT INTO testdb.t (a, b) VALUES (2, 3);
 exec-sql
 REFRESH MATERIALIZED VIEW mv;
 ----
+
+
+# Pause the schema change intentionally to refresh a view on mv2
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec'
+----
+
+
+exec-sql expect-error-regex=(pq: job \d+ was paused before it completed with reason: pause point "schemachanger.before.exec" hit)
+REFRESH MATERIALIZED VIEW mv2;
+----
+regex matches error
 
 exec-sql
 BACKUP INTO 'nodelocal://1/test/'


### PR DESCRIPTION
Previously, restore operations could end up generating schema jobs without session data. While most schema changes do not require this, schema changes with refresh materialized view require this field to be setup. To address this, this patch sets up a session data in the schema change job to prevent panics.

Fixes: #156515

Release note (bug fix): Addressed a bug where schema changes could fail after a RESTORE due to missing session data.