### PR TITLE
sql: enable INSPECT command by default

### DIFF
--- a/pkg/cmd/roachtest/operations/inspect.go
+++ b/pkg/cmd/roachtest/operations/inspect.go
@@ -23,15 +23,10 @@ func runInspect(
 	conn := c.Conn(ctx, o.L(), 1)
 	defer conn.Close()
 
-	_, err := conn.ExecContext(ctx, "SET enable_inspect_command = true;")
-	if err != nil {
-		o.Fatal(err)
-	}
-
 	dbName := helpers.PickRandomDB(ctx, o, conn, []string{} /* excludeDBs */)
 
 	o.Status(fmt.Sprintf("inspecting database %s", dbName))
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("INSPECT DATABASE %s", lexbase.EscapeSQLIdent(dbName)))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("INSPECT DATABASE %s", lexbase.EscapeSQLIdent(dbName)))
 	if err != nil {
 		o.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/roachtestutil/validation_check.go
+++ b/pkg/cmd/roachtest/roachtestutil/validation_check.go
@@ -243,7 +243,6 @@ func launchInspectJobs(
 			l.Printf("Launching INSPECT DATABASE %s", dbName)
 
 			statements := []string{
-				"SET enable_inspect_command = true",
 				fmt.Sprintf("INSPECT DATABASE %s WITH OPTIONS DETACHED", lexbase.EscapeSQLIdent(dbName)),
 			}
 

--- a/pkg/cmd/roachtest/testdata/pg_regress/sysviews.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/sysviews.diffs
@@ -104,7 +104,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/sysviews.out --la
 + enable_implicit_select_for_update                | on
 + enable_implicit_transaction_for_batch_statements | on
 + enable_insert_fast_path                          | on
-+ enable_inspect_command                           | off
 + enable_multiple_modifications_of_table           | off
 + enable_multiregion_placement_policy              | off
 + enable_seqscan                                   | on

--- a/pkg/cmd/roachtest/tests/admission_control_inspect.go
+++ b/pkg/cmd/roachtest/tests/admission_control_inspect.go
@@ -163,9 +163,6 @@ func makeInspectAdmissionControlTest(
 				t.Status("running " + description)
 				tickHistogram(histogramName)
 				startTime := timeutil.Now()
-				if _, err := db.ExecContext(ctx, "SET enable_inspect_command = true"); err != nil {
-					t.Fatal(err)
-				}
 				if _, err := db.ExecContext(ctx, "INSPECT TABLE bulkingest.bulkingest"); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/roachtest/tests/inspect_throughput.go
+++ b/pkg/cmd/roachtest/tests/inspect_throughput.go
@@ -213,8 +213,7 @@ func makeInspectThroughputTest(
 				t.Fatal(err)
 			}
 
-			// Enable INSPECT feature flag.
-			if _, err := db.Exec("USE bulkingest; SET enable_inspect_command = true"); err != nil {
+			if _, err := db.Exec("USE bulkingest;"); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/sql/inspect/inspect_metrics_test.go
+++ b/pkg/sql/inspect/inspect_metrics_test.go
@@ -36,7 +36,6 @@ func TestInspectMetrics(t *testing.T) {
 	runner := sqlutils.MakeSQLRunner(db)
 	runner.Exec(t, `
 		CREATE DATABASE db;
-		SET enable_inspect_command = true;
 		CREATE TABLE db.t (
 			id INT PRIMARY KEY,
 			val INT

--- a/pkg/sql/inspect/inspect_plan.go
+++ b/pkg/sql/inspect/inspect_plan.go
@@ -177,12 +177,7 @@ func inspectPlanHook(
 
 	switch inspectStmt.Typ {
 	case tree.InspectTable, tree.InspectDatabase:
-		if !p.ExtendedEvalContext().SessionData().EnableInspectCommand {
-			return nil, nil, false, errors.WithHint(
-				pgerror.Newf(pgcode.ExperimentalFeature, "INSPECT is an experimental feature and is disabled by default"),
-				"To enable, run SET enable_inspect_command = true;",
-			)
-		}
+		// valid types.
 	default:
 		return nil, nil, false, errors.AssertionFailedf("unexpected INSPECT type received, got: %v", inspectStmt.Typ)
 	}

--- a/pkg/sql/inspect/inspect_resumer_test.go
+++ b/pkg/sql/inspect/inspect_resumer_test.go
@@ -69,7 +69,6 @@ func TestInspectJobImplicitTxnSemantics(t *testing.T) {
 
 	runner.Exec(t, `
 		CREATE DATABASE db;
-		SET enable_inspect_command = true;
 		CREATE TABLE db.t (
 			id INT PRIMARY KEY,
 			val INT
@@ -201,7 +200,6 @@ func TestInspectJobProtectedTimestamp(t *testing.T) {
 			runner := sqlutils.MakeSQLRunner(db)
 			runner.Exec(t, `
 				CREATE DATABASE db;
-				SET enable_inspect_command = true;
 				CREATE TABLE db.t (
 					id INT PRIMARY KEY,
 					val INT
@@ -369,7 +367,6 @@ func TestInspectProgressWithMultiRangeTable(t *testing.T) {
 	// Start the INSPECT job.
 	t.Logf("Starting INSPECT job on table with %d ranges distributed across %d nodes", rangeCount, nodeCount)
 	_, err := db.Exec(`
-		SET enable_inspect_command = true;
 		COMMIT;
 		INSPECT TABLE multi_range_table`)
 	require.NoError(t, err)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_inspect
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_inspect
@@ -5,12 +5,6 @@ skip under race
 subtest setup
 
 statement ok
-SET enable_inspect_command = true;
-
-statement ok
-SET enable_inspect_command = true;
-
-statement ok
 CREATE VIEW last_inspect_job AS
 SELECT status, COALESCE(jsonb_array_length(
     crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload)->'inspectDetails'->'checks'

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3818,7 +3818,6 @@ enable_implicit_fk_locking_for_serializable                      off
 enable_implicit_select_for_update                                on
 enable_implicit_transaction_for_batch_statements                 on
 enable_insert_fast_path                                          on
-enable_inspect_command                                           off
 enable_multiple_modifications_of_table                           off
 enable_multiregion_placement_policy                              off
 enable_seqscan                                                   on

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -30,15 +30,6 @@ CREATE TABLE foo (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
 let $foo_created_ts
 SELECT now()
 
-statement error pq: INSPECT is an experimental feature and is disabled by default
-INSPECT TABLE foo;
-
-statement error pq: INSPECT is an experimental feature and is disabled by default
-INSPECT DATABASE test;
-
-statement ok
-SET enable_inspect_command = true;
-
 subtest transaction_behavior
 
 # Test that regular INSPECT cannot run within a transaction.
@@ -217,9 +208,6 @@ CREATE USER testuser2;
 
 user testuser2
 
-statement ok
-SET enable_inspect_command = true;
-
 statement error pq: user testuser2 does not have INSPECT privilege
 INSPECT TABLE foo;
 
@@ -232,9 +220,6 @@ statement ok
 GRANT SYSTEM INSPECT TO testuser2;
 
 user testuser2
-
-statement ok
-SET enable_inspect_command = true;
 
 statement ok
 INSPECT TABLE foo;
@@ -389,9 +374,6 @@ CREATE TABLE dbfoo.public.t1 (c1 INT, INDEX idx_c1 (c1));
 
 
 statement ok
-SET enable_inspect_command = true;
-
-statement ok
 INSPECT DATABASE dbfoo WITH OPTIONS INDEX (t1@idx_c1);
 
 statement ok
@@ -451,9 +433,6 @@ CREATE TABLE dbfoo.public.t1 (c1 INT, INDEX idx_c1 (c1));
 CREATE TABLE dbfoo.s1.t1 (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
 CREATE TABLE dbbar.public.t1 (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
 CREATE TABLE dbbar.public.t2 (c1 INT, c2 INT, INDEX idx_c1 (c1), INDEX idx_c2 (c2));
-
-statement ok
-SET enable_inspect_command = true;
 
 subtest all_forms
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3088,7 +3088,6 @@ enable_implicit_fk_locking_for_serializable                      off            
 enable_implicit_select_for_update                                on                  NULL      NULL        NULL        string
 enable_implicit_transaction_for_batch_statements                 on                  NULL      NULL        NULL        string
 enable_insert_fast_path                                          on                  NULL      NULL        NULL        string
-enable_inspect_command                                           off                 NULL      NULL        NULL        string
 enable_multiple_modifications_of_table                           off                 NULL      NULL        NULL        string
 enable_multiregion_placement_policy                              off                 NULL      NULL        NULL        string
 enable_seqscan                                                   on                  NULL      NULL        NULL        string
@@ -3339,7 +3338,6 @@ enable_implicit_fk_locking_for_serializable                      off            
 enable_implicit_select_for_update                                on                  NULL  user     NULL      on                  on
 enable_implicit_transaction_for_batch_statements                 on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                                          on                  NULL  user     NULL      on                  on
-enable_inspect_command                                           off                 NULL  user     NULL      off                 off
 enable_multiple_modifications_of_table                           off                 NULL  user     NULL      off                 off
 enable_multiregion_placement_policy                              off                 NULL  user     NULL      off                 off
 enable_seqscan                                                   on                  NULL  user     NULL      on                  on
@@ -3578,7 +3576,6 @@ enable_implicit_fk_locking_for_serializable                      NULL    NULL   
 enable_implicit_select_for_update                                NULL    NULL     NULL     NULL        NULL
 enable_implicit_transaction_for_batch_statements                 NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                                          NULL    NULL     NULL     NULL        NULL
-enable_inspect_command                                           NULL    NULL     NULL     NULL        NULL
 enable_multiple_modifications_of_table                           NULL    NULL     NULL     NULL        NULL
 enable_multiregion_placement_policy                              NULL    NULL     NULL     NULL        NULL
 enable_seqscan                                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -102,7 +102,6 @@ enable_implicit_fk_locking_for_serializable                      off
 enable_implicit_select_for_update                                on
 enable_implicit_transaction_for_batch_statements                 on
 enable_insert_fast_path                                          on
-enable_inspect_command                                           off
 enable_multiple_modifications_of_table                           off
 enable_multiregion_placement_policy                              off
 enable_seqscan                                                   on

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -512,7 +512,6 @@ statement ok
 RESET vectorize;
 CREATE TABLE t38626 (id int PRIMARY KEY, name STRING, CONSTRAINT abc CHECK (name > 'he'));
 INSERT INTO t38626 VALUES (1, 'hello');
-SET enable_inspect_command = true;
 
 statement ok
 INSPECT TABLE t38626;

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -911,7 +911,6 @@ CREATE TABLE d.emptynorows (); -- zero columns, zero rows
 CREATE TABLE d.emptyrows (x INT);
 INSERT INTO d.emptyrows VALUES (1),(2),(3);
 ALTER TABLE d.emptyrows DROP COLUMN x; -- zero columns, 3 rows
-SET enable_inspect_command = true;
 `
 	if _, err := db.Exec(initStmt); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -737,8 +737,7 @@ message LocalOnlySessionData {
   // HoistJoinProjectLeft normalization rule hoists more kinds of projections
   // above joins.
   bool optimizer_use_improved_hoist_join_project = 186;
-  // EnableInspectCommand controls use of the INSPECT command.
-  bool enable_inspect_command = 187;
+  reserved 187;
   // RowSecurity controls whether row-level security is enabled.
   bool row_security = 188;
   // OptimizerClampLowHistogramSelectivity, when true, causes the optimizer to

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1059,10 +1059,6 @@ func (m *SessionDataMutator) SetOptimizerUseExistsFilterHoistRule(val bool) {
 	m.Data.OptimizerUseExistsFilterHoistRule = val
 }
 
-func (m *SessionDataMutator) SetEnableInspectCommand(val bool) {
-	m.Data.EnableInspectCommand = val
-}
-
 func (m *SessionDataMutator) SetInitialRetryBackoffForReadCommitted(val time.Duration) {
 	m.Data.InitialRetryBackoffForReadCommitted = val
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4264,26 +4264,11 @@ var varGen = map[string]sessionVar{
 
 	// CockroachDB extension.
 	// This is only kept for backwards compatibility and no longer has any effect.
-	`enable_scrub_job`: makeBackwardsCompatBoolVar(
-		"enable_scrub_job", false,
-	),
+	`enable_scrub_job`: makeBackwardsCompatBoolVar("enable_scrub_job", false),
 
 	// CockroachDB extension.
-	`enable_inspect_command`: {
-		GetStringVal: makePostgresBoolGetStringValFn(`enable_inspect_command`),
-		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar("enable_inspect_command", s)
-			if err != nil {
-				return err
-			}
-			m.SetEnableInspectCommand(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableInspectCommand), nil
-		},
-		GlobalDefault: globalFalse,
-	},
+	// This is only kept for backwards compatibility and no longer has any effect.
+	`enable_inspect_command`: makeBackwardsCompatBoolVar("enable_inspect_command", true),
 
 	// CockroachDB extension. Configures the initial backoff duration for
 	// automatic retries of statements in explicit READ COMMITTED transactions

--- a/pkg/testutils/sqlutils/inspect.go
+++ b/pkg/testutils/sqlutils/inspect.go
@@ -62,10 +62,6 @@ func RunInspect(sqlDB *gosql.DB, database string, table string) error {
 
 // runInspectWithOptions will run an inspect check for a table with the specified options string.
 func runInspectWithOptions(sqlDB *gosql.DB, database string, table string, options string) error {
-	if _, err := sqlDB.Exec(`SET enable_inspect_command = true;`); err != nil {
-		return err
-	}
-
 	if _, err := sqlDB.Exec(fmt.Sprintf(`INSPECT TABLE %s.%s %s`, database, table, options)); err == nil {
 		return nil
 	} else if !(strings.Contains(err.Error(), "INSPECT found inconsistencies") || strings.Contains(err.Error(), "INSPECT encountered internal errors")) {

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -654,9 +654,6 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 			return err
 		}
 	}
-	if _, err := conn.Exec(ctx, "SET enable_inspect_command = true;"); err != nil {
-		return err
-	}
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {


### PR DESCRIPTION
Epic CRDB-55075

Release note (sql change): INSPECT is now a generally available feature. The enable_inspect_command session variable has been deprecated, and is now effectively always true.