### PR TITLE
release-26.1: tsdump: initialize write stream later in dump

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -253,11 +253,6 @@ will then convert it to the --format requested in the current invocation.
 
 			tsClient := conn.NewTimeSeriesClient()
 			if debugTimeSeriesDumpOpts.format == tsDumpRaw {
-				stream, err := tsClient.DumpRaw(context.Background(), req)
-				if err != nil {
-					return errors.Wrapf(err, "connecting to %s", target)
-				}
-
 				// get the node details so that we can get the SQL port
 				statusClient := conn.NewStatusClient()
 				resp, err := statusClient.Details(ctx, &serverpb.DetailsRequest{NodeId: "local"})
@@ -283,6 +278,11 @@ will then convert it to the --format requested in the current invocation.
 					Version:        build.BinaryVersion(),
 					StoreToNodeMap: storeToNodeMap,
 					CreatedAt:      timeutil.Now(),
+				}
+
+				stream, err := tsClient.DumpRaw(context.Background(), req)
+				if err != nil {
+					return errors.Wrapf(err, "connecting to %s", target)
 				}
 
 				// Buffer the writes to os.Stdout since we're going to


### PR DESCRIPTION
Backport 1/1 commits from #159287 on behalf of @dhartunian.

----

We might be encountering timeouts and problems because we do a lot of reading after initializing the stream.

Part of: CRDB-57722
Epic: CRDB-56325
Release note: None

----

Release justification: low-risk change to improve tsdump reliability