### PR TITLE
backup: standardize uri redaction across regular and compacted backups

### DIFF
--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -820,7 +820,7 @@ func processProgress(
 
 // compactionJobDescription generates a redacted description of the job.
 func compactionJobDescription(details jobspb.BackupDetails) (string, error) {
-	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple | tree.FmtShowFullURIs)
 	redactedURIs, err := sanitizeURIList(details.Destination.To)
 	if err != nil {
 		return "", err

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -93,6 +93,10 @@ func TestBackupCompaction(t *testing.T) {
 		backupStmt := fullBackupQuery(fullCluster, collectionURI, start, noOpts)
 		db.Exec(t, backupStmt)
 
+		var fullJobId jobspb.JobID
+		db.QueryRow(t, "SELECT system.jobs.id from system.jobs WHERE system.jobs.job_type = 'BACKUP'").Scan(&fullJobId)
+		fullRedactedUri := getDescUri(t, db, fullJobId)
+
 		// Run twice to test compaction on top of compaction.
 		for i := range 2 {
 			db.Exec(t, "INSERT INTO foo VALUES (2, 2), (3, 3)")
@@ -102,7 +106,13 @@ func TestBackupCompaction(t *testing.T) {
 			db.Exec(t, "DELETE FROM foo WHERE a = 3")
 			end := getTime()
 			db.Exec(t, incBackupQuery(fullCluster, collectionURI, end, noOpts))
-			jobutils.WaitForJobToSucceed(t, db, startCompaction(db, backupStmt, getLatestFullDir(collectionURI), start, end))
+
+			compactionJobId := startCompaction(db, backupStmt, getLatestFullDir(collectionURI), start, end)
+			compactionRedactedUri := getDescUri(t, db, compactionJobId)
+			require.Equal(t, fullRedactedUri, compactionRedactedUri)
+
+			jobutils.WaitForJobToSucceed(t, db, compactionJobId)
+
 			validateCompactedBackupForTables(t, db, collectionURI, []string{"foo"}, start, end, noOpts, noOpts, 2+i)
 			start = end
 		}
@@ -1125,4 +1135,13 @@ func aostExpr(aost hlc.Timestamp) string {
 		return ""
 	}
 	return fmt.Sprintf("AS OF SYSTEM TIME '%s'", aost.AsOfSystemTime())
+}
+
+func getDescUri(t *testing.T, db *sqlutils.SQLRunner, jobId jobspb.JobID) string {
+	var desc string
+	db.QueryRow(t, fmt.Sprintf("SELECT system.jobs.description from system.jobs WHERE system.jobs.id = %d", jobId)).Scan(&desc)
+	inStart := strings.Index(desc, "IN ")
+	uriStart := inStart + strings.Index(desc[inStart:], "'") + 1
+	uriEnd := uriStart + strings.Index(desc[uriStart:], "'")
+	return desc[uriStart:uriEnd]
 }


### PR DESCRIPTION
This patch makes backup compaction descriptions follow the same uri redaction standard as regular backups. In both cases, the backup system does its own uri redaction prior to formatting, and as such should turn off uri redaction in formatting.

Fixes: #159426

Release note: None