### PR TITLE
release-25.3: storeliveness: record latency metric for disk access

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -17382,6 +17382,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storeliveness.heartbeat.persist_duration
+      exported_name: storeliveness_heartbeat_persist_duration
+      description: Latency of persisting Store Liveness requester meta before sending heartbeats
+      y_axis_label: Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
     - name: storeliveness.heartbeat.successes
       exported_name: storeliveness_heartbeat_successes
       description: Number of Store Liveness heartbeats sent out by the Store Liveness Support Manager
@@ -17398,6 +17406,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storeliveness.message_handle.persist_duration
+      exported_name: storeliveness_message_handle_persist_duration
+      description: Latency of persisting Store Liveness state when handling incoming messages
+      y_axis_label: Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
     - name: storeliveness.message_handle.successes
       exported_name: storeliveness_message_handle_successes
       description: Number of incoming Store Liveness messages handled by the Store Liveness Support Manager
@@ -17430,6 +17446,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: storeliveness.support_withdraw.persist_duration
+      exported_name: storeliveness_support_withdraw_persist_duration
+      description: Latency of persisting Store Liveness state when withdrawing support
+      y_axis_label: Duration
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
     - name: storeliveness.support_withdraw.successes
       exported_name: storeliveness_support_withdraw_successes
       description: Number of times the Store Liveness Support Manager has successfully withdrawn support for another store

--- a/pkg/kv/kvserver/storeliveness/metrics.go
+++ b/pkg/kv/kvserver/storeliveness/metrics.go
@@ -56,6 +56,10 @@ type SupportManagerMetrics struct {
 
 	ReceiveQueueSize  *metric.Gauge
 	ReceiveQueueBytes *metric.Gauge
+
+	HeartbeatPersistDuration       metric.IHistogram
+	MessageHandlePersistDuration   metric.IHistogram
+	SupportWithdrawPersistDuration metric.IHistogram
 }
 
 func newSupportManagerMetrics() *SupportManagerMetrics {
@@ -78,6 +82,30 @@ func newSupportManagerMetrics() *SupportManagerMetrics {
 		SupportForStores:  metric.NewGauge(metaSupportForStores),
 		ReceiveQueueSize:  metric.NewGauge(metaReceiveQueueSize),
 		ReceiveQueueBytes: metric.NewGauge(metaReceiveQueueBytes),
+		HeartbeatPersistDuration: metric.NewHistogram(
+			metric.HistogramOptions{
+				Mode:         metric.HistogramModePreferHdrLatency,
+				Metadata:     metaHeartbeatPersistDuration,
+				Duration:     base.DefaultHistogramWindowInterval(),
+				BucketConfig: metric.IOLatencyBuckets,
+			},
+		),
+		MessageHandlePersistDuration: metric.NewHistogram(
+			metric.HistogramOptions{
+				Mode:         metric.HistogramModePreferHdrLatency,
+				Metadata:     metaMessageHandlePersistDuration,
+				Duration:     base.DefaultHistogramWindowInterval(),
+				BucketConfig: metric.IOLatencyBuckets,
+			},
+		),
+		SupportWithdrawPersistDuration: metric.NewHistogram(
+			metric.HistogramOptions{
+				Mode:         metric.HistogramModePreferHdrLatency,
+				Metadata:     metaSupportWithdrawPersistDuration,
+				Duration:     base.DefaultHistogramWindowInterval(),
+				BucketConfig: metric.IOLatencyBuckets,
+			},
+		),
 	}
 }
 
@@ -205,6 +233,24 @@ var (
 	metaCallbacksProcessingDuration = metric.Metadata{
 		Name:        "storeliveness.callbacks.processing_duration",
 		Help:        "Duration of support withdrawal callback processing",
+		Measurement: "Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaHeartbeatPersistDuration = metric.Metadata{
+		Name:        "storeliveness.heartbeat.persist_duration",
+		Help:        "Latency of persisting Store Liveness requester meta before sending heartbeats",
+		Measurement: "Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaMessageHandlePersistDuration = metric.Metadata{
+		Name:        "storeliveness.message_handle.persist_duration",
+		Help:        "Latency of persisting Store Liveness state when handling incoming messages",
+		Measurement: "Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaSupportWithdrawPersistDuration = metric.Metadata{
+		Name:        "storeliveness.support_withdraw.persist_duration",
+		Help:        "Latency of persisting Store Liveness state when withdrawing support",
 		Measurement: "Duration",
 		Unit:        metric.Unit_NANOSECONDS,
 	}

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -313,11 +313,14 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	livenessInterval := sm.options.SupportDuration
 	heartbeats := rsfu.getHeartbeatsToSend(sm.storeID, sm.clock.Now(), livenessInterval)
+	beforePersist := timeutil.Now()
 	if err := rsfu.write(ctx, sm.engine); err != nil {
 		log.Warningf(ctx, "failed to write requester meta: %v", err)
 		sm.metrics.HeartbeatFailures.Inc(int64(len(heartbeats)))
 		return
 	}
+	persistDur := timeutil.Since(beforePersist)
+	sm.metrics.HeartbeatPersistDuration.RecordValue(persistDur.Nanoseconds())
 	sm.requesterStateHandler.checkInUpdate(rsfu)
 
 	// Send heartbeats to each remote store.
@@ -352,24 +355,28 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 
 	batch := sm.engine.NewBatch()
 	defer batch.Close()
+	// NB: updating the support state involves a few writes under the hood, so we
+	// do them using a batch.
 	if err := ssfu.write(ctx, batch); err != nil {
 		log.Warningf(ctx, "failed to write supporter meta and state: %v", err)
 		sm.metrics.SupportWithdrawFailures.Inc(int64(numWithdrawn))
 		return
 	}
+	beforePersist := timeutil.Now()
 	if err := batch.Commit(true /* sync */); err != nil {
 		log.Warningf(ctx, "failed to commit supporter meta and state: %v", err)
 		sm.metrics.SupportWithdrawFailures.Inc(int64(numWithdrawn))
 		return
 	}
+	persistDur := timeutil.Since(beforePersist)
+	sm.metrics.SupportWithdrawPersistDuration.RecordValue(persistDur.Nanoseconds())
 	sm.supporterStateHandler.checkInUpdate(ssfu)
 	log.Infof(ctx, "withdrew support from %d stores", numWithdrawn)
 	sm.metrics.SupportWithdrawSuccesses.Inc(int64(numWithdrawn))
 	if sm.withdrawalCallback != nil {
 		beforeProcess := timeutil.Now()
 		sm.withdrawalCallback(supportWithdrawnForStoreIDs)
-		afterProcess := timeutil.Now()
-		processDur := afterProcess.Sub(beforeProcess)
+		processDur := timeutil.Since(beforeProcess)
 		if processDur > minCallbackDurationToRecord {
 			sm.metrics.CallbacksProcessingDuration.RecordValue(processDur.Nanoseconds())
 		}
@@ -412,11 +419,14 @@ func (sm *SupportManager) handleMessages(ctx context.Context, msgs []*slpb.Messa
 		sm.metrics.MessageHandleFailures.Inc(int64(len(msgs)))
 		return
 	}
+	beforePersist := timeutil.Now()
 	if err := batch.Commit(true /* sync */); err != nil {
 		log.Warningf(ctx, "failed to sync supporter and requester state: %v", err)
 		sm.metrics.MessageHandleFailures.Inc(int64(len(msgs)))
 		return
 	}
+	persistDur := timeutil.Since(beforePersist)
+	sm.metrics.MessageHandlePersistDuration.RecordValue(persistDur.Nanoseconds())
 	sm.requesterStateHandler.checkInUpdate(rsfu)
 	sm.supporterStateHandler.checkInUpdate(ssfu)
 	sm.metrics.MessageHandleSuccesses.Inc(int64(len(msgs)))


### PR DESCRIPTION
Backport 1/1 commits from #159852.

/cc @cockroachdb/release

---

Closes https://github.com/cockroachdb/cockroach/issues/155381

Release note: None
