### PR TITLE
release-26.1: spanconfigsqlwatcherccl: skip TestSQLWatcherMultiple under race

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -282,6 +283,7 @@ func TestSQLWatcherReactsToUpdates(t *testing.T) {
 // processes, both sequentially and concurrently.
 func TestSQLWatcherMultiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t, "slow test")
 
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{


### PR DESCRIPTION
Backport 1/1 commits from #159655 on behalf of @rafiss.

----

fixes https://github.com/cockroachdb/cockroach/issues/159464
fixes https://github.com/cockroachdb/cockroach/issues/159266

Release note: None

----

Release justification: test only change