### PR TITLE
backup: allow backup compactions on revision-history schedules

### DIFF
--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -75,8 +75,6 @@ func maybeStartCompactionJob(
 	switch {
 	case len(triggerJob.ExecutionLocality.Tiers) != 0:
 		return 0, errors.New("execution locality not supported for compaction")
-	case triggerJob.RevisionHistory:
-		return 0, errors.New("revision history not supported for compaction")
 	case triggerJob.ScheduleID == 0:
 		return 0, errors.New("only scheduled backups can be compacted")
 	case len(triggerJob.Destination.IncrementalStorage) != 0:
@@ -634,6 +632,8 @@ func (c compactionChain) createCompactionManifest(
 	cManifest.Descriptors = details.ResolvedTargets
 	cManifest.IntroducedSpans = introducedSpans
 	cManifest.IsCompacted = true
+	// Compacted backups do not store revision-history.
+	cManifest.MVCCFilter = backuppb.MVCCFilter_Latest
 
 	cManifest.Dir = cloudpb.ExternalStorage{}
 	// As this manifest will be used prior to the manifest actually being written

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -594,14 +594,6 @@ func TestBackupCompactionUnsupportedOptions(t *testing.T) {
 			"execution locality not supported for compaction",
 		},
 		{
-			"revision history not supported",
-			jobspb.BackupDetails{
-				ScheduleID:      1,
-				RevisionHistory: true,
-			},
-			"revision history not supported for compaction",
-		},
-		{
 			"scheduled backups only",
 			jobspb.BackupDetails{
 				ScheduleID: 0,
@@ -798,6 +790,7 @@ func TestCheckCompactionManifestFields(t *testing.T) {
 		"StartTime",
 		"IntroducedSpans",
 		"IsCompacted",
+		"MVCCFilter",
 	}
 	emptied := []string{
 		"Dir",
@@ -825,7 +818,6 @@ func TestCheckCompactionManifestFields(t *testing.T) {
 		"Tenants",
 		"LocalityKVs",
 		"PartitionDescriptorFilenames",
-		"MVCCFilter",
 		"RevisionStartTime",
 	}
 
@@ -875,6 +867,7 @@ func TestCheckCompactionManifestFields(t *testing.T) {
 		StatisticsFilenames: statisticsFilenames,
 		DescriptorCoverage:  tree.AllDescriptors,
 		ElidedPrefix:        execinfrapb.ElidePrefix_TenantAndTable,
+		MVCCFilter:          backuppb.MVCCFilter_All,
 		IsCompacted:         false,
 	}
 	lastBackupStruct := structs.New(lastBackup)


### PR DESCRIPTION
This commit allows backup compactions to be run on schedules that create revision-history backups. It also adds a test to verify that the work in #158709 now allows restores to work with revision-history backups that contain compacted backups.

Closes: #158696