### PR TITLE
backup: ignore invalid index entries

### DIFF
--- a/pkg/backup/backupinfo/BUILD.bazel
+++ b/pkg/backup/backupinfo/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/stats",
         "//pkg/storage",
+        "//pkg/util",
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -23,9 +23,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -162,7 +164,11 @@ func IndexExists(ctx context.Context, store cloud.ExternalStorage, subdir string
 func ListIndexes(
 	ctx context.Context, store cloud.ExternalStorage, subdir string,
 ) ([]string, error) {
-	var indexBasenames []string
+	type indexTimes struct {
+		file       string
+		start, end time.Time
+	}
+	var indexes []indexTimes
 	indexDir, err := indexSubdir(subdir)
 	if err != nil {
 		return nil, err
@@ -172,52 +178,46 @@ func ListIndexes(
 		indexDir+"/",
 		"",
 		func(file string) error {
-			indexBasenames = append(indexBasenames, path.Base(file))
+			// We assert that if a file ends with .pb in the index, it should be a
+			// parsable index file. Otherwise, we ignore it. This circumvents any temp
+			// files that may be created by the external storage implementation.
+			if !strings.HasSuffix(file, ".pb") {
+				log.Dev.Warningf(ctx, "unexpected file %s in index directory", file)
+				return nil
+			}
+
+			base := path.Base(file)
+			i := indexTimes{
+				file: base,
+			}
+			i.start, i.end, err = parseIndexFilename(base)
+			if err != nil {
+				return err
+			}
+			indexes = append(indexes, i)
 			return nil
 		},
 	); err != nil {
 		return nil, errors.Wrapf(err, "listing indexes in %s", subdir)
 	}
 
-	timeMemo := make(map[string][2]time.Time)
-	indexTimesFromFile := func(basename string) (time.Time, time.Time, error) {
-		if times, ok := timeMemo[basename]; ok {
-			return times[0], times[1], nil
-		}
-		start, end, err := parseIndexFilename(basename)
-		if err != nil {
-			return time.Time{}, time.Time{}, err
-		}
-		timeMemo[basename] = [2]time.Time{start, end}
-		return start, end, nil
-	}
-	var sortErr error
-	slices.SortFunc(indexBasenames, func(a, b string) int {
-		aStart, aEnd, err := indexTimesFromFile(a)
-		if err != nil {
-			sortErr = err
-		}
-		bStart, bEnd, err := indexTimesFromFile(b)
-		if err != nil {
-			sortErr = err
-		}
-		if aEnd.Before(bEnd) {
+	slices.SortFunc(indexes, func(a, b indexTimes) int {
+		if a.end.Before(b.end) {
 			return -1
-		} else if aEnd.After(bEnd) {
+		} else if a.end.After(b.end) {
 			return 1
 		}
 		// End times are equal, so break tie with start time.
-		if aStart.Before(bStart) {
+		if a.start.Before(b.start) {
 			return -1
 		} else {
 			return 1
 		}
 	})
-	if sortErr != nil {
-		return nil, errors.Wrapf(sortErr, "sorting index filenames")
-	}
 
-	return indexBasenames, nil
+	return util.Map(indexes, func(i indexTimes) string {
+		return i.file
+	}), nil
 }
 
 // GetBackupTreeIndexMetadata concurrently retrieves the index metadata for all

--- a/pkg/backup/backupinfo/backup_index_test.go
+++ b/pkg/backup/backupinfo/backup_index_test.go
@@ -238,6 +238,107 @@ func TestWriteBackupIndexMetadataWithSpecifiedIncrementalLocation(t *testing.T) 
 	require.Len(t, chainIndexes, 1)
 }
 
+func TestListIndexesHandlesInvalidFiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettingsWithVersions(
+		clusterversion.Latest.Version(),
+		clusterversion.Latest.Version(),
+		true,
+	)
+	execCfg := &sql.ExecutorConfig{Settings: st}
+	const collectionURI = "nodelocal://1/backup"
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	externalStorage, err := cloud.ExternalStorageFromURI(
+		ctx,
+		collectionURI,
+		base.ExternalIODirConfig{},
+		st,
+		blobs.TestBlobServiceClient(dir),
+		username.RootUserName(),
+		nil, /* db */
+		nil, /* limiters */
+		cloud.NilMetrics,
+	)
+	require.NoError(t, err)
+	makeExternalStorage := func(
+		_ context.Context, _ string, _ username.SQLUsername, _ ...cloud.ExternalStorageOption,
+	) (cloud.ExternalStorage, error) {
+		return externalStorage, nil
+	}
+
+	subdir := "/2025/07/18-120000.00"
+	// Write 3 valid index files.
+	zeroTime := time.Unix(0, 0).UTC()
+	fullBackupEndTime := time.Date(2025, 7, 18, 12, 0, 0, 0, time.UTC)
+	incBackup1EndTime := time.Date(2025, 7, 18, 13, 0, 0, 0, time.UTC)
+	incBackup2EndTime := time.Date(2025, 7, 18, 14, 0, 0, 0, time.UTC)
+	backupTimes := [][2]time.Time{
+		{zeroTime, fullBackupEndTime},
+		{fullBackupEndTime, incBackup1EndTime},
+		{incBackup1EndTime, incBackup2EndTime},
+	}
+
+	for _, times := range backupTimes {
+		details := jobspb.BackupDetails{
+			Destination: jobspb.BackupDetails_Destination{
+				To:     []string{collectionURI},
+				Subdir: subdir,
+			},
+			StartTime:     hlc.Timestamp{WallTime: times[0].UnixNano()},
+			EndTime:       hlc.Timestamp{WallTime: times[1].UnixNano()},
+			CollectionURI: collectionURI,
+			URI:           collectionURI + subdir,
+		}
+		require.NoError(t, WriteBackupIndexMetadata(
+			ctx, execCfg, username.RootUserName(), makeExternalStorage, details, hlc.Timestamp{},
+		))
+	}
+
+	indexDir := path.Join(
+		backupbase.BackupIndexDirectoryPath,
+		backuputils.EncodeDescendingTS(fullBackupEndTime)+"_"+
+			fullBackupEndTime.Format(backupbase.BackupIndexFilenameTimestampFormat),
+	)
+
+	t.Run("non .pb files should be skipped", func(t *testing.T) {
+		validFilename := getBackupIndexFileName(
+			hlc.Timestamp{WallTime: zeroTime.UnixNano()},
+			hlc.Timestamp{WallTime: fullBackupEndTime.UnixNano()},
+		)
+		tmpFile := path.Join(indexDir, validFilename+"123.tmp")
+		writer1, err := externalStorage.Writer(ctx, tmpFile)
+		require.NoError(t, err)
+		require.NoError(t, writer1.Close())
+		defer func() {
+			err := externalStorage.Delete(ctx, tmpFile)
+			require.NoError(t, err)
+		}()
+
+		indexes, err := ListIndexes(ctx, externalStorage, subdir)
+		require.NoError(t, err)
+		require.Len(t, indexes, 3)
+	})
+
+	t.Run("invalid .pb files should error", func(t *testing.T) {
+		invalidTSFile := path.Join(indexDir, "invalid_badts_notreal_metadata.pb")
+		writer2, err := externalStorage.Writer(ctx, invalidTSFile)
+		require.NoError(t, err)
+		require.NoError(t, writer2.Close())
+		defer func() {
+			err := externalStorage.Delete(ctx, invalidTSFile)
+			require.NoError(t, err)
+		}()
+
+		_, err = ListIndexes(ctx, externalStorage, subdir)
+		require.Error(t, err)
+	})
+}
+
 func TestDontWriteBackupIndexMetadata(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
It was discovered in nodelocal implementations, a tmp file could be created for the index entries, which would cause `ListIndexes` calls to fail. This commit teaches `ListIndexes` to simply ignore any indexes that are invalid, which will make it more resilient to any weird idiosyncrasies of the external storage providers.

Epic: None

Release note: None