### PR TITLE
workload: reduce import concurrency in large schema benchmark

### DIFF
--- a/pkg/workload/tpcc/tpcc_multi_db.go
+++ b/pkg/workload/tpcc/tpcc_multi_db.go
@@ -98,7 +98,7 @@ var tpccMultiDBMeta = workload.Meta{
 			"password used to authenticate the console API")
 		// Because this workload can create a large number of objects, the import
 		// concurrent may need to be limited.
-		g.flags.Int(workload.ImportDataLoaderConcurrencyFlag, 32, workload.ImportDataLoaderConcurrencyFlagDescription)
+		g.flags.Int(workload.ImportDataLoaderConcurrencyFlag, 16, workload.ImportDataLoaderConcurrencyFlagDescription)
 		return &g
 	},
 }


### PR DESCRIPTION
Reduce the import concurrency in the large schema benchmark to mitigate system overload issues observed recently, particularly in the multi-region variant. Given recent changes to how clusters are initialized to avoid deadlocks, we probably don't need such a high concurrency anyway.

Closes #158947

Release note: None
Epic: None