### PR TITLE
release-26.1: schemachanger: support metadata-only TTL parameters and ttl_job_cron

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -768,13 +768,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return err
 			}
 
-			paramIsDelete := t.StorageParams.GetVal("ttl_delete_rate_limit") != nil
-			paramIsSelect := t.StorageParams.GetVal("ttl_select_rate_limit") != nil
-
-			if paramIsDelete || paramIsSelect {
-				printTTLRateLimitNotice(params.ctx, params.p)
-			}
-
 		case *tree.AlterTableResetStorageParams:
 			setter := tablestorageparam.NewSetter(n.tableDesc, false /* isNewObject */)
 			if err := storageparam.Reset(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1431,13 +1431,6 @@ func NewTableDesc(
 		return nil, err
 	}
 
-	paramIsDelete := n.StorageParams.GetVal("ttl_delete_rate_limit") != nil
-	paramIsSelect := n.StorageParams.GetVal("ttl_select_rate_limit") != nil
-
-	if paramIsDelete || paramIsSelect {
-		printTTLRateLimitNotice(ctx, evalCtx.ClientNoticeSender)
-	}
-
 	setter.TableDesc.RowLevelTTL = setter.UpdatedRowLevelTTL
 
 	indexEncodingVersion := descpb.StrictIndexColumnIDGuaranteesVersion

--- a/pkg/sql/descmetadata/BUILD.bazel
+++ b/pkg/sql/descmetadata/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/descmetadata",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
+        "//pkg/scheduledjobs",
         "//pkg/settings",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_storage_param.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_storage_param.go
@@ -27,9 +27,9 @@ import (
 func validateStorageParamKey(t tree.NodeFormatter, key string) {
 	loweredKey := strings.ToLower(key)
 	// These TTL params still require legacy schema changer because they
-	// affect column management, column dependencies, or schedule management.
+	// affect column management or column dependencies.
 	switch loweredKey {
-	case "ttl", "ttl_expire_after", "ttl_expiration_expression", "ttl_job_cron":
+	case "ttl", "ttl_expire_after", "ttl_expiration_expression":
 		panic(scerrors.NotImplementedErrorf(t, redact.Sprintf("%s not implemented yet", redact.SafeString(key))))
 	}
 	if loweredKey == catpb.RBRUsingConstraintTableSettingName {

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -499,6 +499,10 @@ func (w *walkCtx) walkStorageParams(tbl catalog.TableDescriptor) {
 			// schema_locked is handled separately via the TableSchemaLocked element.
 			continue
 		}
+		if strings.HasPrefix(key, "ttl") {
+			// ttl parameters are handled separately via the RowLevelTTL element.
+			continue
+		}
 		w.ev(scpb.Status_PUBLIC, &scpb.TableStorageParam{
 			TableID: tableID,
 			Name:    key,

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1341,6 +1341,14 @@ func (s *TestState) UpdateTTLScheduleLabel(ctx context.Context, tbl catalog.Tabl
 	return nil
 }
 
+// UpdateTTLScheduleCron implements scexec.DescriptorMetadataUpdater
+func (s *TestState) UpdateTTLScheduleCron(
+	ctx context.Context, scheduleID jobspb.ScheduleID, cronExpr string,
+) error {
+	s.LogSideEffectf("update ttl schedule cron #%d to %q", scheduleID, cronExpr)
+	return nil
+}
+
 // DescriptorMetadataUpdater implement scexec.Dependencies.
 func (s *TestState) DescriptorMetadataUpdater(
 	ctx context.Context,

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -386,6 +386,9 @@ type DescriptorMetadataUpdater interface {
 	// UpdateTTLScheduleLabel updates the schedule_name for the TTL Scheduled Job
 	// of the given table.
 	UpdateTTLScheduleLabel(ctx context.Context, tbl catalog.TableDescriptor) error
+
+	// UpdateTTLScheduleCron updates the cron schedule for a TTL job.
+	UpdateTTLScheduleCron(ctx context.Context, scheduleID jobspb.ScheduleID, cronExpr string) error
 }
 
 type TemporarySchemaCreator interface {

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -530,6 +530,12 @@ func (noopMetadataUpdater) UpdateTTLScheduleLabel(
 	return nil
 }
 
+func (u noopMetadataUpdater) UpdateTTLScheduleCron(
+	ctx context.Context, scheduleID jobspb.ScheduleID, cronExpr string,
+) error {
+	return nil
+}
+
 type noopTemporarySchemaCreator struct{}
 
 var _ scexec.TemporarySchemaCreator = noopTemporarySchemaCreator{}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -159,4 +159,7 @@ type DeferredMutationStateUpdater interface {
 
 	// UpdateTTLScheduleMetadata updates the TTL schedule metadata for a table.
 	UpdateTTLScheduleMetadata(ctx context.Context, tableID descpb.ID, newName string) error
+
+	// UpdateTTLScheduleCron updates the cron expression for a TTL schedule.
+	UpdateTTLScheduleCron(ctx context.Context, scheduleID jobspb.ScheduleID, cronExpr string) error
 }

--- a/pkg/sql/schemachanger/scexec/scmutationexec/table.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/table.go
@@ -77,3 +77,9 @@ func (d *deferredVisitor) UpdateTTLScheduleMetadata(
 ) error {
 	return d.DeferredMutationStateUpdater.UpdateTTLScheduleMetadata(ctx, op.TableID, op.NewName)
 }
+
+func (d *deferredVisitor) UpdateTTLScheduleCron(
+	ctx context.Context, op scop.UpdateTTLScheduleCron,
+) error {
+	return d.DeferredMutationStateUpdater.UpdateTTLScheduleCron(ctx, op.ScheduleID, op.NewCronExpr)
+}

--- a/pkg/sql/schemachanger/scop/deferred_mutation.go
+++ b/pkg/sql/schemachanger/scop/deferred_mutation.go
@@ -107,3 +107,11 @@ type UpdateTTLScheduleMetadata struct {
 	TableID descpb.ID
 	NewName string
 }
+
+// UpdateTTLScheduleCron updates the cron schedule expression for a TTL job.
+type UpdateTTLScheduleCron struct {
+	deferredMutationOp
+	TableID     descpb.ID
+	ScheduleID  jobspb.ScheduleID
+	NewCronExpr string
+}

--- a/pkg/sql/schemachanger/scop/deferred_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/deferred_mutation_visitor_generated.go
@@ -27,6 +27,7 @@ type DeferredMutationVisitor interface {
 	RefreshStats(context.Context, RefreshStats) error
 	MaybeAddSplitForIndex(context.Context, MaybeAddSplitForIndex) error
 	UpdateTTLScheduleMetadata(context.Context, UpdateTTLScheduleMetadata) error
+	UpdateTTLScheduleCron(context.Context, UpdateTTLScheduleCron) error
 }
 
 // Visit is part of the DeferredMutationOp interface.
@@ -77,4 +78,9 @@ func (op MaybeAddSplitForIndex) Visit(ctx context.Context, v DeferredMutationVis
 // Visit is part of the DeferredMutationOp interface.
 func (op UpdateTTLScheduleMetadata) Visit(ctx context.Context, v DeferredMutationVisitor) error {
 	return v.UpdateTTLScheduleMetadata(ctx, op)
+}
+
+// Visit is part of the DeferredMutationOp interface.
+func (op UpdateTTLScheduleCron) Visit(ctx context.Context, v DeferredMutationVisitor) error {
+	return v.UpdateTTLScheduleCron(ctx, op)
 }

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1271,3 +1271,11 @@ type ResetTableStorageParam struct {
 	immediateMutationOp
 	Param scpb.TableStorageParam
 }
+
+// UpsertRowLevelTTL sets the RowLevelTTL on a table descriptor.
+type UpsertRowLevelTTL struct {
+	immediateMutationOp
+	TableID     descpb.ID
+	RowLevelTTL catpb.RowLevelTTL
+	TTLExpr     *scpb.Expression
+}

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -180,6 +180,7 @@ type ImmediateMutationVisitor interface {
 	SetTableSchemaLocked(context.Context, SetTableSchemaLocked) error
 	SetTableStorageParam(context.Context, SetTableStorageParam) error
 	ResetTableStorageParam(context.Context, ResetTableStorageParam) error
+	UpsertRowLevelTTL(context.Context, UpsertRowLevelTTL) error
 }
 
 // Visit is part of the ImmediateMutationOp interface.
@@ -995,4 +996,9 @@ func (op SetTableStorageParam) Visit(ctx context.Context, v ImmediateMutationVis
 // Visit is part of the ImmediateMutationOp interface.
 func (op ResetTableStorageParam) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.ResetTableStorageParam(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op UpsertRowLevelTTL) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.UpsertRowLevelTTL(ctx, op)
 }

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -770,6 +770,10 @@ message RowLevelTTL {
   // ExpirationExpr is not set. This expression is used to establish column
   // dependencies.
   Expression ttl_expr = 3 [(gogoproto.customname) = "TTLExpr"];
+  // SeqNum differentiates different versions of the TTL configuration for the
+  // same table. When modifying TTL parameters, the old element is dropped and
+  // a new one with an incremented SeqNum is added.
+  uint32 seq_num = 4 [(gogoproto.customname) = "SeqNum"];
 }
 
 message ColumnName {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -365,6 +365,7 @@ object RowLevelTTL
 RowLevelTTL :  TableID
 RowLevelTTL :  RowLevelTTL
 RowLevelTTL :  TTLExpr
+RowLevelTTL :  SeqNum
 
 object Schema
 

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         ":scplan",
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/jobs/jobspb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_row_level_ttl.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_row_level_ttl.go
@@ -15,8 +15,12 @@ func init() {
 		toPublic(
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.RowLevelTTL) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.RowLevelTTL, md *opGenContext) *scop.UpsertRowLevelTTL {
+					return &scop.UpsertRowLevelTTL{
+						TableID:     this.TableID,
+						RowLevelTTL: this.RowLevelTTL,
+						TTLExpr:     this.TTLExpr,
+					}
 				}),
 			),
 		),
@@ -25,7 +29,10 @@ func init() {
 			to(scpb.Status_ABSENT,
 				// TODO(postamar): remove revertibility constraint when possible
 				revertible(false),
-				emit(func(this *scpb.RowLevelTTL) *scop.DeleteSchedule {
+				emit(func(this *scpb.RowLevelTTL, md *opGenContext) *scop.DeleteSchedule {
+					if ttlAppliedLater(this, md) {
+						return nil
+					}
 					return &scop.DeleteSchedule{
 						ScheduleID: this.RowLevelTTL.ScheduleID,
 					}
@@ -33,4 +40,27 @@ func init() {
 			),
 		),
 	)
+}
+
+// ttlAppliedLater returns true if there is another RowLevelTTL element
+// with the same ScheduleID and TableID, a higher SeqNum, and
+// a target status of PUBLIC. This indicates that the TTL schedule
+// will be applied later, so we should not delete the schedule yet.
+func ttlAppliedLater(this *scpb.RowLevelTTL, md *opGenContext) bool {
+	if this.RowLevelTTL.ScheduleID == 0 {
+		return false
+	}
+	for _, t := range md.Targets {
+		other, ok := t.Element().(*scpb.RowLevelTTL)
+		if !ok || other == this {
+			continue
+		}
+		if other.RowLevelTTL.ScheduleID == this.RowLevelTTL.ScheduleID &&
+			other.TableID == this.TableID &&
+			other.SeqNum > this.SeqNum &&
+			t.TargetStatus == scpb.Status_PUBLIC {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3832,6 +3832,17 @@ deprules
     - SmallerSeqNumFirst(*scpb.PartitionZoneConfig, *scpb.PartitionZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure row level TTL configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.RowLevelTTL'
+    - $earlier-seqNum[Type] = '*scpb.RowLevelTTL'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $table-id)
+    - SmallerSeqNumFirst(*scpb.RowLevelTTL, *scpb.RowLevelTTL)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
 - name: ensure table zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence
@@ -9095,6 +9106,17 @@ deprules
     - $later-seqNum-Node[CurrentStatus] = $status
     - $earlier-seqNum-Node[CurrentStatus] = $status
     - SmallerSeqNumFirst(*scpb.PartitionZoneConfig, *scpb.PartitionZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure row level TTL configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.RowLevelTTL'
+    - $earlier-seqNum[Type] = '*scpb.RowLevelTTL'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $table-id)
+    - SmallerSeqNumFirst(*scpb.RowLevelTTL, *scpb.RowLevelTTL)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
 - name: ensure table zone configs are in increasing seqNum order

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
@@ -216,3 +216,48 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
         Name: sql_stats_histogram_buckets_count
         TableID: 106
         Value: "100"
+
+setup
+CREATE TABLE ttl_table (id INT PRIMARY KEY, ts TIMESTAMPTZ) WITH (ttl_expiration_expression = 'ts');
+----
+
+ops
+ALTER TABLE ttl_table SET (ttl_select_rate_limit = 10);
+----
+StatementPhase stage 1 of 1 with 1 MutationType op
+  transitions:
+    [[RowLevelTTL:{DescID: 107, SeqNum: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[RowLevelTTL:{DescID: 107, SeqNum: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.UpsertRowLevelTTL
+      RowLevelTTL:
+        ExpirationExpr: ts
+        ScheduleID: 1131800315919433729
+        SelectRateLimit: 10
+      TTLExpr:
+        expr: ts
+        referencedColumnIds:
+        - 2
+      TableID: 107
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[RowLevelTTL:{DescID: 107, SeqNum: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[RowLevelTTL:{DescID: 107, SeqNum: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 1 MutationType op
+  transitions:
+    [[RowLevelTTL:{DescID: 107, SeqNum: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[RowLevelTTL:{DescID: 107, SeqNum: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.UpsertRowLevelTTL
+      RowLevelTTL:
+        ExpirationExpr: ts
+        ScheduleID: 1131800315919433729
+        SelectRateLimit: 10
+      TTLExpr:
+        expr: ts
+        referencedColumnIds:
+        - 2
+      TableID: 107

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
@@ -232,7 +232,7 @@ StatementPhase stage 1 of 1 with 1 MutationType op
     *scop.UpsertRowLevelTTL
       RowLevelTTL:
         ExpirationExpr: ts
-        ScheduleID: 1131801715215400961
+        ScheduleID: 1
         SelectRateLimit: 10
       TTLExpr:
         expr: ts
@@ -254,7 +254,7 @@ PreCommitPhase stage 2 of 2 with 1 MutationType op
     *scop.UpsertRowLevelTTL
       RowLevelTTL:
         ExpirationExpr: ts
-        ScheduleID: 1131801715215400961
+        ScheduleID: 1
         SelectRateLimit: 10
       TTLExpr:
         expr: ts
@@ -263,7 +263,7 @@ PreCommitPhase stage 2 of 2 with 1 MutationType op
       TableID: 107
 
 ops
-ALTER TABLE ttl_table SET (ttl_job_cron = '0 0 * * *');
+ALTER TABLE ttl_table SET (ttl_select_rate_limit = 10, ttl_job_cron = '0 0 * * *');
 ----
 StatementPhase stage 1 of 1 with 1 MutationType op
   transitions:
@@ -274,7 +274,8 @@ StatementPhase stage 1 of 1 with 1 MutationType op
       RowLevelTTL:
         DeletionCron: 0 0 * * *
         ExpirationExpr: ts
-        ScheduleID: 1131801715215400961
+        ScheduleID: 1
+        SelectRateLimit: 10
       TTLExpr:
         expr: ts
         referencedColumnIds:
@@ -296,7 +297,8 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
       RowLevelTTL:
         DeletionCron: 0 0 * * *
         ExpirationExpr: ts
-        ScheduleID: 1131801715215400961
+        ScheduleID: 1
+        SelectRateLimit: 10
       TTLExpr:
         expr: ts
         referencedColumnIds:
@@ -304,5 +306,5 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
       TableID: 107
     *scop.UpdateTTLScheduleCron
       NewCronExpr: 0 0 * * *
-      ScheduleID: 1131801715215400961
+      ScheduleID: 1
       TableID: 107

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_set_storage_param
@@ -232,7 +232,7 @@ StatementPhase stage 1 of 1 with 1 MutationType op
     *scop.UpsertRowLevelTTL
       RowLevelTTL:
         ExpirationExpr: ts
-        ScheduleID: 1131800315919433729
+        ScheduleID: 1131801715215400961
         SelectRateLimit: 10
       TTLExpr:
         expr: ts
@@ -254,10 +254,55 @@ PreCommitPhase stage 2 of 2 with 1 MutationType op
     *scop.UpsertRowLevelTTL
       RowLevelTTL:
         ExpirationExpr: ts
-        ScheduleID: 1131800315919433729
+        ScheduleID: 1131801715215400961
         SelectRateLimit: 10
       TTLExpr:
         expr: ts
         referencedColumnIds:
         - 2
+      TableID: 107
+
+ops
+ALTER TABLE ttl_table SET (ttl_job_cron = '0 0 * * *');
+----
+StatementPhase stage 1 of 1 with 1 MutationType op
+  transitions:
+    [[RowLevelTTL:{DescID: 107, SeqNum: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[RowLevelTTL:{DescID: 107, SeqNum: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.UpsertRowLevelTTL
+      RowLevelTTL:
+        DeletionCron: 0 0 * * *
+        ExpirationExpr: ts
+        ScheduleID: 1131801715215400961
+      TTLExpr:
+        expr: ts
+        referencedColumnIds:
+        - 2
+      TableID: 107
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[RowLevelTTL:{DescID: 107, SeqNum: 0}, ABSENT], ABSENT] -> PUBLIC
+    [[RowLevelTTL:{DescID: 107, SeqNum: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[RowLevelTTL:{DescID: 107, SeqNum: 0}, ABSENT], PUBLIC] -> ABSENT
+    [[RowLevelTTL:{DescID: 107, SeqNum: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.UpsertRowLevelTTL
+      RowLevelTTL:
+        DeletionCron: 0 0 * * *
+        ExpirationExpr: ts
+        ScheduleID: 1131801715215400961
+      TTLExpr:
+        expr: ts
+        referencedColumnIds:
+        - 2
+      TableID: 107
+    *scop.UpdateTTLScheduleCron
+      NewCronExpr: 0 0 * * *
+      ScheduleID: 1131801715215400961
       TableID: 107

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -263,6 +263,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	),
 	rel.EntityMapping(t((*scpb.RowLevelTTL)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
+		rel.EntityAttr(SeqNum, "SeqNum"),
 	),
 	rel.EntityMapping(t((*scpb.Trigger)(nil)),
 		rel.EntityAttr(DescID, "TableID"),

--- a/pkg/sql/storageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/storageparam",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/docs",
         "//pkg/server/telemetry",
         "//pkg/sql/paramparse",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
@@ -25,5 +25,6 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )


### PR DESCRIPTION
Backport 4/4 commits from #159276 on behalf of @rafiss.

----

See individual commits.

### schemachanger: handle basic TTL params

The builder was updated so that it modifies the scpb.RowLevelTTL element
for when handling TTL storage params. This is needed so that we can do
proper validation on the TTL params, since the validation logic checks
dependencies between different parameters.

The UpsertRowLevelTTL immediate mutation takes care of modifying the
descriptor. Logic was also needed to avoid dropping the TTL schedule if
we are modifying parameters.

### schemachanger: support ttl_job_cron parameter in declarative schema changer

Previously, modifying the ttl_job_cron storage parameter required falling
back to the legacy schema changer because the declarative schema changer
had no mechanism to update the TTL scheduled job's cron expression.

This commit adds support for ttl_job_cron by:

1. Adding UpdateTTLScheduleCron as a new deferred mutation operation that
    updates the cron expression on the existing TTL scheduled job.

2. Implementing findOldTTLCron in opgen to detect when the cron expression
    has changed by comparing the new RowLevelTTL element against the one
    being dropped, emitting UpdateTTLScheduleCron only when necessary.

3. Adding UpdateTTLScheduleCron to metadataUpdater which loads the
    scheduled job, updates its cron expression, and persists the change.

informs: https://github.com/cockroachdb/cockroach/issues/122379
Release note: None

----

Release justification: feature targeted for 26.1