### PR TITLE
release-25.2: sql/stats: prevent stats collection in read-only tenants

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -620,6 +620,10 @@ type TestSharedProcessTenantArgs struct {
 	// TenantID is the ID of the tenant to be created. If not set, an ID is
 	// assigned automatically.
 	TenantID roachpb.TenantID
+	// TenantReadOnly indicates if this tenant should be created as read-only
+	// (for testing PCR reader tenants). This field is used for testing purposes
+	// and overrides the tenant record check.
+	TenantReadOnly bool
 
 	Knobs TestingKnobs
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -485,6 +485,9 @@ type SQLConfig struct {
 	TenantID   roachpb.TenantID
 	TenantName roachpb.TenantName
 
+	// TenantReadOnly indicates if this tenant is read-only (PCR reader tenant).
+	TenantReadOnly bool
+
 	// If set, will to be called at server startup to obtain the tenant id and
 	// locality.
 	DelayedSetTenantID func(context.Context) (roachpb.TenantID, roachpb.Locality, error)
@@ -552,8 +555,9 @@ func MakeSQLConfig(
 	tenID roachpb.TenantID, tenName roachpb.TenantName, tempStorageCfg base.TempStorageConfig,
 ) SQLConfig {
 	sqlCfg := SQLConfig{
-		TenantID:   tenID,
-		TenantName: tenName,
+		TenantID:       tenID,
+		TenantName:     tenName,
+		TenantReadOnly: false, // Default to false, will be set during tenant initialization
 	}
 	sqlCfg.SetDefaults(tempStorageCfg)
 	return sqlCfg

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -64,13 +64,18 @@ func (s *topLevelServer) newTenantServer(
 	portStartHint int,
 	testArgs base.TestSharedProcessTenantArgs,
 ) (onDemandServer, error) {
-	tenantID, err := s.getTenantID(ctx, tenantNameContainer.Get())
+	tenantID, tenantReadOnly, err := s.getTenantID(ctx, tenantNameContainer.Get())
 	if err != nil {
 		return nil, err
 	}
 
+	// Use test override for tenant read-only status if provided.
+	if testArgs.TenantReadOnly {
+		tenantReadOnly = true
+	}
+
 	baseCfg, sqlCfg, err := s.makeSharedProcessTenantConfig(ctx, tenantID, tenantNameContainer.Get(), portStartHint,
-		tenantStopper, testArgs.Settings)
+		tenantStopper, testArgs.Settings, tenantReadOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -100,23 +105,27 @@ var ErrInvalidTenant error = errInvalidTenantMarker{}
 
 func (s *topLevelServer) getTenantID(
 	ctx context.Context, tenantName roachpb.TenantName,
-) (roachpb.TenantID, error) {
+) (roachpb.TenantID, bool, error) {
 	var rec *mtinfopb.TenantInfo
 	if err := s.sqlServer.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		var err error
 		rec, err = sql.GetTenantRecordByName(ctx, s.cfg.Settings, txn, tenantName)
 		return err
 	}); err != nil {
-		return roachpb.TenantID{}, errors.Mark(err, ErrInvalidTenant)
+		return roachpb.TenantID{}, false, errors.Mark(err, ErrInvalidTenant)
 	}
 
 	tenantID, err := roachpb.MakeTenantID(rec.ID)
 	if err != nil {
-		return roachpb.TenantID{}, errors.Mark(
+		return roachpb.TenantID{}, false, errors.Mark(
 			errors.NewAssertionErrorWithWrappedErrf(err, "stored tenant ID %d does not convert to TenantID", rec.ID),
 			ErrInvalidTenant)
 	}
-	return tenantID, nil
+
+	// Check if tenant is read-only (PCR reader tenant).
+	readOnlyTenant := rec.ReadFromTenant != nil
+
+	return tenantID, readOnlyTenant, nil
 }
 
 // newTenantServerInternal instantiates a server for the given target
@@ -151,6 +160,7 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
 	portStartHint int,
 	stopper *stop.Stopper,
 	testSettings *cluster.Settings,
+	tenantReadOnly bool,
 ) (BaseConfig, SQLConfig, error) {
 	// Create a configuration for the new tenant.
 	parentCfg := s.cfg
@@ -167,7 +177,7 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
 	}
 
 	baseCfg, sqlCfg, err := makeSharedProcessTenantServerConfig(ctx, tenantID, tenantName, portStartHint, parentCfg,
-		localServerInfo, st, stopper, s.recorder)
+		localServerInfo, st, stopper, s.recorder, tenantReadOnly)
 	if err != nil {
 		return BaseConfig{}, SQLConfig{}, err
 	}
@@ -186,6 +196,7 @@ func makeSharedProcessTenantServerConfig(
 	st *cluster.Settings,
 	stopper *stop.Stopper,
 	nodeMetricsRecorder *status.MetricsRecorder,
+	tenantReadOnly bool,
 ) (baseCfg BaseConfig, sqlCfg SQLConfig, err error) {
 	tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
 
@@ -329,6 +340,7 @@ func makeSharedProcessTenantServerConfig(
 	}
 
 	sqlCfg = MakeSQLConfig(tenantID, tenantName, tempStorageCfg)
+	sqlCfg.TenantReadOnly = tenantReadOnly
 	baseCfg.ExternalIODirConfig = kvServerCfg.BaseConfig.ExternalIODirConfig
 
 	baseCfg.ExternalIODir = kvServerCfg.BaseConfig.ExternalIODir

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1061,6 +1061,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		RangeStatsFetcher:          rangeStatsFetcher,
 		NodeDescs:                  cfg.nodeDescs,
 		TenantCapabilitiesReader:   cfg.tenantCapabilitiesReader,
+		TenantReadOnly:             cfg.SQLConfig.TenantReadOnly,
 		CidrLookup:                 cfg.BaseConfig.CidrLookup,
 		LicenseEnforcer:            cfg.SQLConfig.LicenseEnforcer,
 	}
@@ -1210,6 +1211,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		execCfg.TableStatsCache,
 		stats.DefaultAsOfTime,
 		tableStatsTestingKnobs,
+		execCfg.TenantReadOnly,
 	)
 	execCfg.StatsRefresher = statsRefresher
 	distSQLServer.ServerConfig.StatsRefresher = statsRefresher

--- a/pkg/sql/catalog/replication/reader_catalog_test.go
+++ b/pkg/sql/catalog/replication/reader_catalog_test.go
@@ -70,10 +70,11 @@ func newReaderCatalogTest(
 	})
 	require.NoError(t, err)
 	destTenant, _, err := ts.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
-		TenantID:   serverutils.TestTenantID2(),
-		TenantName: "dest",
-		Knobs:      destTestingKnobs,
-		Settings:   destSettings,
+		TenantID:       serverutils.TestTenantID2(),
+		TenantName:     "dest",
+		Knobs:          destTestingKnobs,
+		Settings:       destSettings,
+		TenantReadOnly: true, // Mark the dest tenant as read-only for testing
 	})
 	require.NoError(t, err)
 	srcRunner := sqlutils.MakeSQLRunner(srcTenant.SQLConn(t))
@@ -543,6 +544,34 @@ func TestReaderCatalogTSAdvanceWithLongTxn(t *testing.T) {
 	_, err = tx.Exec("SELECT * FROM sq1")
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit())
+}
+
+func TestReaderCatalogAutoStatsDisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDuress(t)
+
+	ctx := context.Background()
+	r, cleanup := newReaderCatalogTest(t, ctx, base.TestingKnobs{}, nil)
+	defer cleanup()
+
+	// Create a table and insert some data in the source tenant.
+	r.srcRunner.Exec(t, `
+		CREATE TABLE t1(n int);
+		INSERT INTO t1 VALUES (1), (2), (3);
+	`)
+
+	// Enable auto stats collection in the source tenant.
+	r.srcRunner.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true`)
+
+	// Advance the reader catalog timestamp to replicate the table.
+	require.NoError(t, r.advanceTS(ctx, r.ts.Clock().Now(), true))
+
+	// Verify the table exists in the reader catalog.
+	r.compareEqual(t, "SELECT * FROM t1 ORDER BY n")
+
+	// Now verify that stats collection is disabled for the read-only tenant.
+	// Manual CREATE STATISTICS should fail with our tenant-level read-only error.
+	r.destRunner.ExpectErr(t, "cannot create statistics in read-only tenant", "CREATE STATISTICS test_stats FROM t1")
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -229,6 +229,12 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 // makeJobRecord creates a CreateStats job record which can be used to plan and
 // execute statistics creation.
 func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, error) {
+	// Check tenant-level read-only status first (applies to all tables in tenant).
+	if n.p.ExecCfg().TenantReadOnly {
+		return nil, pgerror.Newf(
+			pgcode.WrongObjectType, "cannot create statistics in read-only tenant")
+	}
+
 	var tableDesc catalog.TableDescriptor
 	var fqTableName string
 	var err error

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1605,6 +1605,9 @@ type ExecutorConfig struct {
 
 	TenantCapabilitiesReader SystemTenantOnly[tenantcapabilities.Reader]
 
+	// TenantReadOnly indicates if this tenant is read-only (PCR reader tenant).
+	TenantReadOnly bool
+
 	// VirtualClusterName contains the name of the virtual cluster
 	// (tenant).
 	VirtualClusterName roachpb.TenantName


### PR DESCRIPTION
Backport 1/1 commits from #150562.

/cc @cockroachdb/release

---

This change prevents both automatic and manual statistics collection
in PCR reader tenants by detecting read-only tenant status at the
tenant level rather than checking individual table descriptors.

Key changes:
- Add TenantReadonly field to SQLConfig and ExecutorConfig to track
  tenant-level read-only status
- Modify tenant initialization to detect read-only tenants by checking
  mtinfopb.TenantInfoWithUsage.ReadFromTenant \!= nil
- Update MakeRefresher to accept readOnlyTenant parameter
- Prevent automatic stats collection in autoStatsEnabled()
- Prevent manual stats collection in makeJobRecord()
- Add TenantReadonly field to TestSharedProcessTenantArgs for testing
- Update tests to use tenant-level detection instead of table-level
  ReplicatedPCRVersion checks
- Enhance test coverage for both autoStatsEnabled() and
  autoStatsEnabledForTableID() functions

The tenant-level approach is more reliable than checking individual
table descriptors because some tables within read-only tenants are
not replicated (e.g. system.statement_statistics), yet we cannot
record stats for any tables since the system.table_statistics table
itself is read-only.

Fixes #135828

Release note: None

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Release justification: the busy loop of failed stats jobs has been observed to destabilize production clusters.
