### PR TITLE
release-26.1: sql/repair: update UnsafeUpsertDescriptor for locked leasing

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -123,6 +124,10 @@ type Collection struct {
 	// repairs.
 	skipValidationOnWrite bool
 
+	// waitForLockedLeaseBump indicates that we need to wait for the locked
+	// lease timestamp to bump as well.
+	waitForLockedLeaseBump bool
+
 	// readerCatalogSetup indicates that replicated descriptors can be modified
 	// by this collection.
 	readerCatalogSetup bool
@@ -189,6 +194,18 @@ func (tc *Collection) SkipValidationOnWrite() {
 	tc.skipValidationOnWrite = true
 }
 
+// MaybeSetLockedLeaseBump requires that the locked lease timestamp
+// is also bumped after this operation. This is needed in scenarios
+// where WaitForOneVersion has no prior version checked out, and the
+// previous version is invalid (i.e. has validation errors).
+func (tc *Collection) MaybeSetLockedLeaseBump(ctx context.Context) {
+	if !lease.LockedLeaseTimestamp.Get(&tc.settings.SV) ||
+		!tc.settings.Version.IsActive(ctx, clusterversion.V26_1) {
+		return
+	}
+	tc.waitForLockedLeaseBump = true
+}
+
 // SetReaderCatalogSetup indicates this collection is being used to
 // modify reader catalogs.
 func (tc *Collection) SetReaderCatalogSetup() {
@@ -199,6 +216,29 @@ func (tc *Collection) SetReaderCatalogSetup() {
 // the passed slice. Errors are logged but ignored.
 func (tc *Collection) ReleaseSpecifiedLeases(ctx context.Context, descs []lease.IDVersion) {
 	tc.leased.release(ctx, descs)
+}
+
+// MaybeWaitForLeaseTimestampBump waits for any lease timestamp bump, which
+// is normally used by repair queries to ensure the new version is available.
+// Normally for schema changes WaitForOneVersion is enough, since it guarantees
+// no one can lease the old version. However, if the prior version was invalid,
+// then there will be a delay after which the new version will be usable, as the
+// locked lease timestamp gets bumped.
+func (tc *Collection) MaybeWaitForLeaseTimestampBump(
+	ctx context.Context, commitTime hlc.Timestamp,
+) {
+	// This transaction does not require any leased timestamp bump.
+	if !tc.waitForLockedLeaseBump {
+		return
+	}
+	// Confirm the lease manager is leasing out any new descriptor versions
+	// at the commit time.
+	r := retry.StartWithCtx(ctx, retry.Options{})
+	for r.Next() {
+		if !tc.leased.lm.GetSafeReplicationTS().Less(commitTime) {
+			break
+		}
+	}
 }
 
 // ReleaseLeases releases all leases. Errors are logged but ignored.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4228,6 +4228,11 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			if err := ex.waitForInitialVersionForNewDescriptors(cachedRegions); err != nil {
 				return advanceInfo{}, err
 			}
+			// If a repair query was executed, then we need to confirm that the lease manager
+			// is handing out the new descirptor version. This is covered by the previous waits
+			// if the prior version was valid, but if it was invalid then we need the lease manager
+			// to have a new timestamp available.
+			ex.extraTxnState.descCollection.MaybeWaitForLeaseTimestampBump(ex.Ctx(), advInfo.txnEvent.commitTimestamp)
 
 			execCfg := ex.planner.ExecCfg()
 			if err := UpdateDescriptorCount(ex.Ctx(), execCfg, execCfg.SchemaChangerMetrics); err != nil {

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -170,6 +170,10 @@ func (p *planner) UnsafeUpsertDescriptor(
 	if force {
 		p.Descriptors().SkipValidationOnWrite()
 	}
+	// Indicate that for locked leasing we should wait for the
+	// locked lease timestamp to bump as well, in case the prior
+	// version of the descriptor was invalid.
+	p.Descriptors().MaybeSetLockedLeaseBump(ctx)
 
 	// If we are pushing out a brand new descriptor confirm that no leases
 	// exist before we publish it. This could happen if we did an unsafe delete,


### PR DESCRIPTION
Backport 1/1 commits from #159634 on behalf of @fqazi.

----

Previously, the logic to repair descriptors relied on WaitForOneVersion only to ensure that the new version was propagated. This was sufficient if the prior version was valid, since it would be leased out and guarantee that queries could only see the new version. With locked leasing, if the prior version is not checked out, then we need to further ensure the time stamp in the lease manager gets bumped. To address this, this patch adds logic in the collection to wait for lease manager time stamp bumps when descriptors are repaired.

Fixes: #159578
Fixes: #159577
Fixes: #159609
Fixes: #159590
Fixes: #159217

Release note: None

----

Release justification: bug fix in new code