### PR TITLE
changefeedccl: validate that avro_schema_prefix follows Avro naming rules

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7886,6 +7886,14 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `unknown enriched_properties: potato, valid values are: source, schema`,
 		`CREATE CHANGEFEED FOR foo INTO 'null://' WITH enriched_properties='schema,potato'`,
 	)
+	sqlDB.ExpectErrWithTimeout(
+		t, `avro_schema_prefix must start with \[A-Za-z_\] and subsequently contain only \[A-Za-z0-9_\]`,
+		`CREATE CHANGEFEED FOR foo INTO 'null://' WITH avro_schema_prefix='1abc'`,
+	)
+	sqlDB.ExpectErrWithTimeout(
+		t, `avro_schema_prefix must start with \[A-Za-z_\] and subsequently contain only \[A-Za-z0-9_\]`,
+		`CREATE CHANGEFEED FOR foo INTO 'null://' WITH avro_schema_prefix='abc-d'`,
+	)
 
 	t.Run("sinkless enriched non-json", func(t *testing.T) {
 		skip.WithIssue(t, 130949, "sinkless feed validations are subpar")


### PR DESCRIPTION
An invalid avro_schema_prefix caused changefeeds to hang indefinitely.
This validates that avro_schema_prefix follows Avro naming rules at
statement time.

Release note: Invalid avro_schema_prefix is now caught during statement
time. The prefix must start with [A-Za-z_] and subsequently contain only
[A-Za-z0-9_], as specified in the avro specification
https://avro.apache.org/docs/1.8.1/spec.html

Part of: https://github.com/cockroachlabs/support/issues/3513