### PR TITLE
release-25.2: bincheck: enable debug mode in bincheck script

### DIFF
--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 
 export COCKROACH_INCONSISTENT_TIME_ZONES=true
 


### PR DESCRIPTION
Backport 1/1 commits from #159297 on behalf of @rail.

----

Epic: none
Release note: none
Release justification: release automation change

----

Release justification: