### PR TITLE
kvnemesis: enable node crashes to kvnemesis

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -182,12 +182,12 @@ func (a *Applier) applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 		o.Result = resultInit(ctx, err)
 	case *StopNodeOperation:
 		serverID := int(o.NodeId) - 1
-		a.env.Restarter.StopServer(serverID)
+		a.env.ServerController.StopServer(serverID)
 		a.nodes.setStopped(int(o.NodeId))
 		o.Result = resultInit(ctx, nil)
 	case *RestartNodeOperation:
 		serverID := int(o.NodeId) - 1
-		err := a.env.Restarter.RestartServer(serverID)
+		err := a.env.ServerController.RestartServer(serverID)
 		a.nodes.setRunning(int(o.NodeId))
 		o.Result = resultInit(ctx, err)
 	case *ClosureTxnOperation:

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -190,6 +190,11 @@ func (a *Applier) applyOp(ctx context.Context, db *kv.DB, op *Operation) {
 		err := a.env.ServerController.RestartServer(serverID)
 		a.nodes.setRunning(int(o.NodeId))
 		o.Result = resultInit(ctx, err)
+	case *CrashNodeOperation:
+		serverID := int(o.NodeId) - 1
+		a.env.ServerController.CrashNode(serverID)
+		a.nodes.setCrashed(int(o.NodeId))
+		o.Result = resultInit(ctx, nil)
 	case *ClosureTxnOperation:
 		// Use a backoff loop to avoid thrashing on txn aborts. Don't wait between
 		// epochs of the same transaction to avoid waiting while holding locks.

--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -27,7 +27,7 @@ type Logger interface {
 	WriteFile(basename string, contents string) string
 }
 
-type Restarter interface {
+type ServerController interface {
 	StopServer(idx int)
 	RestartServer(idx int) error
 }
@@ -35,11 +35,11 @@ type Restarter interface {
 // Env manipulates the environment (cluster settings, zone configurations) that
 // the Applier operates in.
 type Env struct {
-	SQLDBs      []*gosql.DB
-	Tracker     *SeqTracker
-	L           Logger
-	Partitioner *rpc.Partitioner
-	Restarter   Restarter
+	SQLDBs           []*gosql.DB
+	Tracker          *SeqTracker
+	L                Logger
+	Partitioner      *rpc.Partitioner
+	ServerController ServerController
 }
 
 func (e *Env) anyNode() *gosql.DB {

--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -30,6 +30,7 @@ type Logger interface {
 type ServerController interface {
 	StopServer(idx int)
 	RestartServer(idx int) error
+	CrashNode(idx int)
 }
 
 // Env manipulates the environment (cluster settings, zone configurations) that

--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -80,6 +80,7 @@ func TestRandStep(t *testing.T) {
 	n := nodes{
 		running: map[int]struct{}{1: {}, 2: {}, 3: {}},
 		stopped: make(map[int]struct{}),
+		crashed: make(map[int]struct{}),
 	}
 	g, err := MakeGenerator(config, getReplicasFn, 0, &n)
 	require.NoError(t, err)
@@ -443,6 +444,11 @@ func TestRandStep(t *testing.T) {
 			counts.Fault.RestartNode++
 			n.mu.Lock()
 			n.running[int(o.NodeId)] = struct{}{}
+			n.mu.Unlock()
+		case *CrashNodeOperation:
+			counts.Fault.CrashNode++
+			n.mu.Lock()
+			n.crashed[int(o.NodeId)] = struct{}{}
 			n.mu.Unlock()
 		default:
 			t.Fatalf("%T", o)

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -109,6 +109,7 @@ func RunNemesis(
 	n := nodes{
 		running: make(map[int]struct{}),
 		stopped: make(map[int]struct{}),
+		crashed: make(map[int]struct{}),
 	}
 	for i := 1; i <= config.NumNodes; i++ {
 		// In liveness mode, we don't allow stopping and restarting the two

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -197,7 +197,7 @@ func RunNemesis(
 	}
 	env.Partitioner.EnablePartitions(false)
 	for i := 0; i < config.NumNodes; i++ {
-		_ = env.Restarter.RestartServer(i)
+		_ = env.ServerController.RestartServer(i)
 	}
 
 	allSteps := make(steps, 0, numSteps)

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -697,7 +697,7 @@ func testKVNemesisImpl(t testing.TB, cfg kvnemesisTestCfg) {
 
 	logger := newTBridge(t)
 	defer dumpRaftLogsOnFailure(t, logger.ll.dir, tc.Servers)
-	env := &Env{SQLDBs: sqlDBs, Tracker: tr, L: logger, Partitioner: &partitioner, Restarter: tc}
+	env := &Env{SQLDBs: sqlDBs, Tracker: tr, L: logger, Partitioner: &partitioner, ServerController: tc}
 	failures, err := RunNemesis(ctx, rng, env, config, cfg.concurrency, cfg.numSteps, cfg.mode, dbs...)
 
 	logMetricsReport(t, tc)

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -270,7 +270,7 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 		}
 	}
 
-	reg := fs.NewStickyRegistry()
+	reg := fs.NewStickyRegistry(fs.UseStrictMemFS)
 	lisReg := listenerutil.NewListenerRegistry()
 	args := base.TestClusterArgs{
 		ReusableListenerReg: lisReg,
@@ -581,6 +581,47 @@ func TestKVNemesisMultiNode_Restart_Liveness(t *testing.T) {
 			cfg.Ops.ChangeReplicas = ChangeReplicasConfig{}
 		},
 	})
+}
+
+func TestKVNemesisMultiNode_Crash(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testKVNemesisImpl(t, kvnemesisTestCfg{
+		numNodes:                     4,
+		numSteps:                     defaultNumSteps,
+		concurrency:                  5,
+		seedOverride:                 0,
+		invalidLeaseAppliedIndexProb: 0.2,
+		injectReproposalErrorProb:    0.2,
+		// assertRaftApply is disabled because the asserter assumes no node
+		// restarts (see asserter.go:29).
+		//
+		// Crashing nodes violates this assumption since node crashes differ
+		// from graceful restarts (abrupt stop vs a graceful shutdown).
+		//
+		// There's a race condition in crash simulation where
+		// CrashNode/CrashClone() can run while the server is still active, so
+		// WAL syncs and Raft applies can complete between the snapshot and
+		// stopServerLocked(). When assertRaftApply is true, the Asserter may
+		// record applies that aren't in the crash snapshot; after restart, the
+		// replica recovers from an earlier snapshot and re-applies, causing the
+		// Asserter to flag a false regression. This is a bug in the crash
+		// simulation code, not a bug in the database logic.
+		// TODO(dodeca12): resolve crash simulation bug for kvnemesis crashes for
+		// when assertRaftApply is true.
+		assertRaftApply: false,
+		mode:            Liveness,
+		testGeneratorConfig: func(cfg *GeneratorConfig) {
+			cfg.Ops.Fault.CrashNode = 1
+			cfg.Ops.Fault.RestartNode = 1
+
+			// Disallow replica changes because they interfere with the zone config
+			// constraints (at least one replica on nodes 1 and 2).
+			cfg.Ops.ChangeReplicas = ChangeReplicasConfig{}
+		},
+	},
+	)
 }
 
 func TestKVNemesisMultiNode(t *testing.T) {

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -74,6 +74,8 @@ func (op Operation) Result() *Result {
 		return &o.Result
 	case *RestartNodeOperation:
 		return &o.Result
+	case *CrashNodeOperation:
+		return &o.Result
 	default:
 		panic(errors.AssertionFailedf(`unknown operation: %T %v`, o, o))
 	}
@@ -253,6 +255,8 @@ func (op Operation) format(w *strings.Builder, fctx formatCtx) {
 	case *StopNodeOperation:
 		o.format(w, fctx)
 	case *RestartNodeOperation:
+		o.format(w, fctx)
+	case *CrashNodeOperation:
 		o.format(w, fctx)
 	default:
 		fmt.Fprintf(w, "%v", op.GetValue())
@@ -526,12 +530,17 @@ func (op RemoveNetworkPartitionOperation) format(w *strings.Builder, fctx format
 }
 
 func (op StopNodeOperation) format(w *strings.Builder, fctx formatCtx) {
-	fmt.Fprintf(w, `env.Restarter.StopNode(%d)`, int(op.NodeId))
+	fmt.Fprintf(w, `env.ServerController.StopNode(%d)`, int(op.NodeId))
 	op.Result.format(w)
 }
 
 func (op RestartNodeOperation) format(w *strings.Builder, fctx formatCtx) {
-	fmt.Fprintf(w, `env.Restarter.RestartNode(%d)`, int(op.NodeId))
+	fmt.Fprintf(w, `env.ServerController.RestartNode(%d)`, int(op.NodeId))
+	op.Result.format(w)
+}
+
+func (op CrashNodeOperation) format(w *strings.Builder, fctx formatCtx) {
+	fmt.Fprintf(w, `env.ServerController.CrashNode(%d)`, int(op.NodeId))
 	op.Result.format(w)
 }
 

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -206,6 +206,11 @@ message RestartNodeOperation {
   Result result = 2 [(gogoproto.nullable) = false];
 }
 
+message CrashNodeOperation {
+  int32 node_id = 1;
+  Result result = 2 [(gogoproto.nullable) = false];
+}
+
 message Operation {
   option (gogoproto.goproto_stringer) = false;
   option (gogoproto.onlyone) = true;
@@ -242,6 +247,7 @@ message Operation {
   RemoveNetworkPartitionOperation removeNetworkPartition = 28;
   StopNodeOperation stopNode = 29;
   RestartNodeOperation restartNode = 30;
+  CrashNodeOperation crashNode = 31;
 }
 
 enum ResultType {

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1024,6 +1024,9 @@ func (v *validator) processOp(op Operation) {
 	case *RestartNodeOperation:
 		execTimestampStrictlyOptional = true
 		v.checkError(op, t.Result)
+	case *CrashNodeOperation:
+		execTimestampStrictlyOptional = true
+		v.checkError(op, t.Result)
 	default:
 		panic(errors.AssertionFailedf(`unknown operation type: %T %v`, t, t))
 	}

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2054,6 +2055,91 @@ func (tc *TestCluster) RestartServerWithInspect(
 			}
 			return ctx.Err()
 		})
+}
+
+// isolateNodeFromPeers trips circuit breakers on the crashed node's dialer to
+// isolate it from all peer nodes. This simulates network partition behavior
+// during a crash. The circuit breakers will automatically reset when the node
+// is restarted and connections are successfully re-established via the
+// background `AsyncProbe` mechanism; manual undo is not needed.
+func (tc *TestCluster) isolateNodeFromPeers(idx int) {
+	nodeDialer, ok := tc.Servers[idx].NodeDialer().(*nodedialer.Dialer)
+	if !ok {
+		return
+	}
+	for peerIdx := range tc.Servers {
+		if peerIdx == idx {
+			continue
+		}
+		peerNodeID := tc.Servers[peerIdx].NodeID()
+		for c := 0; c < rpcbase.NumConnectionClasses; c++ {
+			if brk, found := nodeDialer.GetCircuitBreaker(
+				peerNodeID,
+				rpcbase.ConnectionClass(c),
+			); found {
+				brk.Report(errors.New("connection terminated by crash emulation"))
+			}
+		}
+	}
+}
+
+// CrashNode emulates a crash of the server at the given index by stopping it
+// and creating a snapshot of its in-memory filesystems (capturing state at the
+// last sync point). This allows testing crash recovery scenarios. Requires all
+// stores to use sticky VFS with in-memory storage. Also reports connection
+// failures to peer nodes' circuit breakers to simulate network disconnection.
+func (tc *TestCluster) CrashNode(idx int) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if tc.mu.serverStoppers[idx] == nil {
+		tc.t.Fatalf("server %d is already stopped", idx)
+	}
+
+	serverArgs := tc.serverArgs[idx]
+
+	serverKnobs, ok := serverArgs.Knobs.Server.(*server.TestingKnobs)
+	if !ok || serverKnobs.StickyVFSRegistry == nil {
+		tc.t.Fatalf(
+			"server %d does not have sticky VFS registry; crash emulation requires sticky VFS", idx)
+	}
+
+	// Isolate the crashed node from its peers by tripping circuit breakers.
+	// This simulates network partition behavior during a crash. Circuit breakers
+	// will automatically reset when the node is restarted and connections are
+	// successfully re-established (via background probe mechanisms), so no manual
+	// undo is needed.
+	//
+	// This step is first because we want to prevent any message sent after the
+	// CrashClone of the VFS. Otherwise it would be able to leak false durability
+	// signal into the cluster, such as with raft messages like
+	// MsgVoteResp / MsgAppResp.
+	tc.isolateNodeFromPeers(idx)
+
+	crashedVFSesMap := make(map[string]*vfs.MemFS)
+	for i, spec := range serverArgs.StoreSpecs {
+		if !spec.InMemory || spec.StickyVFSID == "" {
+			tc.t.Fatalf(
+				"crash emulation requires all stores to be in-memory with sticky VFS IDs; "+
+					"store %d on server %d does not meet requirements", i, idx)
+		}
+
+		// Get the current in-memory filesystem for this store and create a crash
+		// snapshot. CrashClone captures the filesystem state at the last sync point,
+		// simulating what would be on disk after a crash (only synced data survives).
+		currentVFS := serverKnobs.StickyVFSRegistry.Get(spec.StickyVFSID)
+		crashedVFSesMap[spec.StickyVFSID] = currentVFS.CrashClone(vfs.CrashCloneCfg{})
+	}
+
+	tc.stopServerLocked(idx)
+
+	// Replace the filesystems in the registry with the crash snapshots. When the
+	// server is restarted, it will see the filesystem state as it was at the last
+	// sync point (the crash snapshot), not the current state. This simulates a
+	// real crash where only synced data persists.
+	for stickyID, crashFS := range crashedVFSesMap {
+		serverKnobs.StickyVFSRegistry.Set(stickyID, crashFS)
+	}
 }
 
 // ServerStopped determines if a server has been explicitly


### PR DESCRIPTION
Previously, `kvnemesis` could only simulate graceful node stops and restarts, which limited its ability to test crash recovery scenarios. This was inadequate because real-world failures often involve abrupt crashes of nodes, leaving data in an inconsistent state that must be recovered on restart.

To address this, this PR adds crash operation support to `kvnemesis` through three commits:

1. Renames the `Restarter` interface to `ServerController` to better reflect its broader purpose of controlling server lifecycle operations, preparing for the addition of crash operations.

2. Extends `testcluster.TestCluster` with a `CrashServer` method that emulates a crash by stopping a server and creating a snapshot of its in-memory filesystems at the last sync point using `vfs.MemFS.CrashClone`. This simulates what would persist on disk after a real crash. The method also isolates the crashed node from peers by tripping circuit breakers, simulating network partition behavior. Adds `CrashNodeOperation` to the kvnemesis protobuf schema, integrates it into the generator to randomly crash nodes during test runs, implements crash application in the applier, and updates the validator to handle crash scenarios. The generator now tracks crashed nodes separately from stopped nodes.

3. Enables crash operations in kvnemesis test configurations by adding `removeRandCrashed` and `removeRandStoppedOrCrashed` methods to the nodes tracker. The `restartRandNode` function now randomly selects from both stopped and crashed nodes. Adds a new test `TestKVNemesisMultiNode_Crash_Liveness` that exercises crash operations with strict in-memory filesystem mode, which is required for proper crash simulation. 

Fixes #64828