### PR TITLE
security: Disabling DRPC on TestRotateCerts unit test

### DIFF
--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -66,6 +66,9 @@ func TestRotateCerts(t *testing.T) {
 		InsecureWebAccess: true,
 
 		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110007),
+		// Disable DRPC for this test due to #159661: since it's flaky
+		// with "connection closed" errors when DRPC is enabled.
+		DefaultDRPCOption: base.TestDRPCDisabled,
 	}
 	srv := serverutils.StartServerOnly(t, params)
 	defer srv.Stopper().Stop(context.Background())


### PR DESCRIPTION
* The test was flaky when ran under stress, on DRPC enabled.
* Disabling DRPC until the RCA is done

Fixes: #159661
Epic: CRDB-57970