### PR TITLE
builtins: call Parse instead of ParseOne in crdb_internal.inject_hint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -943,3 +943,11 @@ statement hints count: 1
       missing stats
       table: xy@xy_pkey
       spans: FULL SCAN
+
+# Test error handling for crdb_internal.inject_hint.
+
+statement error pq: could not parse statement fingerprint as a single SQL statement
+SELECT crdb_internal.inject_hint('', '')
+
+statement error pq: could not parse hint donor statement as a single SQL statement
+SELECT crdb_internal.inject_hint('SELECT 1', 'SELECT 2; SELECT 3')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9677,18 +9677,32 @@ WHERE object_id = table_descriptor_id
 				fingerprintFlags := tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(
 					&evalCtx.Settings.SV,
 				))
-				targetStmt, err := parserutils.ParseOne(stmtFingerprint)
+				stmts, err := parserutils.Parse(stmtFingerprint)
 				if err != nil {
 					return nil, pgerror.Wrap(
 						err, pgcode.InvalidParameterValue, "could not parse statement fingerprint",
 					)
 				}
-				donorStmt, err := parserutils.ParseOne(donorSQL)
+				if len(stmts) != 1 {
+					return nil, pgerror.New(
+						pgcode.InvalidParameterValue,
+						"could not parse statement fingerprint as a single SQL statement",
+					)
+				}
+				targetStmt := stmts[0]
+				stmts, err = parserutils.Parse(donorSQL)
 				if err != nil {
 					return nil, pgerror.Wrap(
 						err, pgcode.InvalidParameterValue, "could not parse hint donor statement",
 					)
 				}
+				if len(stmts) != 1 {
+					return nil, pgerror.New(
+						pgcode.InvalidParameterValue,
+						"could not parse hint donor statement as a single SQL statement",
+					)
+				}
+				donorStmt := stmts[0]
 				donor, err := tree.NewHintInjectionDonor(donorStmt.AST, fingerprintFlags)
 				if err != nil {
 					return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error while creating donor")


### PR DESCRIPTION
This changes an internal error to a regular error with a pgcode.

Fixes: #158658
Fixes: #159232

Release note: None