### PR TITLE
sql: fix SHOW CREATE FUNCTION with cast to UDT

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3373,7 +3373,7 @@ func createRoutinePopulate(
 			for i := range treeNode.Options {
 				if body, ok := treeNode.Options[i].(tree.RoutineBodyStr); ok {
 					bodyStr := string(body)
-					bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, p.EvalContext(), &p.semaCtx, p.SessionData(), bodyStr, fnDesc.GetLanguage())
+					bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, bodyStr, fnDesc.GetLanguage())
 					if err != nil {
 						return err
 					}
@@ -3455,7 +3455,7 @@ func createRoutinePopulateByFnIndex(
 	for i := range treeNode.Options {
 		if body, ok := treeNode.Options[i].(tree.RoutineBodyStr); ok {
 			bodyStr := string(body)
-			bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, p.EvalContext(), &p.semaCtx, p.SessionData(), bodyStr, fnDesc.GetLanguage())
+			bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, bodyStr, fnDesc.GetLanguage())
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1192,3 +1192,55 @@ statement ok
 DROP VIEW v_builtin;
 
 subtest end
+
+subtest show_create_func_cast_udt
+
+statement ok
+CREATE TYPE cast_udf_enum AS ENUM ('a', 'b', 'c');
+
+statement ok
+DROP TABLE IF EXISTS cast_udf_enum_t;
+
+statement ok
+CREATE TABLE cast_udf_enum_t (c STRING);
+
+statement ok
+CREATE FUNCTION cast_to_enum() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT 1 INTO i FROM cast_udf_enum_t WHERE c::cast_udf_enum IN ();
+    RETURN i;
+  END
+$$;
+
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION cast_to_enum];
+----
+CREATE FUNCTION public.cast_to_enum()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  DECLARE
+  i INT8;
+  BEGIN
+  SELECT 1 FROM public.cast_udf_enum_t WHERE c::public.cast_udf_enum IN () INTO i;
+  RETURN i;
+  END;
+$$
+
+statement ok
+DROP FUNCTION cast_to_enum;
+
+statement ok
+DROP TABLE cast_udf_enum_t;
+
+statement ok
+DROP TYPE cast_udf_enum;
+
+subtest end
+

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -388,18 +388,8 @@ func formatViewQueryTypesForDisplay(
 
 // formatFunctionQueryTypesForDisplay is similar to
 // formatViewQueryTypesForDisplay but can only be used for functions.
-// nil is used as the table descriptor for schemaexpr.FormatExprForDisplay call.
-// This is fine assuming that UDFs cannot be created with expression casting a
-// column/var to an enum in function body. This is super rare case for now, and
-// it's tracked with issue #87475. We should also unify this function with
-// formatViewQueryTypesForDisplay.
 func formatFunctionQueryTypesForDisplay(
-	ctx context.Context,
-	evalCtx *eval.Context,
-	semaCtx *tree.SemaContext,
-	sessionData *sessiondata.SessionData,
-	queries string,
-	lang catpb.Function_Language,
+	ctx context.Context, semaCtx *tree.SemaContext, queries string, lang catpb.Function_Language,
 ) (string, error) {
 	// replaceFunc is a visitor function that replaces user defined type IDs in
 	// SQL expressions with their names.
@@ -426,17 +416,20 @@ func formatFunctionQueryTypesForDisplay(
 		if !typ.UserDefined() {
 			return true, expr, nil
 		}
-		formattedExpr, err := schemaexpr.FormatExprForDisplay(
-			ctx, nil, expr.String(), evalCtx, semaCtx, sessionData, tree.FmtParsable,
-		)
-		if err != nil {
-			return false, expr, err
+		name := typ.TypeMeta.Name
+		typName := tree.MakeTypeNameWithPrefix(tree.ObjectNamePrefix{
+			CatalogName:    tree.Name(name.Catalog),
+			SchemaName:     tree.Name(name.Schema),
+			ExplicitSchema: name.ExplicitSchema,
+		}, name.Name)
+		typeRef := typName.ToUnresolvedObjectName()
+		switch n := expr.(type) {
+		case *tree.CastExpr:
+			n.Type = typeRef
+		case *tree.AnnotateTypeExpr:
+			n.Type = typeRef
 		}
-		newExpr, err = parser.ParseExpr(formattedExpr)
-		if err != nil {
-			return false, expr, err
-		}
-		return false, newExpr, nil
+		return false, expr, nil
 	}
 	// replaceTypeFunc is a visitor function that replaces type annotations
 	// containing user defined types IDs with their name. This is currently only


### PR DESCRIPTION
Fixes #152233
Fixes #159145
Fixes #87475

Previously, if a function contains cast to UDT in the body, the SHOW CREATE TABLE for it will error out. This commit is to fix it.

Release note (bug fix): enable SHOW CREATE TABLE for function created with user defined types.