### PR TITLE
roachtest: wait for rapid-restart termination

### DIFF
--- a/pkg/cmd/roachtest/tests/rapid_restart.go
+++ b/pkg/cmd/roachtest/tests/rapid_restart.go
@@ -53,8 +53,11 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 			time.Sleep(waitTime)
 
 			sig := [2]int{2, 9}[rand.Intn(2)]
+			t.L().Printf("stopping node with signal %d after %s\n", sig, waitTime)
 			stopOpts := option.DefaultStopOpts()
 			stopOpts.RoachprodOpts.Sig = sig
+			stopOpts.RoachprodOpts.Wait = true
+			stopOpts.RoachprodOpts.GracePeriod = 1
 			if err := c.StopE(ctx, t.L(), stopOpts, node); err != nil {
 				t.Fatalf("error during stop: %v", err)
 			}


### PR DESCRIPTION
Make rapid-restart always wait for the cockroach process to exit (even when using SIGINT), with a short grace period, and log which signal was used. This reduces flakiness from racing restarts.

Fixes #159477.
Epic: none