### PR TITLE
mmaprototype: fix isConstraintSatisfied

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
@@ -668,14 +668,14 @@ lease-preference +region=a -zone=a1
 # - Only prohibiting constraints.
 # - Common configurations not already included such as REGION survival.
 
-# Regression test for a bug where isConstraintSatisfied should only count
-# voters for voter constraints.
+# Test: Voter constraint assignment prioritizes voters over non-voters.
 #
 # In analyzedConstraints.initialize, isConstraintSatisfied determines if a
 # constraint is satisfied before moving to the next one. Stores satisfying
 # multiple constraints are deferred, then assigned to the first under-satisfied
-# constraint. The bug: isConstraintSatisfied counts voters + non-voters, but
-# for voter constraints only voters should count.
+# constraint. For voter constraints, non-voters that satisfy only one constraint
+# are also deferred to phase 2 (see isVoterConstraints parameter) so that voters
+# get first chance to satisfy constraints.
 #
 # Setup:
 #   - voter constraint: [+region=a]:2, [+zone=b1]:1
@@ -740,10 +740,7 @@ leaseholder pref-index s10:0
 lease pref-indices: s10:0 s12:0 s13:0
 diversity: voter 0.888889, all 0.777778
 
-# Test: Non-voter spreading for all-replica constraints.
-#
-# This verifies that the fix for voter constraints (only count voters) does NOT
-# break the spreading behavior for all-replica constraints (should count both).
+# Test: Non-voter spreading of non-voters on voter constraints.
 #
 # Setup:
 #   - All-replica constraints: [+region=a]:1, [+zone=b1]:1, [+region=b]:1
@@ -785,10 +782,10 @@ non-voters: 20(=a,=b1,=20) 21(=a,=b1,=21)
 voter-constraints:
   +region=a:1
     voters:
-    non-voters: 20 21
+    non-voters: 20
   +zone=b1:1
     voters:
-    non-voters:
+    non-voters: 21
   +region=b:1
     voters: 22
     non-voters:

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
@@ -728,10 +728,10 @@ constraints:
     non-voters:
 voter-constraints:
   +region=a:2
-    voters: 10
+    voters: 10 12
     non-voters: 11
   +zone=b1:1
-    voters: 12
+    voters:
     non-voters:
   satisfied-no-contraint:
     voters: 13

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
@@ -667,3 +667,75 @@ lease-preference +region=a -zone=a1
 #   constraints and voter constraints.
 # - Only prohibiting constraints.
 # - Common configurations not already included such as REGION survival.
+
+# Regression test for a bug where isConstraintSatisfied should only count
+# voters for voter constraints.
+#
+# In analyzedConstraints.initialize, isConstraintSatisfied determines if a
+# constraint is satisfied before moving to the next one. Stores satisfying
+# multiple constraints are deferred, then assigned to the first under-satisfied
+# constraint. The bug: isConstraintSatisfied counts voters + non-voters, but
+# for voter constraints only voters should count.
+#
+# Setup:
+#   - voter constraint: [+region=a]:2, [+zone=b1]:1
+#   - s10 (voter, a/a1): satisfies [+region=a]:2 only -> assigned 
+#   - s11 (non-voter, a/a1): satisfies [+region=a]:2 only -> assigned to zone=b1
+#   - s12 (voter, a/b1): satisfies both -> should be assigned to [+region=a]:2
+#   but is assigned to [+zone=b1]:1
+#   - s13 (voter, b): satisfies neither
+# Buggy output: [+region=a]:2 gets only 1 voter (s10), [+zone=b1]:1 gets s12.
+# Correct output: [+region=a]:2 gets 2 voters (s10, s12), [+zone=b1]:1 empty
+# since it should prioritize fully satisfying a constraint before the next one.
+store
+  store-id=10 locality-tiers=region=a,zone=a1 node-id=10
+  store-id=11 locality-tiers=region=a,zone=a1 node-id=11
+  store-id=12 locality-tiers=region=a,zone=b1 node-id=12
+  store-id=13 locality-tiers=region=b node-id=13
+----
+
+span-config name=voter-constraint-bug num-replicas=4 num-voters=3
+voter-constraint num-replicas=2 +region=a
+voter-constraint num-replicas=1 +zone=b1
+----
+ num-replicas=4 num-voters=3
+ constraints:
+   +zone=b1:1
+   +region=a:2
+   :1
+ voter-constraints:
+   +region=a:2
+   +zone=b1:1
+
+analyze-constraints config-name=voter-constraint-bug leaseholder=10
+store-id=10 type=VOTER_FULL
+store-id=11 type=NON_VOTER
+store-id=12 type=VOTER_FULL
+store-id=13 type=VOTER_FULL
+----
+needed: voters 3 non-voters 1
+voters: 10(=a,=a1,=10) 12(=a,=b1,=12) 13(=b,=13)
+non-voters: 11(=a,=a1,=11)
+constraints:
+  +zone=b1:1
+    voters: 12
+    non-voters:
+  +region=a:2
+    voters: 10
+    non-voters: 11
+  :1
+    voters: 13
+    non-voters:
+voter-constraints:
+  +region=a:2
+    voters: 10
+    non-voters: 11
+  +zone=b1:1
+    voters: 12
+    non-voters:
+  satisfied-no-contraint:
+    voters: 13
+    voters:
+leaseholder pref-index s10:0
+lease pref-indices: s10:0 s12:0 s13:0
+diversity: voter 0.888889, all 0.777778

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/range_analyzed_constraints
@@ -739,3 +739,59 @@ voter-constraints:
 leaseholder pref-index s10:0
 lease pref-indices: s10:0 s12:0 s13:0
 diversity: voter 0.888889, all 0.777778
+
+# Test: Non-voter spreading for all-replica constraints.
+#
+# This verifies that the fix for voter constraints (only count voters) does NOT
+# break the spreading behavior for all-replica constraints (should count both).
+#
+# Setup:
+#   - All-replica constraints: [+region=a]:1, [+zone=b1]:1, [+region=b]:1
+#   - s20 (non-voter, a/b1): satisfies both [+region=a] and [+zone=b1]
+#   - s21 (non-voter, a/b1): satisfies both [+region=a] and [+zone=b1]
+#   - s22 (voter, b): satisfies [+region=b] only
+#
+# Expected: Non-voters should spread out:
+#   - [+region=a]:1 gets s20
+#   - [+zone=b1]:1 gets s21 
+#   - [+region=b]:1 gets s22
+# NOT: both non-voters on [+region=a], leaving [+zone=b1] empty.
+
+store 
+  store-id=20 locality-tiers=region=a,zone=b1 node-id=20
+  store-id=21 locality-tiers=region=a,zone=b1 node-id=21
+  store-id=22 locality-tiers=region=b node-id=22
+----
+
+span-config name=non-voter-spreading num-replicas=3 num-voters=3
+voter-constraint num-replicas=1 +region=a
+voter-constraint num-replicas=1 +zone=b1
+voter-constraint num-replicas=1 +region=b
+----
+ num-replicas=3 num-voters=3
+ voter-constraints:
+   +region=a:1
+   +zone=b1:1
+   +region=b:1
+
+analyze-constraints config-name=non-voter-spreading leaseholder=22
+store-id=20 type=NON_VOTER
+store-id=21 type=NON_VOTER
+store-id=22 type=VOTER_FULL
+----
+needed: voters 3 non-voters 0
+voters: 22(=b,=22)
+non-voters: 20(=a,=b1,=20) 21(=a,=b1,=21)
+voter-constraints:
+  +region=a:1
+    voters:
+    non-voters: 20 21
+  +zone=b1:1
+    voters:
+    non-voters:
+  +region=b:1
+    voters: 22
+    non-voters:
+leaseholder pref-index s22:0
+lease pref-indices: s22:0
+diversity: voter 1.000000, all 0.777778


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: add test case for isConstraintSatisfied**

This commit adds a test case for isConstraintSatisfied to show that it produces
unintended results with voter constraints, as it counts both voters and
non-voters when evaluating constraint satisfaction.

---
**mmaprototype: fix isConstraintSatisfied**

Previously, we were incorrectly including both voterIndex and nonVoterIndex in
satisfiedByReplica for voter constraints's isConstraintSatisfied. This commit
fixes isConstraintSatisfied by updating it to check only voters when evaluating
voter constraints.

---
**mmaprototype: add test case for over-assigning nonvoters**

This commit adds a test case for range analyzed constraint to
illustrate the reason why isConstraintSatisfied needs to
include both voter and nonvoter for voter constraints.

---
**mmaprototype: fix voter constraint check**

finishInit currently prioritizes assigning stores that satisfy only one
constraint as an optimization. However, this can be suboptimal when the replica
is a non-voter, and we are satisfying voter constraints; in that case, we should
delay assigning the non-voter to give voters a chance to satisfy the constraint
first, even if those voters match multiple constraints.

