### PR TITLE
kvserver: use StateEngine for eval batches

### DIFF
--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -765,7 +765,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 // OpLogger is attached to the returned engine.Batch, recording all operations.
 // Its recording should be attached to the Result of request evaluation.
 func (r *Replica) newBatchedEngine(g *concurrency.Guard) (storage.Batch, *storage.OpLoggerBatch) {
-	batch := r.store.TODOEngine().NewBatch()
+	batch := r.store.StateEngine().NewBatch()
 	if !batch.ConsistentIterators() {
 		// This is not currently needed for correctness, but future optimizations
 		// may start relying on this, so we assert here.


### PR DESCRIPTION
Currently, eval batches are using the TODO engine because there are a couple of cases where they currently touch LogEngine spans. However, those places are currently explicitly using DisableForbiddenSpanAssertions() to disable the assertions.

This commit changes the TODO engine to the State engine, and will open the door to adding engine assertions (both for State and Log) engines.

References: #97627

References: #158281

Release note: None