### PR TITLE
roachtest: remove datadog api key as binary argument

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -348,12 +348,6 @@ var (
 		Usage: `Datadog site to communicate with (e.g., us5.datadoghq.com).`,
 	})
 
-	DatadogAPIKey string = ""
-	_                    = registerRunOpsFlag(&DatadogAPIKey, FlagInfo{
-		Name:  "datadog-api-key",
-		Usage: `Datadog API key to emit telemetry data to Datadog.`,
-	})
-
 	DatadogApplicationKey string = ""
 	_                            = registerRunOpsFlag(&DatadogApplicationKey, FlagInfo{
 		Name:  "datadog-app-key",

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -495,10 +495,7 @@ func newDatadogContext(ctx context.Context) context.Context {
 		datadogSite = os.Getenv("DD_SITE")
 	}
 
-	datadogAPIKey := roachtestflags.DatadogAPIKey
-	if datadogAPIKey == "" {
-		datadogAPIKey = os.Getenv("DD_API_KEY")
-	}
+	datadogAPIKey := os.Getenv("DD_API_KEY")
 
 	datadogApplicationKey := roachtestflags.DatadogApplicationKey
 	if datadogApplicationKey == "" {


### PR DESCRIPTION
Previously, the datadog api key could be passed in via roachtest argument. Now the key is configurable from TC so we can remove the flag and just read it in as an env var which is more canonical.