### PR TITLE
bulkmerge: prevent loopback processor hang on task failure

### DIFF
--- a/pkg/sql/bulkmerge/BUILD.bazel
+++ b/pkg/sql/bulkmerge/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "merge_loopback.go",
         "merge_planning.go",
         "merge_processor.go",
+        "testing_knobs.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/bulkmerge",
     visibility = ["//visibility:public"],
@@ -61,6 +62,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/bulksst",
         "//pkg/sql/bulkutil",
+        "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sem/tree",
         "//pkg/storage",
@@ -73,6 +75,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/taskset",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/bulkmerge/merge_coordinator.go
+++ b/pkg/sql/bulkmerge/merge_coordinator.go
@@ -110,6 +110,7 @@ func (m *mergeCoordinator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMeta
 			m.done = true
 			return m.emitResults()
 		case meta.Err != nil:
+			m.closeLoopback()
 			m.MoveToDraining(meta.Err)
 		default:
 			// If there is non-nil meta, we pass it up the processor chain. It might

--- a/pkg/sql/bulkmerge/merge_processor.go
+++ b/pkg/sql/bulkmerge/merge_processor.go
@@ -157,6 +157,14 @@ func (m *bulkMergeProcessor) handleRow(row rowenc.EncDatumRow) (rowenc.EncDatumR
 		return nil, err
 	}
 
+	if knobs, ok := m.flowCtx.Cfg.TestingKnobs.BulkMergeTestingKnobs.(*TestingKnobs); ok {
+		if knobs.RunBeforeMergeTask != nil {
+			if err := knobs.RunBeforeMergeTask(m.Ctx(), m.flowCtx.ID, input.taskID); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	results, err := m.mergeSSTs(m.Ctx(), input.taskID)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/bulkmerge/testing_knobs.go
+++ b/pkg/sql/bulkmerge/testing_knobs.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulkmerge
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/taskset"
+)
+
+// TestingKnobs contains testing hooks for the distributed merge pipeline.
+type TestingKnobs struct {
+	// RunBeforeMergeTask, if set, is invoked before the merge processor merges
+	// a specific task. Returning an error causes the processor to fail the task.
+	RunBeforeMergeTask func(
+		ctx context.Context,
+		flowID execinfrapb.FlowID,
+		taskID taskset.TaskID,
+	) error
+}
+
+var _ base.ModuleTestingKnobs = &TestingKnobs{}
+
+// ModuleTestingKnobs implements base.ModuleTestingKnobs.
+func (*TestingKnobs) ModuleTestingKnobs() {}

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -323,6 +323,9 @@ type TestingKnobs struct {
 	// testing knobs.
 	IndexBackfillMergerTestingKnobs base.ModuleTestingKnobs
 
+	// BulkMergeTestingKnobs are specific to the distributed merge pipeline.
+	BulkMergeTestingKnobs base.ModuleTestingKnobs
+
 	// ProcessorNoTracingSpan is used to disable the creation of a tracing span
 	// in ProcessorBase.StartInternal if the tracing is enabled.
 	ProcessorNoTracingSpan bool


### PR DESCRIPTION
Prior to this change, the loopback processor in the distributed merge pipeline could hang if a worker failed during execution. This commit ensures that merge_coordinator closes the loopback as soon as it sees meta.Err, preventing such hangs.

Also adds testing hooks via BulkMergeTestingKnobs, enabling injection of errors for validation purposes.

Informs #156658
Epic: CRDB-48845
Release note: none