### PR TITLE
server, drpc: enable new REST-RPC bridge

### DIFF
--- a/pkg/rpc/rpcbase/nodedialer.go
+++ b/pkg/rpc/rpcbase/nodedialer.go
@@ -29,7 +29,7 @@ var ExperimentalDRPCEnabled = settings.RegisterBoolSetting(
 
 // TODODRPC is a marker to identify sites that needs to be updated to support
 // DRPC.
-const TODODRPC = false
+const TODODRPC = true
 
 // NodeDialer interface defines methods for dialing peer nodes using their
 // node IDs.

--- a/pkg/server/application_api/config_test.go
+++ b/pkg/server/application_api/config_test.go
@@ -66,9 +66,7 @@ func TestAdminAPISettings(t *testing.T) {
 		"view_activity_user":          {userName: "view_activity_user", redactableSettings: true, grantRole: "SYSTEM VIEWACTIVITY", consoleOnly: true},
 		"view_activity_redacted_user": {userName: "view_activity_redacted_user", redactableSettings: true, grantRole: "SYSTEM VIEWACTIVITYREDACTED", consoleOnly: true},
 	}
-	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultDRPCOption: base.TestDRPCDisabled,
-	})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer ts.Stopper().Stop(ctx)
 	forSystemTenant := ts.ApplicationLayer().Codec().ForSystemTenant()
 	conn := sqlutils.MakeSQLRunner(ts.ApplicationLayer().SQLConn(t))

--- a/pkg/server/application_api/main_test.go
+++ b/pkg/server/application_api/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -20,7 +21,8 @@ import (
 
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestServerFactory(server.TestServerFactory,
+		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	rangetestutils.InitRangeTestServerFactory(server.TestServerFactory)
 	kvtenant.InitTestConnectorFactory()

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -1643,9 +1643,7 @@ func TestDrainSqlStats_partialOutage(t *testing.T) {
 func TestDrainSqlStatsPermissionDenied(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultDRPCOption: base.TestDRPCDisabled,
-	})
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	ctx := context.Background()
 	nonRootUser := apiconstants.TestingUserNameNoAdmin()
 	sqlutils.MakeSQLRunner(ts.SQLConn(t)).Exec(t, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", nonRootUser))

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -581,7 +581,6 @@ func TestStatusUpdateTableMetadataCache(t *testing.T) {
 	ctx := context.Background()
 	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: &jobs.TestingKnobs{
 					IntervalOverrides: jobs.TestingIntervalOverrides{


### PR DESCRIPTION
This fix enables the new REST-RPC bridge (`apiInternalServer`) that would serve the `status`, `admin` and `ts` http endpoints for both grpc and drpc.
**Note**: Existing tests that test these internal endpoints will be modified to enable drpc as part of a follow-up exercise.

Epic: [CRDB-48924](https://cockroachlabs.atlassian.net/browse/CRDB-48924)
Fixes: https://github.com/cockroachdb/cockroach/issues/151398
Release note: None