### PR TITLE
roachtest: set cluster os

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -692,6 +692,12 @@ func (r *testRunner) allocateOrAttachToCluster(
 		lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s (arch=%q)", t.Name, t.Cluster, arch)
 	}
 
+	var clusterOS string
+	if clustersOpt.typ == localCluster {
+		clusterOS = runtime.GOOS
+	} else {
+		clusterOS = "linux" // Currently only test against linux clusters
+	}
 	cfg := clusterConfig{
 		nameOverride: clustersOpt.clusterName, // only set if we hit errClusterFound above
 		spec:         t.Cluster,
@@ -699,6 +705,7 @@ func (r *testRunner) allocateOrAttachToCluster(
 		username:     clustersOpt.user,
 		localCluster: clustersOpt.typ == localCluster,
 		arch:         arch,
+		os:           clusterOS,
 	}
 	return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus, lopt.tee)
 }


### PR DESCRIPTION
Previously `clusterConfig.os`, which later gets assigned to `clusterImpl.os`, is never set in roachtest. When roachprod `Stage` is called, it checks to see if it's a local cluster and if so use's the runtime OS, otherwise just uses linux.

This change moves that check into roachtest. Currently, both `clusterConfig.os` and `clusterImpl.os` are unused as either `linux` or `darwin` is implied based on whether this cluster is running local or not. This change just tries to make that more clear in roachtest without having to rely on a roachprod default.