### PR TITLE
release-26.1: backup: deflake ResolveDestination test under race

### DIFF
--- a/pkg/backup/backupdest/BUILD.bazel
+++ b/pkg/backup/backupdest/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/sql",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/hlc",

--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -37,6 +38,8 @@ import (
 func TestBackupRestoreResolveDestination(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "multinode clusters are slow under race")
 
 	var params base.TestClusterArgs
 	params.ServerArgs.DefaultDRPCOption = base.TestDRPCDisabled


### PR DESCRIPTION
Backport 1/1 commits from #159631 on behalf of @kev-cao.

----

Epic: None

Release note: None

----

Release justification: Test-only change.