### PR TITLE
release-26.1: sql/tests: skip TestDependencyDigestOptimization under race

### DIFF
--- a/pkg/sql/tests/dependency_digest_test.go
+++ b/pkg/sql/tests/dependency_digest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -25,6 +26,7 @@ import (
 func TestDependencyDigestOptimization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "test is too slow under race")
 
 	c := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 


### PR DESCRIPTION
Backport 1/1 commits from #159656 on behalf of @rafiss.

----

fixes https://github.com/cockroachdb/cockroach/issues/159459
Release note: None

----

Release justification: test only change