### PR TITLE
bulkmerge: fix SST boundary handling for column families

### DIFF
--- a/pkg/sql/bulkingest/BUILD.bazel
+++ b/pkg/sql/bulkingest/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/cloud",
         "//pkg/clusterversion",
-        "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/sql/bulkmerge/BUILD.bazel
+++ b/pkg/sql/bulkmerge/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/ccl/storageccl",
+        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/sql",
@@ -52,6 +53,7 @@ go_test(
         "//pkg/ccl/storageccl",
         "//pkg/cloud",
         "//pkg/cloud/externalconn/providers",
+        "//pkg/keys",
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
@@ -68,6 +70,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/bulkmerge/merge_processor.go
+++ b/pkg/sql/bulkmerge/merge_processor.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/bulksst"
@@ -235,7 +236,7 @@ func (m *bulkMergeProcessor) mergeSSTs(
 		return execinfrapb.BulkMergeSpec_Output{}, nil
 	}
 
-	sstMaxSize := targetFileSize.Get(&m.flowCtx.EvalCtx.Settings.SV)
+	sstTargetSize := targetFileSize.Get(&m.flowCtx.EvalCtx.Settings.SV)
 	iterOpts := storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: mergeSpan.Key,
@@ -256,7 +257,7 @@ func (m *bulkMergeProcessor) mergeSSTs(
 
 	var mergedSSTs execinfrapb.BulkMergeSpec_Output
 
-	var firstKey roachpb.Key
+	var firstKey, endKey roachpb.Key
 	var sstSize int64
 	// Write all KVs
 	for iter.SeekGE(storage.MVCCKey{Key: mergeSpan.Key}); ; iter.NextKey() {
@@ -277,15 +278,18 @@ func (m *bulkMergeProcessor) mergeSSTs(
 			firstKey = key.Key.Clone()
 		}
 
-		// Write the key-value pair
-		if err := mergedSSTWriter.PutRawMVCC(key, val); err != nil {
-			return execinfrapb.BulkMergeSpec_Output{}, err
+		// If our file has grown too large, pick an endpoint after the current key.
+		if endKey == nil && sstSize >= sstTargetSize {
+			safeKey, err := keys.EnsureSafeSplitKey(key.Key)
+			if err != nil {
+				return execinfrapb.BulkMergeSpec_Output{}, err
+			}
+			endKey = safeKey.PrefixEnd()
 		}
-		sstSize += int64(len(key.Key) + len(val))
 
-		// Flush large SSTs after writing the key
-		if sstSize >= sstMaxSize {
-			endKey := key.Key.Next()
+		// If we've selected an endKey and this key is at or beyond that point, create a new SST
+		// for the current key.
+		if endKey != nil && key.Key.Compare(endKey) >= 0 {
 			mergedSSTs.SSTs = append(mergedSSTs.SSTs, execinfrapb.BulkMergeSpec_SST{
 				StartKey: firstKey,
 				EndKey:   endKey,
@@ -300,10 +304,23 @@ func (m *bulkMergeProcessor) mergeSSTs(
 				return execinfrapb.BulkMergeSpec_Output{}, err
 			}
 			mergedSSTWriter = storage.MakeIngestionSSTWriter(ctx, m.flowCtx.EvalCtx.Settings, mergedSSTFile)
-			// Next SST starts where this one ended to maintain contiguous non-overlapping ranges
+
+			// Next SST starts where this one ended to maintain contiguous
+			// non-overlapping ranges. This has the side-effect of the startKey
+			// not necessarily being the first key in the file. If we use the first
+			// observed key after the break as the StartKey, we end up with ranges
+			// that start at /0, which is not exactly wrong, but it's different than
+			// what is observed with non-distributed ingest.
 			firstKey = endKey
+			endKey = nil
 			sstSize = 0
 		}
+
+		// Write the key-value pair
+		if err := mergedSSTWriter.PutRawMVCC(key, val); err != nil {
+			return execinfrapb.BulkMergeSpec_Output{}, err
+		}
+		sstSize += int64(len(key.Key) + len(val))
 	}
 
 	// Finish writing the SST


### PR DESCRIPTION
Previously, the merge processor would split SSTs at arbitrary byte positions when reaching the target SST size, which could result in splits within column families. Additionally, the split picker was validating that SST boundaries were already at safe split points and rejecting SSTs that weren't, which was both overly strict (rejecting valid splits) and ineffective (the check itself was flawed).

This commit fixes both issues:

1. In the merge processor, SST endpoints are now selected using EnsureSafeSplitKey() to find the next safe split point (row boundary) after reaching the target size, then using PrefixEnd() to properly bound the SST. This ensures we never split within a column family.

2. In the split picker, the incorrect validation check has been removed. The merge processor now ensures SST boundaries are correct at write time, making validation at split-picking time redundant.

3. In combine_file_info, merge span boundaries are now validated using EnsureSafeSplitKey() to ensure they start at safe split points.

Informs: #156658

Release note: none

Epic: CRDB-48845