### PR TITLE
server: allow on-demand goroutine dumps

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1259,6 +1259,11 @@ type StoreConfig struct {
 
 	TestingKnobs StoreTestingKnobs
 
+	// GoroutineDumpNow, if set, triggers an on-demand goroutine dump.
+	//
+	// The returned bool indicates whether a dump was taken.
+	GoroutineDumpNow func(context.Context, redact.RedactableString) (bool, error)
+
 	// EagerLeaseAcquisitionLimiter is used to limit the number of concurrent
 	// eager lease extensions. Normally shared between all stores on a node.
 	// Can be nil, which disables the limit.

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -44,7 +44,6 @@ type sampleEnvironmentCfg struct {
 	st                    *cluster.Settings
 	stopper               *stop.Stopper
 	minSampleInterval     time.Duration
-	goroutineDumpDirName  string
 	heapProfileDirName    string
 	cpuProfileDirName     string
 	executionTraceDirName string
@@ -76,7 +75,6 @@ func startSampleEnvironment(
 		st:                    srvCfg.Settings,
 		stopper:               stopper,
 		minSampleInterval:     metricsSampleInterval,
-		goroutineDumpDirName:  srvCfg.GoroutineDumpDirName,
 		heapProfileDirName:    srvCfg.HeapProfileDirName,
 		cpuProfileDirName:     srvCfg.CPUProfileDirName,
 		executionTraceDirName: srvCfg.ExecutionTraceDirName,
@@ -85,18 +83,6 @@ func startSampleEnvironment(
 		rootMemMonitor:        rootMemMonitor,
 		cgoMemTarget:          max(uint64(pebbleCacheSize), 128*1024*1024),
 	}
-	// Immediately record summaries once on server startup.
-
-	// Initialize a goroutine dumper if we have an output directory specified and
-	// no pre-built dumper was provided.
-	if goroutineDumper == nil {
-		var err error
-		goroutineDumper, err = maybeNewGoroutineDumper(ctx, cfg.goroutineDumpDirName, cfg.st)
-		if err != nil {
-			return errors.Wrap(err, "starting goroutine dumper worker")
-		}
-	}
-
 	// Initialize a heap profiler if we have an output directory
 	// specified.
 	var heapProfiler *profiler.HeapProfiler

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -64,6 +64,7 @@ func startSampleEnvironment(
 	pebbleCacheSize int64,
 	stopper *stop.Stopper,
 	runtimeSampler *status.RuntimeStatSampler,
+	goroutineDumper *goroutinedumper.GoroutineDumper,
 	sessionRegistry *sql.SessionRegistry,
 	rootMemMonitor *mon.BytesMonitor,
 ) error {
@@ -86,26 +87,13 @@ func startSampleEnvironment(
 	}
 	// Immediately record summaries once on server startup.
 
-	// Initialize a goroutine dumper if we have an output directory
-	// specified.
-	var goroutineDumper *goroutinedumper.GoroutineDumper
-	if cfg.goroutineDumpDirName != "" {
-		hasValidDumpDir := true
-		if err := os.MkdirAll(cfg.goroutineDumpDirName, 0755); err != nil {
-			// This is possible when running with only in-memory stores;
-			// in that case the start-up code sets the output directory
-			// to the current directory (.). If running the process
-			// from a directory which is not writable, we won't
-			// be able to create a sub-directory here.
-			log.Dev.Warningf(ctx, "cannot create goroutine dump dir -- goroutine dumps will be disabled: %v", err)
-			hasValidDumpDir = false
-		}
-		if hasValidDumpDir {
-			var err error
-			goroutineDumper, err = goroutinedumper.NewGoroutineDumper(ctx, cfg.goroutineDumpDirName, cfg.st)
-			if err != nil {
-				return errors.Wrap(err, "starting goroutine dumper worker")
-			}
+	// Initialize a goroutine dumper if we have an output directory specified and
+	// no pre-built dumper was provided.
+	if goroutineDumper == nil {
+		var err error
+		goroutineDumper, err = maybeNewGoroutineDumper(ctx, cfg.goroutineDumpDirName, cfg.st)
+		if err != nil {
+			return errors.Wrap(err, "starting goroutine dumper worker")
 		}
 	}
 
@@ -208,4 +196,21 @@ func startSampleEnvironment(
 				}
 			}
 		})
+}
+
+func maybeNewGoroutineDumper(
+	ctx context.Context, goroutineDumpDirName string, st *cluster.Settings,
+) (*goroutinedumper.GoroutineDumper, error) {
+	if goroutineDumpDirName == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(goroutineDumpDirName, 0755); err != nil {
+		// This is possible when running with only in-memory stores; in that case
+		// the start-up code sets the output directory to the current directory (.).
+		// If running the process from a directory which is not writable, we won't
+		// be able to create a sub-directory here.
+		log.Dev.Warningf(ctx, "cannot create goroutine dump dir -- goroutine dumps will be disabled: %v", err)
+		return nil, nil
+	}
+	return goroutinedumper.NewGoroutineDumper(ctx, goroutineDumpDirName, st)
 }

--- a/pkg/server/goroutinedumper/BUILD.bazel
+++ b/pkg/server/goroutinedumper/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/server/goroutinedumper/BUILD.bazel
+++ b/pkg/server/goroutinedumper/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -101,6 +102,16 @@ func (gd *GoroutineDumper) MaybeDump(ctx context.Context, st *cluster.Settings, 
 			break
 		}
 	}
+}
+
+// DumpNow requests a goroutine dump on demand.
+//
+// This is currently a stub and does not take a dump.
+func (gd *GoroutineDumper) DumpNow(
+	ctx context.Context, reason redact.RedactableString,
+) (didDump bool, _ error) {
+	log.Dev.Infof(ctx, "on-demand goroutine dump requested: %s", reason)
+	return false, nil
 }
 
 // NewGoroutineDumper returns a GoroutineDumper which enables

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -176,12 +176,14 @@ func (gd *GoroutineDumper) gcDumps(ctx context.Context, now time.Time) {
 }
 
 // PreFilter is part of the dumpstore.Dumper interface.
+//
+// GC is intentionally heuristic-agnostic: all dumps share the same size budget
+// and the most recent dump is preserved regardless of which heuristic created it.
 func (gd *GoroutineDumper) PreFilter(
 	ctx context.Context, files []os.DirEntry, cleanupFn func(fileName string) error,
 ) (preserved map[int]bool, _ error) {
 	preserved = make(map[int]bool)
 	for i := len(files) - 1; i >= 0; i-- {
-		// Always preserve the last dump in chronological order.
 		if gd.CheckOwnsFile(ctx, files[i]) {
 			preserved[i] = true
 			break

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -116,6 +116,7 @@ func (gd *GoroutineDumper) MaybeDump(ctx context.Context, st *cluster.Settings, 
 }
 
 // DumpNow requests a goroutine dump on demand.
+// nolint:deferunlockcheck
 func (gd *GoroutineDumper) DumpNow(
 	ctx context.Context, reason redact.RedactableString,
 ) (didDump bool, _ error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,6 +76,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
+	"github.com/cockroachdb/cockroach/pkg/server/goroutinedumper"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
 	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -180,6 +181,7 @@ type topLevelServer struct {
 	ctSender             *sidetransport.Sender
 	policyRefresher      *policyrefresher.PolicyRefresher
 	nodeCapacityProvider *load.NodeCapacityProvider
+	goroutineDumper      *goroutinedumper.GoroutineDumper
 
 	http            *httpServer
 	adminAuthzCheck privchecker.CheckerForRPCHandlers
@@ -1371,6 +1373,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		},
 	)
 
+	goroutineDumper, err := maybeNewGoroutineDumper(ctx, cfg.BaseConfig.GoroutineDumpDirName, st)
+	if err != nil {
+		return nil, errors.Wrap(err, "starting goroutine dumper worker")
+	}
+
 	*lateBoundServer = topLevelServer{
 		nodeIDContainer:           nodeIDContainer,
 		cfg:                       cfg,
@@ -1399,6 +1406,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		policyRefresher:           policyRefresher,
 		nodeCapacityProvider:      nodeCapacityProvider,
 		runtime:                   runtimeSampler,
+		goroutineDumper:           goroutineDumper,
 		http:                      sHTTP,
 		adminAuthzCheck:           adminAuthzCheck,
 		admin:                     sAdmin,
@@ -2009,6 +2017,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.cfg.CacheSize,
 		s.stopper,
 		s.runtime,
+		s.goroutineDumper,
 		s.status.sessionRegistry,
 		s.sqlServer.execCfg.RootMemoryMonitor,
 	); err != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -785,6 +785,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			0, /* pebbleCacheSize */
 			s.stopper,
 			s.runtime,
+			nil, /* goroutineDumper */
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
 		); err != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -780,12 +780,16 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	}
 	if !s.sqlServer.cfg.DisableRuntimeStatsMonitor {
 		// Begin recording runtime statistics.
+		goroutineDumper, err := maybeNewGoroutineDumper(workersCtx, s.sqlServer.cfg.GoroutineDumpDirName, s.ClusterSettings())
+		if err != nil {
+			return err
+		}
 		if err := startSampleEnvironment(workersCtx,
 			s.sqlServer.cfg,
 			0, /* pebbleCacheSize */
 			s.stopper,
 			s.runtime,
-			nil, /* goroutineDumper */
+			goroutineDumper,
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
 		); err != nil {


### PR DESCRIPTION
Enable programmatic, rate-limited goroutine dumps that KV can trigger on demand.

Move goroutine dumper construction out of env sampling so it can be shared. Add (*GoroutineDumper).DumpNow(ctx, reason) (reason logged, not in the filename), and plumb it down to KV via kvserver.StoreConfig.GoroutineDumpNow. Implement DumpNow to write a dump tagged on_demand while preserving the existing naming scheme, and gate requests via server.goroutine_dump.on_demand.min_interval (default 10s).

Closes https://github.com/cockroachdb/cockroach/issues/159342

Epic: none
