### PR TITLE
release-26.1: kvstreamer: add a cluster setting for initial estimate

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/avg_response_estimator_test.go
+++ b/pkg/kv/kvclient/kvstreamer/avg_response_estimator_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -22,10 +23,12 @@ func TestAvgResponseEstimator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	e := avgResponseEstimator{avgResponseSizeMultiple: defaultAvgResponseSizeMultiple}
+	settings := cluster.MakeTestingClusterSettings()
+	var e avgResponseEstimator
+	e.init(&settings.SV)
 
 	// Before receiving any responses, we should be using the initial estimate.
-	require.Equal(t, int64(InitialAvgResponseSize), e.getAvgResponseSize())
+	require.Equal(t, int64(DefaultInitialAvgResponseSize), e.getAvgResponseSize())
 
 	// Simulate receiving a single response.
 	firstResponseSize := int64(42)
@@ -59,7 +62,10 @@ func TestAvgResponseSizeForPartialResponses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	e := avgResponseEstimator{avgResponseSizeMultiple: defaultAvgResponseSizeMultiple}
+	settings := cluster.MakeTestingClusterSettings()
+	var e avgResponseEstimator
+	e.init(&settings.SV)
+
 	// Simulate a ScanRequest that needs to fetch 100 rows, 1KiB each in size.
 	const totalRows, rowSize = 100, 1 << 10
 	rowsLeft := int64(totalRows)

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -267,7 +267,7 @@ func TestStreamerCorrectlyDiscardsResponses(t *testing.T) {
 	// request by the Streamer will be numRowsPerRange x InitialAvgResponseSize,
 	// so we pick the blob size such that about half of rows are included in the
 	// partial responses.
-	const blobSize = 2 * kvstreamer.InitialAvgResponseSize
+	const blobSize = 2 * kvstreamer.DefaultInitialAvgResponseSize
 	const numRows = 20
 	const numRowsPerRange = 4
 
@@ -297,9 +297,9 @@ func TestStreamerCorrectlyDiscardsResponses(t *testing.T) {
 	// the budget. This includes 4/3 factor since the vectorized ColIndexJoin
 	// gives 3/4 of the workmem limit to the Streamer.
 	for _, workmem := range []int{
-		3 * kvstreamer.InitialAvgResponseSize * numRows / 2,
-		7 * kvstreamer.InitialAvgResponseSize * numRows / 4,
-		2 * kvstreamer.InitialAvgResponseSize * numRows,
+		3 * kvstreamer.DefaultInitialAvgResponseSize * numRows / 2,
+		7 * kvstreamer.DefaultInitialAvgResponseSize * numRows / 4,
+		2 * kvstreamer.DefaultInitialAvgResponseSize * numRows,
 	} {
 		t.Run(fmt.Sprintf("workmem=%s", humanize.Bytes(uint64(workmem))), func(t *testing.T) {
 			_, err = db.Exec(fmt.Sprintf("SET distsql_workmem = '%dB'", workmem))
@@ -326,7 +326,7 @@ func TestStreamerWideRows(t *testing.T) {
 	})
 	defer s.Stopper().Stop(context.Background())
 
-	const blobSize = 10 * kvstreamer.InitialAvgResponseSize
+	const blobSize = 10 * kvstreamer.DefaultInitialAvgResponseSize
 	const numRows = 2
 
 	_, err := db.Exec("CREATE TABLE t (pk INT PRIMARY KEY, k INT, blob1 STRING, blob2 STRING, INDEX (k), FAMILY (pk, k, blob1), FAMILY (blob2))")


### PR DESCRIPTION
Backport 1/1 commits from #159540 on behalf of @yuzefovich.

----

Previously, we had a hard-coded initial estimate for average response size of 1KiB, but it might be helpful to adjust this value based on the workload, so this commit adds an undocumented cluster setting.

Epic: None
Release note: None

----

Release justification: off by default, configuration improvement.