### PR TITLE
ui: bump cluster-ui to 26.1.0

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "26.1.0-prerelease.0",
+  "version": "26.1.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Epic: REL-3909
Resolves: CC-34332
Release note: None

Release Justification: version bump that's part of release flow. no production code changed.