### PR TITLE
release-25.2: roachtest: deflake npgsql

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -665,6 +665,7 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CopyTests(Multiplexing).Import_numeric`:                                            "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Import_string_array`:                                       "flaky",
 	`Npgsql.Tests.CopyTests(Multiplexing).Prepended_messages`:                                        "flaky",
+	`Npgsql.Tests.NotificationTests.Wait_with_timeout`:                                               "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).Failed_transaction_on_close_with_custom_timeout`: "flaky",
 	`Npgsql.Tests.TransactionTests(Multiplexing).Failed_transaction_on_close_with_custom_timeout`:    "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #159167 on behalf of @fqazi.

----

Recently we have been seeing the test "Wait_with_timeout" as flaky, so we will add it in the ignore list.

Release note: None
Fixes: #158495

----

Release justification: test only change