### PR TITLE
release-25.3: backup: deflake ResolveDestination test under race

### DIFF
--- a/pkg/backup/backupdest/BUILD.bazel
+++ b/pkg/backup/backupdest/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -36,6 +37,8 @@ import (
 func TestBackupRestoreResolveDestination(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "multinode clusters are slow under race")
 
 	tc, _, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(t, backuptestutils.MultiNode)
 	defer cleanupFn()


### PR DESCRIPTION
Backport 1/1 commits from #159631.

/cc @cockroachdb/release

---

Epic: None

Release note: None

---

Release justification: Test-only change.