### PR TITLE
WIP: rpc: ShallowCopy MuxRangeFeedEvent's in internalClientAdapter

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2151,6 +2151,14 @@ func (b *BulkOpSummary) DeepCopy() BulkOpSummary {
 	return cpy
 }
 
+// ShallowCopy returns a shallow copy of the receiver and the underlying
+// RangeFeedEvent.
+func (e *MuxRangeFeedEvent) ShallowCopy() *MuxRangeFeedEvent {
+	cpy := *e
+	cpy.RangeFeedEvent = *cpy.RangeFeedEvent.ShallowCopy()
+	return &cpy
+}
+
 // MustSetValue is like SetValue, except it resets the enum and panics if the
 // provided value is not a valid variant type.
 func (e *RangeFeedEvent) MustSetValue(value interface{}) {

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1020,7 +1020,7 @@ func (a internalClientAdapter) MuxRangeFeed(
 	//    -> RPC caller
 
 	eventWriter, eventReader := makePipe(func(dst interface{}, src interface{}) {
-		*dst.(*kvpb.MuxRangeFeedEvent) = *src.(*kvpb.MuxRangeFeedEvent)
+		*dst.(*kvpb.MuxRangeFeedEvent) = *(src.(*kvpb.MuxRangeFeedEvent).ShallowCopy())
 	})
 	requestWriter, requestReader := makePipe(func(dst interface{}, src interface{}) {
 		*dst.(*kvpb.RangeFeedRequest) = *src.(*kvpb.RangeFeedRequest)


### PR DESCRIPTION
When the internalClientAdapter is in use, the client and server may share memory. This catches many who haven't encountered it before off guard and requires all users of MuxRangeFeed and BatchRequest to be careful about memory reuse.

For rangefeeds this is particularly problematic because the same event generated by a replica may be delivered to many rangefeeds subscribed to that replica.

Here we limit the exposure to these bugs for rangefeeds by introducing an extra shallow copy. Note that the backing array for keys and values in the events may very well still be shared. However, this is more expected by users of the API.

Informs #159166

Release note: none