### PR TITLE
admission: improve the help string of the exhausted_duration metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10771,7 +10771,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.elastic_cpu.nanos_exhausted_duration
       exported_name: admission_elastic_cpu_nanos_exhausted_duration
-      description: Total duration when elastic CPU nanoseconds were exhausted, in micros
+      description: Total duration (in micros) when elastic CPU tokens (tokens measured in nanoseconds) were exhausted, as observed by the token granter (not waiters)
       y_axis_label: Microseconds
       type: GAUGE
       unit: COUNT
@@ -11011,7 +11011,7 @@ layers:
       derivative: NONE
     - name: admission.granter.elastic_io_tokens_exhausted_duration.kv
       exported_name: admission_granter_elastic_io_tokens_exhausted_duration_kv
-      description: Total duration when Elastic IO tokens were exhausted, in micros
+      description: Total duration (in micros) when Elastic IO tokens were exhausted, as observed by the token granter (not waiters)
       y_axis_label: Microseconds
       type: COUNTER
       unit: COUNT
@@ -11035,7 +11035,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.io_tokens_exhausted_duration.kv
       exported_name: admission_granter_io_tokens_exhausted_duration_kv
-      description: Total duration when IO tokens were exhausted, in micros
+      description: Total duration (in micros) when IO tokens were exhausted, as observed by the token granter (not waiters)
       y_axis_label: Microseconds
       type: COUNTER
       unit: COUNT
@@ -11075,7 +11075,7 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
     - name: admission.granter.slots_exhausted_duration.kv
       exported_name: admission_granter_slots_exhausted_duration_kv
-      description: Total duration when KV slots were exhausted, in micros
+      description: Total duration (in micros) when KV slots were exhausted, as observed by the slot granter (not waiters)
       y_axis_label: Microseconds
       type: COUNTER
       unit: COUNT

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -296,8 +296,9 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 	}
 
 	elasticCPUNanosExhaustedDuration = metric.Metadata{
-		Name:        "admission.elastic_cpu.nanos_exhausted_duration",
-		Help:        "Total duration when elastic CPU nanoseconds were exhausted, in micros",
+		Name: "admission.elastic_cpu.nanos_exhausted_duration",
+		Help: "Total duration (in micros) when elastic CPU tokens (tokens measured in nanoseconds) " +
+			"were exhausted, as observed by the token granter (not waiters)",
 		Measurement: "Microseconds",
 		Unit:        metric.Unit_COUNT,
 	}

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -845,8 +845,9 @@ var (
 	// NB: this metric is independent of whether slots enforcement is happening
 	// or not.
 	kvSlotsExhaustedDuration = metric.Metadata{
-		Name:        "admission.granter.slots_exhausted_duration.kv",
-		Help:        "Total duration when KV slots were exhausted, in micros",
+		Name: "admission.granter.slots_exhausted_duration.kv",
+		Help: "Total duration (in micros) when KV slots were exhausted, as observed by the slot " +
+			"granter (not waiters)",
 		Measurement: "Microseconds",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -879,14 +880,16 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 	kvIOTokensExhaustedDuration = metric.Metadata{
-		Name:        "admission.granter.io_tokens_exhausted_duration.kv",
-		Help:        "Total duration when IO tokens were exhausted, in micros",
+		Name: "admission.granter.io_tokens_exhausted_duration.kv",
+		Help: "Total duration (in micros) when IO tokens were exhausted, as observed by " +
+			"the token granter (not waiters)",
 		Measurement: "Microseconds",
 		Unit:        metric.Unit_COUNT,
 	}
 	kvElasticIOTokensExhaustedDuration = metric.Metadata{
-		Name:        "admission.granter.elastic_io_tokens_exhausted_duration.kv",
-		Help:        "Total duration when Elastic IO tokens were exhausted, in micros",
+		Name: "admission.granter.elastic_io_tokens_exhausted_duration.kv",
+		Help: "Total duration (in micros) when Elastic IO tokens were exhausted, as observed by " +
+			"the token granter (not waiters)",
 		Measurement: "Microseconds",
 		Unit:        metric.Unit_COUNT,
 	}


### PR DESCRIPTION
Epic: none

Release note: None