### PR TITLE
mmaprototype: skip metrics unregistered warning in tests

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mmaprototype/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
+        "//pkg/util/buildutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/metric",


### PR DESCRIPTION
Previously, the warning for unregistered metrics would fire in test builds since
no metrics registry is provided. This was noisy since tests often don't set up a
full metrics registry. This change adds a shouldLogUnregisteredMetrics helper
that skip this logging if this is a test build and rate limits to once per
minute in production.

Release Notes: None
Epic: None