### PR TITLE
release: add update-workflow-branches command and TeamCity scripts

### DIFF
--- a/.github/BUILD.bazel
+++ b/.github/BUILD.bazel
@@ -1,3 +1,4 @@
 exports_files([
     "CODEOWNERS",
+    "workflows/update_releases.yaml",
 ])

--- a/build/teamcity/internal/cockroach/release/process/update_workflow_branches.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_workflow_branches.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run Update Workflow Branches Release Phase"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e GH_TOKEN" \
+  run_bazel build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
+tc_end_block "Run Update Workflow Branches Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -xeuo pipefail
+
+dry_run=true
+# override dev defaults with production values
+if [[ -z "${DRY_RUN:-}" ]] ; then
+  echo "Setting production values"
+  dry_run=false
+fi
+
+# run git fetch in order to get all remote branches
+git fetch --tags -q origin
+
+# Ensure we're starting from a clean master branch
+git checkout master
+git reset --hard origin/master
+
+# install gh CLI tool
+curl -fsSL -o /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz
+echo "5c9a70b6411cc9774f5f4e68f9227d5d55ca0bfbd00dfc6353081c9b705c8939  /tmp/gh.tar.gz" | sha256sum -c -
+tar --strip-components 1 -xf /tmp/gh.tar.gz
+export PATH=$PWD/bin:$PATH
+
+# Build the release tool
+bazel build --config=crosslinux //pkg/cmd/release
+
+# Run the update-workflow-branches command and capture output
+echo "Running release update-workflow-branches command..."
+OUTPUT=$($(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release update-workflow-branches 2>&1)
+echo "$OUTPUT"
+
+# Extract the branch name from output (line like "Latest release branch: release-26.1")
+RELEASE_BRANCH=$(echo "$OUTPUT" | grep "Latest release branch:" | sed 's/Latest release branch: //')
+
+if [[ -z "$RELEASE_BRANCH" ]]; then
+  echo "ERROR: Could not determine release branch from command output"
+  exit 1
+fi
+
+# Check if any changes were made
+if git diff --quiet .github/workflows/update_releases.yaml; then
+  echo "No changes to workflow file, nothing to commit"
+  exit 0
+fi
+
+echo "Changes detected in workflow file"
+
+if [[ "$dry_run" == "true" ]]; then
+  echo "DRY RUN: Would create PR with the following changes:"
+  git diff .github/workflows/update_releases.yaml
+  exit 0
+fi
+
+# Set git user for commits
+export GIT_AUTHOR_NAME="Justin Beaver"
+export GIT_COMMITTER_NAME="Justin Beaver"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+
+# Check for GitHub token
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "ERROR: GH_TOKEN environment variable must be set"
+  exit 1
+fi
+
+# Create a branch for the PR
+BRANCH_NAME="update-workflow-branches-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH_NAME"
+
+# Commit the changes
+git add .github/workflows/update_releases.yaml
+git commit -m "workflows: run \`update_releases\` on \`$RELEASE_BRANCH\`
+
+Epic: None
+Release note: None
+Release justification: non-production (release infra) change."
+
+# Push the branch to cockroach-teamcity fork (like update_releases.yaml workflow does)
+git push "https://oauth2:${GH_TOKEN}@github.com/cockroach-teamcity/cockroach" "$BRANCH_NAME"
+
+# Create the pull request from the fork
+gh pr create \
+  --repo cockroachdb/cockroach \
+  --base master \
+  --head "cockroach-teamcity:$BRANCH_NAME" \
+  --title "workflows: run \`update_releases\` on \`$RELEASE_BRANCH\`" \
+  --body "Epic: None
+Release note: None
+Release justification: non-production (release infra) change."
+
+echo "Pull request created successfully"

--- a/build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
@@ -15,6 +15,12 @@ if [[ -z "${DRY_RUN:-}" ]] ; then
   dry_run=false
 fi
 
+# Check for GitHub token early, before any network or build operations.
+if [[ "$dry_run" == "false" ]] && [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "ERROR: GH_TOKEN environment variable must be set"
+  exit 1
+fi
+
 # run git fetch in order to get all remote branches
 git fetch --tags -q origin
 
@@ -31,18 +37,18 @@ export PATH=$PWD/bin:$PATH
 # Build the release tool
 bazel build --config=crosslinux //pkg/cmd/release
 
-# Run the update-workflow-branches command and capture output
-echo "Running release update-workflow-branches command..."
-OUTPUT=$($(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release update-workflow-branches 2>&1)
-echo "$OUTPUT"
+RELEASE_BIN=$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release
 
-# Extract the branch name from output (line like "Latest release branch: release-26.1")
-RELEASE_BRANCH=$(echo "$OUTPUT" | grep "Latest release branch:" | sed 's/Latest release branch: //')
+# Get the latest release branch name without modifying any files.
+RELEASE_BRANCH=$("$RELEASE_BIN" update-workflow-branches --print-branch)
 
 if [[ -z "$RELEASE_BRANCH" ]]; then
-  echo "ERROR: Could not determine release branch from command output"
+  echo "ERROR: Could not determine release branch"
   exit 1
 fi
+
+# Update the workflow file.
+"$RELEASE_BIN" update-workflow-branches
 
 # Check if any changes were made
 if git diff --quiet .github/workflows/update_releases.yaml; then
@@ -63,12 +69,6 @@ export GIT_AUTHOR_NAME="Justin Beaver"
 export GIT_COMMITTER_NAME="Justin Beaver"
 export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
 export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
-
-# Check for GitHub token
-if [[ -z "${GH_TOKEN:-}" ]]; then
-  echo "ERROR: GH_TOKEN environment variable must be set"
-  exit 1
-fi
 
 # Create a branch for the PR
 BRANCH_NAME="update-workflow-branches-$(date +%Y%m%d-%H%M%S)"

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "update_helm.go",
         "update_releases.go",
         "update_versions.go",
+        "update_workflow.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",
     visibility = ["//visibility:private"],

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@com_github_jordan_wright_email//:email",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )
 
@@ -38,16 +39,21 @@ go_test(
     srcs = [
         "git_test.go",
         "update_releases_test.go",
+        "update_workflow_test.go",
     ],
     data = glob([
         "templates/**",
         "testdata/**",
-    ]),
+    ]) + [
+        "//.github:workflows/update_releases.yaml",
+    ],
     embed = [":release_lib"],
     deps = [
+        "//pkg/testutils/datapathutils",
         "//pkg/testutils/release",
         "@com_github_cockroachdb_version//:version",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -38,4 +38,5 @@ func main() {
 func init() {
 	rootCmd.AddCommand(updateReleasesTestFilesCmd)
 	rootCmd.AddCommand(updateVersionsCmd)
+	rootCmd.AddCommand(updateWorkflowBranchesCmd)
 }

--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -1,0 +1,255 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/version"
+	"github.com/spf13/cobra"
+)
+
+const workflowFile = ".github/workflows/update_releases.yaml"
+
+var updateWorkflowBranchesCmd = &cobra.Command{
+	Use:   "update-workflow-branches",
+	Short: "Update the branch matrix in update_releases.yaml workflow",
+	Long:  "Detects the latest release branch and adds it to the GitHub Actions workflow if not present",
+	RunE:  updateWorkflowBranches,
+}
+
+// updateWorkflowBranches is the main command handler.
+func updateWorkflowBranches(_ *cobra.Command, _ []string) error {
+	fmt.Println("Finding latest release branch...")
+	latestBranch, err := findLatestReleaseBranch()
+	if err != nil {
+		return fmt.Errorf("failed to find latest release branch: %w", err)
+	}
+
+	fmt.Printf("Latest release branch: %s\n", latestBranch)
+
+	fmt.Println("Updating workflow file...")
+	if err := addBranchToWorkflow(latestBranch); err != nil {
+		return fmt.Errorf("failed to update workflow file: %w", err)
+	}
+
+	fmt.Println("Successfully updated workflow file")
+	return nil
+}
+
+// findLatestReleaseBranch detects the latest release branch by querying git remote branches.
+func findLatestReleaseBranch() (string, error) {
+	// Get all release branches
+	branches, err := listRemoteBranches("release-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to list remote branches: %w", err)
+	}
+
+	// Filter out RC branches - we only want major release branches like "release-25.4"
+	var releaseBranches []string
+	for _, branch := range branches {
+		if !strings.Contains(branch, "-rc") {
+			releaseBranches = append(releaseBranches, branch)
+		}
+	}
+
+	if len(releaseBranches) == 0 {
+		return "", fmt.Errorf("no release branches found")
+	}
+
+	// Parse versions and sort
+	type branchVersion struct {
+		branch  string
+		version version.Version
+	}
+	var versions []branchVersion
+
+	for _, branch := range releaseBranches {
+		// Extract version from "release-X.Y" format
+		versionStr := strings.TrimPrefix(branch, "release-")
+		// Add .0 for patch to make it a valid semantic version
+		v, err := version.Parse("v" + versionStr + ".0")
+		if err != nil {
+			log.Printf("WARNING: cannot parse version from branch %s: %v", branch, err)
+			continue
+		}
+		versions = append(versions, branchVersion{branch, v})
+	}
+
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no valid version branches found")
+	}
+
+	// Sort by version
+	slices.SortFunc(versions, func(a, b branchVersion) int {
+		return a.version.Compare(b.version)
+	})
+
+	// Return highest version
+	return versions[len(versions)-1].branch, nil
+}
+
+// addBranchToWorkflow adds the specified branch to the workflow file if not already present.
+func addBranchToWorkflow(branch string) error {
+	// Read the workflow file
+	rawData, err := os.ReadFile(workflowFile)
+	if err != nil {
+		return fmt.Errorf("failed to read workflow file: %w", err)
+	}
+
+	lines := strings.Split(string(rawData), "\n")
+
+	// Find the branch section and extract current branches
+	currentBranches, branchStart, branchEnd, indent, err := parseBranchSection(lines)
+	if err != nil {
+		return err
+	}
+
+	// Check if branch already exists
+	for _, b := range currentBranches {
+		if b == branch {
+			fmt.Printf("Branch %s is already in the workflow file\n", branch)
+			return nil
+		}
+	}
+
+	// Add the new branch
+	currentBranches = append(currentBranches, branch)
+
+	// Sort branches: master first, then release branches in version order
+	slices.SortFunc(currentBranches, func(a, b string) int {
+		if a == "master" {
+			return -1
+		}
+		if b == "master" {
+			return 1
+		}
+
+		// Compare release versions
+		aVer := strings.TrimPrefix(a, "release-")
+		bVer := strings.TrimPrefix(b, "release-")
+
+		va, err1 := version.Parse("v" + aVer + ".0")
+		vb, err2 := version.Parse("v" + bVer + ".0")
+
+		// If either fails to parse, fall back to string comparison
+		if err1 != nil || err2 != nil {
+			return strings.Compare(a, b)
+		}
+
+		return va.Compare(vb)
+	})
+
+	// Write the updated file
+	if err := writeBranchSection(lines, currentBranches, branchStart, branchEnd, indent); err != nil {
+		return err
+	}
+
+	fmt.Printf("Added branch %s to workflow file\n", branch)
+	return nil
+}
+
+// parseBranchSection parses the workflow file to find the branch matrix section.
+func parseBranchSection(
+	lines []string,
+) (branches []string, start int, end int, indent string, err error) {
+	start = -1
+	end = -1
+
+	for i, line := range lines {
+		// Look for "branch:" within the matrix section
+		if strings.Contains(line, "branch:") && !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			start = i + 1
+			// Determine indentation from the next line
+			if i+1 < len(lines) {
+				nextLine := lines[i+1]
+				// Count leading spaces
+				trimmed := strings.TrimLeft(nextLine, " ")
+				indent = strings.Repeat(" ", len(nextLine)-len(trimmed))
+			}
+		} else if start != -1 && end == -1 {
+			// Check if this line is still part of branch list
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				// Empty line, continue
+				continue
+			}
+			if !strings.HasPrefix(trimmed, "-") {
+				// Found the end of the branch list
+				end = i
+				break
+			} else {
+				// Extract branch name from line like '- "release-25.4"'
+				// Remove leading "- " and quotes
+				branchLine := strings.TrimSpace(trimmed)
+				branchLine = strings.TrimPrefix(branchLine, "- ")
+				branchLine = strings.Trim(branchLine, "\"")
+				branches = append(branches, branchLine)
+			}
+		}
+	}
+
+	if start == -1 {
+		return nil, 0, 0, "", fmt.Errorf("branch section not found in workflow file")
+	}
+
+	// If we reached end of file, set end to len(lines)
+	if end == -1 {
+		end = len(lines)
+	}
+
+	return branches, start, end, indent, nil
+}
+
+// writeBranchSection writes the updated branch list back to the workflow file.
+func writeBranchSection(
+	lines []string, branches []string, start int, end int, indent string,
+) error {
+	// Build new lines
+	var newLines []string
+	newLines = append(newLines, lines[:start]...)
+
+	// Add branch lines
+	for _, branch := range branches {
+		newLines = append(newLines, fmt.Sprintf("%s- %q", indent, branch))
+	}
+
+	// Add remaining lines
+	newLines = append(newLines, lines[end:]...)
+
+	// Write back to file using atomic write pattern
+	// Create temp file in the same directory as target to avoid cross-device link errors
+	dir := ".github/workflows"
+	f, err := os.CreateTemp(dir, "update_releases_*.yaml")
+	if err != nil {
+		return fmt.Errorf("could not create temporary file: %w", err)
+	}
+	tmpName := f.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = f.WriteString(strings.Join(newLines, "\n")); err != nil {
+		f.Close()
+		return fmt.Errorf("error writing to temp file: %w", err)
+	}
+
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("error closing temp file: %w", err)
+	}
+
+	if err = os.Rename(tmpName, workflowFile); err != nil {
+		return fmt.Errorf("error moving file to final destination: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -131,7 +131,7 @@ func addBranchToWorkflow(branch string) error {
 	}
 
 	var workflow yaml.Node
-	if err := yaml.Unmarshal(data, &workflow); err != nil {
+	if err := yaml.Unmarshal(data, &workflow); err != nil { //nolint:yaml
 		return fmt.Errorf("failed to parse workflow YAML: %w", err)
 	}
 

--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -18,11 +18,20 @@ import (
 
 const workflowFile = ".github/workflows/update_releases.yaml"
 
+var printBranchOnly bool
+
 var updateWorkflowBranchesCmd = &cobra.Command{
 	Use:   "update-workflow-branches",
 	Short: "Update the branch matrix in update_releases.yaml workflow",
 	Long:  "Detects the latest release branch and adds it to the GitHub Actions workflow if not present",
 	RunE:  updateWorkflowBranches,
+}
+
+func init() {
+	updateWorkflowBranchesCmd.Flags().BoolVar(
+		&printBranchOnly, "print-branch", false,
+		"print only the detected branch name to stdout and exit without modifying any files",
+	)
 }
 
 // updateWorkflowBranches is the main command handler.
@@ -31,6 +40,11 @@ func updateWorkflowBranches(_ *cobra.Command, _ []string) error {
 	latestBranch, err := findLatestReleaseBranch()
 	if err != nil {
 		return fmt.Errorf("failed to find latest release branch: %w", err)
+	}
+
+	if printBranchOnly {
+		fmt.Println(latestBranch)
+		return nil
 	}
 
 	fmt.Printf("Latest release branch: %s\n", latestBranch)
@@ -46,13 +60,17 @@ func updateWorkflowBranches(_ *cobra.Command, _ []string) error {
 
 // findLatestReleaseBranch detects the latest release branch by querying git remote branches.
 func findLatestReleaseBranch() (string, error) {
-	// Get all release branches
 	branches, err := listRemoteBranches("release-*")
 	if err != nil {
 		return "", fmt.Errorf("failed to list remote branches: %w", err)
 	}
+	return selectLatestBranch(branches)
+}
 
-	// Filter out RC branches - we only want major release branches like "release-25.4"
+// selectLatestBranch returns the highest-version release branch from the
+// provided list, filtering out -rc branches.
+func selectLatestBranch(branches []string) (string, error) {
+	// filter out RC branches; we only want major release branches like "release-25.4"
 	var releaseBranches []string
 	for _, branch := range branches {
 		if !strings.HasSuffix(branch, "-rc") {
@@ -64,7 +82,7 @@ func findLatestReleaseBranch() (string, error) {
 		return "", fmt.Errorf("no release branches found")
 	}
 
-	// Parse versions and sort
+	// parse versions and sort
 	type branchVersion struct {
 		branch  string
 		version version.Version
@@ -72,9 +90,9 @@ func findLatestReleaseBranch() (string, error) {
 	var versions []branchVersion
 
 	for _, branch := range releaseBranches {
-		// Extract version from "release-X.Y" format
+		// extract version from "release-X.Y" format
 		versionStr := strings.TrimPrefix(branch, "release-")
-		// Add .0 for patch to make it a valid semantic version
+		// add .0 for patch to make it a valid semantic version
 		v, err := version.Parse("v" + versionStr + ".0")
 		if err != nil {
 			fmt.Printf("WARNING: cannot parse version from branch %s: %v\n", branch, err)
@@ -87,33 +105,35 @@ func findLatestReleaseBranch() (string, error) {
 		return "", fmt.Errorf("no valid version branches found")
 	}
 
-	// Sort by version
 	slices.SortFunc(versions, func(a, b branchVersion) int {
 		return a.version.Compare(b.version)
 	})
 
-	// Return highest version
 	return versions[len(versions)-1].branch, nil
 }
 
-// sortBranches sorts branches with master first, then release branches in version order.
+// sortBranches sorts branches with master first, then release branches in
+// ascending version order.
 func sortBranches(branches []string) {
 	slices.SortFunc(branches, func(a, b string) int {
 		if a == "master" {
+			if b == "master" {
+				return 0
+			}
 			return -1
 		}
 		if b == "master" {
 			return 1
 		}
 
-		// Compare release versions
+		// compare release versions
 		aVer := strings.TrimPrefix(a, "release-")
 		bVer := strings.TrimPrefix(b, "release-")
 
 		va, err1 := version.Parse("v" + aVer + ".0")
 		vb, err2 := version.Parse("v" + bVer + ".0")
 
-		// If either fails to parse, fall back to string comparison
+		// if either fails to parse, fall back to string comparison
 		if err1 != nil || err2 != nil {
 			return strings.Compare(a, b)
 		}
@@ -122,10 +142,18 @@ func sortBranches(branches []string) {
 	})
 }
 
-// addBranchToWorkflow adds the specified branch to the workflow file if not already present.
+// addBranchToWorkflow adds the specified branch to the workflow file if not
+// already present.
 func addBranchToWorkflow(branch string) error {
-	// Read and parse the workflow file
-	data, err := os.ReadFile(workflowFile)
+	return addBranchToWorkflowFile(branch, workflowFile)
+}
+
+// addBranchToWorkflowFile adds the specified branch to the given workflow file
+// path if not already present. Exposed separately from addBranchToWorkflow to
+// allow tests to operate on a temp file.
+func addBranchToWorkflowFile(branch, path string) error {
+	// read and parse the workflow file
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read workflow file: %w", err)
 	}
@@ -135,13 +163,13 @@ func addBranchToWorkflow(branch string) error {
 		return fmt.Errorf("failed to parse workflow YAML: %w", err)
 	}
 
-	// Navigate to jobs.update-crdb-releases-yaml.strategy.matrix.branch
+	// navigate to jobs.update-crdb-releases-yaml.strategy.matrix.branch
 	branchNode, err := findBranchNode(&workflow)
 	if err != nil {
 		return err
 	}
 
-	// Extract current branches
+	// extract current branches
 	var currentBranches []string
 	for _, item := range branchNode.Content {
 		if item.Kind == yaml.ScalarNode {
@@ -149,17 +177,17 @@ func addBranchToWorkflow(branch string) error {
 		}
 	}
 
-	// Check if branch already exists
+	// check if branch already exists
 	if slices.Contains(currentBranches, branch) {
 		fmt.Printf("Branch %s is already in the workflow file\n", branch)
 		return nil
 	}
 
-	// Add the new branch and sort
+	// add the new branch and sort
 	currentBranches = append(currentBranches, branch)
 	sortBranches(currentBranches)
 
-	// Update the YAML node with sorted branches
+	// update the YAML node with sorted branches
 	branchNode.Content = make([]*yaml.Node, 0, len(currentBranches))
 	for _, b := range currentBranches {
 		branchNode.Content = append(branchNode.Content, &yaml.Node{
@@ -169,7 +197,7 @@ func addBranchToWorkflow(branch string) error {
 		})
 	}
 
-	// Marshal back to YAML
+	// marshal back to YAML
 	var buf strings.Builder
 	encoder := yaml.NewEncoder(&buf)
 	encoder.SetIndent(2)
@@ -180,8 +208,8 @@ func addBranchToWorkflow(branch string) error {
 		return fmt.Errorf("failed to close YAML encoder: %w", err)
 	}
 
-	// Write back to file
-	if err := os.WriteFile(workflowFile, []byte(buf.String()), 0644); err != nil {
+	// write back to file
+	if err := os.WriteFile(path, []byte(buf.String()), 0644); err != nil {
 		return fmt.Errorf("failed to write workflow file: %w", err)
 	}
 
@@ -213,7 +241,7 @@ func findBranchNode(root *yaml.Node) (*yaml.Node, error) {
 		return nil, fmt.Errorf("invalid YAML structure: expected mapping at top level")
 	}
 
-	// Navigate to jobs.update-crdb-releases-yaml.strategy.matrix.branch
+	// navigate to jobs.update-crdb-releases-yaml.strategy.matrix.branch
 	// If this path changes in the workflow file, update it here and in the comment above.
 	expectedPath := []string{"jobs", "update-crdb-releases-yaml", "strategy", "matrix", "branch"}
 	branchNode, err := navigateYAMLPath(topMap, expectedPath)
@@ -240,7 +268,6 @@ func navigateYAMLPath(start *yaml.Node, path []string) (*yaml.Node, error) {
 	for i, key := range path {
 		next := findMapValue(current, key)
 		if next == nil {
-			// Provide context about where in the path we failed
 			completedPath := strings.Join(path[:i], " -> ")
 			if completedPath != "" {
 				completedPath += " -> "
@@ -258,7 +285,7 @@ func findMapValue(mapNode *yaml.Node, key string) *yaml.Node {
 		return nil
 	}
 
-	// Mapping nodes have alternating key-value pairs in Content
+	// mapping nodes have alternating key-value pairs in Content
 	for i := 0; i < len(mapNode.Content); i += 2 {
 		if mapNode.Content[i].Value == key {
 			return mapNode.Content[i+1]

--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -7,13 +7,13 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/cockroachdb/version"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 const workflowFile = ".github/workflows/update_releases.yaml"
@@ -55,7 +55,7 @@ func findLatestReleaseBranch() (string, error) {
 	// Filter out RC branches - we only want major release branches like "release-25.4"
 	var releaseBranches []string
 	for _, branch := range branches {
-		if !strings.Contains(branch, "-rc") {
+		if !strings.HasSuffix(branch, "-rc") {
 			releaseBranches = append(releaseBranches, branch)
 		}
 	}
@@ -77,7 +77,7 @@ func findLatestReleaseBranch() (string, error) {
 		// Add .0 for patch to make it a valid semantic version
 		v, err := version.Parse("v" + versionStr + ".0")
 		if err != nil {
-			log.Printf("WARNING: cannot parse version from branch %s: %v", branch, err)
+			fmt.Printf("WARNING: cannot parse version from branch %s: %v\n", branch, err)
 			continue
 		}
 		versions = append(versions, branchVersion{branch, v})
@@ -96,35 +96,9 @@ func findLatestReleaseBranch() (string, error) {
 	return versions[len(versions)-1].branch, nil
 }
 
-// addBranchToWorkflow adds the specified branch to the workflow file if not already present.
-func addBranchToWorkflow(branch string) error {
-	// Read the workflow file
-	rawData, err := os.ReadFile(workflowFile)
-	if err != nil {
-		return fmt.Errorf("failed to read workflow file: %w", err)
-	}
-
-	lines := strings.Split(string(rawData), "\n")
-
-	// Find the branch section and extract current branches
-	currentBranches, branchStart, branchEnd, indent, err := parseBranchSection(lines)
-	if err != nil {
-		return err
-	}
-
-	// Check if branch already exists
-	for _, b := range currentBranches {
-		if b == branch {
-			fmt.Printf("Branch %s is already in the workflow file\n", branch)
-			return nil
-		}
-	}
-
-	// Add the new branch
-	currentBranches = append(currentBranches, branch)
-
-	// Sort branches: master first, then release branches in version order
-	slices.SortFunc(currentBranches, func(a, b string) int {
+// sortBranches sorts branches with master first, then release branches in version order.
+func sortBranches(branches []string) {
+	slices.SortFunc(branches, func(a, b string) int {
 		if a == "master" {
 			return -1
 		}
@@ -146,109 +120,149 @@ func addBranchToWorkflow(branch string) error {
 
 		return va.Compare(vb)
 	})
+}
 
-	// Write the updated file
-	if err := writeBranchSection(lines, currentBranches, branchStart, branchEnd, indent); err != nil {
+// addBranchToWorkflow adds the specified branch to the workflow file if not already present.
+func addBranchToWorkflow(branch string) error {
+	// Read and parse the workflow file
+	data, err := os.ReadFile(workflowFile)
+	if err != nil {
+		return fmt.Errorf("failed to read workflow file: %w", err)
+	}
+
+	var workflow yaml.Node
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		return fmt.Errorf("failed to parse workflow YAML: %w", err)
+	}
+
+	// Navigate to jobs.update-crdb-releases-yaml.strategy.matrix.branch
+	branchNode, err := findBranchNode(&workflow)
+	if err != nil {
 		return err
+	}
+
+	// Extract current branches
+	var currentBranches []string
+	for _, item := range branchNode.Content {
+		if item.Kind == yaml.ScalarNode {
+			currentBranches = append(currentBranches, item.Value)
+		}
+	}
+
+	// Check if branch already exists
+	if slices.Contains(currentBranches, branch) {
+		fmt.Printf("Branch %s is already in the workflow file\n", branch)
+		return nil
+	}
+
+	// Add the new branch and sort
+	currentBranches = append(currentBranches, branch)
+	sortBranches(currentBranches)
+
+	// Update the YAML node with sorted branches
+	branchNode.Content = make([]*yaml.Node, 0, len(currentBranches))
+	for _, b := range currentBranches {
+		branchNode.Content = append(branchNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Style: yaml.DoubleQuotedStyle,
+			Value: b,
+		})
+	}
+
+	// Marshal back to YAML
+	var buf strings.Builder
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&workflow); err != nil {
+		return fmt.Errorf("failed to encode YAML: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("failed to close YAML encoder: %w", err)
+	}
+
+	// Write back to file
+	if err := os.WriteFile(workflowFile, []byte(buf.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write workflow file: %w", err)
 	}
 
 	fmt.Printf("Added branch %s to workflow file\n", branch)
 	return nil
 }
 
-// parseBranchSection parses the workflow file to find the branch matrix section.
-func parseBranchSection(
-	lines []string,
-) (branches []string, start int, end int, indent string, err error) {
-	start = -1
-	end = -1
-
-	for i, line := range lines {
-		// Look for "branch:" within the matrix section
-		if strings.Contains(line, "branch:") && !strings.HasPrefix(strings.TrimSpace(line), "#") {
-			start = i + 1
-			// Determine indentation from the next line
-			if i+1 < len(lines) {
-				nextLine := lines[i+1]
-				// Count leading spaces
-				trimmed := strings.TrimLeft(nextLine, " ")
-				indent = strings.Repeat(" ", len(nextLine)-len(trimmed))
-			}
-		} else if start != -1 && end == -1 {
-			// Check if this line is still part of branch list
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "" {
-				// Empty line, continue
-				continue
-			}
-			if !strings.HasPrefix(trimmed, "-") {
-				// Found the end of the branch list
-				end = i
-				break
-			} else {
-				// Extract branch name from line like '- "release-25.4"'
-				// Remove leading "- " and quotes
-				branchLine := strings.TrimSpace(trimmed)
-				branchLine = strings.TrimPrefix(branchLine, "- ")
-				branchLine = strings.Trim(branchLine, "\"")
-				branches = append(branches, branchLine)
-			}
-		}
+// findBranchNode navigates the YAML tree to find the branch array node.
+//
+// IMPORTANT: This function expects the workflow YAML to have the following structure:
+//
+//	jobs:
+//	  update-crdb-releases-yaml:
+//	    strategy:
+//	      matrix:
+//	        branch:
+//	          - "master"
+//	          - "release-X.Y"
+//
+// If the workflow structure changes (job name, nesting, etc.), this function will
+// return an error. Update the expectedPath below if the structure needs to change.
+func findBranchNode(root *yaml.Node) (*yaml.Node, error) {
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("invalid YAML structure: expected document node")
 	}
 
-	if start == -1 {
-		return nil, 0, 0, "", fmt.Errorf("branch section not found in workflow file")
+	topMap := root.Content[0]
+	if topMap.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("invalid YAML structure: expected mapping at top level")
 	}
 
-	// If we reached end of file, set end to len(lines)
-	if end == -1 {
-		end = len(lines)
+	// Navigate to jobs.update-crdb-releases-yaml.strategy.matrix.branch
+	// If this path changes in the workflow file, update it here and in the comment above.
+	expectedPath := []string{"jobs", "update-crdb-releases-yaml", "strategy", "matrix", "branch"}
+	branchNode, err := navigateYAMLPath(topMap, expectedPath)
+	if err != nil {
+		return nil, fmt.Errorf("workflow structure does not match expected format.\n"+
+			"Expected path: %s\n"+
+			"Error: %w\n\n"+
+			"If the workflow file structure has changed, update the expectedPath in findBranchNode()",
+			strings.Join(expectedPath, " -> "), err)
 	}
 
-	return branches, start, end, indent, nil
+	if branchNode.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("expected 'branch' to be a sequence (array), but found %v.\n"+
+			"The workflow file structure may have changed. Update the code in findBranchNode() if needed",
+			branchNode.Kind)
+	}
+
+	return branchNode, nil
 }
 
-// writeBranchSection writes the updated branch list back to the workflow file.
-func writeBranchSection(
-	lines []string, branches []string, start int, end int, indent string,
-) error {
-	// Build new lines
-	var newLines []string
-	newLines = append(newLines, lines[:start]...)
-
-	// Add branch lines
-	for _, branch := range branches {
-		newLines = append(newLines, fmt.Sprintf("%s- %q", indent, branch))
-	}
-
-	// Add remaining lines
-	newLines = append(newLines, lines[end:]...)
-
-	// Write back to file using atomic write pattern
-	// Create temp file in the same directory as target to avoid cross-device link errors
-	dir := ".github/workflows"
-	f, err := os.CreateTemp(dir, "update_releases_*.yaml")
-	if err != nil {
-		return fmt.Errorf("could not create temporary file: %w", err)
-	}
-	tmpName := f.Name()
-	defer func() {
-		if err != nil {
-			_ = os.Remove(tmpName)
+// navigateYAMLPath navigates through a sequence of keys in a YAML mapping structure.
+func navigateYAMLPath(start *yaml.Node, path []string) (*yaml.Node, error) {
+	current := start
+	for i, key := range path {
+		next := findMapValue(current, key)
+		if next == nil {
+			// Provide context about where in the path we failed
+			completedPath := strings.Join(path[:i], " -> ")
+			if completedPath != "" {
+				completedPath += " -> "
+			}
+			return nil, fmt.Errorf("key '%s' not found after navigating: %s", key, completedPath+"[HERE]")
 		}
-	}()
+		current = next
+	}
+	return current, nil
+}
 
-	if _, err = f.WriteString(strings.Join(newLines, "\n")); err != nil {
-		f.Close()
-		return fmt.Errorf("error writing to temp file: %w", err)
+// findMapValue finds a value in a mapping node by key.
+func findMapValue(mapNode *yaml.Node, key string) *yaml.Node {
+	if mapNode.Kind != yaml.MappingNode {
+		return nil
 	}
 
-	if err = f.Close(); err != nil {
-		return fmt.Errorf("error closing temp file: %w", err)
-	}
-
-	if err = os.Rename(tmpName, workflowFile); err != nil {
-		return fmt.Errorf("error moving file to final destination: %w", err)
+	// Mapping nodes have alternating key-value pairs in Content
+	for i := 0; i < len(mapNode.Content); i += 2 {
+		if mapNode.Content[i].Value == key {
+			return mapNode.Content[i+1]
+		}
 	}
 
 	return nil

--- a/pkg/cmd/release/update_workflow_test.go
+++ b/pkg/cmd/release/update_workflow_test.go
@@ -32,7 +32,7 @@ func TestWorkflowFileStructure(t *testing.T) {
 	}
 
 	var workflow yaml.Node
-	if err := yaml.Unmarshal(data, &workflow); err != nil {
+	if err := yaml.Unmarshal(data, &workflow); err != nil { //nolint:yaml
 		t.Fatalf("Failed to parse workflow YAML: %v", err)
 	}
 
@@ -78,7 +78,7 @@ func TestAddBranchToWorkflow_NoOp(t *testing.T) {
 	}
 
 	var workflow yaml.Node
-	if err := yaml.Unmarshal(originalData, &workflow); err != nil {
+	if err := yaml.Unmarshal(originalData, &workflow); err != nil { //nolint:yaml
 		t.Fatalf("Failed to parse workflow YAML: %v", err)
 	}
 

--- a/pkg/cmd/release/update_workflow_test.go
+++ b/pkg/cmd/release/update_workflow_test.go
@@ -7,9 +7,11 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,83 +22,41 @@ import (
 // any structural changes are caught immediately. If this test fails, you need to:
 // 1. Update the expectedPath in findBranchNode() to match the new structure
 // 2. Update this test if needed
-//
-// This test will catch structural changes that would break update_workflow.go.
 func TestWorkflowFileStructure(t *testing.T) {
-	// Read the actual workflow file from .github/workflows/
 	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
 	data, err := os.ReadFile(workflowPath)
-	if err != nil {
-		t.Fatalf("Failed to read workflow file %s: %v\n"+
-			"The workflow file may have been moved or renamed.", workflowPath, err)
-	}
+	require.NoError(t, err, "workflow file may have been moved or renamed")
 
 	var workflow yaml.Node
-	if err := yaml.Unmarshal(data, &workflow); err != nil { //nolint:yaml
-		t.Fatalf("Failed to parse workflow YAML: %v", err)
-	}
+	require.NoError(t, yaml.Unmarshal(data, &workflow), "failed to parse workflow YAML") //nolint:yaml
 
-	// Validate the structure matches what findBranchNode() expects
 	branchNode, err := findBranchNode(&workflow)
-	if err != nil {
-		t.Fatalf("Workflow file structure validation failed.\n"+
-			"This likely means the structure of %s has changed.\n"+
-			"Error: %v\n\n"+
-			"To fix this:\n"+
-			"1. Update the expectedPath in findBranchNode() to match the new structure\n"+
-			"2. Update this test if needed",
-			workflowFile, err)
-	}
+	require.NoError(t, err,
+		"workflow file structure validation failed — structure of %s may have changed;\n"+
+			"update expectedPath in findBranchNode() to match", workflowFile)
 
-	// Verify it's a sequence node with at least one branch
-	if branchNode.Kind != yaml.SequenceNode {
-		t.Fatalf("Expected 'branch' to be a sequence, got %v", branchNode.Kind)
-	}
+	require.Equal(t, yaml.SequenceNode, branchNode.Kind, "expected 'branch' to be a sequence")
+	require.NotEmpty(t, branchNode.Content, "expected at least one branch in the workflow matrix")
 
-	if len(branchNode.Content) == 0 {
-		t.Fatal("Expected at least one branch in the workflow matrix, found none")
-	}
-
-	// Verify branches are strings
 	for i, node := range branchNode.Content {
-		if node.Kind != yaml.ScalarNode {
-			t.Errorf("Branch at index %d is not a scalar node (expected string)", i)
-		}
+		require.Equal(t, yaml.ScalarNode, node.Kind, "branch at index %d is not a string", i)
 	}
-
-	t.Logf("Workflow structure validation passed")
-	t.Logf("Found %d branches in the matrix", len(branchNode.Content))
 }
 
-// TestAddBranchToWorkflow_NoOp tests that the branch extraction logic works correctly.
-func TestAddBranchToWorkflow_NoOp(t *testing.T) {
-	// Read the actual workflow file from .github/workflows/
+// TestFindBranchNode_ExtractsValues verifies that findBranchNode returns a
+// sequence node whose string values can be extracted correctly.
+func TestFindBranchNode_ExtractsValues(t *testing.T) {
 	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
-	originalData, err := os.ReadFile(workflowPath)
-	if err != nil {
-		t.Fatalf("Failed to read workflow file: %v", err)
-	}
+	data, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
 
 	var workflow yaml.Node
-	if err := yaml.Unmarshal(originalData, &workflow); err != nil { //nolint:yaml
-		t.Fatalf("Failed to parse workflow YAML: %v", err)
-	}
+	require.NoError(t, yaml.Unmarshal(data, &workflow)) //nolint:yaml
 
-	// Get the branch node
 	branchNode, err := findBranchNode(&workflow)
-	if err != nil {
-		t.Fatalf("Failed to find branch node: %v", err)
-	}
+	require.NoError(t, err)
+	require.NotEmpty(t, branchNode.Content)
 
-	// Should have at least one branch
-	if len(branchNode.Content) == 0 {
-		t.Fatal("No branches found in workflow file")
-	}
-
-	// Get the first branch (should be "master" based on current structure)
-	firstBranch := branchNode.Content[0].Value
-
-	// Verify extracting branches works
 	var branches []string
 	for _, item := range branchNode.Content {
 		if item.Kind == yaml.ScalarNode {
@@ -104,19 +64,151 @@ func TestAddBranchToWorkflow_NoOp(t *testing.T) {
 		}
 	}
 
-	// Verify the first branch is in the list
-	found := false
+	// the first branch should be "master"
+	require.Equal(t, "master", branches[0], "expected master to be first branch")
+	// every extracted value should be non-empty
 	for _, b := range branches {
-		if b == firstBranch {
-			found = true
-			break
+		require.NotEmpty(t, b)
+	}
+}
+
+// TestSortBranches verifies ordering: master first, then release branches in
+// ascending semantic-version order, with fallback to lexicographic order for
+// unparseable entries.
+func TestSortBranches(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "master first",
+			input:    []string{"release-25.1", "master", "release-24.3"},
+			expected: []string{"master", "release-24.3", "release-25.1"},
+		},
+		{
+			name:     "semantic version order not lexicographic",
+			input:    []string{"release-25.2", "release-9.1", "release-25.10"},
+			expected: []string{"release-9.1", "release-25.2", "release-25.10"},
+		},
+		{
+			name:     "two masters degenerate case",
+			input:    []string{"master", "release-25.1", "master"},
+			expected: []string{"master", "master", "release-25.1"},
+		},
+		{
+			name:     "unparseable falls back to string compare",
+			input:    []string{"release-25.1", "not-a-release", "release-24.3"},
+			expected: []string{"not-a-release", "release-24.3", "release-25.1"},
+		},
+		{
+			name:     "single entry",
+			input:    []string{"master"},
+			expected: []string{"master"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := make([]string, len(tc.input))
+			copy(got, tc.input)
+			sortBranches(got)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestSelectLatestBranch verifies RC filtering and highest-version selection.
+func TestSelectLatestBranch(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "selects highest version",
+			input:    []string{"release-24.3", "release-25.1", "release-25.2"},
+			expected: "release-25.2",
+		},
+		{
+			name:     "filters RC branches",
+			input:    []string{"release-25.1", "release-25.2-rc", "release-25.2"},
+			expected: "release-25.2",
+		},
+		{
+			name:        "all RC branches returns error",
+			input:       []string{"release-25.1-rc", "release-25.2-rc"},
+			expectError: true,
+		},
+		{
+			name:        "empty input returns error",
+			input:       []string{},
+			expectError: true,
+		},
+		{
+			name:     "semantic version not lexicographic",
+			input:    []string{"release-9.1", "release-25.2", "release-25.10"},
+			expected: "release-25.10",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectLatestBranch(tc.input)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+// TestAddBranchToWorkflowFile verifies the full mutation path: reading the YAML,
+// adding a branch, sorting, re-encoding, and writing back — using a temp copy of
+// the real workflow file so the live file is never modified.
+func TestAddBranchToWorkflowFile(t *testing.T) {
+	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
+	original, err := os.ReadFile(workflowPath)
+	require.NoError(t, err)
+
+	// work on a temp copy
+	tmp := filepath.Join(t.TempDir(), "update_releases.yaml")
+	require.NoError(t, os.WriteFile(tmp, original, 0644))
+
+	t.Run("adds new branch", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(tmp, original, 0644))
+		require.NoError(t, addBranchToWorkflowFile("release-99.9", tmp))
+
+		data, err := os.ReadFile(tmp)
+		require.NoError(t, err)
+
+		var workflow yaml.Node
+		require.NoError(t, yaml.Unmarshal(data, &workflow)) //nolint:yaml
+		branchNode, err := findBranchNode(&workflow)
+		require.NoError(t, err)
+
+		var branches []string
+		for _, item := range branchNode.Content {
+			if item.Kind == yaml.ScalarNode {
+				branches = append(branches, item.Value)
+			}
 		}
-	}
+		require.Contains(t, branches, "release-99.9")
+		// master should still be first
+		require.Equal(t, "master", branches[0])
+	})
 
-	if !found {
-		t.Fatalf("Expected to find branch %q in the workflow file", firstBranch)
-	}
+	t.Run("idempotent for existing branch", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(tmp, original, 0644))
+		// add "master" which is already present
+		require.NoError(t, addBranchToWorkflowFile("master", tmp))
 
-	t.Logf("Successfully extracted %d branches from workflow file", len(branches))
-	t.Logf("First branch: %s", firstBranch)
+		data, err := os.ReadFile(tmp)
+		require.NoError(t, err)
+		// file should be unchanged
+		require.Equal(t, string(original), string(data))
+	})
 }

--- a/pkg/cmd/release/update_workflow_test.go
+++ b/pkg/cmd/release/update_workflow_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"gopkg.in/yaml.v3"
+)
+
+// TestWorkflowFileStructure validates that the update_releases.yaml workflow file
+// has the expected structure that update_workflow.go depends on.
+//
+// This test reads the actual workflow file from .github/workflows/ to ensure
+// any structural changes are caught immediately. If this test fails, you need to:
+// 1. Update the expectedPath in findBranchNode() to match the new structure
+// 2. Update this test if needed
+//
+// This test will catch structural changes that would break update_workflow.go.
+func TestWorkflowFileStructure(t *testing.T) {
+	// Read the actual workflow file from .github/workflows/
+	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("Failed to read workflow file %s: %v\n"+
+			"The workflow file may have been moved or renamed.", workflowPath, err)
+	}
+
+	var workflow yaml.Node
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("Failed to parse workflow YAML: %v", err)
+	}
+
+	// Validate the structure matches what findBranchNode() expects
+	branchNode, err := findBranchNode(&workflow)
+	if err != nil {
+		t.Fatalf("Workflow file structure validation failed.\n"+
+			"This likely means the structure of %s has changed.\n"+
+			"Error: %v\n\n"+
+			"To fix this:\n"+
+			"1. Update the expectedPath in findBranchNode() to match the new structure\n"+
+			"2. Update this test if needed",
+			workflowFile, err)
+	}
+
+	// Verify it's a sequence node with at least one branch
+	if branchNode.Kind != yaml.SequenceNode {
+		t.Fatalf("Expected 'branch' to be a sequence, got %v", branchNode.Kind)
+	}
+
+	if len(branchNode.Content) == 0 {
+		t.Fatal("Expected at least one branch in the workflow matrix, found none")
+	}
+
+	// Verify branches are strings
+	for i, node := range branchNode.Content {
+		if node.Kind != yaml.ScalarNode {
+			t.Errorf("Branch at index %d is not a scalar node (expected string)", i)
+		}
+	}
+
+	t.Logf("Workflow structure validation passed")
+	t.Logf("Found %d branches in the matrix", len(branchNode.Content))
+}
+
+// TestAddBranchToWorkflow_NoOp tests that the branch extraction logic works correctly.
+func TestAddBranchToWorkflow_NoOp(t *testing.T) {
+	// Read the actual workflow file from .github/workflows/
+	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
+	originalData, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("Failed to read workflow file: %v", err)
+	}
+
+	var workflow yaml.Node
+	if err := yaml.Unmarshal(originalData, &workflow); err != nil {
+		t.Fatalf("Failed to parse workflow YAML: %v", err)
+	}
+
+	// Get the branch node
+	branchNode, err := findBranchNode(&workflow)
+	if err != nil {
+		t.Fatalf("Failed to find branch node: %v", err)
+	}
+
+	// Should have at least one branch
+	if len(branchNode.Content) == 0 {
+		t.Fatal("No branches found in workflow file")
+	}
+
+	// Get the first branch (should be "master" based on current structure)
+	firstBranch := branchNode.Content[0].Value
+
+	// Verify extracting branches works
+	var branches []string
+	for _, item := range branchNode.Content {
+		if item.Kind == yaml.ScalarNode {
+			branches = append(branches, item.Value)
+		}
+	}
+
+	// Verify the first branch is in the list
+	found := false
+	for _, b := range branches {
+		if b == firstBranch {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("Expected to find branch %q in the workflow file", firstBranch)
+	}
+
+	t.Logf("Successfully extracted %d branches from workflow file", len(branches))
+	t.Logf("First branch: %s", firstBranch)
+}


### PR DESCRIPTION
This PR automates the creation of PRs like https://github.com/cockroachdb/cockroach/pull/154038

Adds the `update-workflow-branches` command and companion scripts to automatically add the latest release branch to `.github/workflows/update_releases.yaml` when cutting a new release branch.

This script will be triggered by this TeamCity build:
- [Update workflows update_releases](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Cockroach_Release_Publish_UpdateWorkflowsUpdateReleases?branch=159216&buildTypeTab=overview&focusLine=NaN&mode=builds)

## Changes

- **New command**: `release update-workflow-branches`
  - Auto-detects the latest release branch via `git ls-remote`
  - Uses `gopkg.in/yaml.v3` to parse and update the workflow YAML (structured node navigation, preserves formatting and comments)
  - Adds the branch to `.github/workflows/update_releases.yaml` matrix if not present
  - Sorts branches (master first, then release branches in semantic version order)
  - Idempotent — no-ops if the branch is already present
  - `--print-branch` flag: emits only the detected branch name to stdout (used by the shell script to capture the branch without grepping progress output)

- **TeamCity scripts**:
  - `update_workflow_branches.sh` — wrapper script
  - `update_workflow_branches_impl.sh` — implementation that runs the command and creates PRs

- **Tests** (`update_workflow_test.go`):
  - `TestWorkflowFileStructure` — validates the live workflow file has the YAML structure the code depends on; catches structural regressions at the source
  - `TestFindBranchNode_ExtractsValues` — verifies branch values are correctly extracted from the parsed YAML node
  - `TestSortBranches` — table-driven; covers master-first ordering, semantic version order (not lexicographic), unparseable fallback, and the degenerate two-master case
  - `TestSelectLatestBranch` — table-driven; covers RC branch filtering, highest-version selection, all-unparseable error, and empty-input error
  - `TestAddBranchToWorkflowFile` — exercises the full mutation path (read, parse, append, sort, re-encode, write) on a temp copy of the real workflow file; includes an idempotency case

Epic: None
Release note: None