### PR TITLE
release-25.3: bazci: improve github issues when test.xml does not contain fully qualified unit test names

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -543,12 +543,28 @@ func listFailuresFromTestXML(
 						fmt.Printf("couldn't parse time %s as float64: %+v\n", testCase.Time, err)
 					}
 				}
-				event := testEvent{
-					Action:  "fail",
-					Package: pkg,
-					Test:    testCase.Name,
-					Output:  result.Contents,
-					Elapsed: elapsed,
+				var event testEvent
+				if pkg == testCase.Name {
+					// Test case or suite name is potentially irregular and does not
+					// match the expected format. Test binary may not have successfully
+					// executed or encountered some other error. We will make a special
+					// testEvent for this case.
+					// See unit tests for an example. See #159708 for more details.
+					log.Printf("encountered xml with non fully qualified test failure(s) %s and test suite(s) %s", pkg, testCase.Name)
+					event = testEvent{
+						Package: pkg,
+						Test:    testCase.Name,
+						Output: fmt.Sprintf("Test binary potentially failed to execute because of bazel test timeout,"+
+							" init() issue, or some other error. Content: %s", result.Contents),
+					}
+				} else {
+					event = testEvent{
+						Action:  "fail",
+						Package: pkg,
+						Test:    testCase.Name,
+						Output:  result.Contents,
+						Elapsed: elapsed,
+					}
 				}
 				failures[key] = append(failures[key], event)
 			}

--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -407,6 +407,15 @@ func TestListFailuresFromTestXML(t *testing.T) {
 				mention: []string{"@cockroachdb/unowned"},
 			}},
 		},
+		{
+			fileName: "test-error-142.xml", // #159708 case
+			expPkg:   "pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test",
+			expIssues: []issue{{
+				testName: "pkg",
+				title:    "pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test: pkg failed",
+				message:  `Test binary potentially failed to execute because of bazel test timeout, init() issue, or some other error.`,
+			}},
+		},
 	}
 
 	for _, c := range testCases {

--- a/pkg/cmd/bazci/githubpost/testdata/test-error-142.xml
+++ b/pkg/cmd/bazci/githubpost/testdata/test-error-142.xml
@@ -1,0 +1,8 @@
+<testsuites>
+<testsuite errors="1" failures="0" skipped="0" tests="1" time="0"
+           name="pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test" timestamp="">
+  <testcase name="pkg/sql/opt/testutils/testcat/testcat_test_/testcat_test" time="60">
+    <error message="exited with error code 142" />
+  </testcase>
+</testsuite>
+</testsuites>


### PR DESCRIPTION
Backport 1/1 commits from #159751 on behalf of @williamchoe3.

----

Because of behavior described in https://github.com/cockroachdb/cockroach/issues/159708, certain failure modes can result in test.xml files that result in ambiguous github issues. 

This change simply adds a message to the eventual github issue body so that test-eng or any team that's triaging can better see what's going on at a glance

Informs #159708

----

Release justification: CI testing related change