### PR TITLE
release-26.1: sql: add query id to recorded statement stats in UDFs / SPs

### DIFF
--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -393,6 +393,7 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 					}
 					stmtStats := statsBuilder.
 						SessionID(g.p.ExtendedEvalContext().SessionID).
+						QueryID(g.p.execCfg.GenerateID()).
 						LatencyRecorder(latencyRecorder).
 						PlanMetadata(
 							flags.IsSet(planFlagGeneric),


### PR DESCRIPTION
Backport 1/1 commits from #159200 on behalf of @kyle-a-wong.

----

Generates a query id for sub statements executed in UDFs and SPs. This is used by the insights system to provide execution specific insights.

Epic: None
Release note: None

----

Release justification: Fixes an insight bug for a feature introduced in 26.1