### PR TITLE
release-26.1: restore: check span config conformance before beginning main flow

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -11467,6 +11467,10 @@ func TestRestoreConformanceFailure(t *testing.T) {
 	backupURI := "nodelocal://1/restore_conformance_failure"
 	sqlDB.Exec(t, "BACKUP DATABASE test INTO $1", backupURI)
 
+	// Ensure rf=5 zone config has been applied as the default span config, so
+	// that when restore creates new descriptors, they inherit the rf=5 default.
+	sqlutils.WaitForSpanConfigReconciliation(t, sqlDB)
+
 	// This will take a long time: we give 60 seconds for the span configs to
 	// advance, then restore will chew up 60s to fail to conform.
 	sqlDB.ExpectErr(t, "ranges for restoring objects could not conform to zone configs", fmt.Sprintf(

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -11292,6 +11292,14 @@ func TestBackupRestoreDatabaseRevisionHistory(t *testing.T) {
 	}
 }
 
+func speedUpSpanConfigReconciliation(t *testing.T, sqlDB *sqlutils.SQLRunner) {
+	sqlDB.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '200ms'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`)
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.allocator.load_based_rebalancing = off")
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '10ms'")
+}
+
 // TestStrictLocalityAwareBackupRegionalByRow tests that a strict locality-aware
 // backup.
 func TestStrictLocalityAwareBackup(t *testing.T) {
@@ -11302,21 +11310,36 @@ func TestStrictLocalityAwareBackup(t *testing.T) {
 
 	ctx := context.Background()
 
+	knobs := base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		BackupRestore: &sql.BackupRestoreTestingKnobs{
+			RestoreSpanConfigConformanceRetryPolicy: &retry.Options{
+				InitialBackoff: time.Millisecond,
+				Multiplier:     2,
+				MaxBackoff:     1 * time.Second,
+				MaxDuration:    30 * time.Second,
+			},
+		}}
+
 	args := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			// Increases allocator queue frequency.
+			ScanMaxIdleTime: 10 * time.Millisecond,
 			// The range scanner validation requires the system tenant.
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			Knobs:             knobs,
 		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
-			0: {Locality: localityFromStr(t, "region=east1")},
-			1: {Locality: localityFromStr(t, "region=east2")},
-			2: {Locality: localityFromStr(t, "region=east3")},
+			0: {Locality: localityFromStr(t, "region=east1"), Knobs: knobs},
+			1: {Locality: localityFromStr(t, "region=east2"), Knobs: knobs},
+			2: {Locality: localityFromStr(t, "region=east3"), Knobs: knobs},
 		}}
 
 	tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, 3, 0 /* numAccounts */, func(tc *testcluster.TestCluster) {}, args)
 	defer cleanupFn()
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'`)
+	speedUpSpanConfigReconciliation(t, sqlDB)
+	sqlDB.Exec(t, `SET CLUSTER SETTING restore.wait_for_span_config_conformance.enabled = true`)
 
 	sqlDB.Exec(t, "CREATE DATABASE test")
 	sqlDB.Exec(t, `ALTER DATABASE test CONFIGURE ZONE USING constraints = '[+region=east3]', num_replicas = 1;`)
@@ -11395,4 +11418,111 @@ func TestStrictLocalityAwareBackup(t *testing.T) {
 		"BACKUP DATABASE test INTO (%q,%q)",
 		backupURIs[0], backupURIs[1],
 	))
+}
+
+func TestRestoreConformanceFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderDuress(t, "takes too long under duress")
+
+	knobs := base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		BackupRestore: &sql.BackupRestoreTestingKnobs{
+			RestoreSpanConfigConformanceRetryPolicy: &retry.Options{
+				InitialBackoff: time.Millisecond,
+				Multiplier:     2,
+				MaxBackoff:     1 * time.Second,
+				MaxDuration:    60 * time.Second,
+			},
+		}}
+
+	args := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			// Increases allocator queue frequency.
+			ScanMaxIdleTime: 10 * time.Millisecond,
+			Knobs:           knobs,
+		},
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			0: {Locality: localityFromStr(t, "region=east1"), Knobs: knobs},
+			1: {Locality: localityFromStr(t, "region=east2"), Knobs: knobs},
+			2: {Locality: localityFromStr(t, "region=east3"), Knobs: knobs},
+		}}
+
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, 3, 0 /* numAccounts */, InitManualReplication, args)
+	defer cleanupFn()
+
+	speedUpSpanConfigReconciliation(t, sqlDB)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING restore.wait_for_span_config_conformance.enabled = true`)
+
+	// 3 Node cluster will never conform to an rf of 5.
+	sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING num_replicas = 5;`)
+
+	sqlDB.Exec(t, "CREATE DATABASE test")
+	sqlDB.Exec(t, "CREATE TABLE test.x (id INT PRIMARY KEY, n INT)")
+	sqlDB.Exec(t, "INSERT INTO test.x VALUES (1, 1)")
+
+	backupURI := "nodelocal://1/restore_conformance_failure"
+	sqlDB.Exec(t, "BACKUP DATABASE test INTO $1", backupURI)
+
+	// This will take a long time: we give 60 seconds for the span configs to
+	// advance, then restore will chew up 60s to fail to conform.
+	sqlDB.ExpectErr(t, "ranges for restoring objects could not conform to zone configs", fmt.Sprintf(
+		"RESTORE DATABASE test FROM LATEST IN %q with new_db_name = test_restored",
+		backupURI,
+	))
+
+	// After resetting the zone configs, the restore should succeed.
+	sqlDB.Exec(t, `ALTER RANGE default CONFIGURE ZONE USING num_replicas = 3;`)
+	sqlDB.Exec(t, fmt.Sprintf(
+		"RESTORE DATABASE test FROM LATEST IN %q with new_db_name = test_restored",
+		backupURI,
+	))
+}
+
+// TestRestoreConformanceSingleNode tests that a restore on a single-node works
+// with span conformance is enabled and ensures the checkpointing logic works.
+func TestRestoreConformanceSingleNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+
+	params := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			// To manipulate span config knobs
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			},
+		},
+	}
+
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, NoInitManipulation, params)
+	defer cleanupFn()
+
+	speedUpSpanConfigReconciliation(t, sqlDB)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING restore.wait_for_span_config_conformance.enabled = true`)
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_publishing_descriptors'")
+
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE data INTO '%s'", localFoo))
+
+	var jobId int
+	sqlDB.QueryRow(t, fmt.Sprintf("RESTORE DATABASE data FROM LATEST IN '%s' with detached, new_db_name=data2", localFoo)).Scan(&jobId)
+	jobutils.WaitForJobToPause(t, sqlDB, jobspb.JobID(jobId))
+	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = ''`)
+
+	sqlDB.Exec(t, fmt.Sprintf("RESUME JOB %d", jobId))
+	jobutils.WaitForJobToSucceed(t, sqlDB, jobspb.JobID(jobId))
+
+	// Ensure we only checked for span config conformance once.
+	query := fmt.Sprintf(`SELECT count(*) FROM system.job_message WHERE job_id = %d AND message = 'checking span config conformance'`, jobId)
+	sqlDB.CheckQueryResults(t, query, [][]string{{"1"}})
+
+	query2 := fmt.Sprintf(`SELECT count(*) FROM system.job_message WHERE job_id = %d AND message = 'span config conformance check completed'`, jobId)
+	sqlDB.CheckQueryResults(t, query2, [][]string{{"1"}})
 }

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/ttl/ttlinit"
@@ -102,6 +103,13 @@ var (
 		5*time.Minute,
 		settings.WithVisibility(settings.Reserved),
 		settings.PositiveDuration,
+	)
+
+	restoreWaitForConformance = settings.RegisterBoolSetting(
+		settings.ApplicationLevel,
+		"restore.wait_for_span_config_conformance.enabled",
+		"if enabled, RESTORE will ensure span config conformance before ingestion",
+		false,
 	)
 )
 
@@ -2084,6 +2092,20 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		resTotal.Add(res)
 		log.Dev.Infof(ctx, "finished restoring the validate data bundle")
 	}
+
+	_, sqlInstanceIDs, err := p.DistSQLPlanner().SetupAllNodesPlanning(ctx, p.ExtendedEvalContext(), p.ExecCfg())
+	if err != nil {
+		return err
+	}
+	numNodes := len(sqlInstanceIDs)
+	if numNodes == 0 {
+		numNodes = 1
+	}
+
+	if err := r.MaybeWaitForSpanConfigConformance(ctx, p.ExecCfg(), numNodes, mainData); err != nil {
+		return err
+	}
+
 	{
 		// Restore the main data bundle. We notably only restore the system tables
 		// later.
@@ -2225,18 +2247,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	// Emit an event now that the restore job has completed.
 	emitRestoreJobEvent(ctx, p, jobs.StateSucceeded, r.job)
 
-	// Restore used all available SQL instances.
-	_, sqlInstanceIDs, err := p.DistSQLPlanner().SetupAllNodesPlanning(ctx, p.ExtendedEvalContext(), p.ExecCfg())
-	if err != nil {
-		return err
-	}
-	numNodes := len(sqlInstanceIDs)
-	if numNodes == 0 {
-		// This shouldn't ever happen, but we know that we have at least one
-		// instance (which is running this code right now).
-		numNodes = 1
-	}
-
 	// Collect telemetry.
 	{
 		telemetry.Count("restore.total.succeeded")
@@ -2354,6 +2364,172 @@ func (r *restoreResumer) notifyStatsRefresherOfNewTables(ctx context.Context) {
 		desc := tabledesc.NewBuilder(details.TableDescs[i]).BuildImmutableTable()
 		r.execCfg.StatsRefresher.NotifyMutation(ctx, desc, math.MaxInt32 /* rowsAffected */)
 	}
+}
+
+func waitForSpanConfigReconciliationCheckpoint(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	targetTimestamp hlc.Timestamp,
+	retryOpts retry.Options,
+) error {
+	log.Dev.Infof(ctx, "waiting for span config reconciliation job to checkpoint past %s", targetTimestamp)
+
+	var resolvedWalltime int64
+
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+
+		if !restoreWaitForConformance.Get(&execCfg.Settings.SV) {
+			log.Dev.Infof(ctx, "skipping span config conformance check")
+			return nil
+		}
+
+		// Tragically, the span config reconcilation job only stores progress in its
+		// progress details field.
+		//
+		// TODO(msbutler): modify span config job to persist progress via progress
+		// storage.
+		checkQuery := `WITH progress AS (
+    SELECT
+        crdb_internal.pb_to_json(
+            'progress',
+            progress
+        )->'AutoSpanConfigReconciliation'->'checkpoint' AS checkpoint
+    FROM crdb_internal.system_jobs
+    WHERE status = 'running'
+      AND job_type = 'AUTO SPAN CONFIG RECONCILIATION'
+)
+SELECT
+    (checkpoint->>'wallTime')::INT64 AS walltime
+FROM progress;`
+		row, err := execCfg.InternalDB.Executor().QueryRowEx(ctx, "wait-for-span-config-progress", nil, sessiondata.NodeUserSessionDataOverride, checkQuery)
+		if err != nil {
+			return err
+		}
+		if row == nil {
+			return errors.New("running span config reconciliation job not found")
+		}
+		if row[0] == tree.DNull {
+			return errors.New("resolve time not found")
+		}
+
+		resolvedWallTimeDInt, ok := row[0].(*tree.DInt)
+		if !ok {
+			return errors.AssertionFailedf("expected resolved to be DInt (was %T)", row[0])
+		}
+		resolvedWalltime = int64(*resolvedWallTimeDInt)
+
+		if resolvedWalltime > targetTimestamp.WallTime {
+			log.Dev.Infof(ctx, "span config reconciliation job checkpointed past %d (at %d)", targetTimestamp.WallTime, resolvedWalltime)
+			return nil
+		}
+	}
+	return errors.Newf("span config reconciliation job did not checkpoint %d past target timestamp %d", resolvedWalltime, targetTimestamp.WallTime)
+}
+
+func (r *restoreResumer) MaybeWaitForSpanConfigConformance(
+	ctx context.Context, execCfg *sql.ExecutorConfig, numNodes int, mainData restorationData,
+) error {
+
+	if !restoreWaitForConformance.Get(&execCfg.Settings.SV) {
+		log.Dev.Infof(ctx, "skipping span config conformance check")
+		return nil
+	}
+
+	spansConformedInfoKey := "spans-conformed"
+	var alreadyConformed bool
+	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		jobInfo := jobs.InfoStorageForJob(txn, r.job.ID())
+		_, conformed, err := jobInfo.Get(
+			ctx, "get-span-conformed-info-key", spansConformedInfoKey,
+		)
+		if err != nil {
+			return err
+		}
+		if conformed {
+			alreadyConformed = true
+			return nil
+		}
+		return r.job.Messages().Record(
+			ctx, txn, "error", "checking span config conformance",
+		)
+	}); err != nil {
+		log.Dev.Warningf(ctx, "failed to record job error message: %v", err)
+	}
+	if alreadyConformed {
+		log.Dev.Infof(ctx, "already checked that spans conform to zone configs")
+		return nil
+	}
+
+	retryOpts := retry.Options{
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     5 * time.Second,
+		Multiplier:     2,
+		MaxDuration:    5 * time.Minute,
+	}
+
+	testingKnobs := execCfg.BackupRestoreTestingKnobs
+
+	if testingKnobs != nil && testingKnobs.RestoreSpanConfigConformanceRetryPolicy != nil {
+		retryOpts = *testingKnobs.RestoreSpanConfigConformanceRetryPolicy
+	}
+
+	// Before polling for span config conformance (i.e. replicas match span
+	// configs), wait for the span config reconciliation job to checkpoint past
+	// the current time to ensure the span config table is synced with zone
+	// configs.
+	targetTimestamp := execCfg.Clock.Now()
+	if err := waitForSpanConfigReconciliationCheckpoint(ctx, execCfg, targetTimestamp, retryOpts); err != nil {
+		return errors.Wrap(err, "waiting for span config reconciliation checkpoint")
+	}
+
+	// Wait for span config conformance before restoring the main data bundle.
+	spans, err := mainData.getRekeyedSpans(r.execCfg.Codec)
+	if err != nil {
+		return err
+	}
+
+	expectUnderReplication := numNodes < 3
+	var lastReport roachpb.SpanConfigConformanceReport
+	for ret := retry.StartWithCtx(ctx, retryOpts); ret.Next(); {
+
+		if !restoreWaitForConformance.Get(&execCfg.Settings.SV) {
+			log.Dev.Infof(ctx, "skipping span config conformance check")
+			return nil
+		}
+
+		report, err := execCfg.SpanConfigReporter.SpanConfigConformance(ctx, spans)
+		if err != nil {
+			return errors.Wrap(err, "checking span config conformance")
+		}
+
+		lastReport = report
+
+		if len(report.Unavailable) == 0 &&
+			len(report.OverReplicated) == 0 &&
+			len(report.ViolatingConstraints) == 0 &&
+			(expectUnderReplication || len(report.UnderReplicated) == 0) {
+			if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				jobInfo := jobs.InfoStorageForJob(txn, r.job.ID())
+				if err := jobInfo.Write(
+					ctx, spansConformedInfoKey, []byte{},
+				); err != nil {
+					return err
+				}
+				return r.job.Messages().Record(
+					ctx, txn, "error", "span config conformance check completed",
+				)
+			}); err != nil {
+				log.Dev.Warningf(ctx, "failed to record job error message: %v", err)
+			}
+			return nil
+		}
+
+		log.Dev.Infof(ctx, "waiting for span config conformance: unavailable=%d, under-replicated=%d, over-replicated=%d, violating-constraints=%d",
+			len(report.Unavailable), len(report.UnderReplicated), len(report.OverReplicated), len(report.ViolatingConstraints))
+	}
+
+	return errors.Errorf("ranges for restoring objects could not conform to zone configs. Non conformant range count: unavailable=%d, under-replicated=%d, over-replicated=%d, violating-constraints=%d",
+		len(lastReport.Unavailable), len(lastReport.UnderReplicated), len(lastReport.OverReplicated), len(lastReport.ViolatingConstraints))
 }
 
 // tempSystemDatabaseID returns the ID of the descriptor for the temporary

--- a/pkg/backup/utils_test.go
+++ b/pkg/backup/utils_test.go
@@ -65,6 +65,7 @@ const (
 // tc.WaitForFullReplication before calling this method,
 // so up-replication has usually already taken place.
 var InitManualReplication = backuptestutils.InitManualReplication
+var NoInitManipulation = func(tc *testcluster.TestCluster) {}
 
 func backupRestoreTestSetupWithParams(
 	t testing.TB,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1232,6 +1232,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		nodeDescs:                g,
 		systemConfigWatcher:      systemConfigWatcher,
 		spanConfigAccessor:       spanConfig.kvAccessor,
+		spanConfigReporter:       spanConfig.reporter,
 		keyVisServerAccessor:     keyVisServerAccessor,
 		kvNodeDialer:             kvNodeDialer,
 		distSender:               distSender,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -311,6 +311,8 @@ type sqlServerArgs struct {
 	// Used by the span config reconciliation job.
 	spanConfigAccessor spanconfig.KVAccessor
 
+	spanConfigReporter spanconfig.Reporter
+
 	// Used by the Key Visualizer job.
 	keyVisServerAccessor *spanstatskvaccessor.SpanStatsKVAccessor
 
@@ -1345,6 +1347,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	execCfg.SpanConfigKVAccessor = cfg.spanConfigAccessor
 	execCfg.SpanConfigLimiter = spanConfig.limiter
 	execCfg.SpanConfigSplitter = spanConfig.splitter
+	execCfg.SpanConfigReporter = cfg.spanConfigReporter
 
 	var waitForInstanceReaderStarted func(context.Context) error
 	if cfg.sqlInstanceReader != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1388,6 +1388,7 @@ func makeTenantSQLServerArgs(
 		nodeDescs:                tenantConnect,
 		systemConfigWatcher:      systemConfigWatcher,
 		spanConfigAccessor:       tenantConnect,
+		spanConfigReporter:       tenantConnect,
 		kvNodeDialer:             kvNodeDialer,
 		distSender:               ds,
 		db:                       db,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1887,6 +1887,9 @@ type ExecutorConfig struct {
 	// records.
 	SpanConfigKVAccessor spanconfig.KVAccessor
 
+	// SpanConfigReporter is used to get span conformance reports.
+	SpanConfigReporter spanconfig.Reporter
+
 	// InternalDB is used to create an isql.Executor bound with SessionData and
 	// other ExtraTxnState.
 	InternalDB *InternalDB

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -94,6 +94,8 @@ type BackupRestoreTestingKnobs struct {
 	// AfterRevertRestoreDropDescriptors is called after a reverting restore
 	// drops its descriptors.
 	AfterRevertRestoreDropDescriptors func() error
+
+	RestoreSpanConfigConformanceRetryPolicy *retry.Options
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
Backport 2/2 commits from #159193 on behalf of @msbutler.

----

When enabled, restore will ensure the restoring key space conforms to span
configs before replication. This should ensure that ingesting data obeys zone
config constraints and that restore doesn't split and scatter ranges with
unreconciled span configs.

Informs [#158999](https://github.com/cockroachdb/cockroach/issues/158999)
Fixes [#137103](https://github.com/cockroachdb/cockroach/issues/137103)

Release note: none

----

Release justification: