### PR TITLE
serverutils: prioritize COCKROACH_TEST_DRPC over package level override

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -636,15 +636,15 @@ func ShouldEnableDRPC(
 	var logSuffix string
 
 	if option == base.TestDRPCUnset {
-		if globalDefaultDRPCOptionOverride.isSet {
+		if envOption := parseDefaultTestDRPCOptionFromEnv(); envOption != base.TestDRPCUnset {
+			option = envOption
+			logSuffix = " (via COCKROACH_TEST_DRPC environment variable)"
+		} else if globalDefaultDRPCOptionOverride.isSet {
 			option = globalDefaultDRPCOptionOverride.value
 			logSuffix = " (via override by TestingGlobalDRPCOption)"
 		} else if factoryDefaultDRPC != nil {
 			option = *factoryDefaultDRPC
 			logSuffix = " (via testserver factory defaults)"
-		} else if envOption := parseDefaultTestDRPCOptionFromEnv(); envOption != base.TestDRPCUnset {
-			option = envOption
-			logSuffix = " (via COCKROACH_TEST_DRPC environment variable)"
 		} else {
 			return base.TestDRPCUnset
 		}


### PR DESCRIPTION
One important use of this environment variable is to stress a test with DRPC enabled vs DRPC disabled. If this is at a lower priority than the test package then we can't use it for that purpose.

Epic: none
Release note: None