### PR TITLE
release-26.1: sql/stats: fix cleaning up stale stats job on txn error

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -185,14 +185,14 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 		}
 		return n.p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &job, jobID, txn, *record)
 	}); err != nil {
-		if !errorOnConcurrentCreateStats.Get(n.p.ExecCfg().SV()) && errors.Is(err, stats.ConcurrentCreateStatsError) {
-			log.Dev.Infof(ctx, "concurrent create stats job found, skipping")
-			return nil
-		}
 		if job != nil {
 			if cleanupErr := job.CleanupOnRollback(ctx); cleanupErr != nil {
 				log.Dev.Warningf(ctx, "failed to cleanup StartableJob: %v", cleanupErr)
 			}
+		}
+		if !errorOnConcurrentCreateStats.Get(n.p.ExecCfg().SV()) && errors.Is(err, stats.ConcurrentCreateStatsError) {
+			log.Dev.Infof(ctx, "concurrent create stats job found, skipping")
+			return nil
 		}
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #159669 on behalf of @yuzefovich.

----

In somewhat recent d1dfc80906fe027e3b727649481a6fb8ce7e8916 we introduced an edge case bug where if we managed to initialize the stats job (which means including it into `jobs.Registry.mu.adoptedJobs` map), yet the DB txn encounters an error AND `sql.stats.error_on_concurrent_create_stats.enabled` is set to `false` (which is default on 25.3+), we'd not call `CleanupOnRollback`, so we'd have the initialized but dangling job reference in the map left. This commit fixes that oversight.

I don't know the impact of having that stale entry in the map though.

Epic: None
Release note: None

----

Release justification: low-risk bug fix.