### PR TITLE
roachprod: allow gce arm64 instance creation in non-t2a zones

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1049,6 +1049,8 @@ type ProjectsVal struct {
 // ARM64 builds), but we randomize the specific zone. This is to avoid
 // "zone exhausted" errors in one particular zone, especially during
 // nightly roachtest runs.
+// TODO(manojpillai): use same defaults for ARM64, given c4a wide availability.
+// But review roachtest impact before changing.
 func DefaultZones(arch string, geoDistributed bool) []string {
 	zones := []string{"us-east1-b", "us-east1-c", "us-east1-d"}
 	if vm.ParseArch(arch) == vm.ArchARM64 {
@@ -1481,7 +1483,8 @@ func computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, err
 			zones = []string{"us-central1-a"}
 		}
 
-		if !IsSupportedT2AZone(providerOpts.Zones) {
+		if strings.HasPrefix(strings.ToLower(providerOpts.MachineType), "t2a-") &&
+			!IsSupportedT2AZone(providerOpts.Zones) {
 			return nil, errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(SupportedT2AZones, ","))
 		}
 	}


### PR DESCRIPTION
Until recently, roachprod only supported t2a instance types in gce in the arm64 category. Support was recently added for other instance types including the widely available c4a, but creation only worked in zones where t2a was available.

This patch retains the current defaults for gce arm64 zones but allows users to create instances like c4a in any zone where they are available by using the --gce-zones flag.

Epic: none
Part of: #139527

Release note: None