### PR TITLE
changefeedccl: add missing error return in changeAggregator.Start

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -235,6 +235,9 @@ go_test(
         "testfeed_test.go",
         "validations_test.go",
     ],
+    data = [
+        "changefeed_processors.go",
+    ],
     embed = [":changefeedccl"],
     exec_properties = select({
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
@@ -245,6 +248,7 @@ go_test(
         "//pkg/base",
         "//pkg/blobs",
         "//pkg/build",
+        "//pkg/build/bazel",
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl/cdceval",
         "//pkg/ccl/changefeedccl/cdcevent",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -426,6 +426,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		log.Changefeed.Warningf(ca.Ctx(), "moving to draining due to error wrapping metrics controller: %v", err)
 		ca.MoveToDraining(err)
 		ca.cancel()
+		return
 	}
 
 	ca.sink, err = getEventSink(ctx, ca.FlowCtx.Cfg, ca.spec.Feed, timestampOracle,

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -8,9 +8,14 @@ package changefeedccl
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -151,4 +156,176 @@ func TestSaveRateLimiterError(t *testing.T) {
 			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
+}
+
+// TestMoveToDrainingInStartFollowedByReturn ensures that all MoveToDraining
+// calls in the Start methods of changeAggregator and changeFrontier are
+// followed by a return statement (optionally preceded by a cancel() call).
+// This prevents bugs where error handling forgets to return after calling
+// MoveToDraining, allowing execution to continue with potentially nil values.
+func TestMoveToDrainingInStartFollowedByReturn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Get the path to the source file. In Bazel, we need to use Runfile.
+	sourceFile := "pkg/ccl/changefeedccl/changefeed_processors.go"
+	if bazel.BuiltWithBazel() {
+		var err error
+		sourceFile, err = bazel.Runfile(sourceFile)
+		require.NoError(t, err)
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, sourceFile, nil, 0 /* mode */)
+	require.NoError(t, err)
+
+	var violations []string
+
+	// Only check Start methods for changeAggregator and changeFrontier.
+	targetTypes := map[string]struct{}{
+		"changeAggregator": {},
+		"changeFrontier":   {},
+	}
+	seenTypes := make(map[string]struct{})
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		// Descend into the file to find function declarations.
+		if _, ok := n.(*ast.File); ok {
+			return true
+		}
+		funcDecl, ok := n.(*ast.FuncDecl)
+		if !ok {
+			return false
+		}
+
+		// Check if this is a Start method on one of our target types.
+		if funcDecl.Name.Name != "Start" {
+			return false
+		}
+		if funcDecl.Recv == nil || len(funcDecl.Recv.List) == 0 {
+			return false
+		}
+
+		// Get the receiver type name.
+		var recvTypeName string
+		recvType := funcDecl.Recv.List[0].Type
+		if star, ok := recvType.(*ast.StarExpr); ok {
+			if ident, ok := star.X.(*ast.Ident); ok {
+				recvTypeName = ident.Name
+			}
+		}
+		if _, ok := targetTypes[recvTypeName]; !ok {
+			return false
+		}
+		if _, seen := seenTypes[recvTypeName]; seen {
+			t.Fatalf("found duplicate Start method for %s", recvTypeName)
+		}
+		seenTypes[recvTypeName] = struct{}{}
+
+		// Now check all MoveToDraining calls within this function.
+		ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+			block, ok := n.(*ast.BlockStmt)
+			if !ok {
+				return true
+			}
+
+			for i, stmt := range block.List {
+				exprStmt, ok := stmt.(*ast.ExprStmt)
+				if !ok {
+					continue
+				}
+
+				call, ok := exprStmt.X.(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "MoveToDraining" {
+					continue
+				}
+
+				// Get receiver name for cancel() checking.
+				var recvName string
+				if recvIdent, ok := sel.X.(*ast.Ident); ok {
+					recvName = recvIdent.Name
+				}
+
+				// Found a MoveToDraining call. Check what follows.
+				if i+1 >= len(block.List) {
+					pos := fset.Position(stmt.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: MoveToDraining call not followed by return",
+						pos.Filename, pos.Line,
+					))
+					continue
+				}
+
+				// If next statement is a return, we're good.
+				nextStmt := block.List[i+1]
+				if _, ok := nextStmt.(*ast.ReturnStmt); ok {
+					continue
+				}
+
+				// Check for receiver.cancel() followed by return.
+				if recvName != "" && isMethodCallOn(nextStmt, recvName, "cancel") {
+					if i+2 < len(block.List) {
+						if _, ok := block.List[i+2].(*ast.ReturnStmt); ok {
+							continue
+						}
+					}
+					pos := fset.Position(stmt.Pos())
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: MoveToDraining followed by cancel() but no return",
+						pos.Filename, pos.Line,
+					))
+					continue
+				}
+
+				pos := fset.Position(stmt.Pos())
+				violations = append(violations, fmt.Sprintf(
+					"%s:%d: MoveToDraining must be followed by return (or cancel() then return)",
+					pos.Filename, pos.Line,
+				))
+			}
+
+			return true
+		})
+
+		// We've already inspected the body with the inner Inspect, so skip it.
+		return false
+	})
+
+	// Verify we found exactly one Start method for each target type.
+	for typeName := range targetTypes {
+		if _, seen := seenTypes[typeName]; !seen {
+			t.Fatalf("did not find Start method for %s", typeName)
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("MoveToDraining calls in Start methods must be followed by return:\n%s",
+			strings.Join(violations, "\n"))
+	}
+}
+
+// isMethodCallOn checks if stmt is an expression statement calling receiver.methodName().
+func isMethodCallOn(stmt ast.Stmt, receiver, methodName string) bool {
+	exprStmt, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	recvIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return recvIdent.Name == receiver && sel.Sel.Name == methodName
 }


### PR DESCRIPTION
This patch adds a missing error return in `changeAggregator.Start`,
which could cause a nil dereference panic.

An unit test to catch this class of bugs has also been added.

Fixes #159446
Informs #158438

Release note (bug fix): Fixes a rare bug that could cause a panic
on changefeed startup.