### PR TITLE
release-26.1: lease: bump lease generation synchronously for system privilege tables

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1282,6 +1282,11 @@ func (m *Manager) acquireNodeLease(
 				if err := m.upsertDescriptorIntoState(ctx, id, session, desc); err != nil {
 					return false, err
 				}
+				// Descriptor versions for these tables participate directly in memo
+				// staleness checks. Bump the lease generation now so queries that
+				// rely on the new privileges/options are forced to replan immediately
+				// instead of waiting for the asynchronous lease update.
+				m.leaseGeneration.Add(1)
 
 				desc, err = doAcquisition()
 				if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #159354 on behalf of @spilchen.

----

Version bumps on system.privileges drive memo staleness checks. Previously the lease generation advanced only after the lease row hit KV, so cached plans could keep bypassing RLS until the async bump arrived. Increment the generation immediately after we upsert the refreshed descriptor so dependent queries replan right away.

While only system.privileges needed the fix, we apply the synchronous bump to all tables that go through writeVersionBump (users/role_members/role_options/system.privileges) for consistency. Those tables already cause an async bump later, so the generation now increments twice, which is fine because leaseGeneration is just a monotonic “something changed” flag.

No new tests were added; the regression can be reproduced with
```
dev testlogic base --files=row_level_security --subtests=bypassrls --config=local --count=5000
```

Closes #158635
Epic: none
Release note (bug fix): fixes a race where queries run after revoking BYPASSRLS could return wrong results because cached plans failed to notice the change immediately.

----

Release justification: bug fix for wrong query results