### PR TITLE
cloud: skip temporary files when listing nodelocal

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+const TmpFileSuffix = ".tmp"
+
 // LocalStorage wraps all operations with the local file system
 // that the blob service makes.
 type LocalStorage struct {
@@ -119,7 +121,7 @@ func (l *LocalStorage) Writer(ctx context.Context, filename string) (io.WriteClo
 	//   exotic edge cases, hence the use fileutil.Move below.)
 	// See the explanatory comment for os.CreateTemp to understand
 	// what the "*" in the suffix means.
-	tmpFile, err := os.CreateTemp(targetDir, filepath.Base(fullPath)+"*.tmp")
+	tmpFile, err := os.CreateTemp(targetDir, filepath.Base(fullPath)+"*"+TmpFileSuffix)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating temporary file")
 	}

--- a/pkg/cloud/nodelocal/BUILD.bazel
+++ b/pkg/cloud/nodelocal/BUILD.bazel
@@ -34,9 +34,12 @@ go_test(
     srcs = ["nodelocal_storage_test.go"],
     embed = [":nodelocal"],
     deps = [
+        "//pkg/cloud/cloudpb",
         "//pkg/cloud/cloudtestutils",
         "//pkg/security/username",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/util/leaktest",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -189,6 +189,10 @@ func (l *localFileStorage) List(
 	sort.Strings(res)
 	var prevPrefix string
 	for _, f := range res {
+		// Skip temporary files.
+		if strings.HasSuffix(f, blobs.TmpFileSuffix) {
+			continue
+		}
 		f = strings.TrimPrefix(f, dest)
 		if delim != "" {
 			if i := strings.Index(f, delim); i >= 0 {

--- a/pkg/cloud/nodelocal/nodelocal_storage_test.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage_test.go
@@ -6,12 +6,16 @@
 package nodelocal
 
 import (
+	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudtestutils"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPutLocal(t *testing.T) {
@@ -30,4 +34,32 @@ func TestPutLocal(t *testing.T) {
 	cloudtestutils.CheckExportStore(t, info)
 	info.URI = "nodelocal://1/listing-test/basepath"
 	cloudtestutils.CheckListFiles(t, info)
+}
+
+func TestListLocalSkipsTempFiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	ctx := context.Background()
+	externalStorage := TestingMakeNodelocalStorage(
+		dir,
+		cluster.MakeTestingClusterSettings(),
+		cloudpb.ExternalStorage{},
+	)
+	writer, err := externalStorage.Writer(ctx, "foo.txt")
+	require.NoError(t, err)
+	writer.Close()
+
+	tmpWriter, err := externalStorage.Writer(ctx, "foo.txt1234.tmp")
+	require.NoError(t, err)
+	tmpWriter.Close()
+
+	var files []string
+	err = externalStorage.List(ctx, "/", "", func(name string) error {
+		files = append(files, name)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/foo.txt"}, files)
 }


### PR DESCRIPTION
The `LocalStorage` writer creates temporary files when writing files, which can end up being listed by the nodelocal implementation if the file is not cleaned up before the list call. This commit teaches the nodelocal implementation to skip all temporary files.

Epic: None

Release note: None