### PR TITLE
kvserver: rm unused ID in snapWriteBuilder

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -627,8 +627,6 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	}
 
 	sb := snapWriteBuilder{
-		id: r.ID(),
-
 		todoEng:  r.store.TODOEngine(),
 		sl:       r.raftMu.stateLoader,
 		writeSST: writeSST,

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -22,8 +22,6 @@ import (
 //
 // TODO(pav-kv): move this struct to kvstorage package.
 type snapWriteBuilder struct {
-	id roachpb.FullReplicaID
-
 	todoEng  storage.Engine
 	sl       kvstorage.StateLoader
 	writeSST func(context.Context, func(context.Context, storage.Writer) error) error

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -86,7 +86,6 @@ func TestPrepareSnapApply(t *testing.T) {
 	}
 
 	swb := snapWriteBuilder{
-		id:       id,
 		todoEng:  eng,
 		sl:       sl,
 		writeSST: writeSST,
@@ -101,8 +100,7 @@ func TestPrepareSnapApply(t *testing.T) {
 		},
 	}
 
-	err := swb.prepareSnapApply(ctx)
-	require.NoError(t, err)
+	require.NoError(t, swb.prepareSnapApply(ctx))
 
 	// The snapshot construction code is spread across MultiSSTWriter and
 	// snapWriteBuilder. We only test the latter here, but for information also


### PR DESCRIPTION
After #155953, this ID is not used.

Epic: CRDB-55220