### PR TITLE
release-25.4: unsafesql: fix failure modes detected in the logictests

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -961,7 +961,7 @@ func (p *planner) objectIsUnsafe(ctx context.Context, privilegeObject privilege.
 		return false
 	}
 
-	// All system descriptors are considered unsafe.
+	// All system descriptors are considered unsafe
 	if catalog.IsSystemDescriptor(d) {
 		return true
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4491,6 +4491,13 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 `,
 	resultColumns: colinfo.RangesNoLeases,
 	generator: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, _ *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+		// We have to disable the unsafe check on execution, because for this table
+		// we may have gotten to it through delegate execution, eg. SHOW RANGES.
+		// Accessing it will still fail if queried directly during planning, eg
+		// `SELECT * FROM crdb_internal.ranges_no_leases`, so it's safe to unblock
+		// here.
+		defer p.DisableUnsafeInternalsCheck()()
+
 		hasAdmin, err := p.HasAdminRole(ctx)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -721,6 +721,13 @@ func (b *Builder) checkPrivilege(name opt.MDDepName, ds cat.DataSource, priv pri
 	// Add dependency on this object to the metadata, so that the metadata can be
 	// cached and later checked for freshness.
 	b.factory.Metadata().AddDependency(name, ds, priv)
+
+	// If we're building within a builtin context (unsafe checks disabled),
+	// mark this dependency as coming from a builtin so it can bypass unsafe
+	// checks during memo staleness checking.
+	if b.skipUnsafeInternalsCheck {
+		b.factory.Metadata().AddDependency(name, ds, privilege.BUILTIN_UNSAFE_ALLOWED)
+	}
 }
 
 // resolveNumericColumnRefs converts a list of tree.ColumnIDs from a

--- a/pkg/sql/privilege/kind.go
+++ b/pkg/sql/privilege/kind.go
@@ -66,7 +66,11 @@ const (
 	REPLICATIONDEST          Kind = 39
 	REPLICATIONSOURCE        Kind = 40
 	INSPECT                  Kind = 41
-	largestKind                   = INSPECT
+	// BUILTIN_UNSAFE_ALLOWED is a special pseudo-privilege that marks a dependency
+	// as coming from a SQL-bodied builtin function. This allows the dependency to
+	// bypass unsafe internal checks during memo staleness checking.
+	BUILTIN_UNSAFE_ALLOWED Kind = 42
+	largestKind                 = BUILTIN_UNSAFE_ALLOWED
 )
 
 var isDeprecatedKind = map[Kind]bool{
@@ -162,6 +166,8 @@ func (k Kind) InternalKey() KindInternalKey {
 		return "REPLICATIONSOURCE"
 	case INSPECT:
 		return "INSPECT"
+	case BUILTIN_UNSAFE_ALLOWED:
+		return "BUILTIN_UNSAFE_ALLOWED"
 	default:
 		panic(errors.AssertionFailedf("unhandled kind: %d", int(k)))
 	}


### PR DESCRIPTION
There were several failures in the logictests which flushed out a variety of indirect accesses to the unsafe internals. These had been patched up on the master branch, but these changes hadn't made it down to the 25.4 release. This PR cherry-picks the changes from that commit, excluding the additional whitelisting, and override mechanics required to get those test to pass in the case of direct acceses.

Fixes: #159717
Epic: CRDB-55276
Release note: none

Release justification: Prevents unexpected query failures from testing the new allow_unsafe_internals variable.