### PR TITLE
server: recover from index out of range panic in MuxRangeFeed Send

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -476,6 +476,7 @@ go_test(
         "listen_and_update_addrs_test.go",
         "load_endpoint_test.go",
         "main_test.go",
+        "maybe_recover_panic_test.go",
         "migration_test.go",
         "multi_store_test.go",
         "node_http_router_test.go",

--- a/pkg/server/maybe_recover_panic_test.go
+++ b/pkg/server/maybe_recover_panic_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaybeRecoverPanic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	event := &kvpb.MuxRangeFeedEvent{
+		RangeFeedEvent: kvpb.RangeFeedEvent{
+			Checkpoint: &kvpb.RangeFeedCheckpoint{
+				Span: roachpb.Span{
+					Key:    roachpb.Key("a"),
+					EndKey: roachpb.Key("b"),
+				},
+			},
+		},
+	}
+
+	// Case 1: error already set, function returns early without recovering.
+	// This tests the `if *errp != nil { return }` branch.
+	t.Run("error already set", func(t *testing.T) {
+		existingErr := errors.New("existing error")
+		err := existingErr
+		require.NotPanics(t, func() {
+			defer maybeRecoverPanic(ctx, &err, event)
+			// No panic - just verify the function handles err being set.
+		})
+		require.Equal(t, existingErr, err)
+	})
+
+	// Case 2: no panic occurs, common case.
+	t.Run("no panic", func(t *testing.T) {
+		var err error
+		require.NotPanics(t, func() {
+			defer maybeRecoverPanic(ctx, &err, event)
+			// No panic, just return normally.
+		})
+		require.NoError(t, err)
+	})
+
+	// Case 3: panic with "index out of range" - should recover and set error.
+	t.Run("index out of range panic is recovered", func(t *testing.T) {
+		var err error
+		require.NotPanics(t, func() {
+			defer maybeRecoverPanic(ctx, &err, event)
+			panic("runtime error: index out of range [0] with length 0")
+		})
+		require.Error(t, err)
+		t.Logf("err: %v", err)
+		require.Contains(t, err.Error(), "recovered from panic in lockedMuxStream.Send")
+	})
+
+	// Case 4: panic without "index out of range" - should re-panic.
+	t.Run("other panic is re-raised", func(t *testing.T) {
+		var err error
+		require.Panics(t, func() {
+			defer maybeRecoverPanic(ctx, &err, event)
+			panic("some other panic")
+		})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
We suspect a data race in rangefeed checkpoint marshaling where a RangeFeedEvent containing a RangeFeedCheckpoint can be modified while being marshaled. This causes panics with "index out of range" errors because marshaling computes the size needed first, then creates a buffer, and the buffer ends up too small when the underlying data changes.

This commit adds panic recovery in `lockedMuxStream.Send` to catch these specific panics and convert them to errors instead of crashing. Other panics are still re-raised after logging.

This patch backports with relative ease all the way back to 24.1.

Informs: https://github.com/cockroachdb/cockroach/issues/159166
Informs: https://github.com/cockroachdb/cockroach/issues/157882
Informs: https://github.com/cockroachdb/cockroach/issues/138895
Informs: https://github.com/cockroachdb/cockroach/issues/158166
Informs: https://github.com/cockroachlabs/support/issues/3506

Release note: None