### PR TITLE
catalog: avoid using locked leasing for privilege caches

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1590,7 +1590,7 @@ func (tc *Collection) LockDescriptorWithLease(
 		return uint64(vo.Desc().GetVersion()), nil
 	}
 	// Otherwise, we should be able to lease the relevant object out.
-	desc, shouldReadFromStore, err := tc.leased.getByID(ctx, txn, id)
+	desc, shouldReadFromStore, err := tc.leased.getByID(ctx, txn, id, false /* withoutLockedTimestamp */)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -441,7 +441,7 @@ func (q *byIDLookupContext) lookupLeased(
 	if q.tc.cr.IsDescIDKnownToNotExist(id, q.flags.descFilters.maybeParentID) {
 		return nil, catalog.NoValidation, catalog.NewDescriptorNotFoundError(id)
 	}
-	desc, shouldReadFromStore, err := q.tc.leased.getByID(q.ctx, q.tc.deadlineHolder(q.txn), id)
+	desc, shouldReadFromStore, err := q.tc.leased.getByID(q.ctx, q.tc.deadlineHolder(q.txn), id, q.flags.descFilters.withoutLockedTimestamp)
 	if err != nil || shouldReadFromStore {
 		// Leasing does not support leasing adding descriptors, and in certain contexts,
 		// we may want them leased. So, we will fallback to the KV based reads if requested.
@@ -654,7 +654,7 @@ func (tc *Collection) getNonVirtualDescriptorID(
 			return continueLookups, descpb.InvalidID, nil
 		}
 		ld, shouldReadFromStore, err := tc.leased.getByName(
-			ctx, tc.deadlineHolder(txn), parentID, parentSchemaID, name,
+			ctx, tc.deadlineHolder(txn), parentID, parentSchemaID, name, flags.descFilters.withoutLockedTimestamp,
 		)
 		if err != nil {
 			return haltLookups, descpb.InvalidID, err

--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -482,6 +482,10 @@ type descFilters struct {
 	// maybeParentID specifies, when set, that the looked-up descriptor
 	// should have the same parent ID, when set.
 	maybeParentID descpb.ID
+	// withoutLockedTimestamp, specifies that leased descriptors should
+	// be resolved at the current timestamp. This is to ensure caches
+	// are up to date.
+	withoutLockedTimestamp bool
 }
 
 func defaultUnleasedFlags() (f getterFlags) {
@@ -570,6 +574,13 @@ func (b ByIDGetterBuilder) WithoutOtherParent(parentID catid.DescID) ByIDGetterB
 	return b
 }
 
+// WithoutLockedTimestamp configures the ByIDGetterBuilder to ensure
+// that leased descriptors are looked up at the read timestamp.
+func (b ByIDGetterBuilder) WithoutLockedTimestamp() ByIDGetterBuilder {
+	b.flags.descFilters.withoutLockedTimestamp = true
+	return b
+}
+
 // Get builds a ByIDGetter.
 func (b ByIDGetterBuilder) Get() ByIDGetter {
 	if b.flags.isMutable {
@@ -631,6 +642,13 @@ type ByNameGetterBuilder getterBase
 // of offline descriptors.
 func (b ByNameGetterBuilder) WithOffline() ByNameGetterBuilder {
 	b.flags.descFilters.withoutOffline = false
+	return b
+}
+
+// WithoutLockedTimestamp configures the ByNameGetterBuilder to ensure
+// that leased descriptors are looked up at the read timestamp.
+func (b ByNameGetterBuilder) WithoutLockedTimestamp() ByNameGetterBuilder {
+	b.flags.descFilters.withoutLockedTimestamp = true
 	return b
 }
 

--- a/pkg/sql/catalog/descs/table.go
+++ b/pkg/sql/catalog/descs/table.go
@@ -19,7 +19,7 @@ import (
 func (tc *Collection) GetLeasedImmutableTableByID(
 	ctx context.Context, txn *kv.Txn, tableID descpb.ID,
 ) (catalog.TableDescriptor, error) {
-	desc, _, err := tc.leased.getByID(ctx, tc.deadlineHolder(txn), tableID)
+	desc, _, err := tc.leased.getByID(ctx, tc.deadlineHolder(txn), tableID, false /* withoutLockedTimestamp */)
 	if err != nil || desc == nil {
 		return nil, err
 	}

--- a/pkg/sql/rolemembershipcache/cache.go
+++ b/pkg/sql/rolemembershipcache/cache.go
@@ -69,7 +69,7 @@ func NewMembershipCache(
 func (m *MembershipCache) RunAtCacheReadTS(
 	ctx context.Context, db descs.DB, txn descs.Txn, f func(context.Context, descs.Txn) error,
 ) error {
-	tableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.RoleMembersTableID)
+	tableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.RoleMembersTableID)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (m *MembershipCache) GetRolesForMember(
 	}
 
 	// Lookup table versions.
-	roleMembersTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.RoleMembersTableID)
+	roleMembersTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.RoleMembersTableID)
 	if err != nil {
 		return nil, err
 	}
@@ -155,12 +155,12 @@ func (m *MembershipCache) GetRolesForMember(
 	}
 
 	if txn.SessionData().AllowRoleMembershipsToChangeDuringTransaction {
-		systemUsersTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.UsersTableID)
+		systemUsersTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.UsersTableID)
 		if err != nil {
 			return nil, err
 		}
 
-		roleOptionsTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.RoleOptionsTableID)
+		roleOptionsTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.RoleOptionsTableID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sessioninit/cache.go
+++ b/pkg/sql/sessioninit/cache.go
@@ -138,11 +138,11 @@ func (a *Cache) GetAuthInfo(
 		if err := txn.Descriptors().MaybeSetReplicationSafeTS(ctx, txn.KV()); err != nil {
 			return err
 		}
-		usersTableDesc, err = txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.UsersTableID)
+		usersTableDesc, err = txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.UsersTableID)
 		if err != nil {
 			return err
 		}
-		roleOptionsTableDesc, err = txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.RoleOptionsTableID)
+		roleOptionsTableDesc, err = txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.RoleOptionsTableID)
 		return err
 	})
 	if err != nil {
@@ -306,7 +306,7 @@ func (a *Cache) GetDefaultSettings(
 	err = db.DescsTxn(ctx, func(
 		ctx context.Context, txn descs.Txn,
 	) error {
-		dbRoleSettingsTableDesc, err = txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.DatabaseRoleSettingsTableID)
+		dbRoleSettingsTableDesc, err = txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutLockedTimestamp().Get().Table(ctx, keys.DatabaseRoleSettingsTableID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/syntheticprivilegecache/cache.go
+++ b/pkg/sql/syntheticprivilegecache/cache.go
@@ -66,7 +66,7 @@ func New(
 func (c *Cache) Get(
 	ctx context.Context, txn isql.Txn, col *descs.Collection, spo syntheticprivilege.Object,
 ) (*catpb.PrivilegeDescriptor, error) {
-	_, desc, err := descs.PrefixAndTable(ctx, col.ByNameWithLeased(txn.KV()).Get(), syntheticprivilege.SystemPrivilegesTableName)
+	_, desc, err := descs.PrefixAndTable(ctx, col.ByNameWithLeased(txn.KV()).WithoutLockedTimestamp().Get(), syntheticprivilege.SystemPrivilegesTableName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, after a GRANT / REVOKE statement the table version would be bumped, and the schema change would be considered complete once the new version was available via the system.lease table. With locked leasing its not guaranteed the new version will be used by transactions, until the lease manager confirms all descriptors have been picked up by a schema change (via the range feed). The purpose of locked leasing is mainly to guarantee that user descriptors always have a consistent view in the face of schema changes. To address this, this patch ensures that descriptors leased by the privilege caches avoid locked leasing, ensuring that any later transactions on the same connection sees the changes. For other schema changes this is a non-issue because they use wait for one version protocol, which confirms that stale versions are not used / handed out.

Fixes: #159602
Fixes: #159600

Release note: None