### PR TITLE
sql: add row count check

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1525,6 +1525,9 @@ message InspectDetails {
       // INDEX_CONSISTENCY performs validation between primary and secondary indexes
       // to detect missing or dangling index entries.
       INSPECT_CHECK_INDEX_CONSISTENCY = 1 [(gogoproto.enumvalue_customname) = "InspectCheckIndexConsistency"];
+
+      // INSPECT_CHECK_ROW_COUNT validates a table has the expected number of rows.
+      INSPECT_CHECK_ROW_COUNT = 2 [(gogoproto.enumvalue_customname) = "InspectCheckRowCount"];
     }
 
     // Type is the kind of validation to perform.
@@ -1551,6 +1554,10 @@ message InspectDetails {
       (gogoproto.customname) = "TableVersion",
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.DescriptorVersion"
     ];
+
+    // RowCount indicates the expected number of rows in the table, if applicable. Should be set
+    // for row count checks.
+    uint64 row_count = 5;
   }
 
   // Checks is the list of individual checks this job will perform.
@@ -1626,6 +1633,7 @@ message HotRangesLoggerProgress {
 message InspectProgress {
   int64 job_total_check_count = 1;
   int64 job_completed_check_count = 2;
+  uint64 row_count = 3; // Accumulator of row counts of each index.
 }
 
 // InspectProcessorProgress is the per-processor progress for an INSPECT job.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -344,7 +344,8 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 			tableName = tblDesc.GetName()
-			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc)
+			expectedRowCount := uint64(r.res.Rows)
+			checks, err = inspect.ChecksForTable(ctx, nil /* p */, tblDesc, &expectedRowCount)
 			return err
 		}); err != nil {
 			return err

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "issue_test.go",
         "main_test.go",
         "progress_test.go",
+        "row_count_check_test.go",
         "runner_test.go",
         "table_sink_test.go",
     ],

--- a/pkg/sql/inspect/inspect_plan.go
+++ b/pkg/sql/inspect/inspect_plan.go
@@ -109,7 +109,7 @@ func newInspectRun(
 		// No INDEX options or INDEX ALL specified - inspect all indexes.
 		switch stmt.Typ {
 		case tree.InspectTable:
-			checks, err := ChecksForTable(ctx, p, run.table)
+			checks, err := ChecksForTable(ctx, p, run.table, nil /* rowCount */)
 			if err != nil {
 				return inspectRun{}, err
 			}

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -529,6 +529,19 @@ func buildInspectCheckFactories(
 					asOf:         asOf,
 				}
 			})
+		case jobspb.InspectCheckRowCount:
+			checkFactories = append(checkFactories, func(asOf hlc.Timestamp) inspectCheck {
+				return &rowCountCheck{
+					rowCountCheckApplicability: rowCountCheckApplicability{
+						tableID: tableID,
+					},
+					execCfg:      execCfg,
+					tableVersion: tableVersion,
+					asOf:         asOf,
+
+					expected: specCheck.RowCount,
+				}
+			})
 		default:
 			return nil, errors.AssertionFailedf("unsupported inspect check type: %v", specCheck.Type)
 		}

--- a/pkg/sql/inspect/inspect_resumer.go
+++ b/pkg/sql/inspect/inspect_resumer.go
@@ -374,6 +374,10 @@ func buildApplicabilityCheckers(
 			checkers = append(checkers, &indexConsistencyCheckApplicability{
 				tableID: specCheck.TableID,
 			})
+		case jobspb.InspectCheckRowCount:
+			checkers = append(checkers, &rowCountCheckApplicability{
+				tableID: specCheck.TableID,
+			})
 		default:
 			return nil, errors.AssertionFailedf("unsupported inspect check type: %v", specCheck.Type)
 		}

--- a/pkg/sql/inspect/inspectpb/inspect.proto
+++ b/pkg/sql/inspect/inspectpb/inspect.proto
@@ -5,21 +5,22 @@
 
 syntax = "proto3";
 package cockroach.sql.inspect.inspectpb;
-option go_package = "github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb";
 
+import "gogoproto/gogo.proto";
 import "roachpb/data.proto";
 import "util/hlc/timestamp.proto";
-import "gogoproto/gogo.proto";
+
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb";
 
 message InspectProgressDetails {
-    InspectProcessorProgress progress = 1; // Progress update from an inspect processor.
-    InspectProcessorSpanCheckData span_check_data = 2; // Check data accumulated from an inspect processor.
+  InspectProcessorProgress progress = 1; // Progress update from an inspect processor.
+  InspectProcessorSpanCheckData span_check_data = 2; // Check data accumulated from an inspect processor.
 }
 
 // InspectProcessorProgress is the per-processor progress for an INSPECT job.
 message InspectProcessorProgress {
-  int64 checks_completed = 1;  // Number of checks completed since last update.
-  bool finished = 2;           // Processor finished all checks.
+  int64 checks_completed = 1; // Number of checks completed since last update.
+  bool finished = 2; // Processor finished all checks.
 
   // SpanStarted indicates a span has begun processing. When set, the
   // coordinator should set up protected timestamp protection for this span.
@@ -29,7 +30,11 @@ message InspectProcessorProgress {
   util.hlc.Timestamp started_at = 4 [(gogoproto.nullable) = false];
 }
 
-message InspectProcessorSpanCheckData {}
+message InspectProcessorSpanCheckData {
+  uint64 span_row_count = 1; // Number of rows in the span processed.
+}
 
 // InspectSpanCheckData persists check-specific data accumulated during span processing.
-message InspectSpanCheckData {}
+message InspectSpanCheckData {
+  uint64 row_count = 1; // Number of rows in the table.
+}

--- a/pkg/sql/inspect/issue.go
+++ b/pkg/sql/inspect/issue.go
@@ -102,4 +102,8 @@ const (
 	// issues) prevents the check from completing normally. These errors indicate
 	// potential data corruption or other serious issues that require investigation.
 	InternalError inspectErrorType = "internal_error"
+
+	// RowCountMismatch occurs when a index's row count doesn't match the
+	// expected value.
+	RowCountMismatch inspectErrorType = "row_count_mismatch"
 )

--- a/pkg/sql/inspect/progress.go
+++ b/pkg/sql/inspect/progress.go
@@ -840,5 +840,6 @@ func (t *inspectProgressTracker) applySpanCheckData(
 		return
 	}
 
-	// For future span-level checks.
+	// Update the row count field.
+	t.mu.spanCheckData.RowCount += incomingSpanCheckData.SpanRowCount
 }

--- a/pkg/sql/inspect/row_count_check.go
+++ b/pkg/sql/inspect/row_count_check.go
@@ -5,11 +5,216 @@
 
 package inspect
 
-// inspectCheckRowCount defines an inspectCheck that counts rows in addition to
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/inspect/inspectpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// inspectCheckRowCount extends an inspectCheck that counts rows in addition to
 // its primary validation.
 type inspectCheckRowCount interface {
-	inspectCheck
-
 	// Rows returns the number of rows counted by the check.
 	RowCount() uint64
+}
+
+// rowCountCheck verifies a table's row count matches the expected count.
+// It relies on other jobs to perform the row count.
+type rowCountCheck struct {
+	rowCountCheckApplicability
+
+	execCfg *sql.ExecutorConfig
+	// tableVersion is the descriptor version recorded when the check was planned.
+	// It is used to detect concurrent schema changes for non-AS OF inspections.
+	tableVersion descpb.DescriptorVersion
+	asOf         hlc.Timestamp
+
+	state checkState // State of the check when run on a span.
+
+	expected uint64
+
+	tableDesc catalog.TableDescriptor // Populated from the tableID for the cluster check.
+	rowCount  uint64                  // Populated from the job progress for the cluster check.
+
+	clusterState checkClusterState // State of the check when run as a cluster-level check.
+}
+
+// rowCountCheckApplicability is a lightweight version that only implements applicability logic.
+type rowCountCheckApplicability struct {
+	tableID descpb.ID
+}
+
+// AppliesTo implements the inspectCheckApplicability interface.
+func (c *rowCountCheckApplicability) AppliesTo(
+	codec keys.SQLCodec, span roachpb.Span,
+) (bool, error) {
+	return spanContainsTable(c.tableID, codec, span)
+}
+
+func (c *rowCountCheckApplicability) IsSpanLevel() bool {
+	return true
+}
+
+// AppliesToCluster implements the inspectCheckClusterApplicability interface.
+func (c *rowCountCheckApplicability) AppliesToCluster() (bool, error) {
+	return true, nil
+}
+
+var _ inspectCheck = (*rowCountCheck)(nil)
+var _ inspectCheckApplicability = (*rowCountCheckApplicability)(nil)
+var _ inspectCheckClusterApplicability = (*rowCountCheckApplicability)(nil)
+
+var _ inspectSpanCheck = (*rowCountCheck)(nil)
+var _ inspectClusterCheck = (*rowCountCheck)(nil)
+
+// Started implements the inspectCheck interface.
+func (c *rowCountCheck) Started() bool {
+	return c.state != checkNotStarted
+}
+
+// Start implements the inspectCheck interface.
+func (c *rowCountCheck) Start(
+	ctx context.Context, cfg *execinfra.ServerConfig, span roachpb.Span, workerIndex int,
+) error {
+	if err := assertCheckApplies(c, cfg.Codec, span); err != nil {
+		return err
+	}
+
+	c.state = checkRunning
+
+	return nil
+}
+
+func (c *rowCountCheck) Next(
+	ctx context.Context, cfg *execinfra.ServerConfig,
+) (*inspectIssue, error) {
+	c.state = checkDone
+	return nil, nil
+}
+
+// Done implements the inspectCheck interface.
+func (c *rowCountCheck) Done(context.Context) bool {
+	return c.state == checkDone
+}
+
+// Close implements the inspectCheck interface.
+func (c *rowCountCheck) Close(context.Context) error {
+	return nil
+}
+
+// CheckSpan implements the inspectSpanCheck interface.
+func (c *rowCountCheck) CheckSpan(
+	ctx context.Context,
+	checks inspectChecks,
+	logger *inspectLoggerBundle,
+	data *inspectpb.InspectProcessorSpanCheckData,
+) error {
+	for _, check := range checks {
+		// TODO(#160989): Handle inconsistency btwn checks on the same span.
+		if check, ok := check.(inspectCheckRowCount); ok {
+			data.SpanRowCount = check.RowCount()
+			return nil
+		}
+	}
+
+	return errors.AssertionFailedf("rowCountCheck requires an inspectCheckRowCount to be registered")
+}
+
+// StartedCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) StartedCluster() bool {
+	return c.clusterState != clusterCheckNotStarted
+}
+
+// StartCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) StartCluster(
+	ctx context.Context, checkData *inspectpb.InspectSpanCheckData,
+) error {
+	c.clusterState = clusterCheckRunning
+
+	if err := c.loadTableDesc(ctx); err != nil {
+		return err
+	}
+	c.rowCount = checkData.RowCount
+
+	return nil
+}
+
+func (c *rowCountCheck) loadTableDesc(ctx context.Context) error {
+	return c.execCfg.DistSQLSrv.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		if !c.asOf.IsEmpty() {
+			if err := txn.KV().SetFixedTimestamp(ctx, c.asOf); err != nil {
+				return err
+			}
+		}
+
+		byIDGetter := txn.Descriptors().ByIDWithLeased(txn.KV())
+		if !c.asOf.IsEmpty() {
+			byIDGetter = txn.Descriptors().ByIDWithoutLeased(txn.KV())
+		}
+
+		var err error
+		c.tableDesc, err = byIDGetter.WithoutNonPublic().Get().Table(ctx, c.tableID)
+		if err != nil {
+			return err
+		}
+		if c.tableVersion != 0 && c.tableDesc.GetVersion() != c.tableVersion {
+			return errors.WithHintf(
+				errors.Newf(
+					"table %s [%d] has had a schema change since the job has started at %s",
+					c.tableDesc.GetName(),
+					c.tableDesc.GetID(),
+					c.tableDesc.GetModificationTime().GoTime().Format(time.RFC3339),
+				),
+				"use AS OF SYSTEM TIME to avoid schema changes during inspection",
+			)
+		}
+
+		return nil
+	})
+}
+
+// NextCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) NextCluster(ctx context.Context) (*inspectIssue, error) {
+	if c.clusterState != clusterCheckRunning {
+		return nil, nil
+	}
+
+	c.clusterState = clusterCheckDone
+
+	if c.rowCount != c.expected {
+		return &inspectIssue{
+			ErrorType:  RowCountMismatch,
+			AOST:       c.asOf.GoTime(),
+			DatabaseID: c.tableDesc.GetParentID(),
+			SchemaID:   c.tableDesc.GetParentSchemaID(),
+			ObjectID:   c.tableDesc.GetID(),
+			Details: map[redact.RedactableString]interface{}{
+				"expected": c.expected,
+				"actual":   c.rowCount,
+			},
+		}, nil
+	}
+
+	return nil, nil
+}
+
+// DoneCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) DoneCluster(ctx context.Context) bool {
+	return c.clusterState == clusterCheckDone
+}
+
+// CloseCluster implements the inspectClusterCheck interface.
+func (c *rowCountCheck) CloseCluster(ctx context.Context) error {
+	return nil
 }

--- a/pkg/sql/inspect/row_count_check_test.go
+++ b/pkg/sql/inspect/row_count_check_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowCountCheck(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	codec := s.ApplicationLayer().Codec()
+	execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
+	r := sqlutils.MakeSQLRunner(db)
+
+	// Create a table and populate it with 100 rows.
+	r.ExecMultiple(t,
+		`CREATE DATABASE test`,
+		`CREATE TABLE test.t (id INT PRIMARY KEY, INDEX idx (id))`,
+		`INSERT INTO test.t SELECT * FROM generate_series(1, 100)`,
+	)
+
+	// Get the table descriptor
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", "t")
+
+	// Create checks for the table with expected row count of 105 which will
+	// report an error.
+	badExpectedRowCount := uint64(105)
+	checks, err := ChecksForTable(ctx, nil /* PlanHookState */, tableDesc, &badExpectedRowCount)
+	require.NoError(t, err)
+	require.Len(t, checks, 2)
+
+	// Get a timestamp for AS OF SYSTEM TIME
+	var timestampStr string
+	r.QueryRow(t, "SELECT cluster_logical_timestamp()::STRING").Scan(&timestampStr)
+	asOfTimestamp, err := hlc.ParseHLC(timestampStr)
+	require.NoError(t, err)
+
+	// Trigger the inspect job directly
+	job, err := TriggerJob(
+		ctx,
+		"test row count check",
+		&execCfg,
+		checks,
+		asOfTimestamp,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+
+	// Wait for the job to complete
+	err = job.AwaitCompletion(ctx)
+	require.Error(t, err, "inspect job should error on the row count mismatch")
+
+	// Verify the job succeeded
+	var jobStatus string
+	var fractionCompleted float64
+	r.QueryRow(t,
+		`SELECT status, fraction_completed FROM [SHOW JOBS] WHERE job_type = 'INSPECT' ORDER BY created DESC LIMIT 1`,
+	).Scan(&jobStatus, &fractionCompleted)
+	require.Equal(t, "failed", jobStatus, "inspect job should fail with mismatching row count")
+	require.InEpsilon(t, 1.0, fractionCompleted, 0.01, "progress should reach 100% on successful completion")
+
+	// Query the inspect_errors table to verify a row count mismatch issue was reported
+	// There should be exactly one error (row count checks produce one error per table)
+	var errorType string
+	var databaseName, schemaName, tableName, primaryKey, aost, details string
+	var jobID int64
+	var errorCount int
+	r.QueryRow(t,
+		fmt.Sprintf(`SELECT count(*) FROM [SHOW INSPECT ERRORS FOR JOB %d]`, job.ID()),
+	).Scan(&errorCount)
+	require.Equal(t, 1, errorCount, "should have exactly one row count mismatch error")
+
+	r.QueryRow(t,
+		fmt.Sprintf(`SHOW INSPECT ERRORS FOR JOB %d WITH DETAILS`, job.ID()),
+	).Scan(&errorType, &databaseName, &schemaName, &tableName, &primaryKey, &jobID, &aost, &details)
+
+	require.Equal(t, string(RowCountMismatch), errorType)
+	require.Equal(t, "test", databaseName, "issue should reference the correct database")
+	require.Equal(t, "public", schemaName, "issue should reference the correct schema")
+	require.Equal(t, "t", tableName, "issue should reference the correct table")
+
+	// Parse the details JSON to verify expected and actual counts
+	var detailsMap map[string]interface{}
+	err = json.Unmarshal([]byte(details), &detailsMap)
+	require.NoError(t, err, "details should be valid JSON")
+	require.Contains(t, detailsMap, "expected", "details should contain expected count")
+	require.Contains(t, detailsMap, "actual", "details should contain actual count")
+	require.Equal(t, float64(badExpectedRowCount), detailsMap["expected"], "expected count should match")
+	require.Equal(t, float64(100), detailsMap["actual"], "actual count should be 100")
+}


### PR DESCRIPTION
Adds an inspect check that validates the row count of the scanned
indexes. The check sums up row counts generated by other checks.

Part of:#155472
Epic: CRDB-55075

Release note: None