### PR TITLE
changefeedccl: ShallowCopy RangeFeedCheckpoint before updating

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -133,6 +133,18 @@ func (t Type) Index() int {
 	}
 }
 
+// ResolvedBackward moves the ResolvedTS of an underlying RangeFeedCheckpoint
+// event backwards to the given timestamps.
+//
+// Panics if the Event is not a RangeFeedCheckpoint event.
+func (e *Event) ResolvedBackward(ts hlc.Timestamp) {
+	if e.ev == nil || e.ev.Checkpoint == nil {
+		panic("ResolvedBackwards called on event without a RangeFeedCheckpoint")
+	}
+	e.ev = e.ev.ShallowCopy()
+	e.ev.Checkpoint.ResolvedTS.Backward(ts)
+}
+
 // Raw returns the underlying RangeFeedEvent.
 func (e *Event) Raw() *kvpb.RangeFeedEvent {
 	return e.ev

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -783,7 +783,7 @@ func copyFromSourceToDestUntilTableEvent(
 		// Otherwise (if `e.ts` >= `boundary.ts`), we will act as follows:
 		//  - KV event: do nothing (we shouldn't emit this event)
 		//  - Resolved event: advance this span to `boundary.ts` in the frontier
-		checkCopyBoundary = func(e kvevent.Event) (skipEvent, stopCopying bool, err error) {
+		checkCopyBoundary = func(e *kvevent.Event) (skipEvent, stopCopying bool, err error) {
 			if boundary == nil {
 				return false, false, nil
 			}
@@ -815,7 +815,7 @@ func copyFromSourceToDestUntilTableEvent(
 					// subsequent checkpoints for this span until entire frontier reaches
 					// boundary timestamp.
 					if boundaryResolvedTimestamp.Compare(spanFrontier(resolved.Span)) > 0 {
-						e.Raw().Checkpoint.ResolvedTS = boundaryResolvedTimestamp
+						e.ResolvedBackward(boundaryResolvedTimestamp)
 						skipEvent = false
 					}
 				}
@@ -831,7 +831,7 @@ func copyFromSourceToDestUntilTableEvent(
 				// for completeness.
 				return false, false, nil
 			default:
-				return false, false, &errUnknownEvent{e}
+				return false, false, &errUnknownEvent{*e}
 			}
 		}
 
@@ -863,7 +863,7 @@ func copyFromSourceToDestUntilTableEvent(
 			if err := checkForTableEvent(e.Timestamp()); err != nil {
 				return err
 			}
-			skipEntry, stopCopying, err := checkCopyBoundary(e)
+			skipEntry, stopCopying, err := checkCopyBoundary(&e)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
We suspect that the (*RangeFeedCheckpoint) used here may be shared by other clients and the rangefeed server side code when our rangefeed is being served by a local replica and thus the MuxRangeFeed RPC uses the local client optimization which avoid the network and also avoids marshling and unmarshaling the response across the RPC boundary.

This is currently our best theory for the source of the marshalling error seen in #159166. However, we have not yet been able to reproduce the crash locally.

Informs: https://github.com/cockroachdb/cockroach/issues/159166
Informs: https://github.com/cockroachdb/cockroach/issues/157882
Informs: https://github.com/cockroachdb/cockroach/issues/138895
Informs: https://github.com/cockroachdb/cockroach/issues/158166
Informs: https://github.com/cockroachlabs/support/issues/3506

Release note (bug fix): Fixes a bug which could lead to a node crash in the presence of a CHANGEFEED that uses the end_time option.