### PR TITLE
asim: only populate spanconfig in store leaseholder msg when needed

### DIFF
--- a/pkg/kv/kvserver/asim/mmaintegration/mma_integration.go
+++ b/pkg/kv/kvserver/asim/mmaintegration/mma_integration.go
@@ -15,6 +15,11 @@ import (
 
 // MakeStoreLeaseholderMsgFromState creates a StoreLeaseholderMsg from the
 // state of the simulator.
+//
+// The span config is populated when the replica's mmaSpanConfigIsUpToDate flag
+// is false (new replica, span config changed, or lease was just acquired).
+// The caller is responsible for setting mmaSpanConfigIsUpToDate=true on replicas
+// after successfully sending the message to MMA.
 func MakeStoreLeaseholderMsgFromState(
 	s state.State, storeID state.StoreID,
 ) mmaprototype.StoreLeaseholderMsg {
@@ -76,13 +81,16 @@ func MakeStoreLeaseholderMsgFromState(
 		rl.Load[mmaprototype.CPURate] = mmaprototype.LoadValue(load.RaftCPUNanosPerSecond + load.RequestCPUNanosPerSecond)
 		rl.RaftCPU = mmaprototype.LoadValue(load.RaftCPUNanosPerSecond)
 
-		rangeMessages = append(rangeMessages, mmaprototype.RangeMsg{
+		rangeMsg := mmaprototype.RangeMsg{
 			RangeID:                  roachpb.RangeID(replica.Range()),
-			MaybeSpanConfIsPopulated: true,
+			MaybeSpanConfIsPopulated: !replica.MMASpanConfigIsUpToDate(),
 			Replicas:                 replicas,
-			MaybeSpanConf:            *rng.SpanConfig(),
 			RangeLoad:                rl,
-		})
+		}
+		if rangeMsg.MaybeSpanConfIsPopulated {
+			rangeMsg.MaybeSpanConf = *rng.SpanConfig()
+		}
+		rangeMessages = append(rangeMessages, rangeMsg)
 	}
 
 	return mmaprototype.StoreLeaseholderMsg{

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -293,6 +293,14 @@ type Replica interface {
 	HoldsLease() bool
 	// String returns a string representing the state of the replica.
 	String() string
+	// MMASpanConfigIsUpToDate returns whether the span config for this replica
+	// has been sent to MMA. This is set to false when the span config changes,
+	// when the replica acquires a lease, or when a new replica is created.
+	// It is set to true after the span config is successfully sent to MMA.
+	MMASpanConfigIsUpToDate() bool
+	// SetMMASpanConfigIsUpToDate sets whether the span config for this replica
+	// has been sent to MMA.
+	SetMMASpanConfigIsUpToDate(bool)
 }
 
 // ManualSimClock implements the WallClock interface in the hlc pkg. This clock


### PR DESCRIPTION
Previously, the StoreLeaseholderMsg MaybeSpanConf was always populated in asim, but in the real MMA system this field is only populated when the span config has a possible change, such as when there is a new leaseholder for the range, or if there is a new replica. This meant that asim didn't adequately test codepaths where the span config was not populated. Now, the span config is only populated in asim when there was a probable change. This is done by adding a mmaSpanConfigIsUpToDate to the asim `replica` struct, similar to the mmaSpanConfigIsUpToDate field on the `Replica` type.

Epic: CRDB-55052
Fixes: #158674
Release note: none