### PR TITLE
release-25.4: catalog/lease: make memory management safer

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -198,7 +198,8 @@ func newDescriptorVersionState(
 	if !expiration.IsEmpty() {
 		descState.expiration.Store(&expiration)
 	}
-
+	// Populate the size of the structure.
+	descState.byteSize = descState.calculateByteSize()
 	return descState
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #159527 on behalf of @fqazi.

----

Previously, the sizes used to allocate and release memory could shift due to a variety of reasons. There are scenarios where stored leases may be intentionally cleaned up from descriptor states earlier, for example if the session based leasing logic expires an old version. This can lead to accounting issues in the bound account. To avoid these, the descriptor state will store the size of the allocation used initially, which will be also used on clean up.

Fixes: #158403

Release note (bug fix): Fixes a memory accounting issue that could occur when a lease expires due to a SQL liveness session based timeout.

----

Release justification: low risk fix for a memory tacking bug in the lease manager