### PR TITLE
pkg/ts,util: make metric visibility proto field optional

### DIFF
--- a/pkg/ts/catalog/chart_catalog.proto
+++ b/pkg/ts/catalog/chart_catalog.proto
@@ -91,7 +91,7 @@ message ChartMetric {
   // exportedName is the name of metrics as seen by external scrapers.
   required string exportedName = 6 [(gogoproto.nullable) = false];
   // visibility indicates the intended audience for this metric (INTERNAL, SUPPORT, or ESSENTIAL).
-  required string visibility = 7 [(gogoproto.nullable) = false];
+  optional string visibility = 7 [(gogoproto.nullable) = false];
   // howToUse is the usage instructions for the metric.
   optional string howToUse = 8 [(gogoproto.nullable) = false];
   // labeledName is the name of the metric with its labels, formatted as name{label1: value1, ...}.

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -130,7 +130,7 @@ message Metadata {
 
   // visibility defines the intended audience and usage level for this metric.
   // See MetricVisibility for details on each visibility level.
-  required MetricVisibility visibility = 10 [(gogoproto.nullable) = false];
+  optional MetricVisibility visibility = 10 [(gogoproto.nullable) = false];
   // category is the dashboard category of this metric. This is
   // required if visibility is ESSENTIAL.
   required Category category = 11 [(gogoproto.nullable) = false];


### PR DESCRIPTION
The `visibility` field in `Metadata` (metric.proto) and `ChartMetric` (chart_catalog.proto) was 
introduced as `required` in v26.1. This causes `cockroach debug tsdump` to fail when a v26.1 
CLI connects to an older cluster (e.g., v25.4) because the older cluster's messages don't contain 
the `visibility` field, resulting in the error.

This patch change the field from `required` to `optional` to enable backward compatibility. 
When `visibility` is absent (older clusters), it defaults to `INTERNAL` (0), which is semantically 
correct for metrics that were not explicitly categorized.

Part of: none
Epic: CRDB-55082
Release note: none