### PR TITLE
catalog/lease: allow historical queries on dropped descriptors

### DIFF
--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1564,7 +1564,7 @@ func TestGetDescriptorsFromStoreForIntervalCPULimiterPagination(t *testing.T) {
 	var tableID int
 	sqlDB.QueryRow(t, `SELECT id FROM system.namespace WHERE name = 'baz'`).Scan(&tableID)
 	descs, err := getDescriptorsFromStoreForInterval(ctx, kvDB, s.Codec(), descpb.ID(tableID),
-		beforeCreate, afterCreate)
+		beforeCreate, afterCreate, false /*isOffline */)
 	require.NoError(t, err)
 	require.Len(t, descs, 3)
 	require.Equal(t, numRequests, 1)


### PR DESCRIPTION
Previously, when attempting to lease historical descriptors that were dropped we would always produce the "descriptor is dropped" error, once all leases are released on the prior version. This is problematic because with locked timestamp leasing, we can end up doing historical queries on dropped descriptors. To address this, this patch allows the lease manager to query historical descriptors on dropped objects. Dropped descriptor leases however are still not handed out.

This patch also tolerates missing targets (indexes and constraints) for comments within descriptors for SHOW CREATE. This is expected since leased descriptors may not fully line up with comments read from storage.

Fixes: #159583
Fixes: #159672

Release note: None