### PR TITLE
storage: refactor default pebble options

### DIFF
--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -560,7 +560,7 @@ func Open(
 	var cfg engineConfig
 	cfg.env = env
 	cfg.settings = settings
-	cfg.opts = DefaultPebbleOptionsForOpen(&cfg.settings.SV)
+	cfg.opts = initPebbleOptions()
 	cfg.opts.FS = env
 	cfg.opts.ReadOnly = env.IsReadOnly()
 	for _, opt := range opts {


### PR DESCRIPTION
This commit cleans up the code around default pebble options and calls
`EnsureDefaults` in `DefaultPebbleOptions()`.

Epic: none
Release note: None