### PR TITLE
backup: re-enable drpc randomly in backup tests

### DIFF
--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -41,15 +41,15 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "multinode clusters are slow under race")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
 	var params base.TestClusterArgs
-	params.ServerArgs.DefaultDRPCOption = base.TestDRPCDisabled
 
 	tc, _, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(t,
 		backuptestutils.MultiNode, backuptestutils.WithParams(params))
 	defer cleanupFn()
 
-	ctx := context.Background()
 	execCfg := tc.Server(0).ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
 
 	externalStorageFromURI := execCfg.DistSQLSrv.ExternalStorageFromURI

--- a/pkg/backup/main_test.go
+++ b/pkg/backup/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -23,7 +24,8 @@ func TestMain(m *testing.M) {
 	start := timeutil.Now()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	exit := m.Run()
 	testcluster.PrintTimings(timeutil.Since(start))


### PR DESCRIPTION
Some failing backup tests were disabled earlier due to the drpc metadata issue described here - #157188. 
This PR re-enables all the failing tests, since the metadata issue is now fixed.

Epic: CRDB-48935
Fixes: #157206
Release note: None