### PR TITLE
sslocal: link insights ingester into the memory monitor

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -515,7 +515,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		cfg.SQLStatsTestingKnobs,
 	)
 	sqlStatsIngester := sslocal.NewSQLStatsIngester(
-		cfg.Settings, cfg.SQLStatsTestingKnobs, serverMetrics.IngesterMetrics, insightsProvider, localSQLStats)
+		cfg.Settings, cfg.SQLStatsTestingKnobs, serverMetrics.IngesterMetrics, pool, insightsProvider, localSQLStats)
 	// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
 	sqlstats.TxnStatsEnable.SetOnChange(&cfg.Settings.SV, func(_ context.Context) {
 		if !sqlstats.TxnStatsEnable.Get(&cfg.Settings.SV) {

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/appstatspb",
         "//pkg/sql/clusterunique",
         "//pkg/sql/execstats",
+        "//pkg/sql/memsize",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlcommenter",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_ingestor.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_ingestor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/contention/contentionutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	prometheus "github.com/prometheus/client_model/go"
 )
@@ -90,6 +91,14 @@ type SQLStatsIngester struct {
 	// We buffer ingested statementsBySessionID by session id.
 	statementsBySessionID map[clusterunique.ID]*statementBuf
 	resetStatementsBuf    atomic.Bool
+
+	// acc is the memory account that tracks memory allocations for buffered
+	// statements in statementsBySessionID.
+	acc *mon.ConcurrentBoundAccount
+
+	// stmtSizes tracks the memory footprint of buffered statements per session.
+	// This is used to properly account for memory when statements are flushed.
+	stmtSizes map[clusterunique.ID]int64
 
 	sinks []SQLStatsSink
 
@@ -187,6 +196,8 @@ func (i *SQLStatsIngester) Start(ctx context.Context, stopper *stop.Stopper, opt
 				i.ingest(ctx, payload.events) // note that ingest clears the buffer
 				if payload.resetStatementsBuf {
 					i.statementsBySessionID = make(map[clusterunique.ID]*statementBuf)
+					i.stmtSizes = make(map[clusterunique.ID]int64)
+					i.acc.Clear(ctx) // Clear all memory accounting when resetting the buffer.
 				}
 				eventBufferPool.Put(payload.events)
 
@@ -247,7 +258,7 @@ func (i *SQLStatsIngester) ingest(ctx context.Context, events *eventBuffer) {
 			break
 		}
 		if e.statement != nil {
-			i.processStatement(e.statement)
+			i.processStatement(ctx, e.statement)
 			i.metrics.NumProcessed.Inc(1)
 			i.metrics.QueueSize.Dec(1)
 			// When under an outer transaction, we don't have a txn to associate
@@ -264,7 +275,7 @@ func (i *SQLStatsIngester) ingest(ctx context.Context, events *eventBuffer) {
 			if e.forceFlush {
 				i.flushStatementsOnly(ctx, e.sessionID)
 			} else {
-				i.clearSession(e.sessionID)
+				i.clearSession(ctx, e.sessionID)
 			}
 			i.metrics.NumProcessed.Inc(1)
 			i.metrics.QueueSize.Dec(1)
@@ -344,7 +355,11 @@ func (i *SQLStatsIngester) FlushBuffer(sessionID clusterunique.ID) {
 }
 
 func NewSQLStatsIngester(
-	st *cluster.Settings, knobs *sqlstats.TestingKnobs, metrics Metrics, sinks ...SQLStatsSink,
+	st *cluster.Settings,
+	knobs *sqlstats.TestingKnobs,
+	metrics Metrics,
+	parentMon *mon.BytesMonitor,
+	sinks ...SQLStatsSink,
 ) *SQLStatsIngester {
 	i := &SQLStatsIngester{
 		// A channel size of 1 is sufficient to avoid unnecessarily
@@ -356,10 +371,17 @@ func NewSQLStatsIngester(
 		eventBufferCh:         make(chan eventBufChPayload, 1),
 		closeCh:               make(chan struct{}),
 		statementsBySessionID: make(map[clusterunique.ID]*statementBuf),
+		stmtSizes:             make(map[clusterunique.ID]int64),
 		sinks:                 sinks,
 		settings:              st,
 		testingKnobs:          knobs,
 		metrics:               metrics,
+	}
+
+	if parentMon != nil {
+		i.acc = parentMon.MakeConcurrentBoundAccount()
+	} else {
+		i.acc = mon.NewStandaloneUnlimitedConcurrentAccount()
 	}
 
 	if knobs != nil && knobs.SynchronousSQLStats {
@@ -393,10 +415,16 @@ func NewSQLStatsIngester(
 
 // clearSession removes the session from the registry and releases the
 // associated statement buffer.
-func (i *SQLStatsIngester) clearSession(sessionID clusterunique.ID) {
+func (i *SQLStatsIngester) clearSession(ctx context.Context, sessionID clusterunique.ID) {
 	if b, ok := i.statementsBySessionID[sessionID]; ok {
 		delete(i.statementsBySessionID, sessionID)
 		b.release()
+
+		// Release memory for this session's buffered statements.
+		if size, ok := i.stmtSizes[sessionID]; ok {
+			i.acc.Shrink(ctx, size)
+			delete(i.stmtSizes, sessionID)
+		}
 
 		if i.testingKnobs != nil && i.testingKnobs.OnIngesterSessionClear != nil {
 			i.testingKnobs.OnIngesterSessionClear(sessionID)
@@ -405,7 +433,18 @@ func (i *SQLStatsIngester) clearSession(sessionID clusterunique.ID) {
 	}
 }
 
-func (i *SQLStatsIngester) processStatement(statement *sqlstats.RecordedStmtStats) {
+func (i *SQLStatsIngester) processStatement(
+	ctx context.Context, statement *sqlstats.RecordedStmtStats,
+) {
+	stmtSize := statement.Size()
+	if err := i.acc.Grow(ctx, stmtSize); err != nil {
+		// If we hit memory limits, we cannot buffer this statement.
+		// The error will propagate through the SQL memory pool accounting,
+		// causing queries to fail with "budget exceeded error" when the pool is exhausted.
+		return
+	}
+	i.stmtSizes[statement.SessionID] += stmtSize
+
 	b, ok := i.statementsBySessionID[statement.SessionID]
 	if !ok {
 		b = statementsBufPool.Get().(*statementBuf)
@@ -431,6 +470,12 @@ func (i *SQLStatsIngester) flushBuffer(
 		return
 	}
 	defer statements.release()
+
+	// Release memory for this session's buffered statements.
+	if size, ok := i.stmtSizes[sessionID]; ok {
+		i.acc.Shrink(ctx, size)
+		delete(i.stmtSizes, sessionID)
+	}
 
 	if len(*statements) == 0 {
 		return
@@ -467,6 +512,11 @@ func (i *SQLStatsIngester) flushStatementsOnly(ctx context.Context, sessionID cl
 		defer sessionStatements.release()
 		statements = *sessionStatements
 		delete(i.statementsBySessionID, sessionID)
+
+		if size, ok := i.stmtSizes[sessionID]; ok {
+			i.acc.Shrink(ctx, size)
+			delete(i.stmtSizes, sessionID)
+		}
 	} else {
 		// No statements to flush, return early
 		return

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -462,7 +462,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		nil, /* knobs */
 	)
 
-	ingester := sslocal.NewSQLStatsIngester(st, nil /* knobs */, sslocal.NewIngesterMetrics(), sqlStats)
+	ingester := sslocal.NewSQLStatsIngester(st, nil /* knobs */, sslocal.NewIngesterMetrics(), nil /* parentMon */, sqlStats)
 	ingester.Start(ctx, stopper)
 
 	appStats := sqlStats.GetApplicationStats("" /* appName */)
@@ -587,7 +587,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			nil,
 			nil,
 		)
-		ingester := sslocal.NewSQLStatsIngester(st, nil /* knobs */, sslocal.NewIngesterMetrics(), sqlStats)
+		ingester := sslocal.NewSQLStatsIngester(st, nil /* knobs */, sslocal.NewIngesterMetrics(), nil /* parentMon */, sqlStats)
 		appStats := sqlStats.GetApplicationStats("" /* appName */)
 		statsCollector := sslocal.NewStatsCollector(
 			st,


### PR DESCRIPTION
The sql stats ingester is not currently plugged into the memory monitor, and this has caused
issues in the past with long running transactions having their statements stats occupy memory
while being unaccounted for.

This change introduces the memory monitor into sql stats ingester and uses it to account for
the memory usage for statements.

Resolves: #158453
Epic: None
Release Note: None