### PR TITLE
util/admission: add stub pacer for non-bazel builds

### DIFF
--- a/pkg/util/admission/pacer.go
+++ b/pkg/util/admission/pacer.go
@@ -3,6 +3,9 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+// Pacer's internals rely on our fork of Go. See pacer_nofork.go.
+//go:build bazel
+
 package admission
 
 import (

--- a/pkg/util/admission/pacer_nofork.go
+++ b/pkg/util/admission/pacer_nofork.go
@@ -1,0 +1,38 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// If a stock/off-the-shelf Go SDK is used instead of the bazel-managed SDK
+// pulled from Cockroach's fork of Go, the Pacer, which normally interacts with
+// our fork's runtime extensions, cannot function normally. To allow the package
+// to at least compile, we have a stub copy of pacer. Note: we fork the whole
+// Pacer instead of having a narrower Yielder with separate implementations to
+// avoid any overhead of calling a wrapper as Pace() is extremely sensitive to
+// per-call cost.
+//go:build !bazel
+
+package admission
+
+import (
+	"context"
+	"time"
+)
+
+// Pacer is a stub for use in non-bazel builds.
+type Pacer struct {
+	unit time.Duration
+	wi   WorkInfo
+	wq   *ElasticCPUWorkQueue
+
+	Yield bool
+}
+
+// Pace is a noop.
+func (p *Pacer) Pace(ctx context.Context) (readmitted bool, err error) {
+	return false, nil
+}
+
+// Close is part of the Pacer interface.
+func (p *Pacer) Close() {
+}


### PR DESCRIPTION
Some tools/IDEs may try to build crdb code/packages without using our supported bazel build and in particular, may try to do so with a version of Go other than CRDB's fork. While the right answer for cases like this is probably to build with the CRDB fork (setting GOROOT accordingly), in many cases these tools can be made to work well enough by just giving them stubs that don't include functionality which depends on our fork.

Release note: none.
Epic: none.