### PR TITLE
bazci: improve github issues when test.xml does not contain fully qualified unit test names

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -410,6 +410,15 @@ func TestListFailuresFromTestXML(t *testing.T) {
 				mention: []string{"@cockroachdb/unowned"},
 			}},
 		},
+		{
+			fileName: "test-error-142.xml", // #159708 case
+			expPkg:   "pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test",
+			expIssues: []issue{{
+				testName: "pkg",
+				title:    "pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test: pkg failed",
+				message:  `Test binary potentially failed to execute because of bazel test timeout, init() issue, or some other error.`,
+			}},
+		},
 	}
 
 	for _, c := range testCases {

--- a/pkg/cmd/bazci/githubpost/testdata/test-error-142.xml
+++ b/pkg/cmd/bazci/githubpost/testdata/test-error-142.xml
@@ -1,0 +1,8 @@
+<testsuites>
+<testsuite errors="1" failures="0" skipped="0" tests="1" time="0"
+           name="pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test" timestamp="">
+  <testcase name="pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test" time="60">
+    <error message="exited with error code 142" />
+  </testcase>
+</testsuite>
+</testsuites>


### PR DESCRIPTION
Because of behavior described in https://github.com/cockroachdb/cockroach/issues/159708, certain failure modes can result in test.xml files that result in ambiguous github issues. 

This change simply adds a message to the eventual github issue body so that test-eng or any team that's triaging can better see what's going on at a glance

Informs #159708