### PR TITLE
apiinternal: fix data race in decoder initialization

### DIFF
--- a/pkg/server/apiinternal/api_internal.go
+++ b/pkg/server/apiinternal/api_internal.go
@@ -37,7 +37,12 @@ const (
 	POST httpMethod = http.MethodPost
 )
 
-var decoder = schema.NewDecoder()
+var decoder = func() *schema.Decoder {
+	d := schema.NewDecoder()
+	d.SetAliasTag("json")
+	d.IgnoreUnknownKeys(true)
+	return d
+}()
 
 // route defines a REST endpoint with its handler and HTTP method.
 type route struct {
@@ -93,9 +98,6 @@ func NewAPIInternalServer(
 	r.registerStatusRoutes()
 	r.registerAdminRoutes()
 	r.registerTimeSeriesRoutes()
-
-	decoder.SetAliasTag("json")
-	decoder.IgnoreUnknownKeys(true)
 
 	return r, nil
 }


### PR DESCRIPTION
Before this change, the global `decoder` variable was initialized with `schema.NewDecoder()` but configured later inside each call to `NewAPIInternalServer()` with `SetAliasTag("json")` and `IgnoreUnknownKeys(true)`. When multiple test servers started in parallel (e.g., in `TestClusterConnectivity`), concurrent calls to `NewAPIInternalServer()` resulted in multiple goroutines writing to the same decoder instance simultaneously, causing a data race.

This commit moves the decoder configuration to package initialization time, before any concurrent server initialization can occur. This eliminates the race condition caused.

To test: `./dev test pkg/server --filter TestClusterConnectivity -v --race`

Epic: None
Fixes: #159591
Release note: None