### PR TITLE
release-26.1: catalog/lease: fix race condition against rangefeed start

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -2809,11 +2809,18 @@ func (m *Manager) watchForUpdates(ctx context.Context) {
 		}
 		log.Dev.Warningf(ctx, "range feed was not closed before a restart attempt")
 	}
+	// Always populate a timestamp on the range feed, otherwise we run the risk
+	// of a race condition between when the range feed selects a timestamp versus
+	// when we start handing out leases (i.e. close waitForInit) The startup below
+	// is asynchronous in nature, so the timestamp could be after close the waitForInit
+	// channel.
+	now := m.storage.db.KV().Clock().Now()
+	log.Dev.Infof(ctx, "starting lease manager rangefeed at timestamp %s", now)
 	// Ignore errors here because they indicate that the server is shutting down.
 	// Also note that the range feed automatically shuts down when the server
 	// shuts down, so we don't need to call Close() ourselves.
 	m.mu.rangeFeed, _ = m.rangeFeedFactory.RangeFeed(
-		ctx, "lease", []roachpb.Span{descriptorTableSpan}, hlc.Timestamp{}, handleEvent,
+		ctx, "lease", []roachpb.Span{descriptorTableSpan}, now, handleEvent,
 		rangefeed.WithSystemTablePriority(),
 		rangefeed.WithOnCheckpoint(handleCheckpoint),
 		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {


### PR DESCRIPTION
Backport 1/1 commits from #159541 on behalf of @fqazi.

----

Previously, it was possible for the lease manager range feed to start tracking updates later then when we started handing out leases. This was possible because no timestamp was provided to the range feed, so the server would select the start time, when the request was processed. This meant there was a small timing window during which updates to descriptors could be lost, which could happen within test scenarios. To address this, this patch explicitly selects the current time to start the range feed to avoid risk of missing updates.

Fixes: #158328

Release note: None

----

Release justification: bug fix in new code