### PR TITLE
changefeedccl: enable DB-level feeds

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1181,7 +1180,6 @@ func TestAlterChangefeedDatabaseScope(t *testing.T) {
 func TestAlterChangefeedDatabaseLevelChangefeedFilters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	// The cases in this test will either a) create a changefeed with no filter,
 	// and then remove the filter with an ALTER CHANGEFEED, or b) create a
@@ -1274,7 +1272,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedFilters(t *testing.T) {
 func TestAlterChangefeedDatabaseLevelChangefeedDoesntRemoveFilter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1316,7 +1313,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedDoesntRemoveFilter(t *testing.T) 
 func TestAlterChangefeedDatabaseLevelChangefeedRemainsDatabaseLevel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1360,7 +1356,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedRemainsDatabaseLevel(t *testing.T
 func TestAlterChangefeedDatabaseLevelChangefeedDiff(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1399,7 +1394,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedDiff(t *testing.T) {
 func TestAlterChangefeedDatabaseLevelChangefeedFailsOnTargetAlter(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	for _, op := range []string{"ADD", "DROP"} {
 		testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
@@ -1432,7 +1426,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedFailsOnTargetAlter(t *testing.T) 
 func TestAlterChangefeedDatabaseLevelChangefeedMultipleSetClauses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1473,7 +1466,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedMultipleSetClauses(t *testing.T) 
 func TestAlterChangefeedDatabaseLevelChangefeedFilterSemantics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	type alterSpec struct {
 		stmt string
@@ -1691,7 +1683,6 @@ func TestAlterChangefeedDatabaseLevelChangefeedFilterSemantics(t *testing.T) {
 func TestAlterChangefeedFilterChangesDontEmitPreAlterEvents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1749,7 +1740,6 @@ func TestAlterChangefeedFilterChangesDontEmitPreAlterEvents(t *testing.T) {
 func TestAlterChangefeedFilterChangesWriteProgressForTablesThatWillBeAdded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1808,7 +1798,6 @@ func TestAlterChangefeedFilterChangesWriteProgressForTablesThatWillBeAdded(t *te
 func TestAlterChangefeedFilterChangesDontWriteProgressForTablesThatWillBeDropped(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1859,7 +1848,6 @@ func TestAlterChangefeedFilterChangesDontWriteProgressForTablesThatWillBeDropped
 func TestAlterChangefeedFilterChangesDontOverwriteProgress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -1945,7 +1933,6 @@ func TestAlterChangefeedFilterChangesDontOverwriteProgress(t *testing.T) {
 func TestAlterChangefeedDatabaseLevelChangefeedWithInitialScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backupresolver"
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcprogresspb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -189,13 +188,6 @@ func changefeedPlanHook(
 	changefeedStmt := getChangefeedStatement(stmt)
 	if changefeedStmt == nil {
 		return nil, nil, false, nil
-	}
-	if changefeedStmt.Level != tree.ChangefeedLevelTable {
-		return nil, nil, false,
-			errors.UnimplementedError(
-				errors.IssueLink{IssueURL: build.MakeIssueURL(154053)},
-				"database-level changefeed is not implemented yet",
-			)
 	}
 
 	exprEval := p.ExprEvaluator("CREATE CHANGEFEED")

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1147,8 +1147,7 @@ type optOutOfMetamorphicEnrichedEnvelope struct {
 	reason string
 }
 
-// TODO(#154053): Add back metamorphic testing for db-level changefeeds once it's enabled.
-var forceDBLevelChangefeed = false
+var forceDBLevelChangefeed = metamorphic.ConstantWithTestBool("changefeed-force-database-level", false)
 
 type optOutOfMetamorphicDBLevelChangefeed struct {
 	reason string

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -61,7 +60,6 @@ func (d *fakeResumer) CollectProfile(context.Context, interface{}) error {
 func TestShowChangefeedJobsDatabaseLevel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 154053, "unreleased feature")
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)


### PR DESCRIPTION
Previously, DB-level feeds were disabled as they were not ready to be released.

This patch enables DB-level changefeeds. It also enables metamorphic testing for DB-level changefeeds and un-skips DB-level changefeed unit tests.

Resolves: #159300
Epic: CRDB-55919

Release note: None