### PR TITLE
tabledesc: deflake TestLatestIndexDescriptorVersionValues

### DIFF
--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
+        "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
- Use cluster setting to disable declarative schema changer, so that other connections opened by the pool get that setting.
- Avoid t.Fatal in a goroutine; use ctxgroup instead.

fixes https://github.com/cockroachdb/cockroach/issues/159368
fixes https://github.com/cockroachdb/cockroach/issues/159268

Release note: None