### PR TITLE
sql/schemachanger: clean up constraint comments on column drop

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -5040,6 +5040,129 @@ CREATE SEQUENCE public.t1_serial_columns_z_seq1 MINVALUE 1 MAXVALUE 922337203685
 statement ok
 RESET create_table_with_schema_locked
 
+# Regression for #158804: dropping constraints with comments should not leave
+# dangling constraint comments in system.comments table.
+subtest drop_constraint_removes_comments
+
+# Setup: Create parent table for foreign key constraints.
+statement ok
+CREATE TABLE t_parent (
+  id INT PRIMARY KEY
+);
+
+# Test table with various constraint types.
+statement ok
+CREATE TABLE t_constraints (
+  a INT,
+  b INT NOT NULL,
+  c INT UNIQUE,
+  d INT,
+  e INT,
+  CONSTRAINT pkey_a PRIMARY KEY (a),
+  CONSTRAINT check_b CHECK (b > 0),
+  CONSTRAINT unique_d UNIQUE WITHOUT INDEX (d),
+  CONSTRAINT fk_e FOREIGN KEY (e) REFERENCES t_parent(id),
+  FAMILY f1 (a, b, c, d, e)
+) WITH (schema_locked = false);
+
+# Add comments on all constraints.
+statement ok
+COMMENT ON CONSTRAINT pkey_a ON t_constraints IS 'primary key comment';
+
+statement ok
+COMMENT ON CONSTRAINT check_b ON t_constraints IS 'check constraint comment';
+
+statement ok
+COMMENT ON CONSTRAINT t_constraints_c_key ON t_constraints IS 'unique with index comment';
+
+statement ok
+COMMENT ON CONSTRAINT unique_d ON t_constraints IS 'unique without index comment';
+
+statement ok
+COMMENT ON CONSTRAINT fk_e ON t_constraints IS 'foreign key comment';
+
+# Verify all comments exist (5 constraint comments).
+query I
+SELECT count(*) FROM system.comments WHERE type = 5 AND object_id = (
+  SELECT table_id FROM crdb_internal.tables
+  WHERE name = 't_constraints' AND schema_name = 'public' AND database_name = current_database()
+);
+----
+5
+
+# Drop check constraint directly - should remove its comment.
+statement ok
+ALTER TABLE t_constraints DROP CONSTRAINT check_b;
+
+query I
+SELECT count(*) FROM system.comments WHERE type = 5 AND object_id = (
+  SELECT table_id FROM crdb_internal.tables
+  WHERE name = 't_constraints' AND schema_name = 'public' AND database_name = current_database()
+);
+----
+4
+
+# Drop foreign key constraint via column drop - should remove its comment.
+statement ok
+ALTER TABLE t_constraints DROP COLUMN e;
+
+query I
+SELECT count(*) FROM system.comments WHERE type = 5 AND object_id = (
+  SELECT table_id FROM crdb_internal.tables
+  WHERE name = 't_constraints' AND schema_name = 'public' AND database_name = current_database()
+);
+----
+3
+
+# Drop unique without index constraint via column drop - should remove its comment.
+statement ok
+ALTER TABLE t_constraints DROP COLUMN d;
+
+query I
+SELECT count(*) FROM system.comments WHERE type = 5 AND object_id = (
+  SELECT table_id FROM crdb_internal.tables
+  WHERE name = 't_constraints' AND schema_name = 'public' AND database_name = current_database()
+);
+----
+2
+
+# Drop unique constraint with index via column drop - should remove its comment.
+statement ok
+ALTER TABLE t_constraints DROP COLUMN c;
+
+query I
+SELECT count(*) FROM system.comments WHERE type = 5 AND object_id = (
+  SELECT table_id FROM crdb_internal.tables
+  WHERE name = 't_constraints' AND schema_name = 'public' AND database_name = current_database()
+);
+----
+1
+
+# Change primary key - should retain old primary key comment and move it to the new PK.
+statement ok
+ALTER TABLE t_constraints ALTER PRIMARY KEY USING COLUMNS (b);
+
+query I
+SELECT count(*) FROM system.comments WHERE type = 5 AND object_id = (
+  SELECT table_id FROM crdb_internal.tables
+  WHERE name = 't_constraints' AND schema_name = 'public' AND database_name = current_database()
+);
+----
+1
+
+query T
+SELECT obj_description(oid) FROM pg_constraint WHERE conrelid = 't_constraints'::regclass AND contype = 'p';
+----
+primary key comment
+
+statement ok
+DROP TABLE t_constraints;
+
+statement ok
+DROP TABLE t_parent;
+
+subtest end
+
 # Regression tests for issue #137326. Add column with IF NOT EXIST.
 subtest add_col_if_not_exists
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1558,6 +1558,19 @@ func WaitToUpdateLeases(
 	return desc, err
 }
 
+type commentToDelete struct {
+	id          int64
+	subID       int64
+	commentType catalogkeys.CommentType
+}
+
+type commentToSwap struct {
+	id          int64
+	oldSubID    int64
+	newSubID    int64
+	commentType catalogkeys.CommentType
+}
+
 // done finalizes the mutations (adds new cols/indexes to the table).
 // It ensures that all nodes are on the current (pre-update) version of
 // sc.descID and that all nodes are on the new (post-update) version of
@@ -1566,18 +1579,6 @@ func WaitToUpdateLeases(
 // It also kicks off GC jobs as needed.
 func (sc *SchemaChanger) done(ctx context.Context) error {
 	// Gathers ant comments that need to be swapped/cleaned.
-	type commentToDelete struct {
-		id          int64
-		subID       int64
-		commentType catalogkeys.CommentType
-	}
-	type commentToSwap struct {
-		id          int64
-		oldSubID    int64
-		newSubID    int64
-		commentType catalogkeys.CommentType
-	}
-	var commentsToDelete []commentToDelete
 	var commentsToSwap []commentToSwap
 	// Jobs (for GC, etc.) that need to be started immediately after the table
 	// descriptor updates are published.
@@ -1935,6 +1936,11 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 		// Trim the executed mutations from the descriptor.
 		scTable.Mutations = scTable.Mutations[i:]
 
+		commentsToDelete, err := sc.findCommentsToDelete(ctx, txn, scTable)
+		if err != nil {
+			return err
+		}
+
 		// Check any jobs that we need to depend on for the current
 		// job to be successful.
 		existingDepMutationJobs, err := sc.getDependentMutationsJobs(ctx, scTable, committedMutations)
@@ -2203,6 +2209,46 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// findCommentsToDelete will collect any constraint comments whose referenced
+// constraint no longer exists on the table. This is a catch-all for constraints
+// implicitly removed by other operations (e.g. column drops).
+func (sc *SchemaChanger) findCommentsToDelete(
+	ctx context.Context, txn descs.Txn, tbl catalog.TableDescriptor,
+) ([]commentToDelete, error) {
+	seen := make(map[commentToDelete]struct{})
+	constraintIDs := make(map[uint32]struct{})
+	for _, c := range tbl.AllConstraints() {
+		constraintIDs[uint32(c.GetConstraintID())] = struct{}{}
+	}
+	ckPrefix := catalogkeys.MakeObjectCommentsMetadataPrefix(
+		sc.execCfg.Codec, catalogkeys.ConstraintCommentType, tbl.GetID())
+	kvs, err := txn.KV().Scan(ctx, ckPrefix, ckPrefix.PrefixEnd(), 0 /* maxRows */)
+	if err != nil {
+		return nil, err
+	}
+	var comments []commentToDelete
+	for _, kv := range kvs {
+		_, key, err := catalogkeys.DecodeCommentMetadataID(sc.execCfg.Codec, kv.Key)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := constraintIDs[key.SubID]; ok {
+			continue
+		}
+		ctd := commentToDelete{
+			id:          int64(tbl.GetID()),
+			subID:       int64(key.SubID),
+			commentType: catalogkeys.ConstraintCommentType,
+		}
+		if _, dup := seen[ctd]; dup {
+			continue
+		}
+		comments = append(comments, ctd)
+		seen[ctd] = struct{}{}
+	}
+	return comments, nil
 }
 
 // maybeUpdateZoneConfigsForPKChange moves zone configs for any rewritten

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -244,6 +244,22 @@ func dropColumn(
 				"cannot drop column %q because trigger %q on table %q depends on it",
 				cn.Name, triggerName.Name, tableName.Name,
 			))
+		case *scpb.CheckConstraint:
+			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
+			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
+			alterTableDropConstraint(b, tn, tbl, stmt, &tree.AlterTableDropConstraint{
+				IfExists:     false,
+				Constraint:   tree.Name(constraintName.Name),
+				DropBehavior: behavior,
+			})
+		case *scpb.CheckConstraintUnvalidated:
+			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
+			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
+			alterTableDropConstraint(b, tn, tbl, stmt, &tree.AlterTableDropConstraint{
+				IfExists:     false,
+				Constraint:   tree.Name(constraintName.Name),
+				DropBehavior: behavior,
+			})
 		case *scpb.UniqueWithoutIndexConstraint:
 			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
 			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
@@ -260,6 +276,23 @@ func dropColumn(
 				Constraint:   tree.Name(constraintName.Name),
 				DropBehavior: behavior,
 			})
+		case *scpb.ForeignKeyConstraint:
+			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
+			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
+			alterTableDropConstraint(b, tn, tbl, stmt, &tree.AlterTableDropConstraint{
+				IfExists:     false,
+				Constraint:   tree.Name(constraintName.Name),
+				DropBehavior: behavior,
+			})
+		case *scpb.ForeignKeyConstraintUnvalidated:
+			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
+			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
+			alterTableDropConstraint(b, tn, tbl, stmt, &tree.AlterTableDropConstraint{
+				IfExists:     false,
+				Constraint:   tree.Name(constraintName.Name),
+				DropBehavior: behavior,
+			})
+
 		case *scpb.RowLevelTTL:
 			// If a duration expression is set, the column level dependency is on the
 			// internal ttl column, which we are attempting to drop.
@@ -308,6 +341,7 @@ func walkColumnDependencies(
 	var sequenceDeps catalog.DescriptorIDSet
 	var indexDeps catid.IndexSet
 	var columnDeps catalog.TableColSet
+	var constraintDeps catid.ConstraintSet
 	tblElts := b.QueryByID(col.TableID).Filter(orFilter(publicTargetFilter, transientTargetFilter))
 
 	// Panic if `col` is referenced in a predicate of an index or
@@ -368,6 +402,7 @@ func walkColumnDependencies(
 			}
 		})
 
+	// First loop: Process columns and indexes, collecting constraint IDs.
 	tblElts.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
 		switch elt := e.(type) {
 		case *scpb.Column:
@@ -376,14 +411,31 @@ func walkColumnDependencies(
 			}
 		case *scpb.PrimaryIndex:
 			if indexDeps.Contains(elt.IndexID) {
+				if elt.ConstraintID != 0 {
+					constraintDeps.Add(elt.ConstraintID)
+				}
 				fn(e, op, objType)
 			}
 		case *scpb.SecondaryIndex:
 			if indexDeps.Contains(elt.IndexID) {
+				if elt.ConstraintID != 0 {
+					constraintDeps.Add(elt.ConstraintID)
+				}
 				fn(e, op, objType)
 			}
 		}
 	})
+
+	// Second loop: Process constraint comments using the fully-populated constraintDeps.
+	if !constraintDeps.Empty() {
+		tblElts.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
+			if cc, ok := e.(*scpb.ConstraintComment); ok {
+				if constraintDeps.Contains(cc.ConstraintID) {
+					fn(e, op, objType)
+				}
+			}
+		})
+	}
 	sequenceDeps.ForEach(func(id descpb.ID) {
 		_, target, seq := scpb.FindSequence(b.QueryByID(id))
 		if target == scpb.ToPublic && seq != nil {

--- a/pkg/sql/schemachanger/scbuild/testdata/zone_cfg
+++ b/pkg/sql/schemachanger/scbuild/testdata/zone_cfg
@@ -89,6 +89,8 @@ ALTER TABLE defaultdb.foo_index_zone_cfg DROP COLUMN k
   {indexId: 3, tableId: 105}
 - [[CheckConstraint:{DescID: 105, IndexID: 0, ConstraintID: 4, ReferencedColumnIDs: [2]}, ABSENT], PUBLIC]
   {columnIds: [2], constraintId: 4, expr: 'k > 10:::INT8', referencedColumnIds: [2], tableId: 105}
+- [[ConstraintWithoutIndexName:{DescID: 105, Name: check_k, ConstraintID: 4}, ABSENT], PUBLIC]
+  {constraintId: 4, name: check_k, tableId: 105}
 - [[IndexZoneConfig:{DescID: 105, IndexID: 3, SeqNum: 0}, ABSENT], PUBLIC]
   {indexId: 3, oldIdxRef: -1, subzone: {config: {gc: {ttlSeconds: 10}, inheritedConstraints: true, inheritedLeasePreferences: true}, indexId: 3}, subzoneSpans: [{key: iw==}], tableId: 105}
 - [[TableData:{DescID: 105, ReferencedDescID: 100}, PUBLIC], PUBLIC]

--- a/pkg/sql/sem/catid/BUILD.bazel
+++ b/pkg/sql/sem/catid/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "catid",
     srcs = [
+        "constraint_id_set.go",
         "ids.go",
         "index_id_set.go",
     ],

--- a/pkg/sql/sem/catid/constraint_id_set.go
+++ b/pkg/sql/sem/catid/constraint_id_set.go
@@ -1,0 +1,84 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package catid
+
+import "github.com/cockroachdb/cockroach/pkg/util/intsets"
+
+// ConstraintSet efficiently stores an unordered set of constraint ids.
+type ConstraintSet struct {
+	set intsets.Fast
+}
+
+// MakeConstraintIDSet returns a set initialized with the given values.
+func MakeConstraintIDSet(vals ...ConstraintID) ConstraintSet {
+	var res ConstraintSet
+	for _, v := range vals {
+		res.Add(v)
+	}
+	return res
+}
+
+// Add adds a constraint to the set. No-op if the constraint is already in the set.
+func (s *ConstraintSet) Add(constraintID ConstraintID) { s.set.Add(int(constraintID)) }
+
+// Contains returns true if the set contains the constraint.
+func (s ConstraintSet) Contains(constraintID ConstraintID) bool {
+	return s.set.Contains(int(constraintID))
+}
+
+// Empty returns true if the set is empty.
+func (s ConstraintSet) Empty() bool { return s.set.Empty() }
+
+// Len returns the number of the constraints in the set.
+func (s ConstraintSet) Len() int { return s.set.Len() }
+
+// Next returns the first value in the set which is >= startVal. If there is no
+// value, the second return value is false.
+func (s ConstraintSet) Next(startVal ConstraintID) (ConstraintID, bool) {
+	c, ok := s.set.Next(int(startVal))
+	return ConstraintID(c), ok
+}
+
+// ForEach calls a function for each constraint in the set (in increasing order).
+func (s ConstraintSet) ForEach(f func(col ConstraintID)) {
+	s.set.ForEach(func(i int) { f(ConstraintID(i)) })
+}
+
+// SubsetOf returns true if s is a subset of other.
+func (s ConstraintSet) SubsetOf(other ConstraintSet) bool {
+	return s.set.SubsetOf(other.set)
+}
+
+// Intersection returns the intersection between s and other.
+func (s ConstraintSet) Intersection(other ConstraintSet) ConstraintSet {
+	return ConstraintSet{set: s.set.Intersection(other.set)}
+}
+
+// Difference returns the constraint IDs in s which are not in other.
+func (s ConstraintSet) Difference(other ConstraintSet) ConstraintSet {
+	return ConstraintSet{set: s.set.Difference(other.set)}
+}
+
+// Ordered returns a slice with all the ConstraintIDs in the set, in
+// increasing order.
+func (s ConstraintSet) Ordered() []ConstraintID {
+	if s.Empty() {
+		return nil
+	}
+	result := make([]ConstraintID, 0, s.Len())
+	s.ForEach(func(i ConstraintID) {
+		result = append(result, i)
+	})
+	return result
+}
+
+// UnionWith adds all the constraints from rhs to this set.
+func (s *ConstraintSet) UnionWith(rhs ConstraintSet) { s.set.UnionWith(rhs.set) }
+
+// String returns a list representation of elements. Sequential runs of positive
+// numbers are shown as ranges. For example, for the set {1, 2, 3  5, 6, 10},
+// the output is "(1-3,5,6,10)".
+func (s ConstraintSet) String() string { return s.set.String() }


### PR DESCRIPTION
Previously, when dropping a column that implicitly removed a constraint with an associated comment, the comment was not cleaned up. This commit ensures that such dangling comments are now removed for both the legacy and declarative schema changers.

Additionally, this commit addresses several issues in the declarative schema changer:
- Foreign key constraints were not dropped when their referenced columns were removed. This is now fixed.
- scpb.ConstraintColumn entries were inconsistently populated in decomp.go, which has been corrected.

Closes #158804
Release note (bug fix): Fixes a bug where comments associated with constraints were left behind after the column and constraint were dropped.