### PR TITLE
sql: ascii built-in should not error with an empty string

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/strings.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/strings.diffs
@@ -1488,19 +1488,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/strings.out --lab
  --
  -- Additional string functions
  --
-@@ -2456,11 +2101,7 @@
- (1 row)
- 
- SELECT ascii('');
-- ascii 
---------
--     0
--(1 row)
--
-+ERROR:  the input string must not be empty
- SELECT chr(65);
-  chr 
- -----
 @@ -2468,7 +2109,11 @@
  (1 row)
  

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -533,8 +533,10 @@ select ascii('禅')
 ----
 31109
 
-query error the input string must not be empty
+query I
 select ascii('')
+----
+0
 
 query T
 select chr(122)

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -11,5 +11,5 @@ INSERT INTO t111474_0 (c0) VALUES (1);
 # error. The error could still occur if the plan is distributed, so we only run
 # this in the local config.
 query II
-SELECT * FROM t111474_0, t111474_1 WHERE ascii('') > 0;
+SELECT * FROM t111474_0, t111474_1 WHERE chr(-1) > '';
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -109,7 +109,6 @@ import (
 )
 
 var (
-	errEmptyInputString = pgerror.New(pgcode.InvalidParameterValue, "the input string must not be empty")
 	errZeroIP           = pgerror.New(pgcode.InvalidParameterValue, "zero length IP")
 	errChrValueTooSmall = pgerror.New(pgcode.InvalidParameterValue, "input value must be >= 0")
 	errChrValueTooLarge = pgerror.Newf(pgcode.InvalidParameterValue,
@@ -1322,7 +1321,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				for _, ch := range s {
 					return tree.NewDInt(tree.DInt(ch)), nil
 				}
-				return nil, errEmptyInputString
+				return tree.NewDInt(0), nil
 			},
 			types.Int,
 			"Returns the character code of the first character in `val`. Despite the name, the function supports Unicode too.",


### PR DESCRIPTION
Fixes #159174

Release note (bug fix): The `ascii` built-in function now returns `0`
when the input is the empty string instead of an error.
