### PR TITLE
release-26.1: toolchains: use binutils v2.37 for the Windows toolchain

### DIFF
--- a/build/toolchains/REPOSITORIES.bzl
+++ b/build/toolchains/REPOSITORIES.bzl
@@ -12,48 +12,48 @@ def toolchain_dependencies():
         name = "toolchain_cross_aarch64-unknown-linux-gnu",
         host = "x86_64",
         target = "aarch64-unknown-linux-gnu",
-        tarball_sha256 = "f9b073774826747cf2a91514d5ab27e3ba7f0c7b63acaf80a5ed58c82b08fd44",
+        tarball_sha256 = "daa11aa45c6389417378320f74756cfb6667590eaebc2bcf6e2c1e4a8656c624",
     )
     _crosstool_toolchain_repo(
         name = "toolchain_cross_s390x-ibm-linux-gnu",
         host = "x86_64",
         target = "s390x-ibm-linux-gnu",
-        tarball_sha256 = "027d7d3b89d0c9745243610b9c12aa26f5605884b058934645cb344927228dab",
+        tarball_sha256 = "994a327c068a982f4bc56c8d985680b72e0a06a58504c39f0721d5933a31b8d9",
     )
     _crosstool_toolchain_repo(
         name = "toolchain_cross_x86_64-unknown-linux-gnu",
         host = "x86_64",
         target = "x86_64-unknown-linux-gnu",
-        tarball_sha256 = "5f79da0a9e580bc0a869ca32c2e5a21990676ec567aabf54ccc1dec4c3f2c827",
+        tarball_sha256 = "fecff90dd09ee5011bf20e4a1db819ea6c33194440e9d866b83a62658bc44950",
     )
     _crosstool_toolchain_repo(
         name = "toolchain_cross_x86_64-w64-mingw32",
         host = "x86_64",
         target = "x86_64-w64-mingw32",
-        tarball_sha256 = "94e64e0e8de05706dfd5ab2f1fee6e7f75280e35b09b5628980805d27939b418",
+        tarball_sha256 = "84d3fb2c0bc1250acdedd75a8d47b042514e93a7972a3258ba7f693ebeddff51",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_aarch64-unknown-linux-gnu",
         host = "aarch64",
         target = "aarch64-unknown-linux-gnu",
-        tarball_sha256 = "1e7e5ccc142a528ea4e79a002824af8c15225393d42e452259ed4e99ea45eabe",
+        tarball_sha256 = "80618b9a8b46ad45966f59e2ee922cd606f2b12420033703be40d633556ae833",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_s390x-ibm-linux-gnu",
         host = "aarch64",
         target = "s390x-ibm-linux-gnu",
-        tarball_sha256 = "76ede410bba820ff9e5e10d68802abc8cf809720fc035a93b1e16f40e987bfd4",
+        tarball_sha256 = "e3cc0ec7ee206480b5fb2ac4b8e3b65a2c3dcb7b56334dc6068e3a0252b4e847",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_x86_64-unknown-linux-gnu",
         host = "aarch64",
         target = "x86_64-unknown-linux-gnu",
-        tarball_sha256 = "7b6101ec5b55e8d10004734823bca221b54b6163e0b500df25ede38f1cc27d2e",
+        tarball_sha256 = "4370da607fda2692497d520a03f3f3ae9bc99445656f4ddd8472eca248e9f207",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_x86_64-w64-mingw32",
         host = "aarch64",
         target = "x86_64-w64-mingw32",
-        tarball_sha256 = "1bca59b5aac70bdbbb17499141f2f261dbfeb4accb14cd9a3f699579b5372dc4",
+        tarball_sha256 = "cd4f54274d450b88b6aeecb6b46e2903cff219cf03af5dcbc0dac9c185f4011a",
     )
     _macos_toolchain_repos()

--- a/build/toolchains/crosstool-ng/toolchain.bzl
+++ b/build/toolchains/crosstool-ng/toolchain.bzl
@@ -1,8 +1,8 @@
 def _impl(rctx):
     if rctx.attr.host == "x86_64":
-        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20230906-034412/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
+        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20251212-204614/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
     elif rctx.attr.host == "aarch64":
-        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20220711-204538/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
+        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20251212-225503/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
     rctx.download_and_extract(
         url = [url],
         sha256 = rctx.attr.tarball_sha256,

--- a/build/toolchains/toolchainbuild/crosstool-ng/x86_64-w64-mingw.config
+++ b/build/toolchains/toolchainbuild/crosstool-ng/x86_64-w64-mingw.config
@@ -266,22 +266,25 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
+CT_BINUTILS_V_2_37=y
+# CT_BINUTILS_V_2_36 is not set
+# CT_BINUTILS_V_2_35 is not set
+# CT_BINUTILS_V_2_34 is not set
+# CT_BINUTILS_V_2_33 is not set
 # CT_BINUTILS_V_2_32 is not set
 # CT_BINUTILS_V_2_31 is not set
 # CT_BINUTILS_V_2_30 is not set
 # CT_BINUTILS_V_2_29 is not set
-CT_BINUTILS_V_2_28=y
+# CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
 # CT_BINUTILS_NO_VERSIONS is not set
-CT_BINUTILS_VERSION="2.28.1"
+CT_BINUTILS_VERSION="2.37"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
-CT_BINUTILS_2_30_or_older=y
-CT_BINUTILS_older_than_2_30=y
 CT_BINUTILS_later_than_2_27=y
 CT_BINUTILS_2_27_or_later=y
 CT_BINUTILS_later_than_2_25=y


### PR DESCRIPTION
Backport 1/1 commits from #159410 on behalf of @rickystewart.

----

Prior to this change, Windows builds were failing due to this problem:
https://github.com/golang/go/issues/75077

As of Go 1.25, Windows builds require a sufficiently new version of
`binutils`, as captured in the [minimum requirements](https://go.dev/wiki/MinimumRequirements):

> Starting with Go 1.25, use of CGO on Windows requires a C compiler that incorpoates support for DWARF 5. For those using GCC, this requirement translates to selecting a version of GCC built with binutils version 2.37 or later. Programs built with older versions of GCC (those using binutils 2.36 and earlier) will produce non-working executables, see issue 75077 for details.

Here, we make a very specific targeted change to upgrade the version of
binutils used for Windows builds specifically. This is meant to limit
the risk of updating the toolchains and not possibly affect our other
builds.

Closes: #159401
Release note: none
Epic: none

----

Release justification: Fix Windows build