### PR TITLE
importer: delete bulkio.import.write_import_epoch.enabled setting

### DIFF
--- a/pkg/backup/testdata/backup-restore/import-epoch
+++ b/pkg/backup/testdata/backup-restore/import-epoch
@@ -6,10 +6,6 @@ new-cluster name=s1
 ----
 
 exec-sql
-SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=true;
-----
-
-exec-sql
 CREATE DATABASE d;
 USE d;
 CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
@@ -84,23 +80,6 @@ job cancel=a
 ----
 
 # Ensure that the import type is cleared.
-query-sql
-SELECT * FROM import_epoch
-----
-3 <nil>
-
-
-exec-sql
-SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=false;
-----
-
-# Ensure that the correct ImportType is set when the cluster setting is disabled
-import expect-pausepoint tag=b
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export3/export*-n*.0.csv')
-----
-job paused at pausepoint
-
-# We expect the zero-valued version here.
 query-sql
 SELECT * FROM import_epoch
 ----

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -276,6 +276,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	"storage.columnar_blocks.enabled": {},
 
 	// removed as of 26.1
+	"bulkio.import.write_import_epoch.enabled":            {},
 	"sql.distsql_planning.use_gossip.enabled":             {},
 	"rocksdb.ingest_backpressure.l0_file_count_threshold": {},
 	"rocksdb.ingest_backpressure.max_delay":               {},

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -429,13 +429,8 @@ func (r *importResumer) prepareTableForIngestion(
 	// TODO(dt): audit everywhere we get table descs (leases or otherwise) to
 	// ensure that filtering by state handles IMPORTING correctly.
 
-	// We only use the new OfflineForImport on 24.1, which bumps
-	// the ImportEpoch, if we are completely on 24.1.
-	if importEpochs.Get(&p.ExecCfg().Settings.SV) {
-		importing.OfflineForImport()
-	} else {
-		importing.SetOffline(tabledesc.OfflineReasonImporting)
-	}
+	// Use OfflineForImport which bumps the ImportEpoch.
+	importing.OfflineForImport()
 
 	// TODO(dt): de-validate all the FKs.
 	if err := descsCol.WriteDesc(
@@ -707,13 +702,6 @@ var retryDuration = settings.RegisterDurationSetting(
 	"duration during which the IMPORT can be retried in face of non-permanent errors",
 	time.Minute*2,
 	settings.PositiveDuration,
-)
-
-var importEpochs = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"bulkio.import.write_import_epoch.enabled",
-	"controls whether IMPORT will write ImportEpoch's to descriptors",
-	true,
 )
 
 func getFractionCompleted(job *jobs.Job) float64 {

--- a/pkg/sql/importer/import_mvcc_test.go
+++ b/pkg/sql/importer/import_mvcc_test.go
@@ -48,7 +48,6 @@ func TestMVCCValueHeaderImportEpoch(t *testing.T) {
 
 	// Create a table where the first row ( in sort order) comes from an IMPORT
 	// while the second comes from an INSERT.
-	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=true`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (a INT8)`)
 	sqlDB.Exec(t, `INSERT INTO d.t VALUES ('2')`)
 	sqlDB.Exec(t, `IMPORT INTO d.t CSV DATA ($1)`, srv.URL)


### PR DESCRIPTION
This is an internal setting that has been on by default for a few versions now. We need to delete it because setting it to false can cause data corruption if online restore restores a non epoch based import.

Release note: none
Fixes: #153999