### PR TITLE
kvserver: deflake TestReadLoadMetricAccounting

### DIFF
--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/stretchr/testify/require"
 )
@@ -468,6 +470,8 @@ func TestReadLoadMetricAccounting(t *testing.T) {
 	// number of keys being read increases, the read bytes scales by keys * 38.
 	const entrySize = 38
 
+	// NB: All test cases must be idempotent (re-runnable) since we use
+	// SucceedsSoon to retry on interference from background activity.
 	testCases := []struct {
 		ba           *kvpb.BatchRequest
 		expectedRQPS float64
@@ -504,35 +508,42 @@ func TestReadLoadMetricAccounting(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Logf("test #%d", i+1)
-		// Reset the request counts to 0 before sending to clear previous requests.
-		repl.loadStats.Reset()
+		// Wrap each test case in SucceedsSoon to handle interference from
+		// background activity (e.g., async stats recording from lease upgrades).
+		// If stats don't match expectations, we reset and retry.
+		testutils.SucceedsSoon(t, func() error {
+			// Reset the request counts to 0 before sending to clear previous requests.
+			repl.loadStats.Reset()
 
-		requestsBefore := repl.loadStats.TestingGetSum(load.Requests)
-		writesBefore := repl.loadStats.TestingGetSum(load.WriteKeys)
-		readsBefore := repl.loadStats.TestingGetSum(load.ReadKeys)
-		readBytesBefore := repl.loadStats.TestingGetSum(load.ReadBytes)
-		writeBytesBefore := repl.loadStats.TestingGetSum(load.WriteBytes)
+			_, pErr = db.NonTransactionalSender().Send(ctx, testCase.ba)
+			if pErr != nil {
+				return pErr.GoError()
+			}
 
-		_, pErr = db.NonTransactionalSender().Send(ctx, testCase.ba)
-		require.Nil(t, pErr)
+			requestsAfter := repl.loadStats.TestingGetSum(load.Requests)
+			writesAfter := repl.loadStats.TestingGetSum(load.WriteKeys)
+			readsAfter := repl.loadStats.TestingGetSum(load.ReadKeys)
+			readBytesAfter := repl.loadStats.TestingGetSum(load.ReadBytes)
+			writeBytesAfter := repl.loadStats.TestingGetSum(load.WriteBytes)
 
-		require.Equal(t, 0.0, requestsBefore)
-		require.Equal(t, 0.0, writesBefore)
-		require.Equal(t, 0.0, readsBefore)
-		require.Equal(t, 0.0, writeBytesBefore)
-		require.Equal(t, 0.0, readBytesBefore)
-
-		requestsAfter := repl.loadStats.TestingGetSum(load.Requests)
-		writesAfter := repl.loadStats.TestingGetSum(load.WriteKeys)
-		readsAfter := repl.loadStats.TestingGetSum(load.ReadKeys)
-		readBytesAfter := repl.loadStats.TestingGetSum(load.ReadBytes)
-		writeBytesAfter := repl.loadStats.TestingGetSum(load.WriteBytes)
-
-		assertGreaterThanInDelta(t, testCase.expectedRQPS, requestsAfter, epsilonAllowed)
-		assertGreaterThanInDelta(t, testCase.expectedWPS, writesAfter, epsilonAllowed)
-		assertGreaterThanInDelta(t, testCase.expectedRPS, readsAfter, epsilonAllowed)
-		assertGreaterThanInDelta(t, testCase.expectedWBPS, writeBytesAfter, epsilonAllowed)
-		assertGreaterThanInDelta(t, testCase.expectedRBPS, readBytesAfter, epsilonAllowed)
+			// Check write stats first since that's where interference shows up.
+			if writesAfter < testCase.expectedWPS || writesAfter > testCase.expectedWPS+epsilonAllowed {
+				return errors.Errorf("writeKeys: got %f, expected %f±%d", writesAfter, testCase.expectedWPS, epsilonAllowed)
+			}
+			if writeBytesAfter < testCase.expectedWBPS || writeBytesAfter > testCase.expectedWBPS+epsilonAllowed {
+				return errors.Errorf("writeBytes: got %f, expected %f±%d", writeBytesAfter, testCase.expectedWBPS, epsilonAllowed)
+			}
+			if requestsAfter < testCase.expectedRQPS || requestsAfter > testCase.expectedRQPS+epsilonAllowed {
+				return errors.Errorf("requests: got %f, expected %f±%d", requestsAfter, testCase.expectedRQPS, epsilonAllowed)
+			}
+			if readsAfter < testCase.expectedRPS || readsAfter > testCase.expectedRPS+epsilonAllowed {
+				return errors.Errorf("readKeys: got %f, expected %f±%d", readsAfter, testCase.expectedRPS, epsilonAllowed)
+			}
+			if readBytesAfter < testCase.expectedRBPS || readBytesAfter > testCase.expectedRBPS+epsilonAllowed {
+				return errors.Errorf("readBytes: got %f, expected %f±%d", readBytesAfter, testCase.expectedRBPS, epsilonAllowed)
+			}
+			return nil
+		})
 	}
 }
 


### PR DESCRIPTION
`TestReadLoadMetricAccounting` has a history of flaking due to lease-related writes interfering with load metric measurements.

Issue #141716 (and #141586) identified the same failure signature:
```
Error: Max difference between 0 and 85 allowed is 4, but difference was -85
```

The root cause was identified by @pav-kv: an "unexpected" leader lease upgrade write was interfering with the test's write bytes measurements. PR #141843 added `tc.MaybeWaitForLeaseUpgrade()` to wait for lease upgrades before starting measurements.

**The fix from #141843 IS present** in the failing SHA. However, the test still flaked with the same error signature (85 write bytes when expecting 0).

The logs show:
1. AddSSTableRequest evaluated (test setup)
2. Many LeaseInfoRequest polls (from MaybeWaitForLeaseUpgrade)
3. RequestLeaseRequest (the lease upgrade write)
4. More LeaseInfoRequest polls
5. "lease is now of type: LeaseLeader" - **upgrade complete**
6. "test #1" - test loop begins
7. GetRequest evaluated (the actual test request)
8. **Assertion fails** - 85 write bytes observed

The race condition is subtle: `MaybeWaitForLeaseUpgrade()` waits until `FindRangeLeaseEx()` reports the lease is upgraded, but it does **not** guarantee that the write bytes have been recorded to load stats. This is because stats are recorded "awkwardly late" on the client goroutine (`SendWithWriteBytes`).

The fix:
1. Wraps each test case iteration in `SucceedsSoon`
2. Resets load stats, sends the request, checks results
3. If any stat doesn't match (due to background activity like lease upgrades), returns an error to trigger retry
4. Adds a comment noting that test cases must be idempotent (they are—all reads)

## Related Issues/PRs

| Issue/PR | Status | Relevance |
|----------|--------|-----------|
| #159719 | OPEN | Current failure |
| #141716 | CLOSED | Duplicate, Feb 2025 |
| #141586 | CLOSED | Original issue, Feb 2025 |
| #141843 | MERGED | Deflake attempt (wait for lease upgrade) |
| #141599 | MERGED | Added logging to help debug |
| #141905 | CLOSED | Duplicate |
| #134799 | CLOSED | Older occurrence |

This is more robust than trying to synchronize with specific background operations because it handles **any** source of interference, not just lease upgrades.

Epic: none
Closes #159719.
