### PR TITLE
release-26.1: workload/schemachanger: deflake create unique index

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1157,6 +1157,11 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 		stmt.potentialExecErrors.addAll(codesWithConditions{
 			{code: pgcode.UniqueViolation, condition: !uniqueViolationWillNotOccur},
 		})
+		// We can still hit an error on commit if data is inserted that
+		// violates the unique constraint.
+		og.potentialCommitErrors.addAll(codesWithConditions{
+			{code: pgcode.UniqueViolation, condition: def.Unique},
+		})
 	}
 
 	stmt.sql = tree.AsString(def)


### PR DESCRIPTION
Backport 1/1 commits from #159607 on behalf of @fqazi.

----

Previously, the CREATE UNIQUE INDEX operation could fail because an INSERT could arrive after our scan of the table. This would cause a failure to happen later during the commit / validation phase of the query. To address this, this patch adds unique violation as a potential error.

Fixes: #158253

Release note: None

----

Release justification: