### PR TITLE
release-26.1: logictest: use unique TestClusterName

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -452,10 +452,10 @@ RESET application_name                                                0  0
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  1
 SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  1
 
-query T
-SELECT crdb_internal.cluster_name()
+query B
+SELECT length(crdb_internal.cluster_name()) > 0
 ----
-testclustername
+true
 
 # Regression for 41834.
 statement ok

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1576,7 +1576,6 @@ func (t *logicTest) newCluster(
 					IgnoreOnDeleteRangeError: ignoreMVCCRangeTombstoneErrors,
 				},
 			},
-			ClusterName:   "testclustername",
 			ExternalIODir: t.sharedIODir,
 		},
 		// For distributed SQL tests, we use the fake span resolver; it doesn't

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -925,10 +925,10 @@ start_pretty
 /Table/117/1/2
 /Table/117/1/3
 
-query T
-SELECT crdb_internal.cluster_name()
+query B
+SELECT length(crdb_internal.cluster_name()) > 0
 ----
-testclustername
+true
 
 # Regression for 41834.
 statement ok

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -333,6 +333,9 @@ func NewTestCluster(
 		// concise and recognizable.
 		clusterArgs.ServerArgs.ClusterName = fmt.Sprintf("TestCluster-%s",
 			randutil.RandString(rng, 10, randutil.PrintableKeyAlphabet))
+	} else {
+		t.Logf("WARNING: TestCluster using non-unique ClusterName %q; "+
+			"concurrent tests may collide (see #157868)", clusterArgs.ServerArgs.ClusterName)
 	}
 
 	if err := checkServerArgsForCluster(


### PR DESCRIPTION
Backport 2/2 commits from #159704.

/cc @cockroachdb/release

---

This allows https://github.com/cockroachdb/cockroach/pull/157868 to do its thing, avoiding flakes such as:

Fixes (when backported to 25.4): #159528

Epic: none


Release justification: deflake