### PR TITLE
release-25.4.1-custom-build: sql: deserialize AllowUnsafeInternals to true

### DIFF
--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -134,6 +134,15 @@ func (p *planner) DeserializeSessionState(
 	sd.SessionData = m.SessionData
 	sd.LocalUnmigratableSessionData = evalCtx.SessionData().LocalUnmigratableSessionData
 	sd.LocalOnlySessionData = m.LocalOnlySessionData
+
+	// Note(davidh): The line below is mitigation for an issue with
+	// upgrades to 25.4 where the `AllowUnsafeInternals` field was
+	// introduced. The default value of this is `true` and setting it to
+	// `false` will incorrectly block executions that access internals on
+	// migrated sessions.
+	// TODO(davidh): Remove after 25.4 is rolled out everywhere. (CRDB-57952)
+	sd.LocalOnlySessionData.AllowUnsafeInternals = true
+
 	if sd.SessionUser().Normalized() != evalCtx.SessionData().SessionUser().Normalized() {
 		return nil, pgerror.Newf(
 			pgcode.InsufficientPrivilege,

--- a/pkg/sql/testdata/session_migration/session_migration
+++ b/pkg/sql/testdata/session_migration/session_migration
@@ -68,3 +68,30 @@ query
 EXECUTE stmt
 ----
 1
+
+reset
+----
+
+exec
+SET allow_unsafe_internals = false;
+----
+
+let $x
+SELECT encode(crdb_internal.serialize_session(), 'hex')
+----
+
+exec
+SET allow_unsafe_internals = true;
+----
+
+exec
+SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
+----
+
+# Demonstrate that `allow_unsafe_internals` will always get
+# deserialized in `on` state in order to avoid the deserialization bug
+# which sets the setting to `off` by default.
+query
+SHOW allow_unsafe_internals
+----
+on


### PR DESCRIPTION
This won't get deserialized correctly from older node versions because it was introduced in 25.4 and the default should be `true`.

It's understood that this commit is introducing a bug in the other direction, where a customer who sets `allow_unsafe_internals` to false would find their setting to be reset upon session migration to a new pod. Our preference is that this is a significantly safer outcome than how the code behaves prior to this change. The `allow_unsafe_internals` feature is only present in 25.4 to allow users to test functionality before the 26.1 cutover.

CRDB-57952 has been filed to track removing this workaround. CRDB-57954 has been filed to track backporting additional allowlisting

Epic: None
Release note: None