### PR TITLE
workload/tpcc: fix N^2 row updates during long-duration reset

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -133,6 +133,8 @@ type tpcc struct {
 	// context group for any background reset table operation to avoid goroutine leaks during long duration workloads
 	resetTableGrp      ctxgroup.Group
 	resetTableCancelFn context.CancelFunc
+	// resetWorkerOnce ensures the reset worker is started only once across all payment workers
+	resetWorkerOnce sync.Once
 
 	asOfSystemTime string
 


### PR DESCRIPTION
## Summary

- Fixed a bug where the TPC-C reset worker goroutine was started once per worker instead of once total
- With 10 workers per warehouse by default, a workload with W warehouses would spawn (10*W) goroutines, each updating all W rows every 24 hours
- This change uses `sync.Once` to ensure only one reset worker is started, reducing the 24-hour reset from (10*W)*W to W row updates
- For a 1,200 warehouse cluster, this reduces the reset from 14,400,000 row updates to 1,200 row updates

## Test plan

- Manual verification on a running cluster using `curl http://localhost:33333/debug/pprof/goroutine?debug=2 | grep -c startResetValueWorker`
  - Before fix: 2400 matches (1200 goroutines × 2 matches per stack)
  - After fix: should show 2 matches (1 goroutine × 2 matches per stack)

Informs: #124259

🤖 Generated with [Claude Code](https://claude.com/claude-code)