### PR TITLE
cloud: add support for listing after a key

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -1889,9 +1889,12 @@ func (b *backupResumer) deleteCheckpoint(
 		defer exportStore.Close()
 		// Delete will not delete a nonempty directory, so we have to go through
 		// all files and delete each file one by one.
-		return exportStore.List(ctx, backupinfo.BackupProgressDirectory, "", func(p string) error {
-			return exportStore.Delete(ctx, backupinfo.BackupProgressDirectory+p)
-		})
+		return exportStore.List(
+			ctx, backupinfo.BackupProgressDirectory, cloud.ListOptions{},
+			func(p string) error {
+				return exportStore.Delete(ctx, backupinfo.BackupProgressDirectory+p)
+			},
+		)
 	}(); err != nil {
 		log.Dev.Warningf(ctx, "unable to delete checkpointed backup descriptor file in progress directory: %+v", err)
 	}

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -9957,16 +9957,18 @@ func TestBackupNoOverwriteCheckpoint(t *testing.T) {
 	r.Close(ctx)
 
 	var actualNumCheckpointsWritten int
-	require.NoError(t, store.List(ctx, latestFilePath+"/progress/", "", func(f string) error {
-		// Don't double count checkpoints as there will be the manifest and
-		// the checksum.
-		if !strings.HasSuffix(f, backupinfo.BackupManifestChecksumSuffix) {
-			if strings.HasPrefix(f, backupinfo.BackupManifestCheckpointName) {
-				actualNumCheckpointsWritten++
+	require.NoError(t, store.List(
+		ctx, latestFilePath+"/progress/", cloud.ListOptions{},
+		func(f string) error {
+			// Don't double count checkpoints as there will be the manifest and
+			// the checksum.
+			if !strings.HasSuffix(f, backupinfo.BackupManifestChecksumSuffix) {
+				if strings.HasPrefix(f, backupinfo.BackupManifestCheckpointName) {
+					actualNumCheckpointsWritten++
+				}
 			}
-		}
-		return nil
-	}))
+			return nil
+		}))
 
 	// numCheckpointWritten only accounts for checkpoints written in the
 	// progress loop, each time we Resume we write another checkpoint.
@@ -10091,7 +10093,7 @@ func TestBackupTimestampedCheckpointsAreLexicographical(t *testing.T) {
 			}
 			require.NoError(t, err)
 			var actual string
-			err = store.List(ctx, "/progress/", "", func(f string) error {
+			err = store.List(ctx, "/progress/", cloud.ListOptions{}, func(f string) error {
 				actual = f
 				return cloud.ErrListingDone
 			})
@@ -10122,13 +10124,15 @@ func TestBackupNoOverwriteLatest(t *testing.T) {
 	findNumLatestFiles := func() (int, string) {
 		var numLatestFiles int
 		var latestFile string
-		err = store.List(ctx, backupbase.LatestHistoryDirectory, "", func(p string) error {
-			if numLatestFiles == 0 {
-				latestFile = p
-			}
-			numLatestFiles++
-			return nil
-		})
+		err = store.List(
+			ctx, backupbase.LatestHistoryDirectory, cloud.ListOptions{},
+			func(p string) error {
+				if numLatestFiles == 0 {
+					latestFile = p
+				}
+				numLatestFiles++
+				return nil
+			})
 		require.NoError(t, err)
 		return numLatestFiles, latestFile
 	}

--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -303,18 +303,21 @@ func FindLatestFile(
 	// empty object with a trailing '/'. The latter is never created by our code
 	// but can be created by other tools, e.g., AWS DataSync to transfer an existing backup to
 	// another bucket. (See https://github.com/cockroachdb/cockroach/issues/106070.)
-	err := exportStore.List(ctx, backupbase.LatestHistoryDirectory, "", func(p string) error {
-		p = strings.TrimPrefix(p, "/")
-		if p == "" {
-			// N.B. skip the empty object with a trailing '/', created by a third-party tool.
-			return nil
-		}
-		latestFile = p
-		latestFileFound = true
-		// We only want the first latest file so return an error that it is
-		// done listing.
-		return cloud.ErrListingDone
-	})
+	err := exportStore.List(
+		ctx, backupbase.LatestHistoryDirectory, cloud.ListOptions{},
+		func(p string) error {
+			p = strings.TrimPrefix(p, "/")
+			if p == "" {
+				// N.B. skip the empty object with a trailing '/', created by a third-party tool.
+				return nil
+			}
+			latestFile = p
+			latestFileFound = true
+			// We only want the first latest file so return an error that it is
+			// done listing.
+			return cloud.ErrListingDone
+		},
+	)
 	// If the list failed because the storage used does not support listing,
 	// such as http, we can try reading the non-timestamped backup latest
 	// file directly. This can still fail if it is a mixed cluster and the
@@ -478,12 +481,15 @@ func ListFullBackupsInCollection(
 	ctx context.Context, store cloud.ExternalStorage,
 ) ([]string, error) {
 	var backupPaths []string
-	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(f string) error {
-		if deprecatedBackupPathRE.MatchString(f) {
-			backupPaths = append(backupPaths, f)
-		}
-		return nil
-	}); err != nil {
+	if err := store.List(
+		ctx, "", cloud.ListOptions{Delimiter: backupbase.ListingDelimDataSlash},
+		func(f string) error {
+			if deprecatedBackupPathRE.MatchString(f) {
+				backupPaths = append(backupPaths, f)
+			}
+			return nil
+		},
+	); err != nil {
 		// Can't happen, just required to handle the error for lint.
 		return nil, err
 	}

--- a/pkg/backup/backupencryption/encryption.go
+++ b/pkg/backup/backupencryption/encryption.go
@@ -479,15 +479,18 @@ func GetEncryptionInfoFiles(ctx context.Context, dest cloud.ExternalStorage) ([]
 	var files []string
 	// Look for all files in dest that start with "/ENCRYPTION-INFO"
 	// and return them.
-	err := dest.List(ctx, "", backupbase.ListingDelimDataSlash, func(p string) error {
-		paths := strings.Split(p, "/")
-		p = paths[len(paths)-1]
-		if match := strings.HasPrefix(p, backupEncryptionInfoFile); match {
-			files = append(files, p)
-		}
+	err := dest.List(
+		ctx, "", cloud.ListOptions{Delimiter: backupbase.ListingDelimDataSlash},
+		func(p string) error {
+			paths := strings.Split(p, "/")
+			p = paths[len(paths)-1]
+			if match := strings.HasPrefix(p, backupEncryptionInfoFile); match {
+				files = append(files, p)
+			}
 
-		return nil
-	})
+			return nil
+		},
+	)
 	if len(files) < 1 {
 		return nil, errors.New("no ENCRYPTION-INFO files found")
 	}

--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -138,7 +138,7 @@ func IndexExists(ctx context.Context, store cloud.ExternalStorage, subdir string
 	if err := store.List(
 		ctx,
 		indexDir,
-		"/",
+		cloud.ListOptions{Delimiter: "/"},
 		func(file string) error {
 			indexExists = true
 			// Because we delimit on `/` and the index subdir does not contain a
@@ -176,7 +176,7 @@ func ListIndexes(
 	if err := store.List(
 		ctx,
 		indexDir+"/",
-		"",
+		cloud.ListOptions{},
 		func(file string) error {
 			// We assert that if a file ends with .pb in the index, it should be a
 			// parsable index file. Otherwise, we ignore it. This circumvents any temp

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -997,7 +997,9 @@ func (n *mockSinkStorage) Writer(_ context.Context, _ string) (io.WriteCloser, e
 	return n.writer(), nil
 }
 
-func (n *mockSinkStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+func (n *mockSinkStorage) List(
+	_ context.Context, _ string, _ cloud.ListOptions, _ cloud.ListingFn,
+) error {
 	return nil
 }
 

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -694,7 +694,7 @@ func listDir(
 	if log.V(1) {
 		log.Dev.Infof(ctx, "Listing %s", dir)
 	}
-	return es.List(ctx, dir, "/", lsFn)
+	return es.List(ctx, dir, cloud.ListOptions{Delimiter: "/"}, lsFn)
 }
 
 // ListFixtures returns the object paths to all fixtures stored in a FixtureConfig.

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -248,7 +248,7 @@ func runUserFileGet(cmd *cobra.Command, args []string) (resErr error) {
 	defer f.Close()
 
 	var files []string
-	if err := f.List(ctx, "", "", func(s string) error {
+	if err := f.List(ctx, "", cloud.ListOptions{}, func(s string) error {
 		if pattern != "" {
 			if ok, err := path.Match(pattern, s); err != nil || !ok {
 				return err
@@ -442,7 +442,7 @@ func listUserFile(ctx context.Context, conn clisqlclient.Conn, glob string) ([]s
 
 	displayPrefix := strings.TrimPrefix(conf.Path, "/")
 	var res []string
-	if err := f.List(ctx, "", "", func(s string) error {
+	if err := f.List(ctx, "", cloud.ListOptions{}, func(s string) error {
 		if pattern != "" {
 			ok, err := path.Match(pattern, s)
 			if err != nil || !ok {
@@ -519,7 +519,7 @@ func deleteUserFile(ctx context.Context, conn clisqlclient.Conn, glob string) ([
 	displayRoot := strings.TrimPrefix(userFileTableConf.FileTableConfig.Path, "/")
 	var deleted []string
 
-	if err := f.List(ctx, "", "", func(s string) error {
+	if err := f.List(ctx, "", cloud.ListOptions{}, func(s string) error {
 		if pattern != "" {
 			ok, err := path.Match(pattern, s)
 			if err != nil || !ok {

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -950,6 +950,7 @@ func (s *s3Storage) List(
 
 	dest := cloud.JoinPathPreservingTrailingSlash(s.prefix, prefix)
 	sp.SetTag("path", attribute.StringValue(dest))
+	afterKey := opts.CanonicalAfterKey(s.prefix)
 
 	client, err := s.getClient(ctx)
 	if err != nil {
@@ -962,9 +963,18 @@ func (s *s3Storage) List(
 	// s3 clones which return s3://<prefix>/ as the first result of listing
 	// s3://<prefix> to exclude that result.
 	if envutil.EnvOrDefaultBool("COCKROACH_S3_LIST_WITH_PREFIX_SLASH_MARKER", false) {
-		s3Input = &s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(opts.Delimiter), StartAfter: aws.String(dest + "/")}
+		s3Input = &s3.ListObjectsV2Input{
+			Bucket:     s.bucket,
+			Prefix:     aws.String(dest),
+			Delimiter:  nilIfEmpty(opts.Delimiter),
+			StartAfter: aws.String(dest + "/"),
+		}
 	} else {
-		s3Input = &s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(opts.Delimiter)}
+		s3Input = &s3.ListObjectsV2Input{
+			Bucket:    s.bucket,
+			Prefix:    aws.String(dest),
+			Delimiter: nilIfEmpty(opts.Delimiter),
+		}
 	}
 
 	paginator := s3.NewListObjectsV2Paginator(client, s3Input)
@@ -982,12 +992,18 @@ func (s *s3Storage) List(
 		}
 
 		for _, x := range page.CommonPrefixes {
+			if *x.Prefix <= afterKey {
+				continue
+			}
 			if err := fn(strings.TrimPrefix(*x.Prefix, dest)); err != nil {
 				return err
 			}
 		}
 
 		for _, fileObject := range page.Contents {
+			if *fileObject.Key <= afterKey {
+				continue
+			}
 			if err := fn(strings.TrimPrefix(*fileObject.Key, dest)); err != nil {
 				return err
 			}

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -942,7 +942,9 @@ func (s *s3Storage) ReadFile(
 		cloud.ResumingReaderRetryOnErrFnForSettings(ctx, s.settings), s3ErrDelay), fileSize, nil
 }
 
-func (s *s3Storage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+func (s *s3Storage) List(
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
+) error {
 	ctx, sp := tracing.ChildSpan(ctx, "s3.List")
 	defer sp.Finish()
 
@@ -960,9 +962,9 @@ func (s *s3Storage) List(ctx context.Context, prefix, delim string, fn cloud.Lis
 	// s3 clones which return s3://<prefix>/ as the first result of listing
 	// s3://<prefix> to exclude that result.
 	if envutil.EnvOrDefaultBool("COCKROACH_S3_LIST_WITH_PREFIX_SLASH_MARKER", false) {
-		s3Input = &s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(delim), StartAfter: aws.String(dest + "/")}
+		s3Input = &s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(opts.Delimiter), StartAfter: aws.String(dest + "/")}
 	} else {
-		s3Input = &s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(delim)}
+		s3Input = &s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(dest), Delimiter: nilIfEmpty(opts.Delimiter)}
 	}
 
 	paginator := s3.NewListObjectsV2Paginator(client, s3Input)

--- a/pkg/cloud/azure/azure_file_credentials_test.go
+++ b/pkg/cloud/azure/azure_file_credentials_test.go
@@ -204,7 +204,7 @@ func TestAzureFileCredential(t *testing.T) {
 
 			// Despite an error being produced, reloading the file will still
 			// yield a valid token for storage access.
-			require.NoError(t, s.List(ctx, "/", "", func(f string) error {
+			require.NoError(t, s.List(ctx, "/", cloud.ListOptions{}, func(f string) error {
 				return nil
 			}))
 		})
@@ -223,7 +223,7 @@ func TestAzureFileCredential(t *testing.T) {
 			// are loaded.
 			require.NoError(t, writeAzureCredentialsFile(credFile, cfg.tenantID, cfg.clientID, cfg.clientSecret+"garbage"))
 
-			err := s.List(ctx, "/", "", func(f string) error {
+			err := s.List(ctx, "/", cloud.ListOptions{}, func(f string) error {
 				return nil
 			})
 			require.ErrorContains(t, err, "authentication failed")

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -464,14 +464,16 @@ func (s *azureStorage) ReadFile(
 	return r, r.Size, nil
 }
 
-func (s *azureStorage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+func (s *azureStorage) List(
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
+) error {
 	ctx, sp := tracing.ChildSpan(ctx, "azure.List")
 	defer sp.Finish()
 
 	dest := cloud.JoinPathPreservingTrailingSlash(s.prefix, prefix)
 	sp.SetTag("path", attribute.StringValue(dest))
 
-	pager := s.container.NewListBlobsHierarchyPager(delim, &container.ListBlobsHierarchyOptions{Prefix: &dest})
+	pager := s.container.NewListBlobsHierarchyPager(opts.Delimiter, &container.ListBlobsHierarchyOptions{Prefix: &dest})
 	for pager.More() {
 		response, err := pager.NextPage(ctx)
 

--- a/pkg/cloud/cloudtestutils/cloud_nemesis.go
+++ b/pkg/cloud/cloudtestutils/cloud_nemesis.go
@@ -249,7 +249,7 @@ func (c *cloudNemesis) listObjects(ctx context.Context) (err error) {
 	before := c.snapshotObjects()
 
 	listedFiles := map[string]bool{}
-	err = c.storage.List(ctx, "", "", func(filename string) error {
+	err = c.storage.List(ctx, "", cloud.ListOptions{}, func(filename string) error {
 		listedFiles[strings.TrimPrefix(filename, "/")] = true
 		return nil
 	})

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -473,7 +473,7 @@ func CheckListFilesCanonical(t *testing.T, info StoreInfo, canonical string) {
 			t.Run(tc.name, func(t *testing.T) {
 				s := storeFromURI(ctx, t, tc.uri, clientFactory, info.User, info.DB, testSettings)
 				var actual []string
-				require.NoError(t, s.List(ctx, tc.prefix, tc.delimiter, func(f string) error {
+				require.NoError(t, s.List(ctx, tc.prefix, cloud.ListOptions{Delimiter: tc.delimiter}, func(f string) error {
 					actual = append(actual, f)
 					return nil
 				}))
@@ -584,7 +584,7 @@ func CheckNoPermission(t *testing.T, info StoreInfo) {
 	}
 	defer s.Close()
 
-	err = s.List(ctx, "", "", nil)
+	err = s.List(ctx, "", cloud.ListOptions{}, nil)
 	if err == nil {
 		t.Fatalf("expected error when listing %s with no permissions", info.URI)
 	}

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -399,81 +399,133 @@ func CheckListFilesCanonical(t *testing.T, info StoreInfo, canonical string) {
 	}
 
 	t.Run("List", func(t *testing.T) {
+		// NB: When using AfterKey in tests, pick keys such that they do not exist
+		// in the expected output to avoid tests flaking due to different cloud
+		// provider behaviors around AfterKey's inclusiveness.
 		for _, tc := range []struct {
-			name      string
-			uri       string
-			prefix    string
-			delimiter string
-			expected  []string
+			name     string
+			uri      string
+			prefix   string
+			opts     cloud.ListOptions
+			expected []string
 		}{
 			{
 				"root",
 				info.URI,
 				"",
-				"",
+				cloud.ListOptions{},
 				foreach(fileNames, func(s string) string { return "/" + s }),
 			},
 			{
 				"file-slash-numbers-slash",
 				info.URI,
 				"file/numbers/",
-				"",
+				cloud.ListOptions{},
 				[]string{"data1.csv", "data2.csv", "data3.csv"},
 			},
 			{
 				"root-slash",
 				info.URI,
 				"/",
-				"",
+				cloud.ListOptions{},
 				foreach(fileNames, func(s string) string { return s }),
 			},
 			{
 				"file",
 				info.URI,
 				"file",
-				"",
+				cloud.ListOptions{},
 				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file") }),
 			},
 			{
 				"file-slash",
 				info.URI,
 				"file/",
-				"",
+				cloud.ListOptions{},
 				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "file/") }),
 			},
 			{
 				"slash-f",
 				info.URI,
 				"/f",
-				"",
+				cloud.ListOptions{},
 				foreach(fileNames, func(s string) string { return strings.TrimPrefix(s, "f") }),
 			},
 			{
 				"nothing",
 				info.URI,
 				"nothing",
-				"",
+				cloud.ListOptions{},
 				nil,
 			},
 			{
 				"delim-slash-file-slash",
 				info.URI,
 				"file/",
-				"/",
+				cloud.ListOptions{Delimiter: "/"},
 				[]string{"abc/", "letters/", "numbers/"},
 			},
 			{
 				"delim-data",
 				info.URI,
 				"",
-				"data",
+				cloud.ListOptions{Delimiter: "data"},
 				[]string{"/file/abc/A.csv", "/file/abc/B.csv", "/file/abc/C.csv", "/file/letters/data", "/file/numbers/data"},
+			},
+			{
+				"afterkey-no-prefix",
+				info.URI,
+				"",
+				cloud.ListOptions{AfterKey: "file/letters/dataB"},
+				[]string{"/file/letters/dataB.csv", "/file/letters/dataC.csv", "/file/numbers/data1.csv", "/file/numbers/data2.csv", "/file/numbers/data3.csv"},
+			},
+			{
+				"afterkey-with-prefix",
+				info.URI,
+				"file/letters/",
+				cloud.ListOptions{AfterKey: "file/letters/dataB"},
+				[]string{"dataB.csv", "dataC.csv"},
+			},
+			{
+				"afterkey-before-prefix",
+				info.URI,
+				"file/numbers/",
+				cloud.ListOptions{AfterKey: "file/abc/D"},
+				[]string{"data1.csv", "data2.csv", "data3.csv"},
+			},
+			{
+				"afterkey-after-prefix",
+				info.URI,
+				"file/abc/",
+				cloud.ListOptions{AfterKey: "file/z"},
+				nil,
+			},
+			{
+				"afterkey-excluded-from-results",
+				info.URI,
+				"file/abc/",
+				cloud.ListOptions{AfterKey: "file/abc/B.csv"},
+				[]string{"C.csv"},
+			},
+			{
+				"afterkey-with-delim",
+				info.URI,
+				"file/",
+				cloud.ListOptions{Delimiter: "/", AfterKey: "file/bar"},
+				[]string{"letters/", "numbers/"},
+			},
+			{
+				"afterkey-applied-after-delim-grouping",
+				info.URI,
+				"file/",
+				cloud.ListOptions{Delimiter: "/", AfterKey: "file/abc/B"},
+				[]string{"letters/", "numbers/"},
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				s := storeFromURI(ctx, t, tc.uri, clientFactory, info.User, info.DB, testSettings)
 				var actual []string
-				require.NoError(t, s.List(ctx, tc.prefix, cloud.ListOptions{Delimiter: tc.delimiter}, func(f string) error {
+				require.NoError(t, s.List(ctx, tc.prefix, tc.opts, func(f string) error {
 					actual = append(actual, f)
 					return nil
 				}))

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -77,11 +77,9 @@ type ExternalStorage interface {
 	// List enumerates files within the supplied prefix, calling the passed
 	// function with the name of each file found, relative to the external storage
 	// destination's configured prefix. If the passed function returns a non-nil
-	// error, iteration is stopped it is returned. If delimiter is non-empty
-	// names which have the same prefix, prior to the delimiter, are grouped
-	// into a single result which is that prefix. The order that results are
+	// error, iteration is stopped, and it is returned. The order that results are
 	// passed to the callback is undefined.
-	List(ctx context.Context, prefix, delimiter string, fn ListingFn) error
+	List(ctx context.Context, prefix string, opts ListOptions, fn ListingFn) error
 
 	// Delete removes the named file from the store. If the file does not exist,
 	// Delete returns nil.
@@ -89,6 +87,12 @@ type ExternalStorage interface {
 
 	// Size returns the length of the named file in bytes.
 	Size(ctx context.Context, basename string) (int64, error)
+}
+
+type ListOptions struct {
+	// If a Delimiter is set, names which have the same prefix, prior to the
+	// Delimiter, are grouped into a single result which is that prefix.
+	Delimiter string
 }
 
 type ReadOptions struct {

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -93,6 +93,39 @@ type ListOptions struct {
 	// If a Delimiter is set, names which have the same prefix, prior to the
 	// Delimiter, are grouped into a single result which is that prefix.
 	Delimiter string
+
+	// When AfterKey is set, listing will only return results whose names are
+	// strictly lexicographically greater than AfterKey. AfterKey must be a full
+	// key relative to the external storage's base prefix. If a Delimiter is set,
+	// AfterKey filtering is applied after grouping.
+	//
+	// Example:
+	// ExternalStorage rooted at "gs://my-bucket/base/prefix/".
+	// To filter all results after "base/prefix/dir5", AfterKey should be set to
+	// "dir5".
+	//
+	// NB: Due to the fact that Azure does not support AfterKey semantics in
+	// its list API, we decided to handle all AfterKey filtering client-side
+	// across all external storage implementations. This gives us relatively
+	// comparable performance behaviors across all cloud providers, reducing our
+	// blind spots when it comes to testing and benchmarking.
+	//
+	// NB: If at some point Azure does add support for AfterKey, note that Cloud
+	// providers have different semantics for how AfterKey is applied
+	// (inclusive/exclusive, before/after delimiter grouping). This should be
+	// standardized across all implementations at that time.
+	AfterKey string
+}
+
+// CanonicalAfterKey returns the canonicalized AfterKey, given an external
+// storage base prefix. All cloud providers expect a full key to be provided as
+// an AfterKey, so we join the base prefix of the store and AfterKey here. If no
+// AfterKey is set, an empty string is returned.
+func (o ListOptions) CanonicalAfterKey(prefix string) string {
+	if o.AfterKey == "" {
+		return ""
+	}
+	return JoinPathPreservingTrailingSlash(prefix, o.AfterKey)
 }
 
 type ReadOptions struct {

--- a/pkg/cloud/externalconn/utils/connection_utils.go
+++ b/pkg/cloud/externalconn/utils/connection_utils.go
@@ -48,7 +48,7 @@ func CheckExternalStorageConnection(
 
 	// List the sentinel file.
 	var foundFile bool
-	if err := es.List(ctx, "", "", func(s string) error {
+	if err := es.List(ctx, "", cloud.ListOptions{}, func(s string) error {
 		paths := strings.Split(s, "/")
 		s = paths[len(paths)-1]
 		if match := strings.HasPrefix(s, markerFile); match {

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -339,13 +339,15 @@ func (g *gcsStorage) ReadFile(
 	return r, r.Reader.(*gcs.Reader).Attrs.Size, nil
 }
 
-func (g *gcsStorage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {
+func (g *gcsStorage) List(
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
+) error {
 	dest := cloud.JoinPathPreservingTrailingSlash(g.prefix, prefix)
 	ctx, sp := tracing.ChildSpan(ctx, "gcs.List")
 	defer sp.Finish()
 	sp.SetTag("path", attribute.StringValue(dest))
 
-	it := g.bucket.Objects(ctx, &gcs.Query{Prefix: dest, Delimiter: delim})
+	it := g.bucket.Objects(ctx, &gcs.Query{Prefix: dest, Delimiter: opts.Delimiter})
 	for {
 		attrs, err := it.Next()
 		if errors.Is(err, iterator.Done) {

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -179,7 +179,9 @@ func (h *httpStorage) Writer(ctx context.Context, basename string) (io.WriteClos
 	}), nil
 }
 
-func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+func (h *httpStorage) List(
+	_ context.Context, _ string, _ cloud.ListOptions, _ cloud.ListingFn,
+) error {
 	return errors.Mark(errors.New("http storage does not support listing"), cloud.ErrListingUnsupported)
 }
 

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -414,7 +414,7 @@ func (e *esWrapper) ReadFile(
 	return e.wrapReader(ctx, r), s, nil
 }
 
-func (e *esWrapper) List(ctx context.Context, prefix, delimiter string, fn ListingFn) error {
+func (e *esWrapper) List(ctx context.Context, prefix string, opts ListOptions, fn ListingFn) error {
 	if e.httpTracer != nil {
 		ctx = httptrace.WithClientTrace(ctx, e.httpTracer)
 	}
@@ -427,7 +427,7 @@ func (e *esWrapper) List(ctx context.Context, prefix, delimiter string, fn Listi
 			return fn(s)
 		}
 	}
-	return e.ExternalStorage.List(ctx, prefix, delimiter, countingFn)
+	return e.ExternalStorage.List(ctx, prefix, opts, countingFn)
 }
 
 func (e *esWrapper) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -179,6 +179,7 @@ func (l *localFileStorage) List(
 	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
 ) error {
 	dest := cloud.JoinPathPreservingTrailingSlash(l.base, prefix)
+	afterKey := opts.CanonicalAfterKey(l.base)
 
 	res, err := l.blobClient.List(ctx, dest)
 	if err != nil {
@@ -199,6 +200,12 @@ func (l *localFileStorage) List(
 			}
 			prevPrefix = f
 		}
+
+		// afterKey is a full key so we must compare against the full file key.
+		if dest+f <= afterKey {
+			continue
+		}
+
 		if err := fn(f); err != nil {
 			return err
 		}

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -176,7 +176,7 @@ func (l *localFileStorage) ReadFile(
 }
 
 func (l *localFileStorage) List(
-	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
 ) error {
 	dest := cloud.JoinPathPreservingTrailingSlash(l.base, prefix)
 
@@ -190,9 +190,9 @@ func (l *localFileStorage) List(
 	var prevPrefix string
 	for _, f := range res {
 		f = strings.TrimPrefix(f, dest)
-		if delim != "" {
-			if i := strings.Index(f, delim); i >= 0 {
-				f = f[:i+len(delim)]
+		if opts.Delimiter != "" {
+			if i := strings.Index(f, opts.Delimiter); i >= 0 {
+				f = f[:i+len(opts.Delimiter)]
 			}
 			if f == prevPrefix {
 				continue

--- a/pkg/cloud/nullsink/nullsink_storage.go
+++ b/pkg/cloud/nullsink/nullsink_storage.go
@@ -88,7 +88,9 @@ func (n *nullSinkStorage) Writer(_ context.Context, _ string) (io.WriteCloser, e
 	return nullWriter{}, nil
 }
 
-func (n *nullSinkStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+func (n *nullSinkStorage) List(
+	_ context.Context, _ string, _ cloud.ListOptions, _ cloud.ListingFn,
+) error {
 	return nil
 }
 

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -250,6 +250,7 @@ func (f *fileTableStorage) List(
 	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
 ) error {
 	dest := cloud.JoinPathPreservingTrailingSlash(f.prefix, prefix)
+	afterKey := opts.CanonicalAfterKey(f.prefix)
 
 	res, err := f.fs.ListFiles(ctx, dest)
 	if err != nil {
@@ -269,6 +270,12 @@ func (f *fileTableStorage) List(
 			}
 			prevPrefix = f
 		}
+
+		// afterKey is a full key so we must compare against the full file key.
+		if dest+f <= afterKey {
+			continue
+		}
+
 		if err := fn(f); err != nil {
 			return err
 		}

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -247,7 +247,7 @@ func (f *fileTableStorage) Writer(ctx context.Context, basename string) (io.Writ
 
 // List implements the ExternalStorage interface.
 func (f *fileTableStorage) List(
-	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
 ) error {
 	dest := cloud.JoinPathPreservingTrailingSlash(f.prefix, prefix)
 
@@ -260,9 +260,9 @@ func (f *fileTableStorage) List(
 	var prevPrefix string
 	for _, f := range res {
 		f = strings.TrimPrefix(f, dest)
-		if delim != "" {
-			if i := strings.Index(f, delim); i >= 0 {
-				f = f[:i+len(delim)]
+		if opts.Delimiter != "" {
+			if i := strings.Index(f, opts.Delimiter); i >= 0 {
+				f = f[:i+len(opts.Delimiter)]
 			}
 			if f == prevPrefix {
 				continue

--- a/pkg/cmd/roachtest/tests/cdc_helper.go
+++ b/pkg/cmd/roachtest/tests/cdc_helper.go
@@ -93,7 +93,7 @@ func getRandomIndex(sizeOfSlice int) int {
 func listFilesOfTargetTable(
 	cs cloud.ExternalStorage, selectedTargetTable string,
 ) (csFileNames []string, _ error) {
-	err := cs.List(context.Background(), "", "", func(str string) error {
+	err := cs.List(context.Background(), "", cloud.ListOptions{}, func(str string) error {
 		targetTableName, err := extractTableNameFromFileName(str)
 		if err != nil {
 			return err

--- a/pkg/sql/bulkutil/bulk_job_cleaner_test.go
+++ b/pkg/sql/bulkutil/bulk_job_cleaner_test.go
@@ -46,7 +46,7 @@ func (m *mockStorageWithTracking) Delete(ctx context.Context, basename string) e
 }
 
 func (m *mockStorageWithTracking) List(
-	ctx context.Context, prefix, delimiter string, fn cloud.ListingFn,
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
 ) error {
 	m.listed = append(m.listed, prefix)
 	if m.listError != nil {

--- a/pkg/sql/bulkutil/external_storage_mux.go
+++ b/pkg/sql/bulkutil/external_storage_mux.go
@@ -103,7 +103,7 @@ func (c *ExternalStorageMux) ListFiles(
 	if err != nil {
 		return err
 	}
-	return store.List(ctx, prefix, "" /* delimiter */, fn)
+	return store.List(ctx, prefix, cloud.ListOptions{}, fn)
 }
 
 // splitURI splits a URI into its prefix (scheme + host) and path components.

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -396,7 +396,7 @@ func importPlanHook(
 						return err
 					}
 					var expandedFiles []string
-					if err := s.List(ctx, "", "", func(s string) error {
+					if err := s.List(ctx, "", cloud.ListOptions{}, func(s string) error {
 						ok, err := path.Match(pattern, s)
 						if ok {
 							uri.Path = prefix + s

--- a/pkg/sql/importer/read_import_base_test.go
+++ b/pkg/sql/importer/read_import_base_test.go
@@ -331,7 +331,7 @@ func (m *mockExternalStorage) Writer(ctx context.Context, basename string) (io.W
 	return nil, errors.New("not implemented")
 }
 func (m *mockExternalStorage) List(
-	ctx context.Context, prefix, delimiter string, fn cloud.ListingFn,
+	ctx context.Context, prefix string, opts cloud.ListOptions, fn cloud.ListingFn,
 ) error {
 	return errors.New("not implemented")
 }

--- a/pkg/sql/importer/testutils_test.go
+++ b/pkg/sql/importer/testutils_test.go
@@ -251,7 +251,7 @@ func (es *generatorExternalStorage) Writer(
 }
 
 func (es *generatorExternalStorage) List(
-	ctx context.Context, _, _ string, _ cloud.ListingFn,
+	ctx context.Context, _ string, _ cloud.ListOptions, _ cloud.ListingFn,
 ) error {
 	return errors.New("unsupported")
 }

--- a/pkg/storage/shared_storage.go
+++ b/pkg/storage/shared_storage.go
@@ -140,7 +140,7 @@ func (e *externalStorageWrapper) CreateObject(objName string) (io.WriteCloser, e
 // List implements the remote.Storage interface.
 func (e *externalStorageWrapper) List(prefix, delimiter string) ([]string, error) {
 	var directoryList []string
-	err := e.es.List(e.ctx, prefix, delimiter, func(s string) error {
+	err := e.es.List(e.ctx, prefix, cloud.ListOptions{Delimiter: delimiter}, func(s string) error {
 		directoryList = append(directoryList, s)
 		return nil
 	})


### PR DESCRIPTION
This patch adds an `AfterKey` option in `ExternalStorage.List`. If it is specified, only names that are lexicographically greater than `AfterKey` are returned.

Epic: CRDB-57536

Informs: #159647

Release note: None