### PR TITLE
catalog/lease: make memory management safer

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -232,7 +232,8 @@ func newDescriptorVersionState(
 	if !expiration.IsEmpty() {
 		descState.expiration.Store(&expiration)
 	}
-
+	// Populate the size of the structure.
+	descState.byteSize = descState.calculateByteSize()
 	return descState
 }
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -993,6 +993,16 @@ func (m *Manager) insertDescriptorVersions(
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	newVersionsToInsert := make([]*descriptorVersionState, 0, len(versions))
+	defer func() {
+		// Release memory for anything not inserted, entries are
+		// cleared after each insert.
+		for _, state := range newVersionsToInsert {
+			if state == nil {
+				continue
+			}
+			t.m.boundAccount.Shrink(ctx, state.getByteSize())
+		}
+	}()
 	for i := range versions {
 		// Since we gave up the lock while reading the versions from
 		// the store we have to ensure that no one else inserted the
@@ -1007,8 +1017,9 @@ func (m *Manager) insertDescriptorVersions(
 		}
 	}
 	// Only insert if all versions were allocated.
-	for _, descState := range newVersionsToInsert {
+	for idx, descState := range newVersionsToInsert {
 		t.mu.active.insert(descState)
+		newVersionsToInsert[idx] = nil
 	}
 
 	return nil


### PR DESCRIPTION
Previously, the sizes used to allocate and release memory could shift due to a variety of reasons. There are scenarios where stored leases may be intentionally cleaned up from descriptor states earlier, for example if the session based leasing logic expires an old version. This can lead to accounting issues in the bound account. To avoid these, the descriptor state will store the size of the allocation used initially, which will be also used on clean up.

Fixes: #158403

Release note (bug fix): Fixes a memory accounting issue that could occur when a lease expires due to a SQL liveness session based timeout.