### PR TITLE
importer: write keys directly to KV in distributed merge

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
-        "//pkg/sql/bulkingest",
         "//pkg/sql/bulkmerge",
         "//pkg/sql/bulksst",
         "//pkg/sql/catalog",


### PR DESCRIPTION
Previously, the distributed IMPORT merge pipeline used a two-step process: the merge processor would produce SSTs, and then a separate ingest processor would write those SSTs into the KV layer. This added unnecessary write amplification and complexity to the pipeline.

This commit modifies the import processor planning to write keys directly into the KV layer during the merge operation itself. The merge processor now takes a writeTS parameter and uses maxIterations=1, eliminating the need for the separate bulkingest.IngestFiles call. The bulkingest package dependency has been removed from the importer.

This simplifies the IMPORT merge pipeline and reduces write amplification. The index backfill path still uses the old approach and will be addressed separately.

Informs #159374

Release note: none

Epic: CRDB-48845