### PR TITLE
release-26.1: roachtest: disable DO blocks in unoptimized query oracle and costfuzz

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -354,6 +354,7 @@ func runOneRoundQueryComparison(
 			sqlsmith.SetComplexity(.3),
 			sqlsmith.SetScalarComplexity(.1),
 			sqlsmith.SimpleNames(),
+			sqlsmith.DisableDoBlocks(), // TODO(#158667): unskip this.
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #159757 on behalf of @yuzefovich.

----

We've seen the UQO fail due to DO block not respecting statement_timeout (probably because we don't have any cancel checking in the loops). Let's just disable DO blocks for now.

Informs: #158667
Epic: None
Release note: None

----

Release justification: test-only change.