### PR TITLE
build/util: remove unnecessary `Classname` attribute

### DIFF
--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -45,12 +45,11 @@ type testCase struct {
 	// this isn't Java so there isn't a classname) and excluding it causes
 	// the TeamCity UI to display the same data in a slightly more coherent
 	// and usable way.
-	Classname string      `xml:"classname,attr"`
-	Name      string      `xml:"name,attr"`
-	Time      string      `xml:"time,attr"`
-	Failure   *XMLMessage `xml:"failure,omitempty"`
-	Error     *XMLMessage `xml:"error,omitempty"`
-	Skipped   *XMLMessage `xml:"skipped,omitempty"`
+	Name    string      `xml:"name,attr"`
+	Time    string      `xml:"time,attr"`
+	Failure *XMLMessage `xml:"failure,omitempty"`
+	Error   *XMLMessage `xml:"error,omitempty"`
+	Skipped *XMLMessage `xml:"skipped,omitempty"`
 }
 
 // XMLMessage is a catch-all structure containing details about a test

--- a/pkg/build/util/util_test.go
+++ b/pkg/build/util/util_test.go
@@ -118,79 +118,79 @@ func TestOutputsOfGenrule(t *testing.T) {
 func TestMergeXml(t *testing.T) {
 	const xml1 = `<testsuites>
 	<testsuite errors="0" failures="1" skipped="0" tests="6" time="0.010" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestDataDriven" timestamp="2025-10-31T16:31:54.004Z">
-		<testcase classname="dev" name="TestDataDriven" time="0.010"></testcase>
-		<testcase classname="dev" name="TestDataDriven/bench" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/testlogic" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/ui" time="0.000">
+		<testcase name="TestDataDriven" time="0.010"></testcase>
+		<testcase name="TestDataDriven/bench" time="0.000"></testcase>
+		<testcase name="TestDataDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestDataDriven/generate" time="0.000"></testcase>
+		<testcase name="TestDataDriven/testlogic" time="0.000"></testcase>
+		<testcase name="TestDataDriven/ui" time="0.000">
 			<failure message="Failed" type="">FAILED</failure>
 		</testcase>
 	</testsuite>
 	<testsuite errors="0" failures="0" skipped="0" tests="11" time="0.002" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestRecorderDriven" timestamp="2025-10-31T16:31:54.010Z">
-		<testcase classname="dev" name="TestRecorderDriven" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test#01" time="0.000"></testcase>
 	</testsuite>
 </testsuites>`
 	const xml2 = `<testsuites>
 	<testsuite errors="0" failures="0" skipped="0" tests="6" time="0.010" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestDataDriven" timestamp="2025-10-31T16:31:54.004Z">
-		<testcase classname="dev" name="TestDataDriven" time="0.010"></testcase>
-		<testcase classname="dev" name="TestDataDriven/bench" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/testlogic" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/ui" time="0.000"></testcase>
+		<testcase name="TestDataDriven" time="0.010"></testcase>
+		<testcase name="TestDataDriven/bench" time="0.000"></testcase>
+		<testcase name="TestDataDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestDataDriven/generate" time="0.000"></testcase>
+		<testcase name="TestDataDriven/testlogic" time="0.000"></testcase>
+		<testcase name="TestDataDriven/ui" time="0.000"></testcase>
 	</testsuite>
 	<testsuite errors="0" failures="0" skipped="0" tests="11" time="0.002" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestRecorderDriven" timestamp="2025-10-31T16:31:54.010Z">
-		<testcase classname="dev" name="TestRecorderDriven" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint" time="0.000">
+		<testcase name="TestRecorderDriven" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint" time="0.000">
 			<failure message="Failed" type="">FAILED ALSO</failure>
 		</testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test#01" time="0.000"></testcase>
 	</testsuite>
 </testsuites>`
 	const expected = `<testsuites>
 	<testsuite errors="0" failures="1" skipped="0" tests="6" time="0.01" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestDataDriven" timestamp="2025-10-31T16:31:54.004Z">
-		<testcase classname="dev" name="TestDataDriven" time="0.010"></testcase>
-		<testcase classname="dev" name="TestDataDriven/bench" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/testlogic" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/ui" time="0.000">
+		<testcase name="TestDataDriven" time="0.010"></testcase>
+		<testcase name="TestDataDriven/bench" time="0.000"></testcase>
+		<testcase name="TestDataDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestDataDriven/generate" time="0.000"></testcase>
+		<testcase name="TestDataDriven/testlogic" time="0.000"></testcase>
+		<testcase name="TestDataDriven/ui" time="0.000">
 			<failure message="Failed" type="">FAILED</failure>
 		</testcase>
 	</testsuite>
 	<testsuite errors="0" failures="1" skipped="0" tests="11" time="0.002" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestRecorderDriven" timestamp="2025-10-31T16:31:54.010Z">
-		<testcase classname="dev" name="TestRecorderDriven" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint" time="0.000">
+		<testcase name="TestRecorderDriven" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint" time="0.000">
 			<failure message="Failed" type="">FAILED ALSO</failure>
 		</testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test#01" time="0.000"></testcase>
 	</testsuite>
 </testsuites>
 `
@@ -206,47 +206,47 @@ func TestMergeXml(t *testing.T) {
 func TestMungeTestXML(t *testing.T) {
 	beforeXml := `<testsuites>
 	<testsuite errors="0" failures="0" skipped="0" tests="6" time="0.010" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestDataDriven" timestamp="2025-10-30T21:36:57.401Z">
-		<testcase classname="dev" name="TestDataDriven" time="0.010"></testcase>
-		<testcase classname="dev" name="TestDataDriven/bench" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/testlogic" time="0.000"></testcase>
-		<testcase classname="dev" name="TestDataDriven/ui" time="0.000"></testcase>
+		<testcase name="TestDataDriven" time="0.010"></testcase>
+		<testcase name="TestDataDriven/bench" time="0.000"></testcase>
+		<testcase name="TestDataDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestDataDriven/generate" time="0.000"></testcase>
+		<testcase name="TestDataDriven/testlogic" time="0.000"></testcase>
+		<testcase name="TestDataDriven/ui" time="0.000"></testcase>
 	</testsuite>
 	<testsuite errors="0" failures="0" skipped="0" tests="11" time="0.010" name="github.com/cockroachdb/cockroach/pkg/cmd/dev.TestRecorderDriven" timestamp="2025-10-30T21:36:57.406Z">
-		<testcase classname="dev" name="TestRecorderDriven" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/builder#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/generate#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/lint#01" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test" time="0.000"></testcase>
-		<testcase classname="dev" name="TestRecorderDriven/test#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/builder#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/generate#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/lint#01" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test" time="0.000"></testcase>
+		<testcase name="TestRecorderDriven/test#01" time="0.000"></testcase>
 	</testsuite>
 </testsuites>
 `
 
 	expected := `<testsuite errors="0" failures="0" skipped="0" tests="17" time="0.02" name="github.com/cockroachdb/cockroach/pkg/cmd/dev" timestamp="2025-10-30T21:36:57.401Z">
-	<testcase classname="dev" name="TestDataDriven" time="0.010"></testcase>
-	<testcase classname="dev" name="TestDataDriven/bench" time="0.000"></testcase>
-	<testcase classname="dev" name="TestDataDriven/dev-build" time="0.000"></testcase>
-	<testcase classname="dev" name="TestDataDriven/generate" time="0.000"></testcase>
-	<testcase classname="dev" name="TestDataDriven/testlogic" time="0.000"></testcase>
-	<testcase classname="dev" name="TestDataDriven/ui" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/builder" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/builder#01" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/dev-build" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/generate" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/generate#01" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/lint" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/lint#01" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/test" time="0.000"></testcase>
-	<testcase classname="dev" name="TestRecorderDriven/test#01" time="0.000"></testcase>
+	<testcase name="TestDataDriven" time="0.010"></testcase>
+	<testcase name="TestDataDriven/bench" time="0.000"></testcase>
+	<testcase name="TestDataDriven/dev-build" time="0.000"></testcase>
+	<testcase name="TestDataDriven/generate" time="0.000"></testcase>
+	<testcase name="TestDataDriven/testlogic" time="0.000"></testcase>
+	<testcase name="TestDataDriven/ui" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/builder" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/builder#01" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/dev-build" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/dev-build#01" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/generate" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/generate#01" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/lint" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/lint#01" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/test" time="0.000"></testcase>
+	<testcase name="TestRecorderDriven/test#01" time="0.000"></testcase>
 </testsuite>
 `
 	var buf bytes.Buffer


### PR DESCRIPTION
This was added back in, I think accidentally as a result of a bad copy-paste, in `8e6b3935749df40aac835aad15c2b8337426f9f4`. This restores the previous behavior. Note that the comment talks about how `Classname` is missing, so we expect it not to be there.

Release justification: Non-production code changes
Part of: DEVINF-1658
Epic: DEVINF-1582
Release note: none