### PR TITLE
release-25.3: opt: route descriptor lookups for AFTER triggers through cache

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -119,7 +119,8 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_empty_database_Name
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 1,SystemDatabaseQueries/select_system.users_without_schema_Name
-1,TriggerResolution/insert_into_table_with_trigger
+1,TriggerResolution/insert_into_table_with_before_trigger
+4,TriggerResolution/insert_into_table_with_after_trigger
 15,Truncate/truncate_1_column_0_rows
 15,Truncate/truncate_1_column_1_row
 15,Truncate/truncate_1_column_2_rows

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -120,7 +120,7 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 1,SystemDatabaseQueries/select_system.users_without_schema_Name
 1,TriggerResolution/insert_into_table_with_before_trigger
-4,TriggerResolution/insert_into_table_with_after_trigger
+1,TriggerResolution/insert_into_table_with_after_trigger
 15,Truncate/truncate_1_column_0_rows
 15,Truncate/truncate_1_column_1_row
 15,Truncate/truncate_1_column_2_rows

--- a/pkg/bench/rttanalysis/trigger_resolution_test.go
+++ b/pkg/bench/rttanalysis/trigger_resolution_test.go
@@ -13,11 +13,19 @@ func BenchmarkTriggerResolution(b *testing.B) {
 func init() {
 	reg.Register("TriggerResolution", []RoundTripBenchTestCase{
 		{
-			Name: "insert into table with trigger",
+			Name: "insert into table with before trigger",
 			Setup: `
         CREATE TABLE trigger_table (a INT);
         CREATE FUNCTION trigger_fn() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
         CREATE TRIGGER tr BEFORE INSERT ON trigger_table FOR EACH ROW EXECUTE FUNCTION trigger_fn();`,
+			Stmt: `INSERT INTO trigger_table VALUES (100);`,
+		},
+		{
+			Name: "insert into table with after trigger",
+			Setup: `
+        CREATE TABLE trigger_table (a INT);
+        CREATE FUNCTION trigger_fn() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
+        CREATE TRIGGER tr AFTER INSERT ON trigger_table FOR EACH ROW EXECUTE FUNCTION trigger_fn();`,
 			Stmt: `INSERT INTO trigger_table VALUES (100);`,
 		},
 	})

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -660,11 +660,13 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 			tgLevel := tree.NewDString("ROW")
 			tgRelID := tree.NewDOid(oid.Oid(tb.mutatedTable.ID()))
 			tgTableName := tree.NewDString(string(tb.mutatedTable.Name()))
-			fqName, err := b.catalog.FullyQualifiedName(ctx, tb.mutatedTable)
+			schema, err := b.catalog.ResolveSchemaByID(
+				b.ctx, cat.Flags{}, cat.StableID(tb.mutatedTable.GetSchemaID()),
+			)
 			if err != nil {
 				panic(err)
 			}
-			tgTableSchema := tree.NewDString(fqName.Schema())
+			tgTableSchema := tree.NewDString(schema.Name().Schema())
 			var tgOp opt.ScalarExpr
 			switch tb.mutation {
 			case opt.InsertOp:


### PR DESCRIPTION
Backport 2/4 commits from #158708.

/cc @cockroachdb/release

---

#### bench/rttanalysis: add test case with an after trigger

Release note: None

#### opt: route descriptor lookups for AFTER triggers through cache

This commit applies the fix in #144217 for `BEFORE` triggers to `AFTER`
triggers. See that PR for more details.

Fixes #144211

Release note (performance improvement): After triggers now perform the
descriptor lookup for `TG_TABLE_SCHEMA` against a cache. This can
significantly reduce trigger planning latency.

---

Release justification: Low-risk, critical performance improvement
for triggers.
