### PR TITLE
release-26.1: kvserver: default kv.range_split.load_sample_reset_duration to 30m

### DIFF
--- a/pkg/kv/kvserver/replica_split_load.go
+++ b/pkg/kv/kvserver/replica_split_load.go
@@ -74,7 +74,7 @@ var SplitSampleResetDuration = settings.RegisterDurationSetting(
 	"the duration after which the load based split sampler will reset its state, "+
 		"regardless of any split suggestions made, when zero, the sampler will "+
 		"never reset",
-	0, /* disabled */
+	30*time.Minute, // a multiple of the default scan interval of 10m
 	settings.DurationWithMinimumOrZeroDisable(10*time.Second),
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #159499 on behalf of @tbg.

----

See #144407 - the split reservoir can sometimes contain "old state" when the load based splitter is persistently engaged. When the splitter can make a split, it typically is ready to do so in a minute or two, though the range also needs to be picked up by the replica scanner, which is only guaranteed to come around every ~10 minutes. So resetting it every "tens of minutes" is not disruptive but can help ranges getting stuck in a state where they deserve a split but will not perform one.

Epic: none

Release note (ops change): the kv.range_split.load_sample_reset_duration now defaults to 30m. This should improve load-based splitting in rare edge cases.

----

Release justification: improved cluster setting default to reduce escalations due to some limitations of load based splits