### PR TITLE
admission: fix deadlock possibility in SnapshotQueue

### DIFF
--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -155,6 +155,15 @@ func (bq burstQualification) String() string {
 	}
 }
 
+// Mutex ordering between requester and granter:
+//
+// The requester and granter call into each other. To prevent deadlock due to
+// mutex cycles, any mutex in granter is ordered before any mutex in
+// requester. Therefore, a requester must not hold its own mutex when calling
+// into granter. Of course, a granter could choose to release its own mutex
+// before calling into requester, but it is not necessary for deadlock
+// prevention.
+
 // requester is an interface implemented by an object that orders admission
 // work for a particular WorkKind. See WorkQueue for the implementation of
 // requester.

--- a/pkg/util/admission/io_load_listener.go
+++ b/pkg/util/admission/io_load_listener.go
@@ -583,6 +583,8 @@ func (io *ioLoadListener) pebbleMetricsTick(ctx context.Context, metrics StoreMe
 	io.cumFlushWriteThroughput = metrics.Flush.WriteThroughput
 	// We assume that the system is loaded if there is less than unlimited tokens
 	// available.
+	//
+	// TODO(sumeer): this condition should also incorporate disk byte tokens.
 	return io.totalNumByteTokens < unlimitedTokens || io.totalNumElasticByteTokens < unlimitedTokens
 }
 


### PR DESCRIPTION
This could happen if the context passed to the pacer for the incoming snapshot was cancelled, and there was a race with the granter calling into the SnapshotQueue.

Fixes: #159402

Epic: none

Release note (bug fix): Fixes a race in context cancellation of an incoming snapshot.