### PR TITLE
[Option 2] release: simplify update_workflow.go using YAML library

### DIFF
--- a/.github/BUILD.bazel
+++ b/.github/BUILD.bazel
@@ -1,3 +1,4 @@
 exports_files([
     "CODEOWNERS",
+    "workflows/update_releases.yaml",
 ])

--- a/build/teamcity/internal/cockroach/release/process/update_workflow_branches.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_workflow_branches.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run Update Workflow Branches Release Phase"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e GH_TOKEN" \
+  run_bazel build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
+tc_end_block "Run Update Workflow Branches Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_workflow_branches_impl.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -xeuo pipefail
+
+dry_run=true
+# override dev defaults with production values
+if [[ -z "${DRY_RUN:-}" ]] ; then
+  echo "Setting production values"
+  dry_run=false
+fi
+
+# run git fetch in order to get all remote branches
+git fetch --tags -q origin
+
+# Ensure we're starting from a clean master branch
+git checkout master
+git reset --hard origin/master
+
+# install gh CLI tool
+curl -fsSL -o /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz
+echo "5c9a70b6411cc9774f5f4e68f9227d5d55ca0bfbd00dfc6353081c9b705c8939  /tmp/gh.tar.gz" | sha256sum -c -
+tar --strip-components 1 -xf /tmp/gh.tar.gz
+export PATH=$PWD/bin:$PATH
+
+# Build the release tool
+bazel build --config=crosslinux //pkg/cmd/release
+
+# Run the update-workflow-branches command and capture output
+echo "Running release update-workflow-branches command..."
+OUTPUT=$($(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release update-workflow-branches 2>&1)
+echo "$OUTPUT"
+
+# Extract the branch name from output (line like "Latest release branch: release-26.1")
+RELEASE_BRANCH=$(echo "$OUTPUT" | grep "Latest release branch:" | sed 's/Latest release branch: //')
+
+if [[ -z "$RELEASE_BRANCH" ]]; then
+  echo "ERROR: Could not determine release branch from command output"
+  exit 1
+fi
+
+# Check if any changes were made
+if git diff --quiet .github/workflows/update_releases.yaml; then
+  echo "No changes to workflow file, nothing to commit"
+  exit 0
+fi
+
+echo "Changes detected in workflow file"
+
+if [[ "$dry_run" == "true" ]]; then
+  echo "DRY RUN: Would create PR with the following changes:"
+  git diff .github/workflows/update_releases.yaml
+  exit 0
+fi
+
+# Set git user for commits
+export GIT_AUTHOR_NAME="Justin Beaver"
+export GIT_COMMITTER_NAME="Justin Beaver"
+export GIT_AUTHOR_EMAIL="teamcity@cockroachlabs.com"
+export GIT_COMMITTER_EMAIL="teamcity@cockroachlabs.com"
+
+# Check for GitHub token
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "ERROR: GH_TOKEN environment variable must be set"
+  exit 1
+fi
+
+# Create a branch for the PR
+BRANCH_NAME="update-workflow-branches-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH_NAME"
+
+# Commit the changes
+git add .github/workflows/update_releases.yaml
+git commit -m "workflows: run \`update_releases\` on \`$RELEASE_BRANCH\`
+
+Epic: None
+Release note: None
+Release justification: non-production (release infra) change."
+
+# Push the branch to cockroach-teamcity fork (like update_releases.yaml workflow does)
+git push "https://oauth2:${GH_TOKEN}@github.com/cockroach-teamcity/cockroach" "$BRANCH_NAME"
+
+# Create the pull request from the fork
+gh pr create \
+  --repo cockroachdb/cockroach \
+  --base master \
+  --head "cockroach-teamcity:$BRANCH_NAME" \
+  --title "workflows: run \`update_releases\` on \`$RELEASE_BRANCH\`" \
+  --body "Epic: None
+Release note: None
+Release justification: non-production (release infra) change."
+
+echo "Pull request created successfully"

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "update_helm.go",
         "update_releases.go",
         "update_versions.go",
+        "update_workflow.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",
     visibility = ["//visibility:private"],

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -39,16 +39,21 @@ go_test(
     srcs = [
         "git_test.go",
         "update_releases_test.go",
+        "update_workflow_test.go",
     ],
     data = glob([
         "templates/**",
         "testdata/**",
-    ]),
+    ]) + [
+        "//.github:workflows/update_releases.yaml",
+    ],
     embed = [":release_lib"],
     deps = [
+        "//pkg/testutils/datapathutils",
         "//pkg/testutils/release",
         "@com_github_cockroachdb_version//:version",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@com_github_jordan_wright_email//:email",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )
 

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -38,4 +38,5 @@ func main() {
 func init() {
 	rootCmd.AddCommand(updateReleasesTestFilesCmd)
 	rootCmd.AddCommand(updateVersionsCmd)
+	rootCmd.AddCommand(updateWorkflowBranchesCmd)
 }

--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -1,0 +1,255 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/version"
+	"github.com/spf13/cobra"
+)
+
+const workflowFile = ".github/workflows/update_releases.yaml"
+
+var updateWorkflowBranchesCmd = &cobra.Command{
+	Use:   "update-workflow-branches",
+	Short: "Update the branch matrix in update_releases.yaml workflow",
+	Long:  "Detects the latest release branch and adds it to the GitHub Actions workflow if not present",
+	RunE:  updateWorkflowBranches,
+}
+
+// updateWorkflowBranches is the main command handler.
+func updateWorkflowBranches(_ *cobra.Command, _ []string) error {
+	fmt.Println("Finding latest release branch...")
+	latestBranch, err := findLatestReleaseBranch()
+	if err != nil {
+		return fmt.Errorf("failed to find latest release branch: %w", err)
+	}
+
+	fmt.Printf("Latest release branch: %s\n", latestBranch)
+
+	fmt.Println("Updating workflow file...")
+	if err := addBranchToWorkflow(latestBranch); err != nil {
+		return fmt.Errorf("failed to update workflow file: %w", err)
+	}
+
+	fmt.Println("Successfully updated workflow file")
+	return nil
+}
+
+// findLatestReleaseBranch detects the latest release branch by querying git remote branches.
+func findLatestReleaseBranch() (string, error) {
+	// Get all release branches
+	branches, err := listRemoteBranches("release-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to list remote branches: %w", err)
+	}
+
+	// Filter out RC branches - we only want major release branches like "release-25.4"
+	var releaseBranches []string
+	for _, branch := range branches {
+		if !strings.Contains(branch, "-rc") {
+			releaseBranches = append(releaseBranches, branch)
+		}
+	}
+
+	if len(releaseBranches) == 0 {
+		return "", fmt.Errorf("no release branches found")
+	}
+
+	// Parse versions and sort
+	type branchVersion struct {
+		branch  string
+		version version.Version
+	}
+	var versions []branchVersion
+
+	for _, branch := range releaseBranches {
+		// Extract version from "release-X.Y" format
+		versionStr := strings.TrimPrefix(branch, "release-")
+		// Add .0 for patch to make it a valid semantic version
+		v, err := version.Parse("v" + versionStr + ".0")
+		if err != nil {
+			log.Printf("WARNING: cannot parse version from branch %s: %v", branch, err)
+			continue
+		}
+		versions = append(versions, branchVersion{branch, v})
+	}
+
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no valid version branches found")
+	}
+
+	// Sort by version
+	slices.SortFunc(versions, func(a, b branchVersion) int {
+		return a.version.Compare(b.version)
+	})
+
+	// Return highest version
+	return versions[len(versions)-1].branch, nil
+}
+
+// addBranchToWorkflow adds the specified branch to the workflow file if not already present.
+func addBranchToWorkflow(branch string) error {
+	// Read the workflow file
+	rawData, err := os.ReadFile(workflowFile)
+	if err != nil {
+		return fmt.Errorf("failed to read workflow file: %w", err)
+	}
+
+	lines := strings.Split(string(rawData), "\n")
+
+	// Find the branch section and extract current branches
+	currentBranches, branchStart, branchEnd, indent, err := parseBranchSection(lines)
+	if err != nil {
+		return err
+	}
+
+	// Check if branch already exists
+	for _, b := range currentBranches {
+		if b == branch {
+			fmt.Printf("Branch %s is already in the workflow file\n", branch)
+			return nil
+		}
+	}
+
+	// Add the new branch
+	currentBranches = append(currentBranches, branch)
+
+	// Sort branches: master first, then release branches in version order
+	slices.SortFunc(currentBranches, func(a, b string) int {
+		if a == "master" {
+			return -1
+		}
+		if b == "master" {
+			return 1
+		}
+
+		// Compare release versions
+		aVer := strings.TrimPrefix(a, "release-")
+		bVer := strings.TrimPrefix(b, "release-")
+
+		va, err1 := version.Parse("v" + aVer + ".0")
+		vb, err2 := version.Parse("v" + bVer + ".0")
+
+		// If either fails to parse, fall back to string comparison
+		if err1 != nil || err2 != nil {
+			return strings.Compare(a, b)
+		}
+
+		return va.Compare(vb)
+	})
+
+	// Write the updated file
+	if err := writeBranchSection(lines, currentBranches, branchStart, branchEnd, indent); err != nil {
+		return err
+	}
+
+	fmt.Printf("Added branch %s to workflow file\n", branch)
+	return nil
+}
+
+// parseBranchSection parses the workflow file to find the branch matrix section.
+func parseBranchSection(
+	lines []string,
+) (branches []string, start int, end int, indent string, err error) {
+	start = -1
+	end = -1
+
+	for i, line := range lines {
+		// Look for "branch:" within the matrix section
+		if strings.Contains(line, "branch:") && !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			start = i + 1
+			// Determine indentation from the next line
+			if i+1 < len(lines) {
+				nextLine := lines[i+1]
+				// Count leading spaces
+				trimmed := strings.TrimLeft(nextLine, " ")
+				indent = strings.Repeat(" ", len(nextLine)-len(trimmed))
+			}
+		} else if start != -1 && end == -1 {
+			// Check if this line is still part of branch list
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				// Empty line, continue
+				continue
+			}
+			if !strings.HasPrefix(trimmed, "-") {
+				// Found the end of the branch list
+				end = i
+				break
+			} else {
+				// Extract branch name from line like '- "release-25.4"'
+				// Remove leading "- " and quotes
+				branchLine := strings.TrimSpace(trimmed)
+				branchLine = strings.TrimPrefix(branchLine, "- ")
+				branchLine = strings.Trim(branchLine, "\"")
+				branches = append(branches, branchLine)
+			}
+		}
+	}
+
+	if start == -1 {
+		return nil, 0, 0, "", fmt.Errorf("branch section not found in workflow file")
+	}
+
+	// If we reached end of file, set end to len(lines)
+	if end == -1 {
+		end = len(lines)
+	}
+
+	return branches, start, end, indent, nil
+}
+
+// writeBranchSection writes the updated branch list back to the workflow file.
+func writeBranchSection(
+	lines []string, branches []string, start int, end int, indent string,
+) error {
+	// Build new lines
+	var newLines []string
+	newLines = append(newLines, lines[:start]...)
+
+	// Add branch lines
+	for _, branch := range branches {
+		newLines = append(newLines, fmt.Sprintf("%s- %q", indent, branch))
+	}
+
+	// Add remaining lines
+	newLines = append(newLines, lines[end:]...)
+
+	// Write back to file using atomic write pattern
+	// Create temp file in the same directory as target to avoid cross-device link errors
+	dir := ".github/workflows"
+	f, err := os.CreateTemp(dir, "update_releases_*.yaml")
+	if err != nil {
+		return fmt.Errorf("could not create temporary file: %w", err)
+	}
+	tmpName := f.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = f.WriteString(strings.Join(newLines, "\n")); err != nil {
+		f.Close()
+		return fmt.Errorf("error writing to temp file: %w", err)
+	}
+
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("error closing temp file: %w", err)
+	}
+
+	if err = os.Rename(tmpName, workflowFile); err != nil {
+		return fmt.Errorf("error moving file to final destination: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/release/update_workflow.go
+++ b/pkg/cmd/release/update_workflow.go
@@ -176,7 +176,9 @@ func addBranchToWorkflow(branch string) error {
 	if err := encoder.Encode(&workflow); err != nil {
 		return fmt.Errorf("failed to encode YAML: %w", err)
 	}
-	encoder.Close()
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("failed to close YAML encoder: %w", err)
+	}
 
 	// Write back to file
 	if err := os.WriteFile(workflowFile, []byte(buf.String()), 0644); err != nil {

--- a/pkg/cmd/release/update_workflow_test.go
+++ b/pkg/cmd/release/update_workflow_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"gopkg.in/yaml.v3"
+)
+
+// TestWorkflowFileStructure validates that the update_releases.yaml workflow file
+// has the expected structure that update_workflow.go depends on.
+//
+// This test reads the actual workflow file from .github/workflows/ to ensure
+// any structural changes are caught immediately. If this test fails, you need to:
+// 1. Update the expectedPath in findBranchNode() to match the new structure
+// 2. Update this test if needed
+//
+// This test will catch structural changes that would break update_workflow.go.
+func TestWorkflowFileStructure(t *testing.T) {
+	// Read the actual workflow file from .github/workflows/
+	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("Failed to read workflow file %s: %v\n"+
+			"The workflow file may have been moved or renamed.", workflowPath, err)
+	}
+
+	var workflow yaml.Node
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("Failed to parse workflow YAML: %v", err)
+	}
+
+	// Validate the structure matches what findBranchNode() expects
+	branchNode, err := findBranchNode(&workflow)
+	if err != nil {
+		t.Fatalf("Workflow file structure validation failed.\n"+
+			"This likely means the structure of %s has changed.\n"+
+			"Error: %v\n\n"+
+			"To fix this:\n"+
+			"1. Update the expectedPath in findBranchNode() to match the new structure\n"+
+			"2. Update this test if needed",
+			workflowFile, err)
+	}
+
+	// Verify it's a sequence node with at least one branch
+	if branchNode.Kind != yaml.SequenceNode {
+		t.Fatalf("Expected 'branch' to be a sequence, got %v", branchNode.Kind)
+	}
+
+	if len(branchNode.Content) == 0 {
+		t.Fatal("Expected at least one branch in the workflow matrix, found none")
+	}
+
+	// Verify branches are strings
+	for i, node := range branchNode.Content {
+		if node.Kind != yaml.ScalarNode {
+			t.Errorf("Branch at index %d is not a scalar node (expected string)", i)
+		}
+	}
+
+	t.Logf("✓ Workflow structure validation passed")
+	t.Logf("  Found %d branches in the matrix", len(branchNode.Content))
+}
+
+// TestAddBranchToWorkflow_NoOp tests that the branch extraction logic works correctly.
+func TestAddBranchToWorkflow_NoOp(t *testing.T) {
+	// Read the actual workflow file from .github/workflows/
+	workflowPath := datapathutils.RewritableDataPath(t, ".github", "workflows", "update_releases.yaml")
+	originalData, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("Failed to read workflow file: %v", err)
+	}
+
+	var workflow yaml.Node
+	if err := yaml.Unmarshal(originalData, &workflow); err != nil {
+		t.Fatalf("Failed to parse workflow YAML: %v", err)
+	}
+
+	// Get the branch node
+	branchNode, err := findBranchNode(&workflow)
+	if err != nil {
+		t.Fatalf("Failed to find branch node: %v", err)
+	}
+
+	// Should have at least one branch
+	if len(branchNode.Content) == 0 {
+		t.Fatal("No branches found in workflow file")
+	}
+
+	// Get the first branch (should be "master" based on current structure)
+	firstBranch := branchNode.Content[0].Value
+
+	// Verify extracting branches works
+	var branches []string
+	for _, item := range branchNode.Content {
+		if item.Kind == yaml.ScalarNode {
+			branches = append(branches, item.Value)
+		}
+	}
+
+	// Verify the first branch is in the list
+	found := false
+	for _, b := range branches {
+		if b == firstBranch {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("Expected to find branch %q in the workflow file", firstBranch)
+	}
+
+	t.Logf("✓ Successfully extracted %d branches from workflow file", len(branches))
+	t.Logf("  First branch: %s", firstBranch)
+}


### PR DESCRIPTION
This is a draft PR demonstrating **Option 2** for simplifying the `update_workflow.go` logic based on feedback from PR #159216.

## Approach "Option 2"

Uses `gopkg.in/yaml.v3` to parse and manipulate the workflow YAML instead of manual line-by-line parsing.

Other Options:
- **Option 1 (marker-based text replacement)**: Simplest approach, no dependencies, hardest to break https://github.com/cockroachdb/cockroach/pull/159327
- **Option 3 (external template approach)**: https://github.com/cockroachdb/cockroach/pull/159322

## Changes

- Replaced ~100 lines of manual YAML parsing with structured YAML library operations
- Added yaml.v3 dependency for better formatting preservation  
- Simplified `addBranchToWorkflow` logic by navigating the parsed YAML tree instead of manually tracking line numbers and indentation
- Extracted `sortBranches` helper function to reduce duplication

## Pros

- Proper YAML handling with type-safe node navigation
- Preserves formatting and comments (using yaml.v3 Node API)
- Reduces code from ~255 lines to ~260 lines (similar, but much clearer logic)
- No manual indentation tracking
- Less brittle - doesn't depend on exact line positions

## Cons

- Adds yaml.v3 as a new dependency (yaml.v2 is already used elsewhere)
- YAML tree navigation code is somewhat verbose
- May still reformat the file slightly depending on encoder settings

Epic: None
Release note: None