### PR TITLE
release-26.1: pkg/cli: allow tsdump to also dump the labeled child metrics

### DIFF
--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -321,6 +321,12 @@ func (d *datadogWriter) dump(kv *roachpb.KeyValue) (*datadogV2.MetricSeries, err
 	if err := kv.Value.GetProto(&idata); err != nil {
 		return nil, err
 	}
+	braceIdx := strings.IndexByte(name, '{')
+	if braceIdx != -1 {
+		// has child labels
+		// TODO(jasonlmfong): support uploading child labels
+		return nil, errors.Errorf("timeseries key with child labels: %s", name)
+	}
 
 	series := &datadogV2.MetricSeries{
 		Metric:   name,

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -813,25 +813,6 @@ type registryRecorder struct {
 	childMetricNameCache *syncutil.Map[uint64, cacheEntry]
 }
 
-// allowedChangefeedMetrics is the list of changefeed metrics that should have
-// child metrics collected and recorded to TSDB. This is a curated list to prevent
-// unbounded cardinality while still capturing the most important per-changefeed metrics.
-var allowedChangefeedMetrics = map[string]struct{}{
-	"changefeed.max_behind_nanos":                     {},
-	"changefeed.error_retries":                        {},
-	"changefeed.internal_retry_message_count":         {},
-	"changefeed.stage.downstream_client_send.latency": {},
-	"changefeed.emitted_messages":                     {},
-	"changefeed.sink_backpressure_nanos":              {},
-	"changefeed.backfill_pending_ranges":              {},
-	"changefeed.sink_io_inflight":                     {},
-	"changefeed.lagging_ranges":                       {},
-	"changefeed.aggregator_progress":                  {},
-	"changefeed.checkpoint_progress":                  {},
-	"changefeed.emitted_batch_sizes":                  {},
-	"changefeed.total_ranges":                         {},
-}
-
 // extractValue extracts the metric value(s) for the given metric and passes it, along with the metric name, to the
 // provided callback function.
 func extractValue(name string, mtr interface{}, fn func(string, float64)) error {
@@ -1023,7 +1004,7 @@ func (rr registryRecorder) recordChangefeedChildMetrics(dest *[]tspb.TimeSeriesD
 
 	labels := rr.registry.GetLabels()
 	rr.registry.Each(func(name string, v interface{}) {
-		if _, allowed := allowedChangefeedMetrics[name]; !allowed {
+		if _, allowed := tsutil.AllowedChildMetrics[name]; !allowed {
 			return
 		}
 		// Check if the metric has child collection enabled in its metadata

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -1283,8 +1283,8 @@ func BenchmarkRecordChangefeedChildMetrics(b *testing.B) {
 	enableChildCollection := true
 
 	// Get metrics from the allowed list and convert to slice for indexing
-	allowedMetricsList := make([]string, 0, len(allowedChangefeedMetrics))
-	for metricName := range allowedChangefeedMetrics {
+	allowedMetricsList := make([]string, 0, len(tsutil.AllowedChildMetrics))
+	for metricName := range tsutil.AllowedChildMetrics {
 		allowedMetricsList = append(allowedMetricsList, metricName)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #158716 on behalf of @jasonlmfong.

----

This adds the ability to dump the child metrics which was introduced in https://github.com/cockroachdb/cockroach/pull/158148.
These child metrics are discovered in the tsdump through their unique resolution
and a limit list of qualified metric names.

Epic: CRDB-55079
Release: None

----

Release justification: This is a low risk, tsdump improvement that missed the branch cut. no backwards compatibility concern.