### PR TITLE
mmaprototype: improve error handling for constraint normalization

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -13400,6 +13400,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+    - name: mma.span_config.normalization.error
+      exported_name: mma_span_config_normalization_error
+      description: Number of ranges where span config normalization had errors. This includes cases where best-effort normalization may have succeeded (producing a usable config despite the error).
+      y_axis_label: Range
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: node-id
       exported_name: node_id
       description: node ID with labels for advertised RPC and HTTP addresses

--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
+        "//pkg/util/buildutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/allocator_state.go
@@ -724,10 +724,22 @@ func sortTargetCandidateSetAndPick(
 // ensureAnalyzedConstraints ensures that the constraints field of rangeState is
 // populated. It uses rangeState.{replicas,conf} as inputs to the computation.
 //
+// rstate.conf may be nil if basic span config normalization failed (e.g.,
+// invalid config). In this case, constraint analysis is skipped and
+// rstate.constraints remains nil. In addition, rstate.constraints may also
+// remain nil after the call if there is no leaseholder found. In such cases,
+// the range should be skipped from rebalancing.
+//
 // NB: Caller is responsible for calling clearAnalyzedConstraints when rstate or
 // the rstate.constraints is no longer needed.
 func (cs *clusterState) ensureAnalyzedConstraints(rstate *rangeState) {
 	if rstate.constraints != nil {
+		return
+	}
+	// Skip the range if the configuration is invalid for constraint analysis.
+	if rstate.conf == nil {
+		log.KvDistribution.Warning(context.Background(),
+			"no span config due to normalization error, skipping constraint analysis")
 		return
 	}
 	// Populate the constraints.
@@ -750,9 +762,16 @@ func (cs *clusterState) ensureAnalyzedConstraints(rstate *rangeState) {
 		// that there is a new leaseholder (and thus should drop this range).
 		// However, even in this case, replica.IsLeaseholder should still be there
 		// based on to the stale state, so this should still be impossible to hit.
-		panic(errors.AssertionFailedf("no leaseholders found in %v", rstate.replicas))
+		log.KvDistribution.Warningf(context.Background(),
+			"mma: no leaseholders found in %v, skipping constraint analysis", rstate.replicas)
+		return
 	}
-	rac.finishInit(rstate.conf, cs.constraintMatcher, leaseholder)
+	if err := rac.finishInit(rstate.conf, cs.constraintMatcher, leaseholder); err != nil {
+		releaseRangeAnalyzedConstraints(rac)
+		log.KvDistribution.Warningf(context.Background(),
+			"mma: error finishing constraint analysis: %v, skipping range", err)
+		return
+	}
 	rstate.constraints = rac
 }
 

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1545,10 +1545,9 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		if rangeMsg.MaybeSpanConfIsPopulated {
 			normSpanConfig, err := makeNormalizedSpanConfig(&rangeMsg.MaybeSpanConf, cs.constraintMatcher.interner)
 			if err != nil {
-				// TODO(wenyihu6): add metrics here to track 1. developer error or 2.
-				// best-effort normalization.
 				log.KvDistribution.Warningf(
 					ctx, "range r%v span config had errors in normalization: %v, normalized result: %v", rangeMsg.RangeID, err, normSpanConfig)
+				metrics.incSpanConfigNormalizationErrorIfNonNil()
 			}
 			rs.conf = normSpanConfig
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1081,7 +1081,12 @@ type rangeState struct {
 	// addition of s4 to be thrown away while keeping the removal of s1. This is
 	// mostly being defensive to avoid any chance of internal inconsistency.
 	replicas []StoreIDAndReplicaState
-	conf     *normalizedSpanConfig
+	// conf is nil iff developer error or basic span config normalization failed
+	// (invalid config), in which case the range analysis is skipped,
+	// rangeAnalyzedConstraints is always nil, and the range is excluded from
+	// rebalancing. Note that if only doStructuralNormalization failed, conf will
+	// be non-nil.
+	conf *normalizedSpanConfig
 
 	load RangeLoad
 
@@ -1094,9 +1099,10 @@ type rangeState struct {
 	// be identical to clusterState.pendingChanges.
 	pendingChanges []*pendingReplicaChange
 
-	// If non-nil, it is up-to-date. Typically, non-nil for a range that has no
-	// pendingChanges and is not satisfying some constraint, since we don't want
-	// to repeat the analysis work every time we consider it.
+	// Nil if conf is nil (since conf is required input), or if constraint
+	// analysis fails (e.g., no leaseholder found). When nil, the range is
+	// excluded from rebalancing. When non-nil, it is up-to-date and cached to
+	// avoid repeating analysis work.
 	//
 	// REMINDER: rangeAnalyzedConstraints ignores LEARNER and
 	// VOTER_DEMOTING_LEARNER replicas. So if a voter/non-voter is being added
@@ -1539,18 +1545,10 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 		if rangeMsg.MaybeSpanConfIsPopulated {
 			normSpanConfig, err := makeNormalizedSpanConfig(&rangeMsg.MaybeSpanConf, cs.constraintMatcher.interner)
 			if err != nil {
-				if normSpanConfig == nil {
-					// TODO: the roachpb.SpanConfig violated the basic requirements
-					// documented in the proto. We need to ensure that the checks that
-					// happened here are also done when the user set the ZoneConfig, so
-					// that we can reject such violations up front. At this point in the
-					// code we have no way of continuing, so we panic, but we must ensure
-					// we never get here in production for user specified input.
-					panic(err)
-				} else {
-					log.KvDistribution.Warningf(
-						ctx, "range r%v span config had errors in normalization: %v", rangeMsg.RangeID, err)
-				}
+				// TODO(wenyihu6): add metrics here to track 1. developer error or 2.
+				// best-effort normalization.
+				log.KvDistribution.Warningf(
+					ctx, "range r%v span config had errors in normalization: %v, normalized result: %v", rangeMsg.RangeID, err, normSpanConfig)
 			}
 			rs.conf = normSpanConfig
 		}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state.go
@@ -1602,7 +1602,14 @@ func (cs *clusterState) processStoreLeaseholderMsgInternal(
 	localss := cs.stores[msg.StoreID]
 	cs.meansMemo.clear()
 	clusterMeans := cs.meansMemo.getMeans(nil)
-	for _, ss := range cs.stores {
+	// Sort by store ID for deterministic log output in tests.
+	storeIDs := make([]roachpb.StoreID, 0, len(cs.stores))
+	for storeID := range cs.stores {
+		storeIDs = append(storeIDs, storeID)
+	}
+	slices.Sort(storeIDs)
+	for _, storeID := range storeIDs {
+		ss := cs.stores[storeID]
 		topk := ss.adjusted.topKRanges[msg.StoreID]
 		if topk == nil {
 			topk = &topKReplicas{k: numTopKReplicas}

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -469,6 +469,12 @@ func (re *rebalanceEnv) rebalanceReplicas(
 			continue
 		}
 		re.ensureAnalyzedConstraints(rstate)
+		if rstate.constraints == nil {
+			log.KvDistribution.Warningf(ctx,
+				"skipping r%d: no constraints analyzed (conf=%v replicas=%v)",
+				rangeID, rstate.conf, rstate.replicas)
+			continue
+		}
 		isVoter, isNonVoter := rstate.constraints.replicaRole(store.StoreID)
 		if !isVoter && !isNonVoter {
 			// Due to REQUIREMENT(change-computation), the top-k is up to date, so
@@ -666,6 +672,12 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 			continue
 		}
 		re.ensureAnalyzedConstraints(rstate)
+		if rstate.constraints == nil {
+			log.KvDistribution.Warningf(ctx,
+				"skipping r%d: no constraints analyzed (conf=%v replicas=%v)",
+				rangeID, rstate.conf, rstate.replicas)
+			continue
+		}
 		if rstate.constraints.leaseholderID != store.StoreID {
 			// See the earlier comment about assertions.
 			panic(fmt.Sprintf("internal state inconsistency: "+

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -15,11 +15,23 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
 )
+
+// rangeSkippedDueToFailedConstraintsLogEvery rate limits the warning log for
+// ranges skipped due to failed constraint analysis to avoid spamming.
+var rangeSkippedDueToFailedConstraintsLogEvery = log.Every(time.Minute)
+
+// rangeSkippedDueToFailedConstraintsShouldLog returns true if the warning for
+// ranges skipped due to failed constraints should be logged. In test builds, it
+// always returns true; in production, it rate-limits to once per minute.
+func rangeSkippedDueToFailedConstraintsShouldLog() bool {
+	return buildutil.CrdbTestBuild || rangeSkippedDueToFailedConstraintsLogEvery.ShouldLog()
+}
 
 // rebalanceEnv tracks the state and outcomes of a rebalanceStores invocation.
 // Recall that such an invocation is on behalf of a local store, but will
@@ -470,9 +482,11 @@ func (re *rebalanceEnv) rebalanceReplicas(
 		}
 		re.ensureAnalyzedConstraints(rstate)
 		if rstate.constraints == nil {
-			log.KvDistribution.Warningf(ctx,
-				"skipping r%d: no constraints analyzed (conf=%v replicas=%v)",
-				rangeID, rstate.conf, rstate.replicas)
+			if rangeSkippedDueToFailedConstraintsShouldLog() {
+				log.KvDistribution.Warningf(ctx,
+					"skipping r%d: no constraints analyzed (conf=%v replicas=%v)",
+					rangeID, rstate.conf, rstate.replicas)
+			}
 			continue
 		}
 		isVoter, isNonVoter := rstate.constraints.replicaRole(store.StoreID)
@@ -673,9 +687,11 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		}
 		re.ensureAnalyzedConstraints(rstate)
 		if rstate.constraints == nil {
-			log.KvDistribution.Warningf(ctx,
-				"skipping r%d: no constraints analyzed (conf=%v replicas=%v)",
-				rangeID, rstate.conf, rstate.replicas)
+			if rangeSkippedDueToFailedConstraintsShouldLog() {
+				log.KvDistribution.Warningf(ctx,
+					"skipping r%d: no constraints analyzed (conf=%v replicas=%v)",
+					rangeID, rstate.conf, rstate.replicas)
+			}
 			continue
 		}
 		if rstate.constraints.leaseholderID != store.StoreID {

--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_test.go
@@ -520,7 +520,13 @@ func TestClusterState(t *testing.T) {
 					if o, ok := dd.ScanArgOpt[int](t, d, "num-top-k-replicas"); ok {
 						n = o
 					}
-					cs.processStoreLeaseholderMsgInternal(context.Background(), &msg, n, nil)
+					cs.processStoreLeaseholderMsgInternal(ctx, &msg, n, nil)
+					if d.HasArg("trace") {
+						rec := finishAndGet()
+						var sb redact.StringBuilder
+						rec.SafeFormatMinimal(&sb)
+						return sb.String()
+					}
 					return ""
 
 				case "make-pending-changes":

--- a/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/constraint_test.go
@@ -437,7 +437,8 @@ func TestRangeAnalyzedConstraints(t *testing.T) {
 					buf.tryAddingStore(roachpb.StoreID(storeID), typ,
 						ltInterner.intern(stores[roachpb.StoreID(storeID)].NodeLocality))
 				}
-				rac.finishInit(nConf, cm, leaseholder)
+				err := rac.finishInit(nConf, cm, leaseholder)
+				require.NoError(t, err)
 				var b strings.Builder
 				printRangeAnalyzedConstraints(&b, rac, ltInterner)
 				// If there is a previous rangeAnalyzedConstraints, release it before

--- a/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
+++ b/pkg/kv/kvserver/allocator/mmaprototype/testdata/cluster_state/skip_range_invalid_config.txt
@@ -1,0 +1,76 @@
+# Tests that ranges with invalid span configs (where normalization fails)
+# trigger a warning and result in nil conf.
+#
+# Scenario: Range 1 has an invalid config where constraint replicas (2) exceed
+# num_replicas (1). This causes normalization to fail with a warning logged.
+
+set-store
+  store-id=1 node-id=1 attrs=purple locality-tiers=region=us-west-1,zone=us-west-1a
+  store-id=2 node-id=2 attrs=yellow locality-tiers=region=us-east-1,zone=us-east-1a
+----
+node-id=1 locality-tiers=region=us-west-1,zone=us-west-1a,node=1
+  store-id=1 attrs=purple
+node-id=2 locality-tiers=region=us-east-1,zone=us-east-1a,node=2
+  store-id=2 attrs=yellow
+
+store-load-msg
+  store-id=1 node-id=1 load=[100,100,100] capacity=[200,200,200] secondary-load=0 load-time=0s
+----
+
+store-load-msg
+  store-id=2 node-id=2 load=[10,10,10] capacity=[200,200,200] secondary-load=0 load-time=0s
+----
+
+get-load-info
+----
+store-id=1 node-id=1 status=ok accepting all reported=[cpu:100ns/s, write-bandwidth:100 B/s, byte-size:100 B] adjusted=[cpu:100ns/s, write-bandwidth:100 B/s, byte-size:100 B] node-reported-cpu=100 node-adjusted-cpu=100 seq=1
+store-id=2 node-id=2 status=ok accepting all reported=[cpu:10ns/s, write-bandwidth:10 B/s, byte-size:10 B] adjusted=[cpu:10ns/s, write-bandwidth:10 B/s, byte-size:10 B] node-reported-cpu=10 node-adjusted-cpu=10 seq=1
+
+# Range 1: Invalid config - constraint replicas (2) > num_replicas (1).
+# This triggers: "constraint replicas add up to more than configured replicas"
+store-leaseholder-msg trace
+store-id=1
+  range-id=1 load=[50,50,50] raft-cpu=10
+  config=(num_replicas=1 constraints={"+region=us-west-1":2})
+    store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+----
+range r1 span config had errors in normalization: constraint replicas add up to more than configured replicas, normalized result: <nil>
+load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+load summary for dim=WriteBandwidth (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+load summary for dim=ByteSize (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+load summary for dim=WriteBandwidth (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+load summary for dim=ByteSize (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+
+ranges
+----
+range-id=1 local-store=1 load=[cpu:50ns/s, write-bandwidth:50 B/s, byte-size:50 B] raft-cpu=10
+  store-id=1 replica-id=1 type=VOTER_FULL leaseholder=true
+
+# Rebalance from store 1. The rebalancer attempts to shed load from s1 but
+# cannot find a suitable candidate.
+rebalance-stores store-id=1
+----
+[mmaid=1] rebalanceStores begins
+[mmaid=1] cluster means: (stores-load [cpu:55ns/s, write-bandwidth:55 B/s, byte-size:55 B]) (stores-capacity [cpu:200ns/s, write-bandwidth:200 B/s, byte-size:200 B]) (nodes-cpu-load 55) (nodes-cpu-capacity 200)
+[mmaid=1] load summary for dim=CPURate (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+[mmaid=1] load summary for dim=WriteBandwidth (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+[mmaid=1] load summary for dim=ByteSize (s1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+[mmaid=1] load summary for dim=CPURate (n1): overloadSlow, reason: fractionUsed < 75% and >1.75x meanUtil [load=100 meanLoad=55 fractionUsed=50.00% meanUtil=27.50% capacity=200]
+[mmaid=1] evaluating s1: node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] overload-continued s1 ((store=overloadSlow worst=CPURate cpu=overloadSlow writes=overloadSlow bytes=overloadSlow node=overloadSlow high_disk=false frac_pending=0.00,0.00(true))) - within grace period
+[mmaid=1] store s1 was added to shedding store list
+[mmaid=1] load summary for dim=CPURate (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+[mmaid=1] load summary for dim=WriteBandwidth (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+[mmaid=1] load summary for dim=ByteSize (s2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+[mmaid=1] load summary for dim=CPURate (n2): loadLow, reason: load is >10% below mean [load=10 meanLoad=55 fractionUsed=5.00% meanUtil=27.50% capacity=200]
+[mmaid=1] evaluating s2: node load loadLow, store load loadLow, worst dim CPURate
+[mmaid=1] start processing shedding store s1: cpu node load overloadSlow, store load overloadSlow, worst dim CPURate
+[mmaid=1] top-K[CPURate] ranges for s1 with lease on local s1: r1:[cpu:50ns/s, write-bandwidth:50 B/s, byte-size:50 B]
+[mmaid=1] local store s1 is CPU overloaded (overloadSlow >= overloadSlow), attempting lease transfers first
+[mmaid=1] skipping r1: no constraints analyzed (conf=<nil> replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok])
+[mmaid=1] attempting to shed replicas next
+[mmaid=1] skipping r1: no constraints analyzed (conf=<nil> replicas=[s1:replica-id=1 type=VOTER_FULL leaseholder=true lease disposition:ok])
+pending(0)

--- a/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
+++ b/pkg/roachprod/agents/opentelemetry/files/cockroachdb_metrics.yaml
@@ -1381,6 +1381,7 @@ mma_overloaded_store_medium_dur_failure: mma.overloaded_store.medium_dur.failure
 mma_overloaded_store_medium_dur_success: mma.overloaded_store.medium_dur.success
 mma_overloaded_store_short_dur_failure: mma.overloaded_store.short_dur.failure
 mma_overloaded_store_short_dur_success: mma.overloaded_store.short_dur.success
+mma_span_config_normalization_error: mma.span_config.normalization.error
 node_id: node_id
 obs_tablemetadata_update_job_duration: obs.tablemetadata.update_job.duration
 obs_tablemetadata_update_job_duration_bucket: obs.tablemetadata.update_job.duration.bucket


### PR DESCRIPTION
Epic: CRDB-55052 
Release note: none

---
**mmaprototype: improve error handling for constraint normalization**

Previously, span config normalization could panic or fatal on what were
considered developer errors. If a buggy SpanConfig triggered this path, all
nodes would crash and repeatedly crash again on restart. We should never fatal
on user-provided input, even when the underlying bug is ours.

This change replaces panics and fatals with:

- If span config normalization returns an error, leave the conf field empty so
failures propagate without crashing.
- If range constraint analysis fails, leave the constraints empty.
- Add nil checks on results from ensureAnalyzedConstraints to gracefully skip
  ranges with constraints == nil (including conf == nil).

This commit fixes it so that ranges with invalid configs are logged with
warnings and skipped during rebalancing instead of causing node crashes.

---
**mmaprototype: add optional tracing to store-leaseholder-msg in tests**

To support future testing, this commit adds a `trace` argument to the
store-leaseholder-msg datadriven command. When specified, the command returns
the recording span output, making it easier to debug span config processing in
tests. Note that this is currently left unused. Future commits will use it.

---
**mmaprototype: add test for skipping ranges with invalid span configs**

This commit adds skip_range_invalid_config.txt to demonstrate that ranges with
invalid span configs are now handled gracefully.

---
**mmaprototype: add metric for failed normalization**

This commit adds SpanConfigNormalizationError which helps track ranges where
span config normalization encounters an error. It helps operators identify
problematic span configurations in production without requiring log analysis.

Note: this includes cases where best-effort normalization may have succeeded
(producing a usable config despite the error) and does not include cases where
constraint analysis fails.

Resolves: https://github.com/cockroachdb/cockroach/issues/159531

---
**mmaprototype: rate-limit `no constraints analyzed` warning**
