### PR TITLE
backup: remove `SHOW BACKUPS WITH INDEX`

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,5 +1,5 @@
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' collectionURI opt_with_show_backups_options
+	'SHOW' 'BACKUPS' 'IN' collectionURI
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 'WITH' show_backup_options ( ( ',' show_backup_options ) )*
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 'WITH' 'OPTIONS' '(' show_backup_options ( ( ',' show_backup_options ) )* ')'
 	| 'SHOW' 'BACKUP' 'SCHEMAS' 'FROM' subdirectory 'IN' collectionURI 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -864,7 +864,7 @@ use_stmt ::=
 	'USE' var_value
 
 show_backup_stmt ::=
-	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list opt_with_show_backups_options
+	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list
 	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
 	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
 
@@ -2205,11 +2205,6 @@ var_value ::=
 	a_expr
 	| extra_var_value
 
-opt_with_show_backups_options ::=
-	'WITH' show_backups_options_list
-	| 'WITH' 'OPTIONS' '(' show_backups_options_list ')'
-	| 
-
 show_backup_details ::=
 	'SCHEMAS'
 
@@ -3147,9 +3142,6 @@ extra_var_value ::=
 	| 'NONE'
 	| cockroachdb_extra_reserved_keyword
 
-show_backups_options_list ::=
-	( show_backups_options ) ( ( ',' show_backups_options ) )*
-
 show_backup_options_list ::=
 	( show_backup_options ) ( ( ',' show_backup_options ) )*
 
@@ -3760,9 +3752,6 @@ for_locking_item ::=
 
 var_list ::=
 	( var_value ) ( ( ',' var_value ) )*
-
-show_backups_options ::=
-	'INDEX'
 
 show_backup_options ::=
 	'AS_JSON'

--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -475,12 +475,8 @@ func GetURIsByLocalityKV(
 // ListFullBackupsInCollection lists full backup paths in the collection
 // of an export store
 func ListFullBackupsInCollection(
-	ctx context.Context, store cloud.ExternalStorage, useIndex bool,
+	ctx context.Context, store cloud.ExternalStorage,
 ) ([]string, error) {
-	if useIndex {
-		return backupinfo.ListSubdirsFromIndex(ctx, store)
-	}
-
 	var backupPaths []string
 	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(f string) error {
 		if deprecatedBackupPathRE.MatchString(f) {

--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -321,34 +321,6 @@ func parseIndexFilename(basename string) (start time.Time, end time.Time, err er
 	return start, end, nil
 }
 
-// ListSubdirsFromIndex lists the paths of all full backup subdirectories that
-// have an entry in the index. The store should be rooted at the default
-// collection URI. The subdirs are returned in chronological order.
-func ListSubdirsFromIndex(ctx context.Context, store cloud.ExternalStorage) ([]string, error) {
-	var subdirs []string
-	if err := store.List(
-		ctx,
-		backupbase.BackupIndexDirectoryPath,
-		"/",
-		func(indexSubdir string) error {
-			indexSubdir = strings.TrimSuffix(indexSubdir, "/")
-			subdir, err := convertIndexSubdirToSubdir(indexSubdir)
-			if err != nil {
-				return err
-			}
-			subdirs = append(subdirs, subdir)
-			return nil
-		},
-	); err != nil {
-		return nil, errors.Wrapf(err, "listing index subdirs")
-	}
-	// Index subdirs are in descending order and we want chronological order.
-	// TODO (kev-cao): In the new faster `SHOW BACKUP` effort, we will want
-	// the subdirs in descending order.
-	slices.Reverse(subdirs)
-	return subdirs, nil
-}
-
 // shouldWriteIndex determines if a backup index file should be written for a
 // given backup. The rule is:
 //  1. An index should only be written on a v25.4+ cluster.

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -1392,7 +1392,7 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := backupdest.ListFullBackupsInCollection(ctx, store, showStmt.Options.Index)
+		res, err := backupdest.ListFullBackupsInCollection(ctx, store)
 		if err != nil {
 			return err
 		}

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -455,11 +455,9 @@ func TestShowBackups(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_location = $2`, full, remoteInc)
 
 	rows := sqlDBRestore.QueryStr(t, `SHOW BACKUPS IN $1`, full)
-	rowsUsingIndex := sqlDBRestore.QueryStr(t, `SHOW BACKUPS IN $1 WITH INDEX`, full)
 
 	// assert that we see the three, and only the three, full backups.
 	require.Equal(t, 3, len(rows))
-	require.Equal(t, rows, rowsUsingIndex)
 
 	// check that we can show the inc layers in the individual full backups.
 	b1 := sqlDBRestore.QueryStr(t, `SELECT * FROM [SHOW BACKUP FROM $1 IN $2] WHERE object_type='table'`, rows[0][0], full)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1480,7 +1480,7 @@ func (u *sqlSymUnion) filterType() tree.FilterType {
 %type <*tree.TenantReplicationOptions> opt_with_replication_options replication_options replication_options_list source_replication_options source_replication_options_list
 %type <tree.ShowBackupDetails> show_backup_details
 %type <*tree.ShowJobOptions> show_job_options show_job_options_list
-%type <*tree.ShowBackupOptions> opt_with_show_backup_options show_backup_options show_backup_options_list opt_with_show_backups_options show_backups_options show_backups_options_list
+%type <*tree.ShowBackupOptions> opt_with_show_backup_options show_backup_options show_backup_options_list
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list copy_generic_options copy_generic_options_list
 %type <str> import_format
 %type <str> storage_parameter_key
@@ -9013,11 +9013,10 @@ show_histogram_stmt:
 // %Text: SHOW BACKUP [SCHEMAS|FILES|RANGES] <location>
 // %SeeAlso: WEBDOCS/show-backup.html
 show_backup_stmt:
-  SHOW BACKUPS IN string_or_placeholder_opt_list opt_with_show_backups_options
+  SHOW BACKUPS IN string_or_placeholder_opt_list
  {
     $$.val = &tree.ShowBackup{
       InCollection:    $4.stringOrPlaceholderOptList(),
-      Options: *$5.showBackupOptions(),
     }
   }
 | SHOW BACKUP show_backup_details FROM string_or_placeholder IN string_or_placeholder_opt_list opt_with_show_backup_options
@@ -9099,38 +9098,6 @@ show_backup_details:
     /* SKIP DOC */
 	$$.val = tree.BackupValidateDetails
 	}
-
-opt_with_show_backups_options:
-  WITH show_backups_options_list
-  {
-    $$.val = $2.showBackupOptions()
-  }
-| WITH OPTIONS '(' show_backups_options_list ')'
-  {
-    $$.val = $4.showBackupOptions()
-  }
-| /* EMPTY */
-  {
-    $$.val = &tree.ShowBackupOptions{}
-  }
-
-show_backups_options_list:
-  show_backups_options
-  {
-    $$.val = $1.showBackupOptions()
-  }
-| show_backups_options_list ',' show_backups_options
-  {
-    if err := $1.showBackupOptions().CombineWith($3.showBackupOptions()); err != nil {
-      return setErr(sqllex, err)
-    }
-  }
-
-show_backups_options:
- INDEX
- {
-    $$.val = &tree.ShowBackupOptions{Index: true}
- }
 
 opt_with_show_backup_options:
   WITH show_backup_options_list

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -151,29 +151,12 @@ SHOW BACKUPS IN '*****' -- identifiers removed
 SHOW BACKUPS IN 'bar' -- passwords exposed
 
 parse
-SHOW BACKUPS IN 'bar' WITH index
-----
-SHOW BACKUPS IN '*****' WITH OPTIONS (index) -- normalized!
-SHOW BACKUPS IN ('*****') WITH OPTIONS (index) -- fully parenthesized
-SHOW BACKUPS IN '_' WITH OPTIONS (index) -- literals removed
-SHOW BACKUPS IN '*****' WITH OPTIONS (index) -- identifiers removed
-SHOW BACKUPS IN 'bar' WITH OPTIONS (index) -- passwords exposed
-
-parse
 SHOW BACKUPS IN $1
 ----
 SHOW BACKUPS IN $1
 SHOW BACKUPS IN ($1) -- fully parenthesized
 SHOW BACKUPS IN $1 -- literals removed
 SHOW BACKUPS IN $1 -- identifiers removed
-
-parse
-SHOW BACKUPS IN $1 WITH index
-----
-SHOW BACKUPS IN $1 WITH OPTIONS (index) -- normalized!
-SHOW BACKUPS IN ($1) WITH OPTIONS (index) -- fully parenthesized
-SHOW BACKUPS IN $1 WITH OPTIONS (index) -- literals removed
-SHOW BACKUPS IN $1 WITH OPTIONS (index) -- identifiers removed
 
 parse
 SHOW BACKUP 'foo' IN 'bar'

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -107,11 +107,6 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 	if node.Path == nil {
 		ctx.WriteString("SHOW BACKUPS IN ")
 		ctx.FormatURIs(node.InCollection)
-		if !node.Options.IsDefault() {
-			ctx.WriteString(" WITH OPTIONS (")
-			ctx.FormatNode(&node.Options)
-			ctx.WriteString(")")
-		}
 		return
 	}
 	ctx.WriteString("SHOW BACKUP ")
@@ -149,7 +144,6 @@ type ShowBackupOptions struct {
 	EncryptionPassphrase Expr
 	Privileges           bool
 	SkipSize             bool
-	Index                bool
 
 	// EncryptionInfoDir is a hidden option used when the user wants to run the deprecated
 	//
@@ -175,10 +169,6 @@ func (o *ShowBackupOptions) Format(ctx *FmtCtx) {
 			ctx.WriteString(", ")
 		}
 		addSep = true
-	}
-	// Index is only used in SHOW BACKUPS
-	if o.Index {
-		ctx.WriteString("index")
 	}
 
 	if o.AsJson {
@@ -259,8 +249,7 @@ func (o ShowBackupOptions) IsDefault() bool {
 		o.EncryptionInfoDir == options.EncryptionInfoDir &&
 		o.CheckConnectionTransferSize == options.CheckConnectionTransferSize &&
 		o.CheckConnectionDuration == options.CheckConnectionDuration &&
-		o.CheckConnectionConcurrency == options.CheckConnectionConcurrency &&
-		o.Index == options.Index
+		o.CheckConnectionConcurrency == options.CheckConnectionConcurrency
 }
 
 func combineBools(v1 bool, v2 bool, label string) (bool, error) {


### PR DESCRIPTION
This commit removes the `WITH INDEX` option from `SHOW BACKUPS` in favor of the new planned UX.

Epic: CRDB-57536

Informs: #159647