### PR TITLE
sql: introduce span-level checks and level-cluster checks

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2215,6 +2215,7 @@ GO_TARGETS = [
     "//pkg/sql/idxusage:idxusage_test",
     "//pkg/sql/importer:importer",
     "//pkg/sql/importer:importer_test",
+    "//pkg/sql/inspect/inspectpb:inspectpb",
     "//pkg/sql/inspect:inspect",
     "//pkg/sql/inspect:inspect_test",
     "//pkg/sql/inverted:inverted",

--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -65,6 +65,7 @@ PROTOBUF_SRCS = [
     "//pkg/sql/contentionpb:contentionpb_go_proto",
     "//pkg/sql/execinfrapb:execinfrapb_go_proto",
     "//pkg/sql/hintpb:hintpb_go_proto",
+    "//pkg/sql/inspect/inspectpb:inspectpb_go_proto",
     "//pkg/sql/inverted:inverted_go_proto",
     "//pkg/sql/lex:lex_go_proto",
     "//pkg/sql/pgwire/pgerror:pgerror_go_proto",

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1628,7 +1628,11 @@ message InspectProgress {
   int64 job_completed_check_count = 2;
 }
 
+// InspectProcessorProgress is the per-processor progress for an INSPECT job.
+// 
+// Deprecated: Moved to cockroach.sql.inspect.inspectpb.
 message InspectProcessorProgress {
+  option deprecated=true;
   int64 checks_completed = 1;  // Number of checks completed since last update.
   bool finished = 2;           // Processor finished all checks.
 

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "inspect",
     srcs = [
+        "cluster_runner.go",
         "index_consistency_check.go",
         "inspect_job_entry.go",
         "inspect_logger.go",
@@ -40,6 +41,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/inspect/inspectpb",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",
         "//pkg/sql/pgwire/pgcode",
@@ -74,6 +76,7 @@ go_test(
     name = "inspect_test",
     size = "large",
     srcs = [
+        "cluster_runner_test.go",
         "index_consistency_check_test.go",
         "inspect_metrics_test.go",
         "inspect_processor_test.go",
@@ -111,6 +114,7 @@ go_test(
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/inspect/inspectpb",
         "//pkg/sql/isql",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/eval",
@@ -124,6 +128,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/inspect/cluster_runner.go
+++ b/pkg/sql/inspect/cluster_runner.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+)
+
+type clusterRunner struct {
+	// checks holds the list of checks to run. Each check is run to completion
+	// before moving on to the next.
+	checks []inspectClusterCheck
+
+	// logger records issues reported by the checks.
+	logger *inspectLoggerBundle
+
+	progressTracker *inspectProgressTracker
+}
+
+// Step runs any cluster-level checks using the accumulated job progress.
+//
+// Returns true if a check was advanced or an issue was found. Returns false
+// when all checks are complete. If an error occurs at any stage, it is returned
+// immediately.
+func (c *clusterRunner) Step(ctx context.Context) (bool, error) {
+	spanCheckData := c.progressTracker.getSpanCheckData()
+
+	for len(c.checks) > 0 {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+
+		check := c.checks[0]
+
+		if !check.StartedCluster() {
+			if err := check.StartCluster(ctx, &spanCheckData); err != nil {
+				return false, errors.Wrapf(err, "error starting cluster inspect check")
+			}
+		}
+
+		if !check.DoneCluster(ctx) {
+			issue, err := check.NextCluster(ctx)
+			if err != nil {
+				return false, errors.Wrapf(err, "error running cluster inspect check")
+			}
+			if issue != nil {
+				err = c.logger.logIssue(ctx, issue)
+				if err != nil {
+					return false, errors.Wrapf(err, "error logging inspect issue")
+				}
+			}
+			return true, nil
+		}
+
+		if err := check.CloseCluster(ctx); err != nil {
+			return false, errors.Wrapf(err, "error closing cluster inspect check")
+		}
+
+		c.checks = c.checks[1:]
+	}
+
+	return false, nil
+}
+
+// Close cleans up all checks in the runner. It will attempt to close each check,
+// even if errors occur during closing. If multiple checks fail to close, then
+// a combined error is returned.
+func (c *clusterRunner) Close(ctx context.Context) error {
+	var retErr error
+	for _, check := range c.checks {
+		if !check.StartedCluster() {
+			continue
+		}
+
+		if err := check.CloseCluster(ctx); err != nil {
+			retErr = errors.CombineErrors(retErr, err)
+		}
+	}
+	return retErr
+}

--- a/pkg/sql/inspect/cluster_runner_test.go
+++ b/pkg/sql/inspect/cluster_runner_test.go
@@ -1,0 +1,416 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+type mockInspectClusterCheck struct {
+	started bool
+	pos     int
+	closed  bool
+	issues  []inspectIssue
+}
+
+var _ inspectClusterCheck = &mockInspectClusterCheck{}
+
+func (m *mockInspectClusterCheck) StartedCluster() bool {
+	return m.started
+}
+
+func (m *mockInspectClusterCheck) StartCluster(
+	context.Context, *inspectpb.InspectSpanCheckData,
+) error {
+	if m.started {
+		return errors.Newf("cluster inspect check already started")
+	}
+	m.started = true
+	return nil
+}
+
+// NextCluster returns the next inspect error, if any.
+// Returns (nil, nil) when there are no errors remaining.
+func (m *mockInspectClusterCheck) NextCluster(ctx context.Context) (*inspectIssue, error) {
+	if m.DoneCluster(ctx) {
+		return nil, errors.Newf("cluster check is already done")
+	}
+	issue := &m.issues[m.pos]
+	m.pos++
+	return issue, nil
+}
+
+// DoneCluster reports whether the check has produced all results.
+func (m *mockInspectClusterCheck) DoneCluster(context.Context) bool {
+	return m.pos >= len(m.issues)
+}
+
+// CloseCluster cleans up resources for the check.
+func (m *mockInspectClusterCheck) CloseCluster(context.Context) error {
+	if !m.started {
+		return errors.Newf("cluster inspect check hasn't been started")
+	}
+	m.closed = true
+	return nil
+}
+
+func TestClusterRunnerStep(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		desc   string
+		checks [][]inspectIssue
+	}{
+		{desc: "no checks"},
+		{desc: "one check with no errors", checks: [][]inspectIssue{{}}},
+		{desc: "one check with 1 error", checks: [][]inspectIssue{
+			{
+				{
+					ErrorType:  "secondary_index_dangling",
+					DatabaseID: 1,
+					SchemaID:   2,
+					ObjectID:   3,
+					PrimaryKey: "/1/3",
+					Details: map[redact.RedactableString]interface{}{
+						"index_name": "foo_idx",
+					},
+				},
+			},
+		}},
+		{desc: "two checks with 1 error each", checks: [][]inspectIssue{
+			{
+				{
+					ErrorType:  "secondary_index_missing",
+					DatabaseID: 10,
+					SchemaID:   11,
+					ObjectID:   12,
+					PrimaryKey: "/10/12",
+					Details: map[redact.RedactableString]interface{}{
+						"index_name": "bar_idx",
+					},
+				},
+			},
+			{
+				{
+					ErrorType:  "internal_error",
+					DatabaseID: 20,
+					SchemaID:   21,
+					ObjectID:   22,
+					PrimaryKey: "/20/22",
+					Details: map[redact.RedactableString]interface{}{
+						"error": "unexpected data corruption",
+					},
+				},
+			},
+		}},
+		{desc: "two checks with multiple errors", checks: [][]inspectIssue{
+			{
+				{
+					ErrorType:  "secondary_index_dangling",
+					DatabaseID: 100,
+					SchemaID:   101,
+					ObjectID:   102,
+					PrimaryKey: "/100/1",
+					Details: map[redact.RedactableString]interface{}{
+						"index_name": "baz_idx",
+					},
+				},
+				{
+					ErrorType:  "secondary_index_missing",
+					DatabaseID: 100,
+					SchemaID:   101,
+					ObjectID:   102,
+					PrimaryKey: "/100/2",
+					Details: map[redact.RedactableString]interface{}{
+						"index_name": "baz_idx",
+					},
+				},
+			},
+			{
+				{
+					ErrorType:  "secondary_index_missing",
+					DatabaseID: 200,
+					SchemaID:   201,
+					ObjectID:   202,
+					PrimaryKey: "/200/1",
+					Details: map[redact.RedactableString]interface{}{
+						"index_name": "qux_idx",
+					},
+				},
+			},
+		}},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			logger := &testIssueCollector{}
+			// The checks are consumed once they are processed in clusterRunner. So,
+			// save them outside the runner first so we can refer back to them later.
+			checks := make([]*mockInspectClusterCheck, len(tc.checks))
+			for i := range tc.checks {
+				checks[i] = &mockInspectClusterCheck{issues: tc.checks[i]}
+			}
+
+			progressTracker := &inspectProgressTracker{}
+			progressTracker.mu.cachedProgress = &jobspb.Progress{
+				Details: &jobspb.Progress_Inspect{
+					Inspect: &jobspb.InspectProgress{},
+				},
+			}
+
+			loggerBundle := newInspectLoggerBundle(1 /* jobID */, logger)
+			runner := clusterRunner{
+				logger:          loggerBundle,
+				progressTracker: progressTracker,
+			}
+			for i := range tc.checks {
+				runner.checks = append(runner.checks, checks[i])
+			}
+
+			issuesFound := 0
+			for {
+				foundIssue, err := runner.Step(ctx)
+				require.NoError(t, err)
+				if !foundIssue {
+					break
+				}
+				issuesFound++
+			}
+
+			expectedIssuesFound := 0
+			for _, check := range tc.checks {
+				expectedIssuesFound += len(check)
+			}
+			require.Equal(t, expectedIssuesFound, issuesFound)
+			require.Equal(t, issuesFound, logger.numIssuesFound())
+
+			flatExpected := make([]inspectIssue, 0, expectedIssuesFound)
+			for _, check := range tc.checks {
+				flatExpected = append(flatExpected, check...)
+			}
+			for i := range flatExpected {
+				require.Equal(t, flatExpected[i], logger.issue(i))
+			}
+
+			for i := range checks {
+				require.True(t, checks[i].closed)
+			}
+		})
+	}
+}
+
+func TestClusterRunnerStepError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	t.Run("error on start", func(t *testing.T) {
+		logger := &testIssueCollector{}
+		progressTracker := &inspectProgressTracker{}
+		progressTracker.mu.cachedProgress = &jobspb.Progress{
+			Details: &jobspb.Progress_Inspect{
+				Inspect: &jobspb.InspectProgress{},
+			},
+		}
+
+		loggerBundle := newInspectLoggerBundle(1 /* jobID */, logger)
+
+		// Create a check that returns an error on StartCluster
+		errorCheck := &errorInspectClusterCheck{
+			startErr: errors.Newf("start error"),
+		}
+
+		runner := clusterRunner{
+			checks:          []inspectClusterCheck{errorCheck},
+			logger:          loggerBundle,
+			progressTracker: progressTracker,
+		}
+
+		_, err := runner.Step(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error starting cluster inspect check")
+		require.Contains(t, err.Error(), "start error")
+	})
+
+	t.Run("error on next", func(t *testing.T) {
+		logger := &testIssueCollector{}
+		progressTracker := &inspectProgressTracker{}
+		progressTracker.mu.cachedProgress = &jobspb.Progress{
+			Details: &jobspb.Progress_Inspect{
+				Inspect: &jobspb.InspectProgress{},
+			},
+		}
+
+		loggerBundle := newInspectLoggerBundle(1 /* jobID */, logger)
+
+		// Create a check that returns an error on NextCluster
+		errorCheck := &errorInspectClusterCheck{
+			nextErr: errors.Newf("next error"),
+		}
+
+		runner := clusterRunner{
+			checks:          []inspectClusterCheck{errorCheck},
+			logger:          loggerBundle,
+			progressTracker: progressTracker,
+		}
+
+		_, err := runner.Step(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error running cluster inspect check")
+		require.Contains(t, err.Error(), "next error")
+	})
+
+	t.Run("error on close", func(t *testing.T) {
+		logger := &testIssueCollector{}
+		progressTracker := &inspectProgressTracker{}
+		progressTracker.mu.cachedProgress = &jobspb.Progress{
+			Details: &jobspb.Progress_Inspect{
+				Inspect: &jobspb.InspectProgress{},
+			},
+		}
+
+		loggerBundle := newInspectLoggerBundle(1 /* jobID */, logger)
+
+		// Create a check that returns an error on CloseCluster
+		errorCheck := &errorInspectClusterCheck{
+			closeErr: errors.Newf("close error"),
+		}
+
+		runner := clusterRunner{
+			checks:          []inspectClusterCheck{errorCheck},
+			logger:          loggerBundle,
+			progressTracker: progressTracker,
+		}
+
+		// First step: starts and runs the check
+		foundIssue, err := runner.Step(ctx)
+		require.NoError(t, err)
+		require.True(t, foundIssue)
+
+		// Second step: check is done, so it tries to close and returns error
+		_, err = runner.Step(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error closing cluster inspect check")
+		require.Contains(t, err.Error(), "close error")
+	})
+}
+
+func TestClusterRunnerClose(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	t.Run("close all checks", func(t *testing.T) {
+		logger := &testIssueCollector{}
+		progressTracker := &inspectProgressTracker{}
+		progressTracker.mu.cachedProgress = &jobspb.Progress{
+			Details: &jobspb.Progress_Inspect{
+				Inspect: &jobspb.InspectProgress{},
+			},
+		}
+
+		loggerBundle := newInspectLoggerBundle(1 /* jobID */, logger)
+
+		checks := []*mockInspectClusterCheck{
+			{started: true, issues: []inspectIssue{}},
+			{started: true, issues: []inspectIssue{}},
+		}
+
+		runner := clusterRunner{
+			logger:          loggerBundle,
+			progressTracker: progressTracker,
+		}
+		for i := range checks {
+			runner.checks = append(runner.checks, checks[i])
+		}
+
+		err := runner.Close(ctx)
+		require.NoError(t, err)
+
+		for i, check := range checks {
+			require.True(t, check.closed, fmt.Sprintf("check %d should be closed", i))
+		}
+	})
+
+	t.Run("close with errors", func(t *testing.T) {
+		logger := &testIssueCollector{}
+		progressTracker := &inspectProgressTracker{}
+		progressTracker.mu.cachedProgress = &jobspb.Progress{
+			Details: &jobspb.Progress_Inspect{
+				Inspect: &jobspb.InspectProgress{},
+			},
+		}
+
+		loggerBundle := newInspectLoggerBundle(1 /* jobID */, logger)
+
+		checks := []inspectClusterCheck{
+			&errorInspectClusterCheck{started: true, closeErr: errors.Newf("close error 1")},
+			&errorInspectClusterCheck{started: true, closeErr: errors.Newf("close error 2")},
+		}
+
+		runner := clusterRunner{
+			checks:          checks,
+			logger:          loggerBundle,
+			progressTracker: progressTracker,
+		}
+
+		err := runner.Close(ctx)
+		require.ErrorContains(t, err, "close error")
+	})
+}
+
+// errorInspectClusterCheck is a mock cluster check that can return errors at various stages.
+type errorInspectClusterCheck struct {
+	started  bool
+	startErr error
+	nextErr  error
+	closeErr error
+	done     bool
+}
+
+var _ inspectClusterCheck = &errorInspectClusterCheck{}
+
+func (e *errorInspectClusterCheck) StartedCluster() bool {
+	return e.started
+}
+
+func (e *errorInspectClusterCheck) StartCluster(
+	context.Context, *inspectpb.InspectSpanCheckData,
+) error {
+	if e.startErr != nil {
+		return e.startErr
+	}
+	e.started = true
+	return nil
+}
+
+func (e *errorInspectClusterCheck) NextCluster(context.Context) (*inspectIssue, error) {
+	if e.nextErr != nil {
+		return nil, e.nextErr
+	}
+	e.done = true
+	return nil, nil
+}
+
+func (e *errorInspectClusterCheck) DoneCluster(context.Context) bool {
+	return e.done
+}
+
+func (e *errorInspectClusterCheck) CloseCluster(context.Context) error {
+	return e.closeErr
+}

--- a/pkg/sql/inspect/index_consistency_check.go
+++ b/pkg/sql/inspect/index_consistency_check.go
@@ -58,20 +58,9 @@ func (c *indexConsistencyCheckApplicability) AppliesTo(
 	return spanContainsTable(c.tableID, codec, span)
 }
 
-// checkState represents the state of an index consistency check.
-type checkState int
-
-const (
-	// checkNotStarted indicates Start() has not been called yet.
-	checkNotStarted checkState = iota
-	// checkHashMatched indicates the hash precheck passed - no corruption detected,
-	// so the full check can be skipped.
-	checkHashMatched
-	// checkRunning indicates the full check is actively running and may produce more results.
-	checkRunning
-	// checkDone indicates the check has finished (iterator exhausted or error occurred).
-	checkDone
-)
+func (c *indexConsistencyCheckApplicability) IsSpanLevel() bool {
+	return false
+}
 
 // indexConsistencyCheck verifies consistency between a table's primary index
 // and a specified secondary index by streaming rows from both sides of a

--- a/pkg/sql/inspect/inspectpb/BUILD.bazel
+++ b/pkg/sql/inspect/inspectpb/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("//pkg/testutils:buildutil/buildutil.bzl", "disallowed_imports_test")
+load("//build:STRINGER.bzl", "stringer")
+
+proto_library(
+    name = "inspectpb_proto",
+    srcs = [
+        "inspect.proto",
+    ],
+    strip_import_prefix = "/pkg",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb:roachpb_proto",
+        "//pkg/util/hlc:hlc_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
+)
+
+go_proto_library(
+    name = "inspectpb_go_proto",
+    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb",
+    proto = ":inspectpb_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
+)
+
+go_library(
+    name = "inspectpb",
+    embed = [":inspectpb_go_proto"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/sql/inspect/inspectpb/inspect.proto
+++ b/pkg/sql/inspect/inspectpb/inspect.proto
@@ -1,0 +1,35 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.sql.inspect.inspectpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb";
+
+import "roachpb/data.proto";
+import "util/hlc/timestamp.proto";
+import "gogoproto/gogo.proto";
+
+message InspectProgressDetails {
+    InspectProcessorProgress progress = 1; // Progress update from an inspect processor.
+    InspectProcessorSpanCheckData span_check_data = 2; // Check data accumulated from an inspect processor.
+}
+
+// InspectProcessorProgress is the per-processor progress for an INSPECT job.
+message InspectProcessorProgress {
+  int64 checks_completed = 1;  // Number of checks completed since last update.
+  bool finished = 2;           // Processor finished all checks.
+
+  // SpanStarted indicates a span has begun processing. When set, the
+  // coordinator should set up protected timestamp protection for this span.
+  roachpb.Span span_started = 3 [(gogoproto.nullable) = false];
+
+  // StartedAt timestamp is the "now" timestamp chosen for this span.
+  util.hlc.Timestamp started_at = 4 [(gogoproto.nullable) = false];
+}
+
+message InspectProcessorSpanCheckData {}
+
+// InspectSpanCheckData persists check-specific data accumulated during span processing.
+message InspectSpanCheckData {}

--- a/pkg/sql/inspect/progress.go
+++ b/pkg/sql/inspect/progress.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -29,11 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	pbtypes "github.com/gogo/protobuf/types"
+	gogotypes "github.com/gogo/protobuf/types"
 )
 
 // Name for the INSPECT completed spans frontier in jobfrontier.
 const inspectCompletedSpansKey = "inspect_completed_spans"
+
+// Name for the INSPECT data collected from span checks.
+const inspectSpanCheckDataKey = "inspect_span_check_data"
 
 // inspectProgressTracker tracks INSPECT job progress with span checkpointing.
 // It maintains completed spans to enable job restarts without reprocessing.
@@ -78,6 +82,7 @@ type inspectProgressTracker struct {
 		// lastLoggedPercent tracks the last percentage milestone we logged, to avoid
 		// spamming logs with progress updates. We log at every 1% increment.
 		lastLoggedPercent int
+		spanCheckData     inspectpb.InspectSpanCheckData
 	}
 
 	// Goroutine management.
@@ -110,13 +115,21 @@ func newInspectProgressTracker(
 	return t
 }
 
-// loadCompletedSpansFromStorage loads completed spans from jobfrontier.
-func (t *inspectProgressTracker) loadCompletedSpansFromStorage(
+// loadFromStorage loads completed spans from jobfrontier and span check data
+// from storage.
+func (t *inspectProgressTracker) loadFromStorage(
 	ctx context.Context,
-) ([]roachpb.Span, error) {
+) ([]roachpb.Span, inspectpb.InspectSpanCheckData, error) {
 	var completedSpans []roachpb.Span
+	var spanCheckData inspectpb.InspectSpanCheckData
 
 	err := t.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		infoStorage := jobs.InfoStorageForJob(txn, t.jobID)
+		_, err := infoStorage.GetProto(ctx, inspectSpanCheckDataKey, &spanCheckData)
+		if err != nil {
+			return errors.Wrap(err, "failed to load span check data")
+		}
+
 		resolvedSpans, found, err := jobfrontier.GetResolvedSpans(ctx, txn, t.jobID, inspectCompletedSpansKey)
 		if err != nil {
 			return err
@@ -133,13 +146,14 @@ func (t *inspectProgressTracker) loadCompletedSpansFromStorage(
 		return nil
 	})
 
-	return completedSpans, err
+	return completedSpans, spanCheckData, err
 }
 
-// initTracker sets up the progress tracker and returns completed spans from any previous
-// job execution. This should be called before planning to enable span optimization.
+// initTracker sets up the progress tracker, loads span check data, and returns
+// completed spans from any previous job execution. This should be called before
+// planning to enable span optimization.
 func (t *inspectProgressTracker) initTracker(ctx context.Context) ([]roachpb.Span, error) {
-	completedSpans, err := t.loadCompletedSpansFromStorage(ctx)
+	completedSpans, spanCheckData, err := t.loadFromStorage(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -149,6 +163,7 @@ func (t *inspectProgressTracker) initTracker(ctx context.Context) ([]roachpb.Spa
 		t.mu.Lock()
 		defer t.mu.Unlock()
 		t.mu.completedSpans.Add(completedSpans...)
+		t.mu.spanCheckData = spanCheckData
 		log.Dev.Infof(ctx, "INSPECT job restarting with %d existing completed spans", len(completedSpans))
 	}
 
@@ -203,19 +218,19 @@ func (t *inspectProgressTracker) handleProgressUpdate(
 		return nil
 	}
 
-	var incomingProcProgress jobspb.InspectProcessorProgress
-	if err := pbtypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &incomingProcProgress); err != nil {
-		return errors.Wrapf(err, "unable to unmarshal inspect progress details")
+	incomingProgressDetails, err := t.getProgressDetails(&meta.BulkProcessorProgress.ProgressDetails)
+	if err != nil {
+		return err
 	}
 
 	// Handle span started: set up PTS protection.
-	if !incomingProcProgress.SpanStarted.Equal(roachpb.Span{}) {
-		t.setupSpanPTS(ctx, incomingProcProgress.SpanStarted, incomingProcProgress.StartedAt)
+	if !incomingProgressDetails.Progress.SpanStarted.Equal(roachpb.Span{}) {
+		t.setupSpanPTS(ctx, incomingProgressDetails.Progress.SpanStarted, incomingProgressDetails.Progress.StartedAt)
 		return nil
 	}
 
 	// Update the progress cache (with lock).
-	needsImmediatePersistence, err := t.updateProgressCache(meta, incomingProcProgress)
+	needsImmediatePersistence, err := t.updateProgressCache(meta, *incomingProgressDetails)
 	if err != nil {
 		return err
 	}
@@ -242,10 +257,39 @@ func (t *inspectProgressTracker) handleProgressUpdate(
 	return nil
 }
 
+func (t *inspectProgressTracker) getProgressDetails(
+	details *gogotypes.Any,
+) (*inspectpb.InspectProgressDetails, error) {
+	incomingProgressDetails := &inspectpb.InspectProgressDetails{}
+
+	// TODO(bghal): This branch may be removed when 26.1 is past upgrading.
+	//lint:ignore SA1019 jobspb.InspectProcessorProgress is deprecated: Moved to cockroach.sql.inspect.inspectpb.
+	if incomingProcProgress := (&jobspb.InspectProcessorProgress{}); gogotypes.Is(details, incomingProcProgress) {
+		if err := gogotypes.UnmarshalAny(details, incomingProcProgress); err != nil {
+			return nil, errors.Wrapf(err, "unable to unmarshal inspect processor progress from details")
+		}
+
+		incomingProgressDetails = &inspectpb.InspectProgressDetails{
+			Progress: &inspectpb.InspectProcessorProgress{
+				ChecksCompleted: incomingProcProgress.ChecksCompleted,
+				Finished:        incomingProcProgress.Finished,
+				SpanStarted:     incomingProcProgress.SpanStarted,
+				StartedAt:       incomingProcProgress.StartedAt,
+			},
+		}
+	} else {
+		if err := gogotypes.UnmarshalAny(details, incomingProgressDetails); err != nil {
+			return nil, errors.Wrapf(err, "unable to unmarshal inspect progress details")
+		}
+	}
+
+	return incomingProgressDetails, nil
+}
+
 // updateProgressCache computes updated job progress from processor metadata and updates
 // the internal cache. Returns true when immediate persistence is needed.
 func (t *inspectProgressTracker) updateProgressCache(
-	meta *execinfrapb.ProducerMetadata, incomingProcProgress jobspb.InspectProcessorProgress,
+	meta *execinfrapb.ProducerMetadata, incomingProcProgress inspectpb.InspectProgressDetails,
 ) (bool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -269,8 +313,13 @@ func (t *inspectProgressTracker) updateProgressCache(
 	}
 
 	// Update check count.
-	if incomingProcProgress.ChecksCompleted > 0 {
-		inspectProgress.JobCompletedCheckCount += incomingProcProgress.ChecksCompleted
+	if incomingProcProgress.Progress.ChecksCompleted > 0 {
+		inspectProgress.JobCompletedCheckCount += incomingProcProgress.Progress.ChecksCompleted
+	}
+
+	// Update the check-specific fields (e.g. row counts).
+	if incomingProcProgress.SpanCheckData != nil {
+		t.applySpanCheckData(incomingProcProgress.SpanCheckData)
 	}
 
 	// Update cached progress - the goroutine will handle actual persistence.
@@ -285,6 +334,42 @@ func (t *inspectProgressTracker) updateProgressCache(
 	// capture the final state when a processor completes its work, rather than
 	// waiting for the next periodic checkpoint update.
 	return meta.BulkProcessorProgress.Drained, nil
+}
+
+// stepCompletedCheckCount updates the completed check count. This is used for
+// checks run off the processors.
+func (t *inspectProgressTracker) stepCompletedCheckCount(
+	ctx context.Context, count int,
+) (err error) {
+	t.mu.Lock()
+	defer func() {
+		t.mu.Unlock()
+
+		if err == nil {
+			err = t.flushProgress(ctx)
+		}
+	}()
+
+	if t.mu.cachedProgress == nil {
+		return errors.AssertionFailedf("progress not initialized")
+	}
+
+	orig := t.mu.cachedProgress.GetInspect()
+	if orig == nil {
+		return errors.AssertionFailedf("cached progress does not contain Inspect details")
+	}
+	inspectProgress := protoutil.Clone(orig).(*jobspb.InspectProgress)
+
+	// Increment the completed check count
+	inspectProgress.JobCompletedCheckCount += int64(count)
+
+	t.mu.cachedProgress = &jobspb.Progress{
+		Details: &jobspb.Progress_Inspect{
+			Inspect: inspectProgress,
+		},
+	}
+
+	return nil
 }
 
 // terminateTracker performs any necessary cleanup when the job completes or fails.
@@ -586,8 +671,8 @@ func (t *inspectProgressTracker) flushProgress(ctx context.Context) error {
 	})
 }
 
-// flushCheckpointUpdate performs a progress update to include completed spans.
-// The completed spans are stored via jobfrontier.
+// flushCheckpointUpdate performs a progress update of completed spans and span
+// check data. The completed spans are stored via jobfrontier.
 func (t *inspectProgressTracker) flushCheckpointUpdate(ctx context.Context) error {
 	if !t.hasUncheckpointedSpans() {
 		return nil
@@ -595,11 +680,13 @@ func (t *inspectProgressTracker) flushCheckpointUpdate(ctx context.Context) erro
 
 	var completedSpans []roachpb.Span
 	var capturedReceivedCount int
+	var spanCheckData inspectpb.InspectSpanCheckData
 	func() {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 		completedSpans = t.mu.completedSpans.Slice()
 		capturedReceivedCount = t.mu.receivedSpanCount
+		spanCheckData = t.mu.spanCheckData
 	}()
 
 	// If no completed spans, nothing to store.
@@ -614,7 +701,18 @@ func (t *inspectProgressTracker) flushCheckpointUpdate(ctx context.Context) erro
 			return err
 		}
 		defer frontier.Release()
-		return jobfrontier.Store(ctx, txn, t.jobID, inspectCompletedSpansKey, frontier)
+
+		err = jobfrontier.Store(ctx, txn, t.jobID, inspectCompletedSpansKey, frontier)
+		if err != nil {
+			return err
+		}
+
+		infoStorage := jobs.InfoStorageForJob(txn, t.jobID)
+		if err := infoStorage.WriteProto(ctx, inspectSpanCheckDataKey, &spanCheckData); err != nil {
+			return errors.Wrap(err, "failed to store span check data")
+		}
+
+		return nil
 	})
 	if err != nil {
 		return err
@@ -678,24 +776,69 @@ func (t *inspectProgressTracker) hasUncheckpointedSpans() bool {
 	return t.mu.receivedSpanCount > t.mu.lastCheckpointedSpanCount
 }
 
-// countApplicableChecks determines how many checks will actually run across all spans.
+// countApplicableSpanChecks determines how many checks will actually run across all spans.
 // This provides accurate progress calculation by only counting checks that apply to each span.
-func countApplicableChecks(
+func countApplicableSpanChecks(
 	pkSpans []roachpb.Span, checkers []inspectCheckApplicability, codec keys.SQLCodec,
 ) (int64, error) {
 	var totalApplicableChecks int64 = 0
 
 	for _, span := range pkSpans {
 		for _, checker := range checkers {
-			applies, err := checker.AppliesTo(codec, span)
+			isApplicable, err := checker.AppliesTo(codec, span)
 			if err != nil {
 				return 0, err
 			}
-			if applies {
+			if isApplicable {
 				totalApplicableChecks++
+
+				// Span-level checks are run a second time after the regular checks have completed.
+				if checker.IsSpanLevel() {
+					totalApplicableChecks++
+				}
 			}
 		}
 	}
 
 	return totalApplicableChecks, nil
+}
+
+// countApplicableClusterChecks determines how many cluster-level checks apply.
+func countApplicableClusterChecks(checkers []inspectCheckApplicability) (int64, error) {
+	var count int64 = 0
+
+	for _, checker := range checkers {
+		if checker, ok := checker.(inspectCheckClusterApplicability); ok {
+			applies, err := checker.AppliesToCluster()
+			if err != nil {
+				return 0, err
+			}
+			if applies {
+				count++
+			}
+		}
+	}
+
+	return count, nil
+}
+
+// getCachedCheckCounts returns the current cached span check data.
+func (t *inspectProgressTracker) getSpanCheckData() inspectpb.InspectSpanCheckData {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.mu.spanCheckData
+}
+
+// applySpanCheckData updates the cache with data from the check-specific fields
+// in the span progress update. The caller is responsible for acquiring the
+// mutex.
+func (t *inspectProgressTracker) applySpanCheckData(
+	incomingSpanCheckData *inspectpb.InspectProcessorSpanCheckData,
+) {
+	if incomingSpanCheckData == nil {
+		return
+	}
+
+	// For future span-level checks.
 }

--- a/pkg/sql/inspect/progress_test.go
+++ b/pkg/sql/inspect/progress_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -421,15 +422,17 @@ func verifyStoredSpans(
 // Returns both the metadata and the parsed progress struct for use with updateProgressCache.
 func createProcessorProgressUpdate(
 	checksCompleted int64, finished bool, completedSpans []roachpb.Span,
-) (*execinfrapb.ProducerMetadata, jobspb.InspectProcessorProgress, error) {
-	progressMsg := jobspb.InspectProcessorProgress{
-		ChecksCompleted: checksCompleted,
-		Finished:        finished,
+) (*execinfrapb.ProducerMetadata, inspectpb.InspectProgressDetails, error) {
+	progressMsg := inspectpb.InspectProgressDetails{
+		Progress: &inspectpb.InspectProcessorProgress{
+			ChecksCompleted: checksCompleted,
+			Finished:        finished,
+		},
 	}
 
 	progressAny, err := pbtypes.MarshalAny(&progressMsg)
 	if err != nil {
-		return nil, jobspb.InspectProcessorProgress{}, err
+		return nil, inspectpb.InspectProgressDetails{}, err
 	}
 
 	const testNodeID = 1
@@ -632,9 +635,11 @@ func TestInspectProgressTracker_ProgressFlushConditions(t *testing.T) {
 func createSpanStartedProgressUpdate(
 	span roachpb.Span, ts hlc.Timestamp,
 ) (*execinfrapb.ProducerMetadata, error) {
-	progressMsg := jobspb.InspectProcessorProgress{
-		SpanStarted: span,
-		StartedAt:   ts,
+	progressMsg := inspectpb.InspectProgressDetails{
+		Progress: &inspectpb.InspectProcessorProgress{
+			SpanStarted: span,
+			StartedAt:   ts,
+		},
 	}
 
 	progressAny, err := pbtypes.MarshalAny(&progressMsg)

--- a/pkg/sql/inspect/runner_test.go
+++ b/pkg/sql/inspect/runner_test.go
@@ -37,6 +37,10 @@ func (m *mockInspectCheck) AppliesTo(codec keys.SQLCodec, span roachpb.Span) (bo
 	return true, nil
 }
 
+func (c *mockInspectCheck) IsSpanLevel() bool {
+	return false
+}
+
 func (m *mockInspectCheck) Started() bool {
 	return m.started
 }


### PR DESCRIPTION
Previously the checks were independent and could only process individual
spans.
The row count check will be dependent on other checks that perform the
scan of each span and will need to aggregate the row counts after all
the spans have been processed.
This change sets up interfaces for span-level (dependent on other
checks running on the spans) and cluster-level checks (run after all spans have
been processed).

Part of: #155472
Epic: CRDB-55075

Release note: None
