### PR TITLE
release-26.1: sql: skip shared process mode under deadlock in TestShowLastQueryStatistics

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1410,9 +1410,11 @@ func TestShowLastQueryStatistics(t *testing.T) {
 	ctx := context.Background()
 	var testTenant base.DefaultTestTenantOptions
 	if syncutil.DeadlockEnabled {
-		// Under deadlock, the planning latency in the external process mode can
-		// sometimes exceed 1s allowed limit.
-		testTenant = base.TestSkipForExternalProcessMode()
+		// Under deadlock, the planning latency in the secondary test tenant can
+		// sometimes exceed 1s allowed limit. (Note ideally we'd have used a
+		// different test tenant option since it's not "storage-layer specific"
+		// test, but there isn't a more suitable one.)
+		testTenant = base.TestIsSpecificToStorageLayerAndNeedsASystemTenant
 	}
 	s, sqlConn, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: testTenant,


### PR DESCRIPTION
Backport 1/1 commits from #159782 on behalf of @yuzefovich.

----

The test is overload sensitive and hard-codes expected times, so let's just disable secondary test tenant (external process was already disabled).

Fixes: #158859
Release note: None

----

Release justification: test-only change.