### PR TITLE
cli: add CLI flag to enable DRPC for init and node commands

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -475,9 +475,6 @@ type Config struct {
 	// RPCHearbeatTimeout is the timeout for Ping requests.
 	RPCHeartbeatTimeout time.Duration
 
-	// UseDRPC indicates whether to use DRPC as the RPC framework instead of gRPC.
-	UseDRPC bool
-
 	// ApplicationInternalRPCPortMin/PortMax define the range of TCP ports
 	// used to start the internal RPC service for application-level
 	// servers. This service is used for node-to-node RPC traffic and to

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1498,11 +1498,15 @@ func init() {
 		"maximum number of concurrent compactions")
 
 	f = debugRecoverCollectInfoCmd.Flags()
+	cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.VarP(&debugRecoverCollectInfoOpts.Stores, cliflags.RecoverStore.Name, cliflags.RecoverStore.Shorthand, cliflags.RecoverStore.Usage())
 	f.IntVarP(&debugRecoverCollectInfoOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
 		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 
 	f = debugRecoverPlanCmd.Flags()
+	cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.StringVarP(&debugRecoverPlanOpts.outputFileName, "plan", "o", "",
 		"filename to write plan to")
 	f.IntSliceVar(&debugRecoverPlanOpts.deadStoreIDs, "dead-store-ids", nil,
@@ -1520,6 +1524,8 @@ func init() {
 		formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Usage())
 
 	f = debugRecoverExecuteCmd.Flags()
+	cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.VarP(&debugRecoverExecuteOpts.Stores, cliflags.RecoverStore.Name, cliflags.RecoverStore.Shorthand, cliflags.RecoverStore.Usage())
 	f.VarP(&debugRecoverExecuteOpts.confirmAction, cliflags.ConfirmActions.Name, cliflags.ConfirmActions.Shorthand,
 		cliflags.ConfirmActions.Usage())
@@ -1531,6 +1537,8 @@ func init() {
 		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 
 	f = debugRecoverVerifyCmd.Flags()
+	cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.IntVarP(&debugRecoverVerifyOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
 		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1638,12 +1638,18 @@ func init() {
 	f.StringVar(&debugTimeSeriesDumpOpts.metricsListFile, "metrics-list-file", "", "text file containing metric names or regex patterns to dump (one per line). Prefixes cr.node., cr.store., and cockroachdb. are automatically stripped if present. When specified, only matching metrics are dumped instead of all metrics.")
 
 	f = debugSendKVBatchCmd.Flags()
+	cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,
 		"which format to use for the trace output (off, text, jaeger)")
 	f.BoolVar(&debugSendKVBatchContext.keepCollectedSpans, "keep-collected-spans", debugSendKVBatchContext.keepCollectedSpans,
 		"whether to keep the CollectedSpans field on the response, to learn about how traces work")
 	f.StringVar(&debugSendKVBatchContext.traceFile, "trace-output", debugSendKVBatchContext.traceFile,
 		"the output file to use for the trace. If left empty, output to stderr.")
+
+	f = debugResetQuorumCmd.Flags()
+	cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+	_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 }
 
 func initPebbleCmds(cmd *cobra.Command, pebbleTool *tool.T) {

--- a/pkg/cli/debug_list_files.go
+++ b/pkg/cli/debug_list_files.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlexec"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -39,6 +40,10 @@ func runDebugListFiles(cmd *cobra.Command, _ []string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	// Connect to the node pointed to in the command line.
 	conn, finish, err := newClientConn(ctx, serverCfg)

--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -308,6 +309,10 @@ func runDebugDeadReplicaCollect(cmd *cobra.Command, args []string) error {
 	var stats loqrecovery.CollectionStats
 
 	if len(debugRecoverCollectInfoOpts.Stores.Specs) == 0 {
+		// Enable DRPC for inter-node communication if needed.
+		// By default it is off.
+		rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
+
 		c, finish, err := dialAdminClient(ctx, serverCfg)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get admin connection to cluster")
@@ -427,6 +432,10 @@ func runDebugPlanReplicaRemoval(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		// If no replica info is provided, try to connect to a cluster default or
 		// explicitly provided to retrieve replica info.
+		// Enable DRPC for inter-node communication if needed.
+		// By default it is off.
+		rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
+
 		c, finish, err := dialAdminClient(ctx, serverCfg)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get admin connection to cluster")
@@ -677,6 +686,10 @@ func stageRecoveryOntoCluster(
 	ignoreInternalVersion bool,
 	maxConcurrency int,
 ) error {
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
+
 	c, finish, err := dialAdminClient(ctx, serverCfg)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get admin connection to cluster")
@@ -952,6 +965,10 @@ func runDebugVerify(cmd *cobra.Command, args []string) error {
 	if len(updatePlan.Updates) > 0 {
 		_, _ = fmt.Printf("Checking application of recovery plan %s\n", updatePlan.PlanID)
 	}
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	c, finish, err := dialAdminClient(ctx, serverCfg)
 	if err != nil {

--- a/pkg/cli/debug_reset_quorum.go
+++ b/pkg/cli/debug_reset_quorum.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/spf13/cobra"
 )
@@ -38,6 +39,10 @@ Instead, these replicas will be removed irrevocably.
 func runDebugResetQuorum(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	rangeID, err := strconv.ParseInt(args[0], 10, 32)
 	if err != nil {

--- a/pkg/cli/debug_send_kv_batch.go
+++ b/pkg/cli/debug_send_kv_batch.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -166,6 +167,11 @@ func runSendKVBatch(cmd *cobra.Command, args []string) error {
 	// Send BatchRequest.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
+
 	admin, finish, err := dialAdminClient(ctx, serverCfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to the node")

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -626,6 +626,8 @@ func init() {
 		f := initCmd.Flags()
 		cliflagcfg.BoolFlag(f, &initCmdOptions.virtualized, cliflags.Virtualized)
 		cliflagcfg.BoolFlag(f, &initCmdOptions.virtualizedEmpty, cliflags.VirtualizedEmpty)
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 
 	// Multi-tenancy start-sql command flags.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -63,6 +63,7 @@ var goMemLimit int64
 var tenantIDFile string
 var localityFile string
 var encryptionSpecs encryptionSpecList
+var useDRPC bool
 
 // initPreFlagsDefaults initializes the values of the global variables
 // defined above.
@@ -96,6 +97,8 @@ func initPreFlagsDefaults() {
 
 	tenantIDFile = ""
 	localityFile = ""
+
+	useDRPC = false
 }
 
 // AddPersistentPreRunE add 'fn' as a persistent pre-run function to 'cmd'.
@@ -464,7 +467,7 @@ func init() {
 
 		cliflagcfg.BoolFlag(f, &serverCfg.AcceptProxyProtocolHeaders, cliflags.AcceptProxyProtocolHeaders)
 
-		cliflagcfg.BoolFlag(f, &baseCfg.UseDRPC, cliflags.UseNewRPC)
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
 		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -811,10 +811,13 @@ func init() {
 	cliflagcfg.VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionChecks, cliflags.NodeDecommissionChecks)
 	cliflagcfg.BoolFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionDryRun, cliflags.NodeDecommissionDryRun)
 
-	// Decommission and recommission share --self.
+	// Decommission and recommission share --self and --use-new-rpc.
 	for _, cmd := range []*cobra.Command{decommissionNodeCmd, recommissionNodeCmd} {
 		f := cmd.Flags()
 		cliflagcfg.BoolFlag(f, &nodeCtx.nodeDecommissionSelf, cliflags.NodeDecommissionSelf)
+
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 
 	// node drain command.
@@ -823,6 +826,9 @@ func init() {
 		cliflagcfg.DurationFlag(f, &drainCtx.drainWait, cliflags.DrainWait)
 		cliflagcfg.BoolFlag(f, &drainCtx.nodeDrainSelf, cliflags.NodeDrainSelf)
 		cliflagcfg.BoolFlag(f, &drainCtx.shutdown, cliflags.NodeDrainShutdown)
+
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 
 	// Commands that establish a SQL connection.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -783,6 +783,8 @@ func init() {
 	// Zip command.
 	{
 		f := debugZipCmd.Flags()
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 		cliflagcfg.BoolFlag(f, &zipCtx.redactLogs, cliflags.ZipRedactLogs)
 		_ = f.MarkDeprecated(cliflags.ZipRedactLogs.Name, "use --"+cliflags.ZipRedact.Name+" instead")
 		cliflagcfg.BoolFlag(f, &zipCtx.redact, cliflags.ZipRedact)
@@ -792,6 +794,12 @@ func init() {
 		cliflagcfg.BoolFlag(f, &zipCtx.includeStacks, cliflags.ZipIncludeGoroutineStacks)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRunningJobTraces, cliflags.ZipIncludeRunningJobTraces)
 		cliflagcfg.BoolFlag(f, &zipCtx.validateZipFile, cliflags.ZipValidateFile)
+	}
+	// List-files command
+	{
+		f := debugListFilesCmd.Flags()
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 	// List-files + Zip commands.
 	for _, cmd := range []*cobra.Command{debugZipCmd, debugListFilesCmd} {
@@ -1006,6 +1014,8 @@ func init() {
 	{
 		f := debugGossipValuesCmd.Flags()
 		cliflagcfg.StringFlag(f, &debugCtx.inputFile, cliflags.GossipInputFile)
+		cliflagcfg.BoolFlag(f, &useDRPC, cliflags.UseNewRPC)
+		_ = f.MarkHidden(cliflags.UseNewRPC.Name)
 	}
 	{
 		f := debugBallastCmd.Flags()

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1917,8 +1917,13 @@ func TestUseNewRPC(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if baseCfg.UseDRPC != tc.expectedVal {
-				t.Errorf("expected UseDRPC=%v, but got %v", tc.expectedVal, baseCfg.UseDRPC)
+			require.True(t, f.Lookup(cliflags.UseNewRPC.Name).Hidden)
+
+			useDRPC, err := strconv.ParseBool(f.Lookup(cliflags.UseNewRPC.Name).Value.String())
+			require.NoError(t, err)
+
+			if useDRPC != tc.expectedVal {
+				t.Errorf("expected UseDRPC=%v, but got %v", tc.expectedVal, useDRPC)
 			}
 		})
 	}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1890,6 +1890,8 @@ func TestWALFailoverWrapperRoundtrip(t *testing.T) {
 	})
 }
 
+// TestUseNewRPC verifies that the --use-new-rpc flag is properly configured
+// on all commands that support DRPC for inter-node communication.
 func TestUseNewRPC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1897,33 +1899,71 @@ func TestUseNewRPC(t *testing.T) {
 	// Avoid leaking configuration changes after the test ends.
 	defer initCLIDefaults()
 
+	// List of all commands that should have the --use-new-rpc flag.
+	// These commands were modified to support DRPC for inter-node communication.
+	testCommands := []*cobra.Command{
+		initCmd,       // init
+		genHAProxyCmd, // gen haproxy
+
+		// debug commands
+		debugGossipValuesCmd,
+		debugTimeSeriesDumpCmd,
+		debugZipCmd,
+		debugListFilesCmd,
+		debugSendKVBatchCmd,
+		debugResetQuorumCmd,
+		debugRecoverCollectInfoCmd,
+		debugRecoverPlanCmd,
+		debugRecoverExecuteCmd,
+		debugRecoverVerifyCmd,
+
+		// node commands
+		decommissionNodeCmd,
+		recommissionNodeCmd,
+		drainNodeCmd,
+	}
+
 	testCases := []struct {
+		name        string
 		args        []string
 		expectedVal bool
 	}{
-		{[]string{}, false},                      // Default value
-		{[]string{"--use-new-rpc"}, true},        // Flag enabled
-		{[]string{"--use-new-rpc=true"}, true},   // Flag explicitly enabled
-		{[]string{"--use-new-rpc=false"}, false}, // Flag explicitly disabled
+		{"default", []string{}, false},
+		{"enabled", []string{"--use-new-rpc"}, true},
+		{"explicitly_enabled", []string{"--use-new-rpc=true"}, true},
+		{"explicitly_disabled", []string{"--use-new-rpc=false"}, false},
 	}
 
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%v", tc.args), func(t *testing.T) {
-			// Reset to defaults before each test
-			initCLIDefaults()
+	for _, cmd := range testCommands {
+		cmdName := cmd.Use
+		t.Run(cmdName, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					// Reset to defaults before each test
+					initCLIDefaults()
 
-			f := startCmd.Flags()
-			if err := f.Parse(tc.args); err != nil {
-				t.Fatal(err)
-			}
+					f := cmd.Flags()
+					if err := f.Parse(tc.args); err != nil {
+						t.Fatal(err)
+					}
 
-			require.True(t, f.Lookup(cliflags.UseNewRPC.Name).Hidden)
+					// Verify the flag exists
+					flag := f.Lookup(cliflags.UseNewRPC.Name)
+					if flag == nil {
+						t.Fatalf("command %s is missing --%s flag", cmdName, cliflags.UseNewRPC.Name)
+					}
 
-			useDRPC, err := strconv.ParseBool(f.Lookup(cliflags.UseNewRPC.Name).Value.String())
-			require.NoError(t, err)
+					// Verify the flag is hidden
+					require.True(t, flag.Hidden, "flag --%s should be hidden on command %s", cliflags.UseNewRPC.Name, cmdName)
 
-			if useDRPC != tc.expectedVal {
-				t.Errorf("expected UseDRPC=%v, but got %v", tc.expectedVal, useDRPC)
+					// Verify the flag has the correct value
+					useDRPC, err := strconv.ParseBool(flag.Value.String())
+					require.NoError(t, err)
+
+					if useDRPC != tc.expectedVal {
+						t.Errorf("command %s: expected --%s=%v, but got %v", cmdName, cliflags.UseNewRPC.Name, tc.expectedVal, useDRPC)
+					}
+				})
 			}
 		})
 	}

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -350,6 +350,8 @@ func init() {
 	genHAProxyCmd.PersistentFlags().StringVar(&haProxyPath, "out", "haproxy.cfg",
 		"path to generated haproxy configuration file")
 	cliflagcfg.VarFlag(genHAProxyCmd.Flags(), &haProxyLocality, cliflags.Locality)
+	cliflagcfg.BoolFlag(genHAProxyCmd.Flags(), &useDRPC, cliflags.UseNewRPC)
+	_ = genHAProxyCmd.Flags().MarkHidden(cliflags.UseNewRPC.Name)
 
 	f := genSettingsListCmd.PersistentFlags()
 	f.BoolVar(&includeAllSettings, "all-settings", false,

--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
@@ -210,6 +211,10 @@ func filterByLocality(nodeInfos []haProxyNodeInfo) ([]haProxyNodeInfo, error) {
 func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	configTemplate, err := template.New("haproxy template").Parse(haProxyTemplate)
 	if err != nil {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -45,6 +46,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	// Wait for the node to be ready for initialization.
 	if err := dialAndCheckHealth(ctx); err != nil {

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlexec"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -349,6 +350,10 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	conn, finish, err := newClientConn(ctx, serverCfg)
 	if err != nil {
@@ -832,6 +837,10 @@ func runRecommissionNode(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
+
 	conn, finish, err := newClientConn(ctx, serverCfg)
 	if err != nil {
 		return err
@@ -920,6 +929,10 @@ func runDrain(cmd *cobra.Command, args []string) (err error) {
 	if len(args) > 0 {
 		targetNode = args[0]
 	}
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	// Establish a RPC connection.
 	conn, finish, err := newClientConn(ctx, serverCfg)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -434,6 +435,10 @@ func runStartInternal(
 	// The context will be canceled at the end.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	// Check for stores with full disks and exit with an informative exit
 	// code. This needs to happen early during start, before we perform any

--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
@@ -109,6 +110,10 @@ will then convert it to the --format requested in the current invocation.
 	RunE: clierrorplus.MaybeDecorateError(func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// Enable DRPC for inter-node communication if needed.
+		// By default it is off.
+		rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 		var convertFile string
 		if len(args) > 0 {

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
@@ -224,6 +225,10 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Enable DRPC for inter-node communication if needed.
+	// By default it is off.
+	rpcbase.ExperimentalDRPCEnabled.Override(ctx, &serverCfg.Settings.SV, useDRPC)
 
 	zr := zipCtx.newZipReporter("cluster")
 	// Interpret the deprecated `--redact-logs` the same as the new `--redact` flag.

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -425,9 +425,6 @@ type ContextOptions struct {
 
 	// Locality stores the locality of this node.
 	Locality roachpb.Locality
-
-	// UseDRPC indicates if DRPC must be used for internode communication.
-	UseDRPC bool
 }
 
 // DefaultContextOptions are mostly used in tests.
@@ -461,7 +458,6 @@ func ServerContextOptionsFromBaseConfig(cfg *base.Config) ContextOptions {
 		AdvertiseAddrH:                 &cfg.AdvertiseAddrH,
 		SQLAdvertiseAddrH:              &cfg.SQLAdvertiseAddrH,
 		DisableTLSForHTTP:              cfg.DisableTLSForHTTP,
-		UseDRPC:                        cfg.UseDRPC,
 	}
 }
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -665,6 +665,7 @@ func newInitServerConfig(
 			latestVersion, minSupportedVersion)
 	}
 
+	useDRPC := rpcbase.ExperimentalDRPCEnabled.Get(&cfg.Settings.SV)
 	bootstrapAddresses := cfg.FilterGossipBootstrapAddresses(context.Background())
 	return initServerCfg{
 		advertiseAddr:           cfg.AdvertiseAddr,
@@ -674,7 +675,7 @@ func newInitServerConfig(
 		defaultZoneConfig:       cfg.DefaultZoneConfig,
 		getGRPCDialOpts:         getGRPCDialOpts,
 		getDRPCDialOpts:         getDRPCDialOpts,
-		useDRPC:                 cfg.UseDRPC,
+		useDRPC:                 useDRPC,
 		bootstrapAddresses:      bootstrapAddresses,
 		testingKnobs:            cfg.TestingKnobs,
 	}


### PR DESCRIPTION
DRPC is controlled through a cluster setting and is disabled by default. However, CLI commands such as init and debug run without access to cluster settings. To allow these commands to use DRPC, this change introduces a new `--use-new-rpc` flag. This change adds the flag to the init and node commands.

Fixes: #155593, #155596
Epic: CRDB-55200
Release note: None