### PR TITLE
release-26.1: sem/builtins: disable external process rate limiting in a test

### DIFF
--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -688,6 +688,7 @@ func TestTruncateTimestamp(t *testing.T) {
 
 func TestPGBuiltinsCalledOnNull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
 	params := base.TestServerArgs{}


### PR DESCRIPTION
Backport 1/1 commits from #159613 on behalf of @yuzefovich.

----

We just saw a timeout where `TestCrdbInternalDatumsToBytes` took more than 4 minutes out of 5 minutes allocated to its shard. This happened with the external process, and I think it's likely due to rate limiting, so let's disable that for the test.

Fixes: #159581.
Release note: None

----

Release justification: test-only change.