### PR TITLE
release-26.1: sqlstats: flush ingester buffer if above max statements per txn

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -187,8 +187,8 @@ func (ex *connExecutor) recordStatementSummary(
 	ex.metrics.EngineMetrics.StatementBytesRead.Inc(stats.bytesRead)
 	ex.metrics.EngineMetrics.StatementIndexRowsWritten.Inc(stats.indexRowsWritten)
 	ex.metrics.EngineMetrics.StatementIndexBytesWritten.Inc(stats.indexBytesWritten)
-
 	if ex.statsCollector.EnabledForTransaction() {
+		maxRecordedStats := sqlstats.TxnStatsNumStmtFingerprintStatsToRecord.Get(&ex.server.cfg.Settings.SV)
 		b := sqlstats.NewRecordedStatementStatsBuilder(
 			stmtFingerprintID,
 			planner.SessionData().Database,
@@ -228,6 +228,19 @@ func (ex *connExecutor) recordStatementSummary(
 		}
 
 		ex.statsCollector.RecordStatement(ctx, b.Build())
+		if int64(ex.state.mu.stmtCount)%(maxRecordedStats) == 0 {
+			// If the statement count is equal to the configured limit,
+			// force flush the SQL stats ingestion buffer.
+			// Note that these statements that are force flushed cannot be associated
+			// with the transaction in SQL Stats since this association can only be
+			// done once a transaction has been committed. As a result, these
+			// recorded stats will be given a static transaction fingerprint ID to
+			// indicate that they are force flushed. Since these force flushes occur
+			// in batches, any leftover statement stats will be flushed when the
+			// transaction is committed, causing them to be associated with the
+			// correct transaction fingerprint.
+			ex.statsCollector.Flush(ex.planner.extendedEvalCtx.SessionID)
+		}
 	}
 
 	// Record statement execution statistics if span is recorded and no error was

--- a/pkg/sql/sqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/cluster_settings.go
@@ -29,6 +29,23 @@ var TxnStatsNumStmtFingerprintIDsToRecord = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
+// TxnStatsNumStmtFingerprintStatsToRecord limits the number of recorded
+// statement statistics that may be associated with transaction statistics for
+// a single transaction. If the number of statements executed exceeds this
+// value, SQL Stats will force the ingester to flush the buffered stats. These
+// stats will not be associated with the current transaction. SQL Stats will
+// continue to buffer statements until this limit is reached again. In the case
+// that it isn't reached again, the buffered statements will be flushed when
+// the transaction is committed, and they will be associated with the
+// transaction.
+var TxnStatsNumStmtFingerprintStatsToRecord = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"sql.metrics.transaction_details.max_statement_stats",
+	"max number of statement statistics that may be associated with transaction statistics",
+	100_000,
+	settings.PositiveInt,
+)
+
 // TxnStatsEnable determines whether to collect per-application transaction
 // statistics.
 // TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.

--- a/pkg/sql/sqlstats/sqlstats_test.go
+++ b/pkg/sql/sqlstats/sqlstats_test.go
@@ -122,6 +122,7 @@ func GetTxnStats(t *testing.T, conn *sqlutils.SQLRunner, appName string, dbName 
 SELECT 
 	encode(fingerprint_id, 'hex') AS txn_fingerprint_id,
 	metadata->'stmtFingerprintIDs' AS statement_fingerprint_ids,
+  statistics -> 'statistics'->> 'cnt' AS count,
 	(statistics -> 'statistics' -> 'commitLat' -> 'mean')::FLOAT > 0 AS commit_lat_not_zero,
 	(statistics -> 'statistics' -> 'svcLat' -> 'mean')::FLOAT > 0 AS svc_lat_not_zero
 FROM crdb_internal.transaction_statistics ts

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -164,6 +164,14 @@ func (s *StatsCollector) RecordTransaction(_ctx context.Context, value *sqlstats
 	s.statsIngester.RecordTransaction(value)
 }
 
+func (s *StatsCollector) Flush(sessionID clusterunique.ID) {
+	if !s.sendStats {
+		return
+	}
+
+	s.statsIngester.FlushBuffer(sessionID)
+}
+
 func (s *StatsCollector) EnabledForTransaction() bool {
 	return s.sendStats
 }

--- a/pkg/sql/sqlstats/testdata/max_txn_statements
+++ b/pkg/sql/sqlstats/testdata/max_txn_statements
@@ -1,0 +1,73 @@
+# In this test, we verify that statement statistics are force flushed based on
+# the `sql.metrics.transaction_details.max_statement_ids` cluster setting. If
+# the expected criteria is met, statement statistics for a session will be
+# flushed from the buffer, regardless of whether the transaction has ended.
+# When statement statistics are force flushed, there will be no transaction
+# fingerprint ID associated with the flushed statement statistics, since this
+# requires a transaction to have ended to compute.
+
+# Setup baseline to test against with default settings
+exec-sql db=max_txn_stmts_test app-name=exec
+BEGIN;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+END;
+----
+
+exec-sql db=max_txn_stmts_test app-name=exec
+BEGIN;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+END;
+----
+
+show-stats db=max_txn_stmts_test app-name=exec
+----
+{"count": "5", "fingerprint_id": "bdb329db6493db17", "nodes": [1], "parse_lat_not_zero": true, "plan_distributed": false, "plan_full_scan": false, "plan_hash_set": true, "plan_implicit_txn": false, "plan_lat_not_zero": true, "plan_vectorized": true, "query": "SELECT _", "run_lat_not_zero": true, "sql_type": "TypeDML", "summary": "SELECT _", "svc_lat_not_zero": true, "transaction_fingerprint_id": "023097855475259c"}
+{"count": "3", "fingerprint_id": "bdb329db6493db17", "nodes": [1], "parse_lat_not_zero": true, "plan_distributed": false, "plan_full_scan": false, "plan_hash_set": true, "plan_implicit_txn": false, "plan_lat_not_zero": true, "plan_vectorized": true, "query": "SELECT _", "run_lat_not_zero": true, "sql_type": "TypeDML", "summary": "SELECT _", "svc_lat_not_zero": true, "transaction_fingerprint_id": "3b5be2cb288f18aa"}
+
+show-txn-stats db=max_txn_stmts_test app-name=exec
+----
+{"commit_lat_not_zero": true, "count": "1", "statement_fingerprint_ids": ["bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17"], "svc_lat_not_zero": true, "txn_fingerprint_id": "023097855475259c"}
+{"commit_lat_not_zero": true, "count": "1", "statement_fingerprint_ids": ["bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17"], "svc_lat_not_zero": true, "txn_fingerprint_id": "3b5be2cb288f18aa"}
+
+exec-sql db=max_txn_stmts_test app-name=setup-limit
+SET CLUSTER SETTING sql.metrics.transaction_details.max_statement_stats=4;
+----
+
+# This is over the configured settings but below the threshold for force flush,
+# so it will still contribute to the same SQL Stats rows as above.
+exec-sql db=max_txn_stmts_test app-name=exec
+BEGIN;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+END;
+----
+
+# This is over the threshold for force flush, so it results in a new row in
+# SQL stats with a blank transaction fingerprint ID.
+exec-sql db=max_txn_stmts_test app-name=exec
+BEGIN;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+SELECT 1;
+END;
+----
+
+show-stats db=max_txn_stmts_test app-name=exec
+----
+{"count": "6", "fingerprint_id": "bdb329db6493db17", "nodes": [1], "parse_lat_not_zero": true, "plan_distributed": false, "plan_full_scan": false, "plan_hash_set": true, "plan_implicit_txn": false, "plan_lat_not_zero": true, "plan_vectorized": true, "query": "SELECT _", "run_lat_not_zero": true, "sql_type": "TypeDML", "summary": "SELECT _", "svc_lat_not_zero": true, "transaction_fingerprint_id": "023097855475259c"}
+{"count": "6", "fingerprint_id": "bdb329db6493db17", "nodes": [1], "parse_lat_not_zero": true, "plan_distributed": false, "plan_full_scan": false, "plan_hash_set": true, "plan_implicit_txn": false, "plan_lat_not_zero": true, "plan_vectorized": true, "query": "SELECT _", "run_lat_not_zero": true, "sql_type": "TypeDML", "summary": "SELECT _", "svc_lat_not_zero": true, "transaction_fingerprint_id": "3b5be2cb288f18aa"}
+{"count": "4", "fingerprint_id": "bdb329db6493db17", "nodes": [1], "parse_lat_not_zero": true, "plan_distributed": false, "plan_full_scan": false, "plan_hash_set": true, "plan_implicit_txn": false, "plan_lat_not_zero": true, "plan_vectorized": true, "query": "SELECT _", "run_lat_not_zero": true, "sql_type": "TypeDML", "summary": "SELECT _", "svc_lat_not_zero": true, "transaction_fingerprint_id": "ffffffffffffffff"}
+
+show-txn-stats db=max_txn_stmts_test app-name=exec
+----
+{"commit_lat_not_zero": true, "count": "2", "statement_fingerprint_ids": ["bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17"], "svc_lat_not_zero": true, "txn_fingerprint_id": "023097855475259c"}
+{"commit_lat_not_zero": true, "count": "2", "statement_fingerprint_ids": ["bdb329db6493db17", "bdb329db6493db17", "bdb329db6493db17"], "svc_lat_not_zero": true, "txn_fingerprint_id": "3b5be2cb288f18aa"}

--- a/pkg/sql/sqlstats/testdata/query
+++ b/pkg/sql/sqlstats/testdata/query
@@ -35,4 +35,4 @@ show-stats db=random_db app-name=transactions
 
 show-txn-stats db=random_db app-name=transactions
 ----
-{"commit_lat_not_zero": true, "statement_fingerprint_ids": ["5fe99858726d3688", "5fe99858726d3688"], "svc_lat_not_zero": true, "txn_fingerprint_id": "78d7c1c32632f05d"}
+{"commit_lat_not_zero": true, "count": "2", "statement_fingerprint_ids": ["5fe99858726d3688", "5fe99858726d3688"], "svc_lat_not_zero": true, "txn_fingerprint_id": "78d7c1c32632f05d"}


### PR DESCRIPTION
Backport 1/1 commits from #158527.

/cc @cockroachdb/release

---

There have been a couple incidents recently where workloads running
multi day / million statement txns cause sql stats to have unbounded
memory growth. This is happening because SQL Stats are buffered by
sessionID until a transaction commits, which causes the buffer to
flush and the statement stats to be recorded in the SQL stats
subsystem. When there is a long running transaction with many
statements, we buffer is never flushed and continues to grow.

To fix this, we have introduced a new "force flush" event that
forces the SQL stats ingester to flush sql stats in the current
session, if a certain threshold is met. This threshold is currently
set to the value of a new cluster setting:
`sql.metrics.transaction_details.max_statement_stats`.

If this threshold is met, the stats are automatically flushed. The side effect
of this is that these stats will not have an associated transaction
fingerprint id. This is because the transaction fingerprint id
isn't finalized until a transaction is complete and we don't know
the transaction fingerprint id at the time of this forced flush.
There is also no way to "backfill" or set the transaction
fingerprint id once the statement stat has been recorded to the
SQL Stats subsystem.

This commit also includes a change to the
`SQLStatsIngester.flushBuffer` method to recording transaction
stats when there are no statements stats in the buffer. This is
the case when the buffer is being force flushed in the scenario
mentioned above.

Fixes: https://github.com/cockroachdb/cockroach/issues/158800
Epic: None
Release note (bug fix): Addresses a bug with unbounded memory
growth when long running transactions are contain many statements.
In this case, the SQL Stats system will automatically flush these
before the transaction commits. The side effect of this is that
these statement statistics will no longer have an associated
transaction fingerprint id.

Release Justification: Fixes a critical bug seen by multiple customers that causes unexpected unbounded memory growth due to the SQL Stats Ingester.