### PR TITLE
schemachanger: fix EXPLAIN output of storage param operations

### DIFF
--- a/pkg/sql/GEMINI.md
+++ b/pkg/sql/GEMINI.md
@@ -1,0 +1,147 @@
+# SQL Package Development Guide
+
+## Schema Changers: Legacy vs Declarative
+
+CockroachDB has two schema change systems: the legacy schema changer and the newer declarative schema changer. Understanding their differences is crucial for DDL development work.
+
+### Architectural Overview
+
+**Legacy Schema Changer** (`/pkg/sql/schema_changer.go`):
+- **Hard-coded state transitions**: Uses fixed sequences of descriptor mutations stored in the `mutations` slice
+- **Imperative approach**: Logic written procedurally with specific code paths for each DDL operation
+- **Limited state model**: Uses states like `DELETE_ONLY`, `WRITE_ONLY`, `BACKFILL_ONLY` from `DescriptorMutation`
+- **Job type**: Uses `SCHEMA_CHANGE` and `TYPEDESC_SCHEMA_CHANGE` job types
+
+**Declarative Schema Changer** (`/pkg/sql/schemachanger/`):
+- **Element-based modeling**: Schema changes modeled as elements (columns, indexes, constraints) with target statuses
+- **Declarative planning**: Uses rules and dependency graphs to generate execution plans
+- **State stored in descriptors**: Uses `declarative_schema_changer_state` field instead of `mutations` slice
+- **Job type**: Uses `NEW_SCHEMA_CHANGE` job type
+
+### State Management Differences
+
+**Legacy Schema Changer:**
+```go
+// Uses DescriptorMutation in mutations slice
+type DescriptorMutation struct {
+    State     DescriptorMutation_State  // DELETE_ONLY, WRITE_ONLY, etc.
+    Direction DescriptorMutation_Direction // ADD, DROP
+    // ... specific column/index descriptors
+}
+```
+
+**Declarative Schema Changer:**
+```proto
+// Uses element model with target statuses
+message Target {
+    ElementProto element_proto = 1;
+    Status target_status = 3;  // PUBLIC, ABSENT, TRANSIENT_ABSENT
+}
+```
+
+### Element Model (Declarative)
+
+Elements are defined in `/pkg/sql/schemachanger/scpb/elements.proto`:
+- **Table-level**: `Table`, `TableComment`, `TableData`
+- **Column elements**: `Column`, `ColumnName`, `ColumnType`, `ColumnDefaultExpression`
+- **Index elements**: `PrimaryIndex`, `SecondaryIndex`, `IndexColumn`
+- **Constraint elements**: `CheckConstraint`, `ForeignKeyConstraint`
+
+Status transitions: `ABSENT` -> `DELETE_ONLY` -> `WRITE_ONLY` -> `BACKFILL_ONLY` -> `VALIDATED` -> `PUBLIC`
+
+### Planning and Execution
+
+**Legacy Schema Changer:**
+- Planning and execution tightly coupled
+- Each DDL statement has custom imperative logic
+- State transitions are hard-coded sequences
+- Difficult to handle complex multi-statement transactions
+
+**Declarative Schema Changer:**
+- Clear separation between planning and execution phases
+- Uses dependency graphs and rules (`/pkg/sql/schemachanger/scplan/internal/rules/`)
+- Can handle complex multi-statement transactions declaratively
+- Better composition of multiple DDL operations
+
+### Error Handling and Rollback
+
+**Legacy Schema Changer:**
+- Known rollback issues, especially with data loss during failed multi-operation schema changes
+- Example: dropping columns alongside adding indexes can permanently lose data on rollback
+
+**Declarative Schema Changer:**
+- Designed for correct rollbacks by reversing target statuses
+- Uses `OnFailOrCancel` method to revert by flipping directions (ADD becomes DROP)
+- Better handling of complex failure scenarios
+
+### Configuration
+
+Enable declarative schema changer via:
+```sql
+-- Session level
+SET use_declarative_schema_changer = 'on';  -- Options: 'off', 'on', 'unsafe', 'unsafe_always'
+
+-- Cluster-wide default
+SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'on';
+```
+
+### Development Patterns
+
+**Adding New DDL Operations:**
+
+*Legacy Schema Changer:*
+- Add case statements in main schema changer loop
+- Implement specific state transition logic
+- Hard-code mutation sequences
+
+*Declarative Schema Changer:*
+- Define new elements in `elements.proto`
+- Add rules for state transitions in `scplan/internal/rules/`
+- Implement operations in `scop/` and execution in `scexec/`
+- More modular and composable approach
+
+### Code Organization
+
+**Legacy Schema Changer:**
+- `/pkg/sql/schema_changer.go` - Main implementation
+- `/pkg/sql/schema_changer_state.go` - State management
+- `/pkg/sql/type_change.go` - Type changes
+
+**Declarative Schema Changer:**
+- `scpb/` - Protocol buffer definitions for elements and state
+- `scbuild/` - Building targets from DDL ASTs
+- `scplan/` - Planning state transitions and dependencies
+- `scexec/` - Executing operations
+- `scop/` - Operation definitions
+- `screl/` - Relational model for elements
+
+### When to Use Each
+
+**Legacy Schema Changer:**
+- Still required for some DDL operations not yet implemented in declarative changer
+- May be faster for simple, single-operation schema changes
+- More predictable performance due to hard-coded paths
+
+**Declarative Schema Changer:**
+- Better for complex multi-statement transactions
+- More overhead in planning phase but better execution for complex scenarios
+- Required for future transactional schema changes
+- Better correctness guarantees and rollback handling
+
+### Migration Path
+
+CockroachDB is gradually migrating from legacy to declarative:
+1. **Coexistence period**: Both schema changers run simultaneously
+2. **Feature-by-feature migration**: DDL operations migrated individually
+3. **Version compatibility**: Old jobs must continue during upgrades
+4. **Extensive testing**: Test coverage in `schemachanger_test.go` and related files
+
+### Key Benefits of Declarative Approach
+
+1. **Correctness**: Better handling of complex scenarios and rollbacks
+2. **Extensibility**: Easier to add new DDL operations
+3. **Composability**: Can handle multiple DDL operations in single transaction
+4. **Testing**: Better separation of concerns allows more targeted testing
+5. **Future-ready**: Foundation for transactional schema changes
+
+The declarative schema changer represents a significant architectural improvement addressing fundamental limitations of the legacy approach, particularly around correctness, extensibility, and complex transaction handling.

--- a/pkg/sql/schemachanger/scexec/scmutationexec/table.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/table.go
@@ -35,23 +35,23 @@ func (i *immediateVisitor) SetTableSchemaLocked(
 func (i *immediateVisitor) SetTableStorageParam(
 	ctx context.Context, op scop.SetTableStorageParam,
 ) error {
-	tbl, err := i.checkOutTable(ctx, op.TableID)
+	tbl, err := i.checkOutTable(ctx, op.Param.TableID)
 	if err != nil {
 		return err
 	}
 	setter := tablestorageparam.NewSetter(tbl, false /* isNewObject */)
-	return setter.SetToStringValue(ctx, op.Name, op.Value)
+	return setter.SetToStringValue(ctx, op.Param.Name, op.Param.Value)
 }
 
 func (i *immediateVisitor) ResetTableStorageParam(
 	ctx context.Context, op scop.ResetTableStorageParam,
 ) error {
-	tbl, err := i.checkOutTable(ctx, op.TableID)
+	tbl, err := i.checkOutTable(ctx, op.Param.TableID)
 	if err != nil {
 		return err
 	}
 	setter := tablestorageparam.NewSetter(tbl, false /* isNewObject */)
-	return setter.ResetToZeroValue(ctx, op.Name)
+	return setter.ResetToZeroValue(ctx, op.Param.Name)
 }
 
 func (d *deferredVisitor) UpdateTTLScheduleMetadata(

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1263,11 +1263,11 @@ type SetTableSchemaLocked struct {
 // SetTableStorageParam sets a storage parameter on a table.
 type SetTableStorageParam struct {
 	immediateMutationOp
-	scpb.TableStorageParam
+	Param scpb.TableStorageParam
 }
 
 // ResetTableStorageParam resets a storage parameter on a table to its default.
 type ResetTableStorageParam struct {
 	immediateMutationOp
-	scpb.TableStorageParam
+	Param scpb.TableStorageParam
 }

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -970,7 +970,7 @@ message TableSchemaLocked {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
 }
 
-// TableStorageParam models storage parameter `schema_locked` of a table.
+// TableStorageParam models the storage parameters of a table other than `schema_locked` and RowLevelTTL-related ones.
 message TableStorageParam {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   string name = 2;

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table_storage_params.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table_storage_params.go
@@ -18,7 +18,7 @@ func init() {
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.TableStorageParam) *scop.SetTableStorageParam {
 					return &scop.SetTableStorageParam{
-						TableStorageParam: *protoutil.Clone(this).(*scpb.TableStorageParam),
+						Param: *protoutil.Clone(this).(*scpb.TableStorageParam),
 					}
 				}),
 			),
@@ -28,7 +28,7 @@ func init() {
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.TableStorageParam) *scop.ResetTableStorageParam {
 					return &scop.ResetTableStorageParam{
-						TableStorageParam: *protoutil.Clone(this).(*scpb.TableStorageParam),
+						Param: *protoutil.Clone(this).(*scpb.TableStorageParam),
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
@@ -10,7 +10,10 @@ StatementPhase stage 1 of 1 with 1 MutationType op
     [[TableStorageParam:{DescID: 104, Name: exclude_data_from_backup, Value: true}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 104
+        Value: "true"
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[TableStorageParam:{DescID: 104, Name: exclude_data_from_backup, Value: true}, PUBLIC], PUBLIC] -> ABSENT
@@ -22,7 +25,10 @@ PreCommitPhase stage 2 of 2 with 1 MutationType op
     [[TableStorageParam:{DescID: 104, Name: exclude_data_from_backup, Value: true}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 104
+        Value: "true"
 
 ops
 ALTER TABLE defaultdb.foo SET (sql_stats_histogram_buckets_count = 64)
@@ -32,7 +38,10 @@ StatementPhase stage 1 of 1 with 1 MutationType op
     [[TableStorageParam:{DescID: 104, Name: sql_stats_histogram_buckets_count, Value: 64}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: sql_stats_histogram_buckets_count
+        TableID: 104
+        Value: "64"
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[TableStorageParam:{DescID: 104, Name: sql_stats_histogram_buckets_count, Value: 64}, PUBLIC], PUBLIC] -> ABSENT
@@ -44,7 +53,10 @@ PreCommitPhase stage 2 of 2 with 1 MutationType op
     [[TableStorageParam:{DescID: 104, Name: sql_stats_histogram_buckets_count, Value: 64}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: sql_stats_histogram_buckets_count
+        TableID: 104
+        Value: "64"
 
 ops
 ALTER TABLE defaultdb.foo SET (exclude_data_from_backup = true, sql_stats_histogram_buckets_count = 64)
@@ -55,9 +67,15 @@ StatementPhase stage 1 of 1 with 2 MutationType ops
     [[TableStorageParam:{DescID: 104, Name: sql_stats_histogram_buckets_count, Value: 64}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 104
+        Value: "true"
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: sql_stats_histogram_buckets_count
+        TableID: 104
+        Value: "64"
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[TableStorageParam:{DescID: 104, Name: exclude_data_from_backup, Value: true}, PUBLIC], PUBLIC] -> ABSENT
@@ -71,9 +89,15 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
     [[TableStorageParam:{DescID: 104, Name: sql_stats_histogram_buckets_count, Value: 64}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 104
+        Value: "true"
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: sql_stats_histogram_buckets_count
+        TableID: 104
+        Value: "64"
 
 setup
 CREATE TABLE defaultdb.bar (x INT PRIMARY KEY) WITH (exclude_data_from_backup = true);
@@ -88,9 +112,15 @@ StatementPhase stage 1 of 1 with 2 MutationType ops
     [[TableStorageParam:{DescID: 105, Name: exclude_data_from_backup, Value: false}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 105
+        Value: "true"
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 105
+        Value: "false"
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[TableStorageParam:{DescID: 105, Name: exclude_data_from_backup, Value: true}, ABSENT], ABSENT] -> PUBLIC
@@ -104,9 +134,15 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
     [[TableStorageParam:{DescID: 105, Name: exclude_data_from_backup, Value: false}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 105
+        Value: "true"
     *scop.SetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 105
+        Value: "false"
 
 ops
 ALTER TABLE defaultdb.bar RESET (exclude_data_from_backup)
@@ -116,7 +152,10 @@ StatementPhase stage 1 of 1 with 1 MutationType op
     [[TableStorageParam:{DescID: 105, Name: exclude_data_from_backup, Value: true}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 105
+        Value: "true"
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[TableStorageParam:{DescID: 105, Name: exclude_data_from_backup, Value: true}, ABSENT], ABSENT] -> PUBLIC
@@ -128,7 +167,10 @@ PreCommitPhase stage 2 of 2 with 1 MutationType op
     [[TableStorageParam:{DescID: 105, Name: exclude_data_from_backup, Value: true}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 105
+        Value: "true"
 
 setup
 CREATE TABLE defaultdb.baz (y INT PRIMARY KEY) WITH (exclude_data_from_backup = true, sql_stats_histogram_buckets_count = 100);
@@ -143,9 +185,15 @@ StatementPhase stage 1 of 1 with 2 MutationType ops
     [[TableStorageParam:{DescID: 106, Name: sql_stats_histogram_buckets_count, Value: 100}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 106
+        Value: "true"
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: sql_stats_histogram_buckets_count
+        TableID: 106
+        Value: "100"
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[TableStorageParam:{DescID: 106, Name: exclude_data_from_backup, Value: true}, ABSENT], ABSENT] -> PUBLIC
@@ -159,6 +207,12 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
     [[TableStorageParam:{DescID: 106, Name: sql_stats_histogram_buckets_count, Value: 100}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: exclude_data_from_backup
+        TableID: 106
+        Value: "true"
     *scop.ResetTableStorageParam
-      {}
+      Param:
+        Name: sql_stats_histogram_buckets_count
+        TableID: 106
+        Value: "100"

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_storage_param/alter_table_set_storage_param.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_storage_param/alter_table_set_storage_param.explain
@@ -15,8 +15,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› SET ('ex
  │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
  │         └── 3 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
- │              ├── SetTableStorageParam
- │              └── SetTableStorageParam
+ │              ├── SetTableStorageParam {"Param":{"Name":"exclude_data_fro...","TableID":104,"Value":"true"}}
+ │              └── SetTableStorageParam {"Param":{"Name":"sql_stats_histog...","TableID":104,"Value":"64"}}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
@@ -34,8 +34,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› SET ('ex
  │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
  │         └── 5 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
- │              ├── SetTableStorageParam
- │              ├── SetTableStorageParam
+ │              ├── SetTableStorageParam {"Param":{"Name":"exclude_data_fro...","TableID":104,"Value":"true"}}
+ │              ├── SetTableStorageParam {"Param":{"Name":"sql_stats_histog...","TableID":104,"Value":"64"}}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: Updatin..."}
  └── PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_storage_param/alter_table_set_storage_param__rollback_1_of_1.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_set_storage_param/alter_table_set_storage_param__rollback_1_of_1.explain
@@ -13,8 +13,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t SET ('exclude
       │    │    ├── PUBLIC → ABSENT TableStorageParam:{DescID: 104 (t), Name: "exclude_data_from_backup", Value: "true"}
       │    │    └── PUBLIC → ABSENT TableStorageParam:{DescID: 104 (t), Name: "sql_stats_histogram_buckets_count", Value: "64"}
       │    └── 4 Mutation operations
-      │         ├── ResetTableStorageParam
-      │         ├── ResetTableStorageParam
+      │         ├── ResetTableStorageParam {"Param":{"Name":"exclude_data_fro...","TableID":104,"Value":"true"}}
+      │         ├── ResetTableStorageParam {"Param":{"Name":"sql_stats_histog...","TableID":104,"Value":"64"}}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"Pending: Updatin..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase


### PR DESCRIPTION
Since the protobuf was embedded into the scop for mutating storage parameters, it was not being rendered properly in EXPLAIN output. Fix it by making an explicit field instead.

informs #155990
Release note: None