### PR TITLE
release-26.1: kvserver: try avoid iterating over all replicas in nodeIsLiveCallback 

### DIFF
--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -343,6 +344,124 @@ func TestNodeIsLiveCallback(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestNodeIsLiveCallbackBypassWithLeaderLeases verifies that expensive work to
+// check whether replicas need to be unquiesced does not happen when all ranges
+// are using leader leases.
+//
+// See https://github.com/cockroachdb/cockroach/issues/157089.
+func TestNodeIsLiveCallbackBypassWithLeaderLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	manualClock := hlc.NewHybridManualClock()
+	// We only want to record entries after the heartbeat loop has been paused.
+	var started atomic.Bool
+	var invokedCount, workDoneCount atomic.Int64
+
+	st := cluster.MakeTestingClusterSettings()
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Settings: st,
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				WallClock: manualClock,
+			},
+			Store: &kvserver.StoreTestingKnobs{
+				NodeIsLiveCallbackInvoked: func(l livenesspb.Liveness) {
+					if started.Load() {
+						invokedCount.Add(1)
+					}
+				},
+				NodeIsLiveCallbackWorkDone: func(l livenesspb.Liveness) {
+					if started.Load() {
+						workDoneCount.Add(1)
+					}
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	nl := s.NodeLiveness().(*liveness.NodeLiveness)
+	testutils.SucceedsSoon(t, func() error {
+		return verifyLivenessServer(s, 1)
+	})
+	nl.PauseHeartbeatLoopForTest()
+	started.Store(true)
+
+	testCases := []struct {
+		name                string
+		leaderLeasesEnabled bool
+		fortificationFrac   float64
+		expectWorkDone      bool
+	}{
+		{
+			name:                "leader_leases_disabled",
+			leaderLeasesEnabled: false,
+			fortificationFrac:   0.0,
+			expectWorkDone:      true,
+		},
+		{
+			name:                "leader_leases_enabled_fortification_0",
+			leaderLeasesEnabled: true,
+			fortificationFrac:   0.0,
+			expectWorkDone:      true,
+		},
+		{
+			name:                "leader_leases_enabled_fortification_50",
+			leaderLeasesEnabled: true,
+			fortificationFrac:   0.5,
+			expectWorkDone:      true,
+		},
+		{
+			name:                "leader_leases_disabled_fortification_100",
+			leaderLeasesEnabled: false,
+			fortificationFrac:   1.0,
+			expectWorkDone:      true,
+		},
+		{
+			name:                "leader_leases_enabled_fortification_100",
+			leaderLeasesEnabled: true,
+			fortificationFrac:   1.0,
+			expectWorkDone:      false, // bypass
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			kvserver.LeaderLeasesEnabled.Override(ctx, &st.SV, testCase.leaderLeasesEnabled)
+			kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, testCase.fortificationFrac)
+			invokedCount.Store(0)  // reset
+			workDoneCount.Store(0) // reset
+
+			// Advance clock past the liveness threshold so the node is
+			// considered non-live. Then, trigger a heartbeat to make the node
+			// transition to live.
+			manualClock.Increment(nl.TestingGetLivenessThreshold().Nanoseconds() + 1)
+			l, ok := nl.Self()
+			require.True(t, ok)
+			require.NoError(t, nl.Heartbeat(ctx, l))
+
+			// The callback should always be invoked when transitioning from
+			// non-live to live. It's invoked async, so wait for it before asserting
+			// expectations below.
+			testutils.SucceedsSoon(t, func() error {
+				if invokedCount.Load() == 0 {
+					return errors.New("callback not yet invoked")
+				}
+				return nil
+			})
+
+			if testCase.expectWorkDone {
+				require.Equal(t, int64(1), workDoneCount.Load())
+			} else {
+				require.Zero(t, workDoneCount.Load())
+			}
+		})
+	}
 }
 
 // TestNodeHeartbeatCallback verifies that HeartbeatCallback is invoked whenever

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -459,6 +460,117 @@ func TestNodeIsLiveCallbackBypassWithLeaderLeases(t *testing.T) {
 				require.Equal(t, int64(1), workDoneCount.Load())
 			} else {
 				require.Zero(t, workDoneCount.Load())
+			}
+		})
+	}
+}
+
+// TestNodeIsLiveCallbackReactsToTransitions tests that when LeaderLeasesEnabled
+// or RaftLeaderFortificationFractionEnabled settings change, the
+// nodeIsLiveCallback is invoked for all live nodes, and we iterate over all
+// replicas only as necessary. See
+// https://github.com/cockroachdb/cockroach/issues/157089 for more details.
+func TestNodeIsLiveCallbackReactsToTransitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var started atomic.Bool
+	var invokedCount, workDoneCount atomic.Int64
+
+	st := cluster.MakeTestingClusterSettings()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: st,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				NodeIsLiveCallbackInvoked: func(l livenesspb.Liveness) {
+					if started.Load() {
+						invokedCount.Add(1)
+					}
+				},
+				NodeIsLiveCallbackWorkDone: func(l livenesspb.Liveness) {
+					if started.Load() {
+						workDoneCount.Add(1)
+					}
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	nl := s.NodeLiveness().(*liveness.NodeLiveness)
+	testutils.SucceedsSoon(t, func() error {
+		return verifyLivenessServer(s, 1)
+	})
+	nl.PauseHeartbeatLoopForTest()
+	started.Store(true)
+
+	testCases := []struct {
+		name string
+		// NB: SetOnChange is only called when there's a difference in setting
+		// values. This is used to setup initial state that differs from the
+		// defaults.
+		setup          func(sv *settings.Values)
+		testSQL        string
+		expectWorkDone bool
+	}{
+		{
+			name:           "leader_leases_turned_off",
+			testSQL:        "SET CLUSTER SETTING kv.leases.leader_leases.enabled = false",
+			expectWorkDone: true,
+		},
+		{
+			name:           "fortification_set_to_50%",
+			testSQL:        "SET CLUSTER SETTING kv.raft.leader_fortification.fraction_enabled = 0.5",
+			expectWorkDone: true,
+		},
+		{
+			name: "leader_leases_turned_on",
+			setup: func(sv *settings.Values) {
+				kvserver.LeaderLeasesEnabled.Override(ctx, sv, false)
+			},
+			testSQL:        "SET CLUSTER SETTING kv.leases.leader_leases.enabled = true",
+			expectWorkDone: false,
+		},
+		{
+			name: "fortification_set_to_100%",
+			setup: func(sv *settings.Values) {
+				kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, sv, 0.5)
+			},
+			testSQL:        "SET CLUSTER SETTING kv.raft.leader_fortification.fraction_enabled = 1.0",
+			expectWorkDone: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Restore defaults before each test, before running any
+			// test-specific setup and resetting counters.
+			kvserver.LeaderLeasesEnabled.Override(ctx, &st.SV, true)
+			kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 1.0)
+			if testCase.setup != nil {
+				testCase.setup(&st.SV)
+			}
+			invokedCount.Store(0)
+			workDoneCount.Store(0)
+
+			_, err := db.Exec(testCase.testSQL) // execute the settings change
+			require.NoError(t, err)
+
+			// The callback should always be invoked when the setting changes, though
+			// this happens async.
+			testutils.SucceedsSoon(t, func() error {
+				if invokedCount.Load() == 0 {
+					return errors.New("callback not yet invoked")
+				}
+				return nil
+			})
+			if testCase.expectWorkDone {
+				require.NotZero(t, workDoneCount.Load(), "expected work to be done")
+			} else {
+				require.Zero(t, workDoneCount.Load(), "expected no work to be done")
 			}
 		})
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2392,6 +2392,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	// node transitioning from non-live to live.
 	if s.cfg.NodeLiveness != nil {
 		s.cfg.NodeLiveness.RegisterCallback(s.nodeIsLiveCallback)
+		// Register callbacks on settings changes for when the
+		// nodeIsLiveCallback needs to be invoked out of band.
+		s.registerNodeIsLiveCallbackSettingsChange(ctx)
 	}
 
 	// SystemConfigProvider can be nil during some tests.

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -820,6 +820,21 @@ func (s *Store) processRACv2RangeController(ctx context.Context, rangeID roachpb
 // down. Those instances should be rare, however, and we expect the newly live
 // node to eventually unquiesce the range.
 func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
+	if fn := s.cfg.TestingKnobs.NodeIsLiveCallbackInvoked; fn != nil {
+		defer fn(l)
+	}
+
+	// If there are no epoch based leases in the system (leader leases are
+	// enabled and Raft fortification is enabled for all ranges), we do not need
+	// to attempt to unquiesce any replicas -- there can't be any. This allows
+	// us to eschew some expensive iteration, see
+	// https://github.com/cockroachdb/cockroach/issues/157089.
+	leaderLeasesEnabled := LeaderLeasesEnabled.Get(&s.ClusterSettings().SV)
+	fortificationFrac := RaftLeaderFortificationFractionEnabled.Get(&s.ClusterSettings().SV)
+	if leaderLeasesEnabled && fortificationFrac == 1.0 {
+		return
+	}
+
 	ctx := context.TODO()
 	s.updateLivenessMap()
 
@@ -833,6 +848,10 @@ func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
 		}
 		return true
 	})
+
+	if fn := s.cfg.TestingKnobs.NodeIsLiveCallbackWorkDone; fn != nil {
+		fn(l)
+	}
 }
 
 // supportWithdrawnCallback is called every time the local store withdraws

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -854,6 +854,24 @@ func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
 	}
 }
 
+// registerNodeIsLiveCallbackSettingsChange registers callbacks on the
+// LeaderLeasesEnabled and RaftLeaderFortificationFractionEnabled settings. When
+// these settings change such that we can no longer bypassing the expensive
+// nodeIsLiveCallback work, we invoke the callback for all live nodes to ensure
+// quiesced ranges are promptly unquiesced, if necessary.
+func (s *Store) registerNodeIsLiveCallbackSettingsChange(ctx context.Context) {
+	invokeCallbackForAllLiveNodes := func(ctx context.Context) {
+		for _, entry := range s.cfg.NodeLiveness.ScanNodeVitalityFromCache() {
+			if entry.IsLive(livenesspb.IsAliveNotification) {
+				s.nodeIsLiveCallback(entry.GetInternalLiveness())
+			}
+		}
+	}
+
+	LeaderLeasesEnabled.SetOnChange(&s.ClusterSettings().SV, invokeCallbackForAllLiveNodes)
+	RaftLeaderFortificationFractionEnabled.SetOnChange(&s.ClusterSettings().SV, invokeCallbackForAllLiveNodes)
+}
+
 // supportWithdrawnCallback is called every time the local store withdraws
 // support form other stores in store liveness. The goal of this callback is to
 // unquiesce any replicas on the local store that have leaders on any of the

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tenantrate"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
@@ -571,6 +572,15 @@ type StoreTestingKnobs struct {
 	// the batch being applied. If a mismatch is detected, the callback is invoked
 	// with an error describing the mismatch; otherwise it is called with nil.
 	SysBytesVerificationOnRaftApply func(mismatchErr error)
+
+	// NodeIsLiveCallbackInvoked, if set, is called every time the
+	// nodeIsLiveCallback is invoked on the store. Called regardless of any bypass
+	// logic.
+	NodeIsLiveCallbackInvoked func(livenesspb.Liveness)
+
+	// NodeIsLiveCallbackWorkDone, if set, is called after nodeIsLiveCallback
+	// completes its iteration over all replicas on the store.
+	NodeIsLiveCallbackWorkDone func(livenesspb.Liveness)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 2/2 commits from #159657.

/cc @cockroachdb/release

---

See individual commits for details. 

Closes https://github.com/cockroachdb/cockroach/issues/157089
