### PR TITLE
storage: bump Pebble format

### DIFF
--- a/pkg/cli/testdata/ear-list
+++ b/pkg/cli/testdata/ear-list
@@ -8,13 +8,13 @@ list
 000004.log:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: 86 a7 78 ad 4b da 62 56 d5 e2 d1 70
-  counter: 798955289
+  nonce: d0 b1 31 4b 08 b9 f6 08 7e e6 af 40
+  counter: 2167389540
 000005.sst:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: d1 05 79 53 68 35 a0 f1 44 01 22 79
-  counter: 1497766936
+  nonce: 13 78 ef e7 4f 95 15 83 24 d8 1a 9d
+  counter: 1330556971
 COCKROACHDB_DATA_KEYS_000001_monolith:
   env type: Store, AES128_CTR
   keyID: f594229216d81add7811c4360212eb7629b578ef4eab6e5d05679b3c5de48867
@@ -35,11 +35,11 @@ marker.datakeys.000001.COCKROACHDB_DATA_KEYS_000001_monolith:
   keyID: f594229216d81add7811c4360212eb7629b578ef4eab6e5d05679b3c5de48867
   nonce: 55 d7 d4 27 6c 97 9b dd f1 5d 40 c8
   counter: 467030050
-marker.format-version.000013.026:
+marker.format-version.000015.028:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: 23 d9 b2 e1 39 b0 87 ed f9 6d 49 20
-  counter: 3481614039
+  nonce: d1 05 79 53 68 35 a0 f1 44 01 22 79
+  counter: 1497766936
 marker.manifest.000001.MANIFEST-000001:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2506,6 +2506,7 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 // named version, it can be assumed all *nodes* have ratcheted to the pebble
 // version associated with it, since they did so during the fence version.
 var pebbleFormatVersionMap = map[clusterversion.Key]pebble.FormatMajorVersion{
+	clusterversion.V26_1: pebble.FormatMarkForCompactionInVersionEdit,
 	clusterversion.V25_4: pebble.FormatV2BlobFiles,
 }
 


### PR DESCRIPTION
Epic: none
Release note: None