### PR TITLE
cmd/testpyramid: add test pyramid analysis tool

### DIFF
--- a/pkg/cmd/testpyramid/BUILD.bazel
+++ b/pkg/cmd/testpyramid/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "testpyramid_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/testpyramid",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "testpyramid",
+    embed = [":testpyramid_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "testpyramid_test",
+    srcs = ["main_test.go"],
+    embed = [":testpyramid_lib"],
+)

--- a/pkg/cmd/testpyramid/main.go
+++ b/pkg/cmd/testpyramid/main.go
@@ -1,0 +1,684 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// testpyramid analyzes the CockroachDB codebase to generate a test pyramid
+// analysis, categorizing tests into E2E, Integration, and Unit tests.
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// TestCategory represents the category of a test in the pyramid.
+type TestCategory string
+
+const (
+	CategoryE2ERoachtest     TestCategory = "E2E-Roachtest"
+	CategoryE2ECypress       TestCategory = "E2E-Cypress"
+	CategoryE2EAcceptance    TestCategory = "E2E-Acceptance"
+	CategoryIntegrationLogic TestCategory = "Integration-LogicTest"
+	CategoryIntegrationTC    TestCategory = "Integration-TestCluster"
+	CategoryIntegrationTS    TestCategory = "Integration-TestServer"
+	CategoryDatadriven       TestCategory = "Datadriven"
+	CategoryUnit             TestCategory = "Unit"
+	CategoryFrontendUnit     TestCategory = "Frontend-Unit"
+)
+
+// PyramidLevel maps categories to pyramid levels for aggregation.
+var PyramidLevel = map[TestCategory]string{
+	CategoryE2ERoachtest:     "E2E",
+	CategoryE2ECypress:       "E2E",
+	CategoryE2EAcceptance:    "E2E",
+	CategoryIntegrationLogic: "Integration",
+	CategoryIntegrationTC:    "Integration",
+	CategoryIntegrationTS:    "Integration",
+	CategoryDatadriven:       "Datadriven",
+	CategoryUnit:             "Unit",
+	CategoryFrontendUnit:     "Unit",
+}
+
+// TestInfo holds information about a single test.
+type TestInfo struct {
+	Name       string
+	File       string
+	Line       int
+	Category   TestCategory
+	Package    string
+	Subpackage string // e.g., "ccl" for enterprise tests
+}
+
+// Analyzer scans and categorizes tests in the codebase.
+type Analyzer struct {
+	rootDir string
+	tests   []TestInfo
+	fset    *token.FileSet
+}
+
+// NewAnalyzer creates a new test analyzer.
+func NewAnalyzer(rootDir string) *Analyzer {
+	return &Analyzer{
+		rootDir: rootDir,
+		tests:   make([]TestInfo, 0),
+		fset:    token.NewFileSet(),
+	}
+}
+
+// Analyze runs the full analysis on the codebase.
+func (a *Analyzer) Analyze() error {
+	// Scan Go test files
+	if err := a.scanGoTests(); err != nil {
+		return fmt.Errorf("scanning Go tests: %w", err)
+	}
+
+	// Scan roachtests (different pattern - uses r.Add())
+	if err := a.scanRoachtests(); err != nil {
+		return fmt.Errorf("scanning roachtests: %w", err)
+	}
+
+	// Scan Cypress tests
+	if err := a.scanCypressTests(); err != nil {
+		return fmt.Errorf("scanning Cypress tests: %w", err)
+	}
+
+	// Scan frontend unit tests
+	if err := a.scanFrontendTests(); err != nil {
+		return fmt.Errorf("scanning frontend tests: %w", err)
+	}
+
+	return nil
+}
+
+// scanGoTests scans all Go test files and categorizes test functions.
+func (a *Analyzer) scanGoTests() error {
+	return filepath.Walk(a.rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip errors
+		}
+
+		// Skip vendor, node_modules, and .git directories
+		if info.IsDir() {
+			name := info.Name()
+			if name == "vendor" || name == "node_modules" || name == ".git" || name == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only process Go test files, but skip roachtest directory (handled separately)
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		// Skip roachtest tests directory - we handle those separately
+		if strings.Contains(path, "pkg/cmd/roachtest/tests/") {
+			return nil
+		}
+
+		return a.analyzeGoTestFile(path)
+	})
+}
+
+// analyzeGoTestFile parses a Go test file and extracts test functions.
+func (a *Analyzer) analyzeGoTestFile(path string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil // Skip unreadable files
+	}
+
+	file, err := parser.ParseFile(a.fset, path, src, parser.ParseComments)
+	if err != nil {
+		return nil // Skip unparseable files
+	}
+
+	// Collect imports
+	imports := make(map[string]bool)
+	for _, imp := range file.Imports {
+		if imp.Path != nil {
+			imports[strings.Trim(imp.Path.Value, `"`)] = true
+		}
+	}
+
+	// Check for logic test files
+	isLogicTest := strings.Contains(path, "logictest") ||
+		imports["github.com/cockroachdb/cockroach/pkg/sql/logictest"] ||
+		imports["github.com/cockroachdb/cockroach/pkg/ccl/logictestccl"]
+
+	// Analyze each test function
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+
+		// Check if it's a test function
+		if !strings.HasPrefix(fn.Name.Name, "Test") {
+			continue
+		}
+
+		// Must have *testing.T parameter
+		if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+			continue
+		}
+
+		category := a.categorizeTestFunction(fn, imports, isLogicTest, string(src), path)
+
+		relPath, _ := filepath.Rel(a.rootDir, path)
+		pkg := filepath.Dir(relPath)
+		subpkg := ""
+		if strings.Contains(path, "/ccl/") {
+			subpkg = "ccl"
+		}
+
+		pos := a.fset.Position(fn.Pos())
+		a.tests = append(a.tests, TestInfo{
+			Name:       fn.Name.Name,
+			File:       relPath,
+			Line:       pos.Line,
+			Category:   category,
+			Package:    pkg,
+			Subpackage: subpkg,
+		})
+	}
+
+	return nil
+}
+
+// categorizeTestFunction determines the category of a test function.
+func (a *Analyzer) categorizeTestFunction(fn *ast.FuncDecl, imports map[string]bool, isLogicTest bool, src string, path string) TestCategory {
+	// Acceptance tests use Docker and are E2E tests
+	if strings.Contains(path, "pkg/acceptance/") {
+		return CategoryE2EAcceptance
+	}
+
+	// Logic tests are integration tests
+	if isLogicTest && strings.Contains(fn.Name.Name, "Logic") {
+		return CategoryIntegrationLogic
+	}
+
+	// Check function body for integration markers
+	if fn.Body == nil {
+		return CategoryUnit
+	}
+
+	hasTestCluster := false
+	hasTestServer := false
+	hasDatadriven := false
+
+	// Walk the function body looking for calls
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		callStr := a.callExprToString(call)
+
+		// Check for TestCluster patterns
+		if strings.Contains(callStr, "StartTestCluster") ||
+			strings.Contains(callStr, "NewTestCluster") ||
+			strings.Contains(callStr, "testcluster.Start") {
+			hasTestCluster = true
+		}
+
+		// Check for TestServer patterns
+		if strings.Contains(callStr, "StartServer") ||
+			strings.Contains(callStr, "NewServer") ||
+			strings.Contains(callStr, "serverutils.Start") ||
+			strings.Contains(callStr, "serverutils.Make") ||
+			strings.Contains(callStr, "MakeServer") {
+			hasTestServer = true
+		}
+
+		// Check for datadriven patterns
+		if strings.Contains(callStr, "datadriven.Run") ||
+			strings.Contains(callStr, "datadriven.Walk") {
+			hasDatadriven = true
+		}
+
+		return true
+	})
+
+	// Also check imports for stronger signal
+	if imports["github.com/cockroachdb/cockroach/pkg/testutils/testcluster"] {
+		// Check if testcluster is actually used in this function
+		fnSrc := a.getFunctionSource(fn, src)
+		if strings.Contains(fnSrc, "testcluster.") || strings.Contains(fnSrc, "StartTestCluster") {
+			hasTestCluster = true
+		}
+	}
+
+	if imports["github.com/cockroachdb/cockroach/pkg/testutils/serverutils"] ||
+		imports["github.com/cockroachdb/cockroach/pkg/base"] {
+		fnSrc := a.getFunctionSource(fn, src)
+		if strings.Contains(fnSrc, "serverutils.") || strings.Contains(fnSrc, "StartServer") {
+			hasTestServer = true
+		}
+	}
+
+	// Categorize based on findings (most specific first)
+	if hasTestCluster {
+		return CategoryIntegrationTC
+	}
+	if hasTestServer {
+		return CategoryIntegrationTS
+	}
+	if hasDatadriven {
+		return CategoryDatadriven
+	}
+
+	return CategoryUnit
+}
+
+// callExprToString converts a call expression to a string for pattern matching.
+func (a *Analyzer) callExprToString(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		if x, ok := fn.X.(*ast.Ident); ok {
+			return x.Name + "." + fn.Sel.Name
+		}
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+// getFunctionSource extracts the source code of a function.
+func (a *Analyzer) getFunctionSource(fn *ast.FuncDecl, src string) string {
+	start := a.fset.Position(fn.Pos()).Offset
+	end := a.fset.Position(fn.End()).Offset
+	if end > len(src) {
+		end = len(src)
+	}
+	if start >= end || start < 0 {
+		return ""
+	}
+	return src[start:end]
+}
+
+// scanRoachtests scans the roachtest directory for test registrations.
+func (a *Analyzer) scanRoachtests() error {
+	roachtestDir := filepath.Join(a.rootDir, "pkg/cmd/roachtest/tests")
+
+	return filepath.Walk(roachtestDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Skip _test.go files in roachtest - those are unit tests for the roachtest framework
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		return a.analyzeRoachtestFile(path)
+	})
+}
+
+// analyzeRoachtestFile finds r.Add() registrations in a roachtest file.
+func (a *Analyzer) analyzeRoachtestFile(path string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	srcStr := string(src)
+	relPath, _ := filepath.Rel(a.rootDir, path)
+
+	// Look for r.Add() patterns which register roachtests
+	// Pattern: r.Add(registry.TestSpec{Name: "..."
+	re := regexp.MustCompile(`(?m)r\.Add\(registry\.TestSpec\{[^}]*Name:\s*"([^"]+)"`)
+	matches := re.FindAllStringSubmatchIndex(srcStr, -1)
+
+	for _, match := range matches {
+		if len(match) >= 4 {
+			testName := srcStr[match[2]:match[3]]
+			// Calculate line number
+			line := 1 + strings.Count(srcStr[:match[0]], "\n")
+
+			a.tests = append(a.tests, TestInfo{
+				Name:     testName,
+				File:     relPath,
+				Line:     line,
+				Category: CategoryE2ERoachtest,
+				Package:  "pkg/cmd/roachtest/tests",
+			})
+		}
+	}
+
+	// Also look for simpler patterns: r.Add(spec) where spec is defined elsewhere
+	// We can detect these by looking for the registerX() function pattern
+	// that's common in roachtest files
+
+	return nil
+}
+
+// scanCypressTests scans for Cypress test files.
+func (a *Analyzer) scanCypressTests() error {
+	cypressDir := filepath.Join(a.rootDir, "pkg/ui/workspaces/e2e-tests/cypress")
+
+	return filepath.Walk(cypressDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".cy.ts") {
+			return nil
+		}
+
+		return a.analyzeCypressFile(path)
+	})
+}
+
+// analyzeCypressFile counts it() blocks in a Cypress test file.
+func (a *Analyzer) analyzeCypressFile(path string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	srcStr := string(src)
+	relPath, _ := filepath.Rel(a.rootDir, path)
+
+	// Find it() blocks - these are individual test cases
+	// Pattern: it("description", ... or it('description', ...
+	re := regexp.MustCompile(`(?m)\bit\s*\(\s*["']([^"']+)["']`)
+	matches := re.FindAllStringSubmatchIndex(srcStr, -1)
+
+	for _, match := range matches {
+		if len(match) >= 4 {
+			testName := srcStr[match[2]:match[3]]
+			line := 1 + strings.Count(srcStr[:match[0]], "\n")
+
+			a.tests = append(a.tests, TestInfo{
+				Name:     testName,
+				File:     relPath,
+				Line:     line,
+				Category: CategoryE2ECypress,
+				Package:  "pkg/ui/workspaces/e2e-tests",
+			})
+		}
+	}
+
+	return nil
+}
+
+// scanFrontendTests scans for frontend unit tests (.spec.ts/.spec.tsx files).
+func (a *Analyzer) scanFrontendTests() error {
+	uiDir := filepath.Join(a.rootDir, "pkg/ui/workspaces")
+
+	return filepath.Walk(uiDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			// Skip node_modules
+			if info.Name() == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Skip cypress tests (already counted as E2E)
+		if strings.Contains(path, "/cypress/") {
+			return nil
+		}
+
+		if strings.HasSuffix(path, ".spec.ts") || strings.HasSuffix(path, ".spec.tsx") {
+			return a.analyzeFrontendTestFile(path)
+		}
+
+		return nil
+	})
+}
+
+// analyzeFrontendTestFile counts it()/test() blocks in a frontend test file.
+func (a *Analyzer) analyzeFrontendTestFile(path string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	srcStr := string(src)
+	relPath, _ := filepath.Rel(a.rootDir, path)
+
+	// Find it() or test() blocks
+	re := regexp.MustCompile(`(?m)\b(?:it|test)\s*\(\s*["']([^"']+)["']`)
+	matches := re.FindAllStringSubmatchIndex(srcStr, -1)
+
+	for _, match := range matches {
+		if len(match) >= 4 {
+			testName := srcStr[match[2]:match[3]]
+			line := 1 + strings.Count(srcStr[:match[0]], "\n")
+
+			a.tests = append(a.tests, TestInfo{
+				Name:     testName,
+				File:     relPath,
+				Line:     line,
+				Category: CategoryFrontendUnit,
+				Package:  filepath.Dir(relPath),
+			})
+		}
+	}
+
+	return nil
+}
+
+// WriteCSV writes the test data to a CSV file.
+func (a *Analyzer) WriteCSV(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	// Write header
+	if err := w.Write([]string{"test_name", "file", "line", "category", "pyramid_level", "package", "subpackage"}); err != nil {
+		return err
+	}
+
+	// Sort tests by category, then file, then line
+	sort.Slice(a.tests, func(i, j int) bool {
+		if a.tests[i].Category != a.tests[j].Category {
+			return a.tests[i].Category < a.tests[j].Category
+		}
+		if a.tests[i].File != a.tests[j].File {
+			return a.tests[i].File < a.tests[j].File
+		}
+		return a.tests[i].Line < a.tests[j].Line
+	})
+
+	// Write data
+	for _, t := range a.tests {
+		if err := w.Write([]string{
+			t.Name,
+			t.File,
+			fmt.Sprintf("%d", t.Line),
+			string(t.Category),
+			PyramidLevel[t.Category],
+			t.Package,
+			t.Subpackage,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PrintPyramid prints an ASCII visualization of the test pyramid.
+func (a *Analyzer) PrintPyramid() {
+	// Count tests by category and level
+	categoryCount := make(map[TestCategory]int)
+	levelCount := make(map[string]int)
+
+	for _, t := range a.tests {
+		categoryCount[t.Category]++
+		levelCount[PyramidLevel[t.Category]]++
+	}
+
+	total := len(a.tests)
+	if total == 0 {
+		fmt.Println("No tests found.")
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("╔══════════════════════════════════════════════════════════════════════════════╗")
+	fmt.Println("║                        COCKROACHDB TEST PYRAMID                              ║")
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+	fmt.Println()
+
+	// Print pyramid visualization
+	e2eCount := levelCount["E2E"]
+	intCount := levelCount["Integration"]
+	ddCount := levelCount["Datadriven"]
+	unitCount := levelCount["Unit"]
+
+	// Calculate percentages
+	e2ePct := float64(e2eCount) / float64(total) * 100
+	intPct := float64(intCount) / float64(total) * 100
+	ddPct := float64(ddCount) / float64(total) * 100
+	unitPct := float64(unitCount) / float64(total) * 100
+
+	// ASCII pyramid - wider at bottom
+	fmt.Println("                              ╱╲")
+	fmt.Println("                             ╱  ╲")
+	fmt.Printf("                            ╱ E2E╲        %6d tests (%5.1f%%)\n", e2eCount, e2ePct)
+	fmt.Println("                           ╱──────╲")
+	fmt.Println("                          ╱        ╲")
+	fmt.Printf("                         ╱Integration╲   %6d tests (%5.1f%%)\n", intCount, intPct)
+	fmt.Println("                        ╱────────────╲")
+	fmt.Println("                       ╱              ╲")
+	fmt.Printf("                      ╱   Datadriven   ╲  %6d tests (%5.1f%%)\n", ddCount, ddPct)
+	fmt.Println("                     ╱──────────────────╲")
+	fmt.Println("                    ╱                    ╲")
+	fmt.Printf("                   ╱        Unit          ╲ %6d tests (%5.1f%%)\n", unitCount, unitPct)
+	fmt.Println("                  ╱────────────────────────╲")
+	fmt.Println()
+
+	// Print detailed breakdown
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+	fmt.Println("║                           DETAILED BREAKDOWN                                 ║")
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+	fmt.Println()
+
+	categories := []TestCategory{
+		CategoryE2ERoachtest,
+		CategoryE2ECypress,
+		CategoryE2EAcceptance,
+		CategoryIntegrationLogic,
+		CategoryIntegrationTC,
+		CategoryIntegrationTS,
+		CategoryDatadriven,
+		CategoryUnit,
+		CategoryFrontendUnit,
+	}
+
+	maxBar := 50
+	maxCount := 0
+	for _, c := range categoryCount {
+		if c > maxCount {
+			maxCount = c
+		}
+	}
+
+	for _, cat := range categories {
+		count := categoryCount[cat]
+		pct := float64(count) / float64(total) * 100
+		barLen := 0
+		if maxCount > 0 {
+			barLen = count * maxBar / maxCount
+		}
+		bar := strings.Repeat("█", barLen)
+
+		fmt.Printf("  %-25s %6d (%5.1f%%) %s\n", cat, count, pct, bar)
+	}
+
+	fmt.Println()
+	fmt.Printf("  %-25s %6d\n", "TOTAL", total)
+	fmt.Println()
+
+	// Print pyramid health assessment
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+	fmt.Println("║                           PYRAMID HEALTH                                     ║")
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+	fmt.Println()
+
+	// Ideal pyramid ratios (roughly): 70% unit, 20% integration, 10% e2e
+	// Calculate actual ratios
+	unitRatio := float64(unitCount+ddCount) / float64(total) * 100 // Include datadriven as "closer to unit"
+	intRatio := float64(intCount) / float64(total) * 100
+	e2eRatio := float64(e2eCount) / float64(total) * 100
+
+	fmt.Printf("  Unit + Datadriven (ideal ~70%%):  %5.1f%%", unitRatio)
+	if unitRatio >= 60 {
+		fmt.Println("  ✓")
+	} else {
+		fmt.Println("  ⚠ (low)")
+	}
+
+	fmt.Printf("  Integration (ideal ~20%%):        %5.1f%%", intRatio)
+	if intRatio <= 30 {
+		fmt.Println("  ✓")
+	} else {
+		fmt.Println("  ⚠ (high)")
+	}
+
+	fmt.Printf("  E2E (ideal ~10%%):                %5.1f%%", e2eRatio)
+	if e2eRatio <= 15 {
+		fmt.Println("  ✓")
+	} else {
+		fmt.Println("  ⚠ (high)")
+	}
+
+	fmt.Println()
+	fmt.Println("╚══════════════════════════════════════════════════════════════════════════════╝")
+}
+
+func main() {
+	rootDir := flag.String("root", ".", "Root directory of the CockroachDB repository")
+	outputCSV := flag.String("csv", "test_pyramid.csv", "Output CSV file path")
+	flag.Parse()
+
+	// Resolve root directory
+	absRoot, err := filepath.Abs(*rootDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving root directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Analyzing tests in: %s\n", absRoot)
+	fmt.Println("This may take a minute...")
+
+	analyzer := NewAnalyzer(absRoot)
+	if err := analyzer.Analyze(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error analyzing tests: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write CSV
+	if err := analyzer.WriteCSV(*outputCSV); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing CSV: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("CSV written to: %s\n", *outputCSV)
+
+	// Print pyramid
+	analyzer.PrintPyramid()
+}

--- a/pkg/cmd/testpyramid/main_test.go
+++ b/pkg/cmd/testpyramid/main_test.go
@@ -1,0 +1,399 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCategorizeGoTests tests the categorization of Go test functions.
+func TestCategorizeGoTests(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	testCases := []struct {
+		name         string
+		path         string
+		content      string
+		wantCategory TestCategory
+		wantName     string
+	}{
+		{
+			name: "unit test",
+			path: "pkg/util/foo_test.go",
+			content: `package util
+
+import "testing"
+
+func TestSimple(t *testing.T) {
+	if 1 != 1 {
+		t.Fatal("math is broken")
+	}
+}
+`,
+			wantCategory: CategoryUnit,
+			wantName:     "TestSimple",
+		},
+		{
+			name: "test with TestServer",
+			path: "pkg/sql/bar_test.go",
+			content: `package sql
+
+import (
+	"testing"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+)
+
+func TestWithServer(t *testing.T) {
+	s, _, _ := serverutils.StartServer(t, nil)
+	defer s.Stopper().Stop(nil)
+}
+`,
+			wantCategory: CategoryIntegrationTS,
+			wantName:     "TestWithServer",
+		},
+		{
+			name: "test with TestCluster",
+			path: "pkg/kv/baz_test.go",
+			content: `package kv
+
+import (
+	"testing"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+)
+
+func TestWithCluster(t *testing.T) {
+	tc := testcluster.StartTestCluster(t, 3, nil)
+	defer tc.Stopper().Stop(nil)
+}
+`,
+			wantCategory: CategoryIntegrationTC,
+			wantName:     "TestWithCluster",
+		},
+		{
+			name: "datadriven test",
+			path: "pkg/sql/parser/parser_test.go",
+			content: `package parser
+
+import (
+	"testing"
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestDataDriven(t *testing.T) {
+	datadriven.RunTest(t, "testdata/parse", func(t *testing.T, d *datadriven.TestData) string {
+		return ""
+	})
+}
+`,
+			wantCategory: CategoryDatadriven,
+			wantName:     "TestDataDriven",
+		},
+		{
+			name: "logic test",
+			path: "pkg/sql/logictest/tests/local/generated_test.go",
+			content: `package local
+
+import "testing"
+
+func TestLogic_aggregate(t *testing.T) {
+	// logic test
+}
+`,
+			wantCategory: CategoryIntegrationLogic,
+			wantName:     "TestLogic_aggregate",
+		},
+		{
+			name: "acceptance test",
+			path: "pkg/acceptance/cli_test.go",
+			content: `package acceptance
+
+import "testing"
+
+func TestDockerCLI(t *testing.T) {
+	// acceptance test using docker
+}
+`,
+			wantCategory: CategoryE2EAcceptance,
+			wantName:     "TestDockerCLI",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create the file in temp directory
+			fullPath := filepath.Join(tmpDir, tc.path)
+			if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(fullPath, []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Run analyzer
+			analyzer := NewAnalyzer(tmpDir)
+			if err := analyzer.analyzeGoTestFile(fullPath); err != nil {
+				t.Fatal(err)
+			}
+
+			// Verify results
+			if len(analyzer.tests) != 1 {
+				t.Fatalf("expected 1 test, got %d", len(analyzer.tests))
+			}
+
+			test := analyzer.tests[0]
+			if test.Name != tc.wantName {
+				t.Errorf("expected name %q, got %q", tc.wantName, test.Name)
+			}
+			if test.Category != tc.wantCategory {
+				t.Errorf("expected category %q, got %q", tc.wantCategory, test.Category)
+			}
+		})
+	}
+}
+
+// TestRoachtestPatternMatching tests detection of roachtest registrations.
+func TestRoachtestPatternMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	roachtestContent := `package tests
+
+import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+
+func registerFoo(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:  "foo/bar",
+		Owner: "test-team",
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// test code
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:  "foo/baz",
+		Owner: "test-team",
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// test code
+		},
+	})
+}
+`
+
+	roachtestDir := filepath.Join(tmpDir, "pkg/cmd/roachtest/tests")
+	if err := os.MkdirAll(roachtestDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	roachtestFile := filepath.Join(roachtestDir, "foo.go")
+	if err := os.WriteFile(roachtestFile, []byte(roachtestContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer(tmpDir)
+	if err := analyzer.analyzeRoachtestFile(roachtestFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(analyzer.tests) != 2 {
+		t.Fatalf("expected 2 roachtests, got %d", len(analyzer.tests))
+	}
+
+	expectedNames := map[string]bool{"foo/bar": true, "foo/baz": true}
+	for _, test := range analyzer.tests {
+		if test.Category != CategoryE2ERoachtest {
+			t.Errorf("expected category %q, got %q", CategoryE2ERoachtest, test.Category)
+		}
+		if !expectedNames[test.Name] {
+			t.Errorf("unexpected test name: %q", test.Name)
+		}
+		delete(expectedNames, test.Name)
+	}
+
+	if len(expectedNames) > 0 {
+		t.Errorf("missing expected tests: %v", expectedNames)
+	}
+}
+
+// TestCypressPatternMatching tests detection of Cypress test cases.
+func TestCypressPatternMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cypressContent := `describe("Health Check", () => {
+  it("should load the login page", () => {
+    cy.visit("/");
+  });
+
+  it("should display error on invalid login", () => {
+    cy.get("#username").type("invalid");
+  });
+
+  it('handles single quotes too', () => {
+    cy.log("test");
+  });
+});
+`
+
+	cypressDir := filepath.Join(tmpDir, "pkg/ui/workspaces/e2e-tests/cypress/e2e")
+	if err := os.MkdirAll(cypressDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cypressFile := filepath.Join(cypressDir, "health.cy.ts")
+	if err := os.WriteFile(cypressFile, []byte(cypressContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer(tmpDir)
+	if err := analyzer.analyzeCypressFile(cypressFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(analyzer.tests) != 3 {
+		t.Fatalf("expected 3 cypress tests, got %d", len(analyzer.tests))
+	}
+
+	for _, test := range analyzer.tests {
+		if test.Category != CategoryE2ECypress {
+			t.Errorf("expected category %q, got %q", CategoryE2ECypress, test.Category)
+		}
+	}
+}
+
+// TestFrontendTestPatternMatching tests detection of frontend unit tests.
+func TestFrontendTestPatternMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	specContent := `import { render } from "@testing-library/react";
+
+describe("Component", () => {
+  it("renders correctly", () => {
+    render(<Component />);
+  });
+
+  test("handles click events", () => {
+    // test code
+  });
+});
+`
+
+	frontendDir := filepath.Join(tmpDir, "pkg/ui/workspaces/cluster-ui/src/components")
+	if err := os.MkdirAll(frontendDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	specFile := filepath.Join(frontendDir, "component.spec.tsx")
+	if err := os.WriteFile(specFile, []byte(specContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer(tmpDir)
+	if err := analyzer.analyzeFrontendTestFile(specFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(analyzer.tests) != 2 {
+		t.Fatalf("expected 2 frontend tests, got %d", len(analyzer.tests))
+	}
+
+	for _, test := range analyzer.tests {
+		if test.Category != CategoryFrontendUnit {
+			t.Errorf("expected category %q, got %q", CategoryFrontendUnit, test.Category)
+		}
+	}
+}
+
+// TestCSVOutput tests the CSV output format.
+func TestCSVOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	analyzer := NewAnalyzer(tmpDir)
+	analyzer.tests = []TestInfo{
+		{
+			Name:       "TestFoo",
+			File:       "pkg/foo/foo_test.go",
+			Line:       10,
+			Category:   CategoryUnit,
+			Package:    "pkg/foo",
+			Subpackage: "",
+		},
+		{
+			Name:       "TestBar",
+			File:       "pkg/ccl/bar/bar_test.go",
+			Line:       20,
+			Category:   CategoryIntegrationTS,
+			Package:    "pkg/ccl/bar",
+			Subpackage: "ccl",
+		},
+	}
+
+	csvPath := filepath.Join(tmpDir, "output.csv")
+	if err := analyzer.WriteCSV(csvPath); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(csvPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 lines, got %d", len(lines))
+	}
+
+	// Check header
+	expectedHeader := "test_name,file,line,category,pyramid_level,package,subpackage"
+	if lines[0] != expectedHeader {
+		t.Errorf("expected header %q, got %q", expectedHeader, lines[0])
+	}
+
+	// Check that both tests are present
+	csvContent := string(content)
+	if !strings.Contains(csvContent, "TestFoo") {
+		t.Error("CSV should contain TestFoo")
+	}
+	if !strings.Contains(csvContent, "TestBar") {
+		t.Error("CSV should contain TestBar")
+	}
+	if !strings.Contains(csvContent, "ccl") {
+		t.Error("CSV should contain ccl subpackage")
+	}
+}
+
+// TestPyramidLevelMapping tests that all categories map to valid pyramid levels.
+func TestPyramidLevelMapping(t *testing.T) {
+	categories := []TestCategory{
+		CategoryE2ERoachtest,
+		CategoryE2ECypress,
+		CategoryE2EAcceptance,
+		CategoryIntegrationLogic,
+		CategoryIntegrationTC,
+		CategoryIntegrationTS,
+		CategoryDatadriven,
+		CategoryUnit,
+		CategoryFrontendUnit,
+	}
+
+	validLevels := map[string]bool{
+		"E2E":         true,
+		"Integration": true,
+		"Datadriven":  true,
+		"Unit":        true,
+	}
+
+	for _, cat := range categories {
+		level, ok := PyramidLevel[cat]
+		if !ok {
+			t.Errorf("category %q has no pyramid level mapping", cat)
+			continue
+		}
+		if !validLevels[level] {
+			t.Errorf("category %q maps to invalid level %q", cat, level)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

      - Adds a new tool that analyzes the CockroachDB codebase to generate a test pyramid analysis
      - Categorizes tests into E2E (roachtests, Cypress, acceptance), Integration (logic tests, TestCluster, TestServer), Datadriven, and Unit tests
      - Parses Go AST to identify test functions and categorize based on imports/function calls
      - Outputs CSV for spreadsheet analysis and ASCII pyramid visualization

      ## Example Output

      ```
      ╔══════════════════════════════════════════════════════════════════════════════╗
      ║                        COCKROACHDB TEST PYRAMID                              ║
      ╠══════════════════════════════════════════════════════════════════════════════╣

                                    ╱╲
                                   ╱  ╲
                                  ╱ E2E╲           289 tests (  1.5%)
                                 ╱──────╲
                                ╱        ╲
                               ╱Integration╲     9433 tests ( 49.5%)
                              ╱────────────╲
                             ╱              ╲
                            ╱   Datadriven   ╲     203 tests (  1.1%)
                           ╱──────────────────╲
                          ╱                    ╲
                         ╱        Unit          ╲   9140 tests ( 47.9%)
                        ╱────────────────────────╲
      ```

      ## Test plan

      - [x] Unit tests added covering categorization logic, pattern matching, and output format
      - [x] `bazel test //pkg/cmd/testpyramid:testpyramid_test` passes

      🤖 Generated with [Claude Code](https://claude.com/claude-code)