### PR TITLE
kvserver: add overlapsStateEngineKeys

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -1142,18 +1142,18 @@ func MakeRangeIDPrefixBuf(rangeID roachpb.RangeID) RangeIDPrefixBuf {
 	return RangeIDPrefixBuf(MakeRangeIDPrefix(rangeID))
 }
 
-func (b RangeIDPrefixBuf) replicatedPrefix() roachpb.Key {
+func (b RangeIDPrefixBuf) ReplicatedPrefix() roachpb.Key {
 	return append(roachpb.Key(b), LocalRangeIDReplicatedInfix...)
 }
 
-func (b RangeIDPrefixBuf) unreplicatedPrefix() roachpb.Key {
+func (b RangeIDPrefixBuf) UnreplicatedPrefix() roachpb.Key {
 	return append(roachpb.Key(b), localRangeIDUnreplicatedInfix...)
 }
 
 // AbortSpanKey returns a range-local key by Range ID for an AbortSpan
 // entry, with detail specified by encoding the supplied transaction ID.
 func (b RangeIDPrefixBuf) AbortSpanKey(txnID uuid.UUID) roachpb.Key {
-	key := append(b.replicatedPrefix(), LocalAbortSpanSuffix...)
+	key := append(b.ReplicatedPrefix(), LocalAbortSpanSuffix...)
 	return encoding.EncodeBytesAscending(key, txnID.GetBytes())
 }
 
@@ -1162,67 +1162,67 @@ func (b RangeIDPrefixBuf) AbortSpanKey(txnID uuid.UUID) roachpb.Key {
 // specific transaction should serialize on latches. The per-transaction bit is
 // achieved by encoding the supplied transaction ID into the key.
 func (b RangeIDPrefixBuf) ReplicatedSharedLocksTransactionLatchingKey(txnID uuid.UUID) roachpb.Key {
-	key := append(b.replicatedPrefix(), LocalReplicatedSharedLocksTransactionLatchingKeySuffix...)
+	key := append(b.ReplicatedPrefix(), LocalReplicatedSharedLocksTransactionLatchingKeySuffix...)
 	return encoding.EncodeBytesAscending(key, txnID.GetBytes())
 }
 
 // RangeAppliedStateKey returns a system-local key for the range applied state key.
 // See comment on RangeAppliedStateKey function.
 func (b RangeIDPrefixBuf) RangeAppliedStateKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeAppliedStateSuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangeAppliedStateSuffix...)
 }
 
 // RangeForceFlushKey returns a system-local key for the range force flush
 // key.
 func (b RangeIDPrefixBuf) RangeForceFlushKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeForceFlushSuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangeForceFlushSuffix...)
 }
 
 // RangeLeaseKey returns a system-local key for a range lease.
 func (b RangeIDPrefixBuf) RangeLeaseKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeLeaseSuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangeLeaseSuffix...)
 }
 
 // RangePriorReadSummaryKey returns a system-local key for a range's prior read
 // summary.
 func (b RangeIDPrefixBuf) RangePriorReadSummaryKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangePriorReadSummarySuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangePriorReadSummarySuffix...)
 }
 
 // RangeGCThresholdKey returns a system-local key for the GC threshold.
 func (b RangeIDPrefixBuf) RangeGCThresholdKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeGCThresholdSuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangeGCThresholdSuffix...)
 }
 
 // RangeGCHintKey returns a range-local key for the GC hint data.
 func (b RangeIDPrefixBuf) RangeGCHintKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeGCHintSuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangeGCHintSuffix...)
 }
 
 // RangeVersionKey returns a system-local key for the range version.
 func (b RangeIDPrefixBuf) RangeVersionKey() roachpb.Key {
-	return append(b.replicatedPrefix(), LocalRangeVersionSuffix...)
+	return append(b.ReplicatedPrefix(), LocalRangeVersionSuffix...)
 }
 
 // RangeTombstoneKey returns a system-local key for a range tombstone.
 func (b RangeIDPrefixBuf) RangeTombstoneKey() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRangeTombstoneSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRangeTombstoneSuffix...)
 }
 
 // RaftTruncatedStateKey returns a system-local key for a RaftTruncatedState.
 func (b RangeIDPrefixBuf) RaftTruncatedStateKey() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRaftTruncatedStateSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRaftTruncatedStateSuffix...)
 }
 
 // RaftHardStateKey returns a system-local key for a Raft HardState.
 func (b RangeIDPrefixBuf) RaftHardStateKey() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRaftHardStateSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRaftHardStateSuffix...)
 }
 
 // RaftLogPrefix returns the system-local prefix shared by all Entries
 // in a Raft log.
 func (b RangeIDPrefixBuf) RaftLogPrefix() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRaftLogSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRaftLogSuffix...)
 }
 
 // RaftLogKey returns a system-local key for a Raft log entry.
@@ -1232,17 +1232,17 @@ func (b RangeIDPrefixBuf) RaftLogKey(logIndex kvpb.RaftIndex) roachpb.Key {
 
 // RaftReplicaIDKey returns a system-local key for a RaftReplicaID.
 func (b RangeIDPrefixBuf) RaftReplicaIDKey() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRaftReplicaIDSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRaftReplicaIDSuffix...)
 }
 
 // RangeLastReplicaGCTimestampKey returns a range-local key for
 // the range's last replica GC timestamp.
 func (b RangeIDPrefixBuf) RangeLastReplicaGCTimestampKey() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRangeLastReplicaGCTimestampSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRangeLastReplicaGCTimestampSuffix...)
 }
 
 // MVCCRangeKeyGCKey returns a range local key protecting range
 // tombstone mvcc stats calculations during range tombstone GC.
 func (b RangeIDPrefixBuf) MVCCRangeKeyGCKey() roachpb.Key {
-	return append(b.unreplicatedPrefix(), LocalRangeMVCCRangeKeyGCLockSuffix...)
+	return append(b.UnreplicatedPrefix(), LocalRangeMVCCRangeKeyGCLockSuffix...)
 }

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -94,7 +94,7 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 	if util.RaceEnabled {
 		spans := g.LatchSpans()
-		spans.AddForbiddenMatcher(overlapsUnreplicatedRangeIDLocalKeys)
+		spans.AddForbiddenMatcher(overlapsLocalRaftKeys)
 		spans.AddForbiddenMatcher(overlapsStoreLocalKeys)
 		rw = spanset.NewReadWriterAt(rw, spans, ba.Timestamp)
 	}

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -94,8 +94,7 @@ func (r *Replica) executeReadOnlyBatch(
 	}
 	if util.RaceEnabled {
 		spans := g.LatchSpans()
-		spans.AddForbiddenMatcher(overlapsLocalRaftKeys)
-		spans.AddForbiddenMatcher(overlapsStoreLocalKeys)
+		spans.AddForbiddenMatcher(validateIsStateEngineSpan)
 		rw = spanset.NewReadWriterAt(rw, spans, ba.Timestamp)
 	}
 	defer rw.Close()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -15202,9 +15202,7 @@ func TestLeaderlessWatcherInit(t *testing.T) {
 	}
 }
 
-// TestOverlapsLocalRaftKeys verifies that the function overlapsLocalRaftKeys()
-// successfully catches any overlap with unreplicated rangeID local raft keys.
-func TestOverlapsLocalRaftKeys(t *testing.T) {
+func TestValidateIsStateEngineSpan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -15215,13 +15213,14 @@ func TestOverlapsLocalRaftKeys(t *testing.T) {
 		span  roachpb.Span
 		notOk bool
 	}{
-		// Full spans not overlapping with unreplicated local RangeID spans.
+		// Full state engine spans.
 		{span: s(roachpb.KeyMin, keys.LocalRangeIDPrefix.AsRawKey())},
 		{span: s(keys.RangeForceFlushKey(1), keys.RangeLeaseKey(1))},
-		{span: s(keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd(), roachpb.KeyMax)},
+		{span: s(keys.LocalStoreMax, roachpb.KeyMax)},
 
-		// Full spans overlapping with unreplicated local RangeID spans.
+		// Full non-state engine spans.
 		{span: s(roachpb.KeyMin, keys.MakeRangeIDUnreplicatedPrefix(1)), notOk: true}, // partial overlap
+		{span: s(roachpb.KeyMin, roachpb.Key(keys.LocalStorePrefix).Next()), notOk: true},
 		{span: s(roachpb.KeyMin, keys.RaftTruncatedStateKey(1)), notOk: true},
 		{span: s(keys.LocalRangeIDPrefix.AsRawKey(), keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd()),
 			notOk: true},
@@ -15232,8 +15231,11 @@ func TestOverlapsLocalRaftKeys(t *testing.T) {
 		{span: s(keys.RangeTombstoneKey(1), keys.RaftTruncatedStateKey(1)), notOk: true},
 		{span: s(keys.RaftReplicaIDKey(1), keys.RaftTruncatedStateKey(1)), notOk: true},
 		{span: s(keys.RaftTruncatedStateKey(1), roachpb.KeyMax), notOk: true},
+		{span: s(keys.LocalStorePrefix, keys.LocalStoreMax), notOk: true},
+		{span: s(keys.StoreGossipKey(), keys.StoreIdentKey()), notOk: true},
+		{span: s(keys.LocalStoreMax.Prevish(1), roachpb.KeyMax), notOk: true},
 
-		// Point spans not overlapping with unreplicated local RangeID spans.
+		// Point state engine spans.
 		{span: s(roachpb.KeyMin, nil)},
 		{span: s(keys.LocalRangeIDPrefix.AsRawKey().Prevish(1), nil)},
 		{span: s(keys.RangeForceFlushKey(1), nil)},
@@ -15242,90 +15244,110 @@ func TestOverlapsLocalRaftKeys(t *testing.T) {
 		{span: s(keys.RaftReplicaIDKey(1), nil)},
 		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd(), nil)},
 		{span: s(keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd(), nil)},
+		{span: s(roachpb.Key(keys.LocalStorePrefix).Prevish(1), nil)},
+		{span: s(keys.LocalStoreMax, nil)},
+		{span: s(keys.LocalStoreMax.Next(), nil)},
 		{span: s(roachpb.KeyMax, nil)},
 
-		// Point spans overlapping with unreplicated local RangeID spans.
+		// Point non-state engine spans.
 		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1), nil), notOk: true},
 		{span: s(keys.RaftTruncatedStateKey(1), nil), notOk: true},
 		{span: s(keys.RaftTruncatedStateKey(2), nil), notOk: true},
 		{span: s(keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd().Prevish(1), nil), notOk: true},
+		{span: s(keys.LocalStorePrefix, nil), notOk: true},
+		{span: s(keys.StoreGossipKey(), nil), notOk: true},
+		{span: s(keys.LocalStoreMax.Prevish(1), nil), notOk: true},
 
-		// Tricky spans not overlapping with unreplicated local RangeID spans.
+		// Tricky state engine spans.
 		{span: s(nil, keys.LocalRangeIDPrefix.AsRawKey())},
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1))},
 		{span: s(nil, keys.RangeForceFlushKey(1))},
-		{span: s(nil, keys.RangeTombstoneKey(1).Next())},
-		{span: s(nil, keys.RaftReplicaIDKey(1).Next())},
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd().Next())},
 		{span: s(nil, keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd().Next())},
+		{span: s(nil, keys.LocalStorePrefix)},
+		{span: s(nil, keys.LocalStoreMax.Next())},
 
-		// Tricky spans overlapping with unreplicated local RangeID spans.
+		// Tricky non-state engine spans.
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).Next()), notOk: true},
 		{span: s(nil, keys.RaftTruncatedStateKey(1).Next()), notOk: true},
 		{span: s(nil, keys.RaftTruncatedStateKey(2).Next()), notOk: true},
 		{span: s(nil, keys.MakeRangeIDUnreplicatedPrefix(1).PrefixEnd()), notOk: true},
 		{span: s(nil, keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd()), notOk: true}, // can't decode RangeID.
+		{span: s(nil, roachpb.Key(keys.LocalStorePrefix).Next()), notOk: true},
+		{span: s(nil, keys.StoreGossipKey()), notOk: true},
+		{span: s(nil, keys.LocalStoreMax), notOk: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			err := overlapsLocalRaftKeys(spanset.TrickySpan(tc.span))
+			err := validateIsStateEngineSpan(spanset.TrickySpan(tc.span))
 			require.Equal(t, tc.notOk, err != nil, tc.span)
 		})
 	}
 }
 
-// TestOverlapsStoreLocalKeys verifies that the function
-// overlapsStoreLocalKeys() successfully catches any overlap with
-// store local keys.
-func TestOverlapsStoreLocalKeys(t *testing.T) {
+func TestValidateIsRaftEngineSpan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	s := func(start, end roachpb.Key) roachpb.Span {
 		return roachpb.Span{Key: start, EndKey: end}
 	}
-
 	testCases := []struct {
 		span  roachpb.Span
-		notOK bool
+		notOk bool
 	}{
-		// Full spans not overlapping with Store-local span.
-		{span: s(roachpb.KeyMin, keys.LocalStorePrefix)},
-		{span: s(keys.LocalStoreMax, roachpb.KeyMax)},
+		// Full spans not overlapping with state engine spans.
+		{span: s(keys.RangeTombstoneKey(1).Next(), keys.RaftReplicaIDKey(1))},
+		{span: s(keys.RaftReplicaIDKey(1).Next(), keys.RangeLastReplicaGCTimestampKey(1).Next())},
+		{span: s(keys.LocalStorePrefix, keys.LocalStoreMax)},
 
-		// Full spans overlapping with Store-local span.
-		{span: s(roachpb.KeyMin, roachpb.Key(keys.LocalStorePrefix).Next()), notOK: true},
-		{span: s(keys.LocalStorePrefix, keys.LocalStoreMax), notOK: true},
-		{span: s(keys.StoreGossipKey(), keys.StoreIdentKey()), notOK: true},
-		{span: s(keys.LocalStoreMax.Prevish(1), roachpb.KeyMax), notOK: true},
+		// Full spans overlapping with state engine spans.
+		{span: s(keys.MinKey, keys.LocalStorePrefix), notOk: true},
+		{span: s(keys.RangeGCThresholdKey(1), keys.RangeVersionKey(1)), notOk: true},
+		{span: s(keys.RangeTombstoneKey(1), keys.RaftReplicaIDKey(1)), notOk: true},
+		{span: s(keys.RaftReplicaIDKey(1), keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd()), notOk: true},
+		{span: s(keys.RangeGCThresholdKey(1), keys.RangeGCThresholdKey(2)), notOk: true},
+		{span: s(keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd(), keys.LocalStorePrefix), notOk: true},
+		{span: s(keys.LocalStoreMax, keys.MaxKey), notOk: true},
 
-		// Point spans not overlapping with Store-local span.
-		{span: s(roachpb.KeyMin, nil)},
-		{span: s(roachpb.Key(keys.LocalStorePrefix).Prevish(1), nil)},
-		{span: s(keys.LocalStoreMax, nil)},
-		{span: s(keys.LocalStoreMax.Next(), nil)},
-		{span: s(roachpb.KeyMax, nil)},
+		// Point spans not overlapping with state engine spans.
+		{span: s(keys.RaftLogKey(1, 1), nil)},
+		{span: s(keys.RangeTombstoneKey(1).Next(), nil)},
+		{span: s(keys.RaftReplicaIDKey(1).Next(), nil)},
+		{span: s(keys.RaftTruncatedStateKey(1).Next(), nil)},
+		{span: s(keys.LocalStorePrefix, nil)},
+		{span: s(roachpb.Key(keys.LocalStorePrefix).Next(), nil)},
+		{span: s(keys.LocalStoreMax.Prevish(1), nil)},
 
-		// Point spans overlapping with Store-local span.
-		{span: s(keys.LocalStorePrefix, nil), notOK: true},
-		{span: s(keys.StoreGossipKey(), nil), notOK: true},
-		{span: s(keys.LocalStoreMax.Prevish(1), nil), notOK: true},
+		// Point spans overlapping with state engine spans.
+		{span: s(keys.LocalRangeIDPrefix.AsRawKey(), nil), notOk: true}, // invalid start key
+		{span: s(keys.RangeLeaseKey(1), nil), notOk: true},
+		{span: s(keys.RangeTombstoneKey(1), nil), notOk: true},
+		{span: s(keys.RaftReplicaIDKey(1), nil), notOk: true},
+		{span: s(keys.RangeTombstoneKey(2), nil), notOk: true},
+		{span: s(keys.RaftReplicaIDKey(2), nil), notOk: true},
+		{span: s(keys.LocalRangeIDPrefix.AsRawKey().PrefixEnd(), nil), notOk: true},
 
-		// Tricky spans with nil StartKey not overlapping with Store-local span.
-		{span: s(nil, keys.LocalStorePrefix)},
-		{span: s(nil, keys.LocalStoreMax.Next())},
+		// Tricky spans not overlapping with state engine spans.
+		{span: s(nil, keys.RaftLogKey(1, 1))},
+		{span: s(nil, keys.RangeTombstoneKey(1))},
+		{span: s(nil, keys.RaftReplicaIDKey(1))},
+		{span: s(nil, roachpb.Key(keys.LocalStorePrefix).PrefixEnd())},
 
-		// Tricky spans with nil StartKey overlapping with Store-local span.
-		{span: s(nil, roachpb.Key(keys.LocalStorePrefix).Next()), notOK: true},
-		{span: s(nil, keys.StoreGossipKey()), notOK: true},
-		{span: s(nil, keys.LocalStoreMax), notOK: true},
+		// Tricky spans overlapping with state engine spans.
+		{span: s(nil, keys.LocalRangeIDPrefix.AsRawKey()), notOk: true},
+		{span: s(nil, keys.LocalStorePrefix), notOk: true},
+		{span: s(nil, keys.RangeLeaseKey(1)), notOk: true},
+		{span: s(nil, keys.RangeTombstoneKey(1).Next()), notOk: true},
+		{span: s(nil, keys.RaftReplicaIDKey(1).Next()), notOk: true},
+		{span: s(nil, roachpb.Key(keys.LocalStorePrefix).PrefixEnd().Next()), notOk: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			err := overlapsStoreLocalKeys(spanset.TrickySpan(tc.span))
-			require.Equal(t, tc.notOK, err != nil, tc.span)
+			err := validateIsRaftEngineSpan(spanset.TrickySpan(tc.span))
+			require.Equal(t, tc.notOk, err != nil, tc.span)
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -815,8 +815,7 @@ func (r *Replica) newBatchedEngine(g *concurrency.Guard) (storage.Batch, *storag
 		// any write latch would be declared at. But because of this, we don't
 		// assert on access timestamps using spanset.NewBatchAt.
 		spans := g.LatchSpans()
-		spans.AddForbiddenMatcher(overlapsLocalRaftKeys)
-		spans.AddForbiddenMatcher(overlapsStoreLocalKeys)
+		spans.AddForbiddenMatcher(validateIsStateEngineSpan)
 		batch = spanset.NewBatch(batch, spans)
 	}
 

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -815,7 +815,7 @@ func (r *Replica) newBatchedEngine(g *concurrency.Guard) (storage.Batch, *storag
 		// any write latch would be declared at. But because of this, we don't
 		// assert on access timestamps using spanset.NewBatchAt.
 		spans := g.LatchSpans()
-		spans.AddForbiddenMatcher(overlapsUnreplicatedRangeIDLocalKeys)
+		spans.AddForbiddenMatcher(overlapsLocalRaftKeys)
 		spans.AddForbiddenMatcher(overlapsStoreLocalKeys)
 		batch = spanset.NewBatch(batch, spans)
 	}

--- a/pkg/kv/kvserver/spanset/spanset.go
+++ b/pkg/kv/kvserver/spanset/spanset.go
@@ -93,6 +93,8 @@ type SpanSet struct {
 	// shouldn't be accessed (forbidden). This allows for complex pattern matching
 	// like forbidding specific keys across all range IDs without enumerating them
 	// explicitly.
+	// TODO(ibrahim): consider making this a single matcher given that we
+	// currently only use one matcher at a time.
 	forbiddenSpansMatchers []func(TrickySpan) error
 	allowUndeclared        bool
 	allowForbidden         bool


### PR DESCRIPTION
This PR adds the function overlapsStateEngineKeys that checks if a specific span overlaps with any StateEngine keys.
This will be used later to enforce RaftEngine assertions andensure that we do not touch and StateEngine keys.

We also make overlapsUnreplicatedRangeIDLocalKeys more accurate by excluding RangeTombstoneKey and RaftReplicaIDKey from the checks.

References: #158281

Release notes: None