### PR TITLE
kvpb: Remove trailing space of `QuorumReplicationFlowAdmissionEvent.String()`

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2660,3 +2660,13 @@ func (r *AddSSTableRequest) Validate(bh Header) error {
 	}
 	return nil
 }
+
+func (m *QuorumReplicationFlowAdmissionEvent) String() string {
+	return redact.StringWithoutMarkers(m)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (m *QuorumReplicationFlowAdmissionEvent) SafeFormat(w redact.SafePrinter, _ rune) {
+	prefix := redact.SafeString("range controller waited for quorum flow control")
+	w.Printf("%s for %d nanos", prefix, m.WaitDurationNanos)
+}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3879,8 +3879,12 @@ message ContentionEvent {
 // QuorumReplicationFlowAdmissionEvent is a message that is recorded on traces by a
 // range controller when waiting for quorum flow control.
 message QuorumReplicationFlowAdmissionEvent {
+  option (gogoproto.goproto_stringer) = false;
   // WaitDurationNanos is the time spent waiting.
   int64 wait_duration_nanos = 1 [(gogoproto.casttype) = "time.Duration"];
+
+  // When adding a new field, please also update
+  // QuorumReplicationFlowAdmissionEvent.SafeFormat().
 }
 
 // ScanStats is a message that tracks miscellaneous statistics of all Gets,


### PR DESCRIPTION
Fixes #159484

Previously, the auto-generated
`QuorumReplicationFlowAdmissionEvent.String()` uses `proto.CompactTextString(m)`
which returns a string with a trailing space. This commit is to implement
dedicated `String()` and `SafeFormat()` to avoid this problem.

Release note: None