### PR TITLE
backup: disable AC in datadriven tests

### DIFF
--- a/pkg/kv/bulk/cpu_pacer.go
+++ b/pkg/kv/bulk/cpu_pacer.go
@@ -25,7 +25,8 @@ var cpuPacerRequestDuration = settings.RegisterDurationSetting(
 	50*time.Millisecond,
 )
 
-var yieldIfNoPacer = settings.RegisterBoolSetting(
+// YieldIfNoPacer is exported so it can be overridden in tests.
+var YieldIfNoPacer = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"bulkio.elastic_cpu_control.always_yield.enabled",
 	"if true, yield the CPU as needed even when time-based elastic pacing is not enabled",
@@ -38,7 +39,7 @@ func NewCPUPacer(ctx context.Context, db *kv.DB, setting *settings.BoolSetting) 
 	if db == nil || db.AdmissionPacerFactory == nil || !setting.Get(db.SettingsValues()) {
 		log.Dev.Infof(ctx, "admission control is not configured to pace bulk ingestion")
 
-		if db != nil && yieldIfNoPacer.Get(db.SettingsValues()) {
+		if db != nil && YieldIfNoPacer.Get(db.SettingsValues()) {
 			// Return a Pacer that just yields.
 			return &admission.Pacer{Yield: true}
 		}

--- a/pkg/util/admission/elastic_cpu_grant_coordinator.go
+++ b/pkg/util/admission/elastic_cpu_grant_coordinator.go
@@ -84,7 +84,8 @@ func (e *ElasticCPUGrantCoordinator) tryGrant() {
 	e.elasticCPUGranter.tryGrant()
 }
 
-var yieldInPacer = settings.RegisterBoolSetting(
+// YieldInPacer is exported so it can be overridden in tests.
+var YieldInPacer = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"admission.elastic_cpu.yield_in_pacer.enabled",
 	"when true, time-based elastic CPU pacing additionally yields CPU as-needed according to the scheduler",
@@ -100,6 +101,6 @@ func (e *ElasticCPUGrantCoordinator) NewPacer(unit time.Duration, wi WorkInfo) *
 		unit:  unit,
 		wi:    wi,
 		wq:    e.ElasticCPUWorkQueue,
-		Yield: yieldInPacer.Get(&e.ElasticCPUWorkQueue.settings.SV),
+		Yield: YieldInPacer.Get(&e.ElasticCPUWorkQueue.settings.SV),
 	}
 }


### PR DESCRIPTION
These tests, via 'new-cluster', run a large number of nodes in a single process, overloading that process and causing bulk work to starve if it is restricted to using strictly spare capacity (of which there is none).

Release note: none.
Epic: none.