### PR TITLE
logical: fix bug in tombstone updater

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -154,6 +154,7 @@ go_test(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/storageccl",
         "//pkg/crosscluster",
+        "//pkg/crosscluster/ldrrandgen",
         "//pkg/crosscluster/replicationtestutils",
         "//pkg/crosscluster/streamclient",
         "//pkg/crosscluster/streamclient/randclient",

--- a/pkg/crosscluster/logical/tombstone_updater.go
+++ b/pkg/crosscluster/logical/tombstone_updater.go
@@ -168,9 +168,11 @@ func (tu *tombstoneUpdater) getDeleter(ctx context.Context, txn *kv.Txn) (row.De
 			return row.Deleter{}, err
 		}
 
-		cols, err := writeableColunms(ctx, tu.leased.descriptor.Underlying().(catalog.TableDescriptor))
-		if err != nil {
-			return row.Deleter{}, err
+		table := tu.leased.descriptor.Underlying().(catalog.TableDescriptor)
+		schema := getColumnSchema(table)
+		cols := make([]catalog.Column, len(schema))
+		for i, cs := range schema {
+			cols[i] = cs.column
 		}
 
 		tu.leased.deleter = row.MakeDeleter(tu.codec, tu.leased.descriptor.Underlying().(catalog.TableDescriptor), nil /* lockedIndexes */, cols, tu.sd, &tu.settings.SV, nil /* metrics */)

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -212,6 +212,12 @@ func (rd *Deleter) DeleteRow(
 		return err
 	}
 
+	if oth.PreviousWasDeleted {
+		// If we are updating a tombstone, then there are no secondary index entries
+		// that need to be deleted.
+		return nil
+	}
+
 	// Delete the row from any secondary indices.
 	for i, index := range rd.Helper.Indexes {
 		// If the index ID exists in the set of indexes to ignore, do not


### PR DESCRIPTION
This fixes a bug in the tombstone updater. The tombstone decoder was using the columns decoded by the kv writer when it needs to expect the columns decoded by the sql/crud writers. There is one difference between these two sets of columns that impacts computed columns:

1. The sql/crud writer only decode computed columns that are in the primary key.
2. The kv writer decodes virtual computed columns in the primary key and all stored computed columns in the row.

This mismatch can cause panics if the stored column is in an index (which is what the conflict workload noticed) and it can cause the tombstone updater to generate incorrect keys if there is a stored computed column with a lower column id than the primary key column. If that happened, and we hit the tombstone update race condition, we would issue a cput for the wrong row. That would end up creating a tombstone with an origin time stamp at that wrong key value. This would not cause data corruption, since we are using cput, so the write only succeeds if there was nothing there. Additionally we would be creating a tombstone, so it does not have side effects from the SQL layer. But it could LDR to fail to converge, since the tombstone updater is not working.

A secondary discovery here is that the tombstone updater is formatting deletes for indexes other than the primary index. Now, we use the index update helper to ensure we only generate updates for the primary key index.

Fixes: #159306
Release note: None