### PR TITLE
sql: fix SHOW CREATE FUNCTION with column casting to UDT

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3373,7 +3373,7 @@ func createRoutinePopulate(
 			for i := range treeNode.Options {
 				if body, ok := treeNode.Options[i].(tree.RoutineBodyStr); ok {
 					bodyStr := string(body)
-					bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, p.EvalContext(), &p.semaCtx, p.SessionData(), bodyStr, fnDesc.GetLanguage())
+					bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, bodyStr, fnDesc.GetLanguage())
 					if err != nil {
 						return err
 					}
@@ -3455,7 +3455,7 @@ func createRoutinePopulateByFnIndex(
 	for i := range treeNode.Options {
 		if body, ok := treeNode.Options[i].(tree.RoutineBodyStr); ok {
 			bodyStr := string(body)
-			bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, p.EvalContext(), &p.semaCtx, p.SessionData(), bodyStr, fnDesc.GetLanguage())
+			bodyStr, err = formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, bodyStr, fnDesc.GetLanguage())
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1192,3 +1192,219 @@ statement ok
 DROP VIEW v_builtin;
 
 subtest end
+
+subtest show_create_func_cast_enum
+
+statement ok
+CREATE TYPE cast_udf_enum AS ENUM ('a', 'b', 'c');
+
+statement ok
+DROP TABLE IF EXISTS cast_udf_enum_t;
+
+statement ok
+CREATE TABLE cast_udf_enum_t (c STRING);
+
+statement ok
+INSERT INTO cast_udf_enum_t VALUES ('a'), ('a'), ('b')
+
+statement ok
+CREATE FUNCTION cast_to_enum() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    SELECT count(*) INTO i FROM cast_udf_enum_t WHERE c::cast_udf_enum = 'a'::cast_udf_enum;
+    RETURN i;
+  END
+$$;
+
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION cast_to_enum];
+----
+CREATE FUNCTION public.cast_to_enum()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  DECLARE
+  i INT8;
+  BEGIN
+  SELECT count(*) FROM public.cast_udf_enum_t WHERE c::public.cast_udf_enum = 'a'::test.public.cast_udf_enum INTO i;
+  RETURN i;
+  END;
+$$
+
+query I
+SELECT cast_to_enum()
+----
+2
+
+statement ok
+DROP FUNCTION cast_to_enum;
+
+statement ok
+DROP TABLE cast_udf_enum_t;
+
+statement ok
+DROP TYPE cast_udf_enum;
+
+subtest end
+
+subtest show_create_func_cast_composite_type
+
+statement ok
+CREATE TYPE composite_coord AS (x INT, y INT);
+
+statement ok
+CREATE TABLE composite_test_t (id INT, coord STRING);
+
+statement ok
+CREATE FUNCTION cast_to_composite() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    result INT;
+  BEGIN
+    SELECT 1 INTO result FROM composite_test_t WHERE coord::composite_coord IS NOT NULL;
+    RETURN result;
+  END
+$$;
+
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION cast_to_composite];
+----
+CREATE FUNCTION public.cast_to_composite()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  DECLARE
+  result INT8;
+  BEGIN
+  SELECT 1 FROM public.composite_test_t WHERE coord::public.composite_coord IS NOT NULL INTO result;
+  RETURN result;
+  END;
+$$
+
+statement ok
+DROP FUNCTION cast_to_composite;
+
+statement ok
+DROP TABLE composite_test_t;
+
+statement ok
+DROP TYPE composite_coord;
+
+subtest end
+
+subtest show_create_func_cast_array_enum
+
+statement ok
+CREATE TYPE array_status AS ENUM ('active', 'inactive', 'pending');
+
+statement ok
+CREATE TABLE array_test_t (statuses STRING[]);
+
+statement ok
+CREATE FUNCTION process_array() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    count INT;
+  BEGIN
+    SELECT count(*) INTO count FROM array_test_t WHERE statuses[1]::array_status = 'active'::array_status;
+    RETURN count;
+  END
+$$;
+
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION process_array];
+----
+CREATE FUNCTION public.process_array()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  DECLARE
+  count INT8;
+  BEGIN
+  SELECT count(*) FROM public.array_test_t WHERE statuses[1]::public.array_status = 'active'::test.public.array_status INTO count;
+  RETURN count;
+  END;
+$$
+
+statement ok
+DROP FUNCTION process_array;
+
+statement ok
+DROP TABLE array_test_t;
+
+statement ok
+DROP TYPE array_status;
+
+subtest end
+
+subtest show_create_func_multiple_udt_casts
+
+statement ok
+CREATE TYPE user_status AS ENUM ('guest', 'member', 'admin');
+
+statement ok
+CREATE TYPE user_profile AS (name STRING, age INT);
+
+statement ok
+CREATE TABLE mixed_udt_t (status STRING, profile STRING);
+
+statement ok
+CREATE FUNCTION mixed_udt_func() RETURNS TEXT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    status_val user_status;
+    profile_val user_profile;
+    result TEXT;
+  BEGIN
+    SELECT status::user_status, profile::user_profile INTO status_val, profile_val
+    FROM mixed_udt_t WHERE status::user_status = 'admin'::user_status;
+    result := status_val::TEXT;
+    RETURN result;
+  END
+$$;
+
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION mixed_udt_func];
+----
+CREATE FUNCTION public.mixed_udt_func()
+  RETURNS STRING
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  DECLARE
+  status_val public.user_status;
+  profile_val public.user_profile;
+  result STRING;
+  BEGIN
+  SELECT status::public.user_status, profile::user_profile FROM public.mixed_udt_t WHERE status::user_status = 'admin'::test.public.user_status INTO status_val, profile_val;
+  result := status_val::STRING;
+  RETURN result;
+  END;
+$$
+
+statement ok
+DROP FUNCTION mixed_udt_func;
+
+statement ok
+DROP TABLE mixed_udt_t;
+
+statement ok
+DROP TYPE user_profile;
+
+statement ok
+DROP TYPE user_status;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -367,7 +367,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 
 	isSetReturning := cf.ReturnType != nil && cf.ReturnType.SetOf
 	targetVolatility := tree.GetRoutineVolatility(cf.Options)
-	fmtCtx := tree.NewFmtCtx(tree.FmtSerializable)
+	fmtCtx := tree.NewFmtCtx(tree.FmtParsable | tree.FmtAlwaysQualifyUserDefinedTypeNames)
 
 	defer func(origValue bool) {
 		b.insideSQLRoutine = origValue

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -54,7 +54,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS STRING
  │   	LANGUAGE SQL
- │   	AS $$SELECT x'40':::@100055::STRING;$$
+ │   	AS $$SELECT 'MON':::workday::STRING;$$
  └── dependencies
       └── workday
 

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -388,18 +388,8 @@ func formatViewQueryTypesForDisplay(
 
 // formatFunctionQueryTypesForDisplay is similar to
 // formatViewQueryTypesForDisplay but can only be used for functions.
-// nil is used as the table descriptor for schemaexpr.FormatExprForDisplay call.
-// This is fine assuming that UDFs cannot be created with expression casting a
-// column/var to an enum in function body. This is super rare case for now, and
-// it's tracked with issue #87475. We should also unify this function with
-// formatViewQueryTypesForDisplay.
 func formatFunctionQueryTypesForDisplay(
-	ctx context.Context,
-	evalCtx *eval.Context,
-	semaCtx *tree.SemaContext,
-	sessionData *sessiondata.SessionData,
-	queries string,
-	lang catpb.Function_Language,
+	ctx context.Context, semaCtx *tree.SemaContext, queries string, lang catpb.Function_Language,
 ) (string, error) {
 	// replaceFunc is a visitor function that replaces user defined type IDs in
 	// SQL expressions with their names.
@@ -426,17 +416,25 @@ func formatFunctionQueryTypesForDisplay(
 		if !typ.UserDefined() {
 			return true, expr, nil
 		}
-		formattedExpr, err := schemaexpr.FormatExprForDisplay(
-			ctx, nil, expr.String(), evalCtx, semaCtx, sessionData, tree.FmtParsable,
-		)
+
+		typedExpr, err := expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			return false, expr, err
 		}
-		newExpr, err = parser.ParseExpr(formattedExpr)
-		if err != nil {
-			return false, expr, err
+
+		dEnum, ok := typedExpr.(*tree.DEnum)
+		if !ok {
+			return false, expr, errors.Newf("unsupported expression type %T", typedExpr)
 		}
-		return false, newExpr, nil
+		switch n := expr.(type) {
+		case *tree.CastExpr:
+			n.Expr = tree.NewStrVal(dEnum.LogicalRep)
+			n.Type = dEnum.EnumTyp
+		case *tree.AnnotateTypeExpr:
+			n.Expr = tree.NewStrVal(dEnum.LogicalRep)
+			n.Type = dEnum.EnumTyp
+		}
+		return false, expr, nil
 	}
 	// replaceTypeFunc is a visitor function that replaces type annotations
 	// containing user defined types IDs with their name. This is currently only


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/152233
Fixes https://github.com/cockroachdb/cockroach/issues/159145
Fixes https://github.com/cockroachdb/cockroach/issues/87475

Previously, if a function contains cast from a column to UDT in the body,
the SHOW CREATE TABLE statement for this function will error out. This
commit is to fix it.

Release note (bug fix): enable SHOW CREATE TABLE for function created with
columns casting to user defined types.